### PR TITLE
[istio] Fix regex pattern of the CRDs

### DIFF
--- a/ee/modules/110-istio/crds/istiofederation.yaml
+++ b/ee/modules/110-istio/crds/istiofederation.yaml
@@ -58,7 +58,7 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^(https|file)://[0-9a-zA-Z._/-]+$'
+                  pattern: '^https://[0-9a-zA-Z._/-]+$'
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object

--- a/ee/modules/110-istio/crds/istiomulticluster.yaml
+++ b/ee/modules/110-istio/crds/istiomulticluster.yaml
@@ -56,7 +56,7 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^(https|file)://[0-9a-zA-Z._/-]+$'
+                  pattern: '^https://[0-9a-zA-Z._/-]+$'
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object


### PR DESCRIPTION
## Description

This PR addresses an issue in the `IstioFederation` and `IstioMulticluster` Custom Resource Definitions (CRDs) by updating the validation pattern for the `metadataEndpoint` field.

The regular expression has been modified to exclusively permit URLs utilizing the `https://` protocol. Consequently, the use of `file://` protocols is no longer supported, ensuring that all metadata endpoints are secure web-based resources.

## Why do we need it, and what problem does it solve?

The primary motivation for this change is to enhance the security and integrity of the cluster's configuration. By restricting the `metadataEndpoint` to `https://` URLs, we eliminate the possibility of referencing local file paths (`file://`), which could pose a security vulnerability.

This modification enforces a stricter, more secure validation rule, preventing configurations that might inadvertently expose local file system resources. This results in a more robust and secure setup for Istio federation and multicluster communication.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix 
summary: The regex pattern for the `metadataEndpoint` field in `IstioFederation` and `IstioMulticluster` CRDs is fixed to allow only `https://` URLs.
impact_level: low
```
