### PR TITLE
[dhctl] fix(dhctl-for-commander): make ssh keys optional in attach operation

### DIFF
--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -228,11 +228,13 @@ func (i *Attacher) scan(
 		}
 		res.ProviderSpecificClusterConfiguration = string(providerConfiguration)
 
-		sshPrivateKey, err := os.ReadFile(i.Params.SSHClient.PrivateKeys()[0].Key)
-		if err != nil {
-			return fmt.Errorf("unable to read ssh private key: %w", err)
+		if len(i.Params.SSHClient.PrivateKeys()) > 0 {
+			sshPrivateKey, err := os.ReadFile(i.Params.SSHClient.PrivateKeys()[0].Key)
+			if err != nil {
+				return fmt.Errorf("unable to read ssh private key: %w", err)
+			}
+			res.SSHPrivateKey = string(sshPrivateKey)
 		}
-		res.SSHPrivateKey = string(sshPrivateKey)
 
 		if metaConfig.ClusterType == config.StaticClusterType {
 			return nil

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -171,7 +171,7 @@ func (s *Service) commanderAttach(ctx context.Context, p attachParams) *pb.Comma
 	log.InitLoggerWithOptions("pretty", log.LoggerOptions{
 		OutStream:   p.logOptions.DefaultWriter,
 		Width:       int(p.request.Options.LogWidth),
-		DebugStream: p.logOptions.DefaultWriter,
+		DebugStream: p.logOptions.DebugWriter,
 	})
 	app.SanityCheck = true
 	app.UseTfCache = app.UseStateCacheYes

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -146,7 +146,7 @@ func (s *Service) commanderDetach(ctx context.Context, p detachParams) *pb.Comma
 	log.InitLoggerWithOptions("pretty", log.LoggerOptions{
 		OutStream:   p.logOptions.DefaultWriter,
 		Width:       int(p.request.Options.LogWidth),
-		DebugStream: p.logOptions.DefaultWriter,
+		DebugStream: p.logOptions.DebugWriter,
 	})
 	app.SanityCheck = true
 	app.UseTfCache = app.UseStateCacheYes


### PR DESCRIPTION
## Description
Fixed the behaviour of the attach operation when there are no keys in SSHConfig, only a password

Fixed logging in the gRPC server for the attach and detach operations.

## Why do we need it in the patch release (if we do)?
This fix is critical for Commander users who rely on password-based authentication. Without it, they cannot attach their clusters.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed the behaviour of the attach operation when there are no keys in SSHConfig, only a password
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
