### PR TITLE
[user-authn] Truncate long DexAuthenticator resource names

### DIFF
--- a/modules/150-user-authn/docs/FAQ.md
+++ b/modules/150-user-authn/docs/FAQ.md
@@ -52,15 +52,14 @@ To enable Dex authentication for your application, follow these steps:
    - `nginx.ingress.kubernetes.io/auth-signin: https://$host/dex-authenticator/sign_in`
    - `nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email`
    - `nginx.ingress.kubernetes.io/auth-url: https://<SERVICE_NAME>.<NS>.svc.{{ C_DOMAIN }}/dex-authenticator/auth`, where:
-      - `SERVICE_NAME` — is the name of the authenticator's Service. Usually, it is `<NAME>-dex-authenticator` (`<NAME>` is the `metadata.name` of the `DexAuthenticator` resource).
-      - `NS` — the value of the `metadata.namespace` parameter of the `DexAuthenticator` resource.
+      - `SERVICE_NAME` — is the name of the authenticator's Service. Usually, it is `<NAME>-dex-authenticator` (`<NAME>` is the `metadata.name` of the DexAuthenticator).
+      - `NS` — the value of the `metadata.namespace` parameter of the DexAuthenticator.
       - `C_DOMAIN` — the cluster domain (the [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) parameter of the `ClusterConfiguration` resource).
 
-   > **Note:** If the `DexAuthenticator` resource name (`<NAME>`) is too long, the Service name may be truncated. To find the correct service name, you can always use the following command:
+   > **Note:** If the DexAuthenticator name (`<NAME>`) is too long, the Service name may be truncated. To find the correct service name, use the following command (specify namespace name and DexAuthenticator name):
    > ```shell
-   > kubectl get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
+   > d8 k get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
    > ```
-   > Replace `<NS>` and `<NAME>` with your values.
 
    Below is an example of annotations added to an application's Ingress resource so that it can be connected to Dex:
 

--- a/modules/150-user-authn/docs/FAQ.md
+++ b/modules/150-user-authn/docs/FAQ.md
@@ -51,10 +51,16 @@ To enable Dex authentication for your application, follow these steps:
 
    - `nginx.ingress.kubernetes.io/auth-signin: https://$host/dex-authenticator/sign_in`
    - `nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email`
-   - `nginx.ingress.kubernetes.io/auth-url: https://<NAME>-dex-authenticator.<NS>.svc.{{ C_DOMAIN }}/dex-authenticator/auth`, where:
-      - `NAME` — the value of the `metadata.name` parameter of the `DexAuthenticator` resource;
-      - `NS` — the value of the `metadata.namespace` parameter of the `DexAuthenticator` resource;
+   - `nginx.ingress.kubernetes.io/auth-url: https://<SERVICE_NAME>.<NS>.svc.{{ C_DOMAIN }}/dex-authenticator/auth`, where:
+      - `SERVICE_NAME` — is the name of the authenticator's Service. Usually, it is `<NAME>-dex-authenticator` (`<NAME>` is the `metadata.name` of the `DexAuthenticator` resource).
+      - `NS` — the value of the `metadata.namespace` parameter of the `DexAuthenticator` resource.
       - `C_DOMAIN` — the cluster domain (the [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) parameter of the `ClusterConfiguration` resource).
+
+   > **Note:** If the `DexAuthenticator` resource name (`<NAME>`) is too long, the Service name will be truncated to fit within Kubernetes' 63-character limit. In this case, you can find the correct service name by running the following command:
+   > ```shell
+   > kubectl get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
+   > ```
+   > Replace `<NS>` and `<NAME>` with your values. If this command returns an empty string, it means the name was not truncated and you should use the standard `<NAME>-dex-authenticator` format.
 
    Below is an example of annotations added to an application's Ingress resource so that it can be connected to Dex:
 

--- a/modules/150-user-authn/docs/FAQ.md
+++ b/modules/150-user-authn/docs/FAQ.md
@@ -56,11 +56,11 @@ To enable Dex authentication for your application, follow these steps:
       - `NS` — the value of the `metadata.namespace` parameter of the `DexAuthenticator` resource.
       - `C_DOMAIN` — the cluster domain (the [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) parameter of the `ClusterConfiguration` resource).
 
-   > **Note:** If the `DexAuthenticator` resource name (`<NAME>`) is too long, the Service name will be truncated to fit within Kubernetes' 63-character limit. In this case, you can find the correct service name by running the following command:
+   > **Note:** If the `DexAuthenticator` resource name (`<NAME>`) is too long, the Service name may be truncated. To find the correct service name, you can always use the following command:
    > ```shell
    > kubectl get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
    > ```
-   > Replace `<NS>` and `<NAME>` with your values. If this command returns an empty string, it means the name was not truncated and you should use the standard `<NAME>-dex-authenticator` format.
+   > Replace `<NS>` and `<NAME>` with your values.
 
    Below is an example of annotations added to an application's Ingress resource so that it can be connected to Dex:
 

--- a/modules/150-user-authn/docs/FAQ.md
+++ b/modules/150-user-authn/docs/FAQ.md
@@ -57,9 +57,11 @@ To enable Dex authentication for your application, follow these steps:
       - `C_DOMAIN` — the cluster domain (the [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) parameter of the `ClusterConfiguration` resource).
 
    > **Note:** If the DexAuthenticator name (`<NAME>`) is too long, the Service name may be truncated. To find the correct service name, use the following command (specify namespace name and DexAuthenticator name):
+   >
    > ```shell
    > d8 k get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
    > ```
+   >
 
    Below is an example of annotations added to an application's Ingress resource so that it can be connected to Dex:
 

--- a/modules/150-user-authn/docs/FAQ_RU.md
+++ b/modules/150-user-authn/docs/FAQ_RU.md
@@ -50,10 +50,16 @@ title: "Модуль user-authn: FAQ"
 
    - `nginx.ingress.kubernetes.io/auth-signin: https://$host/dex-authenticator/sign_in`
    - `nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email`
-   - `nginx.ingress.kubernetes.io/auth-url: https://<NAME>-dex-authenticator.<NS>.svc.{{ C_DOMAIN }}/dex-authenticator/auth`, где:
-      - `NAME` — значение параметра `metadata.name` ресурса `DexAuthenticator`;
-      - `NS` — значение параметра `metadata.namespace` ресурса `DexAuthenticator`;
+   - `nginx.ingress.kubernetes.io/auth-url: https://<SERVICE_NAME>.<NS>.svc.{{ C_DOMAIN }}/dex-authenticator/auth`, где:
+      - `SERVICE_NAME` — имя Service'а аутентификатора. Как правило, оно соответствует формату `<NAME>-dex-authenticator` (`<NAME>` — это `metadata.name` ресурса `DexAuthenticator`).
+      - `NS` — значение параметра `metadata.namespace` ресурса `DexAuthenticator`.
       - `C_DOMAIN` — домен кластера (параметр [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) ресурса `ClusterConfiguration`).
+
+   > **Важно:** Если имя ресурса `DexAuthenticator` (`<NAME>`) слишком длинное, имя Service будет сокращено, чтобы соответствовать ограничению Kubernetes в 63 символа. В этом случае вы можете найти корректное имя сервиса с помощью следующей команды:
+   > ```shell
+   > kubectl get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
+   > ```
+   > Замените `<NS>` и `<NAME>` на ваши значения. Если команда вернет пустую строку, значит, имя не было сокращено и следует использовать стандартный формат `<NAME>-dex-authenticator`.
 
    Ниже представлен пример аннотаций на Ingress-ресурсе приложения, для подключения его к Dex:
 

--- a/modules/150-user-authn/docs/FAQ_RU.md
+++ b/modules/150-user-authn/docs/FAQ_RU.md
@@ -55,11 +55,11 @@ title: "Модуль user-authn: FAQ"
       - `NS` — значение параметра `metadata.namespace` ресурса `DexAuthenticator`.
       - `C_DOMAIN` — домен кластера (параметр [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) ресурса `ClusterConfiguration`).
 
-   > **Важно:** Если имя ресурса `DexAuthenticator` (`<NAME>`) слишком длинное, имя Service будет сокращено, чтобы соответствовать ограничению Kubernetes в 63 символа. В этом случае вы можете найти корректное имя сервиса с помощью следующей команды:
+   > **Важно:** Если имя ресурса `DexAuthenticator` (`<NAME>`) слишком длинное, имя Service может быть сокращено. Чтобы найти корректное имя сервиса, вы всегда можете воспользоваться следующей командой:
    > ```shell
    > kubectl get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
    > ```
-   > Замените `<NS>` и `<NAME>` на ваши значения. Если команда вернет пустую строку, значит, имя не было сокращено и следует использовать стандартный формат `<NAME>-dex-authenticator`.
+   > Замените `<NS>` и `<NAME>` на ваши значения.
 
    Ниже представлен пример аннотаций на Ingress-ресурсе приложения, для подключения его к Dex:
 

--- a/modules/150-user-authn/docs/FAQ_RU.md
+++ b/modules/150-user-authn/docs/FAQ_RU.md
@@ -56,9 +56,11 @@ title: "Модуль user-authn: FAQ"
       - `C_DOMAIN` — домен кластера (параметр [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) ресурса `ClusterConfiguration`).
 
    > **Важно:** Если имя DexAuthenticator (`<NAME>`) слишком длинное, имя сервиса (Service) может быть сокращено. Чтобы найти корректное имя сервиса, воспользуйтесь следующей командой (укажите имя пространства имен и имя аутентификатора):
+   >
    > ```shell
    > d8 k get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
    > ```
+   >
 
    Ниже представлен пример аннотаций на Ingress-ресурсе приложения, для подключения его к Dex:
 

--- a/modules/150-user-authn/docs/FAQ_RU.md
+++ b/modules/150-user-authn/docs/FAQ_RU.md
@@ -51,15 +51,14 @@ title: "Модуль user-authn: FAQ"
    - `nginx.ingress.kubernetes.io/auth-signin: https://$host/dex-authenticator/sign_in`
    - `nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User,X-Auth-Request-Email`
    - `nginx.ingress.kubernetes.io/auth-url: https://<SERVICE_NAME>.<NS>.svc.{{ C_DOMAIN }}/dex-authenticator/auth`, где:
-      - `SERVICE_NAME` — имя Service'а аутентификатора. Как правило, оно соответствует формату `<NAME>-dex-authenticator` (`<NAME>` — это `metadata.name` ресурса `DexAuthenticator`).
+      - `SERVICE_NAME` — имя сервиса (Service) аутентификатора. Как правило, оно соответствует формату `<NAME>-dex-authenticator` (`<NAME>` — это `metadata.name` DexAuthenticator).
       - `NS` — значение параметра `metadata.namespace` ресурса `DexAuthenticator`.
       - `C_DOMAIN` — домен кластера (параметр [clusterDomain](../../installing/configuration.html#clusterconfiguration-clusterdomain) ресурса `ClusterConfiguration`).
 
-   > **Важно:** Если имя ресурса `DexAuthenticator` (`<NAME>`) слишком длинное, имя Service может быть сокращено. Чтобы найти корректное имя сервиса, вы всегда можете воспользоваться следующей командой:
+   > **Важно:** Если имя DexAuthenticator (`<NAME>`) слишком длинное, имя сервиса (Service) может быть сокращено. Чтобы найти корректное имя сервиса, воспользуйтесь следующей командой (укажите имя пространства имен и имя аутентификатора):
    > ```shell
-   > kubectl get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
+   > d8 k get service -n <NS> -l "deckhouse.io/dex-authenticator-for=<NAME>" -o jsonpath='{.items[0].metadata.name}'
    > ```
-   > Замените `<NS>` и `<NAME>` на ваши значения.
 
    Ниже представлен пример аннотаций на Ingress-ресурсе приложения, для подключения его к Dex:
 

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -283,17 +283,17 @@ spec:
 
 			// Long name checks
 			longID := longName + "@test"
-			Expect(namesMap.Get(longID).Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("name").String()).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("truncated").Bool()).Should(BeTrue())
 			Expect(namesMap.Get(longID).Get("hash").String()).ShouldNot(BeEmpty())
 
-			Expect(namesMap.Get(longID).Get("ingressNames").Get("0").Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("ingressNames").Get("0").Get("name").String()).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("ingressNames").Get("0").Get("truncated").Bool()).Should(BeTrue())
 
-			Expect(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("name").String()).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("truncated").Bool()).Should(BeTrue())
 
-			Expect(namesMap.Get(longID).Get("ingressNames").Get("1").Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("ingressNames").Get("1").Get("name").String()).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("ingressNames").Get("1").Get("truncated").Bool()).Should(BeTrue())
 
 			// Short name checks

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package hooks
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -241,5 +245,103 @@ data:
   }
 }]`))
 		})
+	})
+
+	Context("With DexAuthenticator with multiple applications", func() {
+		const longName = "this-is-a-very-very-long-name-that-will-be-truncated-for-sure"
+		const shortName = "short-name"
+
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v2alpha1
+kind: DexAuthenticator
+metadata:
+  name: ` + longName + `
+  namespace: test
+spec:
+  applications:
+  - domain: long.name.one.com
+    signOutURL: /logout
+  - domain: long.name.two.com
+---
+apiVersion: deckhouse.io/v2alpha1
+kind: DexAuthenticator
+metadata:
+  name: ` + shortName + `
+  namespace: test
+spec:
+  applications:
+  - domain: short.name.one.com
+`))
+			f.RunHook()
+		})
+		It("Should fill names map with base, ingress and sign-out ingress names", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			namesMap := f.ValuesGet("userAuthn.internal.dexAuthenticatorNames")
+			Expect(namesMap.Exists()).To(BeTrue())
+
+			// Long name checks
+			longID := longName + "@test"
+			Expect(namesMap.Get(longID).Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("truncated").Bool()).Should(BeTrue())
+			Expect(namesMap.Get(longID).Get("hash").String()).ShouldNot(BeEmpty())
+
+			Expect(namesMap.Get(longID).Get("ingressNames").Get("0").Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("ingressNames").Get("0").Get("truncated").Bool()).Should(BeTrue())
+
+			Expect(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("truncated").Bool()).Should(BeTrue())
+
+			Expect(namesMap.Get(longID).Get("ingressNames").Get("1").Get("name").String()).Should(HaveLen(63))
+			Expect(namesMap.Get(longID).Get("ingressNames").Get("1").Get("truncated").Bool()).Should(BeTrue())
+
+			// Short name checks
+			shortID := shortName + "@test"
+			Expect(namesMap.Get(shortID).Get("name").String()).Should(Equal(shortName + "-dex-authenticator"))
+			Expect(namesMap.Get(shortID).Get("truncated").Bool()).Should(BeFalse())
+
+			Expect(namesMap.Get(shortID).Get("ingressNames").Get("0").Get("name").String()).Should(Equal(shortName + "-dex-authenticator"))
+			Expect(namesMap.Get(shortID).Get("ingressNames").Get("0").Get("truncated").Bool()).Should(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("safeDNS1123Name", func() {
+	It("keeps names <=63 as-is", func() {
+		name := strings.Repeat("a", 63)
+		safe, truncated, hash5 := SafeDNS1123Name(name)
+		Expect(safe).To(Equal(name))
+		Expect(truncated).To(BeFalse())
+		Expect(hash5).To(Equal(""))
+	})
+
+	It("truncates names >63 to 57 and appends -hash5", func() {
+		original := strings.Repeat("a", 64)
+		h := sha256.Sum256([]byte(original))
+		expected := strings.Repeat("a", 57) + "-" + hex.EncodeToString(h[:])[:5]
+		safe, truncated, hash5 := SafeDNS1123Name(original)
+		Expect(truncated).To(BeTrue())
+		Expect(len(safe)).To(BeNumerically("<=", 63))
+		Expect(safe).To(Equal(expected))
+		Expect(hash5).To(Equal(expected[len(expected)-5:]))
+	})
+
+	It("normalizes invalid characters and case only when truncating is needed", func() {
+		in := "A_B.C-"
+		// len("A_B.C-") is 6 <= 63, so function returns input as-is
+		safe, truncated, hash5 := SafeDNS1123Name(in)
+		Expect(safe).To(Equal(in))
+		Expect(truncated).To(BeFalse())
+		Expect(hash5).To(Equal(""))
+	})
+
+	It("is deterministic for same input", func() {
+		in := strings.Repeat("x", 70)
+		s1, t1, h1 := SafeDNS1123Name(in)
+		s2, t2, h2 := SafeDNS1123Name(in)
+		Expect(s1).To(Equal(s2))
+		Expect(t1).To(Equal(t2))
+		Expect(h1).To(Equal(h2))
 	})
 })

--- a/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_authenticator_crds_test.go
@@ -283,17 +283,17 @@ spec:
 
 			// Long name checks
 			longID := longName + "@test"
-			Expect(namesMap.Get(longID).Get("name").String()).Should(BeNumerically("<=", 63))
+			Expect(len(namesMap.Get(longID).Get("name").String())).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("truncated").Bool()).Should(BeTrue())
 			Expect(namesMap.Get(longID).Get("hash").String()).ShouldNot(BeEmpty())
 
-			Expect(namesMap.Get(longID).Get("ingressNames").Get("0").Get("name").String()).Should(BeNumerically("<=", 63))
+			Expect(len(namesMap.Get(longID).Get("ingressNames").Get("0").Get("name").String())).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("ingressNames").Get("0").Get("truncated").Bool()).Should(BeTrue())
 
-			Expect(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("name").String()).Should(BeNumerically("<=", 63))
+			Expect(len(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("name").String())).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("signOutIngressNames").Get("0").Get("truncated").Bool()).Should(BeTrue())
 
-			Expect(namesMap.Get(longID).Get("ingressNames").Get("1").Get("name").String()).Should(BeNumerically("<=", 63))
+			Expect(len(namesMap.Get(longID).Get("ingressNames").Get("1").Get("name").String())).Should(BeNumerically("<=", 63))
 			Expect(namesMap.Get(longID).Get("ingressNames").Get("1").Get("truncated").Bool()).Should(BeTrue())
 
 			// Short name checks

--- a/modules/150-user-authn/openapi/values.yaml
+++ b/modules/150-user-authn/openapi/values.yaml
@@ -132,6 +132,10 @@ properties:
                   type: string
                 appDexSecret:
                   type: string
+      dexAuthenticatorNames:
+        type: object
+        default: {}
+        additionalProperties: true
       dexClientCRDs:
         type: array
         default: []

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -109,6 +109,56 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
     keepUsersLoggedInFor: "2h20m4s"
 `)
 			hec.ValuesSet("userAuthn.idTokenTTL", "2h20m4s")
+
+			// Since template tests do not run Go hooks, we must mock the values the hook would have created.
+			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
+"test-2@d8-test":
+  name: "test-2-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test-2"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames:
+    "0":
+      name: "test-2-dex-authenticator"
+      truncated: false
+      hash: ""
+    "1":
+      name: "test-2-3230e1af-dex-authenticator"
+      truncated: false
+      hash: ""
+"test-3@d8-test":
+  name: "test-3-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test-3"
+  secretTruncated: false
+  secretHash: ""
+"test-4@d8-test":
+  name: "test-4-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test-4"
+  secretTruncated: false
+  secretHash: ""
+"test@d8-test":
+  name: "test-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames:
+    "0":
+      name: "test-dex-authenticator"
+      truncated: false
+      hash: ""
+    "1":
+      name: "test-05f0e90e-dex-authenticator"
+      truncated: false
+      hash: ""
+`)
 			hec.HelmRender()
 		})
 		It("Should create desired objects", func() {

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -112,7 +112,10 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			hec.HelmRender()
 		})
 		It("Should create desired objects", func() {
-			Expect(hec.KubernetesResource("Service", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
+			svc := hec.KubernetesResource("Service", "d8-test", "test-dex-authenticator")
+			Expect(svc.Exists()).To(BeTrue())
+			Expect(svc.Field("metadata.labels.deckhouse\\.io/dex-authenticator-for").Exists()).To(BeFalse())
+
 			Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("Secret", "d8-test", "registry-dex-authenticator").Exists()).To(BeTrue())
@@ -178,6 +181,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			ingressTest2 := hec.KubernetesResource("Ingress", "d8-test", "test-2-dex-authenticator")
 			Expect(ingressTest2.Exists()).To(BeTrue())
 			Expect(ingressTest2.Field("spec.ingressClassName").String()).To(Equal("test"))
+			Expect(ingressTest2.Field("metadata.labels.deckhouse\\.io/name-truncated").Exists()).To(BeFalse())
 
 			Expect(ingressTest2.Field("spec.tls.0.hosts").String()).To(MatchJSON(`["authenticator.com"]`))
 			Expect(ingressTest2.Field("spec.tls.0.secretName").String()).To(Equal("test"))
@@ -187,6 +191,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			ingressTest2Two := hec.KubernetesResource("Ingress", "d8-test", "test-2-3230e1af-dex-authenticator")
 			Expect(ingressTest2Two.Exists()).To(BeTrue())
 			Expect(ingressTest2Two.Field("spec.ingressClassName").String()).To(Equal("test-two"))
+			Expect(ingressTest2Two.Field("metadata.labels.deckhouse\\.io/name-truncated").Exists()).To(BeFalse())
 
 			Expect(ingressTest2Two.Field("spec.tls.0.hosts").String()).To(MatchJSON(`["authenticator-two.com"]`))
 			Expect(ingressTest2Two.Field("spec.tls.0.secretName").String()).To(Equal("test"))

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -164,7 +164,8 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 		It("Should create desired objects", func() {
 			svc := hec.KubernetesResource("Service", "d8-test", "test-dex-authenticator")
 			Expect(svc.Exists()).To(BeTrue())
-			Expect(svc.Field("metadata.labels.deckhouse\\.io/dex-authenticator-for").Exists()).To(BeFalse())
+			Expect(svc.Field("metadata.labels.deckhouse\\.io/dex-authenticator-for").String()).To(Equal("test"))
+			Expect(svc.Field("metadata.labels.deckhouse\\.io/name-truncated").Exists()).To(BeFalse())
 
 			Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
 			Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", "test-dex-authenticator").Exists()).To(BeTrue())
@@ -231,6 +232,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			ingressTest2 := hec.KubernetesResource("Ingress", "d8-test", "test-2-dex-authenticator")
 			Expect(ingressTest2.Exists()).To(BeTrue())
 			Expect(ingressTest2.Field("spec.ingressClassName").String()).To(Equal("test"))
+			Expect(ingressTest2.Field("metadata.labels.deckhouse\\.io/dex-authenticator-for").String()).To(Equal("test-2"))
 			Expect(ingressTest2.Field("metadata.labels.deckhouse\\.io/name-truncated").Exists()).To(BeFalse())
 
 			Expect(ingressTest2.Field("spec.tls.0.hosts").String()).To(MatchJSON(`["authenticator.com"]`))
@@ -241,6 +243,7 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
 			ingressTest2Two := hec.KubernetesResource("Ingress", "d8-test", "test-2-3230e1af-dex-authenticator")
 			Expect(ingressTest2Two.Exists()).To(BeTrue())
 			Expect(ingressTest2Two.Field("spec.ingressClassName").String()).To(Equal("test-two"))
+			Expect(ingressTest2Two.Field("metadata.labels.deckhouse\\.io/dex-authenticator-for").String()).To(Equal("test-2"))
 			Expect(ingressTest2Two.Field("metadata.labels.deckhouse\\.io/name-truncated").Exists()).To(BeFalse())
 
 			Expect(ingressTest2Two.Field("spec.tls.0.hosts").String()).To(MatchJSON(`["authenticator-two.com"]`))

--- a/modules/150-user-authn/template_tests/authenticator_truncation_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_truncation_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+
+	"github.com/deckhouse/deckhouse/modules/150-user-authn/hooks"
+)
+
+var _ = Describe("Module :: user-authn :: helm template :: truncation", func() {
+	hec := SetupHelmConfig("")
+
+	BeforeEach(func() {
+		hec.ValuesSet("global.discovery.kubernetesVersion", "1.25.0")
+		hec.ValuesSet("global.modules.publicDomainTemplate", "%s.example.com")
+		hec.ValuesSet("global.modules.https.mode", "CertManager")
+		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
+		hec.ValuesSet("global.modulesImages.registry.base", "registry.example.com")
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler"})
+		hec.ValuesSet("global.discovery.kubernetesCA", "plainstring")
+
+		hec.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.crt", "plainstring")
+		hec.ValuesSet("userAuthn.internal.dexTLS.key", "plainstring")
+	})
+
+	It("should render truncated name with labels and ingress backend references it", func() {
+		longName := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbb"
+		hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorCRDs", `
+			- name: `+longName+`
+			encodedName: enc
+			namespace: d8-test
+			credentials:
+				appDexSecret: dexSecret
+				cookieSecret: cookieSecret
+			spec:
+				applications:
+				- domain: app.example.com
+				ingressClassName: test
+			`)
+		hec.HelmRender()
+		Expect(hec.RenderError).ShouldNot(HaveOccurred())
+
+		// Calculate expected truncated names
+		baseFullName := fmt.Sprintf("%s-dex-authenticator", longName)
+		truncatedBaseName, _, baseHash := hooks.SafeDNS1123Name(baseFullName)
+		Expect(len(truncatedBaseName)).Should(BeNumerically("<=", 63))
+
+		// Check Service
+		svc := hec.KubernetesResource("Service", "d8-test", truncatedBaseName)
+		Expect(svc.Exists()).To(BeTrue())
+		Expect(svc.Field("metadata.labels.deckhouse\\.io/dex-authenticator-for").String()).To(Equal(longName))
+		Expect(svc.Field("metadata.labels.deckhouse\\.io/name-truncated").String()).To(Equal("true"))
+		Expect(svc.Field("metadata.labels.deckhouse\\.io/name-hash").String()).To(Equal(baseHash))
+
+		// Deployment/PDB/VPA share the same name and labels
+		dep := hec.KubernetesResource("Deployment", "d8-test", truncatedBaseName)
+		Expect(dep.Exists()).To(BeTrue())
+		Expect(dep.Field("metadata.labels.deckhouse\\.io/dex-authenticator-for").String()).To(Equal(longName))
+		Expect(dep.Field("metadata.labels.deckhouse\\.io/name-hash").String()).To(Equal(baseHash))
+		Expect(hec.KubernetesResource("PodDisruptionBudget", "d8-test", truncatedBaseName).Exists()).To(BeTrue())
+		Expect(hec.KubernetesResource("VerticalPodAutoscaler", "d8-test", truncatedBaseName).Exists()).To(BeTrue())
+
+		// Check Ingress
+		ingressFullName := fmt.Sprintf("%s-dex-authenticator", longName)
+		truncatedIngressName, _, ingressHash := hooks.SafeDNS1123Name(ingressFullName)
+		ing := hec.KubernetesResource("Ingress", "d8-test", truncatedIngressName)
+		Expect(ing.Exists()).To(BeTrue())
+		Expect(ing.Field("metadata.labels.deckhouse\\.io/name-truncated").String()).To(Equal("true"))
+		Expect(ing.Field("metadata.labels.deckhouse\\.io/name-hash").String()).To(Equal(ingressHash))
+		Expect(ing.Field("spec.rules.0.http.paths.0.backend.service.name").String()).To(Equal(truncatedBaseName))
+
+		// Check Secret
+		secretFullName := fmt.Sprintf("dex-authenticator-%s", longName)
+		truncatedSecretName, _, secretHash := hooks.SafeDNS1123Name(secretFullName)
+		secret := hec.KubernetesResource("Secret", "d8-test", truncatedSecretName)
+		Expect(secret.Exists()).To(BeTrue())
+		Expect(secret.Field("metadata.labels.deckhouse\\.io/name-truncated").String()).To(Equal("true"))
+		Expect(secret.Field("metadata.labels.deckhouse\\.io/name-hash").String()).To(Equal(secretHash))
+	})
+})

--- a/modules/150-user-authn/template_tests/authenticator_truncation_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_truncation_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Module :: user-authn :: helm template :: truncation", func() {
 		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
 		hec.ValuesSet("global.modulesImages.registry.base", "registry.example.com")
 		hec.ValuesSet("global.enabledModules", []string{"cert-manager", "vertical-pod-autoscaler"})
+		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
 		hec.ValuesSet("global.discovery.kubernetesCA", "plainstring")
 
 		hec.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", "plainstring")

--- a/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
+++ b/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
@@ -66,6 +66,16 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
     applicationDomain: authenticator.example.com
     applicationIngressCertificateSecretName: test
 `)
+			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
+"test@d8-test":
+  name: "test-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames: {}
+`)
 			hec.HelmRender()
 		})
 		It("Should deploy kubernetes OAuth2Client", func() {
@@ -86,6 +96,16 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
   spec:
     applicationDomain: authenticator.example.com
     applicationIngressCertificateSecretName: test
+`)
+			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
+"test@d8-test":
+  name: "test-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-test"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames: {}
 `)
 			hec.HelmRender()
 		})

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -11,7 +11,7 @@ memory: 25Mi
 {{- $context := . }}
 {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
   {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-  {{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+  {{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
   {{- $baseName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
   {{- $truncated := (index $info "truncated") }}
   {{- $hash := (index $info "hash") }}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -23,9 +23,8 @@ kind: VerticalPodAutoscaler
 metadata:
   name: {{ $baseName }}
   namespace: {{ $crd.namespace }}
-  {{- $vpaLabels := dict "app" "dex-authenticator" }}
+  {{- $vpaLabels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- if $truncated }}
-  {{- $_ := set $vpaLabels "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- $_ := set $vpaLabels "deckhouse.io/name-truncated" "true" }}
   {{- $_ := set $vpaLabels "deckhouse.io/name-hash" $hash }}
   {{- end }}
@@ -58,9 +57,8 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ $baseName }}
   namespace: {{ $crd.namespace }}
-  {{- $pdbLabels := dict "app" "dex-authenticator" }}
+  {{- $pdbLabels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- if $truncated }}
-  {{- $_ := set $pdbLabels "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- $_ := set $pdbLabels "deckhouse.io/name-truncated" "true" }}
   {{- $_ := set $pdbLabels "deckhouse.io/name-hash" $hash }}
   {{- end }}
@@ -77,9 +75,8 @@ kind: Deployment
 metadata:
   name: {{ $baseName }}
   namespace: {{ $crd.namespace }}
-  {{- $depLabels := dict "app" "dex-authenticator" }}
+  {{- $depLabels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- if $truncated }}
-  {{- $_ := set $depLabels "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- $_ := set $depLabels "deckhouse.io/name-truncated" "true" }}
   {{- $_ := set $depLabels "deckhouse.io/name-hash" $hash }}
   {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -9,9 +9,10 @@ memory: 25Mi
 {{- end }}
 
 {{- $context := . }}
-{{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
+{{- $dexAuthenticatorNames := .Values.userAuthn.internal.dexAuthenticatorNames | default dict -}}
+{{- range $crd := .Values.userAuthn.internal.dexAuthenticatorCRDs }}
   {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-  {{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
+  {{- $info := index $dexAuthenticatorNames $id | default dict }}
   {{- $baseName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
   {{- $truncated := (index $info "truncated") }}
   {{- $hash := (index $info "hash") }}

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -10,19 +10,31 @@ memory: 25Mi
 
 {{- $context := . }}
 {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
+  {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
+  {{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+  {{- $baseName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
+  {{- $truncated := (index $info "truncated") }}
+  {{- $hash := (index $info "hash") }}
+  {{- $secretName := (default (printf "dex-authenticator-%s" $crd.name) (index $info "secretName")) }}
   {{- if $context.Values.global.enabledModules | has "vertical-pod-autoscaler" }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ $baseName }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
+  {{- $vpaLabels := dict "app" "dex-authenticator" }}
+  {{- if $truncated }}
+  {{- $_ := set $vpaLabels "deckhouse.io/dex-authenticator-for" $crd.name }}
+  {{- $_ := set $vpaLabels "deckhouse.io/name-truncated" "true" }}
+  {{- $_ := set $vpaLabels "deckhouse.io/name-hash" $hash }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $vpaLabels) | nindent 2 }}
 spec:
   targetRef:
     apiVersion: "apps/v1"
     kind: Deployment
-    name: {{ $crd.name }}-dex-authenticator
+    name: {{ $baseName }}
   updatePolicy:
     updateMode: "Auto"
   resourcePolicy:
@@ -44,9 +56,15 @@ spec:
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ $baseName }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
+  {{- $pdbLabels := dict "app" "dex-authenticator" }}
+  {{- if $truncated }}
+  {{- $_ := set $pdbLabels "deckhouse.io/dex-authenticator-for" $crd.name }}
+  {{- $_ := set $pdbLabels "deckhouse.io/name-truncated" "true" }}
+  {{- $_ := set $pdbLabels "deckhouse.io/name-hash" $hash }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $pdbLabels) | nindent 2 }}
 spec:
   minAvailable: {{ if ne $crd.spec.highAvailability nil }}{{ if $crd.spec.highAvailability }}1{{ else }}0{{ end }}{{ else }}{{ include "helm_lib_is_ha_to_value" (list $context 1 0) }}{{ end }}
   selector:
@@ -57,9 +75,15 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ $baseName }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
+  {{- $depLabels := dict "app" "dex-authenticator" }}
+  {{- if $truncated }}
+  {{- $_ := set $depLabels "deckhouse.io/dex-authenticator-for" $crd.name }}
+  {{- $_ := set $depLabels "deckhouse.io/name-truncated" "true" }}
+  {{- $_ := set $depLabels "deckhouse.io/name-hash" $hash }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $depLabels) | nindent 2 }}
 spec:
   replicas: {{ if ne $crd.spec.highAvailability nil }}{{ if $crd.spec.highAvailability }}2{{ else }}1{{ end }}{{ else }}{{ include "helm_lib_is_ha_to_value" (list $context 2 1) }}{{ end }}
   revisionHistoryLimit: 2
@@ -105,8 +129,8 @@ spec:
         emptyDir: {}
       initContainers:
       - args:
-        - {{ $crd.name }}-dex-authenticator.{{ $crd.namespace }}
-        - {{ $crd.name }}-dex-authenticator.{{ $crd.namespace }}.svc
+        - {{ $baseName }}.{{ $crd.namespace }}
+        - {{ $baseName }}.{{ $crd.namespace }}.svc
         image: {{ include "helm_lib_module_image" (list $context "selfSignedGenerator") }}
         name: self-signed-generator
         volumeMounts:
@@ -172,12 +196,12 @@ spec:
         - name: OAUTH2_PROXY_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: dex-authenticator-{{ $crd.name }}
+              name: {{ $secretName }}
               key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
-              name: dex-authenticator-{{ $crd.name }}
+              name: {{ $secretName }}
               key: cookie-secret
         - name: TRUSTED_ROOT_CA_FILE
           value: /certs/ca.crt

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -6,6 +6,13 @@
   {{- if ne $idx 0 }}
     {{- $nameSuffix = printf "-%s" $hashedDomain }}
   {{- end }}
+  {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
+  {{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+  {{- $svcName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
+  {{- $ingInfo := (index $info.ingressNames (printf "%d" $idx)) }}
+  {{- $ingName := (default (printf "%s%s-dex-authenticator" $crd.name $nameSuffix) (index $ingInfo "name")) }}
+  {{- $ingTruncated := (index $ingInfo "truncated") }}
+  {{- $ingHash := (index $ingInfo "hash") }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -20,9 +27,15 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ $crd.name }}{{ $nameSuffix }}-dex-authenticator
+  name: {{ $ingName }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
+  {{- $labels := dict "app" "dex-authenticator" }}
+  {{- if $ingTruncated }}
+  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
+  {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
+  {{- $_ := set $labels "deckhouse.io/name-hash" $ingHash }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $labels) | nindent 2 }}
 spec:
   ingressClassName: {{ $app.ingressClassName }}
   rules:
@@ -31,7 +44,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ $crd.name }}-dex-authenticator
+            name: {{ $svcName }}
             port:
               number: 443
         path: /dex-authenticator
@@ -46,6 +59,10 @@ spec:
   {{- end }}
 
   {{- if $app.signOutURL }}
+    {{- $signOutIngInfo := (index $info.signOutIngressNames (printf "%d" $idx)) }}
+    {{- $signOutIngressName := (default (printf "%s%s-dex-authenticator-sign-out" $crd.name $nameSuffix) (index $signOutIngInfo "name")) }}
+    {{- $signOutIngTruncated := (index $signOutIngInfo "truncated") }}
+    {{- $signOutIngHash := (index $signOutIngInfo "hash") }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -55,9 +72,15 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /dex-authenticator/sign_out
     nginx.ingress.kubernetes.io/configuration-snippet: |-
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
-  name: {{ $crd.name }}{{ $nameSuffix }}-dex-authenticator-sign-out
+  name: {{ $signOutIngressName }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
+  {{- $labels := dict "app" "dex-authenticator" }}
+  {{- if $signOutIngTruncated }}
+  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
+  {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
+  {{- $_ := set $labels "deckhouse.io/name-hash" $signOutIngHash }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $labels) | nindent 2 }}
 spec:
   ingressClassName: {{ $app.ingressClassName }}
   rules:
@@ -66,7 +89,7 @@ spec:
       paths:
       - backend:
           service:
-            name: {{ $crd.name }}-dex-authenticator
+            name: {{ $svcName }}
             port:
               number: 443
         path: {{ $app.signOutURL }}

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -29,9 +29,8 @@ metadata:
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
   name: {{ $ingName }}
   namespace: {{ $crd.namespace }}
-  {{- $labels := dict "app" "dex-authenticator" }}
+  {{- $labels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- if $ingTruncated }}
-  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
   {{- $_ := set $labels "deckhouse.io/name-hash" $ingHash }}
   {{- end }}
@@ -74,9 +73,8 @@ metadata:
       {{- include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
   name: {{ $signOutIngressName }}
   namespace: {{ $crd.namespace }}
-  {{- $labels := dict "app" "dex-authenticator" }}
+  {{- $labels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- if $signOutIngTruncated }}
-  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
   {{- $_ := set $labels "deckhouse.io/name-hash" $signOutIngHash }}
   {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -7,7 +7,7 @@
     {{- $nameSuffix = printf "-%s" $hashedDomain }}
   {{- end }}
   {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-  {{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+  {{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
   {{- $svcName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
   {{- $ingInfo := (index $info.ingressNames (printf "%d" $idx)) }}
   {{- $ingName := (default (printf "%s%s-dex-authenticator" $crd.name $nameSuffix) (index $ingInfo "name")) }}

--- a/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/ingress.yaml
@@ -1,5 +1,9 @@
 {{- $context := . }}
-{{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
+{{- $dexAuthenticatorNames := .Values.userAuthn.internal.dexAuthenticatorNames | default dict -}}
+{{- range $crd := .Values.userAuthn.internal.dexAuthenticatorCRDs }}
+  {{- if not .spec.applications }}
+    {{- continue }}
+  {{- end }}
   {{- range $idx, $app := $crd.spec.applications }}
   {{- $hashedDomain := sha256sum $app.domain | trunc 8 }}
   {{- $nameSuffix := "" }}
@@ -7,8 +11,8 @@
     {{- $nameSuffix = printf "-%s" $hashedDomain }}
   {{- end }}
   {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-  {{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
-  {{- $svcName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
+  {{- $info := index $dexAuthenticatorNames $id | default dict }}
+  {{- $svcName := $info.name }}
   {{- $ingInfo := (index $info.ingressNames (printf "%d" $idx)) }}
   {{- $ingName := (default (printf "%s%s-dex-authenticator" $crd.name $nameSuffix) (index $ingInfo "name")) }}
   {{- $ingTruncated := (index $ingInfo "truncated") }}

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -11,9 +11,8 @@ kind: Secret
 metadata:
   name: {{ $secretName }}
   namespace: {{ $crd.namespace }}
-  {{- $labels := dict "app" "dex-authenticator" "name" "credentials" }}
+  {{- $labels := dict "app" "dex-authenticator" "name" "credentials" "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- if $secretTruncated }}
-  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
   {{- $_ := set $labels "deckhouse.io/name-hash" $secretHash }}
   {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -1,13 +1,23 @@
 {{- $context := . }}
-{{- $namespaces := list }}
 {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
+  {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
+  {{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+  {{- $secretName := (default (printf "dex-authenticator-%s" $crd.name) (index $info "secretName")) }}
+  {{- $secretTruncated := (index $info "secretTruncated") }}
+  {{- $secretHash := (index $info "secretHash") }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dex-authenticator-{{ $crd.name }}
+  name: {{ $secretName }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator" "name" "credentials")) | nindent 2 }}
+  {{- $labels := dict "app" "dex-authenticator" "name" "credentials" }}
+  {{- if $secretTruncated }}
+  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
+  {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
+  {{- $_ := set $labels "deckhouse.io/name-hash" $secretHash }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $labels) | nindent 2 }}
 data:
   {{- if $crd.allowAccessToKubernetes }}
   client-secret: {{ $context.Values.userAuthn.internal.kubernetesDexClientAppSecret | b64enc }}
@@ -15,6 +25,7 @@ data:
   client-secret: {{ $crd.credentials.appDexSecret | b64enc }}
   {{- end }}
   cookie-secret: {{ $crd.credentials.cookieSecret | b64enc }}
+  {{- $namespaces := (get $context "namespaces") | default (list) }}
   {{- if not (has $crd.namespace $namespaces) }}
 ---
 apiVersion: v1
@@ -26,6 +37,6 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ $context.Values.global.modulesImages.registry.dockercfg }}
-  {{- $namespaces = append $namespaces $crd.namespace }}
+  {{- $_ := set $context "namespaces" (append $namespaces $crd.namespace) }}
   {{- end }}
 {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -1,7 +1,7 @@
 {{- $context := . }}
 {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
   {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-  {{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+  {{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
   {{- $secretName := (default (printf "dex-authenticator-%s" $crd.name) (index $info "secretName")) }}
   {{- $secretTruncated := (index $info "secretTruncated") }}
   {{- $secretHash := (index $info "secretHash") }}

--- a/modules/150-user-authn/templates/dex-authenticator/secret.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/secret.yaml
@@ -1,7 +1,8 @@
 {{- $context := . }}
-{{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
+{{- $dexAuthenticatorNames := .Values.userAuthn.internal.dexAuthenticatorNames | default dict -}}
+{{- range $crd := .Values.userAuthn.internal.dexAuthenticatorCRDs }}
   {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-  {{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
+  {{- $info := index $dexAuthenticatorNames $id | default dict }}
   {{- $secretName := (default (printf "dex-authenticator-%s" $crd.name) (index $info "secretName")) }}
   {{- $secretTruncated := (index $info "secretTruncated") }}
   {{- $secretHash := (index $info "secretHash") }}

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -1,7 +1,7 @@
 {{- $context := . }}
 {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
 {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-{{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+{{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
 {{- $svcName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
 {{- $truncated := (index $info "truncated") }}
 {{- $hash := (index $info "hash") }}

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -11,9 +11,8 @@ kind: Service
 metadata:
   name: {{ $svcName }}
   namespace: {{ $crd.namespace }}
-  {{- $labels := dict "app" "dex-authenticator" }}
+  {{- $labels := dict "app" "dex-authenticator" "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- if $truncated }}
-  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
   {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
   {{- $_ := set $labels "deckhouse.io/name-hash" $hash }}
   {{- end }}

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -1,9 +1,10 @@
 {{- $context := . }}
-{{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
+{{- $dexAuthenticatorNames := .Values.userAuthn.internal.dexAuthenticatorNames | default dict -}}
+{{- range $crd := .Values.userAuthn.internal.dexAuthenticatorCRDs }}
 {{- $id := printf "%s@%s" $crd.name $crd.namespace }}
-{{- $info := (index ($context.Values.userAuthn.internal.dexAuthenticatorNames | default dict) $id) }}
-{{- $svcName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
-{{- $truncated := (index $info "truncated") }}
+{{- $info := index $dexAuthenticatorNames $id | default dict }}
+{{- $svcName := $info.name }}
+{{- $truncated := $info.truncated }}
 {{- $hash := (index $info "hash") }}
 ---
 apiVersion: v1

--- a/modules/150-user-authn/templates/dex-authenticator/service.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/service.yaml
@@ -1,12 +1,23 @@
 {{- $context := . }}
 {{- range $crd := $context.Values.userAuthn.internal.dexAuthenticatorCRDs }}
+{{- $id := printf "%s@%s" $crd.name $crd.namespace }}
+{{- $info := (index $context.Values.userAuthn.internal.dexAuthenticatorNames $id) }}
+{{- $svcName := (default (printf "%s-dex-authenticator" $crd.name) (index $info "name")) }}
+{{- $truncated := (index $info "truncated") }}
+{{- $hash := (index $info "hash") }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $crd.name }}-dex-authenticator
+  name: {{ $svcName }}
   namespace: {{ $crd.namespace }}
-  {{- include "helm_lib_module_labels" (list $context (dict "app" "dex-authenticator")) | nindent 2 }}
+  {{- $labels := dict "app" "dex-authenticator" }}
+  {{- if $truncated }}
+  {{- $_ := set $labels "deckhouse.io/dex-authenticator-for" $crd.name }}
+  {{- $_ := set $labels "deckhouse.io/name-truncated" "true" }}
+  {{- $_ := set $labels "deckhouse.io/name-hash" $hash }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list $context $labels) | nindent 2 }}
 spec:
   ports:
   - name: https


### PR DESCRIPTION
## Description

Ensure validity of resource names for DexAuthenticator by centralizing and lazily truncating long names.

- Introduce `SafeDNS1123Name` and move name generation logic from Helm templates into the Go hook `get_dex_authenticator_crds.go`.
- If a computed resource name exceeds 63 characters, normalize and truncate it to 57 characters and append `-<hash5>`, where `<hash5>` is the first 5 hex characters of the SHA256 of the original full name.
- Precompute safe names and expose them via `.Values.userAuthn.internal.dexAuthenticatorNames` for templates to consume (Service, Deployment, Secret, Ingress, etc.).
- Add diagnostic labels to resources whose names were truncated to simplify identification and debugging:
  - `deckhouse.io/name-truncated: "true"`
  - `deckhouse.io/name-hash: "<hash5>"`
  - `deckhouse.io/dex-authenticator-for: "<original-crd-name>"`

No changes to the DexAuthenticator CRD shape; only internal name map and templates usage changed.

---

## Why do we need it, and what problem does it solve?

Kubernetes requires `metadata.name` length ≤ 63.  
Previously, templated names like `<CRD-name>-dex-authenticator` could exceed that limit for long DexAuthenticator CRD names, causing API-server validation errors and failing `helm upgrade`.  

Centralizing and normalizing name creation in the hook prevents invalid names and avoids runtime failures.  
The approach is conservative — only names that would exceed the limit are modified, preserving backwards compatibility and reducing impact on existing installations.

---

## Why do we need it in the patch release (if we do)?

Not necessarily

---

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

---

## Changelog entries

```changes
section: user-authn
type: fix
summary: Ensure validity of names for DexAuthenticator resources (truncate >63 and add deterministic 5-char hash suffix)
