### PR TITLE
[operator-trivy] bump golang.org/x/oauth2 to v0.31.0

### DIFF
--- a/ee/modules/500-operator-trivy/images/node-collector/patches/002-go-mod.patch
+++ b/ee/modules/500-operator-trivy/images/node-collector/patches/002-go-mod.patch
@@ -1,13 +1,24 @@
 diff --git a/go.mod b/go.mod
-index 5149032..bdfbb6b 100644
+index 5149032..5f69b00 100644
 --- a/go.mod
 +++ b/go.mod
+@@ -1,8 +1,8 @@
+ module github.com/aquasecurity/k8s-node-collector
+ 
+-go 1.22.0
++go 1.24.0
+ 
+-toolchain go1.22.4
++toolchain go1.24.4
+ 
+ require (
+ 	github.com/Masterminds/semver v1.5.0
 @@ -54,13 +54,12 @@ require (
  	github.com/xlab/treeprint v1.2.0 // indirect
  	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
  	golang.org/x/net v0.33.0 // indirect
 -	golang.org/x/oauth2 v0.10.0 // indirect
-+	golang.org/x/oauth2 v0.21.0 // indirect
++	golang.org/x/oauth2 v0.31.0 // indirect
  	golang.org/x/sync v0.10.0 // indirect
  	golang.org/x/sys v0.28.0 // indirect
  	golang.org/x/term v0.27.0 // indirect
@@ -18,7 +29,7 @@ index 5149032..bdfbb6b 100644
  	gopkg.in/inf.v0 v0.9.1 // indirect
  	gopkg.in/yaml.v2 v2.4.0 // indirect
 diff --git a/go.sum b/go.sum
-index 7abb5b9..739772c 100644
+index 7abb5b9..d8228af 100644
 --- a/go.sum
 +++ b/go.sum
 @@ -44,7 +44,6 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
@@ -42,8 +53,8 @@ index 7abb5b9..739772c 100644
  golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 -golang.org/x/oauth2 v0.10.0 h1:zHCpF2Khkwy4mMB4bv0U37YtJdTGW8jI0glAApi0Kh8=
 -golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
-+golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
-+golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
++golang.org/x/oauth2 v0.31.0 h1:8Fq0yVZLh4j4YA47vHKFTa9Ew5XIrCP8LC6UeNZnLxo=
++golang.org/x/oauth2 v0.31.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
  golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Bumped golang.org/x/oauth2 to v0.31.0 to fix CVE-2025-22868

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: chore
summary: Fixed CVE-2025-22868 in trivy node-collector image
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
