### PR TITLE
[ingress-nginx] fix sorting req limits per zones

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/020-fix-sorting.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/020-fix-sorting.patch
@@ -1,0 +1,26 @@
+diff --git a/internal/ingress/controller/store/objectref.go b/internal/ingress/controller/store/objectref.go
+index 89ea47251..44dfe39e7 100644
+--- a/internal/ingress/controller/store/objectref.go
++++ b/internal/ingress/controller/store/objectref.go
+@@ -112,7 +112,7 @@ func (o *objectRefMap) Reference(ref string) []string {
+ 	if !ok {
+ 		return make([]string, 0)
+ 	}
+-	return consumers.UnsortedList()
++	return sets.List(consumers)
+ }
+ 
+ // ReferencedBy returns all objects referenced by the given object.
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index 8628f8090..51607c613 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -870,7 +870,7 @@ func buildRateLimitZones(input interface{}) []string {
+ 		}
+ 	}
+ 
+-	return zones.UnsortedList()
++	return sets.List(zones)
+ }
+ 
+ // buildRateLimit produces an array of limit_req to be used inside the Path of

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -114,3 +114,7 @@ Disabling log messages such as "Error obtaining Endpoints for Service...".
 ### 019-maxmind-alerts.patch
 
 The metric `geoip_errors_total` has been added, which indicates the number of errors related to GeoIP, specifically download errors (`type="download"`).
+
+### 020-fix-sorting.patch
+
+There is a sorting issue in a couple of files that causes unnecessary config reloads.

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -59,6 +59,7 @@ shell:
   - patch -p1 < /patches/017-fix-success-reload-metric.patch
   - patch -p1 < /patches/018-disable-error-logs.patch
   - patch -p1 < /patches/019-maxmind-alerts.patch
+  - patch -p1 < /patches/020-fix-sorting.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/018-fix-sorting.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/018-fix-sorting.patch
@@ -1,0 +1,26 @@
+diff --git a/internal/ingress/controller/store/objectref.go b/internal/ingress/controller/store/objectref.go
+index 89ea47251..44dfe39e7 100644
+--- a/internal/ingress/controller/store/objectref.go
++++ b/internal/ingress/controller/store/objectref.go
+@@ -112,7 +112,7 @@ func (o *objectRefMap) Reference(ref string) []string {
+ 	if !ok {
+ 		return make([]string, 0)
+ 	}
+-	return consumers.UnsortedList()
++	return sets.List(consumers)
+ }
+ 
+ // ReferencedBy returns all objects referenced by the given object.
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index f6816d70a..869463dad 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -852,7 +852,7 @@ func buildRateLimitZones(input interface{}) []string {
+ 		}
+ 	}
+ 
+-	return zones.UnsortedList()
++	return sets.List(zones)
+ }
+ 
+ // buildRateLimit produces an array of limit_req to be used inside the Path of

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -101,3 +101,7 @@ Disabling log messages such as "Error obtaining Endpoints for Service...".
 ### 017-maxmind-alerts.patch
 
 The metric `geoip_errors_total` has been added, which indicates the number of errors related to GeoIP, specifically download errors (`type="download"`).
+
+### 018-fix-sorting.patch
+
+There is a sorting issue in a couple of files that causes unnecessary config reloads.

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/017-fix-sorting.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/017-fix-sorting.patch
@@ -1,0 +1,26 @@
+diff --git a/internal/ingress/controller/store/objectref.go b/internal/ingress/controller/store/objectref.go
+index 89ea47251..44dfe39e7 100644
+--- a/internal/ingress/controller/store/objectref.go
++++ b/internal/ingress/controller/store/objectref.go
+@@ -112,7 +112,7 @@ func (o *objectRefMap) Reference(ref string) []string {
+ 	if !ok {
+ 		return make([]string, 0)
+ 	}
+-	return consumers.UnsortedList()
++	return sets.List(consumers)
+ }
+ 
+ // ReferencedBy returns all objects referenced by the given object.
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index 7410ce6e0..57131fa6f 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -856,7 +856,7 @@ func buildRateLimitZones(input interface{}) []string {
+ 		}
+ 	}
+ 
+-	return zones.UnsortedList()
++	return sets.List(zones)
+ }
+ 
+ // buildRateLimit produces an array of limit_req to be used inside the Path of

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
@@ -82,3 +82,7 @@ Disabling log messages such as "Error obtaining Endpoints for Service...".
 ### 016-maxmind-alerts.patch
 
 The metric `geoip_errors_total` has been added, which indicates the number of errors related to GeoIP, specifically download errors (`type="download"`).
+
+### 017-fix-sorting.patch
+
+There is a sorting issue in a couple of files that causes unnecessary config reloads.

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -74,6 +74,7 @@ shell:
   - patch -p1 < /patches/ingress-nginx/014-fix-success-reload-metric.patch
   - patch -p1 < /patches/ingress-nginx/015-disable-error-logs.patch
   - patch -p1 < /patches/ingress-nginx/016-maxmind-alerts.patch
+  - patch -p1 < /patches/ingress-nginx/017-fix-sorting.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/rootfs/001-balancer-lua.patch
   - patch -p1 < /patches/rootfs/002-nginx-tmpl.patch


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: The order of limit_req_zone statements is maintained across config reloads.
impact: The pods of the ingress-nginx module will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
