### PR TITLE
fix: Fixed set_annotation_validation_suspended.go hook

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5358,6 +5358,11 @@ alerts:
         Validation is disabled to reduce load on the master nodes, as it requires additional resources.
         To re-enable validation, remove the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`
         from the `ingressnginxcontroller` resource.
+
+        To find which `ingressnginxcontroller` resources have the annotation, use the following command:
+        ```shell
+          d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
+        ```
       summary: |
         Warning: Ingress resource validation in the NGINX Ingress Controller is currently disabled.
       severity: "3"

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5359,9 +5359,9 @@ alerts:
         To re-enable validation, remove the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`
         from the `ingressnginxcontroller` resource.
 
-        To find which `ingressnginxcontroller` resources have the annotation, use the following command:
+        To find which `IngressNginxController` resources have the annotation, use the following command:
         ```shell
-          d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
+        d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
         ```
       summary: |
         Warning: Ingress resource validation in the NGINX Ingress Controller is currently disabled.

--- a/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
+++ b/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
@@ -95,7 +95,7 @@ func setAnnotationValidationSuspendedHandleIngressNginxControllers(_ context.Con
 	}
 
 	// If at least one controller has annotation → set metric
-	if controllersHasAnnotationValidationSuspended(controllersSnapshot) {
+	if anyControllerHasAnnotationValidationSuspended(controllersSnapshot) {
 		input.MetricsCollector.Set(validationSuspendMetricName, 1.0, nil)
 	}
 
@@ -120,7 +120,7 @@ func setValidationSuspendedAnnotationToAll(controllers []pkg.Snapshot, input *go
 	}
 }
 
-func controllersHasAnnotationValidationSuspended(controllers []pkg.Snapshot) bool {
+func anyControllerHasAnnotationValidationSuspended(controllers []pkg.Snapshot) bool {
 	for _, item := range controllers {
 		var ctrl internal.IngressNginxController
 		if err := item.UnmarshalTo(&ctrl); err == nil {

--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -248,9 +248,9 @@
         To re-enable validation, remove the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`
         from the `ingressnginxcontroller` resource.
 
-        To find which `ingressnginxcontroller` resources have the annotation, use the following command:
+        To find which `IngressNginxController` resources have the annotation, use the following command:
         ```shell
-          d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
+        d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
         ```
 
   - alert: NginxIngressProfilingIsEnabled

--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -248,6 +248,11 @@
         To re-enable validation, remove the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`
         from the `ingressnginxcontroller` resource.
 
+        To find which `ingressnginxcontroller` resources have the annotation, use the following command:
+        ```shell
+          d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
+        ```
+
   - alert: NginxIngressProfilingIsEnabled
     expr: |
       d8_ingress_nginx_controller_profiling_enabled == 1


### PR DESCRIPTION
## Description
This patch updates the `set_annotation_validation_suspended.go hook`. Previously, the hook only set the `ingress_nginx_validation_suspended` metric but did not remove it when it was no longer needed. This change adds logic to remove the `ingress_nginx_validation_suspended` metric if there are no `ingressNginxControllers` resources in the cluster with the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`.

## Why do we need it, and what problem does it solve?
Without this fix, the `ingress_nginx_validation_suspended` metric can remain set even when all controllers have removed the suspension annotation. This leads to inaccurate monitoring data and potential confusion in alerts or dashboards that rely on this metric.

## Why do we need it in the patch release (if we do)?
Without this fix, the `NginxIngressValidationIsDisabled` alert remains active at all times, regardless of whether there are actually any resources in the cluster with validation disabled.

## How to test?
1. Create 5 `ingressNginxControllers`.
2. Wait a bit and verify the following:
- In all `ingressNginxControllers`, the field `metadata.annotations.network.deckhouse.io/ingress-nginx-validation-suspended` is set to "";
- In all `ingressNginxControllers`, the field `spec.validationEnabled` is set to false;
- In the `d8-ingress-nginx` namespace, a `ConfigMap` named `ingress-nginx-validation-suspended` appears;
- An alert `NginxIngressValidationIsDisabled` is generated.
4. Remove the annotation from all `ingressNginxControllers` resources.
5. Wait a bit and confirm that the alert `NginxIngressValidationIsDisabled` disappears.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: fix set_annotation_validation_suspended.go hook to set correct metric
impact_level: low
```