### PR TITLE
[deckhouse-controller] fix: race condition in concurrent tests with fakeCloak

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -94,6 +94,8 @@ type ReleaseControllerTestSuite struct {
 
 	testDataFileName string
 	testMRName       string
+
+	mu sync.Mutex
 }
 
 func (suite *ReleaseControllerTestSuite) SetupSubTest() {
@@ -865,6 +867,9 @@ func withBasicModulePhase(phase addonmodules.ModuleRunPhase) reconcilerOption {
 }
 
 func (suite *ReleaseControllerTestSuite) setupReleaseController(yamlDoc string, options ...reconcilerOption) {
+	suite.mu.Lock()
+	defer suite.mu.Unlock()
+
 	manifests := releaseutil.SplitManifests(yamlDoc)
 
 	manifests["deckhouse-discovery"] = `

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller_test.go
@@ -94,8 +94,6 @@ type ReleaseControllerTestSuite struct {
 
 	testDataFileName string
 	testMRName       string
-
-	mu sync.Mutex
 }
 
 func (suite *ReleaseControllerTestSuite) SetupSubTest() {
@@ -867,9 +865,6 @@ func withBasicModulePhase(phase addonmodules.ModuleRunPhase) reconcilerOption {
 }
 
 func (suite *ReleaseControllerTestSuite) setupReleaseController(yamlDoc string, options ...reconcilerOption) {
-	suite.mu.Lock()
-	defer suite.mu.Unlock()
-
 	manifests := releaseutil.SplitManifests(yamlDoc)
 
 	manifests["deckhouse-discovery"] = `

--- a/go_lib/dependency/dependency.go
+++ b/go_lib/dependency/dependency.go
@@ -270,6 +270,8 @@ type MockedContainer struct {
 	CRClientMap   map[string]cr.Client
 	VsphereClient *vsphere.ClientMock
 	clock         clockwork.FakeClock
+
+	mu sync.Mutex
 }
 
 func (c *MockedContainer) GetHelmClient(_ string, _ ...helm.Option) (helm.Client, error) {
@@ -340,7 +342,11 @@ func (c *MockedContainer) SetK8sVersion(ver k8s.FakeClusterVersion) {
 	c.K8sClient = cli
 }
 
-func (c *MockedContainer) GetClock() clockwork.Clock { return c.GetFakeClock() }
+func (c *MockedContainer) GetClock() clockwork.Clock {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.GetFakeClock()
+}
 
 func (c *MockedContainer) GetFakeClock() clockwork.FakeClock {
 	if c.clock != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix race condition in concurrent tests with fakeCloak testing

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix concurrent tests with fake cloak
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
