### PR TITLE
Ci fix CVE status

### DIFF
--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -50,13 +50,20 @@ remove_labels:
 
 {!{ define "exctract_pr_number" }!}
 # <template: exctract_pr_number>
-- name: Extract PR number from ref
+- name: Extract PR number and form TAG
   id: extract_pr
   run: |
     echo "REF=${{ github.event.inputs.pull_request_ref }}"
     PR_NUMBER=$(echo "${{ github.event.inputs.pull_request_ref }}" | sed -E 's#refs/pull/([0-9]+)/head#\1#')
     echo "PR_NUMBER=$PR_NUMBER"
-    echo "TAG=pr$PR_NUMBER" >> $GITHUB_ENV
+    REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+    if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+      TAG="pr${PR_NUMBER}"
+    else
+      TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+    fi
+    echo "TAG=$TAG" >> $GITHUB_ENV
+
 # </template: exctract_pr_number>
 {!{- end -}!}
 {!{ define "cve_scan_deckhouse_images" }!}

--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -72,8 +72,5 @@ jobs:
   {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 6 }!}
   {!{ tmpl.Exec "update_comment_on_finish" (slice "workflow,final,no-skipped,restore-separate" $workflowName) | strings.Indent 6 }!}
 
-  {!{ tmpl.Exec "remove_labels_job" $ctx | strings.Indent 2 }!}
-  {!{ tmpl.Exec "set_security_scan_requirement_status" slice | strings.Indent 2 }!}
-
 {!{ tmpl.Exec "remove_labels_job" $ctx | strings.Indent 2 }!}
 {!{ tmpl.Exec "set_security_scan_requirement_status" slice | strings.Indent 2 }!}

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -123,13 +123,20 @@ jobs:
       # </template: link_bin_step>
 
       # <template: exctract_pr_number>
-      - name: Extract PR number from ref
+      - name: Extract PR number and form TAG
         id: extract_pr
         run: |
           echo "REF=${{ github.event.inputs.pull_request_ref }}"
           PR_NUMBER=$(echo "${{ github.event.inputs.pull_request_ref }}" | sed -E 's#refs/pull/([0-9]+)/head#\1#')
           echo "PR_NUMBER=$PR_NUMBER"
-          echo "TAG=pr$PR_NUMBER" >> $GITHUB_ENV
+          REPO_SUFFIX=${GITHUB_REPOSITORY#deckhouse/deckhouse-}
+          if [[ $REPO_SUFFIX == $GITHUB_REPOSITORY ]] ; then
+            TAG="pr${PR_NUMBER}"
+          else
+            TAG="pr${PR_NUMBER}-${REPO_SUFFIX}"
+          fi
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
       # </template: exctract_pr_number>
 
       # <template: cve_scan_deckhouse_images>
@@ -247,61 +254,6 @@ jobs:
             const ci = require('./.github/scripts/js/ci');
             return await ci.updateCommentOnFinish({github, context, core, statusConfig, name, needsContext, jobContext, stepsContext, jobNames});
       # </template: update_comment_on_finish>
-
-    # <template: remove_labels_job>
-  remove_labels:
-    name: Remove labels
-    runs-on: ubuntu-latest
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Remove labels
-        id: remove
-        uses: actions/github-script@v6.4.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const label = "security/cve";
-            const ci = require('./.github/scripts/js/ci');
-            const issue_number = context.payload.inputs.issue_number;
-            console.log("Issue number is", issue_number);
-            return await ci.removeLabel({github, context, core, issue_number, label});
-  # </template: remove_labels_job>
-
-
-  # <template: set_security_scan_requirement_status>
-  set_security_scan_requirement_status: 
-    name: Set commit status after security scan run
-    runs-on: ubuntu-latest
-    needs: test_cve_report_main
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
-    steps:
-
-      # <template: checkout_step>
-      - name: Checkout sources
-        uses: actions/checkout@v3.5.2
-
-      # </template: checkout_step>
-      - name: Install GitHub CLI
-        run: sudo apt-get install gh -y
-      - name: Auth with GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-      - name: Set PR Label
-        env:
-          PR_NUMBER: ${{ inputs.issue_number }}
-        run: |
-          echo "PR Number: $PR_NUMBER"
-          if [ "${{ needs.test_cve_report_main.result }}" == "success" ]; then
-            gh pr edit "$PR_NUMBER" --add-label "security/cve/success"
-          else
-            gh pr edit "$PR_NUMBER" --add-label "security/cve/failed"
-          fi
-  # </template: set_security_scan_requirement_status>
 
   # <template: remove_labels_job>
   remove_labels:


### PR DESCRIPTION
## Description
This pull request adds support for dynamic PR-based image tagging across different repositories (`deckhouse`, `deckhouse-test-1`, `deckhouse-test-2`).  
Tags are now generated in the following format:
- `deckhouse-oss/install-standalone:pr574` — for the main repository  
- `deckhouse-oss/install-standalone:pr574-test-1` — for `deckhouse-test-1`  
- `deckhouse-oss/install-standalone:pr574-test-2` — for `deckhouse-test-2`  

It also fixes the status reporting logic in the **CVE workflow**: if any job fails, the workflow status is now correctly set to **failure** instead of always showing `success`.

## Why do we need it, and what problem does it solve?
Previously:
- In test repositories, images were incorrectly tagged (e.g., `pr574` instead of `pr574-test-1`).  
- Because of this, the **CVE scan** could not find the required image and failed.  
- Additionally, the workflow always reported `success` even when there were errors.

Now:
- Tags are generated correctly for each repository.  
- The **CVE scan** can locate the correct image and runs reliably.  
- The workflow status reflects the actual job results.  

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Ci fix CVE status
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
