### PR TITLE
[docs] Show aliases in the D8 reference

### DIFF
--- a/docs/documentation/_plugins/reference_generator.rb
+++ b/docs/documentation/_plugins/reference_generator.rb
@@ -66,7 +66,7 @@ module ReferenceGenerator
       signature = "d8 #{full_path}" unless parent_titles.empty?
       prepare_signature(signature) if signature
     end
-    
+
     # Escape `{{...}}`
     def escape_liquid_tags(text)
       text.gsub(/\{\{(.*?)\}\}/) { |match| "{% raw %}#{match}{% endraw %}" }
@@ -125,6 +125,16 @@ module ReferenceGenerator
         header_title = build_header_title(parent_titles, data['name'])
 
         result += %Q(<#{header_tag}#{style}>#{header_title}</#{header_tag}>\n)
+
+        # Add aliases if they exist
+        if data['aliases'] && data['aliases'].any?
+          aliases = data['aliases'].map { |alias_name| "<code>#{alias_name}</code>" }.join(', ')
+          if data['aliases'].size == 1
+            result += %Q(<p><strong>Alias:</strong> #{aliases}</p>\n)
+          else
+            result += %Q(<p><strong>Aliases:</strong> #{aliases}</p>\n)
+          end
+        end
 
         if header_tag == 'h3'
           signature = build_full_signature(parent_titles, data['name'])


### PR DESCRIPTION
## Description
Show command aliases in the D8 reference.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Show command aliases in the D8 reference.
impact_level: low
```
