### PR TITLE
[user-authn] fix cert generation job deletion

### DIFF
--- a/modules/150-user-authn/hooks/generate_basic_auth_proxy_cert.go
+++ b/modules/150-user-authn/hooks/generate_basic_auth_proxy_cert.go
@@ -33,6 +33,7 @@ import (
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/ptr"
@@ -176,8 +177,12 @@ func generateProxyAuthCert(_ context.Context, input *go_hook.HookInput, dc depen
 	digest := input.Values.Get("global.modulesImages.digests.userAuthn.selfSignedGenerator").String()
 	job := generateJob(registry, digest, base64.StdEncoding.EncodeToString(gcsr))
 
-	foreground := v1.DeletePropagationForeground
-	_ = kubeClient.BatchV1().Jobs(proxyJobNS).Delete(context.Background(), proxyJobName, v1.DeleteOptions{PropagationPolicy: &foreground})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err = kubeClient.BatchV1().Jobs(proxyJobNS).Delete(ctx, proxyJobName, v1.DeleteOptions{PropagationPolicy: ptr.To(v1.DeletePropagationForeground)})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
 	createdJob, err := kubeClient.BatchV1().Jobs(proxyJobNS).Create(context.Background(), job, v1.CreateOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added a timeout and a check to be sure that old job object is recycled before creating a new one.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Fixed cert generation job deletion.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
