### PR TITLE
[docs] Update the comparison table and modules set on the site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,6 @@ cve-base-images-check-default-user: bin/jq ## Check CVE in our base images.
 
 .PHONY: docs
 docs: bin/werf ## Run containers with the documentation.
-	docker network inspect deckhouse 2>/dev/null 1>/dev/null || docker network create deckhouse
 	cd docs/site/; ../../bin/werf compose up --docker-compose-command-options='-d' --env local --repo ":local" --skip-image-spec-stage=true
 	echo "Open http://localhost to access the documentation..."
 
@@ -250,13 +249,12 @@ docs: bin/werf ## Run containers with the documentation.
 docs-dev: bin/werf ## Run containers with the documentation in the dev mode (allow uncommited files).
 	export DOC_API_URL=dev
 	export DOC_API_KEY=dev
-	docker network inspect deckhouse 2>/dev/null 1>/dev/null || docker network create deckhouse
 	cd docs/site/; ../../bin/werf compose up --docker-compose-command-options='-d' --dev --env development --repo ":local" --skip-image-spec-stage=true
 	echo "Open http://localhost to access the documentation..."
 
 .PHONY: docs-down
 docs-down: ## Stop all the documentation containers (e.g. site_site_1 - for Linux, and site-site-1 for MacOs)
-	docker rm -f site-site-1 site-front-1 site_site_1 site_front_1 documentation 2>/dev/null; docker network rm deckhouse
+	docker rm -f site-site-1 site_site_1 site-router-1  site_router_1  site-front-1 site_front_1 site-frontend-1 site_frontend_1 2>/dev/null || true ; docker network rm deckhouse 2>/dev/null || true
 
 .PHONY: tests-doc-links
 docs-linkscheck: ## Build documentation and run checker of html links.

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -222,38 +222,6 @@
     },
     "path": "modules/metallb/"
   },
-  "managed-memcached": {
-    "editions": [
-      "ee"
-    ],
-    "editionsWithRestrictions": [
-      "ee"
-    ],
-    "editionsWithRestrictionsComments": {
-      "all": {
-        "en": "Limited testing. Contact us to discuss the terms",
-        "ru": "Ограниченное тестирование. Свяжитесь с нами для обсуждения условий"
-      }
-    },
-    "external": "true",
-    "path": "/modules/managed-memcached/stable/"
-  },
-  "managed-postgres": {
-    "editions": [
-      "ee"
-    ],
-    "editionsWithRestrictions": [
-      "ee"
-    ],
-    "editionsWithRestrictionsComments": {
-      "all": {
-        "en": "Limited testing. Contact us to discuss the terms",
-        "ru": "Ограниченное тестирование. Свяжитесь с нами для обсуждения условий"
-      }
-    },
-    "external": "true",
-    "path": "/modules/managed-postgres/stable/"
-  },
   "neuvector": {
     "editions": [
       "ee"

--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -125,13 +125,6 @@ spec:
             name: frontend
             port:
               name: http
-      - path: /modules
-        pathType: Prefix
-        backend:
-          service:
-            name: moduleslibrary
-            port:
-              name: http
       - path: /products/kubernetes-platform/modules
         pathType: Prefix
         backend:
@@ -204,6 +197,13 @@ spec:
             port:
               name: http
 {{- end }}
+      - path: /modules
+        pathType: Prefix
+        backend:
+          service:
+            name: moduleslibrary
+            port:
+              name: http
       - path: /includes
         pathType: Prefix
         backend:

--- a/docs/site/.helm/values.yaml
+++ b/docs/site/.helm/values.yaml
@@ -23,9 +23,11 @@ moduleWatcher:
       - dev-registry.deckhouse.io/sys/deckhouse-oss/modules
       - registry.flant.com/team/foxtrot/docs-example
     web-production:
+      - registry.deckhouse.io/deckhouse/ee/modules
+    web-stage:
       - registry.deckhouse.io/deckhouse/fe/modules
     web-test:
-      - registry.deckhouse.io/deckhouse/fe/modules
+      - registry.deckhouse.io/deckhouse/ee/modules
     web-test2:
       - registry.deckhouse.io/deckhouse/fe/modules
   scanInterval:

--- a/docs/site/.werf/nginx-local.conf
+++ b/docs/site/.werf/nginx-local.conf
@@ -40,7 +40,13 @@ http {
         default           "en";
     }
 
-    map $host $proxyhost {
+    map $host $publicdocupstream {
+        hostnames;
+        "ru.localhost"    "https://deckhouse_ru";
+        default           "https://deckhouse_io";
+    }
+
+    map $host $publicdochost {
         hostnames;
         "ru.localhost"    "deckhouse.ru";
         default           "deckhouse.io";
@@ -50,6 +56,14 @@ http {
     map $channel_name $channel_version {
         default "latest";
         include /app/channels-data/channels.conf;
+    }
+
+    upstream deckhouse_io {
+        server deckhouse.io:443;
+    }
+
+    upstream deckhouse_ru {
+        server deckhouse.ru:443;
     }
 
     server {
@@ -71,28 +85,22 @@ http {
         rewrite ^(.*)/documentation(/(v[0-9]+|v[0-9]+\.[0-9]+|latest))?/deckhouse-overview.html$ /products/kubernetes-platform/documentation$2/admin/configuration/ redirect;
         rewrite ^/documentation/(.*)$ /products/kubernetes-platform/documentation/$1 redirect;
         rewrite ^/gs/(.*)$ /products/kubernetes-platform/gs/$1 redirect;
-        #rewrite ^/modules/(.*)$ /products/kubernetes-platform/modules/$1 redirect;
         rewrite ^/guides/(.*)$ /products/kubernetes-platform/guides/$1 redirect;
-        rewrite ^/(ru|en)/(.*)?$ /$2 permanent;
+        rewrite ^/(ru|en)/(.*)?$ /$2 redirect;
         rewrite ^/ru/terms-of-service\.html /ru/security-policy.html permanent;
         rewrite ^/ru/cookie-policy\.html /ru/security-policy.html permanent;
         rewrite ^/ru/privacy-policy\.html /ru/security-policy.html permanent;
         rewrite ^/en/security-policy\.html /en/privacy-policy.html permanent;
-        #rewrite ^/modules/([^0-9./]+)/?$ /modules/$1/stable/ permanent;
 
-        location / {
-            try_files /$lang/$uri /$lang/$uri/index.html /$lang/$uri/ $uri $uri/index.html $uri/ @proxy_to_deckhouse_io;
-        }
+       location / {
+           proxy_redirect    off;
+           proxy_set_header  Host              $publicdochost;
+           proxy_set_header  X-Real-IP         $remote_addr;
+           proxy_set_header  X-Original-URI    $request_uri;
+           proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
 
-        location @proxy_to_deckhouse_io {
-            proxy_redirect    off;
-            proxy_set_header  Host              $proxyhost;
-            proxy_set_header  X-Real-IP         $remote_addr;
-            proxy_set_header  X-Original-URI    $request_uri;
-            proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
-
-            proxy_pass https://deckhouse.ru;
-        }
+           proxy_pass $publicdocupstream;
+       }
 
         location ~* ^(/images|/js|/assets|/gs|/presentations|/guides|/license_request_expired.html|/license_request_success.html) {
             try_files /$lang/$uri /$lang/$uri/index.html /$lang/$uri/ $uri $uri/index.html $uri/ =404;
@@ -114,7 +122,6 @@ http {
             try_files /modules-from-source/$lang/search-external-modules-index.json =404;
         }
 
-        #location ~* ^/modules/([^/]+)/(?!(v[0-9]+\.[0-9]+|alpha|beta|early-access|stable|rock-solid|latest).*)$  {
         location ~* ^/modules/([^/]+)/((?!v[0-9]+\.[0-9]+|alpha|beta|early-access|stable|rock-solid|latest).*)$ {
             set $embedded_modules_path "/embedded-modules/$lang/modules/$1";
             set $modules_from_source_path "/modules-from-source/$lang/modules/$1";

--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -15,22 +15,19 @@ registry:
 registry-down:
 		docker rm -f registry; docker volume prune -fa
 
-network: registry
-		docker network inspect deckhouse 2>&1 1>/dev/null || docker network create deckhouse
-
-up: network
+up:
 		werf compose up --follow --docker-compose-command-options='-d --force-recreate' --env local --repo localhost:4999/docs
 
 clean:
 		werf cleanup --env local --repo localhost:4999/docs --without-kube
 
 down:
-		docker rm -f site-site-1 site_site_1 site-router-1  site_router_1  site-front-1 site_front_1 site-frontend-1 site_frontend_1 2>/dev/null; docker network rm deckhouse
+		docker rm -f site-site-1 site_site_1 site-router-1  site_router_1  site-front-1 site_front_1 site-frontend-1 site_frontend_1 2>/dev/null || true ; docker network rm deckhouse 2>/dev/null || true
 
-dev: network
+dev:
 		werf compose up --follow --docker-compose-command-options='-d --force-recreate' --dev --env development --repo localhost:4999/docs
 
-debug: network
+debug:
 		werf compose up --config werf-debug.yaml --follow --docker-compose-command-options='-d --force-recreate' --docker-compose-options='-f docker-compose-debug.yml'  --dev --env development --repo localhost:4999/docs
 
 regenerate-menu:

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -189,6 +189,44 @@
     "external": "true",
     "path": "/modules/delivery-kit/stable/"
   },
+  "managed-postgres": {
+    "editions": [
+      "ee"
+    ],
+    "editionsWithRestrictions": [
+      "ee"
+    ],
+    "editionsWithRestrictionsComments": {
+      "all": {
+        "en": "Limited testing. Contact us to discuss the terms",
+        "ru": "Ограниченное тестирование. Свяжитесь с нами для обсуждения условий"
+      }
+    },
+    "tags": [
+      "database"
+    ],
+    "external": "true",
+    "path": "/modules/managed-postgres/stable/"
+  },
+  "managed-memcached": {
+    "editions": [
+      "ee"
+    ],
+    "editionsWithRestrictions": [
+      "ee"
+    ],
+    "editionsWithRestrictionsComments": {
+      "all": {
+        "en": "Limited testing. Contact us to discuss the terms",
+        "ru": "Ограниченное тестирование. Свяжитесь с нами для обсуждения условий"
+      }
+    },
+    "tags": [
+      "database"
+    ],
+    "external": "true",
+    "path": "/modules/managed-memcached/stable/"
+  },
   "neuvector": {
     "editions": [
       "ee"

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -189,44 +189,6 @@
     "external": "true",
     "path": "/modules/delivery-kit/stable/"
   },
-  "managed-postgres": {
-    "editions": [
-      "ee"
-    ],
-    "editionsWithRestrictions": [
-      "ee"
-    ],
-    "editionsWithRestrictionsComments": {
-      "all": {
-        "en": "Limited testing. Contact us to discuss the terms",
-        "ru": "Ограниченное тестирование. Свяжитесь с нами для обсуждения условий"
-      }
-    },
-    "tags": [
-      "database"
-    ],
-    "external": "true",
-    "path": "/modules/managed-postgres/stable/"
-  },
-  "managed-memcached": {
-    "editions": [
-      "ee"
-    ],
-    "editionsWithRestrictions": [
-      "ee"
-    ],
-    "editionsWithRestrictionsComments": {
-      "all": {
-        "en": "Limited testing. Contact us to discuss the terms",
-        "ru": "Ограниченное тестирование. Свяжитесь с нами для обсуждения условий"
-      }
-    },
-    "tags": [
-      "database"
-    ],
-    "external": "true",
-    "path": "/modules/managed-memcached/stable/"
-  },
   "neuvector": {
     "editions": [
       "ee"


### PR DESCRIPTION
## Description

- Removed the `managed-memcached` and `managed-postgres` modules from the comparison table.
- Use EE modules registry for the prod and test envs
- Use FE modules registry for stage and test2 envs
- Fixed local run of the documentation site (Makefiles and Nginx config)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Updated the comparison table and modules set on the site. Fixed local run of the documentation site.
impact_level: low
```
