### PR TITLE
[dhctl] run terraform init once

### DIFF
--- a/dhctl/pkg/infrastructure/tofu/executor.go
+++ b/dhctl/pkg/infrastructure/tofu/executor.go
@@ -35,11 +35,11 @@ type initEntry struct {
 }
 
 var initOnceByKey sync.Map
+var initMutex sync.Mutex
 
-func getInitOnceKey(pluginsDir, workingDir string) *initEntry {
-    key := pluginsDir + "|" + workingDir
-    v, _ := initOnceByKey.LoadOrStore(key, &initEntry{})
-    return v.(*initEntry)
+func getInitOnceKey(workingDir string) *initEntry {
+	v, _ := initOnceByKey.LoadOrStore(workingDir, &initEntry{})
+	return v.(*initEntry)
 }
 
 func tofuCmd(ctx context.Context, workingDir string, args ...string) *exec.Cmd {
@@ -92,7 +92,18 @@ func NewExecutor(workingDir string, looger log.Logger) *Executor {
 }
 
 func (e *Executor) Init(ctx context.Context, pluginsDir string) error {
-    onceKey := getInitOnceKey(pluginsDir, e.workingDir)
+    initMutex.Lock()
+    defer initMutex.Unlock()
+
+    lockFilePath := filepath.Join(e.workingDir, ".terraform.lock.hcl")
+    _, statErr := os.Stat(lockFilePath)
+    if os.IsNotExist(statErr) {
+        e.logger.LogDebugF("tofu.Init .terraform.lock.hcl IsNotExist: path=%q\n", lockFilePath)
+        // Init runs again when lock file is missing
+        initOnceByKey.Delete(e.workingDir)
+    }
+
+    onceKey := getInitOnceKey(e.workingDir)
     e.logger.LogDebugF("tofu.Init called: workingDir=%q pluginsDir=%q\n", e.workingDir, pluginsDir)
     onceKey.once.Do(func() {
         e.logger.LogDebugF("tofu.Init executing once for key=%q\n", pluginsDir+"|"+e.workingDir)

--- a/dhctl/pkg/infrastructure/tofu/executor.go
+++ b/dhctl/pkg/infrastructure/tofu/executor.go
@@ -55,13 +55,12 @@ func tofuCmd(ctx context.Context, workingDir string, args ...string) *exec.Cmd {
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
 	}
 
-    cmd.Env = append(
-        os.Environ(),
-        "TF_IN_AUTOMATION=yes",
-        "TF_SKIP_CREATING_DEPS_LOCK_FILE=yes",
-        "TF_DATA_DIR="+filepath.Join(app.TmpDirName, "tf_dhctl"),
-        "TF_PLUGIN_CACHE_DIR="+filepath.Join(app.TmpDirName, "tf_plugin_cache"),
-    )
+	cmd.Env = append(
+		os.Environ(),
+		"TF_IN_AUTOMATION=yes",
+		"TF_SKIP_CREATING_DEPS_LOCK_FILE=yes",
+		"TF_DATA_DIR="+filepath.Join(app.TmpDirName, "tf_dhctl"),
+	)
 
 	// always use dug log for write its to debug log file
 	cmd.Env = append(cmd.Env, "TF_LOG=DEBUG")


### PR DESCRIPTION
## Description

run terraform | tofu init once

## Why do we need it, and what problem does it solve?

In some rare cases, a race occurs when calling `terraform | tofu init`
It is now guaranteed that `init` will not run in parallel

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: run terraform init once
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
