### PR TITLE
[ingress-controller] Fixing the build and template tests of ingress controllers versions 1.10 and 1.9.

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/010-nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/010-nginx-build.patch
@@ -1,31 +1,25 @@
-Subject: [PATCH] close env build
----
-Index: images/nginx-1.25/rootfs/build.sh
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
 diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.sh
---- a/images/nginx-1.25/rootfs/build.sh	(revision f08a1c4fdac2e0ef6053333b24191c50cc51f30c)
-+++ b/images/nginx-1.25/rootfs/build.sh	(date 1728300078299)
+index f60a260f9..138ebbb84 100755
+--- a/images/nginx-1.25/rootfs/build.sh
++++ b/images/nginx-1.25/rootfs/build.sh
 @@ -14,6 +14,9 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
-
+ 
 +SOURCE_REPO="${SOURCE_REPO}"
 +CONTROLLER_BRANCH="${CONTROLLER_BRANCH}"
 +
  set -o errexit
  set -o nounset
  set -o pipefail
-@@ -110,79 +113,10 @@
+@@ -110,79 +113,10 @@ export OPENTELEMETRY_CPP_VERSION="v1.11.0"
  export OPENTELEMETRY_PROTO_VERSION="v1.1.0"
-
+ 
  export BUILD_PATH=/tmp/build
 +export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/
-
+ 
  ARCH=$(uname -m)
-
+ 
 -get_src()
 -{
 -  hash="$1"
@@ -97,12 +91,12 @@ diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.
 -  protobuf-dev
 -
  # apk add -X http://dl-cdn.alpinelinux.org/alpine/edge/testing opentelemetry-cpp-dev
-
+ 
  # There is some bug with some platforms and git, so force HTTP/1.1
-@@ -194,93 +128,7 @@
+@@ -194,93 +128,7 @@ mkdir -p /etc/nginx
  mkdir --verbose -p "$BUILD_PATH"
  cd "$BUILD_PATH"
-
+ 
 -# download, verify and extract the source files
 -get_src 66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae \
 -        "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
@@ -191,10 +185,10 @@ diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.
 -get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
 -        "https://github.com/microsoft/mimalloc/archive/${MIMALOC_VERSION}.tar.gz" "mimalloc"
 +git clone -b "controller-v1.10.3" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
-
+ 
  # improve compilation times
  CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
-@@ -304,7 +152,7 @@
+@@ -304,7 +152,7 @@ cd "$BUILD_PATH/opentelemetry-cpp"
  export CXXFLAGS="-DBENCHMARK_HAS_NO_INLINE_ASSEMBLY"
  cmake -B build -G Ninja -Wno-dev \
          -DOTELCPP_PROTO_PATH="${BUILD_PATH}/opentelemetry-proto/" \
@@ -203,8 +197,8 @@ diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.
          -DBUILD_SHARED_LIBS=ON \
          -DBUILD_TESTING="OFF" \
          -DBUILD_W3CTRACECONTEXT_TEST="OFF" \
-@@ -327,15 +175,16 @@
-
+@@ -327,15 +175,16 @@ git config --global --add core.compression -1
+ 
  # Get Brotli source and deps
  cd "$BUILD_PATH"
 -git clone --depth=100 https://github.com/google/ngx_brotli.git
@@ -215,15 +209,15 @@ diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.
  git submodule init
 +git submodule set-url deps/brotli "${SOURCE_REPO}/google/brotli.git"
  git submodule update
-
+ 
  cd "$BUILD_PATH"
 -git clone --depth=1 https://github.com/ssdeep-project/ssdeep
 +git clone --depth=1 "${SOURCE_REPO}/ssdeep-project/ssdeep"
  cd ssdeep/
-
+ 
  ./bootstrap
-@@ -346,10 +195,13 @@
-
+@@ -346,10 +195,13 @@ make install
+ 
  # build modsecurity library
  cd "$BUILD_PATH"
 -git clone -n https://github.com/SpiderLabs/ModSecurity
@@ -235,29 +229,40 @@ diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.
 +git submodule set-url others/libinjection "${SOURCE_REPO}/libinjection/libinjection.git"
 +git submodule set-url bindings/python "${SOURCE_REPO}/SpiderLabs/ModSecurity-Python-bindings.git"
  git submodule update
-
+ 
  sh build.sh
-@@ -379,7 +231,7 @@
+@@ -379,7 +231,7 @@ echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecuri
  # Download owasp modsecurity crs
  cd /etc/nginx/
-
+ 
 -git clone -b $OWASP_MODSECURITY_CRS_VERSION https://github.com/coreruleset/coreruleset
 +git clone -b $OWASP_MODSECURITY_CRS_VERSION "${SOURCE_REPO}/coreruleset/coreruleset"
  mv coreruleset owasp-modsecurity-crs
  cd owasp-modsecurity-crs
-
-@@ -521,7 +373,7 @@
+ 
+@@ -510,8 +362,8 @@ WITH_MODULES=" \
+   --without-http_scgi_module \
+   --with-cc-opt="${CC_OPT}" \
+   --with-ld-opt="${LD_OPT}" \
+-  --user=www-data \
+-  --group=www-data \
++  --user=deckhouse \
++  --group=deckhouse \
+   ${WITH_MODULES}
+ 
+ make
+@@ -521,7 +373,7 @@ make install
  export OPENTELEMETRY_CONTRIB_COMMIT=aaa51e2297bcb34297f3c7aa44fa790497d2f7f3
  cd "$BUILD_PATH"
-
+ 
 -git clone https://github.com/open-telemetry/opentelemetry-cpp-contrib.git opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}
 +git clone "${SOURCE_REPO}/open-telemetry/opentelemetry-cpp-contrib.git" opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}
-
+ 
  cd ${BUILD_PATH}/opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}
  git reset --hard ${OPENTELEMETRY_CONTRIB_COMMIT}
-@@ -530,7 +382,15 @@
+@@ -530,7 +382,15 @@ export OTEL_TEMP_INSTALL=/tmp/otel
  mkdir -p ${OTEL_TEMP_INSTALL}
-
+ 
  cd ${BUILD_PATH}/opentelemetry-cpp-contrib-${OPENTELEMETRY_CONTRIB_COMMIT}/instrumentation/nginx
 +# remove downloading nginx from cmake and clone it manually
 +# by default cmake download nginx from internet
@@ -271,12 +276,17 @@ diff --git a/images/nginx-1.25/rootfs/build.sh b/images/nginx-1.25/rootfs/build.
  cd build
  cmake -DCMAKE_BUILD_TYPE=Release \
          -G Ninja \
-@@ -614,7 +474,7 @@
+@@ -614,11 +474,11 @@ writeDirs=( \
    /var/log/nginx \
  );
-
+ 
 -adduser -S -D -H -u 101 -h /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
 +adduser -r -U -u 64535 -d /usr/local/nginx -s /sbin/nologin -c deckhouse deckhouse
-
+ 
  for dir in "${writeDirs[@]}"; do
    mkdir -p ${dir};
+-  chown -R www-data.www-data ${dir};
++  chown -R deckhouse.deckhouse ${dir};
+ done
+ 
+ rm -rf /etc/nginx/owasp-modsecurity-crs/.git

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -5,7 +5,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact
-cacheVersion: "2025-08-26"
+cacheVersion: "2025-09-16"
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/011-nginx-build.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/011-nginx-build.patch
@@ -1,11 +1,11 @@
 diff --git a/images/nginx/rootfs/build.sh b/images/nginx/rootfs/build.sh
-index 8bf372f21..fad97e00e 100755
+index 8bf372f21..921c90728 100755
 --- a/images/nginx/rootfs/build.sh
 +++ b/images/nginx/rootfs/build.sh
 @@ -14,6 +14,9 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
-
+ 
 +SOURCE_REPO="${SOURCE_REPO}"
 +CONTROLLER_BRANCH="${CONTROLLER_BRANCH}"
 +
@@ -14,16 +14,16 @@ index 8bf372f21..fad97e00e 100755
  set -o pipefail
 @@ -126,6 +129,7 @@ export LUA_RESTY_GLOBAL_THROTTLE_VERSION=0.2.0
  export MIMALOC_VERSION=1.7.6
-
+ 
  export BUILD_PATH=/tmp/build
 +export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64/
-
+ 
  ARCH=$(uname -m)
-
+ 
 @@ -150,170 +154,12 @@ get_src()
    rm -rf "$f"
  }
-
+ 
 -# install required packages to build
 -apk add \
 -  bash \
@@ -64,10 +64,10 @@ index 8bf372f21..fad97e00e 100755
 -  coreutils
 -
  mkdir -p /etc/nginx
-
+ 
  mkdir --verbose -p "$BUILD_PATH"
  cd "$BUILD_PATH"
-
+ 
 -# download, verify and extract the source files
 -get_src 66dc7081488811e9f925719e34d1b4504c2801c81dee2920e5452a86b11405ae \
 -        "https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz"
@@ -189,11 +189,11 @@ index 8bf372f21..fad97e00e 100755
 -get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
 -        "https://github.com/microsoft/mimalloc/archive/refs/tags/v${MIMALOC_VERSION}.tar.gz"
 +git clone -b "$CONTROLLER_BRANCH" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
-
+ 
  # improve compilation times
  CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))
 @@ -465,15 +311,16 @@ make install
-
+ 
  # Get Brotli source and deps
  cd "$BUILD_PATH"
 -git clone --depth=100 https://github.com/google/ngx_brotli.git
@@ -204,15 +204,15 @@ index 8bf372f21..fad97e00e 100755
  git submodule init
 +git submodule set-url deps/brotli "${SOURCE_REPO}/google/brotli.git"
  git submodule update
-
+ 
  cd "$BUILD_PATH"
 -git clone --depth=1 https://github.com/ssdeep-project/ssdeep
 +git clone --depth=1 "${SOURCE_REPO}/ssdeep-project/ssdeep"
  cd ssdeep/
-
+ 
  ./bootstrap
 @@ -484,10 +331,13 @@ make install
-
+ 
  # build modsecurity library
  cd "$BUILD_PATH"
 -git clone -n https://github.com/SpiderLabs/ModSecurity
@@ -224,17 +224,17 @@ index 8bf372f21..fad97e00e 100755
 +git submodule set-url others/libinjection "${SOURCE_REPO}/libinjection/libinjection.git"
 +git submodule set-url bindings/python "${SOURCE_REPO}/SpiderLabs/ModSecurity-Python-bindings.git"
  git submodule update
-
+ 
  sh build.sh
 @@ -517,7 +367,7 @@ echo "SecAuditLogStorageDir /var/log/audit/" >> /etc/nginx/modsecurity/modsecuri
  # Download owasp modsecurity crs
  cd /etc/nginx/
-
+ 
 -git clone -b $OWASP_MODSECURITY_CRS_VERSION https://github.com/coreruleset/coreruleset
 +git clone -b $OWASP_MODSECURITY_CRS_VERSION "${SOURCE_REPO}/coreruleset/coreruleset"
  mv coreruleset owasp-modsecurity-crs
  cd owasp-modsecurity-crs
-
+ 
 @@ -582,6 +432,7 @@ WITH_FLAGS="--with-debug \
    --with-http_realip_module \
    --with-http_auth_request_module \
@@ -243,12 +243,28 @@ index 8bf372f21..fad97e00e 100755
    --with-http_gzip_static_module \
    --with-http_sub_module \
    --with-http_v2_module \
-@@ -729,7 +580,7 @@ writeDirs=( \
+@@ -652,8 +503,8 @@ WITH_MODULES=" \
+   --without-http_scgi_module \
+   --with-cc-opt="${CC_OPT}" \
+   --with-ld-opt="${LD_OPT}" \
+-  --user=www-data \
+-  --group=www-data \
++  --user=deckhouse \
++  --group=deckhouse \
+   ${WITH_MODULES}
+ 
+ make
+@@ -729,11 +580,11 @@ writeDirs=( \
    /var/log/nginx \
  );
-
+ 
 -adduser -S -D -H -u 101 -h /usr/local/nginx -s /sbin/nologin -G www-data -g www-data www-data
 +adduser -r -U -u 64535 -d /usr/local/nginx -s /sbin/nologin -c deckhouse deckhouse
-
+ 
  for dir in "${writeDirs[@]}"; do
    mkdir -p ${dir};
+-  chown -R www-data.www-data ${dir};
++  chown -R deckhouse.deckhouse ${dir};
+ done
+ 
+ rm -rf /etc/nginx/owasp-modsecurity-crs/.git

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -5,6 +5,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact
+cacheVersion: "2025-09-16"
 final: false
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches

--- a/modules/402-ingress-nginx/template_tests/controller_test.go
+++ b/modules/402-ingress-nginx/template_tests/controller_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	"sigs.k8s.io/yaml"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
@@ -44,6 +45,8 @@ func init() {
 	if env := os.Getenv("GOLDEN"); env != "" {
 		golden, _ = strconv.ParseBool(env)
 	}
+	format.TruncatedDiff = false
+	format.MaxLength = 0
 }
 
 func Test(t *testing.T) {

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/controller.yaml
@@ -131,6 +131,10 @@ spec:
             cpu: 350m
             ephemeral-storage: 150Mi
             memory: 500Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/controller.yaml
@@ -140,6 +140,10 @@ spec:
         resources:
           requests:
             ephemeral-storage: 150Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path
@@ -394,6 +398,10 @@ spec:
         resources:
           requests:
             ephemeral-storage: 150Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 100m
             ephemeral-storage: 150Mi
             memory: 200Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 100m
             ephemeral-storage: 150Mi
             memory: 200Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 100m
             ephemeral-storage: 150Mi
             memory: 200Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 100m
             ephemeral-storage: 150Mi
             memory: 200Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 100m
             ephemeral-storage: 150Mi
             memory: 200Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 350m
             ephemeral-storage: 150Mi
             memory: 500Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
@@ -125,6 +125,10 @@ spec:
             cpu: 350m
             ephemeral-storage: 150Mi
             memory: 500Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 350m
             ephemeral-storage: 150Mi
             memory: 500Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/controller.yaml
@@ -126,6 +126,10 @@ spec:
             cpu: 100m
             ephemeral-storage: 150Mi
             memory: 200Mi
+        securityContext:
+          runAsGroup: 64535
+          runAsNonRoot: true
+          runAsUser: 64535
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx/body
           name: client-body-temp-path


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixed patches customizing the script build.sh to build nginx images for the ingress controller.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The build is broken due to incomplete modification of the nginx image build script.

The problem is caused by [PR](https://github.com/deckhouse/deckhouse/pull/14245).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  ingress-nginx
type: fix
summary: Fixed nginx image build for ingress controller and template tests.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
