### PR TITLE
[402-ingress-nginx] Enable ExecuteHookOnEvents on hook set_annotation_validation_suspended.go

### DIFF
--- a/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
+++ b/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
@@ -42,7 +42,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion:                   "deckhouse.io/v1",
 			Kind:                         "IngressNginxController",
 			ExecuteHookOnSynchronization: ptr.To(true),
-			ExecuteHookOnEvents:          ptr.To(false),
 			FilterFunc:                   setAnnotationValidationSuspendedFilterIngressNginxController,
 		},
 		{


### PR DESCRIPTION
## Description
This PR sets `ExecuteHookOnEvents` to `true` (the default value) to restore the execution of the hook on changes to `IngressNginxController` objects.

## Why do we need it, and what problem does it solve?
When `ExecuteHookOnEvents` is set to `false`, the hook does not trigger on events related to changes in `IngressNginxController` objects. As a result, the alert resolution logic does not execute.

## Why do we need it in the patch release (if we do)?
If `ExecuteHookOnEvents` remains `false`, hooks will not trigger on changes to `IngressNginxController` objects, preventing the alert resolution logic from running. Therefore, this fix is necessary even in a patch release.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ingress-nginx
type: fix
summary: Enable ExecuteHookOnEvents on hook set_annotation_validation_suspended.go
impact_level: default
```