### PR TITLE
add validation hook staticinstance address is not like control plane …

### DIFF
--- a/modules/040-node-manager/hooks/validate_staticinstance_address_is_not_master_node.go
+++ b/modules/040-node-manager/hooks/validate_staticinstance_address_is_not_master_node.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type NodeInfoAddress struct {
+	Address string
+}
+
+type StaticInstance struct {
+	Address string `json:"address"`
+}
+
+func nodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	node := &v1.Node{}
+	err := sdk.FromUnstructured(obj, node)
+	if err != nil {
+		return nil, err
+	}
+
+	var address string
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == v1.NodeInternalIP {
+			address = addr.Address
+			break
+		}
+		if addr.Type == v1.NodeExternalIP && address == "" {
+			address = addr.Address
+		}
+	}
+
+	return NodeInfoAddress{
+		Address: address,
+	}, nil
+}
+
+func staticInstanceFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	address, found, err := unstructured.NestedString(obj.Object, "spec", "address")
+	if err != nil || !found || address == "" {
+		return nil, fmt.Errorf("failed to get address from StaticInstance: %v", err)
+	}
+
+	return StaticInstance{
+		Address: address,
+	}, nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/validate_static_instances",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "nodes",
+			ApiVersion: "v1",
+			Kind:       "Node",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"node-role.kubernetes.io/control-plane": "",
+				},
+			},
+			FilterFunc: nodeFilter,
+		},
+		{
+			Name:       "static_instances",
+			ApiVersion: "deckhouse.io/v1alpha1",
+			Kind:       "StaticInstance",
+			FilterFunc: staticInstanceFilter,
+		},
+	},
+}, validateStaticInstanceAddresses)
+
+func validateStaticInstanceAddresses(_ context.Context, input *go_hook.HookInput) error {
+	nodeSnapshots := input.Snapshots.Get("nodes")
+	staticInstanceSnapshots := input.Snapshots.Get("static_instances")
+
+	if len(staticInstanceSnapshots) == 0 || len(nodeSnapshots) == 0 {
+		return nil
+	}
+
+	masterAddresses := make(map[string]struct{})
+	for nodeInfo, err := range sdkobjectpatch.SnapshotIter[NodeInfo](nodeSnapshots) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'nodes snapshots': %v", err)
+		}
+		if nodeInfo.Address == "" {
+			return fmt.Errorf("master node has empty address")
+		}
+		masterAddresses[nodeInfo.Address] = struct{}{}
+	}
+
+	for staticInstance, err := range sdkobjectpatch.SnapshotIter[StaticInstance](staticInstanceSnapshots) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over 'static_instances snapshots': %v", err)
+		}
+
+		// Check if static instance address matches any master node address
+		if _, exists := masterAddresses[staticInstance.Address]; exists {
+			return fmt.Errorf("static instance address %s conflicts with master node address", staticInstance.Address)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
…node

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
