### PR TITLE
Test for download and scan deckhouse with united cve script

### DIFF
--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -70,10 +70,42 @@ remove_labels:
     elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
       echo "SCAN_TARGET=regular" >> $GITHUB_ENV
     fi
+
+- name: Download CVE scan script from private GitLab
+  env:
+    DECKHOUSE_PRIVATE_REPO: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
+    CVE_SCRIPT_PROJECT_ID: ${{ secrets.CVE_SCRIPT_PROJECT_ID || 'PROJECT_ID' }}
+    CVE_SCRIPT_PATH: ${{ secrets.CVE_SCRIPT_PATH || 'scripts/cve_scan.sh' }}
+    CVE_SCRIPT_REF: ${{ secrets.CVE_SCRIPT_REF || 'main' }}
+  run: |
+    echo "Downloading CVE scan script from ${DECKHOUSE_PRIVATE_REPO}..."
+    mkdir -p ${{ env.WORKDIR }}/scripts
+    encoded_path=$(echo "${CVE_SCRIPT_PATH}" | sed 's/\//%2F/g' | sed 's/\./%2E/g')
+    script_url="https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${CVE_SCRIPT_PROJECT_ID}/repository/files/${encoded_path}?ref=${CVE_SCRIPT_REF}"
+    
+    echo "Downloading from: ${script_url}"
+    curl -L --fail-with-body \
+         "${script_url}" | jq -r '.content' \
+         | base64 -d > "${{ env.WORKDIR }}/scripts/cve_scan.sh"
+    chmod +x "${{ env.WORKDIR }}/scripts/cve_scan.sh"
+    
+    echo "CVE scan script downloaded successfully"
+
 - name: Run Deckhouse images CVE tests on ${{env.TAG}}
   env:
-    DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
-    DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+    TAG: ${{env.TAG}}
+    CASE: "deckhouse"
+    DD_URL: ${{secrets.DEFECTDOJO_HOST}}
+    DD_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+    DEFAULT_BRANCH: ${{github.default_branch}}
+    COMMIT_TAG: ${{github.ref_name}}
+    COMMIT_SHA: ${{github.sha}}
+    EVENT_NAME: ${{github.event_name}}
+    SCAN_TARGET="pr"
+    LATEST_RELEASES_AMOUNT="3"
+    TAG_TYPE="release"
+    SCAN_SEVERAL_LATEST_RELEASES="false"
+    MODULE_NAME: Deckhouse
     DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
     DEV_REGISTRY: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
     DEV_REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -89,7 +121,7 @@ remove_labels:
     SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   run: |
     echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
-    ./.github/scripts/cve_scan.sh
+    ${{ env.WORKDIR }}/scripts/cve_scan.sh
 # </template: cve_scan_deckhouse_images>
 {!{- end -}!}
 

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -142,10 +142,42 @@ jobs:
           elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
             echo "SCAN_TARGET=regular" >> $GITHUB_ENV
           fi
+
+      - name: Download CVE scan script from private GitLab
+        env:
+          DECKHOUSE_PRIVATE_REPO: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
+          CVE_SCRIPT_PROJECT_ID: ${{ secrets.CVE_SCRIPT_PROJECT_ID || 'PROJECT_ID' }}
+          CVE_SCRIPT_PATH: ${{ secrets.CVE_SCRIPT_PATH || 'scripts/cve_scan.sh' }}
+          CVE_SCRIPT_REF: ${{ secrets.CVE_SCRIPT_REF || 'main' }}
+        run: |
+          echo "Downloading CVE scan script from ${DECKHOUSE_PRIVATE_REPO}..."
+          mkdir -p ${{ env.WORKDIR }}/scripts
+          encoded_path=$(echo "${CVE_SCRIPT_PATH}" | sed 's/\//%2F/g' | sed 's/\./%2E/g')
+          script_url="https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${CVE_SCRIPT_PROJECT_ID}/repository/files/${encoded_path}?ref=${CVE_SCRIPT_REF}"
+
+          echo "Downloading from: ${script_url}"
+          curl -L --fail-with-body \
+               "${script_url}" | jq -r '.content' \
+               | base64 -d > "${{ env.WORKDIR }}/scripts/cve_scan.sh"
+          chmod +x "${{ env.WORKDIR }}/scripts/cve_scan.sh"
+
+          echo "CVE scan script downloaded successfully"
+
       - name: Run Deckhouse images CVE tests on ${{env.TAG}}
         env:
-          DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
-          DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+          TAG: ${{env.TAG}}
+          CASE: "deckhouse"
+          DD_URL: ${{secrets.DEFECTDOJO_HOST}}
+          DD_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+          DEFAULT_BRANCH: ${{github.default_branch}}
+          COMMIT_TAG: ${{github.ref_name}}
+          COMMIT_SHA: ${{github.sha}}
+          EVENT_NAME: ${{github.event_name}}
+          SCAN_TARGET="pr"
+          LATEST_RELEASES_AMOUNT="3"
+          TAG_TYPE="release"
+          SCAN_SEVERAL_LATEST_RELEASES="false"
+          MODULE_NAME: Deckhouse
           DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
           DEV_REGISTRY: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           DEV_REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -161,7 +193,7 @@ jobs:
           SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
-          ./.github/scripts/cve_scan.sh
+          ${{ env.WORKDIR }}/scripts/cve_scan.sh
       # </template: cve_scan_deckhouse_images>
 
       # <template: cve_tests_upload_reports_artifacts>

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -74,10 +74,42 @@ jobs:
           elif [ "${{ github.event_name }}" != "schedule" ] || [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
             echo "SCAN_TARGET=regular" >> $GITHUB_ENV
           fi
+
+      - name: Download CVE scan script from private GitLab
+        env:
+          DECKHOUSE_PRIVATE_REPO: ${{ secrets.DECKHOUSE_PRIVATE_REPO }}
+          CVE_SCRIPT_PROJECT_ID: ${{ secrets.CVE_SCRIPT_PROJECT_ID || 'PROJECT_ID' }}
+          CVE_SCRIPT_PATH: ${{ secrets.CVE_SCRIPT_PATH || 'scripts/cve_scan.sh' }}
+          CVE_SCRIPT_REF: ${{ secrets.CVE_SCRIPT_REF || 'main' }}
+        run: |
+          echo "Downloading CVE scan script from ${DECKHOUSE_PRIVATE_REPO}..."
+          mkdir -p ${{ env.WORKDIR }}/scripts
+          encoded_path=$(echo "${CVE_SCRIPT_PATH}" | sed 's/\//%2F/g' | sed 's/\./%2E/g')
+          script_url="https://${DECKHOUSE_PRIVATE_REPO}/api/v4/projects/${CVE_SCRIPT_PROJECT_ID}/repository/files/${encoded_path}?ref=${CVE_SCRIPT_REF}"
+
+          echo "Downloading from: ${script_url}"
+          curl -L --fail-with-body \
+               "${script_url}" | jq -r '.content' \
+               | base64 -d > "${{ env.WORKDIR }}/scripts/cve_scan.sh"
+          chmod +x "${{ env.WORKDIR }}/scripts/cve_scan.sh"
+
+          echo "CVE scan script downloaded successfully"
+
       - name: Run Deckhouse images CVE tests on ${{env.TAG}}
         env:
-          DEFECTDOJO_API_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
-          DEFECTDOJO_HOST: ${{secrets.DEFECTDOJO_HOST}}
+          TAG: ${{env.TAG}}
+          CASE: "deckhouse"
+          DD_URL: ${{secrets.DEFECTDOJO_HOST}}
+          DD_TOKEN: ${{secrets.DEFECTDOJO_API_TOKEN}}
+          DEFAULT_BRANCH: ${{github.default_branch}}
+          COMMIT_TAG: ${{github.ref_name}}
+          COMMIT_SHA: ${{github.sha}}
+          EVENT_NAME: ${{github.event_name}}
+          SCAN_TARGET="pr"
+          LATEST_RELEASES_AMOUNT="3"
+          TAG_TYPE="release"
+          SCAN_SEVERAL_LATEST_RELEASES="false"
+          MODULE_NAME: Deckhouse
           DECKHOUSE_PRIVATE_REPO: ${{secrets.DECKHOUSE_PRIVATE_REPO}}
           DEV_REGISTRY: ${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}
           DEV_REGISTRY_USER: ${{ secrets.DECKHOUSE_DEV_REGISTRY_USER }}
@@ -93,7 +125,7 @@ jobs:
           SEVERITY: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
         run: |
           echo "⚓️ 🏎 Running Deckhouse images CVE tests on ${TAG}..."
-          ./.github/scripts/cve_scan.sh
+          ${{ env.WORKDIR }}/scripts/cve_scan.sh
       # </template: cve_scan_deckhouse_images>
 
       # <template: cve_tests_upload_reports_artifacts>


### PR DESCRIPTION
## Description
Updated cve-pr and cve-weekly workflow. 

## Why do we need it, and what problem does it solve?
Downloads the combined script from gitlab to test dekhouse and external modules.

## Why do we need it in the patch release (if we do)?

<!---
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
-->

```changes
section: ci
type: chore
summary: The combined script from gitlab to test dekhouse and external modules
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
