### PR TITLE
[dhctl] fix excessive retries when waiting for first master node to become ready

### DIFF
--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -63,25 +63,23 @@ Please check hostname.`, uuidInCluster, config.UUID)
 }
 
 func WaitForFirstMasterNodeBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Waiting for first master node become ready", 45, 3*time.Second).RunContext(ctx, func() error {
-		var nodeName string
-		err := retry.NewSilentLoop("Get master node name", 45, 3*time.Second).RunContext(ctx, func() error {
-			nodes, err := kubeCl.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-			if err != nil {
-				return err
-			}
-
-			if len(nodes.Items) == 0 {
-				return fmt.Errorf("no master node found")
-			}
-
-			nodeName = nodes.Items[0].Name
-
-			return nil
-		})
+	var nodeName string
+	err := retry.NewSilentLoop("Get master node name", 45, 3*time.Second).RunContext(ctx, func() error {
+		nodes, err := kubeCl.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
-		return entity.WaitForSingleNodeBecomeReady(ctx, kubeCl, nodeName)
+
+		if len(nodes.Items) == 0 {
+			return fmt.Errorf("no master node found")
+		}
+
+		nodeName = nodes.Items[0].Name
+
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+	return entity.WaitForSingleNodeBecomeReady(ctx, kubeCl, nodeName)
 }


### PR DESCRIPTION

## Description
Remove excessive retry when waiting for first master node to become ready
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Remove excessive retry when waiting for first master node to become ready
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
You don't

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: remove nested loop
impact: 45 retries instead of 4500 retries
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
