### PR TITLE
[getting started][dvp] Remove rootDiskSize from masterNodeGroup in examples

### DIFF
--- a/docs/site/_includes/getting_started/dvp-provider/partials/config.ru.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/dvp-provider/partials/config.ru.yml.standard.ce.inc
@@ -108,7 +108,6 @@ layout: Standard
 masterNodeGroup:
   replicas: 1
   instanceClass:
-    rootDiskSize: 40
     # [<en>] Virtual machine settings for the created master node.
     # [<ru>] Настройки виртуальной машины для созданного master-узла.
     virtualMachine:

--- a/docs/site/_includes/getting_started/dvp-provider/partials/config.ru.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/dvp-provider/partials/config.ru.yml.standard.other.inc
@@ -110,7 +110,6 @@ layout: Standard
 masterNodeGroup:
   replicas: 1
   instanceClass:
-    rootDiskSize: 40
     # [<en>] Virtual machine settings for the created master node.
     # [<ru>] Настройки виртуальной машины для созданного master-узла.
     virtualMachine:

--- a/docs/site/_includes/getting_started/dvp-provider/partials/config.yml.standard.ce.inc
+++ b/docs/site/_includes/getting_started/dvp-provider/partials/config.yml.standard.ce.inc
@@ -108,7 +108,6 @@ layout: Standard
 masterNodeGroup:
   replicas: 1
   instanceClass:
-    rootDiskSize: 40
     # [<en>] Virtual machine settings for the created master node.
     # [<ru>] Настройки виртуальной машины для созданного master-узла.
     virtualMachine:

--- a/docs/site/_includes/getting_started/dvp-provider/partials/config.yml.standard.other.inc
+++ b/docs/site/_includes/getting_started/dvp-provider/partials/config.yml.standard.other.inc
@@ -110,7 +110,6 @@ layout: Standard
 masterNodeGroup:
   replicas: 1
   instanceClass:
-    rootDiskSize: 40
     # [<en>] Virtual machine settings for the created master node.
     # [<ru>] Настройки виртуальной машины для созданного master-узла.
     virtualMachine:


### PR DESCRIPTION
## Description
Removed rootDiskSize from masterNodeGroup in examples in the DVP getting started.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Removed rootDiskSize from masterNodeGroup in examples in the DVP getting started.
impact_level: low
```
