### PR TITLE
[dhctl] Add output for SSH client start

### DIFF
--- a/dhctl/pkg/system/node/gossh/client.go
+++ b/dhctl/pkg/system/node/gossh/client.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
@@ -169,11 +171,18 @@ func (s *Client) Start() error {
 		return nil
 	}
 
+	noAuthMethodsRemain := func(err error) bool {
+		if s.Settings.User == global.ConvergeNodeUserName {
+			return false
+		}
+		return strings.Contains(err.Error(), "unable to authenticate")
+	}
+
 	if bastionClient == nil {
 		log.DebugLn("Try to direct connect host master host")
 
 		var err error
-		err = retry.NewSilentLoop("Get SSH client", 30, 5*time.Second).Run(func() error {
+		err = retry.NewLoop("Get SSH client", 30, 5*time.Second).BreakIf(noAuthMethodsRemain).Run(func() error {
 			s.Settings.ChoiceNewHost()
 			addr := fmt.Sprintf("%s:%s", s.Settings.Host(), s.Settings.Port)
 			client, err = ssh.Dial("tcp", addr, config)
@@ -211,7 +220,7 @@ func (s *Client) Start() error {
 	var targetClientConn ssh.Conn
 	var targetNewChan <-chan ssh.NewChannel
 	var targetReqChan <-chan *ssh.Request
-	err = retry.NewSilentLoop("Connect to target SSH host", 50, 2*time.Second).Run(func() error {
+	err = retry.NewLoop("Connect to target SSH host", 50, 2*time.Second).BreakIf(noAuthMethodsRemain).Run(func() error {
 		targetClientConn, targetNewChan, targetReqChan, err = ssh.NewClientConn(targetConn, addr, config)
 		return err
 	})


### PR DESCRIPTION
## Description

Add output for start of gossh client

## Why do we need it, and what problem does it solve?

While ssh client is starting and trying to connect to target host due cloud bootstrap, it produces no output, so user cannot find out if he puts the wrong private ssh key. So we should make it more clear for user.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add gossh client start output
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
