### PR TITLE
[deckhouse] Manage chart creation for a read-only filesystem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flant/addon-operator v1.15.0
+	github.com/flant/addon-operator v1.15.1-0.20250923081250-d432d7e58e0f
 	github.com/flant/kube-client v1.3.1
 	github.com/flant/shell-operator v1.11.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.15.0 h1:KUec7kHxFDrd9t9yMkwd7/Tx3BLoK3eZk4ukx8Hr1m0=
 github.com/flant/addon-operator v1.15.0/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
+github.com/flant/addon-operator v1.15.1-0.20250923081250-d432d7e58e0f h1:wlUW+FIwgf+IPZbCytVZkCLNcHybEVXWAGIkN99GOx0=
+github.com/flant/addon-operator v1.15.1-0.20250923081250-d432d7e58e0f/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.3.1 h1:1SdD799sujXNg2F6Z27le/+qkcKQaKf9Z492YGEhVhc=


### PR DESCRIPTION
## Description

This PR implements a virtual Chart.yaml solution to fix readonly filesystem issues in addon-operator. Previously, modules without Chart.yaml files would fail in readonly environments because the operator attempted to create Chart.yaml files on disk.

- Modules without Chart.yaml files crash in readonly filesystem
- Error: open /path/Chart.yaml: read-only file system

## Why do we need it, and what problem does it solve?

- Introduces hasVirtualChart flag to track modules requiring virtual Chart.yaml
- Implements loadChartFromFiles() method that creates charts entirely in memory

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Manage chart creation for a read-only filesystem
impact_level: default
```
