### PR TITLE
[docs][getting-started] Add link for GUI installer in GS

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
+++ b/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
@@ -160,5 +160,4 @@ docker run --privileged --pull always -v /mnt/c/Users/%USERNAME%/.d8installer:/m
   function openMacDefaultTab() {
       document.getElementById("tab-buttons-mac-container").classList.add("active");
   }
-
 </script>

--- a/docs/site/pages/getting_started/getting_started_ru.html
+++ b/docs/site/pages/getting_started/getting_started_ru.html
@@ -105,4 +105,19 @@ toc: false
       document.getElementById(installTabName).classList.add("active");
       evt.currentTarget.classList.add("active");
   }
+
+  function getHashValue() {
+      const hash = window.location.hash;
+      return hash.substring(1);
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+      const hashValue = getHashValue();
+      if (hashValue == "gui-install") {
+        document.getElementById("tab-manual-install").classList.remove("active");
+        document.getElementById("tab-gui-install").classList.add("active");
+        document.getElementById("tab-button-manual-install").classList.remove("active");
+        document.getElementById("tab-button-gui-install").classList.add("active");
+      }
+  });
 </script>

--- a/docs/site/pages/getting_started/getting_started_ru.html
+++ b/docs/site/pages/getting_started/getting_started_ru.html
@@ -96,6 +96,14 @@ toc: false
 
 <script>
   function openInstallTab(evt, installTabName) {
+      const url = new URL(window.location.href);
+      if (installTabName == 'tab-manual-install') {
+        url.hash = '';
+      }
+      if (installTabName == 'tab-gui-install') {
+        url.hash = 'gui-install';
+      }
+      window.history.replaceState(null, '', url.toString());
       document.getElementById("tab-manual-install").classList.remove("active");
       document.getElementById("tab-gui-install").classList.remove("active");
 


### PR DESCRIPTION
## Description

This pull request adds logic to the Russian "Getting Started" documentation page to automatically switch to the GUI installation tab when the URL hash is set to `#gui-install`. This improves the user experience by allowing direct linking to the GUI installation instructions.

Enhancements to tab navigation:

* Added a script that checks the URL hash on page load and, if it matches `gui-install`, switches the active tab and button to display the GUI installation instructions.

Other changes:

* Minor formatting adjustment in the installer block partial for Russian documentation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Added an anchor to the GUI installer.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
