### PR TITLE
[docs] Update modules list generation logic

### DIFF
--- a/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
+++ b/docs/site/backends/docs-builder-template/config/_default/hugo.yaml
@@ -10,6 +10,8 @@ defaultContentLanguageInSubdir: true
 uglyURLs: true
 #relativeURLs: true
 
+printI18nWarnings: true
+
 params:
   display_toc: true
 

--- a/docs/site/backends/docs-builder-template/data/dkp/embedded_modules.json
+++ b/docs/site/backends/docs-builder-template/data/dkp/embedded_modules.json
@@ -612,7 +612,7 @@
       }
     },
     {
-      "title": "The monitoring-custom module",
+      "title": "Automatic configuration of the monitoring system to collect metrics from user applications",
       "description": "Monitoring user applications in Deckhouse Kubernetes Platform.",
       "type": [
         "instruction"
@@ -627,7 +627,7 @@
       "editionMinimumAvailable": "ce",
       "url": "monitoring-custom/",
       "ru": {
-        "title": "Модуль monitoring-custom",
+        "title": "Автоматическая настройка системы мониторинга для сбора метрик с пользовательских приложений",
         "description": "Мониторинг приложений пользователей в Deckhouse Kubernetes Platform.",
         "type": [
           "instruction"
@@ -668,8 +668,8 @@
       }
     },
     {
-      "title": "The monitoring-ping module",
-      "description": "Network connectivity monitoring between Deckhouse Kubernetes Platform cluster nodes.",
+      "title": "Monitoring network interaction between all cluster nodes, as well as (optionally) up to additional external nodes",
+      "description": "Monitoring network interaction between all cluster nodes, as well as (optionally) up to additional external nodes",
       "module": "monitoring-ping",
       "embedded": "true",
       "tags": [
@@ -680,8 +680,8 @@
       "editionMinimumAvailable": "ce",
       "url": "monitoring-ping/",
       "ru": {
-        "title": "Модуль monitoring-ping",
-        "description": "Мониторинг сетевого взаимодействия между узлами кластера Deckhouse Kubernetes Platform."
+        "title": "Мониторинг сетевого взаимодействия между всеми узлами кластера, а также (опционально) до дополнительных внешних узлов",
+        "description": "Мониторинг сетевого взаимодействия между всеми узлами кластера, а также (опционально) до дополнительных внешних узлов."
       }
     },
     {
@@ -862,22 +862,6 @@
       }
     },
     {
-      "title": "The pod-reloader module",
-      "description": "Automatic pod restart on ConfigMap or Secret changes in the Deckhouse Kubernetes Platform cluster.",
-      "module": "pod-reloader",
-      "embedded": "true",
-      "tags": [
-        "core",
-        "embedded"
-      ],
-      "editionMinimumAvailable": "ce",
-      "url": "pod-reloader/",
-      "ru": {
-        "title": "Модуль pod-reloader",
-        "description": "Автоматический перезапуск подов при изменении ConfigMap или Secret в кластере Deckhouse Kubernetes Platform."
-      }
-    },
-    {
       "title": "The Prometheus monitoring module",
       "type": [
         "instruction"
@@ -946,19 +930,19 @@
       }
     },
     {
-      "title": "The runtime-audit-engine module",
-      "description": "Runtime threats detection engine in a Deckhouse Kubernetes Platform cluster.",
-      "module": "runtime-audit-engine",
+      "title": "Registry Module",
+      "description": "Configuration management of DKP component registry and organization of an internal container registry.",
+      "module": "registry",
       "embedded": "true",
       "tags": [
-        "embedded",
-        "security"
+        "core",
+        "embedded"
       ],
-      "editionMinimumAvailable": "ee",
-      "url": "runtime-audit-engine/",
+      "editionMinimumAvailable": "ce",
+      "url": "registry/",
       "ru": {
-        "title": "Модуль runtime-audit-engine",
-        "description": "Поиск угроз безопасности в кластере Deckhouse Kubernetes Platform."
+        "title": "Модуль registry",
+        "description": "Управление конфигурацией registry компонентов DKP и организация внутреннего хранилища образов контейнеров (container registry, registry)."
       }
     },
     {
@@ -1013,7 +997,7 @@
       }
     },
     {
-      "title": "The upmeter module",
+      "title": "Cluster SLA Monitoring",
       "description": "Collecting availability statistics for Deckhouse Kubernetes Platform cluster components.",
       "webIfaces": [
         {
@@ -1032,7 +1016,7 @@
       "editionMinimumAvailable": "ce",
       "url": "upmeter/",
       "ru": {
-        "title": "Модуль upmeter",
+        "title": "Мониторинг SLA кластера",
         "description": "Сбор статистики по доступности компонентов кластера Deckhouse Kubernetes Platform.",
         "webIfaces": [
           {

--- a/docs/site/backends/docs-builder-template/i18n/en.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/en.yaml
@@ -36,6 +36,7 @@ found: found
 length: length
 min_length: minimal length
 max_length: maximum length
+moduleLinkTitleADVANCED_USAGE: Advanced usage
 moduleLinkTitleREADME: Description
 moduleLinkTitleEXAMPLES: Examples
 moduleLinkTitleCONFIGURATION: Configuration

--- a/docs/site/backends/docs-builder-template/i18n/ru.yaml
+++ b/docs/site/backends/docs-builder-template/i18n/ru.yaml
@@ -36,6 +36,7 @@ pattern: шаблон
 length: длина
 min_length: минимальная длина
 max_length: максимальная длина
+moduleLinkTitleADVANCED_USAGE: Расширенная конфигурация
 moduleLinkTitleREADME: Описание
 moduleLinkTitleEXAMPLES: Примеры
 moduleLinkTitleCONFIGURATION: Настройка

--- a/docs/site/backends/docs-builder-template/layouts/modules/modules-list.html
+++ b/docs/site/backends/docs-builder-template/layouts/modules/modules-list.html
@@ -59,11 +59,10 @@
   {{ $moduleDescription := "" }}
   {{ $moduleTags := slice }}
 
-  {{/* Skip the module if there is embedded module with the same name (in the $embeddedModulesList) */}}
+  {{/* Skip the embedded module if there is external module with the same name */}}
   {{ $embeddedModuleWithTheSameName := (where $embeddedModulesList "module" $module) }}
   {{ if gt ($embeddedModuleWithTheSameName | len) 0 }}
-    {{ warnf "Found embedded module %s and external modules with the same name. Use only embedded module." $module }}
-    {{ continue }}
+    {{ warnf "Found embedded module %s and external modules with the same name. Use only external module." $module }}
   {{ end }}
 
   {{ $moduleTags = index (index $modulesEditions $module) "tags" }}
@@ -90,7 +89,16 @@
 {{ warnf "Found %d modules from sources." ($modulesList | len) }}
 {{ if $embeddedModulesList }}
   {{ warnf "Found %d embedded modules." ( $embeddedModulesList | len) }}
-  {{ $modulesList = $modulesList | append $embeddedModulesList }}
+  {{ $filteredEmbeddedModules := slice }}
+  {{ range $embeddedModulesList }}
+    {{ $externalModuleWithSameName := (where $modulesList "module" .module) }}
+    {{ if eq ($externalModuleWithSameName | len) 0 }}
+      {{ $filteredEmbeddedModules = $filteredEmbeddedModules | append . }}
+    {{ else }}
+      {{ warnf "Skipping embedded module %s because external module with same name exists." .module }}
+    {{ end }}
+  {{ end }}
+  {{ $modulesList = $modulesList | append $filteredEmbeddedModules }}
 {{ else }}
   {{ warnf "No embedded modules found!" }}
 {{ end }}


### PR DESCRIPTION
## Description
* Updated logic in modules list to ensure embedded modules are skipped if an external module with the same name exists, preventing duplication and improving warning messages.
* Added new translation keys for "Advanced usage"
* Enabled Hugo's `printI18nWarnings` option to help catch missing or incorrect translations.
* Update embedded modules list

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update modules list generation logic.
impact_level: low
```
