### PR TITLE
[node-manager] Fix nodegroup validation script possible errors

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -268,7 +268,7 @@ EOF
   # check topologyManager.enabled and resourceReservation.mode == "static"
   if context::jq -e -r '.review.request.object.spec.kubelet.resourceReservation.mode == "Static" and .review.request.object.spec.kubelet.topologyManager.enabled == true and .review.request.object.spec.kubelet.resourceReservation.static.cpu == null' >/dev/null 2>&1; then
     cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"for .spec.kubelet.topologyManager.enabled and .spec.kubelet.resourceReservation.mode == "static" and .spec.kubelet.resourceReservation.static.cpu must be specified"}
+{"allowed":false, "message":"for .spec.kubelet.topologyManager.enabled and .spec.kubelet.resourceReservation.mode == \"static\" and .spec.kubelet.resourceReservation.static.cpu must be specified"}
 EOF
     return 0
   fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix error in webhook-handler
`{"level":"error","logger":"shell-operator","msg":"Hook failed. Will retry after delay.","binding":"nodegroup-policy.deckhouse.io","error":"got bad validating response: invalid character '\\n' in string literal","event":"kubernetesValidating","failedCount":1,"hook":"040-node-manager/webhooks/validating/node_group"`
close [issue](https://github.com/deckhouse/deckhouse/issues/15258)
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fix not valid JSON
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix error validating json in validating webhook
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
