### PR TITLE
[docs] update documentation for new d8 mirror filter syntax

### DIFF
--- a/docs/documentation/pages/installing/README.md
+++ b/docs/documentation/pages/installing/README.md
@@ -706,24 +706,29 @@ You can check the current status of versions in the release channels at [release
    /home/user/d8-bundle
    ```
 
-   Examples using the new module filter syntax:
+   Example command to download `stronghold` module with semver `^` constraint from version 1.2.0:
 
    ```shell
-   # Download stronghold module with semver ^ constraint from version 1.2.0
    d8 mirror pull \
    --license='<LICENSE_KEY>' \
    --no-platform --no-security-db \
    --include-module stronghold@1.2.0 \
    /home/user/d8-bundle
+   ```
 
-   # Download secrets-store-integration module with semver ~ constraint from version 1.1.0
+   Example command to download `secrets-store-integration` module with semver `~` constraint from version 1.1.0:
+
+   ```shell
    d8 mirror pull \
    --license='<LICENSE_KEY>' \
    --no-platform --no-security-db \
    --include-module secrets-store-integration@~1.1.0 \
    /home/user/d8-bundle
+   ```
 
-   # Download exact version of stronghold module v1.2.5 and publish to all release channels
+   Example command to download exact version of `stronghold` module 1.2.5 and publish to all release channels:
+
+   ```shell
    d8 mirror pull \
    --license='<LICENSE_KEY>' \
    --no-platform --no-security-db \

--- a/docs/documentation/pages/installing/README_RU.md
+++ b/docs/documentation/pages/installing/README_RU.md
@@ -715,24 +715,29 @@ echo "$MYRESULTSTRING"
    /home/user/d8-bundle
    ```
 
-   Примеры команд с использованием нового синтаксиса фильтров модулей:
+   Пример команды для загрузки модуля `stronghold` с semver `^` ограничением от версии 1.2.0:
 
    ```shell
-   # Загрузка модуля stronghold с semver ^ ограничением от версии 1.2.0
    d8 mirror pull \
    --license='<LICENSE_KEY>' \
    --no-platform --no-security-db \
    --include-module stronghold@1.2.0 \
    /home/user/d8-bundle
+   ```
 
-   # Загрузка модуля secrets-store-integration с semver ~ ограничением от версии 1.1.0
+   Пример команды для загрузки модуля `secrets-store-integration` с semver `~` ограничением от версии 1.1.0:
+
+   ```shell
    d8 mirror pull \
    --license='<LICENSE_KEY>' \
    --no-platform --no-security-db \
    --include-module secrets-store-integration@~1.1.0 \
    /home/user/d8-bundle
+   ```
 
-   # Загрузка точной версии модуля stronghold v1.2.5 с публикацией во все каналы релизов
+   Пример команды для загрузки точной версии модуля `stronghold` 1.2.5 с публикацией во все каналы релизов:
+
+   ```shell
    d8 mirror pull \
    --license='<LICENSE_KEY>' \
    --no-platform --no-security-db \


### PR DESCRIPTION
## Description

This PR updates the documentation to reflect the new module filter syntax introduced in [deckhouse-cli PR #147](https://github.com/deckhouse/deckhouse-cli/pull/147). The changes include comprehensive documentation of the enhanced `--include-module` parameter syntax options for the `d8 mirror pull` command.

New filter syntax options:

- `module-name@1.3.0` — pulls versions with semver ^ constraint (^1.3.0), including v1.3.0, v1.3.3, v1.4.1
- `module-name@~1.3.0` — pulls versions with semver ~ constraint (>=1.3.0 <1.4.0), including only v1.3.0, v1.3.3
- `module-name@=v1.3.0` — pulls exact tag match v1.3.0, publishing to all release channels
- `module-name@=bobV1` — pulls exact tag match "bobV1", publishing to all release channels

## Why do we need it, and what problem does it solve?

- Users can now specify exactly which module versions they need using semantic versioning constraints
- Release channel targeting allows for more controlled deployments
- Support for custom tags and exact version matching provides maximum flexibility
- Users now have comprehensive examples and explanations for all available filter options

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: documentation
type: feature
summary: Update documentation for new d8 mirror filter syntax.
impact_level: low
```
