### PR TITLE
[cloud-provider-vsphere] cloud-data-discoverer fixes

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
@@ -42,6 +42,7 @@ type Discoverer struct {
 	govmomiClient        *govmomi.Client
 	cnsClient            *cns.Client
 	vsphereClient        vsphere.Client
+	vmFolderPath         string
 }
 
 func NewDiscoverer(logger *log.Logger) *Discoverer {
@@ -123,6 +124,11 @@ func NewDiscoverer(logger *log.Logger) *Discoverer {
 		logger.Fatalf("Cannot get ZONE_TAG_CATEGORY env")
 	}
 
+	vmFolderPath := os.Getenv("VM_FOLDER_PATH")
+	if vmFolderPath == "" {
+		logger.Fatal("Cannot get VM_FOLDER_PATH env")
+	}
+
 	config := &vsphere.ProviderClusterConfiguration{
 		Region:            region,
 		RegionTagCategory: regionTagCategory,
@@ -147,6 +153,7 @@ func NewDiscoverer(logger *log.Logger) *Discoverer {
 		govmomiClient:        govmomiClient,
 		cnsClient:            cnsClient,
 		vsphereClient:        vc,
+		vmFolderPath:         vmFolderPath,
 	}
 }
 
@@ -178,6 +185,7 @@ func (d *Discoverer) DiscoveryData(ctx context.Context, cloudProviderDiscoveryDa
 	discoveryData.Datacenter = zonesDatastores.Datacenter
 	discoveryData.Zones = mergeZones(discoveryData.Zones, zonesDatastores.Zones)
 	discoveryData.Datastores = mergeDatastores(discoveryData.Datastores, zonesDatastores.ZonedDataStores)
+	discoveryData.VMFolderPath = d.vmFolderPath
 
 	discoveryDataJSON, err := json.Marshal(discoveryData)
 	if err != nil {


### PR DESCRIPTION
## Description
This PR fixes DiscoveryData logic inside cloud-data-discoverer and ads forgotten necessary `VM_FOLDER_PATH ` env to it. 

## Why do we need it, and what problem does it solve?
As for now, cloud-provider-vsphere discovery hook fails in hybrid clusters which causes deckhouse main queue hanging

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: cloud-data-discoverer fixes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
