### PR TITLE
[040-control-plane-manager] add dex-provider claim mapping

### DIFF
--- a/modules/040-control-plane-manager/docs/README.md
+++ b/modules/040-control-plane-manager/docs/README.md
@@ -95,4 +95,9 @@ By default, in a cluster with Deckhouse, a basic policy is created for logging e
 
 A basic policy can be disabled by setting the [basicAuditPolicyEnabled](configuration.html#parameters-apiserver-basicauditpolicyenabled) flag to `false`.
 
+When OIDC authentication is configured, additional user information is included in audit logs under the `user.extra` field:
+- `user-authn.deckhouse.io/name` - user's display name
+- `user-authn.deckhouse.io/preferred_username` - user's preferred username  
+- `user-authn.deckhouse.io/dex-provider` - Dex provider identifier (requires `federated:id` scope)
+
 You can find how to set up policies in [a special FAQ section](faq.html#how-do-i-configure-additional-audit-policies).

--- a/modules/040-control-plane-manager/docs/README_RU.md
+++ b/modules/040-control-plane-manager/docs/README_RU.md
@@ -91,6 +91,11 @@ description: Deckhouse управляет компонентами control plane
 
 - связаны с операциями создания, удаления и изменения ресурсов;
 - совершаются от имен сервисных аккаунтов из системных Namespace `kube-system`, `d8-*`;
+
+При настройке OIDC-аутентификации в аудит-логах дополнительно включается информация о пользователе в поле `user.extra`:
+- `user-authn.deckhouse.io/name` - отображаемое имя пользователя
+- `user-authn.deckhouse.io/preferred_username` - предпочитаемое имя пользователя
+- `user-authn.deckhouse.io/dex-provider` - идентификатор провайдера Dex (требует скоуп `federated:id`)
 - совершаются с ресурсами в системных пространствах имен `kube-system`, `d8-*`.
 
 Для выключения базовых политик установите флаг [basicAuditPolicyEnabled](configuration.html#parameters-apiserver-basicauditpolicyenabled) в `false`.

--- a/modules/040-control-plane-manager/templates/_authentication_configuration.tpl
+++ b/modules/040-control-plane-manager/templates/_authentication_configuration.tpl
@@ -29,6 +29,8 @@ jwt:
       valueExpression: 'claims.name'
     - key: 'user-authn.deckhouse.io/preferred_username'
       valueExpression: 'has(claims.preferred_username) ? claims.preferred_username : null'
+    - key: 'user-authn.deckhouse.io/dex-provider'
+      valueExpression: "has(claims.federated_claims) && has(claims.federated_claims.connector_id) ? claims.federated_claims.connector_id : null"
   userValidationRules:
   - expression: "!user.username.startsWith('system:')"
     message: 'username cannot used reserved system: prefix'

--- a/modules/150-user-authn/images/kubeconfig-generator/patches/002-already_logged.patch
+++ b/modules/150-user-authn/images/kubeconfig-generator/patches/002-already_logged.patch
@@ -351,6 +351,7 @@ index 0000000..2905d2a
 +      - "--oidc-extra-scope=groups"
 +      - "--oidc-extra-scope=offline_access"
 +      - "--oidc-extra-scope=audience:server:client_id:kubernetes"
++      - "--oidc-extra-scope=federated:id"
 +      {{- if .IDPCaPem }}
 +      - "--certificate-authority-data={{ .IDPCaEncoded }}"
 +      {{- end }}

--- a/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
+++ b/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
@@ -129,6 +129,7 @@ spec:
         - --oidc-scope=email
         - --oidc-scope=groups
         - --oidc-scope=offline_access
+        - --oidc-scope=federated:id
         {{- end }}
         {{- end }}
         ports:

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -163,7 +163,7 @@ spec:
         - --set-authorization-header=true
     {{- end }}
         - --set-xauthrequest
-        - --scope=groups email openid profile offline_access{{- if $crd.allowAccessToKubernetes }} audience:server:client_id:kubernetes{{- end }}
+        - --scope=groups email openid profile offline_access{{- if $crd.allowAccessToKubernetes }} federated:id audience:server:client_id:kubernetes{{- end }}
         - --ssl-insecure-skip-verify=true
         - --proxy-prefix=/dex-authenticator
         - --email-domain=*

--- a/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
+++ b/modules/150-user-authn/templates/kubeconfig-generator/config.yaml
@@ -68,6 +68,7 @@ clusters:
   short_description: "{{ $cluster.description }}"
   scopes:
   - audience:server:client_id:kubernetes
+  - federated:id
 
   k8s_ca_pem: {{ $cluster.masterCA | quote }}
 {{- end }}


### PR DESCRIPTION
### Description
This PR adds an extra claim mapping for the Dex provider ID and ensures clients request the required scope to populate it.

- control-plane-manager:
  - Add extra claim mapping to AuthenticationConfiguration:
    - `user-authn.deckhouse.io/dex-provider` ← from `claims.federated_claims.connector_id`
  - Add a template test asserting the exact key and `valueExpression`.
  - Update docs to mention all extra claims and the `federated:id` scope requirement.

- user-authn:
  - Dex Authenticator: include `federated:id` in requested scopes.
  - Basic Auth Proxy (OIDC): include `federated:id` in requested scopes.
  - Kubeconfig generator: add `federated:id` to scopes and kubelogin exec args to propagate the claim for CLI users.

Notes:
- kube-apiserver reads AuthenticationConfiguration (structured auth) and hot-reloads claim mappings.
- DexAuthenticator/BasicAuth Proxy Deployments will roll due to arg changes.

### Why do we need it, and what problem does it solve?
- The new claim `user-authn.deckhouse.io/dex-provider` records which Dex connector issued the token (e.g., GitLab, Google) and appears in audit logs under `.user.extra`.
- This relies on Dex `federated_claims.connector_id`, which is only present when the client requests the `federated:id` scope.
- The change standardizes scope requests across Dashboard (DexAuthenticator), Basic Auth Proxy, and kubeconfig generator, improving observability and support (clear provider visibility in audit logs).

### Why do we need it in the patch release (if we do)?
Not necessarily.

### Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

### Changelog entries
```changes
section: control-plane-manager | user-authn
type: feature
summary: Add extra claim `user-authn.deckhouse.io/dex-provider` (from `federated_claims.connector_id`) | Request `federated:id` scope in Dex Authenticator, Basic Auth Proxy, and kubeconfig generator to populate `federated_claims.connector_id`
```