### PR TITLE
Backport: [cloud-provider-vsphere] cloud-data-discoverer fixes #15507

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer-legacy/src/go.mod
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer-legacy/src/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
 	github.com/deckhouse/deckhouse/go_lib/cloud-data v0.0.0-00010101000000-000000000000
-	github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250115075301-5b6ae3aa8eb7
+	github.com/deckhouse/deckhouse/pkg/log v0.0.0-20250704135428-7600b0581807
 	github.com/vmware/go-vcloud-director/v2 v2.21.0
 )
 

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
@@ -30,6 +30,11 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
 )
 
+const (
+	DiscoveryDataKind    = "VsphereCloudDiscoveryData"
+	DiscoveryDataVersion = "deckhouse.io/v1"
+)
+
 type Discoverer struct {
 	logger               *log.Logger
 	clusterUUID          string
@@ -154,9 +159,8 @@ func (d *Discoverer) InstanceTypes(ctx context.Context) ([]v1alpha1.InstanceType
 	return nil, nil
 }
 
-// NotImplemented
 func (d *Discoverer) DiscoveryData(ctx context.Context, cloudProviderDiscoveryData []byte) ([]byte, error) {
-	discoveryData := &v1.VsphereCloudDiscoveryData{}
+	discoveryData := new(v1.VsphereCloudDiscoveryData)
 	if len(cloudProviderDiscoveryData) > 0 {
 		err := json.Unmarshal(cloudProviderDiscoveryData, &discoveryData)
 		if err != nil {
@@ -169,6 +173,8 @@ func (d *Discoverer) DiscoveryData(ctx context.Context, cloudProviderDiscoveryDa
 		return nil, fmt.Errorf("error on GetZonesDatastores: %v", err)
 	}
 
+	discoveryData.Kind = DiscoveryDataKind
+	discoveryData.APIVersion = DiscoveryDataVersion
 	discoveryData.Datacenter = zonesDatastores.Datacenter
 	discoveryData.Zones = mergeZones(discoveryData.Zones, zonesDatastores.Zones)
 	discoveryData.Datastores = mergeDatastores(discoveryData.Datastores, zonesDatastores.ZonedDataStores)
@@ -178,7 +184,7 @@ func (d *Discoverer) DiscoveryData(ctx context.Context, cloudProviderDiscoveryDa
 		return nil, fmt.Errorf("failed to marshal discovery data: %w", err)
 	}
 
-	d.logger.Debugf("discovery data: %v", discoveryDataJSON)
+	d.logger.Debug("discovery data:", "discoveryDataJSON", discoveryDataJSON)
 	return discoveryDataJSON, nil
 }
 

--- a/go_lib/cloud-data/reconciler.go
+++ b/go_lib/cloud-data/reconciler.go
@@ -430,15 +430,14 @@ func (c *Reconciler) discoveryDataReconcile(ctx context.Context) {
 
 	err := retryFunc(15, 3*time.Second, 30*time.Second, c.logger, func() error {
 		secret, err := c.k8sClient.CoreV1().Secrets("kube-system").Get(cctx, "d8-provider-cluster-configuration", metav1.GetOptions{})
-		// d8-provider-cluster-configuration can not be exist in hybrid clusters
 		if err != nil {
-			if !errors.IsNotFound(err) {
-				return fmt.Errorf("failed to get 'd8-provider-cluster-configuration' secret: %v", err)
+			if errors.IsNotFound(err) {
+				// d8-provider-cluster-configuration can not be exist in hybrid clusters
+				return nil
 			}
-		} else {
-			cloudDiscoveryData = secret.Data["cloud-provider-discovery-data.json"]
+			return fmt.Errorf("failed to get 'd8-provider-cluster-configuration' secret: %v", err)
 		}
-		c.cloudRequestErrorMetric.WithLabelValues("discovery_data").Set(0.0)
+		cloudDiscoveryData = secret.Data["cloud-provider-discovery-data.json"]
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## Description
Backport https://github.com/deckhouse/deckhouse/pull/15507 to 1.72

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: cloud-data-discoverer fixes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
