### PR TITLE
[docs] Add canonical link tag for documentation pages

### DIFF
--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -77,6 +77,7 @@
 {%- endif %}
 
 <!-- Primary Meta Tags -->
+<link rel="canonical" href="{{ site.urls[page.lang] }}{{ page_meta_url }}" />
 <meta name="title" content="{{ generated_title }} | {{ site.site_title }}">
 <meta name="description" content="{{ description }}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %}{% if page.keywords %}{{page.keywords}}, {% endif %}{% if page.search %}{{page.search}}{% endif %}">


### PR DESCRIPTION
## Description

Added canonical link tag for documentation pages.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Added canonical link tag for documentation pages.
impact_level: low
```
