### PR TITLE
[node-manager] group get_crd errors and make them more readable

### DIFF
--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -808,8 +808,9 @@ metadata:
 		It("Proper NGs must be stored to nodeManager.internal.nodeGroups, hook must warn user about improper NG", func() {
 			Expect(f).NotTo(ExecuteSuccessfully())
 
-			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Wrong classReference: Kind ImproperInstanceClass is not allowed, the only allowed kind is D8TestInstanceClass.")))
-			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (2) should be 3 in snapshots. See errors above for additional information`))
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Invalid classReference.kind 'ImproperInstanceClass'. Expected 'D8TestInstanceClass'. Please update the NodeGroup to use the correct instance class kind.")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`NodeGroup validation failed: 1 NodeGroups have configuration errors.`))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`• NodeGroup 'improper': Invalid classReference.kind 'ImproperInstanceClass'. Expected 'D8TestInstanceClass'. Please update the NodeGroup to use the correct instance class kind.`))
 		})
 	})
 
@@ -905,7 +906,7 @@ metadata:
 				]
 				`
 			Expect(f.ValuesGet("nodeManager.internal.nodeGroups").String()).To(MatchJSON(expectedJSON))
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Wrong classReference: Kind ImproperInstanceClass is not allowed, the only allowed kind is D8TestInstanceClass. Earlier stored version of NG is in use now!"))
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Invalid classReference.kind 'ImproperInstanceClass'. Expected 'D8TestInstanceClass'. Please update the NodeGroup to use the correct instance class kind. Using previously stored NodeGroup configuration to prevent cluster disruption."))
 
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.error").Value()).To(Equal(""))
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.kubernetesVersion").Value()).To(Equal("1.29"))
@@ -913,7 +914,7 @@ metadata:
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.error").Value()).To(Equal(""))
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.kubernetesVersion").Value()).To(Equal("1.29"))
 
-			Expect(f.KubernetesGlobalResource("NodeGroup", "improper").Field("status.error").String()).To(Equal("Wrong classReference: Kind ImproperInstanceClass is not allowed, the only allowed kind is D8TestInstanceClass. Earlier stored version of NG is in use now!"))
+			Expect(f.KubernetesGlobalResource("NodeGroup", "improper").Field("status.error").String()).To(Equal("Invalid classReference.kind 'ImproperInstanceClass'. Expected 'D8TestInstanceClass'. Please update the NodeGroup to use the correct instance class kind. Using previously stored NodeGroup configuration to prevent cluster disruption."))
 		})
 	})
 
@@ -926,8 +927,9 @@ metadata:
 		It("Proper NGs must be stored to nodeManager.internal.nodeGroups, hook must warn user about improper NG", func() {
 			Expect(f).NotTo(ExecuteSuccessfully())
 
-			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass.")))
-			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (2) should be 3 in snapshots. See errors above for additional information`))
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Instance class 'improper' of type 'D8TestInstanceClass' not found. Please create the required instance class or update the NodeGroup to reference an existing one.")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`NodeGroup validation failed: 1 NodeGroups have configuration errors.`))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`• NodeGroup 'improper': Instance class 'improper' of type 'D8TestInstanceClass' not found. Please create the required instance class or update the NodeGroup to reference an existing one.`))
 		})
 	})
 
@@ -940,8 +942,9 @@ metadata:
 		It("Proper NGs must be stored to nodeManager.internal.nodeGroups, hook must warn user about improper NG", func() {
 			Expect(f).NotTo(ExecuteSuccessfully())
 
-			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass.")))
-			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (2) should be 3 in snapshots. See errors above for additional information`))
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Invalid zones specified: [xxx]. Available zones: [a b c]. Please update the NodeGroup to use valid zones.")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`NodeGroup validation failed: 1 NodeGroups have configuration errors.`))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`• NodeGroup 'improper': Invalid zones specified: [xxx]. Available zones: [a b c]. Please update the NodeGroup to use valid zones.`))
 		})
 	})
 
@@ -1037,7 +1040,7 @@ metadata:
 				]
 			`
 			Expect(f.ValuesGet("nodeManager.internal.nodeGroups").String()).To(MatchJSON(expectedJSON))
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass. Earlier stored version of NG is in use now!"))
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("Instance class 'improper' of type 'D8TestInstanceClass' not found. Please create the required instance class or update the NodeGroup to reference an existing one. Using previously stored NodeGroup configuration to prevent cluster disruption."))
 
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.error").Value()).To(Equal(""))
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper1").Field("status.kubernetesVersion").Value()).To(Equal("1.29"))
@@ -1045,7 +1048,7 @@ metadata:
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.error").Value()).To(Equal(""))
 			Expect(f.KubernetesGlobalResource("NodeGroup", "proper2").Field("status.kubernetesVersion").Value()).To(Equal("1.29"))
 
-			Expect(f.KubernetesGlobalResource("NodeGroup", "improper").Field("status.error").String()).To(Equal("Wrong classReference: There is no valid instance class improper of type D8TestInstanceClass. Earlier stored version of NG is in use now!"))
+			Expect(f.KubernetesGlobalResource("NodeGroup", "improper").Field("status.error").String()).To(Equal("Instance class 'improper' of type 'D8TestInstanceClass' not found. Please create the required instance class or update the NodeGroup to reference an existing one. Using previously stored NodeGroup configuration to prevent cluster disruption."))
 		})
 	})
 
@@ -1270,8 +1273,9 @@ spec: {}
 		It("NodeGroup values must be valid", func() {
 			Expect(f).NotTo(ExecuteSuccessfully())
 
-			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Calculate capacity failed for: D8TestInstanceClass")))
-			Expect(f.GoHookError.Error()).Should(ContainSubstring(`incorrect final nodegroups count (0) should be 1 in snapshots. See errors above for additional information`))
+			Expect(bytes.Contains(f.LoggerOutput.Contents(), []byte("Calculate capacity failed")))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`NodeGroup validation failed: 1 NodeGroups have configuration errors.`))
+			Expect(f.GoHookError.Error()).Should(ContainSubstring(`• NodeGroup 'test': Capacity calculation failed for instance class 'D8TestInstanceClass'. The instance type is not found in built-in types and no capacity is set. ScaleFromZero will not work. Please set capacity in the D8TestInstanceClass 'caperror' or use a supported instance type.`))
 		})
 	})
 


### PR DESCRIPTION
## Description
Group get_crd errors and make them more readable
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Group get_crd errors and make them more readable
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Group get_crd errors and make them more readable
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
