### PR TITLE
[user-authn] Fix DEX login denied render

### DIFF
--- a/modules/150-user-authn/images/dex/patches/006-fix-render-error.patch
+++ b/modules/150-user-authn/images/dex/patches/006-fix-render-error.patch
@@ -1,0 +1,72 @@
+diff --git a/server/handlers.go b/server/handlers.go
+index 0dd2a990..8fb95860 100644
+--- a/server/handlers.go
++++ b/server/handlers.go
+@@ -7,6 +7,7 @@ import (
+ 	"crypto/subtle"
+ 	"encoding/base64"
+ 	"encoding/json"
++	"errors"
+ 	"fmt"
+ 	"html/template"
+ 	"net/http"
+@@ -473,6 +474,12 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
+ 		redirectURL, canSkipApproval, err := s.finalizeLogin(r.Context(), identity, authReq, conn.Connector)
+ 		if err != nil {
+ 			s.logger.ErrorContext(r.Context(), "failed to finalize login", "err", err)
++
++			var nae *NotAllowedError
++			if errors.As(err, &nae) {
++				s.renderError(r, w, http.StatusUnauthorized, fmt.Sprintf("Access denied. %s", nae.Reason))
++				return
++			}
+ 			s.renderError(r, w, http.StatusInternalServerError, "Login error.")
+ 			return
+ 		}
+@@ -573,6 +580,11 @@ func (s *Server) handleConnectorCallback(w http.ResponseWriter, r *http.Request)
+ 	redirectURL, canSkipApproval, err := s.finalizeLogin(ctx, identity, authReq, conn.Connector)
+ 	if err != nil {
+ 		s.logger.ErrorContext(r.Context(), "failed to finalize login", "err", err)
++		var nae *NotAllowedError
++		if errors.As(err, &nae) {
++			s.renderError(r, w, http.StatusUnauthorized, fmt.Sprintf("Access denied. %s", nae.Reason))
++			return
++		}
+ 		s.renderError(r, w, http.StatusInternalServerError, "Login error.")
+ 		return
+ 	}
+@@ -591,6 +603,17 @@ func (s *Server) handleConnectorCallback(w http.ResponseWriter, r *http.Request)
+ 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+ }
+ 
++// NotAllowedError is returned when a login attempt is blocked due to
++// restrictions such as allowedEmail or allowedGroup.
++// It contains the specific reason why the user is not allowed.
++type NotAllowedError struct {
++	Reason string
++}
++
++func (e *NotAllowedError) Error() string {
++	return "not allowed: " + e.Reason
++}
++
+ // finalizeLogin associates the user's identity with the current AuthRequest, then returns
+ // the approval page's path.
+ func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity, authReq storage.AuthRequest, conn connector.Connector) (string, bool, error) {
+@@ -611,14 +634,14 @@ func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity,
+ 	if len(client.AllowedEmails) > 0 {
+ 		allowed := slices.Contains(client.AllowedEmails, claims.Email)
+ 		if !allowed {
+-			return "", false, fmt.Errorf("user %q not in allowed emails: %v", claims.Username, claims.Email)
++			return "", false, &NotAllowedError{Reason: fmt.Sprintf("Email %s not allowed", claims.Email)}
+ 		}
+ 	}
+ 
+ 	if len(client.AllowedGroups) > 0 {
+ 		claims.Groups = groups.Filter(claims.Groups, client.AllowedGroups)
+ 		if len(claims.Groups) == 0 {
+-			return "", false, fmt.Errorf("user %q not in allowed groups: %v", claims.Username, claims.Groups)
++			return "", false, &NotAllowedError{Reason: fmt.Sprintf("Email %s not in allowed groups", claims.Email)}
+ 		}
+ 	}
+ 

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -33,3 +33,7 @@ for local user accounts. The following features are added:
 2. Password expiration and forced rotation
 3. Password reuse prevention
 4. Account lockout after failed attempts
+
+### 006-fix-render-error.patch
+
+This patch changes the Internal Error message to a human-readable 'Access Denied' when login with a local user is restricted by group or email.


### PR DESCRIPTION
## Description
This patch improves the login error message for local users. Instead of showing a generic `Internal Error` when access is restricted by allowed group or email, users now see a clear 'Access Denied' message.

## Why do we need it, and what problem does it solve?
Previously, when a local user tried to log in but was restricted due to group/email rules, the system displayed an `Internal Error`, which was confusing. This fix provides a user-friendly message, improving UX and reducing support requests.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: user-authn
type: fix
summary: Show 'Access Denied' instead of 'Internal Error' for restricted local users
impact: Users will see a clear error message when their login is restricted by allowed group or email, instead of a confusing internal error.
impact_level: default
```
