### PR TITLE
[candi] Add a detailed error when checking for containerdv2 support

### DIFF
--- a/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
+++ b/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
@@ -84,23 +84,25 @@ function set_labels() {
 function fail_fast() {
   local unsupported=$1
   local errs=$2
+
   if (( unsupported )); then
-    for err in "${errs[@]}"; do
-      if [[ "$err" == "systemd" ]]; then
-        bb-log-error "minimum required version of systemd ${MIN_SYSTEMD}"
-      fi
+    echo "$errs" | jq -c '.[]' | while read err; do
+        err=$(echo $err | sed 's/"//g')
+        if [ "$err" == "systemd" ]; then
+          bb-log-error "minimum required version of systemd ${MIN_SYSTEMD}"
+        fi
 
-      if [[ "$err" == "kernel" ]]; then
-        bb-log-error "minimum required version of kernel ${MIN_KERNEL}"
-      fi
+        if [ "$err" == "kernel" ]; then
+          bb-log-error "minimum required version of kernel ${MIN_KERNEL}"
+        fi
 
-      if [[ "$err" == "cgroupv2" ]]; then
-        bb-log-error "required cgroupv2 support"
-      fi
+        if [ "$err" == "cgroupv2" ]; then
+          bb-log-error "required cgroupv2 support"
+        fi
 
-      if [[ "$err" == "erofs" ]]; then
-        bb-log-error "required erofs kernel module"
-      fi
+        if [ "$err" == "erofs" ]; then
+          bb-log-error "required erofs kernel module"
+        fi
     done
     bb-log-error "containerd V2 is not supported"
     exit 1
@@ -120,7 +122,7 @@ function main() {
   if [ -f /etc/kubernetes/kubelet.conf ] ; then
     set_labels "$unsupported" "$errs"
   fi
-  
+
   {{- if eq .cri "ContainerdV2" }}
   fail_fast "$unsupported" "$errs"
   {{ end }}


### PR DESCRIPTION
## Description
Add a detailed error when checking for containerdv2 support

## Why do we need it, and what problem does it solve?
Bootstrap may throw an error at step 000_check_containerd_v2_support, but the message doesn't indicate what the problem is

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: chore
summary: Add a detailed error when checking for containerdv2 support
impact_level: low
```