### PR TITLE
[node-manager] CAPS: add condition to enable SSHLegacyMode

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/bootstrap.go
@@ -202,6 +202,7 @@ func (c *Client) setStaticInstancePhaseToBootstrapping(ctx context.Context, inst
 		}
 		if err != nil {
 			instanceScope.Logger.Error(err, "Failed to set StaticInstance: Failed to connect via ssh")
+			return false
 		}
 		data, err := sshCl.ExecSSHCommandToString(instanceScope, "echo check_ssh")
 		if err != nil {

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/instance_scope.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/instance_scope.go
@@ -105,6 +105,9 @@ func (i *InstanceScope) LoadSSHCredentials(ctx context.Context, recorder *event.
 	}
 
 	i.Credentials = credentials
+	if len(i.Credentials.Spec.PrivateSSHKey) > 0 {
+		i.SSHLegacyMode = true
+	}
 
 	return nil
 }

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/instance_scope.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/scope/instance_scope.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -43,11 +42,6 @@ type InstanceScope struct {
 	SSHLegacyMode bool
 }
 
-const (
-	sshLegacySecretName      = "d8-caps-use-legacy-ssh"
-	sshLegacySecretNamespace = "d8-cloud-instance-manager"
-)
-
 // NewInstanceScope creates a new instance scope.
 func NewInstanceScope(
 	scope *Scope,
@@ -67,22 +61,11 @@ func NewInstanceScope(
 	}
 
 	scope.PatchHelper = patchHelper
-	secret := &v1.Secret{}
-	legasyMode := true
-	secretKey := k8sClient.ObjectKey{
-		Name:      sshLegacySecretName,
-		Namespace: sshLegacySecretNamespace,
-	}
-
-	err = scope.Client.Get(ctx, secretKey, secret)
-	if err != nil {
-		legasyMode = false
-	}
 
 	return &InstanceScope{
 		Scope:         scope,
 		Instance:      staticInstance,
-		SSHLegacyMode: legasyMode,
+		SSHLegacyMode: true,
 	}, nil
 }
 
@@ -105,8 +88,8 @@ func (i *InstanceScope) LoadSSHCredentials(ctx context.Context, recorder *event.
 	}
 
 	i.Credentials = credentials
-	if len(i.Credentials.Spec.PrivateSSHKey) > 0 {
-		i.SSHLegacyMode = true
+	if len(i.Credentials.Spec.PrivateSSHKey) == 0 {
+		i.SSHLegacyMode = false
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Enable SSHLegacyMode if SSHPrivateKey is not empty and fix gossh panic

## Why do we need it, and what problem does it solve?

gossh implementation can be unstable and have connection issues. To avoid it we will use clissh implementation if we don't need password auth. Additionally, if credential was wrong, gossh causes panic, so we should fix it.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Enable SSHLegacyMode if SSHPrivateKey is not empty and fix gossh panic.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
