### PR TITLE
[dhctl] sanitize klog

### DIFF
--- a/dhctl/pkg/config/registry.go
+++ b/dhctl/pkg/config/registry.go
@@ -87,7 +87,6 @@ func (r *RegistryData) Auth() (string, error) {
 		return "", fmt.Errorf("cannot base64 decode docker cfg: %v", err)
 	}
 
-	log.DebugF("parse registry data: dockerCfg after base64 decode = %s\n", bytes)
 	err = json.Unmarshal(bytes, &dc)
 	if err != nil {
 		return "", fmt.Errorf("cannot unmarshal docker cfg: %v", err)

--- a/dhctl/pkg/log/log_sanitizer.go
+++ b/dhctl/pkg/log/log_sanitizer.go
@@ -22,7 +22,8 @@ var sensitiveKeywords = []string{
 	`"name":"d8-cluster-terraform-state"`,
 	`"name":"d8-provider-cluster-configuration"`,
 	`"name":"d8-dhctl-converge-state"`,
-	`DexProvider`,
+	`"kind":"DexProvider"`,
+	`"kind":"ModuleConfig"`,
 }
 
 type LogSanitizer struct{}

--- a/dhctl/pkg/log/log_sanitizer.go
+++ b/dhctl/pkg/log/log_sanitizer.go
@@ -15,6 +15,7 @@
 package log
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -31,9 +32,12 @@ type LogSanitizer struct{}
 
 func (l *LogSanitizer) Filter(args []any) []any {
 	for i, arg := range args {
-		v, ok := arg.(string)
-		if ok && containsSensitiveSubstring(v) {
-			args[i] = "[FILTERED]"
+		str, ok := arg.(string)
+		if !ok {
+			continue
+		}
+		if matchedKeyword := findSensitiveSubstring(str); matchedKeyword != "" {
+			args[i] = fmt.Sprintf(`[FILTERED - %s]`, matchedKeyword)
 		}
 	}
 	return args
@@ -47,11 +51,11 @@ func (l *LogSanitizer) FilterS(msg string, keysAndValues []any) (string, []any) 
 	return msg, l.Filter(keysAndValues)
 }
 
-func containsSensitiveSubstring(msg string) bool {
+func findSensitiveSubstring(msg string) string {
 	for _, keyword := range sensitiveKeywords {
 		if strings.Contains(msg, keyword) {
-			return true
+			return keyword
 		}
 	}
-	return false
+	return ""
 }

--- a/dhctl/pkg/log/log_sanitizer.go
+++ b/dhctl/pkg/log/log_sanitizer.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"strings"
+)
+
+var sensitiveKeywords = []string{
+	`"name":"d8-cluster-terraform-state"`,
+	`"name":"d8-provider-cluster-configuration"`,
+	`"name":"d8-dhctl-converge-state"`,
+	`DexProvider`,
+}
+
+type LogSanitizer struct{}
+
+func (f *LogSanitizer) Filter(args []any) []any {
+	for i, arg := range args {
+		v, ok := arg.(string)
+		if ok && containsSensitiveSubstring(v) {
+			args[i] = "[FILTERED]"
+		}
+	}
+	return args
+}
+
+func (f *LogSanitizer) FilterF(format string, args []any) (string, []any) {
+	return format, f.Filter(args)
+}
+
+func (f *LogSanitizer) FilterS(msg string, keysAndValues []any) (string, []any) {
+	return msg, f.Filter(keysAndValues)
+}
+
+func containsSensitiveSubstring(msg string) bool {
+	for _, keyword := range sensitiveKeywords {
+		if strings.Contains(msg, keyword) {
+			return true
+		}
+	}
+	return false
+}

--- a/dhctl/pkg/log/log_sanitizer.go
+++ b/dhctl/pkg/log/log_sanitizer.go
@@ -24,6 +24,7 @@ var sensitiveKeywords = []string{
 	`"name":"d8-dhctl-converge-state"`,
 	`"kind":"DexProvider"`,
 	`"kind":"ModuleConfig"`,
+	`"kind":"Secret"`,
 }
 
 type LogSanitizer struct{}

--- a/dhctl/pkg/log/log_sanitizer.go
+++ b/dhctl/pkg/log/log_sanitizer.go
@@ -27,7 +27,7 @@ var sensitiveKeywords = []string{
 
 type LogSanitizer struct{}
 
-func (f *LogSanitizer) Filter(args []any) []any {
+func (l *LogSanitizer) Filter(args []any) []any {
 	for i, arg := range args {
 		v, ok := arg.(string)
 		if ok && containsSensitiveSubstring(v) {
@@ -37,12 +37,12 @@ func (f *LogSanitizer) Filter(args []any) []any {
 	return args
 }
 
-func (f *LogSanitizer) FilterF(format string, args []any) (string, []any) {
-	return format, f.Filter(args)
+func (l *LogSanitizer) FilterF(format string, args []any) (string, []any) {
+	return format, l.Filter(args)
 }
 
-func (f *LogSanitizer) FilterS(msg string, keysAndValues []any) (string, []any) {
-	return msg, f.Filter(keysAndValues)
+func (l *LogSanitizer) FilterS(msg string, keysAndValues []any) (string, []any) {
+	return msg, l.Filter(keysAndValues)
 }
 
 func containsSensitiveSubstring(msg string) bool {

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -92,6 +92,7 @@ func initKlog(logger Logger) {
 	// (logs will out in standalone installer and dhctl-server)
 	flags := &flag.FlagSet{}
 	klog.InitFlags(flags)
+	klog.SetLogFilter(&LogSanitizer{}) // filter sensitive keywords
 	flags.Set("logtostderr", "false")
 	flags.Set("v", "10")
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Sanitize sensitive data in debug log(klog).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Hide sensitive data in debug log.

behaviour:
 - <details>
    <summary>Before</summary>
  
    ```
    2025-09-26 14:48:57 - klog: I0926 14:48:57.477831      21 round_trippers.go:553] GET http://localhost:22322/api/v1/namespaces/kube-system/secrets/d8-provider-cluster-configuration 200 OK in 46 milliseconds
    2025-09-26 14:48:57 - klog: I0926 14:48:57.477944      21 round_trippers.go:570] HTTP Statistics: GetConnection 0 ms ServerProcessing 46 ms Duration 46 ms
    2025-09-26 14:48:57 - klog: I0926 14:48:57.477959      21 round_trippers.go:577] Response Headers:
    2025-09-26 14:48:57 - klog: I0926 14:48:57.477976      21 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 2dd73ca9-53a2-4a4b-ad6b-cf0fdeba5d51
    2025-09-26 14:48:57 - klog: I0926 14:48:57.477987      21 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: 5298ee09-1c7d-4aff-839e-88df12906831
    2025-09-26 14:48:57 - klog: I0926 14:48:57.477998      21 round_trippers.go:580]     Audit-Id: ef862162-8c51-4e62-a1de-7ae7c05e7505
    2025-09-26 14:48:57 - klog: I0926 14:48:57.478009      21 round_trippers.go:580]     Cache-Control: no-cache, private
    2025-09-26 14:48:57 - klog: I0926 14:48:57.478015      21 round_trippers.go:580]     Content-Length: 2795
    2025-09-26 14:48:57 - klog: I0926 14:48:57.478022      21 round_trippers.go:580]     Content-Type: application/json
    2025-09-26 14:48:57 - klog: I0926 14:48:57.478037      21 round_trippers.go:580]     Date: Fri, 26 Sep 2025 14:48:57 GMT
    2025-09-26 14:48:57 - klog: I0926 14:48:57.478138      21 request.go:1212] Response Body: {"kind":"Secret","apiVersion":"v1","metadata":{"name":"d8-provider-cluster-configuration","namespace":"kube-system","uid":"c0b93f60-54da-43c9-854d-a9e2c4f08442","resourceVersion":"48952","creationTimestamp":"2025-09-10T09:20:37Z","labels":{"name":"d8-provider-cluster-configuration"},"managedFields":[{"manager":"dhctl","operation":"Update","apiVersion":"v1","time":"2025-09-10T09:20:37Z","fieldsType":"FieldsV1","fieldsV1":{"f:data":{".":{},"f:cloud-provider-cluster-configuration.yaml":{},"f:cloud-provider-discovery-data.json":{}},"f:type":{}}},{"manager":"deckhouse-controller","operation":"Update","apiVersion":"v1","time":"2025-09-10T10:39:21Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:labels":{".":{},"f:name":{}}}}}]},"data":{SENSITIVE_DATA},"type":"Opaque"}
    ```
  </details>

- <details>
    <summary>After</summary>
  
    ```
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449457      20 round_trippers.go:553] GET http://localhost:22322/api/v1/namespaces/kube-system/secrets/d8-provider-cluster-configuration 200 OK in 54 milliseconds
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449587      20 round_trippers.go:570] HTTP Statistics: GetConnection 0 ms ServerProcessing 53 ms Duration 54 ms
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449624      20 round_trippers.go:577] Response Headers:
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449655      20 round_trippers.go:580]     Audit-Id: bfe2b39f-fa5e-48a1-8b87-7c4dd3613da4
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449667      20 round_trippers.go:580]     Cache-Control: no-cache, private
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449677      20 round_trippers.go:580]     Content-Length: 2795
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449687      20 round_trippers.go:580]     Content-Type: application/json
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449696      20 round_trippers.go:580]     Date: Fri, 26 Sep 2025 09:29:07 GMT
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449704      20 round_trippers.go:580]     X-Kubernetes-Pf-Flowschema-Uid: 2dd73ca9-53a2-4a4b-ad6b-cf0fdeba5d51
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449712      20 round_trippers.go:580]     X-Kubernetes-Pf-Prioritylevel-Uid: 5298ee09-1c7d-4aff-839e-88df12906831
    2025-09-26 09:29:07 - klog: I0926 09:29:07.449891      20 request.go:1212] Response Body: [FILTERED]
    ```
  </details>

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Sanitize sensitive data in debug log(klog).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
