### PR TITLE
[dhctl][backport] manual backport - change default ssh mode (#15773)

### DIFF
--- a/candi/openapi/dhctl/doc-ru-ssh_configuration.yaml
+++ b/candi/openapi/dhctl/doc-ru-ssh_configuration.yaml
@@ -29,3 +29,9 @@ apiVersions:
       sudoPassword:
         description: |
           Пароль sudo пользователя.
+      legacyMode:
+        description: |
+          Использовать легаси режим SSH (clissh).
+      modernMode:
+        description: |
+          Использовать актуальный режим SSH (gossh).

--- a/candi/openapi/dhctl/ssh_configuration.yaml
+++ b/candi/openapi/dhctl/ssh_configuration.yaml
@@ -68,5 +68,10 @@ apiVersions:
         type: string
       legacyMode:
         description: |
-          Switch to legacy SSH mode
+          Switch to legacy SSH mode (clissh).
         type: boolean
+      modernMode:
+        description: |
+          Switch to modern SSH mode (gossh).
+        type: boolean
+

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -24,9 +24,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 )
 
 func DefineBootstrapInstallDeckhouseCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -40,15 +39,11 @@ func DefineBootstrapInstallDeckhouseCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		var sshClient node.SSHClient
+		var err error
 		if len(app.SSHHosts) != 0 {
-			if app.SSHLegacyMode {
-				sshClient = clissh.NewClientFromFlags()
-			} else {
-				var err error
-				sshClient, err = gossh.NewClientFromFlags()
-				if err != nil {
-					return err
-				}
+			sshClient, err = sshclient.NewClientFromFlags()
+			if err != nil {
+				return err
 			}
 		}
 
@@ -68,14 +63,9 @@ func DefineBootstrapExecuteBashibleCommand(cmd *kingpin.CmdClause) *kingpin.CmdC
 	app.DefineBashibleBundleFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewClientFromFlagsWithHosts()
-		} else {
-			sshClient, err = gossh.NewClientFromFlagsWithHosts()
-		}
+		logger := log.GetDefaultLogger()
 
+		sshClient, err := sshclient.NewClientFromFlagsWithHosts()
 		if err != nil {
 			return fmt.Errorf("unable to create ssh-client: %w", err)
 		}
@@ -98,15 +88,12 @@ func DefineCreateResourcesCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		var sshClient node.SSHClient
+		var err error
+
 		if len(app.SSHHosts) != 0 {
-			if app.SSHLegacyMode {
-				sshClient = clissh.NewClientFromFlags()
-			} else {
-				var err error
-				sshClient, err = gossh.NewClientFromFlags()
-				if err != nil {
-					return err
-				}
+			sshClient, err = sshclient.NewClientFromFlags()
+			if err != nil {
+				return err
 			}
 		}
 
@@ -128,16 +115,13 @@ func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineAbortFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		if app.SSHLegacyMode {
-			sshClient = clissh.NewClientFromFlags()
-		} else {
-			var err error
-			sshClient, err = gossh.NewClientFromFlags()
-			if err != nil {
-				return err
-			}
+		logger := log.GetDefaultLogger()
+
+		sshClient, err := sshclient.NewClientFromFlags()
+		if err != nil {
+			return err
 		}
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
 			NodeInterface: ssh.NewNodeInterfaceWrapper(sshClient),
 		})
@@ -166,13 +150,9 @@ func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefinePostBootstrapScriptFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewClientFromFlagsWithHosts()
-		} else {
-			sshClient, err = gossh.NewClientFromFlagsWithHosts()
-		}
+		logger := log.GetDefaultLogger()
+
+		sshClient, err := sshclient.NewClientFromFlagsWithHosts()
 		if err != nil {
 			return fmt.Errorf("unable to create ssh-client: %w", err)
 		}

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -63,8 +63,6 @@ func DefineBootstrapExecuteBashibleCommand(cmd *kingpin.CmdClause) *kingpin.CmdC
 	app.DefineBashibleBundleFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		logger := log.GetDefaultLogger()
-
 		sshClient, err := sshclient.NewClientFromFlagsWithHosts()
 		if err != nil {
 			return fmt.Errorf("unable to create ssh-client: %w", err)
@@ -115,8 +113,6 @@ func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineAbortFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		logger := log.GetDefaultLogger()
-
 		sshClient, err := sshclient.NewClientFromFlags()
 		if err != nil {
 			return err
@@ -150,8 +146,6 @@ func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefinePostBootstrapScriptFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		logger := log.GetDefaultLogger()
-
 		sshClient, err := sshclient.NewClientFromFlagsWithHosts()
 		if err != nil {
 			return fmt.Errorf("unable to create ssh-client: %w", err)

--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -27,10 +27,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infrastructure/hook"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infrastructure/hook/controlplane"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -41,8 +39,6 @@ func DefineTestControlPlaneManagerReadyCommand(cmd *kingpin.CmdClause) *kingpin.
 	app.DefineControlPlaneFlags(cmd, false)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
 
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
@@ -51,12 +47,7 @@ func DefineTestControlPlaneManagerReadyCommand(cmd *kingpin.CmdClause) *kingpin.
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
-
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}
@@ -95,9 +86,6 @@ func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 	app.DefineControlPlaneFlags(cmd, true)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -105,11 +93,7 @@ func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -24,9 +24,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -36,8 +34,6 @@ func DefineConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineKubeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
 
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
@@ -46,11 +42,7 @@ func DefineConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}
@@ -106,9 +98,6 @@ func DefineConvergeMigrationCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineCheckHasTerraformStateBeforeMigrateToTofu(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -116,11 +105,7 @@ func DefineConvergeMigrationCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -26,10 +26,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -39,9 +37,6 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineKubeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -49,10 +44,9 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
+		if err != nil {
+			return err
 		}
 
 		err = log.Process("default", "Remove Deckhouse️", func() error {
@@ -99,8 +93,6 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return err
 		}
 
-		var sshClient node.SSHClient
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -108,11 +100,7 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -25,10 +25,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/destroy"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 )
@@ -61,8 +59,6 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			}
 		}
 
-		var sshClient node.SSHClient
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -70,16 +66,11 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient = clissh.NewClientFromFlags()
-		} else {
-			var err error
-			sshClient, err = gossh.NewClientFromFlags()
-			if err != nil {
-				return err
-			}
+		sshClient, err := sshclient.NewClientFromFlags()
+		if err != nil {
+			return err
 		}
-		err := sshClient.Start()
+		err = sshClient.Start()
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -24,10 +24,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -43,9 +41,6 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 	app.DefineSanityFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -53,11 +48,7 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -28,10 +28,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infrastructure/hook/controlplane"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/tomb"
 )
@@ -92,8 +90,6 @@ func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 		StringVar(&Name)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
 
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
@@ -102,11 +98,7 @@ func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -26,10 +26,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/lease"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/lock"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 )
@@ -49,9 +47,6 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 	app.DefineKubeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -59,11 +54,7 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/session.go
+++ b/dhctl/cmd/dhctl/commands/session.go
@@ -29,10 +29,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -47,9 +45,6 @@ func DefineSessionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineBecomeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -57,11 +52,7 @@ func DefineSessionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -27,9 +27,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -38,8 +36,6 @@ func DefineTestSSHConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineBecomeFlags(cmd)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshCl node.SSHClient
-		var err error
 
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
@@ -48,12 +44,7 @@ func DefineTestSSHConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshCl, err = clissh.NewClientFromFlagsWithHosts()
-		} else {
-			sshCl, err = gossh.NewClientFromFlagsWithHosts()
-		}
-
+		sshCl, err := sshclient.NewClientFromFlagsWithHosts()
 		if err != nil {
 			return err
 		}
@@ -90,8 +81,6 @@ func DefineTestSCPCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd.Flag("way", "transfer direction: 'up' to upload to remote or 'down' to download from remote").Short('w').StringVar(&Direction)
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		log.DebugLn("scp: start ssh-agent")
-		var sshCl node.SSHClient
-		var err error
 
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
@@ -100,11 +89,7 @@ func DefineTestSCPCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshCl, err = clissh.NewClientFromFlagsWithHosts()
-		} else {
-			sshCl, err = gossh.NewClientFromFlagsWithHosts()
-		}
+		sshCl, err := sshclient.NewClientFromFlagsWithHosts()
 		if err != nil {
 			return err
 		}
@@ -169,8 +154,6 @@ func DefineTestUploadExecCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		BoolVar(&Sudo)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
 
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
@@ -179,15 +162,10 @@ func DefineTestUploadExecCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlagsWithHosts(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlagsWithHosts(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlagsWithHosts(true)
 		if err != nil {
-			return nil
+			return err
 		}
-
 		cmd := sshClient.UploadScript(ScriptPath)
 		if Sudo {
 			cmd.Sudo()
@@ -223,9 +201,6 @@ func DefineTestBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		StringVar(&ScriptName)
 
 	cmd.Action(func(c *kingpin.ParseContext) error {
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -233,13 +208,9 @@ func DefineTestBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlagsWithHosts(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlagsWithHosts(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlagsWithHosts(true)
 		if err != nil {
-			return nil
+			return err
 		}
 
 		cmd := sshClient.UploadScript(ScriptName)

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -29,10 +29,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/check"
 	infrastructurestate "github.com/deckhouse/deckhouse/dhctl/pkg/state/infrastructure"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -59,9 +57,6 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 	cmd.Action(func(c *kingpin.ParseContext) error {
 		log.InfoLn("Check started ...\n")
 
-		var sshClient node.SSHClient
-		var err error
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -69,11 +64,7 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(true)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(true)
-		}
+		sshClient, err := sshclient.NewInitClientFromFlags(true)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/app/ssh.go
+++ b/dhctl/pkg/app/ssh.go
@@ -49,6 +49,7 @@ var (
 	AskBastionPass = false
 
 	SSHLegacyMode = false
+	SSHModernMode = false
 )
 
 type connectionConfigParser interface {
@@ -97,9 +98,12 @@ func DefineSSHFlags(cmd *kingpin.CmdClause, parser connectionConfigParser) {
 	cmd.Flag("connection-config", "SSH connection config file path").
 		Envar(configEnvName("CONNECTION_CONFIG")).
 		StringVar(&ConnectionConfigPath)
-	cmd.Flag("ssh-legacy-mode", "Switch to legacy SSH mode").
+	cmd.Flag("ssh-legacy-mode", "Force legacy SSH mode").
 		Envar(configEnvName("SSH_LEGACY_MODE")).
 		BoolVar(&SSHLegacyMode)
+	cmd.Flag("ssh-modern-mode", "Force modern SSH mode").
+		Envar(configEnvName("SSH_MODERN_MODE")).
+		BoolVar(&SSHModernMode)
 	cmd.Flag("ask-bastion-pass", "Ask for bastion password before the installation process.").
 		Envar(configEnvName("ASK_BASTION_PASS")).
 		BoolVar(&AskBastionPass)
@@ -132,6 +136,12 @@ func DefineSSHFlags(cmd *kingpin.CmdClause, parser connectionConfigParser) {
 			return nil
 		}
 		return processConnectionConfigFlags()
+	})
+	cmd.PreAction(func(c *kingpin.ParseContext) (err error) {
+		if SSHLegacyMode && (AskBecomePass && len(SSHPrivateKeys) == 0) {
+			return fmt.Errorf("SSH legacy mode does not support password-based SSH authentication. If you are using `--ask-become-pass`, please either specify `--ssh-modern-mode`, or leave the SSH mode unset to allow automatic detection of the appropriate method.")
+		}
+		return nil
 	})
 }
 

--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -45,6 +45,7 @@ type SSHConfig struct {
 	SSHBastionPassword  string               `json:"sshBastionPassword,omitempty"`
 	SudoPassword        string               `json:"sudoPassword,omitempty"`
 	LegacyMode          bool                 `json:"legacyMode,omitempty"`
+	ModernMode          bool                 `json:"modernMode,omitempty"`
 }
 
 type SSHAgentPrivateKey struct {
@@ -205,6 +206,7 @@ func (ConnectionConfigParser) ParseConnectionConfigFromFile() error {
 	app.SSHExtraArgs = cfg.SSHConfig.SSHExtraArgs
 	app.SSHBastionPass = cfg.SSHConfig.SSHBastionPassword
 	app.SSHLegacyMode = cfg.SSHConfig.LegacyMode
+	app.SSHModernMode = cfg.SSHConfig.ModernMode
 
 	return nil
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -42,11 +42,10 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/local"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
@@ -206,15 +205,9 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			log.DebugLn("Hosts empty and static cluster. Use local interface")
 			b.Params.NodeInterface = local.NewNodeInterface()
 		} else {
-			var sshClient node.SSHClient
-			if app.SSHLegacyMode {
-				sshClient = clissh.NewClientFromFlags()
-			} else {
-				var err error
-				sshClient, err = gossh.NewClientFromFlags()
-				if err != nil {
-					return err
-				}
+			sshClient, err := sshclient.NewClientFromFlags()
+			if err != nil {
+				return err
 			}
 
 			if metaConfig.IsStatic() {

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -28,11 +28,10 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/entity"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/lock"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 )
 
 type KubeClientSwitcher struct {
@@ -156,7 +155,7 @@ func (s *KubeClientSwitcher) replaceKubeClient(convergeState *State, state map[s
 
 	kubeCl.KubeProxy.StopAll()
 
-	if !app.SSHLegacyMode {
+	if sshclient.IsModernMode() {
 		log.DebugF("Old SSH Client: %-v\n", sshCl)
 		sshCl.Stop()
 	}
@@ -174,15 +173,14 @@ func (s *KubeClientSwitcher) replaceKubeClient(convergeState *State, state map[s
 		BecomePass:     convergeState.NodeUserCredentials.Password,
 	})
 
-	var newSSHClient node.SSHClient
-	if app.SSHLegacyMode {
-		newSSHClient = clissh.NewClient(sess, []session.AgentPrivateKey{privateKey})
-		// Avoid starting a new ssh agent
-		newSSHClient.(*clissh.Client).InitializeNewAgent = false
+	var pkeys []session.AgentPrivateKey
+
+	if sshclient.IsLegacyMode() {
+		pkeys = append(pkeys, session.AgentPrivateKey(privateKey))
 	} else {
-		pkeys := append(sshCl.PrivateKeys(), session.AgentPrivateKey(privateKey))
-		newSSHClient = gossh.NewClient(sess, pkeys)
+		pkeys = append(sshCl.PrivateKeys(), session.AgentPrivateKey(privateKey))
 	}
+	newSSHClient := sshclient.NewClient(sess, pkeys)
 
 	err = newSSHClient.Start()
 	if err != nil {
@@ -192,7 +190,7 @@ func (s *KubeClientSwitcher) replaceKubeClient(convergeState *State, state map[s
 	log.DebugLn("ssh client started for replacing kube client")
 
 	// adding keys to agent is actual only in legacy mode
-	if app.SSHLegacyMode {
+	if sshclient.IsLegacyMode() {
 		err = newSSHClient.(*clissh.Client).Agent.AddKeys(newSSHClient.PrivateKeys())
 		if err != nil {
 			return fmt.Errorf("failed to add keys to ssh agent: %w", err)

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -35,9 +35,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	infrastructurestate "github.com/deckhouse/deckhouse/dhctl/pkg/state/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
 )
 
@@ -139,10 +138,9 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(false)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(false)
+		sshClient, err := sshclient.NewInitClientFromFlags(false)
+		if err != nil {
+			return err
 		}
 
 		if err != nil {
@@ -401,8 +399,6 @@ func (c *Converger) AutoConverge() error {
 	if c.KubeClient != nil {
 		kubeCl = c.KubeClient
 	} else {
-		var sshClient node.SSHClient
-
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -410,12 +406,7 @@ func (c *Converger) AutoConverge() error {
 			return err
 		}
 
-		if app.SSHLegacyMode {
-			sshClient, err = clissh.NewInitClientFromFlags(false)
-		} else {
-			sshClient, err = gossh.NewInitClientFromFlags(false)
-		}
-
+		sshClient, err := sshclient.NewInitClientFromFlags(false)
 		if err != nil {
 			return err
 		}

--- a/dhctl/pkg/operations/exporter.go
+++ b/dhctl/pkg/operations/exporter.go
@@ -31,10 +31,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/check"
 	infrastructurestate "github.com/deckhouse/deckhouse/dhctl/pkg/state/infrastructure"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 
@@ -93,13 +91,7 @@ var (
 )
 
 func NewConvergeExporter(address, path string, interval time.Duration) *ConvergeExporter {
-	var sshClient node.SSHClient
-	var err error
-	if app.SSHLegacyMode {
-		sshClient, err = clissh.NewInitClientFromFlags(true)
-	} else {
-		sshClient, err = gossh.NewInitClientFromFlags(true)
-	}
+	sshClient, err := sshclient.NewInitClientFromFlags(true)
 	if err != nil {
 		panic(err)
 	}

--- a/dhctl/pkg/preflight/common.go
+++ b/dhctl/pkg/preflight/common.go
@@ -21,10 +21,10 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 )
 
 func buildHTTPClientWithLocalhostProxy(proxyUrl *url.URL) *http.Client {
@@ -49,7 +49,7 @@ func setupSSHTunnelToProxyAddr(sshCl node.SSHClient, proxyUrl *url.URL) (node.Tu
 		}
 	}
 	var tunnel string
-	if app.SSHLegacyMode {
+	if sshclient.IsLegacyMode() {
 		tunnel = strings.Join([]string{ProxyTunnelPort, proxyUrl.Hostname(), port}, ":")
 	} else {
 		tunnel = strings.Join([]string{proxyUrl.Hostname(), port, "127.0.0.1", ProxyTunnelPort}, ":")

--- a/dhctl/pkg/preflight/registry_test.go
+++ b/dhctl/pkg/preflight/registry_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 )
 
 type testState struct{}
@@ -199,7 +199,7 @@ deckhouse:
 		bootstrapState := &testState{}
 
 		var sshCl node.SSHClient
-		if app.SSHLegacyMode {
+		if sshclient.IsLegacyMode() {
 			sshCl = &gossh.Client{}
 		} else {
 			sshCl = &clissh.Client{}

--- a/dhctl/pkg/server/pkg/helper/ssh_client.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_client.go
@@ -25,9 +25,8 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/util"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/pkg/util/callback"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 )
 
 func CreateSSHClient(config *config.ConnectionConfig) (node.SSHClient, func() error, error) {
@@ -87,12 +86,7 @@ func CreateSSHClient(config *config.ConnectionConfig) (node.SSHClient, func() er
 	app.SSHPort = util.PortToString(config.SSHConfig.SSHPort)
 	app.SSHExtraArgs = config.SSHConfig.SSHExtraArgs
 
-	var sshClient node.SSHClient
-	if app.SSHLegacyMode {
-		sshClient = clissh.NewClient(sess, keys)
-	} else {
-		sshClient = gossh.NewClient(sess, keys)
-	}
+	sshClient := sshclient.NewClient(sess, keys)
 
 	cleanuper.Add(func() error {
 		if sshClient != nil && !reflect.ValueOf(sshClient).IsNil() {

--- a/dhctl/pkg/system/sshclient/init.go
+++ b/dhctl/pkg/system/sshclient/init.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sshclient
+
+import (
+	"fmt"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+)
+
+func NewInitClientFromFlags(askPassword bool) (node.SSHClient, error) {
+
+	switch {
+	case app.SSHLegacyMode:
+		// if set --ssh-legacy-mode
+		return clissh.NewInitClientFromFlags(askPassword)
+	case app.SSHModernMode:
+		// if set --ssh-modern-mode
+		return gossh.NewInitClientFromFlags(askPassword)
+	case len(app.SSHPrivateKeys) > 0:
+		// if flags doesn't set, but we have private keys
+		return clissh.NewInitClientFromFlags(askPassword)
+	default:
+		return gossh.NewInitClientFromFlags(askPassword)
+	}
+
+}
+
+func NewInitClientFromFlagsWithHosts(askPassword bool) (node.SSHClient, error) {
+	if len(app.SSHHosts) == 0 {
+		return nil, fmt.Errorf("Hosts not passed")
+	}
+
+	return NewInitClientFromFlags(askPassword)
+}
+
+func NewClient(sess *session.Session, privateKeys []session.AgentPrivateKey) node.SSHClient {
+
+	switch {
+	case app.SSHLegacyMode:
+		// if set --ssh-legacy-mode
+		client := clissh.NewClient(sess, privateKeys)
+		client.InitializeNewAgent = false
+		return client
+	case app.SSHModernMode:
+		// if set --ssh-modern-mode
+		return gossh.NewClient(sess, privateKeys)
+	case len(app.SSHPrivateKeys) > 0:
+		// if flags doesn't set, but we have private keys
+		client := clissh.NewClient(sess, privateKeys)
+		client.InitializeNewAgent = false
+		return client
+	default:
+		return gossh.NewClient(sess, privateKeys)
+	}
+}
+
+func NewClientFromFlags() (node.SSHClient, error) {
+	switch {
+	case app.SSHLegacyMode:
+		return clissh.NewClientFromFlags(), nil
+	case app.SSHModernMode:
+		return gossh.NewClientFromFlags()
+	case len(app.SSHPrivateKeys) > 0:
+		return clissh.NewClientFromFlags(), nil
+	default:
+		return gossh.NewClientFromFlags()
+	}
+}
+
+func NewClientFromFlagsWithHosts() (node.SSHClient, error) {
+	if len(app.SSHHosts) == 0 {
+		return nil, fmt.Errorf("Hosts not passed")
+	}
+
+	return NewClientFromFlags()
+}
+
+func IsModernMode() bool {
+	return app.SSHModernMode || len(app.SSHPrivateKeys) == 0
+}
+
+func IsLegacyMode() bool {
+	return app.SSHLegacyMode || (len(app.SSHPrivateKeys) > 0 && !app.SSHModernMode)
+}

--- a/dhctl/pkg/terminal/ask-password.go
+++ b/dhctl/pkg/terminal/ask-password.go
@@ -70,7 +70,7 @@ func AskPassword(prompt string) ([]byte, error) {
 }
 
 func AskBastionPassword() (err error) {
-	if !app.AskBastionPass || app.SSHLegacyMode {
+	if !app.AskBastionPass || app.SSHLegacyMode || (len(app.SSHPrivateKeys) > 0 && !app.SSHModernMode) {
 		return nil
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Manual backport https://github.com/deckhouse/deckhouse/pull/15773 to release-1.72 .

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Change default ssh mode.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
