### PR TITLE
feat: update DeckhouseHighMemoryUsage alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3568,7 +3568,7 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Deckhouse pod `{{ $labels.pod }}` on node `{{ $labels.node }}` has high memory usage.
+        Deckhouse pod `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` on node `{{ $labels.node }}` has high memory usage.
 
         Please, if possible, get the dumps for debugging purposes (it will take around 30 seconds):
 

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -366,15 +366,15 @@
         ```
 
   - alert: DeckhouseHighMemoryUsage
-    expr: max by (pod, node) (container_memory_working_set_bytes{namespace="d8-system", container="deckhouse"} / container_spec_memory_limit_bytes{namespace="d8-system", container="deckhouse"} > 0.9)
-    for: 1m
+    expr: max by (pod, namespace, node) (container_memory_working_set_bytes{container="deckhouse"} / container_spec_memory_limit_bytes{container="deckhouse"} > 0.85)
+    for: 30s
     labels:
       severity_level: "3"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       description: |
-        Deckhouse pod `{{ $labels.pod }}` on node `{{ $labels.node }}` has high memory usage.
+        Deckhouse pod `{{ $labels.pod }}` in namespace `{{ $labels.namespace }}` on node `{{ $labels.node }}` has high memory usage.
 
         Please, if possible, get the dumps for debugging purposes (it will take around 30 seconds):
 


### PR DESCRIPTION
## Description
- Update DeckhouseHighMemoryUsage alert:
  - Add namespace to grouping: max by (pod, namespace, node)
  - Remove hardcoded namespace filter to cover all namespaces
  - Lower threshold to > 0.85
  - Reduce for duration to 30s
- Sync documentation to include namespace in alert description.

This change only affects Prometheus alerting rules and documentation.

## Why do we need it, and what problem does it solve?
- Increases alert accuracy and visibility across namespaces by grouping on namespace instead of hardcoding a single namespace.
- Makes the alert more sensitive and faster to surface memory pressure on the Deckhouse container, improving MTTR.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: deckhouse-controller
type: feature
summary: Widen and tune DeckhouseHighMemoryUsage alert (namespace grouping, 0.85 threshold, 30s for)
```