### PR TITLE
[deckhouse] Deckhouse release information status

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/deckhouse_release.go
@@ -42,6 +42,7 @@ const (
 	DeckhouseReleaseAnnotationNotificationTimeShift = "release.deckhouse.io/notification-time-shift"
 	DeckhouseReleaseAnnotationCurrentRestored       = "release.deckhouse.io/current-restored"
 	DeckhouseReleaseAnnotationChangeCause           = "release.deckhouse.io/change-cause"
+	DeckhouseReleaseAnnotationUpdateInfo            = "release.deckhouse.io/update-info"
 
 	DeckhouseReleaseAnnotationDryrun            = "dryrun"
 	DeckhouseReleaseAnnotationTriggeredByDryrun = "triggered_by_dryrun"


### PR DESCRIPTION
## Description

Create a detailed structure to collect data.

- Task calculation (all data from the task)
- Readiness for cutting (ready)
- Requirements to satisfy
- Time calculation

## Why do we need it, and what problem does it solve?

Collecting deckhouse release processing data can give useful information about release status.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Collect deckhouse release information status
impact_level: default
```
