### PR TITLE
[prometheus] Add POD_IP var to config

### DIFF
--- a/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/configmap.yaml
@@ -7,6 +7,8 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "aggregating-proxy")) | nindent 2 }}
 data:
   mimir.yaml: |
+    memberlist:
+      advertise_addr: ${POD_IP}
     multitenancy_enabled: false
     activity_tracker:
       filepath: ""

--- a/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
+++ b/modules/300-prometheus/templates/aggregating-proxy/deployment.yaml
@@ -86,6 +86,11 @@ spec:
             - "-config.expand-env"
             - "-log.format=json"
             - "-log.level=info"
+          env:
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - mountPath: /etc/mimir/config.yaml
               name: aggregating-proxy-config


### PR DESCRIPTION
## Description
Add POD_IP var to config

## Why do we need it, and what problem does it solve?
In aggregating-proxy, Mimir is used as the query-frontend. When Mimir starts, it launches gossip-rings. In the default configuration (when no bind address or advertise address is specified), Mimir’s code attempts to find interfaces with private addresses and uses the first one it finds for gossip-ring.

If the client uses a pod network that does not belong to private networks, an error occurs, the container crashes, and aggregating-proxy stops working.


## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Added POD_IP var to config.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
