### PR TITLE
[ingress-nginx] Fixed set_annotation_validation_suspended.go hook

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2214,19 +2214,19 @@ alerts:
         1. Check events associated with `kruise-controller-manager` in the `d8-ingress-nginx` namespace. Look for issues related to node failures or memory shortages (OOM events):
 
            ```bash
-           kubectl -n d8-ingress-nginx get events | grep kruise-controller-manager
+           d8 k -n d8-ingress-nginx get events | grep kruise-controller-manager
            ```
 
         2. Analyze the controller's pod descriptions to identify restarted containers and possible causes. Pay attention to exit codes and other details:
 
            ```bash
-           kubectl -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
+           d8 k -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
            ```
 
         3. In case the `kruise` container has restarted, get a list of relevant container logs to identify any meaningful errors:
 
            ```bash
-           kubectl -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
+           d8 k -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
            ```
       summary: |
         Too many Kruise controller restarts detected.
@@ -4003,6 +4003,23 @@ alerts:
         File descriptors for {{ $labels.job }}: {{ $labels.namespace }}/{{ $labels.pod }} are exhausting soon.
       severity: "4"
       markupFormat: default
+    - name: GeoIPDownloadErrorDetected
+      sourceFile: modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+      moduleUrl: 402-ingress-nginx
+      module: ingress-nginx
+      edition: ce
+      description: |-
+        The controller `{{ $labels.controller }}` failed to download the GeoIP database.
+
+        **Reason:** `{{ $labels.reason }}`
+
+        **Type:** `{{ $labels.type }}`
+
+        If this issue persists, investigate network connectivity or database availability.
+      summary: |
+        GeoIP DB download error in controller {{ $labels.controller }}.
+      severity: "4"
+      markupFormat: markdown
     - name: GrafanaDashboardAlertRulesDeprecated
       sourceFile: modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml
       moduleUrl: 300-prometheus
@@ -5158,13 +5175,13 @@ alerts:
         1. Check the controller logs:
 
            ```bash
-           kubectl -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
+           d8 k -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
            ```
 
         2. Find the most recently created Ingress in the cluster:
 
            ```bash
-           kubectl get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
+           d8 k get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
            ```
 
         3. Check for errors in the `configuration-snippet` or `server-snippet` annotations.
@@ -5185,13 +5202,13 @@ alerts:
         1. Check the DaemonSet's status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
            ```
 
         2. Analyze the DaemonSet's description:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
            ```
 
         3. If the parameter `Number of Nodes Scheduled with Up-to-date Pods` does not match
@@ -5211,13 +5228,13 @@ alerts:
         List of unavailable pods:
 
         ```text
-        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_phase{namespace=\"%s\", phase!~\"Running|Succeeded\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
         ```
 
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
       summary: |
         No available replicas remaining in NGINX Ingress DaemonSet {{$labels.namespace}}/{{$labels.daemonset}}.
@@ -5236,13 +5253,13 @@ alerts:
         List of unavailable pods:
 
         ```text
-        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_phase{namespace=\"%s\", phase!~\"Running|Succeeded\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
         ```
 
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
       summary: |
         Some replicas of NGINX Ingress DaemonSet {{$labels.namespace}}/{{$labels.daemonset}} are unavailable.
@@ -5261,6 +5278,20 @@ alerts:
         Too many NGINX Ingress restarts detected.
       severity: "4"
       markupFormat: markdown
+    - name: NginxIngressProfilingIsEnabled
+      sourceFile: modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+      moduleUrl: 402-ingress-nginx
+      module: ingress-nginx
+      edition: ce
+      description: |-
+        Profiling mode is enabled for the NGINX Ingress Controller **"{{ $labels.controller_name }}"**.
+        This may increase memory consumption, slow down request processing, and the process may run as root.
+        It is recommended to disable profiling unless it is actively needed for debugging or performance analysis.
+        To disable profiling, set `nginxProfilingEnabled: false` in the `ingressnginxcontroller` resource configuration for this controller.
+      summary: |
+        Warning: Profiling mode is enabled in the NGINX Ingress Controller &quot;{{ $labels.controller_name }}&quot;.
+      severity: "4"
+      markupFormat: markdown
     - name: NginxIngressProtobufExporterHasErrors
       sourceFile: modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
       moduleUrl: 402-ingress-nginx
@@ -5272,7 +5303,7 @@ alerts:
         To resolve the issue, check the Ingress controller's logs:
 
         ```bash
-        kubectl -n d8-ingress-nginx logs $(kubectl -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
+        d8 k -n d8-ingress-nginx logs $(d8 k -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
         ```
       summary: |
         The Ingress NGINX sidecar container with protobuf_exporter has {{ $labels.type }} errors.
@@ -5289,7 +5320,7 @@ alerts:
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
 
         The site at `https://{{ $labels.host }}` is not accessible.
@@ -5308,7 +5339,7 @@ alerts:
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
       summary: |
         Certificate is expiring soon.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5323,6 +5323,11 @@ alerts:
         Validation is disabled to reduce load on the master nodes, as it requires additional resources.
         To re-enable validation, remove the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`
         from the `ingressnginxcontroller` resource.
+
+        To find which `IngressNginxController` resources have the annotation, use the following command:
+        ```shell
+        d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
+        ```
       summary: |
         Warning: Ingress resource validation in the NGINX Ingress Controller is currently disabled.
       severity: "3"

--- a/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
+++ b/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
@@ -17,6 +17,8 @@ limitations under the License.
 package hooks
 
 import (
+	"github.com/deckhouse/module-sdk/pkg"
+
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -26,6 +28,8 @@ import (
 
 	"github.com/deckhouse/deckhouse/modules/402-ingress-nginx/hooks/internal"
 )
+
+const validationSuspendMetricName = "ingress_nginx_validation_suspended"
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
@@ -72,18 +76,34 @@ func setAnnotationValidationSuspendedFilterIngressNginxController(obj *unstructu
 func setAnnotationValidationSuspendedHandleIngressNginxControllers(input *go_hook.HookInput) error {
 	controllersSnapshot := input.NewSnapshots.Get("ingressNginxControllers")
 	configMapSnapshot := input.NewSnapshots.Get("ingressNginxControllersConfigMap")
+	configMapExists := len(configMapSnapshot) > 0
 
-	// Exit early if the ConfigMap already exists (annotations were already applied once)
-	// or if there are fewer than 5 controllers (do not proceed with annotation patching)
-	configMapOk := len(configMapSnapshot) > 0
-	if configMapOk || len(controllersSnapshot) < 5 {
+	// Reset metric before calculations
+	input.MetricsCollector.Expire(validationSuspendMetricName)
+
+	// Less than 5 controllers → nothing to do
+	if len(controllersSnapshot) < 5 {
 		return nil
 	}
 
-	for _, item := range controllersSnapshot {
+	// First run → set blocking annotations on all controllers
+	if !configMapExists {
+		setValidationSuspendedAnnotationToAll(controllersSnapshot, input)
+		input.MetricsCollector.Set(validationSuspendMetricName, 1.0, nil)
+	}
+
+	// If at least one controller has annotation → set metric
+	if anyControllerHasAnnotationValidationSuspended(controllersSnapshot) {
+		input.MetricsCollector.Set(validationSuspendMetricName, 1.0, nil)
+	}
+
+	return nil
+}
+
+func setValidationSuspendedAnnotationToAll(controllers []pkg.Snapshot, input *go_hook.HookInput) {
+	for _, item := range controllers {
 		var ctrl internal.IngressNginxController
-		err := item.UnmarshalTo(&ctrl)
-		if err != nil {
+		if err := item.UnmarshalTo(&ctrl); err != nil {
 			continue
 		}
 
@@ -96,7 +116,16 @@ func setAnnotationValidationSuspendedHandleIngressNginxControllers(input *go_hoo
 		}
 		input.PatchCollector.PatchWithMerge(patch, "deckhouse.io/v1", "IngressNginxController", ctrl.Namespace, ctrl.Name)
 	}
+}
 
-	input.MetricsCollector.Set("ingress_nginx_validation_suspended", 1.0, nil)
-	return nil
+func anyControllerHasAnnotationValidationSuspended(controllers []pkg.Snapshot) bool {
+	for _, item := range controllers {
+		var ctrl internal.IngressNginxController
+		if err := item.UnmarshalTo(&ctrl); err == nil {
+			if _, ok := ctrl.Annotations[internal.IngressNginxControllerSuspendAnnotation]; ok {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -25,13 +25,13 @@
         1. Check the controller logs:
 
            ```bash
-           kubectl -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
+           d8 k -n {{ $labels.controller_namespace }} logs {{ $labels.controller_pod }} -c controller
            ```
 
         2. Find the most recently created Ingress in the cluster:
 
            ```bash
-           kubectl get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
+           d8 k get ingress --all-namespaces --sort-by="metadata.creationTimestamp"
            ```
 
         3. Check for errors in the `configuration-snippet` or `server-snippet` annotations.
@@ -50,7 +50,7 @@
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
 
   - alert: NginxIngressSslExpired
@@ -68,7 +68,7 @@
         To verify the certificate, run the following command:
 
         ```bash
-        kubectl -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
+        d8 k -n {{ $labels.namespace }} get secret {{ $labels.secret_name }} -o json | jq -r '.data."tls.crt" | @base64d' | openssl x509 -noout -alias -subject -issuer -dates
         ```
 
         The site at `https://{{ $labels.host }}` is not accessible.
@@ -87,7 +87,7 @@
         To resolve the issue, check the Ingress controller's logs:
 
         ```bash
-        kubectl -n d8-ingress-nginx logs $(kubectl -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
+        d8 k -n d8-ingress-nginx logs $(d8 k -n d8-ingress-nginx get pods -l app=controller,name={{ $labels.controller }} -o wide | grep {{ $labels.node }} | awk '{print $1}') -c protobuf-exporter
         ```
 
   - alert: NginxIngressPodIsRestartingTooOften
@@ -126,19 +126,19 @@
         1. Check events associated with `kruise-controller-manager` in the `d8-ingress-nginx` namespace. Look for issues related to node failures or memory shortages (OOM events):
 
            ```bash
-           kubectl -n d8-ingress-nginx get events | grep kruise-controller-manager
+           d8 k -n d8-ingress-nginx get events | grep kruise-controller-manager
            ```
 
         2. Analyze the controller's pod descriptions to identify restarted containers and possible causes. Pay attention to exit codes and other details:
 
            ```bash
-           kubectl -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
+           d8 k -n d8-ingress-nginx describe pod -lapp=kruise,control-plane=controller-manager
            ```
 
         3. In case the `kruise` container has restarted, get a list of relevant container logs to identify any meaningful errors:
 
            ```bash
-           kubectl -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
+           d8 k -n d8-ingress-nginx logs -lapp=kruise,control-plane=controller-manager -c kruise
            ```
 
   - alert: NginxIngressDaemonSetReplicasUnavailable
@@ -162,13 +162,13 @@
         List of unavailable pods:
 
         ```text
-        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_phase{namespace=\"%s\", phase!~\"Running|Succeeded\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
         ```
 
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
 
   - alert: NginxIngressDaemonSetReplicasUnavailable
@@ -190,13 +190,13 @@
         List of unavailable pods:
 
         ```text
-        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_ready{namespace=\"%s\", condition!=\"true\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
+        {{range $index, $result := (printf "(max by (namespace, pod) (kube_pod_status_phase{namespace=\"%s\", phase!~\"Running|Succeeded\"} == 1)) * on (namespace, pod) kube_controller_pod{namespace=\"%s\", controller_type=\"DaemonSet\", controller_name=\"%s\"}" $labels.namespace $labels.namespace $labels.daemonset | query)}}{{if not (eq $index 0)}}, {{ end }}{{ $result.Labels.pod }}{{ end }}
         ```
 
         If you know where the DaemonSet should be scheduled, run the command below to identify the problematic nodes. Use a label selector for pods, if needed.
 
         ```bash
-        kubectl -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
+        d8 k -n {{$labels.namespace}} get pod -ojson | jq -r '.items[] | select(.metadata.ownerReferences[] | select(.name =="{{$labels.daemonset}}")) | select(.status.phase != "Running" or ([ .status.conditions[] | select(.type == "Ready" and .status == "False") ] | length ) == 1 ) | .spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchFields[].values[]'
         ```
 
   - alert: NginxIngressDaemonSetNotUpToDate
@@ -220,13 +220,13 @@
         1. Check the DaemonSet's status:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} get ads {{ $labels.daemonset }}
            ```
 
         2. Analyze the DaemonSet's description:
 
            ```bash
-           kubectl -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
+           d8 k -n {{ $labels.namespace }} describe ads {{ $labels.daemonset }}
            ```
 
         3. If the parameter `Number of Nodes Scheduled with Up-to-date Pods` does not match
@@ -247,3 +247,46 @@
         Validation is disabled to reduce load on the master nodes, as it requires additional resources.
         To re-enable validation, remove the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`
         from the `ingressnginxcontroller` resource.
+
+        To find which `IngressNginxController` resources have the annotation, use the following command:
+        ```shell
+        d8 k get ingressnginxcontrollers.deckhouse.io -o json | jq -r '.items[] | select(.metadata.annotations."network.deckhouse.io/ingress-nginx-validation-suspended" != null) | "\(.metadata.name)"'
+        ```
+
+  - alert: NginxIngressProfilingIsEnabled
+    expr: |
+      d8_ingress_nginx_controller_profiling_enabled == 1
+    for: 3m
+    labels:
+      severity_level: "4"
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: |-
+        Warning: Profiling mode is enabled in the NGINX Ingress Controller "{{ $labels.controller_name }}".
+      description: |-
+        Profiling mode is enabled for the NGINX Ingress Controller **"{{ $labels.controller_name }}"**.
+        This may increase memory consumption, slow down request processing, and the process may run as root.
+        It is recommended to disable profiling unless it is actively needed for debugging or performance analysis.
+        To disable profiling, set `nginxProfilingEnabled: false` in the `ingressnginxcontroller` resource configuration for this controller.
+
+
+  - alert: GeoIPDownloadErrorDetected
+    expr: sum by (controller, reason) (max_over_time(geoip_errors_total{type="download"}[1m])) > 0
+    for: 1m
+    labels:
+      severity_level: "4"
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: |-
+        GeoIP DB download error in controller `{{ $labels.controller }}`.
+      description: |-
+        The controller `{{ $labels.controller }}` failed to download the GeoIP database.
+
+        **Reason:** `{{ $labels.reason }}`
+
+        **Type:** `{{ $labels.type }}`
+
+        If this issue persists, investigate network connectivity or database availability.
+


### PR DESCRIPTION
## Description
Backport [PR#15462](https://github.com/deckhouse/deckhouse/pull/15462) to release-1.72

This patch updates the `set_annotation_validation_suspended.go hook`. Previously, the hook only set the `ingress_nginx_validation_suspended` metric but did not remove it when it was no longer needed. This change adds logic to remove the `ingress_nginx_validation_suspended` metric if there are no `ingressNginxControllers` resources in the cluster with the annotation `network.deckhouse.io/ingress-nginx-validation-suspended`.

## Why do we need it, and what problem does it solve?
Without this fix, the `ingress_nginx_validation_suspended` metric can remain set even when all controllers have removed the suspension annotation. This leads to inaccurate monitoring data and potential confusion in alerts or dashboards that rely on this metric.

## Why do we need it in the patch release (if we do)?
Without this fix, the `NginxIngressValidationIsDisabled` alert remains active at all times, regardless of whether there are actually any resources in the cluster with validation disabled.

## How to test?
1. Create 5 `ingressNginxControllers`.
2. Wait a bit and verify the following:
- In all `ingressNginxControllers`, the field `metadata.annotations.network.deckhouse.io/ingress-nginx-validation-suspended` is set to "";
- In all `ingressNginxControllers`, the field `spec.validationEnabled` is set to false;
- In the `d8-ingress-nginx` namespace, a `ConfigMap` named `ingress-nginx-validation-suspended` appears;
- An alert `NginxIngressValidationIsDisabled` is generated.
4. Remove the annotation from all `ingressNginxControllers` resources.
5. Wait a bit and confirm that the alert `NginxIngressValidationIsDisabled` disappears.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix
summary: fix set_annotation_validation_suspended.go hook to set correct metric
impact_level: low
```
