### PR TITLE
[site] Fix URL for downloading installer

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -211,14 +211,7 @@ spec:
             name: backend
             port:
               name: http
-      - path: /downloads/deckhouse-cli
-        pathType: Prefix
-        backend:
-          service:
-            name: frontend
-            port:
-              name: http
-      - path: /downloads/deckhouse-cli-trdl
+      - path: /downloads
         pathType: Prefix
         backend:
           service:

--- a/docs/site/.werf/nginx-dev.conf
+++ b/docs/site/.werf/nginx-dev.conf
@@ -123,6 +123,27 @@ http {
             try_files /$lang/$1 /$lang/$1/index.html /$lang/$1/ $1 $1/index.html $1/ =404;
         }
 
+        # Redirect for installer
+        location /downloads/installer   {
+            rewrite ^/downloads/installer/latest/(?<filename>.+)$ /v0.4.0/$filename  break;
+            rewrite ^$ /get  break;
+
+            proxy_cache             dcache;
+            proxy_cache_key         $uri;
+            proxy_cache_methods     GET;
+            proxy_set_header        X-Real-IP         $remote_addr;
+            proxy_set_header        X-Original-URI    $request_uri;
+            proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_buffer_size       16k;
+            proxy_buffers           4 16k;
+            proxy_ignore_headers    Set-Cookie;
+            proxy_ignore_headers    Cache-Control;
+            proxy_intercept_errors  on;
+
+#             error_page              301 302 307 = @handle_redirects;
+            proxy_pass              http://installer.ui.foxtrot-dev.ru;
+        }
+
         location /includes {
             proxy_redirect    off;
             proxy_set_header  Host              $host;

--- a/docs/site/.werf/nginx.conf
+++ b/docs/site/.werf/nginx.conf
@@ -96,6 +96,27 @@ http {
             try_files /$lang/$1 /$lang/$1/index.html /$lang/$1/ $1 $1/index.html $1/ =404;
         }
 
+        # Redirect for installer
+        location /downloads/installer   {
+            rewrite ^/downloads/installer/latest/(?<filename>.+)$ /v0.4.0/$filename  break;
+            rewrite ^$ /get  break;
+
+            proxy_cache             dcache;
+            proxy_cache_key         $uri;
+            proxy_cache_methods     GET;
+            proxy_set_header        X-Real-IP         $remote_addr;
+            proxy_set_header        X-Original-URI    $request_uri;
+            proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_buffer_size       16k;
+            proxy_buffers           4 16k;
+            proxy_ignore_headers    Set-Cookie;
+            proxy_ignore_headers    Cache-Control;
+            proxy_intercept_errors  on;
+
+            error_page              301 302 307 = @handle_redirects;
+            proxy_pass              https://installer.ui.foxtrot-dev.ru;
+        }
+
         location ~* ^/downloads/deckhouse-cli/v[0-9]+\.[0-9]+\.[0-9]+/d8-v[0-9]+\.[0-9]+\.[0-9]+-(darwin|linux|windows)-(amd|arm)64.tar.gz(\.sha256sum)?$   {
             rewrite ^/downloads/deckhouse-cli/([^/]+/[^/]+\.gz(\.sha256sum)?)$ /deckhouse/deckhouse-cli/releases/download/$1/  break;
 

--- a/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
+++ b/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
@@ -41,15 +41,15 @@ docker run --privileged --pull always -v $HOME/.d8installer:$HOME/.d8installer -
               <p>Выполните команду:</p>
 {% capture command %}
 ```bash
-curl -sSf https://deckhouse.ru/download/installer | bash
+curl -sSf https://deckhouse.ru/downloads/installer | bash
 ```
 {% endcapture %}
 {{ command | markdownify }}
             </div>
             <div id="tab-mac-content-file" class="tab-content">
               <p>Скачайте установщик:
-                <a href="https://installer.ui.foxtrot-dev.ru/v0.4.0/d8install-darwin-arm64" class="download-btn">d8install-darwin-arm64</a>
-                <a href="https://installer.ui.foxtrot-dev.ru/v0.4.0/d8install-darwin-amd64" class="download-btn">d8install-darwin-amd64</a>
+                <a href="/downloads/installer/latest/d8install-darwin-arm64" class="download-btn">d8install-darwin-arm64</a>
+                <a href="/downloads/installer/latest/d8install-darwin-amd64" class="download-btn">d8install-darwin-amd64</a>
               </p>
               <p>Запустите его, выполнив команды ниже. Например, для архитектуры arm64:</p>
 {% capture command %}
@@ -81,13 +81,13 @@ docker run --privileged --pull always -v $HOME/.d8installer:$HOME/.d8installer -
               <p>Выполните команду:</p>
 {% capture command %}
 ```bash
-curl -sSf https://deckhouse.ru/download/installer | bash
+curl -sSf https://deckhouse.ru/downloads/installer | bash
 ```
 {% endcapture %}
 {{ command | markdownify }}
             </div>
             <div id="tab-linux-content-file" class="tab-content">
-              <p>Скачайте установщик: <a href="https://installer.ui.foxtrot-dev.ru/v0.3.0/d8install-linux-amd64" class="download-btn">d8install-linux-amd64</a></p>
+              <p>Скачайте установщик: <a href="/downloads/installer/latest/d8install-linux-amd64" class="download-btn">d8install-linux-amd64</a></p>
               <p>Запустите его, выполнив команды:</p>
 {% capture command %}
 ```bash


### PR DESCRIPTION
## Description
Fixed URL for downloading installer.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

```changes
section: docs
type: chore
summary: Fixed URL for downloading installer.
impact_level: low
```
