### PR TITLE
[cni-cilium] Fixed 1.14 -> 1.17 migration mechanism

### DIFF
--- a/modules/021-cni-cilium/images/safe-agent-updater/src/main.go
+++ b/modules/021-cni-cilium/images/safe-agent-updater/src/main.go
@@ -136,13 +136,13 @@ func isCiliumCNIVersionAlreadyUpToDate() (bool, string) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	if err != nil {
-		log.Errorf("[SafeAgentUpdater] Failed to execute cilium-cni binary: %v, stderr: %s", err, stderr.String())
+		log.Fatalf("[SafeAgentUpdater] Failed to execute cilium-cni binary: %v, stderr: %s", err, stderr.String())
 		return false, ""
 	}
 
 	version := regexp.MustCompile(`\d+\.\d+\.\d+`).FindString(stderr.String())
 	if version == "" {
-		log.Errorf("[SafeAgentUpdater] Failed to parse cilium-cni version")
+		log.Fatalf("[SafeAgentUpdater] Failed to parse cilium-cni version")
 		return false, ""
 	}
 


### PR DESCRIPTION
## Description
Fixed 1.14 -> 1.17 migration mechanism (bugs in pr https://github.com/deckhouse/deckhouse/pull/15602).

## Why do we need it, and what problem does it solve?
In some cases, the main upgrading logic doesn't work, so agent DaemonSets aren't upgrading.

## Why do we need it in the patch release (if we do)?

It is the fix for patch, that is in patch release.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Fixed 1.14 -> 1.17 migration mechanism
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
