### PR TITLE
[istio] Correct permissions of executable files in EE

### DIFF
--- a/ee/modules/110-istio/images/api-proxy/werf.inc.yaml
+++ b/ee/modules/110-istio/images/api-proxy/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
-fromCacheVersion: "2025-09-25.01"
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/api-proxy

--- a/ee/modules/110-istio/images/metadata-exporter/werf.inc.yaml
+++ b/ee/modules/110-istio/images/metadata-exporter/werf.inc.yaml
@@ -1,7 +1,6 @@
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
-fromCacheVersion: "2025-09-25.01"
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
   add: /src/metadata-exporter


### PR DESCRIPTION
## Description
Fixed api-proxy and metadata-exporter binaries owners if the launch is from a Deckhouse user.

## Why do we need it, and what problem does it solve?
The api-roxy and the metadata-exporter pods are not running correctly due to user changes in the Helm templates. Errors occur at startup:
```
error during container init: exec: "/metadata-exporter": permission denied: unknown
```
```
error during container init: exec: "/api-proxy": permission denied: unknown
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: chore
summary: Corrected permissions of executable files in EE.
impact_level: default
```
