### PR TITLE
[docs][gs] Add redirect configuration for installer downloads

### DIFF
--- a/docs/site/.helm/templates/10-cm-frontend.yaml
+++ b/docs/site/.helm/templates/10-cm-frontend.yaml
@@ -108,6 +108,27 @@ data:
             try_files /$lang/$1 /$lang/$1/index.html /$lang/$1/ $1 $1/index.html $1/ =404;
         }
 
+        # Redirect for installer
+        location /downloads/installer   {
+            rewrite ^/downloads/installer/latest/(?<filename>.+)$ /v0.4.0/$filename  break;
+            rewrite ^ /get  break;
+
+            proxy_cache             dcache;
+            proxy_cache_key         $uri;
+            proxy_cache_methods     GET;
+            proxy_set_header        X-Real-IP         $remote_addr;
+            proxy_set_header        X-Original-URI    $request_uri;
+            proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_buffer_size       16k;
+            proxy_buffers           4 16k;
+            proxy_ignore_headers    Set-Cookie;
+            proxy_ignore_headers    Cache-Control;
+            proxy_intercept_errors  on;
+
+            error_page              301 302 307 = @handle_redirects;
+            proxy_pass              https://installer.ui.foxtrot-dev.ru;
+        }
+
         location ~* ^/downloads/deckhouse-cli/v[0-9]+\.[0-9]+\.[0-9]+/d8-v[0-9]+\.[0-9]+\.[0-9]+-(darwin|linux|windows)-(amd|arm)64.tar.gz(\.sha256sum)?$   {
             rewrite ^/downloads/deckhouse-cli/([^/]+/[^/]+\.gz(\.sha256sum)?)$ /deckhouse/deckhouse-cli/releases/download/$1/  break;
 


### PR DESCRIPTION
## Description
Fix lost redirect configuration for installer downloads.

Ref: #15662, #15661, #15660, #12192

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix lost redirect configuration for installer downloads.
impact_level: low
```
