### PR TITLE
[node-manager] Add separate password and ssh key passphrase fields to CAPS

### DIFF
--- a/modules/040-node-manager/crds/doc-ru-sshcredentials.yaml
+++ b/modules/040-node-manager/crds/doc-ru-sshcredentials.yaml
@@ -20,6 +20,9 @@ spec:
                 privateSSHKey:
                   description: |
                     Закрытый ключ SSH в формате PEM, закодированный в Base64.
+                privateSSHKeyPassphrase:
+                  description: |
+                    Парольная фраза от SSH ключа, закодированная в Base64.
                 sshExtraArgs:
                   description: |
                     Список дополнительных параметров для SSH-клиента (`openssh`).
@@ -52,6 +55,9 @@ spec:
                 privateSSHKey:
                   description: |
                     Закрытый ключ SSH в формате PEM, закодированный в Base64.
+                privateSSHKeyPassphrase:
+                  description: |
+                    Парольная фраза от SSH ключа, закодированная в Base64.
                 sshExtraArgs:
                   description: |
                     Список дополнительных параметров для SSH-клиента (`openssh`).

--- a/modules/040-node-manager/crds/doc-ru-sshcredentials.yaml
+++ b/modules/040-node-manager/crds/doc-ru-sshcredentials.yaml
@@ -61,6 +61,9 @@ spec:
                 sudoPasswordEncoded:
                   description: |
                     Пароль пользователя для использования `sudo`, закодированный в Base64.
+                passwordEncoded:
+                  description: |
+                    Пароль пользователя для входа в систему, закодированный в Base64.
                 user:
                   description: |
                     Имя пользователя для подключения по SSH.

--- a/modules/040-node-manager/crds/doc-ru-sshcredentials.yaml
+++ b/modules/040-node-manager/crds/doc-ru-sshcredentials.yaml
@@ -22,7 +22,7 @@ spec:
                     Закрытый ключ SSH в формате PEM, закодированный в Base64.
                 privateSSHKeyPassphrase:
                   description: |
-                    Парольная фраза от SSH ключа, закодированная в Base64.
+                    Парольная фраза от SSH-ключа, закодированная в Base64.
                 sshExtraArgs:
                   description: |
                     Список дополнительных параметров для SSH-клиента (`openssh`).
@@ -57,7 +57,7 @@ spec:
                     Закрытый ключ SSH в формате PEM, закодированный в Base64.
                 privateSSHKeyPassphrase:
                   description: |
-                    Парольная фраза от SSH ключа, закодированная в Base64.
+                    Парольная фраза от SSH-ключа, закодированная в Base64.
                 sshExtraArgs:
                   description: |
                     Список дополнительных параметров для SSH-клиента (`openssh`).

--- a/modules/040-node-manager/crds/sshcredentials.yaml
+++ b/modules/040-node-manager/crds/sshcredentials.yaml
@@ -100,6 +100,10 @@ spec:
             spec:
               description: SSHCredentialsSpec defines the desired state of SSHCredentials.
               properties:
+                passwordEncoded:
+                  description: |
+                    Base64 encoded login password for the user.
+                  type: string
                 privateSSHKey:
                   description: |
                     Private SSH key in PEM format encoded as base64 string.
@@ -136,7 +140,7 @@ spec:
                   x-doc-required: true
               anyOf:
                 - required: [user, privateSSHKey]
-                - required: [user, sudoPasswordEncoded]
+                - required: [user, passwordEncoded]
               type: object
           type: object
       served: true

--- a/modules/040-node-manager/crds/sshcredentials.yaml
+++ b/modules/040-node-manager/crds/sshcredentials.yaml
@@ -125,6 +125,10 @@ spec:
                   description: |
                     Base64 encoded sudo password for the user.
                   type: string
+                passwordEncoded:
+                  description: |
+                    Base64 encoded login password for the user.
+                  type: string
                 user:
                   description: |
                     A username to connect to the host via SSH.
@@ -132,7 +136,7 @@ spec:
                   x-doc-required: true
               anyOf:
                 - required: [user, privateSSHKey]
-                - required: [user, sudoPasswordEncoded]
+                - required: [user, passwordEncoded]
               type: object
           type: object
       served: true

--- a/modules/040-node-manager/crds/sshcredentials.yaml
+++ b/modules/040-node-manager/crds/sshcredentials.yaml
@@ -104,6 +104,10 @@ spec:
                   description: |
                     Private SSH key in PEM format encoded as base64 string.
                   type: string
+                privateSSHKeyPassphrase:
+                  description: |
+                    Private SSH key passphrase encoded as base64 string.
+                  type: string                
                 sshExtraArgs:
                   description: |
                     A list of additional arguments to pass to the openssh command.
@@ -125,10 +129,6 @@ spec:
                   description: |
                     Base64 encoded sudo password for the user.
                   type: string
-                passwordEncoded:
-                  description: |
-                    Base64 encoded login password for the user.
-                  type: string
                 user:
                   description: |
                     A username to connect to the host via SSH.
@@ -136,7 +136,7 @@ spec:
                   x-doc-required: true
               anyOf:
                 - required: [user, privateSSHKey]
-                - required: [user, passwordEncoded]
+                - required: [user, sudoPasswordEncoded]
               type: object
           type: object
       served: true

--- a/modules/040-node-manager/crds/sshcredentials.yaml
+++ b/modules/040-node-manager/crds/sshcredentials.yaml
@@ -145,6 +145,7 @@ spec:
               anyOf:
                 - required: [user, privateSSHKey]
                 - required: [user, passwordEncoded]
+                - required: [user, sudoPasswordEncoded]
               type: object
           type: object
       served: true

--- a/modules/040-node-manager/crds/sshcredentials.yaml
+++ b/modules/040-node-manager/crds/sshcredentials.yaml
@@ -44,6 +44,10 @@ spec:
                   description: |
                     Private SSH key in PEM format encoded as base64 string.
                   type: string
+                privateSSHKeyPassphrase:
+                  description: |
+                    Private SSH key passphrase encoded as base64 string.
+                  type: string 
                 sshExtraArgs:
                   description: |
                     A list of additional arguments to pass to the openssh command.

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/sshcredentials_types.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/sshcredentials_types.go
@@ -28,9 +28,10 @@ type SSHCredentialsSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	User          string `json:"user"`
-	PrivateSSHKey string `json:"privateSSHKey"`
-	SudoPassword  string `json:"sudoPassword,omitempty"`
+	User                    string `json:"user"`
+	PrivateSSHKey           string `json:"privateSSHKey"`
+	PrivateSSHKeyPassphrase string `json:"privateSSHKeyPassphrase,omitempty"`
+	SudoPassword            string `json:"sudoPassword,omitempty"`
 
 	//+kubebuilder:default:=22
 	//+kubebuilder:validation:Minimum=1

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/zz_generated.conversion.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/zz_generated.conversion.go
@@ -192,6 +192,7 @@ func Convert_v1alpha2_SSHCredentialsList_To_v1alpha1_SSHCredentialsList(in *v1al
 func autoConvert_v1alpha1_SSHCredentialsSpec_To_v1alpha2_SSHCredentialsSpec(in *SSHCredentialsSpec, out *v1alpha2.SSHCredentialsSpec, s conversion.Scope) error {
 	out.User = in.User
 	out.PrivateSSHKey = in.PrivateSSHKey
+	out.PrivateSSHKeyPassphrase = in.PrivateSSHKeyPassphrase
 	// WARNING: in.SudoPassword requires manual conversion: does not exist in peer-type
 	out.SSHPort = in.SSHPort
 	out.SSHExtraArgs = in.SSHExtraArgs
@@ -201,6 +202,8 @@ func autoConvert_v1alpha1_SSHCredentialsSpec_To_v1alpha2_SSHCredentialsSpec(in *
 func autoConvert_v1alpha2_SSHCredentialsSpec_To_v1alpha1_SSHCredentialsSpec(in *v1alpha2.SSHCredentialsSpec, out *SSHCredentialsSpec, s conversion.Scope) error {
 	out.User = in.User
 	out.PrivateSSHKey = in.PrivateSSHKey
+	out.PrivateSSHKeyPassphrase = in.PrivateSSHKeyPassphrase
+	// WARNING: in.PasswordEncoded requires manual conversion: does not exist in peer-type
 	// WARNING: in.SudoPasswordEncoded requires manual conversion: does not exist in peer-type
 	out.SSHPort = in.SSHPort
 	out.SSHExtraArgs = in.SSHExtraArgs

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_types.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_types.go
@@ -31,6 +31,8 @@ type SSHCredentialsSpec struct {
 	User          string `json:"user"`
 	PrivateSSHKey string `json:"privateSSHKey,omitempty"`
 	// base64 encoded password for user
+	PasswordEncoded string `json:"passwordEncoded,omitempty"`
+	// base64 encoded password for sudo
 	SudoPasswordEncoded string `json:"sudoPasswordEncoded,omitempty"`
 
 	//+kubebuilder:default:=22

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_types.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_types.go
@@ -28,8 +28,9 @@ type SSHCredentialsSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	User          string `json:"user"`
-	PrivateSSHKey string `json:"privateSSHKey,omitempty"`
+	User                    string `json:"user"`
+	PrivateSSHKey           string `json:"privateSSHKey,omitempty"`
+	PrivateSSHKeyPassphrase string `json:"privateSSHKeyPassphrase,omitempty"`
 	// base64 encoded password for user
 	PasswordEncoded string `json:"passwordEncoded,omitempty"`
 	// base64 encoded password for sudo

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
@@ -75,12 +75,12 @@ func (r *SSHCredentials) ValidateCreate() (admission.Warnings, error) {
 		if len(passphrase) == 0 {
 			_, err = ssh.ParseRawPrivateKey(privateSSHKey)
 			if err != nil {
-				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "could not parse SSH key from field: privateSSHKey must be a valid private key encoded as base64 string")
 			}
 		} else {
 			_, err = ssh.ParseRawPrivateKeyWithPassphrase(privateSSHKey, passphrase)
 			if err != nil {
-				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "could not parse SSH key from field with passphrase: privateSSHKey must be a valid private key encoded as base64 string")
 			}
 		}
 
@@ -127,12 +127,12 @@ func (r *SSHCredentials) ValidateUpdate(old runtime.Object) (admission.Warnings,
 		if len(passphrase) == 0 {
 			_, err = ssh.ParseRawPrivateKey(privateSSHKey)
 			if err != nil {
-				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "could not parse SSH key from field: privateSSHKey must be a valid private key encoded as base64 string")
 			}
 		} else {
 			_, err = ssh.ParseRawPrivateKeyWithPassphrase(privateSSHKey, passphrase)
 			if err != nil {
-				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "could not parse SSH key from field with passphrase: privateSSHKey must be a valid private key encoded as base64 string")
 			}
 		}
 

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
@@ -56,6 +56,15 @@ var _ webhook.Validator = &SSHCredentials{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *SSHCredentials) ValidateCreate() (admission.Warnings, error) {
 	sshcredentialslog.Info("validate create", "name", r.Name)
+	var passphrase []byte
+	if r.Spec.PrivateSSHKeyPassphrase != "" {
+		decodedPassphrase, err := base64.StdEncoding.DecodeString(r.Spec.PrivateSSHKeyPassphrase)
+		if err != nil {
+			return nil, field.Invalid(field.NewPath("spec", "PrivateSSHKeyPassphrase"), "******", "PrivateSSHKeyPassphrase must be a valid base64 encoded string")
+		}
+		passphrase = decodedPassphrase
+
+	}
 
 	if len(r.Spec.PrivateSSHKey) > 0 {
 		privateSSHKey, err := base64.StdEncoding.DecodeString(r.Spec.PrivateSSHKey)
@@ -63,10 +72,18 @@ func (r *SSHCredentials) ValidateCreate() (admission.Warnings, error) {
 			return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid base64 encoded string")
 		}
 
-		_, err = ssh.ParseRawPrivateKey(privateSSHKey)
-		if err != nil {
-			return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+		if len(passphrase) == 0 {
+			_, err = ssh.ParseRawPrivateKey(privateSSHKey)
+			if err != nil {
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+			}
+		} else {
+			_, err = ssh.ParseRawPrivateKeyWithPassphrase(privateSSHKey, passphrase)
+			if err != nil {
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+			}
 		}
+
 	}
 
 	if r.Spec.SudoPasswordEncoded != "" {
@@ -91,6 +108,15 @@ func (r *SSHCredentials) ValidateCreate() (admission.Warnings, error) {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *SSHCredentials) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 	sshcredentialslog.Info("validate update", "name", r.Name)
+	var passphrase []byte
+	if r.Spec.PrivateSSHKeyPassphrase != "" {
+		decodedPassphrase, err := base64.StdEncoding.DecodeString(r.Spec.PrivateSSHKeyPassphrase)
+		if err != nil {
+			return nil, field.Invalid(field.NewPath("spec", "PrivateSSHKeyPassphrase"), "******", "PrivateSSHKeyPassphrase must be a valid base64 encoded string")
+		}
+		passphrase = decodedPassphrase
+
+	}
 
 	if len(r.Spec.PrivateSSHKey) > 0 {
 		privateSSHKey, err := base64.StdEncoding.DecodeString(r.Spec.PrivateSSHKey)
@@ -98,10 +124,18 @@ func (r *SSHCredentials) ValidateUpdate(old runtime.Object) (admission.Warnings,
 			return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid base64 encoded string")
 		}
 
-		_, err = ssh.ParseRawPrivateKey(privateSSHKey)
-		if err != nil {
-			return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+		if len(passphrase) == 0 {
+			_, err = ssh.ParseRawPrivateKey(privateSSHKey)
+			if err != nil {
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+			}
+		} else {
+			_, err = ssh.ParseRawPrivateKeyWithPassphrase(privateSSHKey, passphrase)
+			if err != nil {
+				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid private key encoded as base64 string")
+			}
 		}
+
 	}
 
 	if r.Spec.SudoPasswordEncoded != "" {

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
@@ -63,21 +63,25 @@ func (r *SSHCredentials) ValidateCreate() (admission.Warnings, error) {
 			return nil, field.Invalid(field.NewPath("spec", "PrivateSSHKeyPassphrase"), "******", "PrivateSSHKeyPassphrase must be a valid base64 encoded string")
 		}
 		passphrase = decodedPassphrase
-
+		sshcredentialslog.Info("validate create: passphrase decoded", "name", r.Name)
 	}
 
 	if len(r.Spec.PrivateSSHKey) > 0 {
+		sshcredentialslog.Info("validate create: decoding privateSSHKey", "name", r.Name)
 		privateSSHKey, err := base64.StdEncoding.DecodeString(r.Spec.PrivateSSHKey)
 		if err != nil {
 			return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "privateSSHKey must be a valid base64 encoded string")
 		}
+		sshcredentialslog.Info("validate create: privateSSHKey decoded", "name", r.Name)
 
 		if len(passphrase) == 0 {
+			sshcredentialslog.Info("validate create: parsing raw key data", "name", r.Name)
 			_, err = ssh.ParseRawPrivateKey(privateSSHKey)
 			if err != nil {
 				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "could not parse SSH key from field: privateSSHKey must be a valid private key encoded as base64 string")
 			}
 		} else {
+			sshcredentialslog.Info("validate create: parsing key data with passphrase", "name", r.Name)
 			_, err = ssh.ParseRawPrivateKeyWithPassphrase(privateSSHKey, passphrase)
 			if err != nil {
 				return nil, field.Invalid(field.NewPath("spec", "privateSSHKey"), "******", "could not parse SSH key from field with passphrase: privateSSHKey must be a valid private key encoded as base64 string")

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/sshcredentials_webhook.go
@@ -77,6 +77,14 @@ func (r *SSHCredentials) ValidateCreate() (admission.Warnings, error) {
 
 	}
 
+	if r.Spec.PasswordEncoded != "" {
+		_, err := base64.StdEncoding.DecodeString(r.Spec.PasswordEncoded)
+		if err != nil {
+			return nil, field.Invalid(field.NewPath("spec", "PasswordEncoded"), "******", "PasswordEncoded must be a valid base64 encoded string")
+		}
+
+	}
+
 	return nil, nil
 }
 
@@ -100,6 +108,14 @@ func (r *SSHCredentials) ValidateUpdate(old runtime.Object) (admission.Warnings,
 		_, err := base64.StdEncoding.DecodeString(r.Spec.SudoPasswordEncoded)
 		if err != nil {
 			return nil, field.Invalid(field.NewPath("spec", "SudoPasswordEncoded"), "******", "SudoPasswordEncoded must be a valid base64 encoded string")
+		}
+
+	}
+
+	if r.Spec.PasswordEncoded != "" {
+		_, err := base64.StdEncoding.DecodeString(r.Spec.PasswordEncoded)
+		if err != nil {
+			return nil, field.Invalid(field.NewPath("spec", "PasswordEncoded"), "******", "PasswordEncoded must be a valid base64 encoded string")
 		}
 
 	}

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/clissh/ssh.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/clissh/ssh.go
@@ -81,11 +81,8 @@ func (s *SSH) ExecSSHCommand(instanceScope *scope.InstanceScope, command string,
 		if err != nil {
 			return err
 		}
-		comment, err := extractComment(privateSSHKey)
-		if err != nil {
-			return err
-		}
-		key, err := ssh.MarshalPrivateKey(crypto.PrivateKey(privateKey), comment)
+
+		key, err := ssh.MarshalPrivateKey(crypto.PrivateKey(privateKey), "")
 		if err != nil {
 			return err
 		}
@@ -187,51 +184,4 @@ func (s *SSH) ExecSSHCommandToString(instanceScope *scope.InstanceScope, command
 	}
 
 	return strings.TrimSpace(string(stdoutBytes)), nil
-}
-
-func extractSSHPrivateKey(data []byte) string {
-	lines := strings.Split(string(data), "\n")
-
-	var start, end int = -1, -1
-
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "-----BEGIN") {
-			start = i + 1
-		} else if strings.HasPrefix(trimmed, "-----END") {
-			end = i
-			break
-		}
-	}
-
-	if start == -1 || end == -1 || start >= end {
-		return ""
-	}
-
-	keyLines := lines[start:end]
-
-	return strings.Join(keyLines, "\n")
-}
-
-func extractComment(data []byte) (string, error) {
-	comment := ""
-	trimmedData := extractSSHPrivateKey(data)
-
-	decodedBuf, err := base64.StdEncoding.DecodeString(string(trimmedData))
-	if err != nil {
-		return comment, err
-	}
-	decodedStr := string(decodedBuf)
-	lastSpaceIndex := -1
-	for i := len(decodedStr) - 1; i >= 0; i-- {
-		if decodedStr[i] == ' ' {
-			lastSpaceIndex = i
-			break
-		}
-	}
-	if lastSpaceIndex != -1 && lastSpaceIndex < len(decodedStr)-1 {
-		comment = decodedStr[lastSpaceIndex+1:]
-	}
-
-	return comment, nil
 }

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/gossh/gossh.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/gossh/gossh.go
@@ -57,7 +57,7 @@ func CreateSSHClient(instanceScope *scope.InstanceScope) (*SSH, error) {
 	}
 
 	if len(instanceScope.Credentials.Spec.PrivateSSHKeyPassphrase) > 0 {
-		passBytes, err := base64.StdEncoding.DecodeString(instanceScope.Credentials.Spec.PasswordEncoded)
+		passBytes, err := base64.StdEncoding.DecodeString(instanceScope.Credentials.Spec.PrivateSSHKeyPassphrase)
 		if err != nil {
 			return nil, err
 		}

--- a/modules/040-node-manager/templates/caps-controller-manager/validation.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/validation.yaml
@@ -1,0 +1,37 @@
+{{- if and (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicy")) (include "helm_lib_kind_exists" (list . "ValidatingAdmissionPolicyBinding")) }}
+{{- $policyName := "caps-controller-manager" }}
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "caps-controller-manager") ) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["deckhouse.io"]
+      apiVersions: ["v1alpha1", "v1alpha2"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["sshcredentials"]
+  validations:
+  - expression: |
+      !(has(object.spec.privateSSHKeyPassphrase) && object.spec.privateSSHKeyPassphrase != "") ||
+      (has(object.spec.privateSSHKey) && object.spec.privateSSHKey != "")
+    message: "privateSSHKeyPassphrase can only be set if privateSSHKey is present."
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $policyName }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "caps-controller-manager") ) | nindent 2 }}
+spec:
+  policyName: {{ $policyName }}
+  validationActions: [Deny]
+  matchResources:
+    resourceRules:
+    - apiGroups: ["deckhouse.io"]
+      apiVersions: ["v1alpha1", "v1alpha2"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["sshcredentials"]
+{{- end }}


### PR DESCRIPTION
## Description

Add separate field for login password and ssh private key passphrase to CAPS SSHCredentials

## Why do we need it, and what problem does it solve?

Login password can differs from sudo password, so we should add field for login password too

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Add separate field for login password and ssh private key passphrase to CAPS SSHCredentials.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
