### PR TITLE
 [runtime-audit-engine] Disable vpa for k8s-metacollector

### DIFF
--- a/ee/modules/650-runtime-audit-engine/template_tests/module_test.go
+++ b/ee/modules/650-runtime-audit-engine/template_tests/module_test.go
@@ -67,73 +67,80 @@ resourcesRequests:
 		})
 	})
 
-	Context("With VPA mode set", func() {
-		BeforeEach(func() {
-			hec.ValuesSetFromYaml("runtimeAuditEngine", `
-debugLogging: false
-internal:
-  webhookCertificate:
-    ca: ABC
-    crt: ABC
-    key: ABC
-resourcesRequests:
-  mode: VPA
-  static:
-    cpu: 5m
-    memory: 4Mi
-  vpa:
-    cpu:
-      max: 500m
-      min: 50m
-    memory:
-      max: 2048Mi
-      min: 64Mi
-    mode: Initial
-`)
-			hec.HelmRender()
-		})
-		It("Should add desired objects", func() {
-			Expect(hec.RenderError).ShouldNot(HaveOccurred())
-
-			testD := hec.KubernetesResource("DaemonSet", "d8-runtime-audit-engine", "runtime-audit-engine")
-			Expect(testD.Exists()).To(BeTrue())
-			Expect(testD.Field("spec.template.spec.containers.0.resources.requests").String()).To(MatchYAML(`
-ephemeral-storage: 50Mi
-`))
-
-			manVPA := hec.KubernetesResource("VerticalPodAutoscaler", "d8-runtime-audit-engine", "runtime-audit-engine")
-			Expect(manVPA.Exists()).To(BeTrue())
-			Expect(manVPA.Field("spec.updatePolicy.updateMode").String()).To(Equal("Initial"))
-			Expect(manVPA.Field("spec.resourcePolicy.containerPolicies").String()).To(MatchYAML(`
-- containerName: falco
-  controlledValues: RequestsAndLimits
-  maxAllowed:
-    cpu: 500m
-    memory: 2048Mi
-  minAllowed:
-    cpu: 50m
-    memory: 64Mi
-- containerName: falcosidekick
-  maxAllowed:
-    cpu: 100m
-    memory: 300Mi
-  minAllowed:
-    cpu: 5m
-    memory: 10Mi
-- containerName: rules-loader
-  maxAllowed:
-    cpu: 100m
-    memory: 300Mi
-  minAllowed:
-    cpu: 10m
-    memory: 25Mi
-- containerName: kube-rbac-proxy
-  maxAllowed:
-    cpu: 20m
-    memory: 25Mi
-  minAllowed:
-    cpu: 10m
-    memory: 25Mi`))
-		})
-	})
+	//	Context("With VPA mode set", func() {
+	//		BeforeEach(func() {
+	//			hec.ValuesSetFromYaml("runtimeAuditEngine", `
+	//
+	// debugLogging: false
+	// internal:
+	//
+	//	webhookCertificate:
+	//	  ca: ABC
+	//	  crt: ABC
+	//	  key: ABC
+	//
+	// resourcesRequests:
+	//
+	//	mode: VPA
+	//	static:
+	//	  cpu: 5m
+	//	  memory: 4Mi
+	//	vpa:
+	//	  cpu:
+	//	    max: 500m
+	//	    min: 50m
+	//	  memory:
+	//	    max: 2048Mi
+	//	    min: 64Mi
+	//	  mode: Initial
+	//
+	// `)
+	//
+	//		hec.HelmRender()
+	//	})
+	//	It("Should add desired objects", func() {
+	//		Expect(hec.RenderError).ShouldNot(HaveOccurred())
+	//
+	//		testD := hec.KubernetesResource("DaemonSet", "d8-runtime-audit-engine", "runtime-audit-engine")
+	//		Expect(testD.Exists()).To(BeTrue())
+	//		Expect(testD.Field("spec.template.spec.containers.0.resources.requests").String()).To(MatchYAML(`
+	//
+	// ephemeral-storage: 50Mi
+	// `))
+	//
+	//	manVPA := hec.KubernetesResource("VerticalPodAutoscaler", "d8-runtime-audit-engine", "runtime-audit-engine")
+	//	Expect(manVPA.Exists()).To(BeTrue())
+	//	Expect(manVPA.Field("spec.updatePolicy.updateMode").String()).To(Equal("Initial"))
+	//	Expect(manVPA.Field("spec.resourcePolicy.containerPolicies").String()).To(MatchYAML(`
+	//   - containerName: falco
+	//     controlledValues: RequestsAndLimits
+	//     maxAllowed:
+	//     cpu: 500m
+	//     memory: 2048Mi
+	//     minAllowed:
+	//     cpu: 50m
+	//     memory: 64Mi
+	//   - containerName: falcosidekick
+	//     maxAllowed:
+	//     cpu: 100m
+	//     memory: 300Mi
+	//     minAllowed:
+	//     cpu: 5m
+	//     memory: 10Mi
+	//   - containerName: rules-loader
+	//     maxAllowed:
+	//     cpu: 100m
+	//     memory: 300Mi
+	//     minAllowed:
+	//     cpu: 10m
+	//     memory: 25Mi
+	//   - containerName: kube-rbac-proxy
+	//     maxAllowed:
+	//     cpu: 20m
+	//     memory: 25Mi
+	//     minAllowed:
+	//     cpu: 10m
+	//     memory: 25Mi`))
+	//     })
+	//     })
 })

--- a/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/daemonset.yaml
@@ -13,6 +13,27 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "disabled_vpa_spec" -}}
+  {{- $targetAPIVersion := index . 0 -}}  {{- /* Target API version */ -}}
+  {{- $targetKind       := index . 1 -}}  {{- /* Target Kind */ -}}
+  {{- $targetName       := index . 2 -}}  {{- /* Target Name */ -}}
+  {{- $configuration    := index . 3 -}}  {{- /* VPA resource configuration [example](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/istio/configuration.html#parameters-controlplane-resourcesmanagement) */ -}}
+
+targetRef:
+  apiVersion: {{ $targetAPIVersion }}
+  kind: {{ $targetKind }}
+  name: {{ $targetName }}
+  {{- if eq ($configuration.mode) "VPA" }}
+updatePolicy:
+  updateMode: "Off"
+resourcePolicy:
+  containerPolicies:
+  {{- else }}
+updatePolicy:
+  updateMode: "Off"
+  {{- end }}
+{{- end }}
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -22,7 +43,11 @@ metadata:
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name)) | nindent 2 }}
 spec:
-    {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "DaemonSet" $.Chart.Name "falco" $.Values.runtimeAuditEngine.resourcesRequests ) | nindent 2}}
+    {{/* Disable falco VPA until memory leak in falco is fixed. Removing that also requires falco-leak-limit-range.y eaml to be removed.*/}}
+    {{/* Also, uncomment the test for VPA template rendering in template_tests/module_test.go */}}
+    {{/* {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "DaemonSet" $.Chart.Name "falco" $.Values.runtimeAuditEngine.resourcesRequests) | nindent 2}} */}}
+    {{- include "disabled_vpa_spec"  (list "apps/v1" "DaemonSet" $.Chart.Name $.Values.runtimeAuditEngine.resourcesRequests) | nindent 2}}
+
     {{- if eq (.Values.runtimeAuditEngine.resourcesRequests.mode) "VPA" }}
     - containerName: "falcosidekick"
       minAllowed:

--- a/ee/modules/650-runtime-audit-engine/templates/falco-leak-limit-range.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/falco-leak-limit-range.yaml
@@ -1,3 +1,4 @@
+{{/*# If removing that, also restore the falco VPA in daemonset.yaml*/}}
 apiVersion: v1
 kind: LimitRange
 metadata:

--- a/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/deployment.yaml
+++ b/ee/modules/650-runtime-audit-engine/templates/k8s-metacollector/deployment.yaml
@@ -3,6 +3,28 @@ cpu: 10m
 memory: 25Mi
 {{- end }}
 
+{{- define "disabled_vpa" -}}
+  {{- $targetAPIVersion := index . 0 -}}  {{- /* Target API version */ -}}
+  {{- $targetKind       := index . 1 -}}  {{- /* Target Kind */ -}}
+  {{- $targetName       := index . 2 -}}  {{- /* Target Name */ -}}
+  {{- $configuration    := index . 3 -}}  {{- /* VPA resource configuration [example](https://deckhouse.io/products/kubernetes-platform/documentation/v1/modules/istio/configuration.html#parameters-controlplane-resourcesmanagement) */ -}}
+
+targetRef:
+  apiVersion: {{ $targetAPIVersion }}
+  kind: {{ $targetKind }}
+  name: {{ $targetName }}
+  {{- if eq ($configuration.mode) "VPA" }}
+updatePolicy:
+  updateMode: "Off"
+resourcePolicy:
+  containerPolicies:
+  {{- else }}
+updatePolicy:
+  updateMode: "Off"
+  {{- end }}
+{{- end }}
+
+
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
 apiVersion: autoscaling.k8s.io/v1
@@ -10,23 +32,26 @@ kind: VerticalPodAutoscaler
 metadata:
   name: k8s-metacollector
   namespace:  d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "k8s-metacollector")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "k8s-metacollector")) | nindent 2 }}  
 spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: k8s-metacollector
-  updatePolicy:
-    updateMode: "Auto"
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "k8s-metacollector"
-      minAllowed:
-        {{- include "k8s-metacollector_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 20m
-        memory: 50Mi
-    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+  # targetRef:
+  #   apiVersion: "apps/v1"
+  #   kind: Deployment
+  #   name: k8s-metacollector
+  # updatePolicy:
+  #   updateMode: "Auto"
+  # resourcePolicy:
+  #   containerPolicies:
+  #   - containerName: "k8s-metacollector"
+  #     minAllowed:
+  #       {{- include "k8s-metacollector_resources" . | nindent 8 }}
+  #     maxAllowed:
+  #       cpu: 20m
+  #       memory: 50Mi
+  {{/* Disable falco VPA until memory leak in falco is fixed. Removing that also requires falco-leak-limit-range.y eaml to be removed.*/}}
+  {{/* Also, uncomment the test for VPA template rendering in template_tests/module_test.go */}}
+  {{- include "disabled_vpa"  (list "apps/v1" "Deployment" "k8s-metacollector" $.Values.runtimeAuditEngine.resourcesRequests) | nindent 2}}  
+  {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
 ---
 apiVersion: policy/v1


### PR DESCRIPTION
## Description
Following  #14984, VPA has been disabled for the k8s-metacollector module.

## Why do we need it, and what problem does it solve?
Fixes issues related to VPA and limitrange conflicts

## Why do we need it in the patch release (if we do)?

Problem actual on releases `1.70`, `1.71`, `1.72`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section:  runtime-audit-engine
type: fix
summary: Disable vpa for k8s-metacollector
impact_level: default 
```
