### PR TITLE
[deckhouse-controller] Update release information fetching process

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -780,7 +780,7 @@ func (f *DeckhouseReleaseFetcher) fetchReleaseMetadata(ctx context.Context, img 
 
 			changelog = make(map[string]any)
 		}
-		
+
 		meta.Changelog = changelog
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -510,7 +510,7 @@ func (md *ModuleDownloader) fetchModuleReleaseMetadata(ctx context.Context, img 
 		if err != nil {
 			changelog = make(map[string]any)
 		}
-		
+
 		meta.Changelog = changelog
 	}
 

--- a/deckhouse-controller/pkg/registry/deckhouse.go
+++ b/deckhouse-controller/pkg/registry/deckhouse.go
@@ -143,7 +143,7 @@ func (svc *deckhouseReleaseService) fetchReleaseMetadata(img v1.Image) (*dhRelea
 
 			changelog = make(map[string]any)
 		}
-		
+
 		meta.Changelog = changelog
 	}
 

--- a/deckhouse-controller/pkg/registry/module.go
+++ b/deckhouse-controller/pkg/registry/module.go
@@ -165,7 +165,7 @@ func (svc *moduleReleaseService) fetchModuleReleaseMetadata(img v1.Image) (*modR
 
 			changelog = make(map[string]any)
 		}
-		
+
 		meta.Changelog = changelog
 	}
 


### PR DESCRIPTION
## Description

The changes ensure that when YAML parsing of changelog data fails, the metadata extraction process continues and processes other critical components like module.yaml instead of terminating early.

## Why do we need it, and what problem does it solve?

Release metadata extraction functions would fail completely when encountering malformed changelog YAML.

**Solution:**
- Logs changelog parsing errors as warnings instead of fatal errors
- Sets an empty changelog as fallback when parsing fails
- Continues processing other metadata components like module.yaml

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Update release information fetching process
impact_level: low
```
