### PR TITLE
fix: remove monitors after afterDelete hook run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flant/addon-operator v1.15.1-0.20250924174638-4197abeaa126
+	github.com/flant/addon-operator v1.15.1
 	github.com/flant/kube-client v1.3.1
 	github.com/flant/shell-operator v1.11.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flant/addon-operator v1.15.0
+	github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf
 	github.com/flant/kube-client v1.3.1
 	github.com/flant/shell-operator v1.11.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf
+	github.com/flant/addon-operator v1.15.1-0.20250924174638-4197abeaa126
 	github.com/flant/kube-client v1.3.1
 	github.com/flant/shell-operator v1.11.0
 	github.com/go-openapi/spec v0.19.8

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.15.0 h1:KUec7kHxFDrd9t9yMkwd7/Tx3BLoK3eZk4ukx8Hr1m0=
 github.com/flant/addon-operator v1.15.0/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
+github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf h1:dIiS6Lmgy5mdGXZ4asjqUThoafps63BhD8MyfIlVYjk=
+github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.3.1 h1:1SdD799sujXNg2F6Z27le/+qkcKQaKf9Z492YGEhVhc=

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/flant/addon-operator v1.15.0 h1:KUec7kHxFDrd9t9yMkwd7/Tx3BLoK3eZk4ukx
 github.com/flant/addon-operator v1.15.0/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
 github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf h1:dIiS6Lmgy5mdGXZ4asjqUThoafps63BhD8MyfIlVYjk=
 github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
+github.com/flant/addon-operator v1.15.1-0.20250924174638-4197abeaa126 h1:xP+OhrKxETzKXkP0BHrDvkic88zFFo2Kj+xEjOr1wc4=
+github.com/flant/addon-operator v1.15.1-0.20250924174638-4197abeaa126/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.3.1 h1:1SdD799sujXNg2F6Z27le/+qkcKQaKf9Z492YGEhVhc=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf h1:dIiS6Lm
 github.com/flant/addon-operator v1.15.1-0.20250924171234-c29cb92678cf/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
 github.com/flant/addon-operator v1.15.1-0.20250924174638-4197abeaa126 h1:xP+OhrKxETzKXkP0BHrDvkic88zFFo2Kj+xEjOr1wc4=
 github.com/flant/addon-operator v1.15.1-0.20250924174638-4197abeaa126/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
+github.com/flant/addon-operator v1.15.1 h1:3rEqp6QKHLZX7wcMwiRr5cmTFU1zTefPdR/B4DXdY2U=
+github.com/flant/addon-operator v1.15.1/go.mod h1:ELZAE4FXEjWDmA6hN+KB7r8/9jbWt+KeCi9xYU3zLts=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.3.1 h1:1SdD799sujXNg2F6Z27le/+qkcKQaKf9Z492YGEhVhc=


### PR DESCRIPTION
### Description
Move disabling of module hook monitors to after `afterDeleteHelm` execution. This preserves Kubernetes snapshots for module hooks bound to `afterDeleteHelm`, aligning runtime behavior with the documentation. Previously, monitors were stopped before running `afterDeleteHelm`, resulting in empty snapshots.

- Stop calling `DisableModuleHooks` before deletion.
- Run Helm delete.
- Run module hooks with `afterDeleteHelm`.
- Then call `DisableModuleHooks` to stop monitors and schedules.

No changes to the behavior of `beforeHelm`/`afterHelm`.

### Why do we need it, and what problem does it solve?
Hooks with `afterDeleteHelm` are expected to receive snapshots of their Kubernetes bindings. In practice they were empty because monitors were stopped right before executing the binding. This fix ensures `afterDeleteHelm` receives the last known snapshots so modules can reliably clean up external resources (secrets, CRs, etc.) during disable.

This addresses the observed bug: empty `snapshots` for `afterDeleteHelm` while `afterHelm` works.

### Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes. 
- [x] Changes were tested in the Kubernetes cluster manually.

### Changelog entries
```changes
section: deckhouse-controller
type: fix
summary: Ensure `afterDeleteHelm` hooks receive Kubernetes snapshots by stopping monitors after hook execution
impact_level: default
```