### PR TITLE
[cni-cilium] Improved migration to 1.17 logic

### DIFF
--- a/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
+++ b/modules/021-cni-cilium/templates/ngc-disruptive-update.yaml
@@ -26,6 +26,17 @@ spec:
 
     desired_sau_ds_generation={{ include "agent_daemonset_template" (list . "undefined") | sha256sum | quote }}
 
+    # If it is the first bashible run, there is nothing to do
+    if [[ "${FIRST_BASHIBLE_RUN}" == "yes" ]]; then
+      exit 0
+    fi
+
+    # If there is no kubelet.conf than node is not bootstrapped and there is nothing to do
+    kubeconfig="/etc/kubernetes/kubelet.conf"
+    if [ ! -f "$kubeconfig" ]; then
+      exit 0
+    fi
+
     # If there is no cilium-cni binary on node than node is not bootstrapped and there is nothing to do
     if [ ! -f "/opt/cni/bin/cilium-cni" ]; then
       exit 0
@@ -43,18 +54,16 @@ spec:
 
     if [[ $major -gt 1 || ( $major -eq 1 && $minor -ge 17 ) ]]; then
         echo "Cilium CNI plugin version is not less than 1.17: $version"
+        until bb-kubectl --kubeconfig $kubeconfig annotate --overwrite=true node "$(bb-d8-node-name)" network.deckhouse.io/cilium-1-17-migration-succeeded=""; do
+          attempt=$(( attempt + 1 ))
+          if [ "$attempt" -gt "$max_attempts" ]; then
+            bb-log-error "failed to annotate node $(bb-d8-node-name) after $max_attempts attempts"
+            exit 1
+          fi
+          echo "Waiting for annotate node $(bb-d8-node-name) (attempt $attempt of $max_attempts)..."
+          sleep 5
+        done
         exit 0
-    fi
-
-    # If it is the first bashible run, there is nothing to do
-    if [[ "${FIRST_BASHIBLE_RUN}" == "yes" ]]; then
-      exit 0
-    fi
-
-    # If there is no kubelet.conf than node is not bootstrapped and there is nothing to do
-    kubeconfig="/etc/kubernetes/kubelet.conf"
-    if [ ! -f "$kubeconfig" ]; then
-      exit 0
     fi
 
     # If the migration has already succeeded, there is nothing to do


### PR DESCRIPTION
## Description
Этот PR дополняет логику миграции cni-cilium это достигается путем двух изменений
1. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
