### PR TITLE
[cni-flannel] enable readOnlyRootFilesystem

### DIFF
--- a/modules/035-cni-flannel/images/flanneld/mount-points.yaml
+++ b/modules/035-cni-flannel/images/flanneld/mount-points.yaml
@@ -1,0 +1,6 @@
+dirs:
+- /etc/kube-flannel/
+- /etc/cni/net.d
+- /run/flannel
+files:
+- /run/xtables.lock

--- a/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/flanneld/werf.inc.yaml
@@ -1,27 +1,4 @@
-{{- $iptables_version := "1.8.9" }}
-{{- $iptables_image_version := $iptables_version | replace "." "-" }}
 {{- $flannel_version := "0.26.2" }}
----
-image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
-final: false
-shell:
-  install:
-  - mkdir -p /relocate/sbin
-  - |
-    for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
-      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
-    done
-    # broken symlinks are not imported from the artifact
-    touch /sbin/iptables-wrapper
-  - |
-    for mode in legacy nft; do
-      for basecmd in iptables ip6tables; do
-        for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
-          ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
-        done
-      done
-    done
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-entrypoint-artifact
 fromImage: builder/golang-alpine
@@ -92,21 +69,6 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-- image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
-  add: /relocate
-  to: /
-  before: setup
-- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
-  add: /
-  to: /sbin
-  includePaths:
-  - xtables-legacy-multi
-  - xtables-nft-multi
-  before: setup
-- image: common/iptables-wrapper
-  add: /iptables-wrapper
-  to: /sbin/iptables-wrapper
-  before: setup
 - image: {{ .ModuleName }}/{{ .ImageName }}-artifact
   add: /src/dist/flanneld
   to: /opt/bin/flanneld
@@ -115,6 +77,8 @@ import:
   add: /entrypoint
   to: /entrypoint
   before: setup
+git:
+{{- include "image mount points" $ }}
 imageSpec:
   config:
     entrypoint: ["/entrypoint"]

--- a/modules/035-cni-flannel/images/iptables-wrapper-init/mount-points.yaml
+++ b/modules/035-cni-flannel/images/iptables-wrapper-init/mount-points.yaml
@@ -1,0 +1,2 @@
+files:
+- /run/xtables.lock

--- a/modules/035-cni-flannel/images/iptables-wrapper-init/werf.inc.yaml
+++ b/modules/035-cni-flannel/images/iptables-wrapper-init/werf.inc.yaml
@@ -1,0 +1,56 @@
+{{- $iptables_version := "1.8.9" }}
+{{- $iptables_image_version := $iptables_version | replace "." "-" }}
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+import:
+- image: tools/coreutils
+  add: /
+  to: /
+  before: setup
+  includePaths:
+  - usr/bin/coreutils
+  - usr/bin/rm
+  - usr/bin/cp
+- image: tools/bash
+  add: /usr/bin/bash
+  to: /bin/bash
+  before: setup
+- image: common/iptables-wrapper
+  add: /iptables-wrapper
+  to: /iptables-wrapper
+  before: setup
+- image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
+  add: /
+  to: /_sbin
+  includePaths:
+  - xtables-legacy-multi
+  - xtables-nft-multi
+  before: setup
+- image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+  add: /relocate
+  to: /relocate
+  before: setup
+git:
+{{- include "image mount points" $ }}
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-relocate-artifact
+final: false
+fromImage: common/relocate-artifact
+shell:
+  install:
+  - mkdir -p /relocate/sbin
+  - |
+    for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+      ln -f -s /sbin/iptables-wrapper "/relocate/sbin/${cmd}"
+    done
+    # broken symlinks are not imported from the artifact
+    touch /iptables-wrapper
+  - |
+    for mode in legacy nft; do
+      for basecmd in iptables ip6tables; do
+        for cmd in ${basecmd}-${mode} ${basecmd}-${mode}-save ${basecmd}-${mode}-restore; do
+          ln -sf /sbin/xtables-${mode}-multi "/relocate/sbin/${cmd}"
+        done
+      done
+    done

--- a/modules/035-cni-flannel/templates/daemonset.yaml
+++ b/modules/035-cni-flannel/templates/daemonset.yaml
@@ -2,6 +2,10 @@
 cpu: 25m
 memory: 50Mi
 {{- end }}
+{{- define "iptables_wrapper_init_resources" }}
+cpu: 10m
+memory: 10Mi
+{{- end }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -61,8 +65,27 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ .Chart.Name }}
       initContainers:
+      - name: iptables-wrapper-init
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
+        image: {{ include "helm_lib_module_image" (list . "iptablesWrapperInit") }}
+        command:
+        - /bin/bash
+        - -c
+        - "/usr/bin/cp /iptables-wrapper /sbin/ -rv && /usr/bin/cp /_sbin/* /sbin/ -rv && /usr/bin/cp /relocate/sbin/* /sbin/ -rv && /sbin/iptables --version && /usr/bin/rm /sbin/iptables-wrapper -v"
+        volumeMounts:
+        - mountPath: /sbin
+          name: sbin
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
+        {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+            {{- include "iptables_wrapper_init_resources" . | nindent 12 }}
+        {{- end }}
       {{- if eq .Values.cniFlannel.internal.podNetworkMode "vxlan" }}
       - name: handle-vxlan-offload
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "NET_ADMIN")) | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "vxlanOffloadingFixer") }}
         imagePullPolicy: IfNotPresent
         env:
@@ -74,18 +97,11 @@ spec:
         resources:
           requests:
           {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-            drop:
-            - ALL
-          privileged: false
         terminationMessagePolicy: FallbackToLogsOnError
       {{- end }}
       containers:
       - name: kube-flannel
-        {{- include "helm_lib_module_container_security_context_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list . (list "NET_ADMIN" "NET_RAW")) | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "flanneld") }}
         args:
         - --ip-masq
@@ -105,13 +121,18 @@ spec:
               fieldPath: metadata.namespace
         volumeMounts:
         - name: run
-          mountPath: /run
+          mountPath: /run/flannel
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
         - name: cni
           mountPath: /etc/cni/net.d
         - name: tmp
           mountPath: /tmp
+        - mountPath: /sbin
+          name: sbin
+          readOnly: true
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
@@ -121,7 +142,11 @@ spec:
       volumes:
         - name: run
           hostPath:
-            path: /run
+            path: /run/flannel
+        - name: xtables-lock
+          hostPath:
+            path: /run/xtables.lock
+            type: FileOrCreate
         - name: cni
           hostPath:
             path: /etc/cni/net.d
@@ -130,3 +155,7 @@ spec:
             name: flannel
         - name: tmp
           emptyDir: {}
+        - name: sbin
+          emptyDir:
+            medium: Memory
+            sizeLimit: 4Mi

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -145,7 +145,8 @@ var DefaultImagesDigests = map[string]interface{}{
 		"safeAgentUpdater":    "imageHash-cniCilium-safeAgentUpdater",
 	},
 	"cniFlannel": map[string]interface{}{
-		"flanneld": "imageHash-cniFlannel-flanneld",
+		"flanneld":            "imageHash-cniFlannel-flanneld",
+		"iptablesWrapperInit": "imageHash-cniFlannel-iptablesWrapperInit",
 	},
 	"cniSimpleBridge": map[string]interface{}{
 		"simpleBridge": "imageHash-cniSimpleBridge-simpleBridge",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

All containers of the cni-flannel module have the readOnlyRootFilesystem setting set to true.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need it to meet security concerns and for overall hardening of the DKP platform.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-flannel
type: chore
summary: The readOnlyRootFilesystem security option is set to true for all containers.
impact: Pods of the cni-flannel module will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
