### PR TITLE
[docs] Remove outdated CRD links in DVP documentation

### DIFF
--- a/docs/site/_data/sidebars/virtualization-platform.yml
+++ b/docs/site/_data/sidebars/virtualization-platform.yml
@@ -562,22 +562,6 @@ entries:
         ru: Справка
       folders:
         - title:
-            en: API
-            ru: API
-          folders:
-            - title:
-                en: ClusterConfiguration
-                ru: ClusterConfiguration
-              url: /virtualization-platform/reference/cr/clusterconfiguration.html
-            - title:
-                en: StaticClusterConfiguration
-                ru: StaticClusterConfiguration
-              url: /virtualization-platform/reference/cr/staticclusterconfiguration.html
-            - title:
-                en: InitConfiguration
-                ru: InitConfiguration
-              url: /virtualization-platform/reference/cr/initconfiguration.html
-        - title:
             en: Console utilities
             ru: Консольные утилиты
           folders:

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/CONTROL_PLANE_MANAGEMENT_AND_CONFIGURATION.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/CONTROL_PLANE_MANAGEMENT_AND_CONFIGURATION.md
@@ -19,7 +19,7 @@ The control plane management functionality includes:
 
 - Configuring kubeconfig. DVP generates an up-to-date configuration file (with `cluster-admin` privileges), handles automatic renewal and updates, and creates a `symlink` for the `root` user.
 
-> Some parameters affecting control plane behavior are taken from the [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration) resource.
+> Some parameters affecting control plane behavior are taken from the [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration) resource.
 
 ## Enabling, disabling, and configuring the module
 

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/CONTROL_PLANE_MANAGEMENT_AND_CONFIGURATION_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/CONTROL_PLANE_MANAGEMENT_AND_CONFIGURATION_RU.md
@@ -20,7 +20,7 @@ Deckhouse Virtualization Platform (DVP) управляет компонента�
 
 - Настройка kubeconfig — DVP формирует актуальный конфигурационный файл (с правами `cluster-admin`), автоматическое продление и обновление, а также создание `symlink` для пользователя `root`.
 
-> Некоторые параметры, влияющие на работу control plane, берутся из ресурса [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration).
+> Некоторые параметры, влияющие на работу control plane, берутся из ресурса [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration).
 
 ## Включение, отключение и настройка модуля
 

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING.md
@@ -14,7 +14,7 @@ The control plane update process in DVP is fully automated.
 
 ### Changing the Kubernetes version
 
-1. Open the [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration) editor:
+1. Open the [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration) editor:
 
    ```shell
    d8 platform edit cluster-configuration

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/control-plane/UPDATING_AND_VERSIONING_RU.md
@@ -15,7 +15,7 @@ lang: ru
 
 ### Изменение версии Kubernetes
 
-1. Откройте редактирование [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/installing/configuration.html#clusterconfiguration):
+1. Откройте редактирование [ClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration):
 
    ```shell
    d8 platform edit cluster-configuration

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE.md
@@ -130,7 +130,7 @@ After the node group is created, a script for adding servers to the group will b
 
 ## Modifying a static cluster configuration
 
-The static cluster settings are stored in the [StaticClusterConfiguration](/products/kubernetes-platform/documentation/v1/installing/configuration.html#staticclusterconfiguration) structure.
+The static cluster settings are stored in the [StaticClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#staticclusterconfiguration) structure.
 
 To modify the static cluster parameters, run the following command:
 

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/platform-scaling/node/BARE_METAL_NODE_RU.md
@@ -131,7 +131,7 @@ lang: ru
 
 ## Изменение конфигурации статического кластера
 
-Настройки статического кластера хранятся в структуре [StaticClusterConfiguration](/products/kubernetes-platform/documentation/v1/installing/configuration.html#staticclusterconfiguration).
+Настройки статического кластера хранятся в структуре [StaticClusterConfiguration](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#staticclusterconfiguration).
 
 Чтобы изменить параметры статического кластера, выполните команду:
 


### PR DESCRIPTION
## Description
Removed outdated API section from sidebar in DVP documentation and fixed links.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Removed outdated API section from sidebar in DVP documentation and fixed links.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
