### PR TITLE
[deckhouse] Remove editions enum from config-values

### DIFF
--- a/modules/002-deckhouse/openapi/config-values.yaml
+++ b/modules/002-deckhouse/openapi/config-values.yaml
@@ -291,7 +291,6 @@ properties:
     properties:
       edition:
         type: string
-        enum: ["CE", "BE", "EE", "SE", "SE-plus"]
         x-examples: ["CE"]
         description: |
           Edition of the Deckhouse Kubernetes Platform:

--- a/modules/002-deckhouse/openapi/doc-ru-config-values.yaml
+++ b/modules/002-deckhouse/openapi/doc-ru-config-values.yaml
@@ -182,7 +182,6 @@ properties:
     properties:
       edition:
         type: string
-        enum: ["CE", "BE", "EE", "SE", "SE-plus"]
         x-examples: ["CE"]
         description: |
           Редакция Deckhouse Kubernetes Platform.


### PR DESCRIPTION
## Description

Remove editions enum from config-values.

## Why do we need it, and what problem does it solve?

We should not validate the revision via openapi spec.
- This is necessary so that we can create a new revision at any time and place it even in old releases.
- We will validate it later via the license token, the available editions will be indicated there and we will compare them.

### Usage example

Add incorrect license edition "DD" to deckhouse ModuleConfig

Main branch:
```bash
>> k edit mc deckhouse
spec.settings are not valid (version 1):  1 error occurred: * deckhouse.license.edition should be one of [CE BE EE SE SE-plus]
```

This PR:
```bash
>> k edit mc deckhouse
moduleconfig.deckhouse.io/deckhouse edited
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Remove editions enum from config-values
impact_level: low
```
