### PR TITLE
[dashboard] add check for user-authn in enabled script

### DIFF
--- a/modules/500-dashboard/enabled
+++ b/modules/500-dashboard/enabled
@@ -19,12 +19,14 @@ source /deckhouse/shell_lib.sh
 function __main__() {
   enabled::disable_module_if_cluster_is_not_bootstraped
 
+  # Check if publicDomainTemplate is set
   if ! values::has global.modules.publicDomainTemplate ; then
     echo "false" > "$MODULE_ENABLED_RESULT"
     echo "spec.settings.modules.publicDomainTemplate is not set in the global configuration, configure it in ModuleConfig/global." > "$MODULE_ENABLED_REASON"
     return
   fi
 
+  # Check HTTPS mode
   https_mode=$(values::get_first_defined dashboard.https.mode global.modules.https.mode)
   if [ "$https_mode" = "Disabled" ]; then
     echo "false" > "$MODULE_ENABLED_RESULT"
@@ -32,13 +34,21 @@ function __main__() {
     return
   fi
 
-  if values::has dashboard.auth.externalAuthentication.authSignInURL && \
-     values::has dashboard.auth.externalAuthentication.authURL ; then
-    echo "true" > "$MODULE_ENABLED_RESULT"
-  else
-    echo "false" > "$MODULE_ENABLED_RESULT"
-    echo "required values settings.auth.externalAuthentication.authSignInURL and settings auth.externalAuthentication.authURL - set it in ModuleConfig/dashboard. " > "$MODULE_ENABLED_REASON"
+  # If user-authn is enabled
+  if values::array_has global.enabledModules "user-authn"; then
+    echo "true" > $MODULE_ENABLED_RESULT
+    return
   fi
+
+  # If user-authn is not enabled, check for external authentication URLs
+  if values::has dashboard.auth.externalAuthentication.authSignInURL && \
+      values::has dashboard.auth.externalAuthentication.authURL ; then
+    echo "true" > $MODULE_ENABLED_RESULT
+    return
+  fi
+
+  echo "false" > "$MODULE_ENABLED_RESULT"
+  echo "required values settings.auth.externalAuthentication.authSignInURL and settings auth.externalAuthentication.authURL - set it in ModuleConfig/dashboard. " > "$MODULE_ENABLED_REASON"
 }
 
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Return add check for user-authn in enabled script
Add commentaries

If user-authn is enabled
```
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  name: dashboard
status:
  conditions:
  - lastProbeTime: "2025-09-10T09:26:13Z"
    lastTransitionTime: "2025-09-10T09:26:13Z"
    status: "True"
    type: EnabledByModuleManager
  - lastProbeTime: "2025-09-10T09:26:13Z"
    lastTransitionTime: "2025-09-10T09:21:41Z"
    message: reconciling
    reason: Reconciling
    status: "False"
    type: IsReady
```


If user-authn is disabled
```
apiVersion: deckhouse.io/v1alpha1
kind: Module
metadata:
  name: dashboard
status:
  conditions:
  - lastProbeTime: "2025-09-10T09:24:29Z"
    lastTransitionTime: "2025-09-10T09:24:29Z"
    message: 'turned off by enabled script: required values settings.auth.externalAuthentication.authSignInURL
      and settings auth.externalAuthentication.authURL - set it in ModuleConfig/dashboard.'
    reason: EnabledScriptExtender
    status: "False"
    type: EnabledByModuleManager
  - lastProbeTime: "2025-09-10T09:24:29Z"
    lastTransitionTime: "2025-09-10T09:21:41Z"
    message: 'turned off by enabled script: required values settings.auth.externalAuthentication.authSignInURL
      and settings auth.externalAuthentication.authURL - set it in ModuleConfig/dashboard.'
    reason: EnabledScriptExtender
    status: "False"
    type: IsReady
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: add check for user-authn in enabled script
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
