### PR TITLE
[candi] Fix nodeuser deletion

### DIFF
--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -320,9 +320,11 @@ function main() {
         do
           # Emulate pkill -U $local_user_id
           ps -u "$(id -nu $local_user_id)" --no-headers | awk '{print $1}' | xargs kill -9
-
-          if userdel -r "$(id -nu $local_user_id)"; then
+          
+          if errmsg=$(userdel -r "$(id -nu $local_user_id)" 2>&1); then
             break
+          else 
+            echo $errmsg |egrep -o "[0-9]{2,}" | xargs kill -9
           fi
         done
       else


### PR DESCRIPTION
## Description

Fix nodeuser deletion

## Why do we need it, and what problem does it solve?

Sometimes, bashible cannot remove converger user, because of there is some processes that uses that user. This behavior blocks bashible on the node.

## Why do we need it in the patch release (if we do)?

Affected since v1.72

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fix nodeuser deletion.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
