### PR TITLE
[control-plane-manager] apply custom audit policies after embedded policies

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -117,14 +117,8 @@ func handleAuditPolicy(_ context.Context, input *go_hook.HookInput) error {
 			return fmt.Errorf("failed to unmarshal configmaps_with_extra_audit_policy snapshot: %w", err)
 		}
 		appendBasicPolicyRules(&policy, extraData)
-	}
-
-	// Add policies for virtualization module.
-	for _, module := range input.Values.Get("global.enabledModules").Array() {
-		if module.String() == "virtualization" {
-			appendVirtualizationPolicyRules(&policy)
-			break
-		}
+		// Add policies for virtualization module.
+		appendVirtualizationPolicyRules(&policy)
 	}
 
 	// Append custom policies if secret is present.

--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -110,6 +110,7 @@ func filterConfigMap(unstructured *unstructured.Unstructured) (go_hook.FilterRes
 func handleAuditPolicy(_ context.Context, input *go_hook.HookInput) error {
 	var policy audit.Policy
 
+	// Start with adding basic policies.
 	if input.Values.Get("controlPlaneManager.apiserver.basicAuditPolicyEnabled").Bool() {
 		extraData, err := sdkobjectpatch.UnmarshalToStruct[ConfigMapInfo](input.Snapshots, "configmaps_with_extra_audit_policy")
 		if err != nil {
@@ -117,22 +118,25 @@ func handleAuditPolicy(_ context.Context, input *go_hook.HookInput) error {
 		}
 		appendBasicPolicyRules(&policy, extraData)
 	}
-	datas, err := sdkobjectpatch.UnmarshalToStruct[[]byte](input.Snapshots, "kube_audit_policy_secret")
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal kube_audit_policy_secret snapshot: %w", err)
-	}
-	if input.Values.Get("controlPlaneManager.apiserver.auditPolicyEnabled").Bool() && len(datas) > 0 {
-		data := datas[0]
-		err := appendAdditionalPolicyRules(&policy, &data)
-		if err != nil {
-			return err
-		}
-	}
 
+	// Add policies for virtualization module.
 	for _, module := range input.Values.Get("global.enabledModules").Array() {
 		if module.String() == "virtualization" {
 			appendVirtualizationPolicyRules(&policy)
 			break
+		}
+	}
+
+	// Append custom policies if secret is present.
+	auditPolicyDataSnaps, err := sdkobjectpatch.UnmarshalToStruct[[]byte](input.Snapshots, "kube_audit_policy_secret")
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal kube_audit_policy_secret snapshot: %w", err)
+	}
+	if input.Values.Get("controlPlaneManager.apiserver.auditPolicyEnabled").Bool() && len(auditPolicyDataSnaps) > 0 {
+		auditPolicyData := auditPolicyDataSnaps[0]
+		err := appendAdditionalPolicyRules(&policy, &auditPolicyData)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/modules/040-control-plane-manager/hooks/audit_policy_test.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_test.go
@@ -170,7 +170,7 @@ rules:
 		})
 	})
 
-	FContext("Cluster started with basic audit policies", func() {
+	Context("Cluster started with basic audit policies", func() {
 		BeforeEach(func() {
 			f.ValuesSet("controlPlaneManager.apiserver.basicAuditPolicyEnabled", true)
 			f.BindingContexts.Set(f.KubeStateSet(configmap))

--- a/modules/040-control-plane-manager/hooks/audit_policy_test.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_test.go
@@ -170,7 +170,7 @@ rules:
 		})
 	})
 
-	Context("Cluster started with basic audit policies", func() {
+	FContext("Cluster started with basic audit policies", func() {
 		BeforeEach(func() {
 			f.ValuesSet("controlPlaneManager.apiserver.basicAuditPolicyEnabled", true)
 			f.BindingContexts.Set(f.KubeStateSet(configmap))
@@ -183,53 +183,31 @@ rules:
 			var policy audit.Policy
 			_ = yaml.UnmarshalStrict(data, &policy)
 
-			istiodServiceAccounts := []string{
-				"system:serviceaccount:d8-istio:istiod-v1x21x6",
-				"system:serviceaccount:d8-istio:istiod-v1x19x7",
+			var expectPolicy audit.Policy
+			extraData := []ConfigMapInfo{
+				{
+					ServiceAccounts: []string{
+						"system:serviceaccount:d8-istio:istiod-v1x21x6",
+						"system:serviceaccount:d8-istio:istiod-v1x19x7",
+					},
+				},
 			}
 
-			// All rules, except last nine are dropping rules.
-			for i := 0; i < len(policy.Rules)-9; i++ {
-				Expect(policy.Rules[i].Level).To(Equal(audit.LevelNone))
+			appendBasicPolicyRules(&expectPolicy, extraData)
+			appendVirtualizationPolicyRules(&expectPolicy)
+
+			for i, actualRule := range policy.Rules {
+				// Note: Equal() is not working here as Rule contains array fields with "omitempty" directive and an empty array is not equal to nil.
+				expectedRule := expectPolicy.Rules[i]
+				Expect(actualRule.Level).To(Equal(expectedRule.Level), "Level in rule %d %+v should match expected rule %+v", i, actualRule, expectedRule)
+				if len(actualRule.Users) > 0 && len(expectedRule.Users) > 0 {
+					Expect(actualRule.Users).To(Equal(expectedRule.Users), "Users in rule %d %+v should match expected rule %+v", i, actualRule, expectedRule)
+				}
+				if len(actualRule.Namespaces) > 0 && len(expectedRule.Namespaces) > 0 {
+					Expect(actualRule.Namespaces).To(Equal(expectedRule.Namespaces), "Namespaces in rule %d %+v should match expected rule %+v", i, actualRule, expectedRule)
+				}
 			}
-
-			allServiceAccounts := append(auditPolicyBasicServiceAccounts, istiodServiceAccounts...)
-
-			saRule := policy.Rules[len(policy.Rules)-8]
-			Expect(saRule.Level).To(Equal(audit.LevelMetadata))
-			Expect(saRule.Users).To(Equal(allServiceAccounts))
-
-			namespaceRule := policy.Rules[len(policy.Rules)-6]
-			Expect(namespaceRule.Level).To(Equal(audit.LevelMetadata))
-			Expect(namespaceRule.Namespaces).To(Equal(auditPolicyBasicNamespaces))
-
-			listRule := policy.Rules[len(policy.Rules)-5]
-			Expect(listRule.Level).To(Equal(audit.LevelMetadata))
-			Expect(listRule.Namespaces).To(BeEmpty())
 		})
 	})
 
-	Context("Cluster started with virtualization audit policies", func() {
-		BeforeEach(func() {
-			f.ValuesSet("global.enabledModules", []string{"virtualization"})
-			f.BindingContexts.Set(f.KubeStateSet(configmap))
-			f.RunHook()
-		})
-
-		It("controlPlaneManager.internal.auditPolicy must contain proper rules", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			data, _ := base64.StdEncoding.DecodeString(f.ValuesGet("controlPlaneManager.internal.auditPolicy").String())
-			var policy audit.Policy
-			_ = yaml.UnmarshalStrict(data, &policy)
-
-			// All rules, except first one are metedata level rules.
-			for i := 1; i < len(policy.Rules); i++ {
-				v := policy.Rules[i]
-				Expect(v.Level).To(Equal(audit.LevelMetadata))
-			}
-
-			vmopRule := policy.Rules[0]
-			Expect(vmopRule.Level).To(Equal(audit.LevelRequestResponse))
-		})
-	})
 })


### PR DESCRIPTION
## Description

Change order of applying virtualization policies and custom policies to prevent breaking virtualization audit configuration.

## Why do we need it, and what problem does it solve?

**Before:**

AuditPolicy manifest is a sum of policies:

```
Basic policies
+
Custom policies from Secret/audit-policy
+
Policies for virtualization module
```

It is a good practice to add audit for all resources with level "Metadata" in some closed environments. For example with this "catch all" additional Policy:

```
apiVersion: audit.k8s.io/v1 # This is required.
kind: Policy
# Don't generate audit events for all requests in RequestReceived stage.
omitStages:
  - "RequestReceived"
rules:
  # A catch-all rule to log all other requests at the Metadata level.
  - level: Metadata
    # Long-running requests like watches that fall under this rule will not
    # generate an audit event in RequestReceived.
    omitStages:
      - "RequestReceived"
```

The order of applying policies in audit-policy hooks makes this rule appear before virtualization rules and all events about VirtualMachineOperations recorded with Metadata level. This breaks VMOP audit, as object name is required. (Metadata level has no object name, e.g. for generated names, RequestResponse with responseObject is required to get object name).

**After:**

AuditPolicy manifest with reordered policies:

```
Basic policies
+
Policies for virtualization module
+
Custom policies from Secret/audit-policy
```

Now there is no way to accidentally degrade virtualization-audit component with custom policies.

## Why do we need it in the patch release (if we do)?

Virtualization audit is required for strict environments.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Append audit policies for virtualization before appending custom policies from Secret.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
