### PR TITLE
[candi] Delete /opt/containerd on cleanup

### DIFF
--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -77,6 +77,7 @@ rm -rf /etc/cni
 rm -rf /var/lib/cni
 rm -rf /var/lib/etcd
 rm -rf /opt/cni
+rm -rf /opt/containerd
 rm -rf /opt/deckhouse
 rm -rf /var/lib/bashible
 rm -rf /etc/containerd


### PR DESCRIPTION
## Description
Add `rm -rf /opt/containerd` to cleanup_static_node script.

## Why do we need it, and what problem does it solve?
`/opt/containerd` is a directory [created by containerd](https://github.com/deckhouse/deckhouse/blob/1e8f688304c62838172f7056140e5523266e9ef9/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl#L208-L209). We need to clean up any artifacts it may have left.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Improved cleanup script for static nodes.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
