### PR TITLE
[docs] Remove links to delivery-kit documentation

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -189,7 +189,7 @@
       "cse-pro"
     ],
     "external": "true",
-    "path": "/modules/delivery-kit/stable/"
+    "path": ""
   },
   "istio": {
     "editionMinimumAvailable": "ce",

--- a/docs/site/_data/topnav-l2-products.json
+++ b/docs/site/_data/topnav-l2-products.json
@@ -141,12 +141,6 @@
           "url": "/products/delivery-kit/",
           "target": "",
           "rel": ""
-        },
-        {
-          "title": "Documentation",
-          "url": "/products/kubernetes-platform/modules/delivery-kit/stable/",
-          "target": "",
-          "rel": "doc"
         }
       ]
     },
@@ -337,12 +331,6 @@
           "url": "/products/delivery-kit/",
           "target": "",
           "rel": ""
-        },
-        {
-          "title": "Документация",
-          "url": "/products/kubernetes-platform/modules/delivery-kit/stable/",
-          "target": "",
-          "rel": "doc"
         }
       ]
     },

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -187,7 +187,7 @@
       "delivery"
     ],
     "external": "true",
-    "path": "/modules/delivery-kit/stable/"
+    "path": ""
   },
   "managed-postgres": {
     "editions": [


### PR DESCRIPTION
## Description
Removed links to delivery-kit documentation from the comparison table.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Removed links to delivery-kit documentation from the comparison table.
impact_level: low
```
