### PR TITLE
[dhctl] gossh client and kubeproxy fixes

### DIFF
--- a/dhctl/pkg/app/ssh.go
+++ b/dhctl/pkg/app/ssh.go
@@ -157,9 +157,14 @@ func ParseSSHPrivateKeyPaths(pathSets []string) ([]string, error) {
 				return nil, fmt.Errorf("get absolute path for '%s': %v", k, err)
 			}
 
-			if _, err := os.Stat(keyPath); err == nil {
-				res = append(res, keyPath)
+			_, err = os.Stat(keyPath)
+			if err != nil {
+				if pathSet == DefaultSSHAgentPrivateKeys {
+					continue
+				}
+				return nil, fmt.Errorf("cannot stat file %s", keyPath)
 			}
+			res = append(res, keyPath)
 		}
 	}
 	return res, nil

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -247,6 +247,9 @@ func (d *ClusterDestroyer) DestroyCluster(ctx context.Context, autoApprove bool)
 	d.d8Destroyer.UnlockConverge(false)
 	// Stop proxy because we have already got all info from kubernetes-api
 	d.d8Destroyer.StopProxy()
+	if clusterType == config.CloudClusterType {
+		d.d8Destroyer.sshClient.Stop()
+	}
 
 	if err := infraDestroyer.DestroyCluster(ctx, autoApprove); err != nil {
 		return err

--- a/dhctl/pkg/system/node/gossh/client.go
+++ b/dhctl/pkg/system/node/gossh/client.go
@@ -129,7 +129,7 @@ func (s *Client) Start() error {
 		if err != nil {
 			return fmt.Errorf("could not connect to bastion host")
 		}
-		log.DebugF("Connected successfully to bastion host %s", bastionAddr)
+		log.DebugF("Connected successfully to bastion host %s\n", bastionAddr)
 	}
 
 	var becomePass string
@@ -263,7 +263,7 @@ func (s *Client) keepAlive() {
 		default:
 			session, err := s.sshClient.NewSession()
 			if err != nil {
-				log.DebugF("Keep-alive to %s failed: %v", s.Settings.Host(), err)
+				log.DebugF("Keep-alive to %s failed: %v\n", s.Settings.Host(), err)
 				s.live = false
 				s.stopChan = nil
 				s.Start()
@@ -271,7 +271,7 @@ func (s *Client) keepAlive() {
 				return
 			}
 			if _, err := session.SendRequest("keepalive", false, nil); err != nil {
-				log.DebugF("Keep-alive failed: %v", err)
+				log.DebugF("Keep-alive failed: %v\n", err)
 				s.live = false
 				s.stopChan = nil
 				s.Start()

--- a/dhctl/pkg/system/node/gossh/client.go
+++ b/dhctl/pkg/system/node/gossh/client.go
@@ -117,12 +117,12 @@ func (s *Client) Start() error {
 			User:            s.Settings.BastionUser,
 			Auth:            AuthMethods,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-			Timeout:         5 * time.Second,
+			Timeout:         3 * time.Second,
 		}
 		bastionAddr := fmt.Sprintf("%s:%s", s.Settings.BastionHost, s.Settings.BastionPort)
 		var err error
 		log.DebugF("Connect to bastion host %s\n", bastionAddr)
-		err = retry.NewSilentLoop("Get bastion SSH client", 60, 2*time.Second).Run(func() error {
+		err = retry.NewSilentLoop("Get bastion SSH client", 30, 5*time.Second).Run(func() error {
 			bastionClient, err = ssh.Dial("tcp", bastionAddr, bastionConfig)
 			return err
 		})

--- a/dhctl/pkg/system/node/gossh/client.go
+++ b/dhctl/pkg/system/node/gossh/client.go
@@ -217,7 +217,7 @@ func (s *Client) Start() error {
 		targetNewChan    <-chan ssh.NewChannel
 		targetReqChan    <-chan *ssh.Request
 	)
-	err = retry.NewSilentLoop("Get SSH client and connect to target host", 50, 2*time.Second).Run(func() error {
+	err = retry.NewLoop("Get SSH client and connect to target host", 50, 2*time.Second).BreakIf(noAuthMethodsRemain).Run(func() error {
 		if len(s.kubeProxies) == 0 {
 			s.Settings.ChoiceNewHost()
 		}


### PR DESCRIPTION
## Description

Fixes to a gossh-related dhctl behavior:
- Fix start and keep-alive behavior, do not change host if any kube-proxies has been started
- Restart kubeProxy fully after 3 retries to restart tunnel
- Exit with error, if there is no SSH key on file system, put with `--ssh-agent-private-keys` flag
- Add ssh client stop to cloud destroy before infra destroy step, to avoid keep-alive related problems
- Adjust ssh client connection timeouts

## Why do we need it, and what problem does it solve?

Sometimes kube-proxy through bastion cannot be restarted or cannot restart tunnel.

## Why do we need it in the patch release (if we do)?

Affected since v1.72

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix start and keep-alive behavior, do not change host if any kube-proxies has been started.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
