### PR TITLE
[kube-dns] Add SVACE analyze for module

### DIFF
--- a/modules/042-kube-dns/images/sts-pods-hosts-appender-init-container/werf.inc.yaml
+++ b/modules/042-kube-dns/images/sts-pods-hosts-appender-init-container/werf.inc.yaml
@@ -10,7 +10,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}
@@ -26,7 +26,8 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd src/
-    - go build -ldflags="-s -w" -o render-etc-hosts-with-cluster-domain-aliases main.go
+    - |
+      {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o render-etc-hosts-with-cluster-domain-aliases main.go`) | indent 6 }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless

--- a/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/werf.inc.yaml
+++ b/modules/042-kube-dns/images/sts-pods-hosts-appender-webhook/werf.inc.yaml
@@ -10,7 +10,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-artifact
-fromImage: builder/golang-alpine
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}
@@ -26,7 +26,8 @@ shell:
   install:
     - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - cd src/
-    - go build -ldflags="-s -w" -o sts-pods-hosts-appender-webhook main.go
+    - |
+      {{- include "image-build.build" (set $ "BuildCommand" `go build -ldflags="-s -w" -o sts-pods-hosts-appender-webhook main.go`) | indent 6 }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless


### PR DESCRIPTION
## Description

This change introduces SVACE static analysis for the `kube-dns` module (only for code written in the Golang language).

## Why do we need it, and what problem does it solve?

By integrating SVACE static analysis into the build process for these network modules, we can proactively identify potential vulnerabilities, bugs, and code quality issues. This enhances the overall security and reliability of the networking components within Deckhouse.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: kube-dns
type: chore
summary: Added SVACE analyze for module.
impact_level: default
```
