### PR TITLE
[user-authn] Refactor DEX rate limit setup

### DIFF
--- a/modules/150-user-authn/templates/dex/ingress.yaml
+++ b/modules/150-user-authn/templates/dex/ingress.yaml
@@ -38,7 +38,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: HTTPS
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-    nginx.ingress.kubernetes.io/limit-rpm: "20"
+    nginx.ingress.kubernetes.io/limit-rpm: "1000"
     # Works only for ingress-controllers >=0.40. It is here to not forget to add the annotation after upgrading ingress controller.
     nginx.ingress.kubernetes.io/limit-burst-multiplier: "2"
     # Send alert only if dex doesn't work at all (resolves issue #204).

--- a/modules/150-user-authn/templates/dex/resource-quota.yaml
+++ b/modules/150-user-authn/templates/dex/resource-quota.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: authrequest-quota
+  namespace: d8-user-authn
+  {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
+spec:
+  hard:
+    count/authrequests.dex.coreos.com: 10000


### PR DESCRIPTION
## Description
Increase flexibility of Dex authentication requests for clients behind a single IP by adjusting Ingress rate limits and adding a global AuthRequest quota.
This prevents user requests from being blocked unnecessarily while still protecting the cluster from excessive AuthRequest objects.
- Raised per-IP request limits using a token-bucket approach in the Dex Ingress.
- Added a ResourceQuota for the total number of AuthRequest objects to protect the database.

## Why do we need it, and what problem does it solve?
Current limit of 20 AuthRequest/min per IP is insufficient for clients where many users share a single IP (e.g., corporate NAT).
Increasing the burst in rate-limiting allows multiple concurrent users without triggering 429 errors.
The ResourceQuota ensures that the total number of AuthRequest objects stays within safe limits, preventing database overload.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: feature
summary: Increase Dex AuthRequest flexibility with token-bucket rate-limiting and global ResourceQuota
impact_level: default
```
