### PR TITLE
[docs] Add local-path-provisioner module to sidebar

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -1626,11 +1626,39 @@ entries:
       - title:
           en: Storage configuration
           ru: Настройка хранилищ
-        url: /storage/admin/supported-storage.html  
+        url: /storage/admin/supported-storage.html
       - title:
           en: SDS
           ru: Программно-определяемые хранилища
         folders:
+          - title:
+              en: Local path provisioner storage
+              ru: Локальное хранилище Local Path Provisioner
+            folders:
+            - title:
+                en: Overview
+                ru: Обзор
+              url: /modules/local-path-provisioner/
+            - title:
+                en: Examples
+                ru: Примеры
+              url: /modules/local-path-provisioner/examples.html
+            - title:
+                en: Reference
+                ru: Справка
+              folders:
+                - title:
+                    en: Configuration
+                    ru: Настройки
+                  url: /modules/local-path-provisioner/configuration.html
+                - title:
+                    en: Custom Resources
+                    ru: Custom Resources
+                  url: /modules/local-path-provisioner/cr.html
+            - title:
+                en: FAQ
+                ru: FAQ
+              url: /modules/local-path-provisioner/faq.html
           - title:
               en: Local storage based on LVM
               ru: Локальное хранилище на основе LVM
@@ -1650,7 +1678,7 @@ entries:
           - title:
               en: vSphere data storage
               ru: Хранилище данных vSphere
-            url: /storage/admin/external/vsphere.html  
+            url: /storage/admin/external/vsphere.html
           - title:
               en: HPE data storage
               ru: Хранилище данных HPE
@@ -1674,7 +1702,7 @@ entries:
           - title:
               en: TATLIN.UNIFIED (Yadro) unified storage
               ru: Унифицированное хранилище TATLIN.UNIFIED (Yadro)
-            url: /storage/admin/external/yadro.html     
+            url: /storage/admin/external/yadro.html
       - title:
          en: Module settings
          ru: Настройки модулей
@@ -1690,7 +1718,7 @@ entries:
           - title:
               en: csi-vsphere
               ru: csi-vsphere
-            url: /reference/mc/csi-vsphere/  
+            url: /reference/mc/csi-vsphere/
           - title:
               en: csi-huawei
               ru: csi-huawei


### PR DESCRIPTION
## Description
Added the Local path provisioner storage section to the documentation sidebar, including Overview, Examples, Reference, and FAQ entries.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Added the Local path provisioner storage section to the documentation sidebar, including Overview, Examples, Reference, and FAQ entries.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
