### PR TITLE
[network-gateway] enable readOnlyRootFilesystem

### DIFF
--- a/ee/modules/450-network-gateway/images/dnsmasq/mount-points.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/mount-points.yaml
@@ -1,0 +1,3 @@
+dirs:
+- /etc/network-gateway-config
+- /var/lib/dnsmasq/

--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -32,6 +32,7 @@ fromImage: common/distroless
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
   to: /prepare-config.py
+{{- include "image mount points" $ }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate

--- a/ee/modules/450-network-gateway/images/iptables-wrapper-init/mount-points.yaml
+++ b/ee/modules/450-network-gateway/images/iptables-wrapper-init/mount-points.yaml
@@ -1,0 +1,2 @@
+files:
+- /run/xtables.lock

--- a/ee/modules/450-network-gateway/images/iptables-wrapper-init/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/iptables-wrapper-init/werf.inc.yaml
@@ -31,6 +31,8 @@ import:
   add: /relocate
   to: /relocate
   before: setup
+git:
+{{- include "image mount points" $ }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
 final: false

--- a/ee/modules/450-network-gateway/images/iptables-wrapper-init/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/iptables-wrapper-init/werf.inc.yaml
@@ -1,0 +1,54 @@
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+import:
+- image: tools/coreutils
+  add: /
+  to: /
+  before: setup
+  includePaths:
+  - usr/bin/coreutils
+  - usr/bin/rm
+  - usr/bin/cp
+- image: tools/bash
+  add: /usr/bin/bash
+  to: /bin/bash
+  before: setup
+- image: common/iptables-wrapper
+  add: /iptables-wrapper
+  to: /iptables-wrapper
+  before: setup
+- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+  add: /
+  to: /_sbin
+  includePaths:
+  - xtables-legacy-multi
+  - xtables-nft-multi
+  before: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+  add: /relocate
+  to: /relocate
+  before: setup
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+final: false
+fromImage: common/relocate-artifact
+shell:
+  install:
+  - mkdir -p /relocate/sbin
+  - |
+    for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
+    done
+    # broken symlinks are not imported from the artifact
+    touch /iptables-wrapper
+  - |
+    for mode in legacy nft; do
+      for basecmd in iptables ip6tables; do
+        for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+          ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+        done
+      done
+    done

--- a/ee/modules/450-network-gateway/images/snat/mount-points.yaml
+++ b/ee/modules/450-network-gateway/images/snat/mount-points.yaml
@@ -1,0 +1,4 @@
+files:
+- /run/xtables.lock
+dirs:
+- /etc/network-gateway-config

--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -1,5 +1,3 @@
-{{- $iptables_version := "1.8.9" }}
-{{- $iptables_image_version := $iptables_version | replace "." "-" }}
 {{- $binaries := "/bin/grep /bin/sed /bin/sh" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
@@ -8,42 +6,17 @@ fromImage: common/relocate-artifact
 shell:
   install:
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate
-  - mkdir -p /relocate/sbin
-  - |
-    for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
-    done
-    # broken symlinks are not imported from the artifact
-    touch /sbin/iptables-wrapper
-  - |
-    for mode in legacy nft; do
-      for basecmd in iptables ip6tables; do
-        for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
-          ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
-        done
-      done
-    done
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/iptables-loop.py
   to: /iptables-loop.py
+{{- include "image mount points" $ }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
   add: /relocate
   to: /
-  before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
-  add: /
-  to: /sbin
-  includePaths:
-  - xtables-legacy-multi
-  - xtables-nft-multi
-  before: setup
-- image: common/iptables-wrapper
-  add: /iptables-wrapper
-  to: /sbin/iptables-wrapper
   before: setup
 - image: base/python
   add: /

--- a/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
+++ b/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
@@ -63,7 +63,7 @@ spec:
       - name: deckhouse-registry
       initContainers:
       - name: iptables-wrapper-init
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "iptablesWrapperInit") }}
         command:
         - /bin/bash
@@ -72,6 +72,8 @@ spec:
         volumeMounts:
         - mountPath: /sbin
           name: sbin
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}

--- a/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
+++ b/ee/modules/450-network-gateway/templates/snat-daemonset.yaml
@@ -2,6 +2,10 @@
 cpu: 25m
 memory: 50Mi
 {{- end }}
+{{- define "iptables_wrapper_init_resources" }}
+cpu: 10m
+memory: 10Mi
+{{- end }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -57,10 +61,28 @@ spec:
 {{- end }}
       imagePullSecrets:
       - name: deckhouse-registry
+      initContainers:
+      - name: iptables-wrapper-init
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        image: {{ include "helm_lib_module_image" (list . "iptablesWrapperInit") }}
+        command:
+        - /bin/bash
+        - -c
+        - "/usr/bin/cp /iptables-wrapper /sbin/ -rv && /usr/bin/cp /_sbin/* /sbin/ -rv && /usr/bin/cp /relocate/sbin/* /sbin/ -rv && /sbin/iptables --version && /usr/bin/rm /sbin/iptables-wrapper -v"
+        volumeMounts:
+        - mountPath: /sbin
+          name: sbin
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+    {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+            {{- include "iptables_wrapper_init_resources" . | nindent 12 }}
+    {{- end }}
       containers:
       - name: snat
          # containers messing with iptables and iptables-wrapper have to be run as root because iptables-legacy binary requires to be run as root (setsuid isn't an option).
         {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 8 }}
+          readOnlyRootFilesystem: true
           capabilities:
             add:
             - NET_RAW
@@ -80,6 +102,9 @@ spec:
         - mountPath: /run/xtables.lock
           name: xtables-lock
           readOnly: false
+        - mountPath: /sbin
+          name: sbin
+          readOnly: true
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
@@ -94,3 +119,7 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
+      - name: sbin
+        emptyDir:
+          medium: Memory
+          sizeLimit: 4Mi

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -330,8 +330,9 @@ var DefaultImagesDigests = map[string]interface{}{
 		"multitenancyManager": "imageHash-multitenancyManager-multitenancyManager",
 	},
 	"networkGateway": map[string]interface{}{
-		"dnsmasq": "imageHash-networkGateway-dnsmasq",
-		"snat":    "imageHash-networkGateway-snat",
+		"dnsmasq":             "imageHash-networkGateway-dnsmasq",
+		"iptablesWrapperInit": "imageHash-networkGateway-iptablesWrapperInit",
+		"snat":                "imageHash-networkGateway-snat",
 	},
 	"networkPolicyEngine": map[string]interface{}{
 		"kubeRouter": "imageHash-networkPolicyEngine-kubeRouter",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

All containers of the network-gateway module have the readOnlyRootFilesystem setting set to true.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need it to meet security concerns and for overall hardening of the DKP platform.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: network-gateway
type: chore
summary: The readOnlyRootFilesystem security option is set to true for all containers.
impact: Pods of the network-gateway module will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
