### PR TITLE
[docs] Add Jekyll plugin to show related page links in the documentation

### DIFF
--- a/docs/documentation/_data/i18n.yml
+++ b/docs/documentation/_data/i18n.yml
@@ -256,6 +256,24 @@ common:
   role:
     en: role
     ru: роль
+  related_links:
+    en: Related links
+    ru: Связанные ссылки
+  global_parameters:
+    en: Global parameters
+    ru: Глобальные параметры
+  global_crds:
+    en: Global custom resources
+    ru: Глобальные кастомные ресурсы
+  module_x_parameters:
+    en: Module XXXX parameters
+    ru: Параметры модуля XXXX
+  module_x_crds:
+    en: Module XXXX custom resources
+    ru: Кастомные ресурсы модуля XXXX
+  module_x_documentation:
+    en: Module XXXX documentation
+    ru: Документация модуля XXXX
   includes_rules_from:
     en: includes all rules from the role
     ru: включает все правила из роли

--- a/docs/documentation/_includes/related_links.liquid
+++ b/docs/documentation/_includes/related_links.liquid
@@ -1,0 +1,21 @@
+{%- if page.related_links and page.related_links.size > 0 %}
+{%- assign page_related_module_reference = page.related_links | where_exp: "item", "item.type == 'module_conf' or item.type == 'module_cr'" | sort: "module" %}
+{%- assign page_related_global_reference = page.related_links | where_exp: "item", "item.type == 'global_ref'"  %}
+{% if page_related_module_reference.size > 0 or page_related_global_reference.size > 0 %}
+  {%- alert level="info" %}
+{{ site.data.i18n.common['related_links'][page.lang] }}:
+  {% if page_related_global_reference.size > 0 %}
+    {%- for link in page_related_global_reference %}
+- [{{ link.title }}]({{ link.url }})
+    {%- endfor %}
+  {%- endif %}
+  {% if page_related_module_reference.size > 0 %}
+   {%- for link in page_related_module_reference %}
+- [{{ link.title }}]({{ link.url }})
+    {%- endfor %}
+  {%- endif %}
+  {%- endalert %}
+{%- endif %}
+{%- else %}
+no Related links:
+{%- endif %}

--- a/docs/documentation/_layouts/page.html
+++ b/docs/documentation/_layouts/page.html
@@ -1,12 +1,14 @@
 ---
 layout: sidebar
 ---
+
 <div class="docs">
     <div class="docs__wrap-title">
         <h1 class="docs__title">{{ page.title }}</h1>
     </div>
 
     {%- include warning-latest.html %}
+    {%- include related_links.liquid %}
 
     <div class="post-content">
 
@@ -44,7 +46,7 @@ layout: sidebar
         {%- if site.disqus %}
     {%- include disqus.html %}
         {%- endif %}
-        
+
     </div>
 
     {%- if page.showPrevNextButton %}

--- a/docs/documentation/_plugins/related_links.rb
+++ b/docs/documentation/_plugins/related_links.rb
@@ -1,0 +1,364 @@
+require 'nokogiri'
+require 'uri'
+
+module Jekyll
+  class LinksExtractor
+    # List of domains to skip when extracting links
+    SKIP_DOMAINS = %w[
+      example.com
+      example.org
+      example.net
+      test.com
+      localhost
+      127.0.0.1
+    ].freeze
+    def self.extract_links_from_content(content, base_url = '', site_data = nil, page_lang = 'en')
+      return [] unless content
+
+      links = []
+
+      # Extract markdown links [text](url)
+      content.scan(/\[([^\]]*)\]\(([^)]+)\)/) do |text, url|
+        next if skip_link?(url)
+
+        link_type = determine_link_type(url, url)
+
+        # Determine title based on link type
+        title = text.strip
+        if link_type == 'module_doc' || link_type == 'module_conf' || link_type == 'module_cr'
+          module_name = extract_module_name(url)
+          if module_name && site_data && site_data['i18n'] && site_data['i18n']['common']
+            case link_type
+            when 'module_conf'
+              template = site_data['i18n']['common']['module_x_parameters'][page_lang]
+              title = template&.gsub('XXXX', module_name) || "Module #{module_name} configuration"
+            when 'module_cr'
+              template = site_data['i18n']['common']['module_x_crds'][page_lang]
+              title = template&.gsub('XXXX', module_name) || "Module #{module_name} custom resources"
+            when 'module_doc'
+              template = site_data['i18n']['common']['module_x_documentation'][page_lang]
+              title = template&.gsub('XXXX', module_name) || "Module #{module_name} documentation"
+            end
+          end
+        elsif link_type == 'global_ref'
+          # Extract resource name from global reference URL
+          resource_name = extract_global_resource_name(url)
+          if resource_name
+            title = "Global #{resource_name} custom resource"
+          else
+            title = site_data['i18n']['common']['global_crds'][page_lang]
+          end
+        end
+
+        # For module_cr and module_conf links, remove anchors from URL
+        final_url = url
+        if link_type == 'module_cr' || link_type == 'module_conf'
+          final_url = url.split('#')[0]
+        end
+
+        link_data = {
+          'url' => final_url,
+          'title' => title,
+          'type' => link_type
+        }
+
+        # Add module property for module links
+        if link_type == 'module_doc' || link_type == 'module_conf' || link_type == 'module_cr'
+          module_name = extract_module_name(url)
+          link_data['module'] = module_name if module_name
+        end
+
+        links << link_data
+      end
+
+      # Extract HTML links <a href="url">text</a>
+      begin
+        doc = Nokogiri::HTML::DocumentFragment.parse(content)
+        doc.css('a[href]').each do |link|
+          url = link['href']
+          next if skip_link?(url)
+
+          title = link.text.strip
+          title = link['title'] if title.empty? && link['title']
+          title = url if title.empty?
+
+        link_type = determine_link_type(url, url)
+
+        # Determine title based on link type
+        if link_type == 'module_doc' || link_type == 'module_conf' || link_type == 'module_cr'
+          module_name = extract_module_name(url)
+          if module_name && site_data && site_data['i18n'] && site_data['i18n']['common']
+            case link_type
+            when 'module_conf'
+              template = site_data['i18n']['common']['module_x_parameters'][page_lang]
+              title = template&.gsub('XXXX', module_name) || "Module #{module_name} configuration"
+            when 'module_cr'
+              template = site_data['i18n']['common']['module_x_crds'][page_lang]
+              title = template&.gsub('XXXX', module_name) || "Module #{module_name} custom resources"
+            when 'module_doc'
+              template = site_data['i18n']['common']['module_x_documentation'][page_lang]
+              title = template&.gsub('XXXX', module_name) || "Module #{module_name} documentation"
+            end
+          end
+        elsif link_type == 'global_ref'
+          # Extract resource name from global reference URL
+          resource_name = extract_global_resource_name(url)
+          if resource_name
+            title = "Global #{resource_name} custom resource"
+          else
+            # Use translation
+            if site_data && site_data['i18n'] && site_data['i18n']['common']
+              title = site_data['i18n']['common']['global_crds'][page_lang] || "Global custom resources"
+            end
+          end
+        end
+
+        # For module_cr and module_conf links, remove anchors from URL
+        final_url = url
+        if link_type == 'module_cr' || link_type == 'module_conf'
+          final_url = url.split('#')[0]
+        end
+
+        link_data = {
+          'url' => final_url,
+          'title' => title,
+          'type' => link_type
+        }
+
+        # Add module property for module links
+        if link_type == 'module_doc' || link_type == 'module_conf' || link_type == 'module_cr'
+          module_name = extract_module_name(url)
+          link_data['module'] = module_name if module_name
+        end
+
+        links << link_data
+        end
+      rescue => e
+        puts "Warning: Error parsing HTML in content: #{e.message}"
+      end
+
+      # Remove duplicates and return
+      links.uniq { |link| link['url'] }
+    end
+
+    private
+
+    def self.skip_link?(url)
+      return true if url.nil? || url.empty?
+
+      # Skip mailto links
+      return true if url.start_with?('mailto:')
+
+      # Skip anchor links (fragments only)
+      return true if url.start_with?('#')
+
+      # Skip asset files
+      asset_extensions = %w[.jpg .jpeg .png .gif .svg .ico .webp .bmp .tiff .css .js .json .xml .pdf .zip .tar .gz .mp4 .mp3 .wav .avi .mov .wmv .flv .webm .ogg .woff .woff2 .ttf .eot .otf]
+      return true if asset_extensions.any? { |ext| url.downcase.end_with?(ext) }
+
+      # Skip data URLs
+      return true if url.start_with?('data:')
+
+      # Skip javascript: and other non-document protocols
+      return true if url.match?(/^javascript:/)
+
+      # Skip external links to domains in the skip list
+      if url.match?(/^https?:\/\//)
+        begin
+          uri = URI.parse(url)
+          domain = uri.host&.downcase
+          return true if domain && SKIP_DOMAINS.any? { |skip_domain| domain == skip_domain || domain.end_with?(".#{skip_domain}") }
+        rescue URI::InvalidURIError
+          # If URL parsing fails, continue with normal processing
+        end
+      end
+
+      # Skip domain-only links (without protocol) that match skip list
+      if url.match?(/^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/) && !url.include?('/')
+        domain = url.downcase
+        return true if SKIP_DOMAINS.any? { |skip_domain| domain == skip_domain || domain.end_with?(".#{skip_domain}") }
+      end
+
+      false
+    end
+
+    def self.determine_link_type(original_url, normalized_url)
+      # Check for external links (begins with a protocol)
+      if original_url.match?(/^[a-zA-Z][a-zA-Z0-9+.-]*:/)
+        return 'external_doc'
+      end
+
+      # Ensure we have a leading slash for pattern matching
+      url_for_matching = normalized_url.start_with?('/') ? normalized_url : "/#{normalized_url}"
+
+      # For module URLs, remove anchors to treat them as the same URL
+      if url_for_matching.match?(%r{/modules/[^/]+/})
+        url_for_matching = url_for_matching.split('#')[0]
+      end
+
+      # Check for module configuration links
+      if url_for_matching.match?(%r{/modules/[^/]+/configuration.*\.html.*$})
+        return 'module_conf'
+      end
+
+      # Check for module CR links
+      if url_for_matching.match?(%r{/modules/[^/]+/cr\.html.*$})
+        return 'module_cr'
+      end
+
+      # Check for module documentation links
+      if url_for_matching.match?(%r{/modules/[^/]+/})
+        return 'module_doc'
+      end
+
+      # Check for global reference links
+      if url_for_matching.match?(%r{/reference/api/})
+        return 'global_ref'
+      end
+
+      # Default to internal document
+      'internal_doc'
+    end
+
+    def self.extract_module_name(url)
+      # Extract module name from module URLs
+      # Remove anchors for consistent matching
+      clean_url = url.split('#')[0]
+
+      # Handle different URL formats: /modules/name/, modules/name/, /en/modules/name/, en/modules/name/
+      match = clean_url.match(%r{^(\/?(en|ru)\/)?\/?modules\/([^/]+)\/})
+      match ? match[3] : nil
+    end
+
+    def self.extract_global_resource_name(url)
+      # Extract resource name from global reference URLs
+      return nil
+      # TODO: refactor this to get the CamelCase name.
+      match = clean_url.match(%r{/reference/api/cr\.html\#([a-z]+).*\.html$})
+      match ? match[1] : nil
+    end
+
+  end
+end
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  puts "Extracting related links..."
+
+  site.pages.each do |page|
+    next unless page.content
+
+    # Skip pages with embedded_modules sidebar
+    next if page.data['sidebar'] == 'embedded-modules'
+
+    # Get the base URL for this page (without the filename)
+    base_url = page.url.sub(/\/[^\/]*$/, '')
+    base_url = base_url[1..-1] if base_url.start_with?('/')
+
+    # Remove language prefix from base URL (en/ or ru/)
+    base_url = base_url.sub(/^(en\/|ru\/)/, '')
+
+    # Extract links from the page content
+    page_lang = page['lang'] || 'en'
+    extracted_links = Jekyll::LinksExtractor.extract_links_from_content(page.content, base_url, site.data, page_lang)
+
+    # Get existing related_links from page metadata
+    existing_links = page.data['related_links'] || []
+
+    # Validate existing_links structure and add type if missing
+    valid_existing_links = []
+    if existing_links.any?
+      begin
+        existing_links.each do |link|
+          if link.is_a?(Hash) && link.key?('url') && link.key?('title')
+            # Create a copy of the link to avoid modifying the original
+            processed_link = link.dup
+
+            # Keep original URL format
+
+            # Add type if missing
+            unless processed_link.key?('type')
+              link_type = Jekyll::LinksExtractor.determine_link_type(processed_link['url'], processed_link['url'])
+              processed_link['type'] = link_type
+            end
+
+            # Add module property and standardized title for module links if missing
+            if processed_link['type'] == 'module_doc' || processed_link['type'] == 'module_conf' || processed_link['type'] == 'module_cr'
+              module_name = Jekyll::LinksExtractor.extract_module_name(processed_link['url'])
+              if module_name
+                # Add module property if missing
+                processed_link['module'] = module_name unless processed_link.key?('module')
+
+                # Update title to standardized format using translations
+                if site.data && site.data['i18n'] && site.data['i18n']['common']
+                  case processed_link['type']
+                  when 'module_conf'
+                    template = site.data['i18n']['common']['module_x_parameters'][page_lang]
+                    processed_link['title'] = template&.gsub('XXXX', module_name) || "Module #{module_name} configuration"
+                  when 'module_cr'
+                    template = site.data['i18n']['common']['module_x_crds'][page_lang]
+                    processed_link['title'] = template&.gsub('XXXX', module_name) || "Module #{module_name} custom resources"
+                  when 'module_doc'
+                    template = site.data['i18n']['common']['module_x_documentation'][page_lang]
+                    processed_link['title'] = template&.gsub('XXXX', module_name) || "Module #{module_name} documentation"
+                  end
+                end
+              end
+            elsif processed_link['type'] == 'global_ref'
+              # Update title for global reference links
+              resource_name = Jekyll::LinksExtractor.extract_global_resource_name(processed_link['url'])
+              if resource_name
+                processed_link['title'] = "Global #{resource_name} custom resource"
+              else
+                processed_link['title'] = site.data['i18n']['common']['global_crds'][page_lang] || "Global custom resources"
+              end
+            end
+
+            # For module_cr and module_conf links, remove anchors from URL
+            if processed_link['type'] == 'module_cr' || processed_link['type'] == 'module_conf'
+              processed_link['url'] = processed_link['url'].split('#')[0]
+            end
+
+            valid_existing_links << processed_link
+          else
+            puts "Warning: Invalid link structure in related_links for #{page.url}: #{link.inspect}"
+          end
+        end
+
+        if valid_existing_links.length != existing_links.length
+          puts "Warning: Skipping malformed related_links for #{page.url}, using only extracted_links"
+          valid_existing_links = []
+        end
+      rescue => e
+        puts "Warning: Error processing related_links for #{page.url}: #{e.message}. Using only extracted_links."
+        valid_existing_links = []
+      end
+    end
+
+    # Merge extracted_links with valid existing_links and remove duplicates
+    all_links = valid_existing_links + extracted_links
+    merged_links = all_links.uniq { |link| link['url'] }
+
+    # Store both extracted_links and merged related_links
+    page.data['extracted_links'] = extracted_links
+    page.data['related_links'] = merged_links
+
+    # Debug output for pages with links
+    if extracted_links.any? || valid_existing_links.any?
+      puts "  #{page.url}: Found #{extracted_links.length} extracted links, #{valid_existing_links.length} valid existing links, #{merged_links.length} total merged links"
+      if extracted_links.any?
+        puts "    Extracted links:"
+        extracted_links.each do |link|
+          puts "      - #{link['title']} -> #{link['url']} (#{link['type']})"
+        end
+      end
+      if valid_existing_links.any?
+        puts "    Existing links (cleaned URLs):"
+        valid_existing_links.each do |link|
+          puts "      - #{link['title']} -> #{link['url']} (#{link['type']})"
+        end
+      end
+    end
+  end
+
+  puts "Finished extracting related links..."
+end


### PR DESCRIPTION
## Description
Add Jekyll plugin to show related page links in the documentation:
- Extract relative links from markdown and HTML content
- Categorize links by type (module_doc, module_ref, global_ref, external_doc, internal_doc)
- Skip unwanted domains and asset files
- Merge extracted links with existing relevant_links metadata
- Remove duplicates based on URL matching

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
