### PR TITLE
[docs] Move "Label assignment" page to Multitenancy section

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -848,16 +848,20 @@ entries:
                   url: /admin/configuration/logging/storage.html
             - title:
                 en: Multitenancy
-                ru: Мультенантность
-              url: /admin/multitenancy.html
+                ru: Мультитенантность
+              folders:
+                - title:
+                    en: Projects
+                    ru: Проекты
+                  url: /admin/multitenancy/projects.html
+                - title:
+                    en: Assigning namespace labels
+                    ru: Назначение лейблов пространствам имён
+                  url: /admin/multitenancy/label-assignment.html
             - title:
                 en: Backup and restore
                 ru: Резервное копирование и восстановление
               url: /admin/configuration/backup/backup-and-restore.html
-            - title:
-                en: Assigning namespace labels
-                ru: Назначение лейблов пространствам имён
-              url: /admin/configuration/label-assignment.html
         - title:
             en: Platform uninstalling
             ru: Удаление платформы

--- a/docs/documentation/pages/admin/configuration/multitenancy/LABEL-ASSIGNMENT.md
+++ b/docs/documentation/pages/admin/configuration/multitenancy/LABEL-ASSIGNMENT.md
@@ -1,6 +1,6 @@
 ---
 title: Automatic assignment of namespace labels and annotations
-permalink: en/admin/configuration/label-assignment.html
+permalink: en/admin/multitenancy/label-assignment.html
 ---
 
 You can automate the assignment of labels and annotations to namespaces in a Deckhouse cluster

--- a/docs/documentation/pages/admin/configuration/multitenancy/LABEL-ASSIGNMENT_RU.md
+++ b/docs/documentation/pages/admin/configuration/multitenancy/LABEL-ASSIGNMENT_RU.md
@@ -1,6 +1,6 @@
 ---
 title: Автоматическое назначение лейблов и аннотаций пространствам имён
-permalink: ru/admin/configuration/label-assignment.html
+permalink: ru/admin/multitenancy/label-assignment.html
 lang: ru
 ---
 

--- a/docs/documentation/pages/admin/configuration/multitenancy/README.md
+++ b/docs/documentation/pages/admin/configuration/multitenancy/README.md
@@ -1,7 +1,6 @@
 ---
-title: Multitenancy
-permalink: en/admin/multitenancy.html
-description: Multitenancy
+title: Projects
+permalink: en/admin/multitenancy/projects.html
 ---
 
 Multitenancy is the ability to create isolated environments (projects) within a Kubernetes cluster.

--- a/docs/documentation/pages/admin/configuration/multitenancy/README_RU.md
+++ b/docs/documentation/pages/admin/configuration/multitenancy/README_RU.md
@@ -1,7 +1,6 @@
 ---
-title: Мультитенантность
-permalink: ru/admin/multitenancy.html
-description: Мультитенантность
+title: Проекты
+permalink: ru/admin/multitenancy/projects.html
 lang: ru
 ---
 


### PR DESCRIPTION
## Description
Relocated the "Label assignment for namespaces" documentation page from the top level of the Platform Configuration section to the Multitenancy subsection.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Relocated the "Label assignment for namespaces" documentation page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
