### PR TITLE
[docs][chore] Add non-indexable and non-sitemap flags to some docs

### DIFF
--- a/docs/site/pages/stronghold/documentation/CONFIGURATION.md
+++ b/docs/site/pages/stronghold/documentation/CONFIGURATION.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold configuration "
 permalink: en/stronghold/documentation/configuration.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/ABOUT.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/ABOUT.md
@@ -1,7 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/stronghold/documentation/admin/platform-management/control-plane-settings/about.html
-lang:
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/AUDITING.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/AUDITING.md
@@ -1,6 +1,8 @@
 ---
 title: "Audit"
 permalink: en/stronghold/documentation/admin/platform-management/control-plane-settings/audit.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/CONTROL_PLANE_COMPONENTS.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/CONTROL_PLANE_COMPONENTS.md
@@ -1,6 +1,8 @@
 ---
 title: "Control plane components"
 permalink: en/stronghold/documentation/admin/platform-management/control-plane-settings/control-plane-components.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/ETCD.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/ETCD.md
@@ -1,6 +1,8 @@
 ---
 title: "Etcd operations"
 permalink: en/stronghold/documentation/admin/platform-management/control-plane-settings/etcd.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/MASTERS.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/MASTERS.md
@@ -1,6 +1,8 @@
 ---
 title: "Master nodes"
 permalink: en/stronghold/documentation/admin/platform-management/control-plane-settings/masters.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/PLACEMENT_MANAGEMENT.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/PLACEMENT_MANAGEMENT.md
@@ -1,6 +1,8 @@
 ---
 title: "Components placement"
 permalink: en/stronghold/documentation/admin/platform-management/control-plane-settings/placement-management.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/SCHEDULER.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/control-plane-settings/SCHEDULER.md
@@ -1,6 +1,8 @@
 ---
 title: "Scheduler"
 permalink: en/stronghold/documentation/admin/platform-management/control-plane-settings/scheduler.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADDING_NODE.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADDING_NODE.md
@@ -1,6 +1,8 @@
 ---
 title: "Node adding and removing"
 permalink: en/stronghold/documentation/admin/platform-management/node-management/adding-node.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADVANCED.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADVANCED.md
@@ -1,6 +1,8 @@
 ---
 title: "Advanced configuration"
 permalink: en/stronghold/documentation/admin/platform-management/node-management/advanced.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/CONFIGURATION.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/CONFIGURATION.md
@@ -1,6 +1,8 @@
 ---
 title: "Node configuration"
 permalink: en/stronghold/documentation/admin/platform-management/node-management/configuration.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/CONTAINERD.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/CONTAINERD.md
@@ -1,6 +1,8 @@
 ---
 title: "Containerd configuration"
 permalink: en/stronghold/documentation/admin/platform-management/node-management/containerd.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/NODE_GROUP.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/NODE_GROUP.md
@@ -1,6 +1,8 @@
 ---
 title: "Node groups"
 permalink: en/stronghold/documentation/admin/platform-management/node-management/node-group.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/OS.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/OS.md
@@ -1,6 +1,8 @@
 ---
 title: "OS configuration"
 permalink: en/stronghold/documentation/admin/platform-management/node-management/os.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/admin/update/MANUAL-UPDATE-MODE.md
+++ b/docs/site/pages/stronghold/documentation/admin/update/MANUAL-UPDATE-MODE.md
@@ -1,6 +1,8 @@
 ---
 title: "Manual update mode"
 permalink: en/stronghold/documentation/admin/update/manual-update-mode.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/architecture/FUNCTIONAL.SPECIFICATIONS.md
+++ b/docs/site/pages/stronghold/documentation/architecture/FUNCTIONAL.SPECIFICATIONS.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: en/stronghold/documentation/architecture/functional-specifications.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/architecture/OVERALL.ARCHITECTURE.md
+++ b/docs/site/pages/stronghold/documentation/architecture/OVERALL.ARCHITECTURE.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/stronghold/documentation/architecture/overall-architecture.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/architecture/OVERALL.ARCHITECTURE_RU.md
+++ b/docs/site/pages/stronghold/documentation/architecture/OVERALL.ARCHITECTURE_RU.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: ru/stronghold/documentation/architecture/overall-architecture.html
+searchable: false
+sitemap_include: false
 lang: ru
 ---
 

--- a/docs/site/pages/stronghold/documentation/architecture/SCHEME.md
+++ b/docs/site/pages/stronghold/documentation/architecture/SCHEME.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: en/stronghold/documentation/architecture/scheme.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/architecture/SCHEME_RU.md
+++ b/docs/site/pages/stronghold/documentation/architecture/SCHEME_RU.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: ru/stronghold/documentation/architecture/scheme.html
+searchable: false
+sitemap_include: false
 lang: ru
 ---
 

--- a/docs/site/pages/stronghold/documentation/architecture/TABLE.md
+++ b/docs/site/pages/stronghold/documentation/architecture/TABLE.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: en/stronghold/documentation/architecture/table.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/architecture/TABLE_RU.md
+++ b/docs/site/pages/stronghold/documentation/architecture/TABLE_RU.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: ru/stronghold/documentation/architecture/table.html
+searchable: false
+sitemap_include: false
 lang: ru
 ---
 

--- a/docs/site/pages/stronghold/documentation/architecture/USED.PORTS.md
+++ b/docs/site/pages/stronghold/documentation/architecture/USED.PORTS.md
@@ -1,6 +1,10 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: en/stronghold/documentation/architecture/used-ports.html
+searchable: false
+sitemap_include: false
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/architecture/USED.PORTS_RU.md
+++ b/docs/site/pages/stronghold/documentation/architecture/USED.PORTS_RU.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Stronghold"
 permalink: ru/stronghold/documentation/architecture/used-ports.html
+searchable: false
+sitemap_include: false
 lang: ru
 ---
 

--- a/docs/site/pages/stronghold/documentation/user/ACCESS.md
+++ b/docs/site/pages/stronghold/documentation/user/ACCESS.md
@@ -1,6 +1,8 @@
 ---
 title: "Configuring access to the project"
 permalink: en/stronghold/documentation/user/access.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/user/OVERVIEW.md
+++ b/docs/site/pages/stronghold/documentation/user/OVERVIEW.md
@@ -1,6 +1,8 @@
 ---
 title: "Overview of the user's guide"
 permalink: en/stronghold/documentation/user/overview.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/stronghold/documentation/user/auth/mfa/multifactor.md
+++ b/docs/site/pages/stronghold/documentation/user/auth/mfa/multifactor.md
@@ -1,7 +1,8 @@
 ---
 title: "MULTIFACTOR Ldap Adapter"
 permalink: en/stronghold/documentation/user/auth/mfa/multifactor.html
-lang: en
+searchable: false
+sitemap_include: false
 ---
 
 ## Configuring LDAP Adapter

--- a/docs/site/pages/stronghold/documentation/user/auth/mfa/totp.md
+++ b/docs/site/pages/stronghold/documentation/user/auth/mfa/totp.md
@@ -1,7 +1,8 @@
 ---
 title: "TOTP"
 permalink: en/stronghold/documentation/user/auth/mfa/totp.html
-lang: en
+searchable: false
+sitemap_include: false
 ---
 
 ## Configure TOTP

--- a/docs/site/pages/virtualization-platform/documentation/architecture/FUNCTIONAL.SPECIFICATIONS.md
+++ b/docs/site/pages/virtualization-platform/documentation/architecture/FUNCTIONAL.SPECIFICATIONS.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/virtualization-platform/documentation/architecture/functional-specifications.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/virtualization-platform/documentation/architecture/OVERALL.ARCHITECTURE.md
+++ b/docs/site/pages/virtualization-platform/documentation/architecture/OVERALL.ARCHITECTURE.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/virtualization-platform/documentation/architecture/overall-architecture.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/virtualization-platform/documentation/architecture/SCHEME.md
+++ b/docs/site/pages/virtualization-platform/documentation/architecture/SCHEME.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/virtualization-platform/documentation/architecture/scheme.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/virtualization-platform/documentation/architecture/SCHEME_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/architecture/SCHEME_RU.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: ru/virtualization-platform/documentation/architecture/scheme.html
+searchable: false
+sitemap_include: false
 lang: ru
 ---
 

--- a/docs/site/pages/virtualization-platform/documentation/architecture/TABLE.md
+++ b/docs/site/pages/virtualization-platform/documentation/architecture/TABLE.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/virtualization-platform/documentation/architecture/table.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/virtualization-platform/documentation/architecture/TABLE_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/architecture/TABLE_RU.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: ru/virtualization-platform/documentation/architecture/table.html
+searchable: false
+sitemap_include: false
 lang: ru
 ---
 

--- a/docs/site/pages/virtualization-platform/documentation/architecture/USED.PORTS.md
+++ b/docs/site/pages/virtualization-platform/documentation/architecture/USED.PORTS.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/virtualization-platform/documentation/architecture/used-ports.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/virtualization-platform/documentation/dvp-editions/CHANGELOG_EN.md
+++ b/docs/site/pages/virtualization-platform/documentation/dvp-editions/CHANGELOG_EN.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: en/virtualization-platform/documentation/dvp-editions/changelog.html
+searchable: false
+sitemap_include: false
 ---
 
 Coming soon...

--- a/docs/site/pages/virtualization-platform/documentation/dvp-editions/CHANGELOG_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/dvp-editions/CHANGELOG_RU.md
@@ -1,6 +1,8 @@
 ---
 title: "Deckhouse Virtualization Platform"
 permalink: ru/virtualization-platform/documentation/dvp-editions/changelog.html
+searchable: false
+sitemap_include: false
 lang: ru
 ---
 


### PR DESCRIPTION
## Description
Added non-indexable and non-sitemap flags to some documentation pages.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add non-indexable and non-sitemap flags to some documentation pages.
impact_level: low
```
