### PR TITLE
[dhctl] Generate own tmp dir for for singleshot server for prevent concurrent clean one temp directory for rpc server and dhctl instance

### DIFF
--- a/dhctl/cmd/dhctl/action.go
+++ b/dhctl/cmd/dhctl/action.go
@@ -1,0 +1,122 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
+)
+
+type actionIniter struct {
+	logFileMutex sync.Mutex
+	logFile      string
+}
+
+func newActionIniter() *actionIniter {
+	return &actionIniter{}
+}
+
+func (i *actionIniter) init(c *kingpin.ParseContext) error {
+	if err := i.initDirectories(); err != nil {
+		return err
+	}
+
+	if err := i.initLogger(c); err != nil {
+		return err
+	}
+
+	tomb.RegisterOnShutdown("Cleanup providers from default cache", func() {
+		infrastructureprovider.CleanupProvidersFromDefaultCache(log.GetDefaultLogger())
+	})
+
+	return nil
+}
+
+func (i *actionIniter) initDirectories() error {
+	tmpDir := app.TmpDirName
+	err := os.MkdirAll(tmpDir, 0o755)
+	if err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+
+		return fmt.Errorf("Cannot create tmp dir %s: %w", tmpDir, err)
+	}
+
+	return nil
+}
+
+func (i *actionIniter) initLogger(c *kingpin.ParseContext) error {
+	log.InitLogger(app.LoggerType)
+	if app.DoNotWriteDebugLogFile {
+		return nil
+	}
+
+	if c.SelectedCommand == nil {
+		return nil
+	}
+
+	logPath := app.DebugLogFilePath
+
+	if logPath == "" {
+		cmdStr := strings.Join(strings.Fields(c.SelectedCommand.FullCommand()), "")
+		logFile := cmdStr + "-" + time.Now().Format("20060102150405") + ".log"
+		logPath = path.Join(app.TmpDirName, logFile)
+	}
+
+	outFile, err := os.Create(logPath)
+	if err != nil {
+		return err
+	}
+
+	err = log.WrapWithTeeLogger(outFile, 1024)
+	if err != nil {
+		return err
+	}
+
+	log.InfoF("Debug log file: %s\n", logPath)
+
+	tomb.RegisterOnShutdown("Finalize logger", func() {
+		if err := log.FlushAndClose(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to flush and close log file: %v\n", err)
+			return
+		}
+	})
+
+	i.logFileMutex.Lock()
+	defer i.logFileMutex.Unlock()
+
+	i.logFile = logPath
+
+	return nil
+}
+
+func (i *actionIniter) getLoggerPath() string {
+	i.logFileMutex.Lock()
+	defer i.logFileMutex.Unlock()
+
+	return i.logFile
+}

--- a/dhctl/cmd/dhctl/commands/server.go
+++ b/dhctl/cmd/dhctl/commands/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/settings"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/singlethreaded"
 )
 
@@ -28,7 +29,15 @@ func DefineServerCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DoNotWriteDebugLogFile = true
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		return server.Serve(app.ServerNetwork, app.ServerAddress, app.ServerParallelTasksLimit, app.ServerRequestsCounterMaxDuration)
+		return server.Serve(settings.ServerParams{
+			ServerGeneralParams: settings.ServerGeneralParams{
+				Network: app.ServerNetwork,
+				Address: app.ServerAddress,
+				TmpDir:  app.TmpDirName,
+			},
+			ParallelTasksLimit:         app.ServerParallelTasksLimit,
+			RequestsCounterMaxDuration: app.ServerRequestsCounterMaxDuration,
+		})
 	})
 	return cmd
 }
@@ -39,7 +48,13 @@ func DefineSingleThreadedServerCommand(cmd *kingpin.CmdClause) *kingpin.CmdClaus
 	app.DoNotWriteDebugLogFile = true
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		return singlethreaded.Serve(app.ServerNetwork, app.ServerAddress)
+		return singlethreaded.Serve(settings.ServerSingleshotParams{
+			ServerGeneralParams: settings.ServerGeneralParams{
+				Network: app.ServerNetwork,
+				Address: app.ServerAddress,
+				TmpDir:  app.TmpDirName,
+			},
+		})
 	})
 	return cmd
 }

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -17,16 +17,9 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
-	"runtime/pprof"
-	"runtime/trace"
-	"slices"
 	"strings"
-	"sync"
-	"time"
 
-	terminal "golang.org/x/term"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/cmd/dhctl/commands"
@@ -34,7 +27,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/global/infrastructure"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/process"
@@ -44,8 +36,7 @@ import (
 )
 
 var (
-	allowedCommands []string
-	commandList     = []Command{
+	commandList = []Command{
 		{
 			Name:       "server",
 			Help:       "Start dhctl as GRPC server.",
@@ -282,20 +273,16 @@ var (
 	}
 )
 
-type Command struct {
-	Name       string
-	Help       string
-	DefineFunc func(cmd *kingpin.CmdClause) *kingpin.CmdClause
-	Parrent    string
-	cmd        *kingpin.CmdClause
-}
-
 func main() {
-	_ = os.Mkdir(app.TmpDirName, 0o755)
-
 	initGlobalVars()
 
-	tomb.RegisterOnShutdown("Trace", EnableTrace())
+	tracesShutdownFn, err := enableTrace()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	tomb.RegisterOnShutdown("Trace", tracesShutdownFn)
 	tomb.RegisterOnShutdown("Restore terminal if needed", restoreTerminal())
 	tomb.RegisterOnShutdown("Stop default SSH session", process.DefaultSession.Stop)
 	tomb.RegisterOnShutdown("Clear dhctl temporary directory", cache.ClearTemporaryDirs)
@@ -312,88 +299,18 @@ func main() {
 		return nil
 	})
 
-	err := registerCommands(kpApp)
-	if err != nil {
+	if err := registerCommands(kpApp); err != nil {
 		panic(err)
 	}
 
 	runApplication(kpApp)
 }
 
-type initer struct {
-	logFileMutex sync.Mutex
-	logFile      string
-}
-
-func newIniter() *initer {
-	return &initer{}
-}
-
-func (i *initer) initLogger(c *kingpin.ParseContext) error {
-	log.InitLogger(app.LoggerType)
-	if app.DoNotWriteDebugLogFile {
-		return nil
-	}
-
-	if c.SelectedCommand == nil {
-		return nil
-	}
-
-	logPath := app.DebugLogFilePath
-
-	if logPath == "" {
-		cmdStr := strings.Join(strings.Fields(c.SelectedCommand.FullCommand()), "")
-		logFile := cmdStr + "-" + time.Now().Format("20060102150405") + ".log"
-		logPath = path.Join(app.TmpDirName, logFile)
-	}
-
-	outFile, err := os.Create(logPath)
-	if err != nil {
-		return err
-	}
-
-	err = log.WrapWithTeeLogger(outFile, 1024)
-	if err != nil {
-		return err
-	}
-
-	log.InfoF("Debug log file: %s\n", logPath)
-
-	tomb.RegisterOnShutdown("Finalize logger", func() {
-		if err := log.FlushAndClose(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to flush and close log file: %v\n", err)
-			return
-		}
-	})
-
-	i.logFileMutex.Lock()
-	defer i.logFileMutex.Unlock()
-
-	i.logFile = logPath
-
-	return nil
-}
-
-func (i *initer) getLoggerPath() string {
-	i.logFileMutex.Lock()
-	defer i.logFileMutex.Unlock()
-
-	return i.logFile
-}
-
 func runApplication(kpApp *kingpin.Application) {
-	init := newIniter()
+	initer := newActionIniter()
 
 	kpApp.Action(func(c *kingpin.ParseContext) error {
-		if err := init.initLogger(c); err != nil {
-			return err
-		}
-
-		tomb.RegisterOnShutdown("Cleanup providers from default cache", func() {
-			infrastructureprovider.CleanupProvidersFromDefaultCache(log.GetDefaultLogger())
-		})
-
-		return nil
+		return initer.init(c)
 	})
 
 	kpApp.Version(app.AppVersion).Author("Flant")
@@ -406,7 +323,7 @@ func runApplication(kpApp *kingpin.Application) {
 
 			msg := err.Error()
 
-			if logFile := init.getLoggerPath(); logFile != "" {
+			if logFile := initer.getLoggerPath(); logFile != "" {
 				msg = fmt.Sprintf("%s\nDebug log file: %s", msg, logFile)
 			}
 
@@ -419,88 +336,6 @@ func runApplication(kpApp *kingpin.Application) {
 	// Block "main" function until teardown callbacks are finished.
 	exitCode := tomb.WaitShutdown()
 	os.Exit(exitCode)
-}
-
-func EnableTrace() func() {
-	traceFileName := os.Getenv("DHCTL_TRACE")
-	cpuProfileFileName := traceFileName + ".prof.cpu"
-
-	if traceFileName == "" || traceFileName == "0" || traceFileName == "no" {
-		return func() {}
-	}
-	if traceFileName == "1" || traceFileName == "yes" {
-		traceFileName = "trace.out"
-		cpuProfileFileName = "pprof.cpu"
-	}
-
-	fns := make([]func(), 0)
-
-	traceF, err := os.Create(traceFileName)
-	if err != nil {
-		log.InfoF("failed to create trace output file '%s': %v", traceFileName, err)
-		os.Exit(1)
-	}
-
-	fns = append([]func(){
-		func() {
-			if err := traceF.Close(); err != nil {
-				log.InfoF("failed to close trace file '%s': %v", traceFileName, err)
-				os.Exit(1)
-			}
-		},
-	}, fns...)
-
-	profCPU, err := os.Create(cpuProfileFileName)
-	if err != nil {
-		log.InfoF("failed to create pprof cpu file '%s': %v", cpuProfileFileName, err)
-		os.Exit(1)
-	}
-
-	fns = append([]func(){
-		func() {
-			if err := profCPU.Close(); err != nil {
-				log.InfoF("failed to close pprof cpu file '%s': %v", cpuProfileFileName, err)
-				os.Exit(1)
-			}
-		},
-	}, fns...)
-
-	if err := trace.Start(traceF); err != nil {
-		log.InfoF("failed to start trace to '%s': %v", traceFileName, err)
-		os.Exit(1)
-	}
-	fns = append([]func(){
-		trace.Stop,
-	}, fns...)
-
-	if err := pprof.StartCPUProfile(profCPU); err != nil {
-		log.InfoF("failed to start profile cpu to '%s': %v", cpuProfileFileName, err)
-		os.Exit(1)
-	}
-
-	fns = append([]func(){
-		pprof.StopCPUProfile,
-	}, fns...)
-
-	return func() {
-		for _, fn := range fns {
-			fn()
-		}
-	}
-}
-
-func restoreTerminal() func() {
-	fd := int(os.Stdin.Fd())
-	if !terminal.IsTerminal(fd) {
-		return func() {}
-	}
-
-	state, err := terminal.GetState(fd)
-	if err != nil {
-		panic(err)
-	}
-
-	return func() { _ = terminal.Restore(fd, state) }
 }
 
 func initGlobalVars() {
@@ -537,113 +372,4 @@ func initGlobalVars() {
 	manifests.InitGlobalVars(dhctlPath)
 	template.InitGlobalVars(dhctlPath)
 	infrastructure.InitGlobalVars(dhctlPath)
-}
-
-func checkCommand(name string, allowedCommands []string) (bool, []string) {
-	if len(allowedCommands) == 0 || slices.Index(allowedCommands, name) != -1 {
-		return true, []string{}
-	}
-
-	for _, cm := range allowedCommands {
-		c := strings.Split(cm, " ")
-		if c[0] == name {
-			return true, c
-		}
-	}
-
-	return false, []string{}
-}
-
-func checkSubcommand(name string, subcommands []string) bool {
-	ex, _ := checkCommand(name, subcommands)
-	if len(subcommands) == 2 && subcommands[1] == "*" || ex {
-		return true
-	}
-
-	return false
-}
-
-func getParrentIndex(commandList []Command, name string) (int, error) {
-	for i, cmd := range commandList {
-		if name == cmd.Name {
-			return i, nil
-		}
-	}
-
-	return -1, fmt.Errorf("parrent command %s not found in command list", name)
-}
-
-func getNestingDepth(cmd Command, commands []Command) (Command, int) {
-	depth := 0
-	visited := make(map[string]bool)
-	topLevel := cmd
-
-	for {
-		found := false
-		for _, c := range commands {
-			if c.Name == cmd.Parrent && !visited[c.Name] {
-				visited[c.Name] = true
-				cmd = c
-				depth++
-				topLevel = cmd
-				found = true
-				break
-			}
-		}
-
-		if !found || cmd.Parrent == "" {
-			break
-		}
-	}
-
-	return topLevel, depth
-}
-
-func initParrent(parrentCmdIndex int, kpApp *kingpin.Application) *kingpin.CmdClause {
-	var pcmd *kingpin.CmdClause
-
-	if commandList[parrentCmdIndex].cmd == nil {
-		pcmd = kpApp.Command(commandList[parrentCmdIndex].Name, commandList[parrentCmdIndex].Help)
-		commandList[parrentCmdIndex].cmd = pcmd
-	} else {
-		pcmd = commandList[parrentCmdIndex].cmd
-	}
-	return pcmd
-}
-
-func registerCommands(kpApp *kingpin.Application) error {
-	for i, command := range commandList {
-		firstNode, depth := getNestingDepth(command, commandList)
-		if depth == 0 {
-			allowed, _ := checkCommand(command.Name, allowedCommands)
-			if allowed {
-				cmd := kpApp.Command(command.Name, command.Help)
-				commandList[i].cmd = cmd
-
-				if command.DefineFunc != nil {
-					command.DefineFunc(cmd)
-				}
-			}
-		} else {
-			parrentCmdIndex, err := getParrentIndex(commandList, command.Parrent)
-			if err != nil {
-				return err
-			}
-
-			allowed, subcommands := checkCommand(firstNode.Name, allowedCommands)
-
-			if allowed && checkSubcommand(command.Name, subcommands) {
-				pcmd := initParrent(parrentCmdIndex, kpApp)
-
-				cmd := pcmd.Command(command.Name, command.Help)
-				commandList[i].cmd = cmd
-
-				if command.DefineFunc != nil {
-					command.DefineFunc(cmd)
-				}
-			}
-		}
-	}
-
-	return nil
 }

--- a/dhctl/cmd/dhctl/register.go
+++ b/dhctl/cmd/dhctl/register.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var allowedCommands []string
+
+type Command struct {
+	Name       string
+	Help       string
+	DefineFunc func(cmd *kingpin.CmdClause) *kingpin.CmdClause
+	Parrent    string
+	cmd        *kingpin.CmdClause
+}
+
+func checkCommand(name string, allowedCommands []string) (bool, []string) {
+	if len(allowedCommands) == 0 || slices.Index(allowedCommands, name) != -1 {
+		return true, []string{}
+	}
+
+	for _, cm := range allowedCommands {
+		c := strings.Split(cm, " ")
+		if c[0] == name {
+			return true, c
+		}
+	}
+
+	return false, []string{}
+}
+
+func checkSubcommand(name string, subcommands []string) bool {
+	ex, _ := checkCommand(name, subcommands)
+	if len(subcommands) == 2 && subcommands[1] == "*" || ex {
+		return true
+	}
+
+	return false
+}
+
+func getParentIndex(commandList []Command, name string) (int, error) {
+	for i, cmd := range commandList {
+		if name == cmd.Name {
+			return i, nil
+		}
+	}
+
+	return -1, fmt.Errorf("parrent command %s not found in command list", name)
+}
+
+func getNestingDepth(cmd Command, commands []Command) (Command, int) {
+	depth := 0
+	visited := make(map[string]bool)
+	topLevel := cmd
+
+	for {
+		found := false
+		for _, c := range commands {
+			if c.Name == cmd.Parrent && !visited[c.Name] {
+				visited[c.Name] = true
+				cmd = c
+				depth++
+				topLevel = cmd
+				found = true
+				break
+			}
+		}
+
+		if !found || cmd.Parrent == "" {
+			break
+		}
+	}
+
+	return topLevel, depth
+}
+
+func initParent(parrentCmdIndex int, kpApp *kingpin.Application) *kingpin.CmdClause {
+	var pcmd *kingpin.CmdClause
+
+	if commandList[parrentCmdIndex].cmd == nil {
+		pcmd = kpApp.Command(commandList[parrentCmdIndex].Name, commandList[parrentCmdIndex].Help)
+		commandList[parrentCmdIndex].cmd = pcmd
+	} else {
+		pcmd = commandList[parrentCmdIndex].cmd
+	}
+	return pcmd
+}
+
+func registerCommands(kpApp *kingpin.Application) error {
+	for i, command := range commandList {
+		firstNode, depth := getNestingDepth(command, commandList)
+		if depth == 0 {
+			allowed, _ := checkCommand(command.Name, allowedCommands)
+			if allowed {
+				cmd := kpApp.Command(command.Name, command.Help)
+				commandList[i].cmd = cmd
+
+				if command.DefineFunc != nil {
+					command.DefineFunc(cmd)
+				}
+			}
+		} else {
+			parrentCmdIndex, err := getParentIndex(commandList, command.Parrent)
+			if err != nil {
+				return err
+			}
+
+			allowed, subcommands := checkCommand(firstNode.Name, allowedCommands)
+
+			if allowed && checkSubcommand(command.Name, subcommands) {
+				pcmd := initParent(parrentCmdIndex, kpApp)
+
+				cmd := pcmd.Command(command.Name, command.Help)
+				commandList[i].cmd = cmd
+
+				if command.DefineFunc != nil {
+					command.DefineFunc(cmd)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/dhctl/cmd/dhctl/terminal.go
+++ b/dhctl/cmd/dhctl/terminal.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	terminal "golang.org/x/term"
+)
+
+func restoreTerminal() func() {
+	fd := int(os.Stdin.Fd())
+	if !terminal.IsTerminal(fd) {
+		return func() {}
+	}
+
+	state, err := terminal.GetState(fd)
+	if err != nil {
+		panic(err)
+	}
+
+	return func() { _ = terminal.Restore(fd, state) }
+}

--- a/dhctl/cmd/dhctl/trace.go
+++ b/dhctl/cmd/dhctl/trace.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"runtime/trace"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+func enableTrace() (func(), error) {
+	traceFileName := os.Getenv("DHCTL_TRACE")
+	cpuProfileFileName := traceFileName + ".prof.cpu"
+
+	if traceFileName == "" || traceFileName == "0" || traceFileName == "no" {
+		return func() {}, nil
+	}
+	if traceFileName == "1" || traceFileName == "yes" {
+		traceFileName = "trace.out"
+		cpuProfileFileName = "pprof.cpu"
+	}
+
+	fns := make([]func(), 0)
+
+	traceF, err := os.Create(traceFileName)
+	if err != nil {
+		return func() {}, fmt.Errorf("Failed to create trace output file '%s': %v", traceFileName, err)
+	}
+
+	fns = append([]func(){
+		func() {
+			if err := traceF.Close(); err != nil {
+				log.InfoF("failed to close trace file '%s': %v", traceFileName, err)
+				os.Exit(1)
+			}
+		},
+	}, fns...)
+
+	profCPU, err := os.Create(cpuProfileFileName)
+	if err != nil {
+		return func() {}, fmt.Errorf("Failed to create pprof cpu file '%s': %v", cpuProfileFileName, err)
+	}
+
+	fns = append([]func(){
+		func() {
+			if err := profCPU.Close(); err != nil {
+				log.InfoF("failed to close pprof cpu file '%s': %v", cpuProfileFileName, err)
+				os.Exit(1)
+			}
+		},
+	}, fns...)
+
+	if err := trace.Start(traceF); err != nil {
+		return func() {}, fmt.Errorf("failed to start trace to '%s': %v", traceFileName, err)
+	}
+	fns = append([]func(){
+		trace.Stop,
+	}, fns...)
+
+	if err := pprof.StartCPUProfile(profCPU); err != nil {
+		return func() {}, fmt.Errorf("Failed to start profile cpu to '%s': %v", cpuProfileFileName, err)
+	}
+
+	fns = append([]func(){
+		pprof.StopCPUProfile,
+	}, fns...)
+
+	return func() {
+		for _, fn := range fns {
+			fn()
+		}
+	}, nil
+}

--- a/dhctl/pkg/server/server/proxy.go
+++ b/dhctl/pkg/server/server/proxy.go
@@ -36,28 +36,42 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/logger"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/settings"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/stringsutil"
 )
 
 type StreamDirector struct {
-	methodsPrefix string
-
 	wg          *sync.WaitGroup
 	syncWriters *syncWriters
+
+	params StreamDirectorParams
 }
 
-func NewStreamDirector(methodsPrefix string) *StreamDirector {
+type StreamDirectorParams struct {
+	MethodsPrefix string
+	TmpDir        string
+}
+
+func (params *StreamDirectorParams) Validate() error {
+	return settings.ValidateTmpPath(params.TmpDir)
+}
+
+func NewStreamDirector(params StreamDirectorParams) (*StreamDirector, error) {
+	if err := params.Validate(); err != nil {
+		return nil, err
+	}
+
 	return &StreamDirector{
-		methodsPrefix: methodsPrefix,
+		params: params,
 
 		wg: &sync.WaitGroup{},
 		syncWriters: &syncWriters{
 			stdoutWriter: &syncWriter{writer: os.Stdout},
 			stderrWriter: &syncWriter{writer: os.Stderr},
 		},
-	}
+	}, nil
 }
 
 func (d *StreamDirector) Wait() {
@@ -70,22 +84,35 @@ func (d *StreamDirector) Director() proxy.StreamDirector {
 		md, _ := metadata.FromIncomingContext(ctx)
 		outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
 
-		if !strings.HasPrefix(fullMethodName, d.methodsPrefix) {
+		if !strings.HasPrefix(fullMethodName, d.params.MethodsPrefix) {
 			return outCtx, nil, status.Errorf(codes.Unimplemented, "Unknown method")
 		}
 
-		address, err := socketPath()
+		proxyUUID, err := uuid.NewUUID()
 		if err != nil {
-			return outCtx, nil, err
+			return outCtx, nil, fmt.Errorf("Cannot create uuid for streaming director: %w", err)
 		}
 
+		proxyUUIDStr := proxyUUID.String()
+
+		address := d.socketPath(proxyUUIDStr)
+		tmpDirForInstance := d.tmpDirPath(proxyUUIDStr)
+
 		log := logger.L(ctx).With(slog.String("addr", address))
+		log.Info(
+			"Tmp dir for standalone dhctl from streaming director",
+			slog.String("proxyUUID", proxyUUIDStr),
+			slog.String("tmpDirForInstance", tmpDirForInstance),
+			slog.String("address", address),
+		)
 
 		cmd := exec.Command(
 			os.Args[0],
 			"_server",
 			"--server-network=unix",
+			"--do-not-write-debug-log-file",
 			fmt.Sprintf("--server-address=%s", address),
+			fmt.Sprintf("--tmp-dir=%s", tmpDirForInstance),
 		)
 
 		// Add parent envs to child envs
@@ -111,12 +138,14 @@ func (d *StreamDirector) Director() proxy.StreamDirector {
 
 		d.writeLogs(log, stdOutReader, stdErrReader)
 
+		log.Info("Dhctl instance will start with next command arguments", slog.String("cmd", strings.Join(cmd.Args, " ")))
+
 		err = cmd.Start()
 		if err != nil {
 			return outCtx, nil, fmt.Errorf("starting dhctl server: %w", err)
 		}
 
-		log.Info("started new dhctl instance")
+		log.Info("Started new dhctl instance")
 
 		d.wg.Add(1)
 		go func() {
@@ -179,14 +208,14 @@ func checkDHCTLServer(ctx context.Context, conn grpc.ClientConnInterface) error 
 	})
 }
 
-func socketPath() (string, error) {
-	sockUUID, err := uuid.NewUUID()
-	if err != nil {
-		return "", fmt.Errorf("creating uuid for socket path")
-	}
+func (d *StreamDirector) socketPath(directorUUID string) string {
+	return filepath.Join(d.params.TmpDir, directorUUID+".sock")
+}
 
-	address := filepath.Join(app.TmpDirName, sockUUID.String()+".sock")
-	return address, nil
+func (d *StreamDirector) tmpDirPath(directorUUID string) string {
+	hash := stringsutil.Sha256Encode(directorUUID)
+	first10Runes := fmt.Sprintf("%.10s", hash)
+	return filepath.Join(d.params.TmpDir, first10Runes)
 }
 
 type syncWriters struct {

--- a/dhctl/pkg/server/server/settings/settings.go
+++ b/dhctl/pkg/server/server/settings/settings.go
@@ -1,0 +1,75 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package settings
+
+import (
+	"fmt"
+	"path"
+	"time"
+)
+
+type ServerGeneralParams struct {
+	Network string
+	Address string
+	TmpDir  string
+}
+
+func (p *ServerGeneralParams) Validate() error {
+	if p.Network == "" {
+		return fmt.Errorf("network is required")
+	}
+	if p.Address == "" {
+		return fmt.Errorf("address is required")
+	}
+
+	if err := ValidateTmpPath(p.TmpDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type ServerSingleshotParams struct {
+	ServerGeneralParams
+}
+
+func (p *ServerSingleshotParams) Validate() error {
+	return p.ServerGeneralParams.Validate()
+}
+
+type ServerParams struct {
+	ServerGeneralParams
+
+	ParallelTasksLimit         int
+	RequestsCounterMaxDuration time.Duration
+}
+
+func (p *ServerParams) Validate() error {
+	return p.ServerGeneralParams.Validate()
+}
+
+func ValidateTmpPath(fullPath string) error {
+	tmpDir := path.Clean(fullPath)
+
+	if tmpDir == "" {
+		return fmt.Errorf("tmpdir is required")
+	}
+
+	if tmpDir == "/" {
+		return fmt.Errorf("tmpdir should not be /")
+	}
+
+	return nil
+}

--- a/dhctl/pkg/server/server/singlethreaded/server.go
+++ b/dhctl/pkg/server/server/singlethreaded/server.go
@@ -30,18 +30,22 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	dhctllog "github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	pbdhctl "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/interceptors"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/logger"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/rpc/dhctl"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/settings"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
 
 // Serve starts GRPC server
-func Serve(network, address string) error {
+func Serve(params settings.ServerSingleshotParams) error {
+	if err := params.Validate(); err != nil {
+		return err
+	}
+
 	dhctllog.InitLoggerWithOptions("silent", dhctllog.LoggerOptions{})
 	lvl := &slog.LevelVar{}
 	lvl.Set(slog.LevelDebug)
@@ -64,19 +68,20 @@ func Serve(network, address string) error {
 		log.Info("grpc server stopped")
 	})
 
-	cacheDir, err := cacheDirectory()
+	cacheDir, err := cacheDirectory(params)
 	if err != nil {
-		return fmt.Errorf("failed to init grpc server: %w", err)
+		return fmt.Errorf("Failed to init grpc server: %w", err)
 	}
 
 	log.Info(
 		"starting grpc server",
-		slog.String("network", network),
-		slog.String("address", address),
+		slog.String("network", params.Network),
+		slog.String("address", params.Address),
+		slog.String("tmp_dir", params.TmpDir),
 		slog.String("cache directory", cacheDir),
 	)
 
-	listener, err := net.Listen(network, address)
+	listener, err := net.Listen(params.Network, params.Address)
 	if err != nil {
 		log.Error("failed to listen", logger.Err(err))
 		return err
@@ -108,7 +113,7 @@ func Serve(network, address string) error {
 		PodName:     podName,
 		CacheDir:    cacheDir,
 		SchemaStore: config.NewSchemaStore(),
-		TmpDir:      app.TmpDirName,
+		TmpDir:      params.TmpDir,
 		IsDebug:     false,
 	})
 
@@ -128,13 +133,13 @@ func Serve(network, address string) error {
 	return nil
 }
 
-func cacheDirectory() (string, error) {
+func cacheDirectory(params settings.ServerSingleshotParams) (string, error) {
 	id, err := uuid.NewUUID()
 	if err != nil {
 		return "", fmt.Errorf("creating uuid for cache directory")
 	}
 
-	path := filepath.Join(os.TempDir(), "dhctl", "cache_"+id.String())
+	path := filepath.Join(params.TmpDir, "cache_"+id.String())
 
 	return path, nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
