### PR TITLE
[deckhouse] make deckhouse privileged

### DIFF
--- a/.werf/defines/dev-prebuild.tmpl
+++ b/.werf/defines/dev-prebuild.tmpl
@@ -38,6 +38,14 @@
   add: /usr/bin/jq
   to: /usr/bin/jq
   after: setup
+- image: tools/erofs-utils
+  add: /usr/bin/mkfs.erofs
+  to: /usr/bin/mkfs.erofs
+  after: setup
+- image: tools/cryptsetup
+  add: /usr/sbin/veritysetup
+  to: /usr/sbin/veritysetup
+  after: setup
 - image: version-map-artifact
   add: /version_map_{{ $context.Env }}.yml
   to: /deckhouse/candi/version_map.yml

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
 {{- else }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
 {{- end }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
       initContainers:
         - name: init-downloaded-modules
           image: {{ include "helm_lib_module_image" (list . "init") }}
@@ -130,7 +130,7 @@ spec:
               name: deckhouse
       containers:
         - name: deckhouse
-          {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux" . | nindent 10 }}
+          {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 10 }}
 {{- if .Values.deckhouse.internal.chrootMode }}
             capabilities:
               drop:
@@ -283,6 +283,8 @@ spec:
               {{- include "deckhouse_resources" . | nindent 14 }}
           workingDir: /deckhouse
           volumeMounts:
+          - mountPath: /dev
+            name: dev-dir
           - mountPath: /tmp
             name: tmp
 {{- if .Values.deckhouse.internal.chrootMode }}
@@ -349,6 +351,10 @@ spec:
       serviceAccountName: deckhouse
       automountServiceAccountToken: true
       volumes:
+      - name: dev-dir
+        hostPath:
+          path: /dev
+          type: Directory
       - emptyDir:
           medium: Memory
         name: tmp


### PR DESCRIPTION
## Description
It makes deckhouse privileged and run as root.

## Why do we need it, and what problem does it solve?
Veritysetup requires privileged and root.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Make deckhouse privileged and run as root.
impact: deckhouse how has privileged mod and runs as root.
impact_level: high 
```
