### PR TITLE
chore/CI Notifications trigger update

### DIFF
--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -284,7 +284,7 @@
     WORKFLOW_NAME: ${{ github.workflow }}
     WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
   run: |
-    bash ./.github/scripts/send-report.sh
+    bash ./.github/scripts/send-report.sh --webhook "ci_fail"
 # </template: send_fail_report>
 {!{- end -}!}
 

--- a/.github/scripts/send-report.sh
+++ b/.github/scripts/send-report.sh
@@ -21,8 +21,9 @@ while [[ "$#" -gt 0 ]]; do
       upload_files=($2)
       shift
       ;;
-    --custom-message)
-      custom_message="$2"
+    --webhook)
+      webhook_type="$2"
+      message="$3"
       shift
       ;;
     --direct-post)
@@ -42,8 +43,10 @@ server_url="${LOOP_SERVICE_NOTIFICATIONS}"
 job_name="${JOB_NAME}"
 workflow_name="${WORKFLOW_NAME}"
 workflow_url="${WORKFLOW_URL}"
-message="${custom_message}"
 
+if [[ -z "$webhook_type" ]]; then
+  webhook_type="ci_fail"
+fi
 if [[ -z "$message" ]]; then
   message="🛑 Workflow: **${workflow_name}** Job: **${job_name}** failed! 🛑\n[URL]($workflow_url)"
 fi
@@ -71,7 +74,7 @@ function send_post_with_webhook() {
   file_ids=$(IFS=,; echo "[${file_id_array[*]}]")
   curl -f -L -X POST $server_url \
     -H "Content-Type: application/json" \
-    --data "{\"type\": \"ci_fail\",\"message\":\"${message}\"}"
+    --data "{\"type\": \"${webhook_type}\",\"message\":\"${message}\"}"
 }
 if [ "$upload" = true ]; then
   for file_path in ${upload_files[@]}; do

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -385,7 +385,7 @@ is used if DECKHOUSE_REGISTRY_HOST is not set.
           LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          bash ./.github/scripts/send-report.sh --custom-message "🛑Deploy to channel {!{ .channel }!} failed!🛑\n[URL]($WORKFLOW_URL)"
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Deploy to channel {!{ .channel }!} failed!🛑\n[URL]($WORKFLOW_URL)"
 
 {!{ tmpl.Exec "update_comment_on_finish" (slice "job,final" $workflowName) | strings.Indent 6 }!}
 

--- a/.github/workflow_templates/k8s-autoupdate.yml
+++ b/.github/workflow_templates/k8s-autoupdate.yml
@@ -103,13 +103,13 @@ jobs:
         LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
       run: |
         PULL_REQUEST_URL="${{ steps.create-pull-request.outputs.pull-request-url }}"
-        bash ./.github/scripts/send-report.sh --custom-message "✅Kubernetes has been automatically updated✅\n[URL]($PULL_REQUEST_URL)"
+        bash ./.github/scripts/send-report.sh --webhook "k8s_update" "✅Kubernetes has been automatically updated✅\n[URL]($PULL_REQUEST_URL)"
     - name: Send failure report
       if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
       env:
         LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
       run: |
         WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-        bash ./.github/scripts/send-report.sh --custom-message "🛑Kubernetes failed to update automatically🛑\n[URL]($WORKFLOW_URL)"
+        bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Kubernetes failed to update automatically🛑\n[URL]($WORKFLOW_URL)"
 
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -159,7 +159,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_fe:
@@ -521,7 +521,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_ee:
@@ -885,7 +885,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_se:
@@ -1249,7 +1249,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_se_plus:
@@ -1613,7 +1613,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_be:
@@ -1977,7 +1977,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_ce:
@@ -2341,7 +2341,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   doc_web_build:
@@ -3676,7 +3676,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   compare_internal_modules:

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -625,7 +625,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_ee:
@@ -999,7 +999,7 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 
   build_se:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -81,6 +81,6 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -143,5 +143,5 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -1339,7 +1339,7 @@ jobs:
           LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          bash ./.github/scripts/send-report.sh --custom-message "🛑Deploy to channel alpha failed!🛑\n[URL]($WORKFLOW_URL)"
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Deploy to channel alpha failed!🛑\n[URL]($WORKFLOW_URL)"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1339,7 +1339,7 @@ jobs:
           LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          bash ./.github/scripts/send-report.sh --custom-message "🛑Deploy to channel beta failed!🛑\n[URL]($WORKFLOW_URL)"
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Deploy to channel beta failed!🛑\n[URL]($WORKFLOW_URL)"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -1339,7 +1339,7 @@ jobs:
           LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          bash ./.github/scripts/send-report.sh --custom-message "🛑Deploy to channel early-access failed!🛑\n[URL]($WORKFLOW_URL)"
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Deploy to channel early-access failed!🛑\n[URL]($WORKFLOW_URL)"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -1339,7 +1339,7 @@ jobs:
           LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          bash ./.github/scripts/send-report.sh --custom-message "🛑Deploy to channel rock-solid failed!🛑\n[URL]($WORKFLOW_URL)"
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Deploy to channel rock-solid failed!🛑\n[URL]($WORKFLOW_URL)"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -1339,7 +1339,7 @@ jobs:
           LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
         run: |
           WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-          bash ./.github/scripts/send-report.sh --custom-message "🛑Deploy to channel stable failed!🛑\n[URL]($WORKFLOW_URL)"
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Deploy to channel stable failed!🛑\n[URL]($WORKFLOW_URL)"
 
       # <template: update_comment_on_finish>
       - name: Update comment on finish

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -70,7 +70,7 @@ jobs:
         WORKFLOW_NAME: ${{ github.workflow }}
         WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
       run: |
-        bash ./.github/scripts/send-report.sh
+        bash ./.github/scripts/send-report.sh --webhook "ci_fail"
     # </template: send_fail_report>
   e2e-pr-clean:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -110,13 +110,13 @@ jobs:
         LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
       run: |
         PULL_REQUEST_URL="${{ steps.create-pull-request.outputs.pull-request-url }}"
-        bash ./.github/scripts/send-report.sh --custom-message "✅Kubernetes has been automatically updated✅\n[URL]($PULL_REQUEST_URL)"
+        bash ./.github/scripts/send-report.sh --webhook "k8s_update" "✅Kubernetes has been automatically updated✅\n[URL]($PULL_REQUEST_URL)"
     - name: Send failure report
       if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
       env:
         LOOP_SERVICE_NOTIFICATIONS: ${{ secrets.LOOP_SERVICE_NOTIFICATIONS }}
       run: |
         WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
-        bash ./.github/scripts/send-report.sh --custom-message "🛑Kubernetes failed to update automatically🛑\n[URL]($WORKFLOW_URL)"
+        bash ./.github/scripts/send-report.sh --webhook "ci_fail" "🛑Kubernetes failed to update automatically🛑\n[URL]($WORKFLOW_URL)"
 
 

--- a/.github/workflows/on-push-release-tag.yml
+++ b/.github/workflows/on-push-release-tag.yml
@@ -67,6 +67,6 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -61,5 +61,5 @@ jobs:
         WORKFLOW_NAME: ${{ github.workflow }}
         WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
       run: |
-        bash ./.github/scripts/send-report.sh
+        bash ./.github/scripts/send-report.sh --webhook "ci_fail"
     # </template: send_fail_report>

--- a/.github/workflows/trivy-db-schedule.yml
+++ b/.github/workflows/trivy-db-schedule.yml
@@ -240,5 +240,5 @@ jobs:
           WORKFLOW_NAME: ${{ github.workflow }}
           WORKFLOW_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}/
         run: |
-          bash ./.github/scripts/send-report.sh
+          bash ./.github/scripts/send-report.sh --webhook "ci_fail"
       # </template: send_fail_report>


### PR DESCRIPTION
## Description
Update CI notification trigger to align with webhook

## Why do we need it, and what problem does it solve?
Unify the process of CI notifications trigger

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: CI Notifications trigger update
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
