### PR TITLE
[docs] Fix search for the global parameters

### DIFF
--- a/docs/documentation/_includes/search.liquid
+++ b/docs/documentation/_includes/search.liquid
@@ -24,7 +24,7 @@
 {%- endif %}
 {
 "name": "{{ item.name }}",
-"module": "{{ item.module }}",
+"module": "{{ item.module | default: "global" }}",
 "moduletype": "embedded",
 "url": "{{ page_canonical_url }}",
 "resName": "{{ item.resourceName | escape }}",


### PR DESCRIPTION
## Description
Fixed search search functionality for global parameters in the documentation by adding a default value for module names. Previously, global parameters without a module property would have empty module values, breaking search functionality.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary:  Fixed search for the global parameters in the documentation.
impact_level: low
```
