### PR TITLE
[keepalived] enable readOnlyRootFilesystem

### DIFF
--- a/ee/modules/450-keepalived/images/keepalived/mount-point.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/mount-point.yaml
@@ -1,0 +1,4 @@
+dirs:
+- /etc/keepalived
+- /etc/keepalived-instance-config
+- /etc/keepalived-instance-secret

--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -57,6 +57,7 @@ fromImage: common/distroless
 git:
 - add: /{{ $.ModulePath }}modules/450-{{ $.ModuleName }}/images/{{ $.ImageName }}/src/prepare-config.py
   to: /prepare-config.py
+{{- include "image mount points" . }}
 import:
 - image: {{ $.ModuleName }}/build-keepalived
   add: /opt/keepalived-static/usr/sbin/keepalived

--- a/ee/modules/450-keepalived/templates/statefulset.yaml
+++ b/ee/modules/450-keepalived/templates/statefulset.yaml
@@ -52,6 +52,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple $ "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" $ | nindent 6 }}
+        readOnlyRootFilesystem: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

All containers of the keepalived module have the readOnlyRootFilesystem setting set to true.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need it to meet security concerns and overall hardening of the DKP platform.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: keepalived
type: chore
summary: The readOnlyRootFilesystem security option is set to true for all containers.
impact: Pods of the openvpn module will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
