### PR TITLE
[docs] Add `core` tag to `registry` module

### DIFF
--- a/docs/documentation/_data/modules/embedded_modules_tags.json
+++ b/docs/documentation/_data/modules/embedded_modules_tags.json
@@ -184,6 +184,9 @@
   "prometheus-pushgateway": [
     "observability"
   ],
+  "registry": [
+    "core"
+  ],
   "runtime-audit-engine": [
     "security"
   ],


### PR DESCRIPTION
## Description
Added `core` tag to `registry` module.

## Changelog entries
```changes
section: docs
type: chore
summary: Added `core` tag to `registry` module.
impact_level: low
```
