### PR TITLE
[ci] Add retries to compare_version script

### DIFF
--- a/.github/scripts/python/compare_version_modules.py
+++ b/.github/scripts/python/compare_version_modules.py
@@ -30,24 +30,41 @@ dangerous_modules = ["controlPlaneManager", "ingressNginx.controller"]
 
 image_from = os.getenv("IMAGE_FROM")
 image_to = os.getenv("IMAGE_TO")
+max_attempts = int(os.getenv("COMPARE_MAX_ATTEMPTS", 1))
+retry_delay = int(os.getenv("COMPARE_RETRY_DELAY", 30))
 
 print(f"Lookup image_digests from {image_from}")
 
-digests_from = json.loads(regctl([
-    "image",
-    "get-file",
-    image_from,
-    "/deckhouse/modules/images_digests.json"
-]))
+for attempts in range(1, max_attempts+1):
+    try:
+        digests_from = json.loads(regctl([
+            "image",
+            "get-file",
+            image_from,
+            "/deckhouse/modules/images_digests.json"
+        ]))
+    except subprocess.CalledProcessError as e:
+        if attempts == max_attempts:
+            raise
+    else:
+        break
+
 
 print(f"Lookup image_digests from {image_to}")
 
-digests_to = json.loads(regctl([
-    "image",
-    "get-file",
-    image_to,
-    "/deckhouse/modules/images_digests.json"
-]))
+for attempts in range(1, max_attempts+1):
+    try:
+        digests_to = json.loads(regctl([
+            "image",
+            "get-file",
+            image_to,
+            "/deckhouse/modules/images_digests.json"
+        ]))
+    except subprocess.CalledProcessError as e:
+        if attempts == max_attempts:
+            raise
+    else:
+        break
 
 digests_unique = {}
 

--- a/.github/workflow_templates/build-and-test_pre-release.yml
+++ b/.github/workflow_templates/build-and-test_pre-release.yml
@@ -276,6 +276,8 @@ jobs:
         id: list_changed_modules
         env:
           IMAGE_TO: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss:${{ github.ref_name }}"
+          COMPARE_MAX_ATTEMPTS: 10
+          COMPARE_RETRY_DELAY: 30
         run: |
           TAG_FROM="$(git ls-remote --tags origin | grep -F tags/v${GITHUB_REF_NAME#release-} | awk -F '/' '{print $3}' | sort -V | tail -n 1)"
           if [[ -n "${TAG_FROM}" ]]; then

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3758,6 +3758,8 @@ jobs:
         id: list_changed_modules
         env:
           IMAGE_TO: "${{ secrets.DECKHOUSE_DEV_REGISTRY_HOST }}/sys/deckhouse-oss:${{ github.ref_name }}"
+          COMPARE_MAX_ATTEMPTS: 10
+          COMPARE_RETRY_DELAY: 30
         run: |
           TAG_FROM="$(git ls-remote --tags origin | grep -F tags/v${GITHUB_REF_NAME#release-} | awk -F '/' '{print $3}' | sort -V | tail -n 1)"
           if [[ -n "${TAG_FROM}" ]]; then


### PR DESCRIPTION
## Description
Add retries to compare_versions script.

## Why do we need it, and what problem does it solve?
Comparing versions sometimes fails due to lag between image being pushed into registry and becoming available in registry.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add retries to compare_versions script.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
