### PR TITLE
[ingress-nginx] Fix severity for NginxIngressValidationIsDisabled alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5409,7 +5409,7 @@ alerts:
         ```
       summary: |
         Warning: Ingress resource validation in the NGINX Ingress Controller is currently disabled.
-      severity: "3"
+      severity: "4"
       markupFormat: markdown
     - name: NodeConntrackTableFull
       sourceFile: modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/node.yaml

--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -237,7 +237,7 @@
       ingress_nginx_validation_suspended != 0
     for: 3m
     labels:
-      severity_level: "3"
+      severity_level: "4"
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"


### PR DESCRIPTION
## Description
This PR lowers the severity level of the IngressNginxController alert from 3 to 4 to better reflect its actual impact on cluster operations

## Why do we need it, and what problem does it solve?
The current severity level of 3 is too high for this alert. Reducing it to level 4 will ensure proper prioritization of responses and reduce noise in engineer notifications, without diminishing awareness of potential issues

## Why do we need it in the patch release (if we do)?
This change affects an existing alert and influences its handling priority. Including it in the patch release allows us to quickly align the alert’s behavior with current requirements and prevent false alarms in the production cluster

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: lowers the severity level of the IngressNginxController alert from 3 to 4
impact_level: low
```
