### PR TITLE
[linter] add linter wrapcheck option to deckhouse

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/start.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/start.go
@@ -410,7 +410,7 @@ func lockOnBootstrap(ctx context.Context, client *client.Client, logger *log.Log
 		Cap:      5 * time.Minute,
 	}
 
-	return retry.OnError(bk, func(err error) bool {
+	err := retry.OnError(bk, func(err error) bool {
 		logger.Error("An error occurred during the bootstrap lock. Retrying", log.Err(err))
 		// retry on any error
 		return true
@@ -444,6 +444,10 @@ func lockOnBootstrap(ctx context.Context, client *client.Client, logger *log.Log
 
 		return nil
 	})
+	if err != nil {
+		return fmt.Errorf("on error: %w", err)
+	}
+	return nil
 }
 
 func registerTelemetry(ctx context.Context) func(ctx context.Context) error {

--- a/deckhouse-controller/crds/crd.go
+++ b/deckhouse-controller/crds/crd.go
@@ -35,9 +35,9 @@ func List() ([]apiextensionsv1.CustomResourceDefinition, error) {
 
 	fsys := os.DirFS(filepath.Join(projectDir, "deckhouse-controller", "crds"))
 	var result []apiextensionsv1.CustomResourceDefinition
-	return result, fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return fmt.Errorf("fs io error: %w", err)
+			return fmt.Errorf("walk dir: %w", err)
 		}
 
 		if _, ok := map[string]struct{}{
@@ -69,4 +69,8 @@ func List() ([]apiextensionsv1.CustomResourceDefinition, error) {
 		result = append(result, crd)
 		return nil
 	})
+	if err != nil {
+		return nil, fmt.Errorf("walk dir: %w", err)
+	}
+	return result, nil
 }

--- a/deckhouse-controller/pkg/controller/confighandler/handler.go
+++ b/deckhouse-controller/pkg/controller/confighandler/handler.go
@@ -17,6 +17,7 @@ package confighandler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/flant/addon-operator/pkg/kube_config_manager/backend"
@@ -102,7 +103,7 @@ func (h *Handler) StartInformer(_ context.Context, eventCh chan config.Event) {
 func (h *Handler) LoadConfig(ctx context.Context, _ ...string) (*config.KubeConfig, error) {
 	configs := new(v1alpha1.ModuleConfigList)
 	if err := h.client.List(ctx, configs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list: %w", err)
 	}
 
 	kubeConfig := config.NewConfig()
@@ -152,7 +153,7 @@ func (h *Handler) valuesByModuleConfig(moduleConfig *v1alpha1.ModuleConfig) (uti
 	converter := conversion.Store().Get(moduleConfig.Name)
 	newVersion, newSettings, err := converter.ConvertToLatest(moduleConfig.Spec.Version, moduleConfig.Spec.Settings)
 	if err != nil {
-		return utils.Values{}, err
+		return utils.Values{}, fmt.Errorf("convert to latest: %w", err)
 	}
 
 	moduleConfig.Spec.Version = newVersion

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -209,7 +209,7 @@ func NewDeckhouseController(
 		if err := retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 			return runtimeManager.GetClient().Get(ctx, client.ObjectKey{Name: moduleName}, module)
 		}); err != nil {
-			return "", err
+			return "", fmt.Errorf("on error: %w", err)
 		}
 
 		// set some version for the modules overridden by mpos

--- a/deckhouse-controller/pkg/controller/ctrlutils/update.go
+++ b/deckhouse-controller/pkg/controller/ctrlutils/update.go
@@ -69,7 +69,7 @@ func UpdateWithRetry(ctx context.Context, c client.Client, obj client.Object, f 
 
 	key := client.ObjectKeyFromObject(obj)
 
-	return retry.OnError(options.OnErrorBackoff, apierrors.IsServiceUnavailable, func() error {
+	err := retry.OnError(options.OnErrorBackoff, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(options.RetryOnConflictBackoff, func() error {
 			if err := c.Get(ctx, key, obj); err != nil {
 				return client.IgnoreNotFound(err)
@@ -101,6 +101,10 @@ func UpdateWithRetry(ctx context.Context, c client.Client, obj client.Object, f 
 			return nil
 		})
 	})
+	if err != nil {
+		return fmt.Errorf("on error: %w", err)
+	}
+	return nil
 }
 
 func UpdateStatusWithRetry(ctx context.Context, c client.Client, obj client.Object, f MutateFn, opts ...UpdateOption) error {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -566,7 +566,7 @@ func (f *DeckhouseReleaseFetcher) createRelease(
 	if len(releaseMetadata.Disruptions) > 0 {
 		version, err := semver.NewVersion(releaseMetadata.Version)
 		if err != nil {
-			return err
+			return fmt.Errorf("new version: %w", err)
 		}
 		disruptionsVersion := fmt.Sprintf("%d.%d", version.Major(), version.Minor())
 		disruptions = releaseMetadata.Disruptions[disruptionsVersion]
@@ -609,7 +609,14 @@ func (f *DeckhouseReleaseFetcher) createRelease(
 		release.ObjectMeta.Annotations[v1alpha1.DeckhouseReleaseAnnotationNotificationTimeShift] = "true"
 	}
 
-	return client.IgnoreAlreadyExists(f.k8sClient.Create(ctx, release))
+	err := f.k8sClient.Create(ctx, release)
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create: %w", err)
+	}
+	return nil
 }
 
 func (f *DeckhouseReleaseFetcher) patchSetSuspendAnnotation(ctx context.Context, release *v1alpha1.DeckhouseRelease, suspend bool) error {
@@ -691,24 +698,24 @@ func (rr *releaseReader) untarMetadata(rc io.Reader) error {
 			return nil
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("next: %w", err)
 		}
 
 		switch hdr.Name {
 		case "version.json":
 			_, err = io.Copy(rr.versionReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 		case "changelog.yaml", "changelog.yml":
 			_, err = io.Copy(rr.changelogReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 		case "module.yaml":
 			_, err := io.Copy(rr.moduleReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 
 		default:
@@ -838,7 +845,11 @@ func parseTime(s string) (time.Time, error) {
 		return t, nil
 	}
 
-	return time.Parse(time.RFC3339, s)
+	t, err = time.Parse(time.RFC3339, s)
+	if err != nil {
+		return t, fmt.Errorf("parse: %w", err)
+	}
+	return t, nil
 }
 
 // FetchReleasesMetadata realize step by step update

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -143,15 +143,18 @@ func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc 
 		Reconciler:              r,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("new: %w", err)
 	}
 
 	r.logger.Info("Controller started")
 
-	return ctrl.NewControllerManagedBy(mgr).
+	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.DeckhouseRelease{}).
 		WithEventFilter(logWrapper{r.logger, newEventFilter()}).
-		Complete(ctr)
+		Complete(ctr); err != nil {
+		return fmt.Errorf("complete: %w", err)
+	}
+	return nil
 }
 
 func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -178,7 +181,7 @@ func (r *deckhouseReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 		r.logger.Debug("get release", log.Err(err))
 
-		return res, err
+		return res, fmt.Errorf("get: %w", err)
 	}
 
 	if !release.DeletionTimestamp.IsZero() {
@@ -233,7 +236,7 @@ func (r *deckhouseReleaseReconciler) createOrUpdateReconcile(ctx context.Context
 		dr.Status.Phase = v1alpha1.DeckhouseReleasePhasePending
 		dr.Status.TransitionTime = metav1.NewTime(r.dc.GetClock().Now().UTC())
 		if err := r.client.Status().Update(ctx, dr); err != nil {
-			return res, err
+			return res, fmt.Errorf("update: %w", err)
 		}
 
 		return ctrl.Result{Requeue: true}, nil // process to the next phase
@@ -299,7 +302,7 @@ func (r *deckhouseReleaseReconciler) proceedRestoredRelease(ctx context.Context,
 	dr.Status.Message = "Release object was restored"
 
 	if err := r.client.Status().Update(ctx, dr); err != nil {
-		return err
+		return fmt.Errorf("update: %w", err)
 	}
 
 	return nil
@@ -364,7 +367,7 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 
 	task, err := taskCalculator.CalculatePendingReleaseTask(ctx, dr)
 	if err != nil {
-		return res, err
+		return res, fmt.Errorf("calculate pending release task: %w", err)
 	}
 
 	if dr.GetForce() {
@@ -1034,7 +1037,7 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 			return nil
 		})
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("update with retry: %w", err)
 		}
 
 		return res, nil
@@ -1046,7 +1049,7 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 			return nil
 		})
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("update status with retry: %w", err)
 		}
 	}
 
@@ -1067,7 +1070,7 @@ func (r *deckhouseReleaseReconciler) updateReleaseStatus(ctx context.Context, dr
 		r.metricsUpdater.PurgeReleaseMetric(dr.GetName())
 	}
 
-	return ctrlutils.UpdateStatusWithRetry(ctx, r.client, dr, func() error {
+	err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, dr, func() error {
 		if dr.Status.Phase != status.Phase {
 			dr.Status.TransitionTime = metav1.NewTime(r.dc.GetClock().Now().UTC())
 		}
@@ -1077,6 +1080,10 @@ func (r *deckhouseReleaseReconciler) updateReleaseStatus(ctx context.Context, dr
 
 		return nil
 	})
+	if err != nil {
+		return fmt.Errorf("update status with retry: %w", err)
+	}
+	return nil
 }
 
 func getDeckhouseContainerIndex(containers []corev1.Container) int {

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -102,7 +102,7 @@ func RegisterController(
 		return fmt.Errorf("create controller: %w", err)
 	}
 
-	return ctrl.NewControllerManagedBy(runtimeManager).
+	if err := ctrl.NewControllerManagedBy(runtimeManager).
 		For(&v1alpha1.ModuleConfig{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Watches(&v1alpha1.Module{}, ctrlhandler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
@@ -119,7 +119,10 @@ func RegisterController(
 				return false
 			},
 		})).
-		Complete(configController)
+		Complete(configController); err != nil {
+		return fmt.Errorf("complete: %w", err)
+	}
+	return nil
 }
 
 type reconciler struct {
@@ -157,7 +160,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		r.logger.Error("failed to get module config", slog.String("name", req.Name), log.Err(err))
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("get: %w", err)
 	}
 
 	// handle delete event
@@ -205,7 +208,7 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 
 		if err := r.client.Patch(ctx, moduleConfig, patch); err != nil {
 			r.logger.Error("failed to remove old finalizer", slog.String("name", moduleConfig.Name), log.Err(err))
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("patch: %w", err)
 		}
 	}
 
@@ -277,7 +280,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 					err := r.client.Delete(ctx, release)
 					if err != nil && !apierrors.IsNotFound(err) {
 						r.logger.Error("failed to delete pending release", slog.String("pending_release", release.Name), log.Err(err))
-						return ctrl.Result{}, err
+						return ctrl.Result{}, fmt.Errorf("delete: %w", err)
 					}
 				}
 			}

--- a/deckhouse-controller/pkg/controller/module-controllers/config/status.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/status.go
@@ -58,15 +58,18 @@ func (r *reconciler) refreshModule(ctx context.Context, moduleName string) error
 	}
 
 	module := new(v1alpha1.Module)
-	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
+	if err := retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(backoff, func() error {
 			if err := r.client.Get(ctx, client.ObjectKey{Name: moduleName}, module); err != nil {
-				return err
+				return fmt.Errorf("get: %w", err)
 			}
 			r.refreshModuleStatus(module)
 			return r.client.Status().Update(ctx, module)
 		})
-	})
+	}); err != nil {
+		return fmt.Errorf("on error: %w", err)
+	}
+	return nil
 }
 
 // refreshModuleConfig refreshes module config in cluster
@@ -78,7 +81,7 @@ func (r *reconciler) refreshModuleConfig(ctx context.Context, configName string)
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricGroup)
 
 	moduleConfig := new(v1alpha1.ModuleConfig)
-	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
+	if err := retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := r.client.Get(ctx, client.ObjectKey{Name: configName}, moduleConfig); err != nil {
 				if apierrors.IsNotFound(err) {
@@ -90,7 +93,7 @@ func (r *reconciler) refreshModuleConfig(ctx context.Context, configName string)
 
 			r.refreshModuleConfigStatus(moduleConfig)
 			if err := r.client.Status().Update(ctx, moduleConfig); err != nil {
-				return err
+				return fmt.Errorf("update: %w", err)
 			}
 
 			// skip firing alert for global module
@@ -108,7 +111,10 @@ func (r *reconciler) refreshModuleConfig(ctx context.Context, configName string)
 			}
 			return nil
 		})
-	})
+	}); err != nil {
+		return fmt.Errorf("on error: %w", err)
+	}
+	return nil
 }
 
 // refreshModuleStatus refreshes module status by addon-operator

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -81,10 +81,10 @@ func RegisterController(mgr manager.Manager, dc dependency.Container, logger *lo
 		Reconciler:              r,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("new: %w", err)
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	err = ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.ModuleDocumentation{}).
 		Watches(&coordv1.Lease{}, handler.EnqueueRequestsFromMapFunc(r.enqueueLeaseMapFunc), builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(event event.CreateEvent) bool {
@@ -106,6 +106,10 @@ func RegisterController(mgr manager.Manager, dc dependency.Container, logger *lo
 		})).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(ctr)
+	if err != nil {
+		return fmt.Errorf("complete: %w", err)
+	}
+	return nil
 }
 
 func (r *reconciler) enqueueLeaseMapFunc(ctx context.Context, _ client.Object) []reconcile.Request {
@@ -116,7 +120,7 @@ func (r *reconciler) enqueueLeaseMapFunc(ctx context.Context, _ client.Object) [
 
 		err := r.client.List(ctx, mdl)
 		if err != nil {
-			return err
+			return fmt.Errorf("list: %w", err)
 		}
 
 		requests = make([]reconcile.Request, 0, len(mdl.Items))
@@ -141,7 +145,10 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	md := new(v1alpha1.ModuleDocumentation)
 
 	if err := r.client.Get(ctx, req.NamespacedName, md); err != nil {
-		return result, client.IgnoreNotFound(err)
+		if client.IgnoreNotFound(err) != nil {
+			return result, fmt.Errorf("get: %w", err)
+		}
+		return result, nil
 	}
 
 	if !md.DeletionTimestamp.IsZero() {
@@ -284,7 +291,7 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 	}
 
 	if err = r.client.Status().Patch(ctx, mdCopy, client.MergeFrom(md)); err != nil {
-		return result, err
+		return result, fmt.Errorf("patch: %w", err)
 	}
 
 	if mdCopy.Status.RenderResult != v1alpha1.ResultRendered {
@@ -296,7 +303,7 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 		if err = r.client.Update(ctx, mdCopy); err != nil {
 			r.logger.Error("update finalizer", log.Err(err))
 
-			return result, err
+			return result, fmt.Errorf("update: %w", err)
 		}
 	}
 
@@ -331,7 +338,7 @@ func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes
 
 	dir, err := os.Stat(moduleDir)
 	if err != nil {
-		return err
+		return fmt.Errorf("stat: %w", err)
 	}
 
 	if !dir.IsDir() {
@@ -356,13 +363,13 @@ func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes
 
 		header, err := tar.FileInfoHeader(info, info.Name())
 		if err != nil {
-			return err
+			return fmt.Errorf("file info header: %w", err)
 		}
 
 		header.Name = strings.TrimPrefix(file, moduleDir)
 
 		if err = tw.WriteHeader(header); err != nil {
-			return err
+			return fmt.Errorf("write header: %w", err)
 		}
 
 		if info.IsDir() {
@@ -371,14 +378,14 @@ func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes
 
 		f, err := os.Open(file)
 		if err != nil {
-			return err
+			return fmt.Errorf("open: %w", err)
 		}
 		defer f.Close()
 
 		r.logger.Debug("copy file", slog.String("path", file))
 
 		if _, err = io.Copy(tw, f); err != nil {
-			return err
+			return fmt.Errorf("copy: %w", err)
 		}
 
 		return nil

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -92,7 +92,7 @@ func (md *ModuleDownloader) DownloadDevImageTag(moduleName, imageTag, checksum s
 
 	digest, err := img.Digest()
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("digest: %w", err)
 	}
 
 	if digest.String() == checksum {
@@ -199,7 +199,11 @@ func (md *ModuleDownloader) GetDocumentationArchive(moduleName, moduleVersion st
 		return nil, fmt.Errorf("fetch image: %w", err)
 	}
 
-	return moduletools.ExtractDocs(img)
+	docs, err := moduletools.ExtractDocs(img)
+	if err != nil {
+		return nil, fmt.Errorf("extract docs: %w", err)
+	}
+	return docs, nil
 }
 
 func (md *ModuleDownloader) fetchImage(moduleName, imageTag string) (crv1.Image, error) {
@@ -208,7 +212,11 @@ func (md *ModuleDownloader) fetchImage(moduleName, imageTag string) (crv1.Image,
 		return nil, fmt.Errorf("fetch module error: %v", err)
 	}
 
-	return regCli.Image(context.TODO(), imageTag)
+	img, err := regCli.Image(context.TODO(), imageTag)
+	if err != nil {
+		return nil, fmt.Errorf("image: %w", err)
+	}
+	return img, nil
 }
 
 func (md *ModuleDownloader) storeModule(moduleStorePath string, img crv1.Image) (*DownloadStatistic, error) {
@@ -236,7 +244,7 @@ func (md *ModuleDownloader) fetchAndCopyModuleByVersion(moduleName, moduleVersio
 func (md *ModuleDownloader) copyModuleToFS(rootPath string, img crv1.Image) (*DownloadStatistic, error) {
 	rc, err := cr.Extract(img)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("extract: %w", err)
 	}
 	defer rc.Close()
 
@@ -283,7 +291,7 @@ func (md *ModuleDownloader) copyLayersToFS(rootPath string, rc io.ReadCloser) (*
 		switch hdr.Typeflag {
 		case tar.TypeDir:
 			if err := os.MkdirAll(path.Join(rootPath, hdr.Name), 0o700); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("mkdir all: %w", err)
 			}
 		case tar.TypeReg:
 			outFile, err := os.Create(path.Join(rootPath, hdr.Name))
@@ -515,7 +523,7 @@ func (md *ModuleDownloader) fetchModuleReleaseMetadata(ctx context.Context, img 
 		meta.ModuleDefinition = &ModuleDefinition
 	}
 
-	return meta, err
+	return meta, nil
 }
 
 type moduleReader struct {
@@ -532,7 +540,7 @@ func (rr *moduleReader) untarMetadata(rc io.ReadCloser) error {
 		}
 
 		if err != nil {
-			return err
+			return fmt.Errorf("next: %w", err)
 		}
 
 		if strings.HasPrefix(hdr.Name, ".werf") {
@@ -543,7 +551,7 @@ func (rr *moduleReader) untarMetadata(rc io.ReadCloser) error {
 		case "module.yaml":
 			_, err := io.Copy(rr.moduleReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 
 			return nil

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/release_reader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/release_reader.go
@@ -19,6 +19,7 @@ package downloader
 import (
 	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 )
@@ -38,7 +39,7 @@ func (rr *releaseReader) untarMetadata(rc io.ReadCloser) error {
 			return nil
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("next: %w", err)
 		}
 		if strings.HasPrefix(hdr.Name, ".werf") {
 			continue
@@ -48,17 +49,17 @@ func (rr *releaseReader) untarMetadata(rc io.ReadCloser) error {
 		case "version.json":
 			_, err = io.Copy(rr.versionReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 		case "changelog.yaml", "changelog.yml":
 			_, err = io.Copy(rr.changelogReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 		case "module.yaml":
 			_, err := io.Copy(rr.moduleReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 
 		default:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -105,7 +105,7 @@ func RegisterController(
 		metricsUpdater:       releaseUpdater.NewMetricsUpdater(ms, releaseUpdater.ModuleReleaseBlockedMetricName),
 		shutdownFunc: func() error {
 			if err := syscall.Kill(1, syscall.SIGUSR2); err != nil {
-				return err
+				return fmt.Errorf("kill: %w", err)
 			}
 
 			return nil
@@ -129,12 +129,15 @@ func RegisterController(
 		return fmt.Errorf("create controller: %w", err)
 	}
 
-	return ctrl.NewControllerManagedBy(runtimeManager).
+	if err := ctrl.NewControllerManagedBy(runtimeManager).
 		For(&v1alpha1.ModuleRelease{}).
 		// for reconcile documentation if accidentally removed
 		Owns(&v1alpha1.ModuleDocumentation{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
-		Complete(releaseController)
+		Complete(releaseController); err != nil {
+		return fmt.Errorf("complete: %w", err)
+	}
+	return nil
 }
 
 type MetricsUpdater interface {
@@ -379,7 +382,7 @@ func (r *reconciler) preHandleCheck(ctx context.Context, release *v1alpha1.Modul
 			return nil
 		})
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("update with retry: %w", err)
 		}
 
 		return ctrl.Result{Requeue: true}, nil
@@ -639,7 +642,7 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	if err = r.client.Update(ctx, settings); err != nil {
 		r.log.Warn("failed to update module settings", slog.String("module", release.GetModuleName()), log.Err(err))
 
-		return res, err
+		return res, fmt.Errorf("update: %w", err)
 	}
 
 	return res, nil
@@ -792,7 +795,7 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 	if err != nil {
 		logger.Error("failed to parse the notification config", log.Err(err))
 
-		return res, err
+		return res, fmt.Errorf("get notification config: %w", err)
 	}
 
 	us := &releaseUpdater.Settings{
@@ -811,7 +814,7 @@ func (r *reconciler) handlePendingRelease(ctx context.Context, release *v1alpha1
 
 	task, err := taskCalculator.CalculatePendingReleaseTask(ctx, release)
 	if err != nil {
-		return res, err
+		return res, fmt.Errorf("calculate pending release task: %w", err)
 	}
 
 	if release.GetForce() {
@@ -1618,7 +1621,7 @@ func (r *reconciler) updateReleaseStatus(ctx context.Context, mr *v1alpha1.Modul
 		r.metricsUpdater.PurgeReleaseMetric(mr.GetName())
 	}
 
-	return ctrlutils.UpdateStatusWithRetry(ctx, r.client, mr, func() error {
+	if err := ctrlutils.UpdateStatusWithRetry(ctx, r.client, mr, func() error {
 		if mr.GetPhase() != status.Phase {
 			mr.Status.TransitionTime = metav1.NewTime(r.dependencyContainer.GetClock().Now().UTC())
 		}
@@ -1627,7 +1630,10 @@ func (r *reconciler) updateReleaseStatus(ctx context.Context, mr *v1alpha1.Modul
 		mr.Status.Message = status.Message
 
 		return nil
-	}, ctrlutils.WithRetryOnConflictBackoff(backoff))
+	}, ctrlutils.WithRetryOnConflictBackoff(backoff)); err != nil {
+		return fmt.Errorf("update status with retry: %w", err)
+	}
+	return nil
 }
 
 func (r *reconciler) updateModuleLastReleaseDeployedStatus(ctx context.Context, mr *v1alpha1.ModuleRelease, msg, reason string, conditionState bool) error {
@@ -1670,7 +1676,7 @@ func (r *reconciler) deleteRelease(ctx context.Context, release *v1alpha1.Module
 		if err := r.client.Status().Update(ctx, release); err != nil {
 			r.log.Warn("failed to set terminating to the release", slog.String("release", release.GetName()), log.Err(err))
 
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("update: %w", err)
 		}
 
 		return ctrl.Result{Requeue: true}, nil
@@ -1680,7 +1686,7 @@ func (r *reconciler) deleteRelease(ctx context.Context, release *v1alpha1.Module
 
 	if err := os.RemoveAll(modulePath); err != nil {
 		r.log.Error("failed to remove module in downloaded dir", slog.String("release", release.GetName()), slog.String("path", modulePath), log.Err(err))
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("remove all: %w", err)
 	}
 
 	if release.GetPhase() == v1alpha1.ModuleReleasePhaseDeployed {
@@ -1689,7 +1695,7 @@ func (r *reconciler) deleteRelease(ctx context.Context, release *v1alpha1.Module
 		symlinkPath := filepath.Join(r.symlinksDir, fmt.Sprintf("%d-%s", release.GetWeight(), release.GetModuleName()))
 		if err := os.RemoveAll(symlinkPath); err != nil {
 			r.log.Error("failed to remove module in downloaded symlinks dir", slog.String("release", release.GetName()), slog.String("path", modulePath), log.Err(err))
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("remove all: %w", err)
 		}
 
 		r.log.Info("module release deleted, waiting for Deckhouse restart", slog.String("release", release.GetName()))
@@ -1706,7 +1712,7 @@ func (r *reconciler) deleteRelease(ctx context.Context, release *v1alpha1.Module
 		controllerutil.RemoveFinalizer(release, v1alpha1.ModuleReleaseFinalizerExistOnFs)
 		if err := r.client.Update(ctx, release); err != nil {
 			r.log.Error("failed to update module release", slog.String("release", release.GetName()), log.Err(err))
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("update: %w", err)
 		}
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -41,7 +41,7 @@ var (
 )
 
 func (r *reconciler) cleanSourceInModule(ctx context.Context, sourceName, moduleName string) error {
-	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
+	if err := retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			module := new(v1alpha1.Module)
 			if err := r.client.Get(ctx, client.ObjectKey{Name: moduleName}, module); err != nil {
@@ -80,7 +80,10 @@ func (r *reconciler) cleanSourceInModule(ctx context.Context, sourceName, module
 
 			return r.client.Update(ctx, module)
 		})
-	})
+	}); err != nil {
+		return fmt.Errorf("on error: %w", err)
+	}
+	return nil
 }
 
 // syncRegistrySettings checks if modules source registry settings were updated

--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -437,7 +437,7 @@ func (l *Loader) cleanupDeletedModules(ctx context.Context) error {
 
 func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, embedded bool) error {
 	module := new(v1alpha1.Module)
-	return retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
+	err := retry.OnError(retry.DefaultRetry, apierrors.IsServiceUnavailable, func() error {
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			if err := l.client.Get(ctx, client.ObjectKey{Name: def.Name}, module); err != nil {
 				if !apierrors.IsNotFound(err) {
@@ -504,6 +504,10 @@ func (l *Loader) ensureModule(ctx context.Context, def *moduletypes.Definition, 
 			return nil
 		})
 	})
+	if err != nil {
+		return fmt.Errorf("on error: %w", err)
+	}
+	return nil
 }
 
 func (l *Loader) ensureModuleSettings(ctx context.Context, module string, rawConfig []byte, conversions []v1alpha1.ModuleSettingsConversion) error {
@@ -520,10 +524,16 @@ func (l *Loader) ensureModuleSettings(ctx context.Context, module string, rawCon
 	if settings.UID == "" {
 		settings.Name = module
 		settings.Labels = map[string]string{"heritage": "deckhouse"}
-		return l.client.Create(ctx, settings)
+		if err := l.client.Create(ctx, settings); err != nil {
+			return fmt.Errorf("create: %w", err)
+		}
+		return nil
 	}
 
-	return l.client.Update(ctx, settings)
+	if err := l.client.Update(ctx, settings); err != nil {
+		return fmt.Errorf("update: %w", err)
+	}
+	return nil
 }
 
 // parseModulesDir returns modules definitions from the target dir
@@ -606,12 +616,12 @@ func (l *Loader) resolveDirEntry(dirPath string, entry os.DirEntry) (string, str
 func resolveSymlinkToDir(dirPath string, entry os.DirEntry) (string, error) {
 	info, err := entry.Info()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("info: %w", err)
 	}
 
 	targetDirPath, isTargetDir, err := addonutils.SymlinkInfo(filepath.Join(dirPath, info.Name()), info)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("symlink info: %w", err)
 	}
 
 	if isTargetDir {
@@ -647,13 +657,13 @@ func (l *Loader) moduleDefinitionByFile(absPath string) (*moduletypes.Definition
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
-		return nil, err
+		return nil, fmt.Errorf("open: %w", err)
 	}
 	defer f.Close()
 
 	def := new(moduletypes.Definition)
 	if err = yaml.NewDecoder(f).Decode(def); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode: %w", err)
 	}
 
 	if def.Name == "" {
@@ -738,7 +748,7 @@ func (l *Loader) loadConversions(conversionsDir string) ([]v1alpha1.ModuleSettin
 func (l *Loader) readConversionFile(filePath string) (*v1alpha1.ModuleSettingsConversion, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read file: %w", err)
 	}
 
 	// Parse YAML directly into a temporary struct

--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -132,7 +132,7 @@ func (l *Loader) restoreAbsentModulesFromOverrides(ctx context.Context) error {
 		if err := l.client.Get(ctx, client.ObjectKey{Name: mpo.Name}, module); err != nil {
 			if !apierrors.IsNotFound(err) {
 				l.logger.Error("failed to get module", slog.String("name", mpo.Name), log.Err(err))
-				return err
+				return fmt.Errorf("get: %w", err)
 			}
 			l.logger.Info("the module does not exist, skip restoring module pull override process", slog.String("name", mpo.Name))
 			continue
@@ -446,7 +446,10 @@ func restoreModuleSymlink(downloadedModulesDir, symlinkPath, moduleRelativePath 
 		return fmt.Errorf("get stat of the '%s': %v", moduleRelativePath, err)
 	}
 
-	return os.Symlink(moduleRelativePath, symlinkPath)
+	if err := os.Symlink(moduleRelativePath, symlinkPath); err != nil {
+		return fmt.Errorf("symlink: %w", err)
+	}
+	return nil
 }
 
 // deleteModuleSymlinks checks if there are symlinks for the module with different weight in the symlink folder

--- a/deckhouse-controller/pkg/debug/debug.go
+++ b/deckhouse-controller/pkg/debug/debug.go
@@ -294,6 +294,9 @@ func DefineCollectDebugInfoCommand(kpApp *kingpin.Application) {
 	collectDebug.Action(func(_ *kingpin.ParseContext) error {
 		res := createTarball()
 		_, err := io.Copy(os.Stdout, res)
-		return err
+		if err != nil {
+			return fmt.Errorf("copy: %w", err)
+		}
+		return nil
 	})
 }

--- a/deckhouse-controller/pkg/debug/module_enable.go
+++ b/deckhouse-controller/pkg/debug/module_enable.go
@@ -43,7 +43,7 @@ func DefineModuleConfigDebugCommands(kpApp *kingpin.Application, logger *log.Log
 			logger.SetLevel(log.LevelError)
 			cli := kubeclient.New(kubeclient.WithLogger(logger))
 			if err := cli.Init(); err != nil {
-				return err
+				return fmt.Errorf("init: %w", err)
 			}
 
 			return moduleSwitch(cli, moduleName, true, "enable", logger)
@@ -55,7 +55,7 @@ func DefineModuleConfigDebugCommands(kpApp *kingpin.Application, logger *log.Log
 			logger.SetLevel(log.LevelError)
 			cli := kubeclient.New(kubeclient.WithLogger(logger))
 			if err := cli.Init(); err != nil {
-				return err
+				return fmt.Errorf("init: %w", err)
 			}
 
 			return moduleSwitch(cli, moduleName, false, "disable", logger)

--- a/deckhouse-controller/pkg/debug/requirements.go
+++ b/deckhouse-controller/pkg/debug/requirements.go
@@ -34,7 +34,9 @@ func DefineRequirementsCommands(kpApp *kingpin.Application) {
 
 		defer resp.Body.Close()
 		_, err = io.Copy(os.Stdout, resp.Body)
-
-		return err
+		if err != nil {
+			return fmt.Errorf("copy: %w", err)
+		}
+		return nil
 	})
 }

--- a/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
+++ b/deckhouse-controller/pkg/helpers/change_registry/change_registry.go
@@ -91,7 +91,7 @@ func ChangeRegistry(newRegistry, username, password, caFile, newDeckhouseImageTa
 	nameOpts := newNameOptions(scheme)
 	newRepo, err := name.NewRepository(strings.TrimRight(newRegistry, "/"), nameOpts...)
 	if err != nil {
-		return err
+		return fmt.Errorf("new repository: %w", err)
 	}
 
 	caTransport := cr.GetHTTPTransport(caContent)
@@ -181,13 +181,17 @@ func newTransport(ctx context.Context, repo name.Repository, authConfig authn.Au
 	authorizer := authn.FromConfig(authConfig)
 
 	scopes := []string{repo.Scope(transport.PullScope)}
-	return transport.NewWithContext(ctx, repo.Registry, authorizer, caTransport, scopes)
+	t, err := transport.NewWithContext(ctx, repo.Registry, authorizer, caTransport, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("new with context: %w", err)
+	}
+	return t, nil
 }
 
 func newKubeClient() (*kclient.KubernetesClient, error) {
 	kubeCl := kclient.NewKubernetesClient()
 	if err := kubeCl.Init(kclient.AppKubernetesInitParams()); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("init: %w", err)
 	}
 	return kubeCl, nil
 }
@@ -196,7 +200,7 @@ func modifyPullSecret(ctx context.Context, kubeCl *kclient.KubernetesClient, new
 	secretClient := kubeCl.KubeClient.CoreV1().Secrets(d8SystemNS)
 	deckhouseRegSecret, err := secretClient.Get(ctx, "deckhouse-registry", metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get: %w", err)
 	}
 	deckhouseRegSecret.StringData = newSecretData
 
@@ -210,7 +214,7 @@ func updateImagePullSecret(ctx context.Context, kubeCl *kclient.KubernetesClient
 
 	updateOpts := metav1.UpdateOptions{FieldValidation: metav1.FieldValidationStrict}
 	if _, err := secretClient.Update(ctx, newSecret, updateOpts); err != nil {
-		return err
+		return fmt.Errorf("update: %w", err)
 	}
 	return nil
 }
@@ -224,7 +228,7 @@ func newImagePullSecretData(newRepo name.Repository, authConfig authn.AuthConfig
 		},
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("marshal: %w", err)
 	}
 
 	scheme := specScheme
@@ -252,7 +256,7 @@ func getCAContent(caFile string) (string, error) {
 
 	caBytes, err := os.ReadFile(caFile)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("read file: %w", err)
 	}
 
 	keyBlock, _ := pem.Decode(caBytes)
@@ -262,14 +266,18 @@ func getCAContent(caFile string) (string, error) {
 
 	// Check that file content is a certificate
 	if _, err := x509.ParseCertificate(keyBlock.Bytes); err != nil {
-		return "", err
+		return "", fmt.Errorf("parse certificate: %w", err)
 	}
 	return strings.TrimSpace(string(caBytes)), nil
 }
 
 func deckhouseDeployment(ctx context.Context, kubeCl *kclient.KubernetesClient) (*appsv1.Deployment, error) {
 	deployClient := kubeCl.KubeClient.AppsV1().Deployments(d8SystemNS)
-	return deployClient.Get(ctx, "deckhouse", metav1.GetOptions{})
+	deploy, err := deployClient.Get(ctx, "deckhouse", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get: %w", err)
+	}
+	return deploy, nil
 }
 
 func updateDeployContainersImagesToNewRepo(deploy *appsv1.Deployment, newRepo name.Repository, nameOpts []name.Option, remoteOpts []remote.Option, newDeckhouseTag string) error {
@@ -297,7 +305,7 @@ func updateDeployment(ctx context.Context, kubeCl *kclient.KubernetesClient, dep
 	deployClient := kubeCl.KubeClient.AppsV1().Deployments(deploy.Namespace)
 	updateOpts := metav1.UpdateOptions{FieldValidation: metav1.FieldValidationStrict}
 	if _, err := deployClient.Update(ctx, deploy, updateOpts); err != nil {
-		return err
+		return fmt.Errorf("update: %w", err)
 	}
 	return nil
 }
@@ -306,7 +314,7 @@ func updateImageRepoForContainers(containers []v1.Container, newRepository strin
 	for i, container := range containers {
 		oldImage, err := name.ParseReference(container.Image)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse reference: %w", err)
 		}
 
 		tagOrDigestref := oldImage.Identifier()
@@ -326,7 +334,7 @@ func updateImageRepoForContainers(containers []v1.Container, newRepository strin
 
 		newRef, err := name.ParseReference(newRepository+delim+tagOrDigestref, nameOpts...)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("parse reference: %w", err)
 		}
 
 		// Check that new reference exists in the new repo before applying changes.
@@ -344,11 +352,11 @@ func updateImageRepoForContainers(containers []v1.Container, newRepository strin
 func checkImageExists(imageRef name.Reference, opts []remote.Option) error {
 	img, err := remote.Image(imageRef, opts...)
 	if err != nil {
-		return err
+		return fmt.Errorf("image: %w", err)
 	}
 
 	if _, err := img.Digest(); err != nil {
-		return err
+		return fmt.Errorf("digest: %w", err)
 	}
 	return nil
 }
@@ -383,32 +391,38 @@ func checkAuthSupport(ctx context.Context, reg name.Registry, roundTripper http.
 		errs = multierror.Append(errs, fmt.Errorf("check auth support with %q scheme failed: %w", scheme, err))
 	}
 
-	return errs.ErrorOrNil()
+	if err := errs.ErrorOrNil(); err != nil {
+		return fmt.Errorf("error or nil: %w", err)
+	}
+	return nil
 }
 
 func makeRequestWithScheme(ctx context.Context, client *http.Client, scheme, registryName string) (*http.Response, error) {
 	u, err := url.Parse(fmt.Sprintf("%s://%s/v2/", scheme, registryName))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new request with context: %w", err)
 	}
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("do: %w", err)
 	}
 
 	// Close body, because we only need headers
-	return resp, resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		return resp, fmt.Errorf("close: %w", err)
+	}
+	return resp, nil
 }
 
 func checkResponseForAuthSupport(resp *http.Response, registryHost string) error {
 	if resp.StatusCode != http.StatusUnauthorized {
-		return transport.CheckError(resp, http.StatusUnauthorized)
+		return fmt.Errorf("check error: %w", transport.CheckError(resp, http.StatusUnauthorized))
 	}
 
 	if authHeader(resp.Header) {

--- a/deckhouse-controller/pkg/helpers/jwt/gen.go
+++ b/deckhouse-controller/pkg/helpers/jwt/gen.go
@@ -25,12 +25,12 @@ import (
 func GenJWT(privateKeyPath string, claims map[string]string, ttl time.Duration) error {
 	privKeyBytes, err := os.ReadFile(privateKeyPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("os.ReadFile: %w", err)
 	}
 
 	tokenString, err := jwt.GenerateJWT(privKeyBytes, claims, ttl)
 	if err != nil {
-		return err
+		return fmt.Errorf("jwt.GenerateJWT: %w", err)
 	}
 
 	fmt.Fprint(os.Stdout, tokenString)

--- a/deckhouse-controller/pkg/registry/deckhouse.go
+++ b/deckhouse-controller/pkg/registry/deckhouse.go
@@ -101,7 +101,7 @@ func (svc *deckhouseReleaseService) fetchReleaseMetadata(img v1.Image) (*dhRelea
 
 	rc, err := cr.Extract(img)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("extract: %w", err)
 	}
 	defer rc.Close()
 
@@ -119,7 +119,7 @@ func (svc *deckhouseReleaseService) fetchReleaseMetadata(img v1.Image) (*dhRelea
 	if rr.versionReader.Len() > 0 {
 		err = json.NewDecoder(rr.versionReader).Decode(&meta)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decode: %w", err)
 		}
 	}
 

--- a/deckhouse-controller/pkg/registry/module.go
+++ b/deckhouse-controller/pkg/registry/module.go
@@ -65,7 +65,7 @@ func (svc *moduleReleaseService) ListModules(ctx context.Context) ([]string, err
 		return nil, fmt.Errorf("list tags: %w", err)
 	}
 
-	return ls, err
+	return ls, nil
 }
 
 var (
@@ -123,7 +123,7 @@ func (svc *moduleReleaseService) fetchModuleReleaseMetadata(img v1.Image) (*modR
 
 	rc, err := cr.Extract(img)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("extract: %w", err)
 	}
 	defer rc.Close()
 
@@ -141,7 +141,7 @@ func (svc *moduleReleaseService) fetchModuleReleaseMetadata(img v1.Image) (*modR
 	if rr.versionReader.Len() > 0 {
 		err = json.NewDecoder(rr.versionReader).Decode(&meta)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("decode: %w", err)
 		}
 	}
 

--- a/deckhouse-controller/pkg/registry/release_reader.go
+++ b/deckhouse-controller/pkg/registry/release_reader.go
@@ -19,6 +19,7 @@ package registry
 import (
 	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 )
@@ -40,7 +41,7 @@ func (rr *releaseReader) untarMetadata(rc io.ReadCloser) error {
 		}
 
 		if err != nil {
-			return err
+			return fmt.Errorf("next: %w", err)
 		}
 
 		if strings.HasPrefix(hdr.Name, ".werf") {
@@ -51,17 +52,17 @@ func (rr *releaseReader) untarMetadata(rc io.ReadCloser) error {
 		case "version.json":
 			_, err = io.Copy(rr.versionReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 		case "changelog.yaml", "changelog.yml":
 			_, err = io.Copy(rr.changelogReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 		case "module.yaml":
 			_, err := io.Copy(rr.moduleReader, tr)
 			if err != nil {
-				return err
+				return fmt.Errorf("copy: %w", err)
 			}
 		default:
 			continue

--- a/deckhouse-controller/pkg/releaseupdater/release.go
+++ b/deckhouse-controller/pkg/releaseupdater/release.go
@@ -18,6 +18,7 @@ package releaseupdater
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 )
@@ -30,7 +31,11 @@ func (sp StatusPatch) MarshalJSON() ([]byte, error) {
 		"status": v1alpha1.DeckhouseReleaseStatus(sp),
 	}
 
-	return json.Marshal(m)
+	if result, err := json.Marshal(m); err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	} else {
+		return result, nil
+	}
 }
 
 type ByVersion[R v1alpha1.Release] []R

--- a/deckhouse-controller/pkg/releaseupdater/release_notifier.go
+++ b/deckhouse-controller/pkg/releaseupdater/release_notifier.go
@@ -147,13 +147,13 @@ func sendWebhookNotification(ctx context.Context, config NotificationConfig, dat
 
 		err := json.NewEncoder(buf).Encode(data)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("encode: %w", err)
 		}
 
 		var req *http.Request
 		req, err = http.NewRequestWithContext(ctx, http.MethodPost, config.WebhookURL, buf)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("new request with context: %w", err)
 		}
 
 		req.Header.Add("Content-Type", "application/json")
@@ -161,7 +161,7 @@ func sendWebhookNotification(ctx context.Context, config NotificationConfig, dat
 
 		resp, err := client.Do(req)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("do: %w", err)
 		}
 		defer resp.Body.Close()
 

--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
@@ -170,7 +170,7 @@ func (c *deckhouseVersionCheck) Verify(_ context.Context, dr *v1alpha1.Deckhouse
 		// or an enabled module has requirements
 		// prevent deckhouse release from becoming predicted
 		if releaseName == "" || c.enabledModules.Has(releaseName) {
-			return err
+			return fmt.Errorf("validate base version: %w", err)
 		}
 	}
 
@@ -213,7 +213,7 @@ func (c *kubernetesVersionCheck) Verify(_ context.Context, dr *v1alpha1.Deckhous
 			// or an enabled module has requirements
 			// prevent deckhouse release from becoming predicted
 			if moduleName == "" || c.enabledModules.Has(moduleName) {
-				return err
+				return fmt.Errorf("validate base version: %w", err)
 			}
 		}
 	}
@@ -377,7 +377,7 @@ func (c *moduleRequirementsCheck) GetName() string {
 func (c *moduleRequirementsCheck) Verify(_ context.Context, mr *v1alpha1.ModuleRelease) error {
 	err := c.exts.CheckModuleReleaseRequirements(mr.GetModuleName(), mr.GetName(), mr.GetVersion(), mr.GetModuleReleaseRequirements())
 	if err != nil {
-		return err
+		return fmt.Errorf("check module release requirements: %w", err)
 	}
 
 	return nil

--- a/global-hooks/calculate_resources_requests.go
+++ b/global-hooks/calculate_resources_requests.go
@@ -51,7 +51,7 @@ func applyNodesResourcesFilter(obj *unstructured.Unstructured) (go_hook.FilterRe
 	node := &v1.Node{}
 	err := sdk.FromUnstructured(obj, node)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	n := &Node{}

--- a/global-hooks/cluster_is_bootstrapped.go
+++ b/global-hooks/cluster_is_bootstrapped.go
@@ -74,7 +74,7 @@ func applyReadyNotMasterNodeFilter(obj *unstructured.Unstructured) (go_hook.Filt
 	var node v1core.Node
 	err := sdk.FromUnstructured(obj, &node)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	for _, taint := range node.Spec.Taints {

--- a/global-hooks/default_cluster_storage_class.go
+++ b/global-hooks/default_cluster_storage_class.go
@@ -16,6 +16,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -64,7 +65,7 @@ func setupDefaultStorageClass(_ context.Context, input *go_hook.HookInput, dc de
 
 	client, err := dc.GetK8sClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("get k8s client: %w", err)
 	}
 
 	storageClasses, err := client.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})

--- a/global-hooks/discovery/cluster_configuration.go
+++ b/global-hooks/discovery/cluster_configuration.go
@@ -41,7 +41,7 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 	secret := &v1.Secret{}
 	err := sdk.FromUnstructured(obj, secret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	cc := &ClusterConfigurationYaml{}
@@ -53,7 +53,7 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 
 	cc.Content = ccYaml
 
-	return cc, err
+	return cc, nil
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -89,7 +89,7 @@ func clusterConfiguration(_ context.Context, input *go_hook.HookInput) error {
 		var metaConfig *config.MetaConfig
 		metaConfig, err = config.ParseConfigFromData(string(configYamlBytes.Content))
 		if err != nil {
-			return err
+			return fmt.Errorf("parse config from data: %w", err)
 		}
 
 		kubernetesVersionFromMetaConfig, err := rawMessageToString(metaConfig.ClusterConfig["kubernetesVersion"])
@@ -170,8 +170,11 @@ func rawMessageToString(message json.RawMessage) (string, error) {
 	var result string
 	b, err := message.MarshalJSON()
 	if err != nil {
-		return result, err
+		return result, fmt.Errorf("marshal json: %w", err)
 	}
 	err = json.Unmarshal(b, &result)
-	return result, err
+	if err != nil {
+		return result, fmt.Errorf("unmarshal: %w", err)
+	}
+	return result, nil
 }

--- a/global-hooks/discovery/cluster_dns_address.go
+++ b/global-hooks/discovery/cluster_dns_address.go
@@ -62,7 +62,7 @@ func applyDNSServiceIPFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 	var service v1core.Service
 	err := sdk.FromUnstructured(obj, &service)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("from unstructured: %w", err)
 	}
 
 	return ServiceAddr{service.Name, service.Spec.ClusterIP}, nil

--- a/global-hooks/discovery/cluster_domain.go
+++ b/global-hooks/discovery/cluster_domain.go
@@ -97,7 +97,7 @@ func applyClusterDomainFromConfigMapFilter(obj *unstructured.Unstructured) (go_h
 	var cm v1core.ConfigMap
 	err := sdk.FromUnstructured(obj, &cm)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("from unstructured: %w", err)
 	}
 
 	coreFile, ok := cm.Data["Corefile"]
@@ -115,7 +115,11 @@ func applyClusterDomainFromConfigMapFilter(obj *unstructured.Unstructured) (go_h
 }
 
 func applyClusterDomainFromDNSPodFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	return filter.GetArgFromUnstructuredPodWithRegexp(obj, clusterDomainFromPodRegexp, 1, "")
+	result, err := filter.GetArgFromUnstructuredPodWithRegexp(obj, clusterDomainFromPodRegexp, 1, "")
+	if err != nil {
+		return "", fmt.Errorf("get arg from unstructured pod with regexp: %w", err)
+	}
+	return result, nil
 }
 
 // We have a hook for handling clusterConfiguration.

--- a/global-hooks/discovery/cluster_ip_ranges.go
+++ b/global-hooks/discovery/cluster_ip_ranges.go
@@ -16,6 +16,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"regexp"
 
@@ -140,7 +141,7 @@ func applyClusterConfigurationFilter(obj *unstructured.Unstructured) (go_hook.Fi
 	var cm v1core.Secret
 	err := sdk.FromUnstructured(obj, &cm)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("from unstructured: %w", err)
 	}
 
 	clusterConf, ok := cm.Data["cluster-configuration.yaml"]
@@ -152,11 +153,19 @@ func applyClusterConfigurationFilter(obj *unstructured.Unstructured) (go_hook.Fi
 }
 
 func applyPodSubnetsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	return filter.GetArgFromUnstructuredPodWithRegexp(obj, podSubnetRegexp, 1, "kube-controller-manager")
+	result, err := filter.GetArgFromUnstructuredPodWithRegexp(obj, podSubnetRegexp, 1, "kube-controller-manager")
+	if err != nil {
+		return nil, fmt.Errorf("get arg from unstructured pod with regexp: %w", err)
+	}
+	return result, nil
 }
 
 func applyServiceSubnetsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
-	return filter.GetArgFromUnstructuredPodWithRegexp(obj, serviceSubnetRegexp, 1, "kube-apiserver")
+	result, err := filter.GetArgFromUnstructuredPodWithRegexp(obj, serviceSubnetRegexp, 1, "kube-apiserver")
+	if err != nil {
+		return nil, fmt.Errorf("get arg from unstructured pod with regexp: %w", err)
+	}
+	return result, nil
 }
 
 func getSubnetsFromSnapshots(input *go_hook.HookInput, snapshotsNames ...string) string {

--- a/global-hooks/discovery/deckhouse_registry.go
+++ b/global-hooks/discovery/deckhouse_registry.go
@@ -66,7 +66,7 @@ func applyD8RegistrySecretFilter(obj *unstructured.Unstructured) (go_hook.Filter
 
 	err := sdk.FromUnstructured(obj, &secret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	scheme, ok := secret.Data["scheme"]

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -148,7 +148,7 @@ func applyEndpointsAPIServerFilter(obj *unstructured.Unstructured) (go_hook.Filt
 
 	err := sdk.FromUnstructured(obj, &endpointSlices)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	addresses := make([]string, 0)
@@ -177,7 +177,7 @@ func applyServiceAPIServerFilter(obj *unstructured.Unstructured) (go_hook.Filter
 
 	err := sdk.FromUnstructured(obj, &service)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	return service.Spec.ClusterIP, nil
@@ -193,16 +193,16 @@ func getKubeVersionForServer(endpoint string, cl d8http.Client) (*semver.Version
 	url := fmt.Sprintf("https://%s/version?timeout=5s", endpoint)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new request: %w", err)
 	}
 	err = d8http.SetKubeAuthToken(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("set kube auth token: %w", err)
 	}
 
 	res, err := cl.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("do: %w", err)
 	}
 
 	defer res.Body.Close()
@@ -214,12 +214,12 @@ func getKubeVersionForServer(endpoint string, cl d8http.Client) (*semver.Version
 	var info apimachineryversion.Info
 	err = json.NewDecoder(res.Body).Decode(&info)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode: %w", err)
 	}
 
 	ver, err := semver.NewVersion(info.GitVersion)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("new version: %w", err)
 	}
 
 	return ver, nil
@@ -356,7 +356,7 @@ func k8sVersions(ctx context.Context, input *go_hook.HookInput) error {
 
 	err = os.WriteFile(kubeVersionFileName, []byte(minVerStr), os.FileMode(0644))
 	if err != nil {
-		return err
+		return fmt.Errorf("write file: %w", err)
 	}
 	input.Values.Set("global.discovery.kubernetesVersions", versions)
 	input.Values.Set("global.discovery.kubernetesVersion", minVerStr)

--- a/global-hooks/discovery/virtualization_level.go
+++ b/global-hooks/discovery/virtualization_level.go
@@ -16,6 +16,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math"
 	"strconv"
@@ -58,7 +59,7 @@ func applyMasterNodesFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 
 	err := sdk.FromUnstructured(obj, node)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	virtualizationLevel := 0

--- a/global-hooks/enable_cloud_provider.go
+++ b/global-hooks/enable_cloud_provider.go
@@ -65,7 +65,7 @@ func applyClusterConfigForProviderFilter(obj *unstructured.Unstructured) (go_hoo
 	var cm v1core.Secret
 	err := sdk.FromUnstructured(obj, &cm)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("from unstructured: %w", err)
 	}
 
 	clusterConf, ok := cm.Data["cluster-configuration.yaml"]

--- a/global-hooks/enable_cni.go
+++ b/global-hooks/enable_cni.go
@@ -88,7 +88,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func applyMCFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	v, _, err := unstructured.NestedBool(obj.UnstructuredContent(), "spec", "enabled")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nested bool: %w", err)
 	}
 
 	if !v {
@@ -102,7 +102,7 @@ func applyCniConfigFilter(obj *unstructured.Unstructured) (go_hook.FilterResult,
 	var cm v1core.Secret
 	err := sdk.FromUnstructured(obj, &cm)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("from unstructured: %w", err)
 	}
 
 	cni, ok := cm.Data["cni"]

--- a/global-hooks/generate_kube_rbac_proxy_ca.go
+++ b/global-hooks/generate_kube_rbac_proxy_ca.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -53,7 +54,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func generateSelfSignedCA(_ context.Context, input *go_hook.HookInput) error {
 	selfSignedCA, err := certificate.GetOrCreateCa(input, caSnapshot, selfSignedSecretName)
 	if err != nil {
-		return err
+		return fmt.Errorf("get or create ca: %w", err)
 	}
 
 	input.Values.Set("global.internal.modules.kubeRBACProxyCA.cert", selfSignedCA.Cert)

--- a/global-hooks/migrate/grafana_v8_cleanup.go
+++ b/global-hooks/migrate/grafana_v8_cleanup.go
@@ -168,7 +168,7 @@ func filterResources(obj *unstructured.Unstructured) (go_hook.FilterResult, erro
 
 	err := sdk.FromUnstructured(obj, &resource)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	resource.APIVersion = obj.GetAPIVersion()

--- a/global-hooks/migrate/migrate_k8s_upgrade.go
+++ b/global-hooks/migrate/migrate_k8s_upgrade.go
@@ -60,7 +60,7 @@ func k8sUpgradeHookTriggerFilter(obj *unstructured.Unstructured) (go_hook.Filter
 	secret := &v1.Secret{}
 	err := sdk.FromUnstructured(obj, secret)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 	version, ok := secret.Data["maxUsedControlPlaneKubernetesVersion"]
 	if !ok {

--- a/global-hooks/resources/cluster_autoscaler.go
+++ b/global-hooks/resources/cluster_autoscaler.go
@@ -51,7 +51,7 @@ func applyAutoscalerResourcesFilter(obj *unstructured.Unstructured) (go_hook.Fil
 	var depl appsv1.Deployment
 	err := sdk.FromUnstructured(obj, &depl)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	return depl.Spec.Template.Spec.Containers[0].Resources, nil
@@ -79,7 +79,7 @@ func removeResourcesLimitsForClusterAutoscaler(_ context.Context, input *go_hook
 		var depl appsv1.Deployment
 		err := sdk.FromUnstructured(u, &depl)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("from unstructured: %w", err)
 		}
 
 		// Remove resource limits from the first container

--- a/global-hooks/set_deckhouse_leader_pod.go
+++ b/global-hooks/set_deckhouse_leader_pod.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -41,7 +42,7 @@ func setLeaderLabelToPod(_ context.Context, input *go_hook.HookInput, dc depende
 
 	client, err := dc.GetK8sClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("get k8s client: %w", err)
 	}
 
 	pods, err := client.CoreV1().Pods(d8Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "app=deckhouse"})

--- a/modules/002-deckhouse/hooks/metrics.go
+++ b/modules/002-deckhouse/hooks/metrics.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -44,7 +45,7 @@ func collectMetrics(_ context.Context, input *go_hook.HookInput) error {
 	if exists {
 		windows, err := update.FromJSON([]byte(windowsData.Raw))
 		if err != nil {
-			return err
+			return fmt.Errorf("from json: %w", err)
 		}
 
 		for _, windows := range windows {

--- a/modules/002-deckhouse/hooks/migrate/change_helm_annotation_flowschema_priorityclass.go
+++ b/modules/002-deckhouse/hooks/migrate/change_helm_annotation_flowschema_priorityclass.go
@@ -67,7 +67,7 @@ func changeAnnotationUnstructured(
 
 	list, err := client.List(ctx, labelSelector)
 	if err != nil {
-		return err
+		return fmt.Errorf("list: %w", err)
 	}
 
 	for _, v := range list.Items {
@@ -75,7 +75,7 @@ func changeAnnotationUnstructured(
 
 		annotations, found, err := unstructured.NestedStringMap(obj.Object, "metadata", "annotations")
 		if err != nil {
-			return err
+			return fmt.Errorf("nested string map: %w", err)
 		}
 		if !found {
 			continue
@@ -88,11 +88,11 @@ func changeAnnotationUnstructured(
 		annotations[helmAnnotation] = "deckhouse"
 
 		if err := unstructured.SetNestedStringMap(obj.Object, annotations, "metadata", "annotations"); err != nil {
-			return err
+			return fmt.Errorf("set nested string map: %w", err)
 		}
 
 		if _, err := client.Update(ctx, &obj, v1.UpdateOptions{}); err != nil {
-			return err
+			return fmt.Errorf("update: %w", err)
 		}
 	}
 
@@ -109,7 +109,7 @@ func changeAnnotation(_ context.Context, input *go_hook.HookInput, dc dependency
 
 	k8sClient, err := dc.GetK8sClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("get k8s client: %w", err)
 	}
 
 	schemas := []schema.GroupVersionResource{

--- a/modules/015-admission-policy-engine/hooks/bootstrap_handler.go
+++ b/modules/015-admission-policy-engine/hooks/bootstrap_handler.go
@@ -133,7 +133,7 @@ func filterGatekeeperTemplates(obj *unstructured.Unstructured) (go_hook.FilterRe
 	// check if CRD has been successfully created from the ConstraintTemplate
 	created, found, err := unstructured.NestedBool(obj.Object, "status", "created")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nested bool: %w", err)
 	}
 
 	return cTemplate{
@@ -165,25 +165,25 @@ func getRequiredTemplates() ([]string, error) {
 			return nil
 		}
 		if matched, err := filepath.Match(pattern, filepath.Base(path)); err != nil {
-			return err
+			return fmt.Errorf("match: %w", err)
 		} else if matched {
 			files = append(files, path)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("walk dir: %w", err)
 	}
 
 	for _, file := range files {
 		template := &ctemplate{}
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("read file: %w", err)
 		}
 		err = yaml.Unmarshal(yamlFile, template)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unmarshal: %w", err)
 		}
 		if template.ObjectMeta != nil && template.Kind == "ConstraintTemplate" && template.APIVersion == "templates.gatekeeper.sh/v1" {
 			requiredTemplates = append(requiredTemplates, template.ObjectMeta.Name)

--- a/modules/015-admission-policy-engine/hooks/detect_pss_default_policy.go
+++ b/modules/015-admission-policy-engine/hooks/detect_pss_default_policy.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 
@@ -116,7 +117,7 @@ func getDefaultPolicy(_ context.Context, input *go_hook.HookInput) string {
 func getVersion(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	version, _, err := unstructured.NestedString(obj.Object, "data", "version")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("nested string: %w", err)
 	}
 
 	return version, nil

--- a/modules/015-admission-policy-engine/hooks/detect_pss_enforcement_actions.go
+++ b/modules/015-admission-policy-engine/hooks/detect_pss_enforcement_actions.go
@@ -99,7 +99,7 @@ func handleActions(_ context.Context, input *go_hook.HookInput) error {
 func filterNamespaces(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	action, _, err := unstructured.NestedString(obj.Object, "metadata", "labels", pssEnforcementActionLabel)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nested string: %w", err)
 	}
 
 	return action, nil

--- a/modules/015-admission-policy-engine/hooks/detect_track_match_resources.go
+++ b/modules/015-admission-policy-engine/hooks/detect_track_match_resources.go
@@ -67,11 +67,11 @@ func handleValidationKinds(_ context.Context, input *go_hook.HookInput, _ depend
 	mutateRes := make([]matchResource, 0)
 
 	if err := yaml.Unmarshal([]byte(resourcesRaw[0].ValidateData), &validateRes); err != nil {
-		return err
+		return fmt.Errorf("unmarshal: %w", err)
 	}
 
 	if err := yaml.Unmarshal([]byte(resourcesRaw[0].MutateData), &mutateRes); err != nil {
-		return err
+		return fmt.Errorf("unmarshal: %w", err)
 	}
 
 	input.Values.Set("admissionPolicyEngine.internal.trackedConstraintResources", validateRes)
@@ -85,7 +85,7 @@ func filterExporterCM(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 
 	err := sdk.FromUnstructured(obj, &cm)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	return matchData{

--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies.go
@@ -50,7 +50,7 @@ func handleOP(_ context.Context, input *go_hook.HookInput) error {
 
 	data, err := json.Marshal(ops)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal: %w", err)
 	}
 
 	input.Values.Set("admissionPolicyEngine.internal.operationPolicies", json.RawMessage(data))
@@ -63,7 +63,7 @@ func filterOP(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 
 	err := sdk.FromUnstructured(obj, &op)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	return &op, nil

--- a/modules/015-admission-policy-engine/hooks/trivy_provider_registry_secrets.go
+++ b/modules/015-admission-policy-engine/hooks/trivy_provider_registry_secrets.go
@@ -81,7 +81,11 @@ func (a *authConfig) MarshalJSON() ([]byte, error) {
 	if a.Username != "" && a.Password != "" {
 		a.Auth = base64.StdEncoding.EncodeToString([]byte(a.Username + ":" + a.Password))
 	}
-	return json.Marshal(a)
+	data, err := json.Marshal(a)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	return data, nil
 }
 
 func filterTrivyProviderSecret(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/modules/021-cni-cilium/hooks/check_kernel_versions.go
+++ b/modules/021-cni-cilium/hooks/check_kernel_versions.go
@@ -86,7 +86,7 @@ type nodeKernelVersion struct {
 func filterNodes(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var node corev1.Node
 	if err := sdk.FromUnstructured(obj, &node); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 	return nodeKernelVersion{
 		Name:          node.Name,

--- a/modules/021-cni-cilium/requirements/check.go
+++ b/modules/021-cni-cilium/requirements/check.go
@@ -83,5 +83,9 @@ func checkMinimalKernelVersionFunc(requirementValue string, getter requirements.
 
 func parseKernelSemver(version string) (*semver.Version, error) {
 	base := strings.SplitN(version, "-", 2)[0]
-	return semver.NewVersion(base)
+	v, err := semver.NewVersion(base)
+	if err != nil {
+		return nil, fmt.Errorf("new version: %w", err)
+	}
+	return v, nil
 }

--- a/modules/030-cloud-provider-aws/hooks/aws_cluster_configuration.go
+++ b/modules/030-cloud-provider-aws/hooks/aws_cluster_configuration.go
@@ -125,19 +125,19 @@ func clusterConfiguration(_ context.Context, input *go_hook.HookInput) error {
 
 	var provider Provider
 	if err := json.Unmarshal(metaCfg.ProviderClusterConfig["provider"], &provider); err != nil {
-		return err
+		return fmt.Errorf("unmarshal: %w", err)
 	}
 
 	var discoveryData DiscoveryData
 	err = json.Unmarshal(cloudDiscoveryData, &discoveryData)
 	if err != nil {
-		return err
+		return fmt.Errorf("unmarshal: %w", err)
 	}
 
 	tags := make(map[string]string)
 	if len(metaCfg.ProviderClusterConfig["tags"]) != 0 {
 		if err := json.Unmarshal(metaCfg.ProviderClusterConfig["tags"], &tags); err != nil {
-			return err
+			return fmt.Errorf("unmarshal: %w", err)
 		}
 	}
 

--- a/modules/030-cloud-provider-aws/hooks/set_etcd_disk_old_hardcoded_size_in_provider_configuration.go
+++ b/modules/030-cloud-provider-aws/hooks/set_etcd_disk_old_hardcoded_size_in_provider_configuration.go
@@ -72,12 +72,12 @@ func patchClusterConfiguration(_ context.Context, input *go_hook.HookInput) erro
 	var clusterConfiguration map[string]interface{}
 
 	if err := yaml.Unmarshal(data, &clusterConfiguration); err != nil {
-		return err
+		return fmt.Errorf("unmarshal: %w", err)
 	}
 
 	value, _, err := unstructured.NestedString(clusterConfiguration, "masterNodeGroup", "instanceClass", "etcdDisk", "type")
 	if err != nil {
-		return err
+		return fmt.Errorf("nested string: %w", err)
 	}
 
 	// skip if values are set
@@ -92,7 +92,7 @@ func patchClusterConfiguration(_ context.Context, input *go_hook.HookInput) erro
 
 	err = unstructured.SetNestedField(clusterConfiguration, etcdDiskValues, "masterNodeGroup", "instanceClass", "etcdDisk")
 	if err != nil {
-		return err
+		return fmt.Errorf("set nested field: %w", err)
 	}
 
 	buf := bytes.NewBuffer(nil)
@@ -100,7 +100,7 @@ func patchClusterConfiguration(_ context.Context, input *go_hook.HookInput) erro
 	enc.SetIndent(2)
 	err = enc.Encode(clusterConfiguration)
 	if err != nil {
-		return err
+		return fmt.Errorf("encode: %w", err)
 	}
 
 	patch := map[string]interface{}{

--- a/modules/030-cloud-provider-aws/hooks/storage_classes.go
+++ b/modules/030-cloud-provider-aws/hooks/storage_classes.go
@@ -108,7 +108,7 @@ func storageClasses(_ context.Context, input *go_hook.HookInput) error {
 	for _, excludePattern := range provisionExcludeNames {
 		var r, err = regexp.Compile(excludePattern.String())
 		if err != nil {
-			return err
+			return fmt.Errorf("compile: %w", err)
 		}
 		provisionRegexps = append(provisionRegexps, r)
 	}
@@ -138,7 +138,7 @@ func storageClasses(_ context.Context, input *go_hook.HookInput) error {
 	for _, excludePattern := range excludeStorageClasses {
 		var r, err = regexp.Compile(excludePattern.String())
 		if err != nil {
-			return err
+			return fmt.Errorf("compile: %w", err)
 		}
 		excludeRegexps = append(excludeRegexps, r)
 	}

--- a/modules/030-cloud-provider-azure/hooks/storage_classes.go
+++ b/modules/030-cloud-provider-azure/hooks/storage_classes.go
@@ -100,7 +100,7 @@ func storageClasses(_ context.Context, input *go_hook.HookInput) error {
 		for _, excludePattern := range excludeStorageClasses {
 			var r, err = regexp.Compile(excludePattern.String())
 			if err != nil {
-				return false, err
+				return false, fmt.Errorf("compile regexp: %w", err)
 			}
 			if r.MatchString(storageClassName) {
 				return true, nil

--- a/modules/030-cloud-provider-gcp/hooks/storage_classes.go
+++ b/modules/030-cloud-provider-gcp/hooks/storage_classes.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -79,7 +80,7 @@ func storageClasses(_ context.Context, input *go_hook.HookInput) error {
 		for _, excludePattern := range excludeStorageClasses {
 			var r, err = regexp.Compile(excludePattern.String())
 			if err != nil {
-				return false, err
+				return false, fmt.Errorf("compile regexp: %w", err)
 			}
 			if r.MatchString(storageClassName) {
 				return true, nil

--- a/modules/030-cloud-provider-gcp/hooks/wait_for_all_master_nodes_to_become_initialized.go
+++ b/modules/030-cloud-provider-gcp/hooks/wait_for_all_master_nodes_to_become_initialized.go
@@ -39,12 +39,12 @@ func isAllMasterNodesInitialized(_ context.Context, input *go_hook.HookInput, dc
 	kubeClient, err := dc.GetK8sClient()
 	if err != nil {
 		input.Logger.Error(err.Error())
-		return false, err
+		return false, fmt.Errorf("get k8s client: %w", err)
 	}
 	masterNodes, err := kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/control-plane="})
 	if err != nil {
 		input.Logger.Error(err.Error())
-		return false, err
+		return false, fmt.Errorf("list nodes: %w", err)
 	}
 
 	for _, node := range masterNodes.Items {

--- a/modules/038-registry/hooks/checker/checker.go
+++ b/modules/038-registry/hooks/checker/checker.go
@@ -54,7 +54,7 @@ func checkRegistryItem(ctx context.Context, puller *gcr_remote.Puller, isHTTPS b
 	_, err = puller.Head(ctx, ref)
 	if err != nil {
 		if ctx.Err() == nil {
-			return err
+			return fmt.Errorf("head: %w", err)
 		}
 
 		return fmt.Errorf("Request timeout")
@@ -140,10 +140,14 @@ func buildPuller(params RegistryParams) (*gcr_remote.Puller, error) {
 		}
 	}
 
-	return gcr_remote.NewPuller(
+	puller, err := gcr_remote.NewPuller(
 		gcr_remote.WithTransport(transport),
 		gcr_remote.WithAuth(auth),
 	)
+	if err != nil {
+		return nil, fmt.Errorf("new puller: %w", err)
+	}
+	return puller, nil
 }
 
 func checkRegistry(ctx context.Context, queue *registryQueue, params RegistryParams) (int, error) {

--- a/modules/038-registry/hooks/helpers/docker_cfg.go
+++ b/modules/038-registry/hooks/helpers/docker_cfg.go
@@ -45,7 +45,11 @@ func DockerCfgFromCreds(username, password, host string) ([]byte, error) {
 			},
 		},
 	}
-	return json.Marshal(cfg)
+	result, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	return result, nil
 }
 
 func CredsFromDockerCfg(rawCfg []byte, host string) (string, string, error) {

--- a/modules/038-registry/hooks/orchestrator/models.go
+++ b/modules/038-registry/hooks/orchestrator/models.go
@@ -74,12 +74,15 @@ func (p Params) Validate() error {
 
 	switch p.Mode {
 	case registry_const.ModeDirect, registry_const.ModeUnmanaged:
-		return validation.ValidateStruct(&p,
+		if err := validation.ValidateStruct(&p,
 			validation.Field(&p.ImagesRepo, validation.Required),
 			validation.Field(&p.Scheme, validation.In("HTTP", "HTTPS")),
 			validation.Field(&p.UserName, validation.When(p.Password != "", validation.Required)),
 			validation.Field(&p.Password, validation.When(p.UserName != "", validation.Required)),
-		)
+		); err != nil {
+			return fmt.Errorf("validate struct: %w", err)
+		}
+		return nil
 	}
 	return fmt.Errorf("Unknown registry mode: %q", p.Mode)
 }

--- a/modules/038-registry/hooks/orchestrator/pki/models.go
+++ b/modules/038-registry/hooks/orchestrator/pki/models.go
@@ -33,13 +33,17 @@ func (pcm *CertModel) toPKI() (pki.CertKey, error) {
 	if pcm == nil {
 		return pki.CertKey{}, fmt.Errorf("cannot convert nil to CertKey")
 	}
-	return pki.DecodeCertKey([]byte(pcm.Cert), []byte(pcm.Key))
+	result, err := pki.DecodeCertKey([]byte(pcm.Cert), []byte(pcm.Key))
+	if err != nil {
+		return pki.CertKey{}, fmt.Errorf("decode cert key: %w", err)
+	}
+	return result, nil
 }
 
 func pkiCertModel(value pki.CertKey) (*CertModel, error) {
 	cert, key, err := pki.EncodeCertKey(value)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("encode cert key: %w", err)
 	}
 	return &CertModel{Cert: string(cert), Key: string(key)}, nil
 }

--- a/modules/038-registry/hooks/orchestrator/state.go
+++ b/modules/038-registry/hooks/orchestrator/state.go
@@ -641,7 +641,7 @@ func (state *State) processRegistrySwitcher(params registryswitcher.Params, inpu
 	// Update Deckhouse-registry secret and wait
 	result, err := state.RegistrySecret.Process(params, inputs.RegistrySwitcher)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("process: %w", err)
 	}
 	if !result.Ready {
 		state.setCondition(metav1.Condition{

--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -507,7 +507,7 @@ func serializePolicy(policy *audit.Policy) (string, error) {
 	}
 	err := builder.AddToScheme(schema)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("add to scheme: %w", err)
 	}
 	serializer := json.NewSerializerWithOptions(
 		json.DefaultMetaFactory, schema, schema,

--- a/modules/040-control-plane-manager/hooks/common.go
+++ b/modules/040-control-plane-manager/hooks/common.go
@@ -62,10 +62,14 @@ func getETCDClient(input *go_hook.HookInput, dc dependency.Container, endpoints 
 
 	caCert, clientCert, err := certificate.ParseCertificatesFromPEM(cert.CA, cert.Cert, cert.Key)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse certificates from pem: %w", err)
 	}
 
-	return dc.GetEtcdClient(endpoints, etcd.WithClientCert(clientCert, caCert), etcd.WithInsecureSkipVerify())
+	etcdClient, err := dc.GetEtcdClient(endpoints, etcd.WithClientCert(clientCert, caCert), etcd.WithInsecureSkipVerify())
+	if err != nil {
+		return nil, fmt.Errorf("get etcd client: %w", err)
+	}
+	return etcdClient, nil
 }
 
 var (

--- a/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
+++ b/modules/040-control-plane-manager/hooks/ensure_secret_encryption_key.go
@@ -141,7 +141,7 @@ func generateSecretEncryptionKey() ([]byte, error) {
 	secret := make([]byte, 32)
 	_, err := rand.Read(secret)
 	if err != nil {
-		return []byte{}, err
+		return []byte{}, fmt.Errorf("read: %w", err)
 	}
 
 	return secret, nil

--- a/modules/040-control-plane-manager/hooks/kube_scheduler_extenders.go
+++ b/modules/040-control-plane-manager/hooks/kube_scheduler_extenders.go
@@ -83,7 +83,7 @@ func handleExtenders(_ context.Context, input *go_hook.HookInput) error {
 
 			urlPrefix, err := url.JoinPath(fmt.Sprintf("https://%s.%s.svc.%s:%d", config.ClientConfig.Service.Name, config.ClientConfig.Service.Namespace, clusterDomain, config.ClientConfig.Service.Port), config.ClientConfig.Service.Path)
 			if err != nil {
-				return err
+				return fmt.Errorf("join path: %w", err)
 			}
 			newExtender := extenderConfig{
 				URLPrefix: urlPrefix,
@@ -102,10 +102,13 @@ func handleExtenders(_ context.Context, input *go_hook.HookInput) error {
 func verifyCAChain(caBase64 string) error {
 	caData, err := base64.StdEncoding.DecodeString(caBase64)
 	if err != nil {
-		return err
+		return fmt.Errorf("decode string: %w", err)
 	}
 	_, err = certificate.ParseCertificate(string(caData))
-	return err
+	if err != nil {
+		return fmt.Errorf("parse certificate: %w", err)
+	}
+	return nil
 }
 
 type KubeSchedulerWebhookConfiguration struct {

--- a/modules/040-control-plane-manager/hooks/lock_main_queue.go
+++ b/modules/040-control-plane-manager/hooks/lock_main_queue.go
@@ -99,7 +99,7 @@ func lockQueueFilterPod(unstructured *unstructured.Unstructured) (go_hook.Filter
 	podGenerationStr := pod.Labels["pod-template-generation"]
 	podGeneration, err := strconv.ParseInt(podGenerationStr, 10, 64)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse int: %w", err)
 	}
 
 	var isReady bool

--- a/modules/040-control-plane-manager/requirements/check.go
+++ b/modules/040-control-plane-manager/requirements/check.go
@@ -18,6 +18,7 @@ package requirements
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -30,7 +31,7 @@ func init() {
 	f := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
 		desiredVersion, err := semver.NewVersion(requirementValue)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("new version: %w", err)
 		}
 		currentVersionStr, exists := getter.Get(minK8sVersionRequirementKey)
 		if !exists {
@@ -38,7 +39,7 @@ func init() {
 		}
 		currentVersion, err := semver.NewVersion(currentVersionStr.(string))
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("new version: %w", err)
 		}
 
 		if currentVersion.LessThan(desiredVersion) {

--- a/modules/040-node-manager/hooks/check_unmet_conditions.go
+++ b/modules/040-node-manager/hooks/check_unmet_conditions.go
@@ -95,5 +95,8 @@ func updateCloudConditionsFilter(obj *unstructured.Unstructured) (go_hook.Filter
 	}
 
 	var conditions []CloudCondition
-	return conditions, json.Unmarshal([]byte(cm.Data["conditions"]), &conditions)
+	if err := json.Unmarshal([]byte(cm.Data["conditions"]), &conditions); err != nil {
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+	return conditions, nil
 }

--- a/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
+++ b/modules/040-node-manager/hooks/convert_static_cluster_configuration.go
@@ -86,7 +86,7 @@ func internalNetworkFromStaticConfiguration(data []byte) (interface{}, error) {
 
 	metaConfig, err = config.ParseConfigFromData(string(data))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse config from data: %w", err)
 	}
 
 	intNet := metaConfig.StaticClusterConfig["internalNetworkCIDRs"]

--- a/modules/040-node-manager/hooks/create_master_node_group.go
+++ b/modules/040-node-manager/hooks/create_master_node_group.go
@@ -16,6 +16,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -64,7 +65,7 @@ func getDefaultMasterNg(clusterType string) (*unstructured.Unstructured, error) 
 	}
 	o, err := sdk.ToUnstructured(&ng)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("to unstructured: %w", err)
 	}
 
 	return o, nil

--- a/modules/040-node-manager/hooks/discover_kubernetes_ca.go
+++ b/modules/040-node-manager/hooks/discover_kubernetes_ca.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -33,7 +34,7 @@ const rootCAFile = "/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 func discoverKubernetesCAHandler(_ context.Context, input *go_hook.HookInput) error {
 	caBytes, err := os.ReadFile(rootCAFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("read file: %w", err)
 	}
 
 	input.Values.Set("nodeManager.internal.kubernetesCA", string(caBytes))

--- a/modules/040-node-manager/hooks/fencing_controller.go
+++ b/modules/040-node-manager/hooks/fencing_controller.go
@@ -101,7 +101,7 @@ func fencingControllerHandler(_ context.Context, input *go_hook.HookInput, dc de
 	kubeClient, err := dc.GetK8sClient()
 	if err != nil {
 		input.Logger.Error(err.Error())
-		return err
+		return fmt.Errorf("get k8s client: %w", err)
 	}
 
 	// make map with nodes to kill

--- a/modules/040-node-manager/hooks/gen_bashible_apiserver_certs.go
+++ b/modules/040-node-manager/hooks/gen_bashible_apiserver_certs.go
@@ -100,10 +100,10 @@ func generateNewBashibleCert(_ context.Context, input *go_hook.HookInput) (certi
 		certificate.WithKeySize(256),
 		certificate.WithCAExpiry("87600h"))
 	if err != nil {
-		return certificate.Certificate{}, err
+		return certificate.Certificate{}, fmt.Errorf("generate ca: %w", err)
 	}
 
-	return certificate.GenerateSelfSignedCert(input.Logger,
+	cert, err := certificate.GenerateSelfSignedCert(input.Logger,
 		"node-manager",
 		ca,
 		certificate.WithSANs("127.0.0.1", "bashible-api.d8-cloud-instance-manager.svc"),
@@ -116,4 +116,8 @@ func generateNewBashibleCert(_ context.Context, input *go_hook.HookInput) (certi
 			"requestheader-client",
 		}),
 	)
+	if err != nil {
+		return certificate.Certificate{}, fmt.Errorf("generate self signed cert: %w", err)
+	}
+	return cert, nil
 }

--- a/modules/040-node-manager/hooks/generate_capi_kubeconfig.go
+++ b/modules/040-node-manager/hooks/generate_capi_kubeconfig.go
@@ -155,7 +155,7 @@ func createCAPIServiceAccount(k8sClient k8s.Client, saName string) error {
 
 	_, err := k8sClient.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
+		return fmt.Errorf("create: %w", err)
 	}
 
 	serviceAccount := &corev1.ServiceAccount{

--- a/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
+++ b/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
@@ -18,6 +18,7 @@ package capacity
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -94,11 +95,11 @@ func (vic vsphereInstanceClass) ExtractCapacity(_ *InstanceTypesCatalog) (*v1alp
 
 	cpuRes, err := resource.ParseQuantity(cpuStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 	memRes, err := resource.ParseQuantity(memStr + "Mi")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 
 	return &v1alpha1.InstanceType{
@@ -170,11 +171,11 @@ func (yic yandexInstanceClass) ExtractCapacity(_ *InstanceTypesCatalog) (*v1alph
 
 	cpuRes, err := resource.ParseQuantity(cpuStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 	memRes, err := resource.ParseQuantity(memStr + "Mi")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 
 	return &v1alpha1.InstanceType{
@@ -228,11 +229,11 @@ func (zic zvirtInstanceClass) ExtractCapacity(_ *InstanceTypesCatalog) (*v1alpha
 
 	cpuRes, err := resource.ParseQuantity(cpuStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 	memRes, err := resource.ParseQuantity(memStr + "Mi")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 
 	return &v1alpha1.InstanceType{
@@ -253,11 +254,11 @@ func (d dynamixInstanceClass) ExtractCapacity(_ *InstanceTypesCatalog) (*v1alpha
 
 	cpuRes, err := resource.ParseQuantity(cpuStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 	memRes, err := resource.ParseQuantity(memStr + "Mi")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 
 	return &v1alpha1.InstanceType{
@@ -297,11 +298,11 @@ func (d dvpInstanceClass) ExtractCapacity(_ *InstanceTypesCatalog) (*v1alpha1.In
 
 	cpuRes, err := resource.ParseQuantity(cpuStr)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 	memRes, err := resource.ParseQuantity(memStr + "Mi")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse quantity: %w", err)
 	}
 
 	return &v1alpha1.InstanceType{
@@ -399,8 +400,12 @@ func CalculateNodeTemplateCapacity(instanceClassName string, instanceClassSpec i
 	data, _ := json.Marshal(instanceClassSpec)
 	err := json.Unmarshal(data, extractor)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 
-	return extractor.ExtractCapacity(catalog)
+	capacity, err := extractor.ExtractCapacity(catalog)
+	if err != nil {
+		return nil, fmt.Errorf("extract capacity: %w", err)
+	}
+	return capacity, nil
 }

--- a/modules/040-node-manager/hooks/migration/migrate_add_status_subresource_to_node_user.go
+++ b/modules/040-node-manager/hooks/migration/migrate_add_status_subresource_to_node_user.go
@@ -52,7 +52,7 @@ type existingStatus struct {
 func applyNodeUsersFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	_, exists, err := unstructured.NestedFieldNoCopy(obj.Object, "status")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nested field no copy: %w", err)
 	}
 
 	return existingStatus{
@@ -86,7 +86,7 @@ func addStatusSubresourceForNodeUser(_ context.Context, input *go_hook.HookInput
 			}
 			err := unstructured.SetNestedField(objCopy.Object, status, "status")
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("set nested field: %w", err)
 			}
 			return objCopy, nil
 		}, "deckhouse.io/v1", "NodeUser", "", nu.UserName)

--- a/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
+++ b/modules/040-node-manager/hooks/migration/migrate_system_reserve.go
@@ -82,7 +82,7 @@ func ngFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var ng v1.NodeGroup
 	err := sdk.FromUnstructured(obj, &ng)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("from unstructured: %w", err)
 	}
 
 	return &NodeGroup{
@@ -99,7 +99,7 @@ func configMapName(obj *unstructured.Unstructured) (go_hook.FilterResult, error)
 	var cm corev1.ConfigMap
 	err := sdk.FromUnstructured(obj, &cm)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("from unstructured: %w", err)
 	}
 
 	return &CM{Name: cm.Name}, nil
@@ -126,7 +126,7 @@ func systemReserve(_ context.Context, input *go_hook.HookInput) error {
 			objCopy := u.DeepCopy()
 			err := unstructured.SetNestedField(objCopy.Object, "Off", "spec", "kubelet", "resourceReservation", "mode")
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("set nested field: %w", err)
 			}
 			return objCopy, nil
 		}, "deckhouse.io/v1", "NodeGroup", "", ng.Name)

--- a/modules/040-node-manager/requirements/check.go
+++ b/modules/040-node-manager/requirements/check.go
@@ -109,7 +109,7 @@ func baseFuncMinVerOS(requirementValue string, getter requirements.ValueGetter, 
 
 	desiredVersion, err := semver.NewVersion(normalizedRequirementValue)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("new version: %w", err)
 	}
 	switch osImage {
 	case "Ubuntu":
@@ -131,7 +131,7 @@ func baseFuncMinVerOS(requirementValue string, getter requirements.ValueGetter, 
 
 	currentVersion, err := semver.NewVersion(normalizedCurrentVersion)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("new version: %w", err)
 	}
 
 	if currentVersion.LessThan(desiredVersion) {

--- a/modules/042-kube-dns/hooks/migration_deployment.go
+++ b/modules/042-kube-dns/hooks/migration_deployment.go
@@ -16,6 +16,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -70,7 +71,7 @@ func applyDeploymentCorednsPortsFilter(obj *unstructured.Unstructured) (go_hook.
 	var depl appsv1.Deployment
 	err := sdk.FromUnstructured(obj, &depl)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 	ports := []v1.ContainerPort{}
 	for _, v := range depl.Spec.Template.Spec.Containers {
@@ -91,7 +92,7 @@ func ensureCorednsPorts(_ context.Context, input *go_hook.HookInput) error {
 		var depl appsv1.Deployment
 		err := sdk.FromUnstructured(u, &depl)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unmarshal: %w", err)
 		}
 
 		for i, v := range depl.Spec.Template.Spec.Containers {

--- a/modules/101-cert-manager/hooks/generate_selfsigned_ca.go
+++ b/modules/101-cert-manager/hooks/generate_selfsigned_ca.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -51,7 +52,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func generateSelfSignedCA(_ context.Context, input *go_hook.HookInput) error {
 	selfSignedCA, err := certificate.GetOrCreateCa(input, caSnapshot, "cluster-selfsigned-ca")
 	if err != nil {
-		return err
+		return fmt.Errorf("get or create ca: %w", err)
 	}
 
 	input.Values.Set("certManager.internal.selfSignedCA.cert", selfSignedCA.Cert)

--- a/modules/110-istio/hooks/cleanup_cni_daemonset_hostports.go
+++ b/modules/110-istio/hooks/cleanup_cni_daemonset_hostports.go
@@ -99,6 +99,9 @@ func handleHostNetworkFalseWithHostPorts(_ context.Context, input *go_hook.HookI
 	}
 
 	_, err = k8sClient.AppsV1().DaemonSets("d8-istio").Update(context.TODO(), ds, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("update daemonset: %w", err)
+	}
 
-	return err
+	return nil
 }

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -110,7 +110,7 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 	for _, version := range operatorVersionsToInstall {
 		versionSemver, err := semver.NewVersion(version)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse version: %w", err)
 		}
 		if minVersion == nil || versionSemver.LessThan(minVersion) {
 			minVersion = versionSemver

--- a/modules/110-istio/hooks/discovery_preflight_check.go
+++ b/modules/110-istio/hooks/discovery_preflight_check.go
@@ -68,7 +68,7 @@ func applyClusterConfigurationYamlFilter(obj *unstructured.Unstructured) (go_hoo
 	var metaConfig *config.MetaConfig
 	metaConfig, err = config.ParseConfigFromData(string(ccYaml))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
 	kubernetesVersion, err := rawMessageToString(metaConfig.ClusterConfig["kubernetesVersion"])
@@ -109,8 +109,11 @@ func rawMessageToString(message json.RawMessage) (string, error) {
 	var result string
 	b, err := message.MarshalJSON()
 	if err != nil {
-		return result, err
+		return result, fmt.Errorf("marshal: %w", err)
 	}
 	err = json.Unmarshal(b, &result)
-	return result, err
+	if err != nil {
+		return result, fmt.Errorf("unmarshal: %w", err)
+	}
+	return result, nil
 }

--- a/modules/110-istio/hooks/discovery_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_versions_to_install.go
@@ -61,7 +61,7 @@ func revisionsDiscovery(_ context.Context, input *go_hook.HookInput, dc dependen
 		// maybe there is a global istiod Service with annotation?
 		k8sClient, err := dc.GetK8sClient()
 		if err != nil {
-			return err
+			return fmt.Errorf("get k8s client: %w", err)
 		}
 
 		service, err := k8sClient.CoreV1().Services("d8-istio").Get(context.TODO(), "istiod", metav1.GetOptions{})

--- a/modules/110-istio/hooks/ensure_crds_istio.go
+++ b/modules/110-istio/hooks/ensure_crds_istio.go
@@ -56,7 +56,7 @@ func ensureCRDs(ctx context.Context, input *go_hook.HookInput, dc dependency.Con
 	for i, version := range istioVersions {
 		v, err := semver.NewVersion(version)
 		if err != nil {
-			return err
+			return fmt.Errorf("new version: %w", err)
 		}
 		semvers[i] = v
 	}

--- a/modules/110-istio/hooks/generate_ca.go
+++ b/modules/110-istio/hooks/generate_ca.go
@@ -89,13 +89,13 @@ func generateCA(_ context.Context, input *go_hook.HookInput) error {
 				A: "rsa",
 				S: 2048,
 			}))
+			if err != nil {
+				return fmt.Errorf("generate ca: %w", err)
+			}
 			istioCA.Cert = selfSignedCA.Cert
 			istioCA.Key = selfSignedCA.Key
 			istioCA.Chain = selfSignedCA.Cert
 			istioCA.Root = selfSignedCA.Cert
-			if err != nil {
-				return err
-			}
 		}
 	}
 

--- a/modules/110-istio/hooks/lib/common.go
+++ b/modules/110-istio/hooks/lib/common.go
@@ -53,7 +53,7 @@ func Contains(s []string, str string) bool {
 func HTTPGet(httpClient d8http.Client, url string, bearerToken string) ([]byte, int, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("new request: %w", err)
 	}
 
 	if len(bearerToken) > 0 {
@@ -62,13 +62,13 @@ func HTTPGet(httpClient d8http.Client, url string, bearerToken string) ([]byte, 
 
 	res, err := httpClient.Do(req)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("do: %w", err)
 	}
 	defer res.Body.Close()
 
 	dataBytes, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("read all: %w", err)
 	}
 
 	return dataBytes, res.StatusCode, nil

--- a/modules/110-istio/hooks/migration_delete_obsolete_ingress.go
+++ b/modules/110-istio/hooks/migration_delete_obsolete_ingress.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -43,7 +44,7 @@ func deleteIngress(_ context.Context, _ *go_hook.HookInput, dc dependency.Contai
 	kubeClient := dc.MustGetK8sClient()
 
 	if err := kubeClient.NetworkingV1().Ingresses(istioNs).Delete(context.Background(), obsoleteIngress, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	return nil

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -19,6 +19,7 @@ package hooks
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -73,11 +74,11 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc dependency.Container) error {
 	patch, err := json.Marshal(deleteFinalizersPatch)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal: %w", err)
 	}
 	k8sClient, err := dc.GetK8sClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("get k8s client: %w", err)
 	}
 
 	// Clean up cluster-wide IstioFederation resources

--- a/modules/110-istio/requirements/check.go
+++ b/modules/110-istio/requirements/check.go
@@ -36,7 +36,7 @@ func init() {
 	checkMinimalIstioVersionFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
 		minimalIstioVersion, err := semver.NewVersion(requirementValue)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("new version: %w", err)
 		}
 		currentVersionRaw, exists := getter.Get(minVersionValuesKey)
 		if !exists {
@@ -45,7 +45,7 @@ func init() {
 		currentVersionStr := currentVersionRaw.(string)
 		currentVersion, err := semver.NewVersion(currentVersionStr)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("new version: %w", err)
 		}
 
 		if currentVersion.LessThan(minimalIstioVersion) {
@@ -58,7 +58,7 @@ func init() {
 	checkIstioAndK8sVersionsCompatibilityFunc := func(requirementValue string, getter requirements.ValueGetter) (bool, error) {
 		comingDefaultK8sVersionSemver, err := semver.NewVersion(requirementValue)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("new version: %w", err)
 		}
 		comingDefaultK8sVersion := fmt.Sprintf("%d.%d", comingDefaultK8sVersionSemver.Major(), comingDefaultK8sVersionSemver.Minor())
 

--- a/modules/300-prometheus/hooks/alertmanager_crd_discovery.go
+++ b/modules/300-prometheus/hooks/alertmanager_crd_discovery.go
@@ -182,7 +182,7 @@ func parseServiceCR(am Alertmanager, k8 k8s.Client) (alertmanagerService, error)
 	var value alertmanagerService
 	serviceName, ok, err := unstructured.NestedString(am.Spec, "external", "service", "name")
 	if err != nil {
-		return value, err
+		return value, fmt.Errorf("nested string: %w", err)
 	}
 	if !ok {
 		return value, fmt.Errorf("service name required: %v", am.Spec)
@@ -190,7 +190,7 @@ func parseServiceCR(am Alertmanager, k8 k8s.Client) (alertmanagerService, error)
 
 	serviceNamespace, ok, err := unstructured.NestedString(am.Spec, "external", "service", "namespace")
 	if err != nil {
-		return value, err
+		return value, fmt.Errorf("nested string: %w", err)
 	}
 	if !ok {
 		return value, fmt.Errorf("service namespace required: %v", am.Spec)
@@ -203,7 +203,7 @@ func parseServiceCR(am Alertmanager, k8 k8s.Client) (alertmanagerService, error)
 
 	svc, err := k8.CoreV1().Services(serviceNamespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
 	if err != nil {
-		return value, err
+		return value, fmt.Errorf("get: %w", err)
 	}
 
 	value.ResourceName = am.Name
@@ -234,7 +234,7 @@ func parseTargetCR(am Alertmanager) (alertmanagerAddress, error) {
 
 	parsedAddress, err := url.Parse(address)
 	if err != nil {
-		return value, err
+		return value, fmt.Errorf("parse: %w", err)
 	}
 
 	ca, _, _ := unstructured.NestedString(am.Spec, "external", "tls", "ca")
@@ -275,7 +275,7 @@ func parseTargetCR(am Alertmanager) (alertmanagerAddress, error) {
 func parseInternalCR(am Alertmanager) (alertmanagerInternal, error) {
 	value, ok, err := unstructured.NestedMap(am.Spec, "internal")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nested map: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("internal spec field required: %v", am.Spec)

--- a/modules/302-vertical-pod-autoscaler/hooks/order_certificate.go
+++ b/modules/302-vertical-pod-autoscaler/hooks/order_certificate.go
@@ -112,7 +112,7 @@ func vpaCertHandler(_ context.Context, input *go_hook.HookInput) error {
 
 		shouldGenerateNewCert, err = certificate.IsCertificateExpiringSoon([]byte(vpaCert.ServerCert), time.Hour*7*24)
 		if err != nil {
-			return err
+			return fmt.Errorf("check certificate expiry: %w", err)
 		}
 	}
 

--- a/modules/340-monitoring-custom/hooks/reserved_domain_nodes.go
+++ b/modules/340-monitoring-custom/hooks/reserved_domain_nodes.go
@@ -40,7 +40,7 @@ func applyLabelTaintFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 	node := &v1.Node{}
 	err := sdk.FromUnstructured(obj, node)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
 	n := ReservedNode{Name: node.Name}

--- a/modules/402-ingress-nginx/hooks/chaos_monkey.go
+++ b/modules/402-ingress-nginx/hooks/chaos_monkey.go
@@ -128,7 +128,7 @@ func chaosMonkey(_ context.Context, input *go_hook.HookInput, dc dependency.Cont
 
 	kubeClient, err := dc.GetK8sClient()
 	if err != nil {
-		return err
+		return fmt.Errorf("get k8s client: %w", err)
 	}
 
 	for res, err := range sdkobjectpatch.SnapshotIter[ingressDaemonSetFilterResult](daemonsets) {
@@ -152,7 +152,7 @@ func chaosMonkey(_ context.Context, input *go_hook.HookInput, dc dependency.Cont
 
 		podList, err := kubeClient.CoreV1().Pods(internal.Namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.FormatLabels(res.LabelSelector)})
 		if err != nil {
-			return err
+			return fmt.Errorf("list pods: %w", err)
 		}
 
 		if len(podList.Items) < 2 {

--- a/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer.go
+++ b/modules/402-ingress-nginx/hooks/migration/migrate_remove_ingress_validation_cve_fixer.go
@@ -18,6 +18,7 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -47,35 +48,35 @@ func removeFixer(_ context.Context, _ *go_hook.HookInput, dc dependency.Containe
 	kubeClient := dc.MustGetK8sClient()
 
 	if err := kubeClient.CoreV1().ServiceAccounts(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	if err := kubeClient.CoreV1().Secrets(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	if err := kubeClient.CoreV1().Services(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	if err := kubeClient.CoreV1().ConfigMaps(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	if err := kubeClient.AppsV1().Deployments(d8SystemNs).Delete(context.Background(), fixerName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	if err := kubeClient.RbacV1().ClusterRoles().Delete(context.Background(), fixerRBACName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	if err := kubeClient.RbacV1().ClusterRoleBindings().Delete(context.Background(), fixerRBACName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	if err := kubeClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.Background(), fixerName+"-hooks", metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-		return err
+		return fmt.Errorf("delete: %w", err)
 	}
 
 	return nil

--- a/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
+++ b/modules/402-ingress-nginx/hooks/minimal_ingress_nginx_version.go
@@ -57,12 +57,12 @@ const (
 func applySpecControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	version, _, err := unstructured.NestedString(obj.Object, "spec", "controllerVersion")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nested string: %w", err)
 	}
 
 	ingressClass, ok, err := unstructured.NestedString(obj.Object, "spec", "ingressClass")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("nested string: %w", err)
 	}
 	if !ok {
 		return nil, nil
@@ -102,7 +102,7 @@ func discoverMinimalNginxVersion(_ context.Context, input *go_hook.HookInput) er
 		}
 		ctrlVersion, err := semver.NewVersion(ctrl.Version)
 		if err != nil {
-			return err
+			return fmt.Errorf("parse version: %w", err)
 		}
 
 		if v, ok := classVersionMap[ctrl.IngressClass]; ok {

--- a/modules/402-ingress-nginx/hooks/order_certificates.go
+++ b/modules/402-ingress-nginx/hooks/order_certificates.go
@@ -122,7 +122,7 @@ func orderCertificate(_ context.Context, input *go_hook.HookInput) error {
 			if certData != nil && len(certData.Cert) > 0 && len(certData.Key) > 0 {
 				shouldGenerateNewCert, err := certificate.IsCertificateExpiringSoon([]byte(certData.Cert), time.Hour*24*365) // 1 year
 				if err != nil {
-					return err
+					return fmt.Errorf("is certificate expiring soon: %w", err)
 				}
 
 				if !shouldGenerateNewCert {
@@ -150,7 +150,7 @@ func orderCertificate(_ context.Context, input *go_hook.HookInput) error {
 		)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("generate self signed cert: %w", err)
 		}
 
 		certificates = append(certificates, CertificateInfo{

--- a/modules/460-log-shipper/hooks/generate_config.go
+++ b/modules/460-log-shipper/hooks/generate_config.go
@@ -45,7 +45,7 @@ func filterPodLoggingConfig(obj *unstructured.Unstructured) (go_hook.FilterResul
 
 	err := sdk.FromUnstructured(obj, &src)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 	return src, nil
 }
@@ -55,7 +55,7 @@ func filterClusterLoggingConfig(obj *unstructured.Unstructured) (go_hook.FilterR
 
 	err := sdk.FromUnstructured(obj, &src)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 	return src, nil
 }
@@ -65,7 +65,7 @@ func filterClusterLogDestination(obj *unstructured.Unstructured) (go_hook.Filter
 
 	err := sdk.FromUnstructured(obj, &dst)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 	return dst, nil
 }
@@ -328,12 +328,12 @@ func generateConfig(_ context.Context, input *go_hook.HookInput) error {
 
 	composerFromInput, err := composer.FromInput(input, destinations)
 	if err != nil {
-		return err
+		return fmt.Errorf("from input: %w", err)
 	}
 
 	configContent, err := composerFromInput.Do()
 	if err != nil {
-		return err
+		return fmt.Errorf("do: %w", err)
 	}
 
 	activated := len(configContent) != 0

--- a/modules/460-log-shipper/hooks/internal/vector/transform/filter.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/filter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package transform
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/deckhouse/deckhouse/go_lib/set"
@@ -79,7 +80,7 @@ func createFilterTransform(name string, filters []v1alpha1.Filter, mutate mutate
 
 		condition, err := rule.Render(vrl.Args{"filter": filter})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("render: %w", err)
 		}
 
 		transforms = append(transforms, &DynamicTransform{

--- a/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
+++ b/modules/460-log-shipper/hooks/internal/vector/transform/transforms.go
@@ -87,5 +87,9 @@ func (t *DynamicTransform) MarshalJSON() ([]byte, error) {
 		m[k] = b
 	}
 
-	return json.Marshal(m)
+	result, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	return result, nil
 }

--- a/modules/500-upmeter/hooks/clean_probe_garbage.go
+++ b/modules/500-upmeter/hooks/clean_probe_garbage.go
@@ -110,7 +110,7 @@ func (r *configMapRepo) List(ctx context.Context) ([]metav1.Object, error) {
 		ConfigMaps("d8-upmeter").
 		List(ctx, metav1.ListOptions{LabelSelector: "heritage=upmeter"})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list: %w", err)
 	}
 	objects := make([]metav1.Object, 0, len(list.Items))
 	for i := range list.Items {
@@ -120,7 +120,11 @@ func (r *configMapRepo) List(ctx context.Context) ([]metav1.Object, error) {
 }
 
 func (r *configMapRepo) Delete(ctx context.Context, name string) error {
-	return r.k.CoreV1().ConfigMaps("d8-upmeter").Delete(ctx, name, metav1.DeleteOptions{})
+	err := r.k.CoreV1().ConfigMaps("d8-upmeter").Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+	return nil
 }
 
 var certificateGVR = schema.GroupVersionResource{
@@ -151,10 +155,14 @@ func (r *certRepo) List(ctx context.Context) ([]metav1.Object, error) {
 }
 
 func (r *certRepo) Delete(ctx context.Context, name string) error {
-	return r.k.Dynamic().
+	err := r.k.Dynamic().
 		Resource(certificateGVR).
 		Namespace("d8-upmeter").
 		Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+	return nil
 }
 
 type certSecretRepo struct {
@@ -167,7 +175,7 @@ func (r *certSecretRepo) List(ctx context.Context) ([]metav1.Object, error) {
 		Secrets("d8-upmeter").
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list: %w", err)
 	}
 	objects := make([]metav1.Object, 0, len(list.Items))
 	for i := range list.Items {
@@ -181,9 +189,13 @@ func (r *certSecretRepo) List(ctx context.Context) ([]metav1.Object, error) {
 }
 
 func (r *certSecretRepo) Delete(ctx context.Context, name string) error {
-	return r.k.CoreV1().
+	err := r.k.CoreV1().
 		Secrets("d8-upmeter").
 		Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+	return nil
 }
 
 type namespaceRepo struct {
@@ -195,7 +207,7 @@ func (r *namespaceRepo) List(ctx context.Context) ([]metav1.Object, error) {
 		Namespaces().
 		List(ctx, metav1.ListOptions{LabelSelector: "heritage=upmeter"})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list: %w", err)
 	}
 	objects := make([]metav1.Object, 0, len(list.Items))
 	for i := range list.Items {
@@ -205,7 +217,11 @@ func (r *namespaceRepo) List(ctx context.Context) ([]metav1.Object, error) {
 }
 
 func (r *namespaceRepo) Delete(ctx context.Context, name string) error {
-	return r.k.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	err := r.k.CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+	return nil
 }
 
 type podRepo struct {
@@ -217,7 +233,7 @@ func (r *podRepo) List(ctx context.Context) ([]metav1.Object, error) {
 		Pods("d8-upmeter").
 		List(ctx, metav1.ListOptions{LabelSelector: "heritage=upmeter"})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list: %w", err)
 	}
 	objects := make([]metav1.Object, 0, len(list.Items))
 	for i := range list.Items {
@@ -227,7 +243,11 @@ func (r *podRepo) List(ctx context.Context) ([]metav1.Object, error) {
 }
 
 func (r *podRepo) Delete(ctx context.Context, name string) error {
-	return r.k.CoreV1().Pods("d8-upmeter").Delete(ctx, name, metav1.DeleteOptions{})
+	err := r.k.CoreV1().Pods("d8-upmeter").Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+	return nil
 }
 
 type deployRepo struct {
@@ -239,7 +259,7 @@ func (r *deployRepo) List(ctx context.Context) ([]metav1.Object, error) {
 		Deployments("d8-upmeter").
 		List(ctx, metav1.ListOptions{LabelSelector: "heritage=upmeter"})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list: %w", err)
 	}
 	objects := make([]metav1.Object, 0, len(list.Items))
 	for i := range list.Items {
@@ -249,7 +269,11 @@ func (r *deployRepo) List(ctx context.Context) ([]metav1.Object, error) {
 }
 
 func (r *deployRepo) Delete(ctx context.Context, name string) error {
-	return r.k.AppsV1().Deployments("d8-upmeter").Delete(ctx, name, metav1.DeleteOptions{})
+	err := r.k.AppsV1().Deployments("d8-upmeter").Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		return fmt.Errorf("delete: %w", err)
+	}
+	return nil
 }
 
 var upmeterHookProbeGVR = schema.GroupVersionResource{
@@ -277,5 +301,5 @@ func (r *upmeterHookProbeRepo) Delete(ctx context.Context, name string) error {
 		// Since we look for a specific name, it only deletes once
 		return nil
 	}
-	return err
+	return fmt.Errorf("delete: %w", err)
 }


### PR DESCRIPTION
## Description

- Comprehensive error wrapping improvements
- Added wrapcheck linter with proper configuration
- Systematic replacement of bare error returns with contextual wrapping

## Why do we need it, and what problem does it solve?

- Problem: Poor error observability making debugging difficult
- Root Issues: Bare error returns, lost context, inconsistent patterns
- Solution: Contextual error wrapping with automated linter enforcement
- Impact: Faster debugging, better monitoring, improved maintainability

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Add linter wrapcheck option to deckhouse
impact_level: low
```
