### PR TITLE
[deckhouse] Set embedded source for embedded modules

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -493,6 +493,11 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 
 				// set deckhouse version to embedded modules
 				module.Properties.Version = l.version
+
+				// set embedded source if its unset
+				if len(module.Properties.Source) == 0 {
+					module.Properties.Source = v1alpha1.ModuleSourceEmbedded
+				}
 			}
 
 			if !reflect.DeepEqual(moduleCopy.Properties, module.Properties) ||


### PR DESCRIPTION
## Description
It sets embedded source for embedded modules(but only if its unset).

## Why do we need it, and what problem does it solve?
Help with making a downloaded module an embedded one.

WARNING:
BUT MAKING A DOWNLOADED MODULE AN EMBEDDED ONE IS DANGEROUS, IF THE MODULE WAS ENABLED IT CAN BREAK HIM.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Setting embedded source for embedded modules.
```