### PR TITLE
[deckhouse] Add alert for deprecated modules

### DIFF
--- a/deckhouse-controller/internal/metrics/metrics.go
+++ b/deckhouse-controller/internal/metrics/metrics.go
@@ -19,4 +19,5 @@ const (
 	MigratedModuleNotFoundGroup             = "migrated_module_not_found"
 	ExperimentalModulesAreAllowedMetricName = "is_experimental_modules_allowed"
 	ExperimentalModuleIsEnabled             = "is_experimental_module_enabled"
+	DeprecatedModuleIsEnabled               = "is_deprecated_module_enabled"
 )

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -92,6 +92,7 @@ const (
 	ModuleDependencyRequirementFieldName string = "modules"
 
 	ExperimentalModuleStage = "Experimental"
+	DeprecatedModuleStage   = "Deprecated"
 )
 
 var (
@@ -400,4 +401,8 @@ func (m *Module) GetVersion() string {
 
 func (m *Module) IsExperimental() bool {
 	return m.Properties.Stage == ExperimentalModuleStage
+}
+
+func (m *Module) IsDeprecated() bool {
+	return m.Properties.Stage == DeprecatedModuleStage
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -316,6 +316,10 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 		r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 1.0, map[string]string{"module": moduleConfig.GetName()})
 	}
 
+	if module.IsDeprecated() {
+		r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 1.0, map[string]string{"module": moduleConfig.GetName()})
+	}
+
 	if err := r.addFinalizer(ctx, moduleConfig); err != nil {
 		r.logger.Error("failed to add finalizer", slog.String("module", module.Name), log.Err(err))
 		return ctrl.Result{}, err
@@ -404,6 +408,7 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricGroup)
 
 	r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 0.0, map[string]string{"module": moduleConfig.GetName()})
+	r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 0.0, map[string]string{"module": moduleConfig.GetName()})
 
 	module := new(v1alpha1.Module)
 	if err := r.client.Get(ctx, client.ObjectKey{Name: moduleConfig.Name}, module); err != nil {

--- a/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/types/definition.go
@@ -33,6 +33,7 @@ const (
 	DefinitionFile = "module.yaml"
 
 	ExperimentalModuleStage = "Experimental"
+	DeprecatedModuleStage   = "Deprecated"
 )
 
 // Definition of module.yaml file struct
@@ -264,4 +265,8 @@ func (d *Definition) Labels() map[string]string {
 
 func (d *Definition) IsExperimental() bool {
 	return d.Stage == ExperimentalModuleStage
+}
+
+func (d *Definition) IsDeprecated() bool {
+	return d.Stage == DeprecatedModuleStage
 }

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -425,3 +425,18 @@
         ```bash
         d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```{{ end }}
+
+  - alert: ModuleIsDeprecated
+    expr: d8_is_deprecated_module_enabled >= 1
+    labels:
+      severity_level: "9"
+      d8_module: deckhouse
+      d8_component: deckhouse
+      tier: cluster
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      summary: |
+        Module `{{ $labels.module }}` is deprecated.
+      description: |
+        The module `{{ $labels.module }}` is deprecated and will not receive new updates. The module may be removed in the future, so please disable it in a controlled manner.


### PR DESCRIPTION
## Description

Add alert for deprecated modules

## Why do we need it, and what problem does it solve?

Add alert for deprecated modules

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Add alert for deprecated modules
impact_level: default
```
