### PR TITLE
[ingress-nginx] backport fix limit req zone sorting

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/017-fix-sorting.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/017-fix-sorting.patch
@@ -1,0 +1,26 @@
+diff --git a/internal/ingress/controller/store/objectref.go b/internal/ingress/controller/store/objectref.go
+index 89ea47251..44dfe39e7 100644
+--- a/internal/ingress/controller/store/objectref.go
++++ b/internal/ingress/controller/store/objectref.go
+@@ -112,7 +112,7 @@ func (o *objectRefMap) Reference(ref string) []string {
+ 	if !ok {
+ 		return make([]string, 0)
+ 	}
+-	return consumers.UnsortedList()
++	return sets.List(consumers)
+ }
+ 
+ // ReferencedBy returns all objects referenced by the given object.
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index 8628f8090..51607c613 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -870,7 +870,7 @@ func buildRateLimitZones(input interface{}) []string {
+ 		}
+ 	}
+ 
+-	return zones.UnsortedList()
++	return sets.List(zones)
+ }
+ 
+ // buildRateLimit produces an array of limit_req to be used inside the Path of

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -100,3 +100,9 @@ Slightly tunes some logic related to validating ingress objects.
 ### 016-verbose-maxmind-logs.patch
 
 Added additional logging when downloading GeoIP databases from the MaxMind service.
+
+### 017-fix-sorting.patch
+
+There is a sorting issue in a couple of files that causes unnecessary config reloads.
+
+https://github.com/kubernetes/ingress-nginx/pull/14005

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -53,6 +53,7 @@ shell:
   - patch -p1 < /patches/013-default-backend-fix.patch
   - patch -p1 < /patches/015-validation-mode.patch
   - patch -p1 < /patches/016-verbose-maxmind-logs.patch
+  - patch -p1 < /patches/017-fix-sorting.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/015-fix-sorting.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/015-fix-sorting.patch
@@ -1,0 +1,26 @@
+diff --git a/internal/ingress/controller/store/objectref.go b/internal/ingress/controller/store/objectref.go
+index 89ea47251..44dfe39e7 100644
+--- a/internal/ingress/controller/store/objectref.go
++++ b/internal/ingress/controller/store/objectref.go
+@@ -112,7 +112,7 @@ func (o *objectRefMap) Reference(ref string) []string {
+ 	if !ok {
+ 		return make([]string, 0)
+ 	}
+-	return consumers.UnsortedList()
++	return sets.List(consumers)
+ }
+ 
+ // ReferencedBy returns all objects referenced by the given object.
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index f6816d70a..869463dad 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -852,7 +852,7 @@ func buildRateLimitZones(input interface{}) []string {
+ 		}
+ 	}
+ 
+-	return zones.UnsortedList()
++	return sets.List(zones)
+ }
+ 
+ // buildRateLimit produces an array of limit_req to be used inside the Path of

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -87,3 +87,9 @@ Slightly tunes some logic related to validating ingress objects.
 ### 014-verbose-maxmind-logs.patch
 
 Added additional logging when downloading GeoIP databases from the MaxMind service.
+
+### 015-fix-sorting.patch
+
+There is a sorting issue in a couple of files that causes unnecessary config reloads.
+
+https://github.com/kubernetes/ingress-nginx/pull/14005

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/014-fix-sorting.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/014-fix-sorting.patch
@@ -1,0 +1,26 @@
+diff --git a/internal/ingress/controller/store/objectref.go b/internal/ingress/controller/store/objectref.go
+index 89ea47251..44dfe39e7 100644
+--- a/internal/ingress/controller/store/objectref.go
++++ b/internal/ingress/controller/store/objectref.go
+@@ -112,7 +112,7 @@ func (o *objectRefMap) Reference(ref string) []string {
+ 	if !ok {
+ 		return make([]string, 0)
+ 	}
+-	return consumers.UnsortedList()
++	return sets.List(consumers)
+ }
+ 
+ // ReferencedBy returns all objects referenced by the given object.
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index 7410ce6e0..57131fa6f 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -856,7 +856,7 @@ func buildRateLimitZones(input interface{}) []string {
+ 		}
+ 	}
+ 
+-	return zones.UnsortedList()
++	return sets.List(zones)
+ }
+ 
+ // buildRateLimit produces an array of limit_req to be used inside the Path of

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
@@ -68,3 +68,10 @@ Slightly tunes some logic related to validating ingress objects.
 ### 013-verbose-maxmind-logs.patch
 
 Added additional logging when downloading GeoIP databases from the MaxMind service.
+
+
+### 014-fix-sorting.patch
+
+There is a sorting issue in a couple of files that causes unnecessary config reloads.
+
+https://github.com/kubernetes/ingress-nginx/pull/14005

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -64,6 +64,7 @@ shell:
   - patch -p1 < /patches/ingress-nginx/011-nginx-build.patch
   - patch -p1 < /patches/ingress-nginx/012-validation-mode.patch
   - patch -p1 < /patches/ingress-nginx/013-verbose-maxmind-logs.patch
+  - patch -p1 < /patches/ingress-nginx/014-fix-sorting.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/rootfs/001-balancer-lua.patch
   - patch -p1 < /patches/rootfs/002-nginx-tmpl.patch


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

It adds sorting before returning a list of limit_req_zones statements.
Upstream https://github.com/kubernetes/ingress-nginx/pull/14005

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If the nginx.ingress.kubernetes.io/limit-rpm or/and nginx.ingress.kubernetes.io/limit-rps annotations are used, there is a possibility the order of the resulting limit_req_zone statements changes on every config-related event, causing unnecessary config reloads. The diff would look like below:
```
-	limit_req_zone $limit_ZGVmYXVsdF9uZ2lueHhfZGNmYjczOGUtMDg1Mi00Nzg4LTkzMDUtZTM0YWFhODU3M2I1 zone=default_nginxx_dcfb738e-0852-4788-9305-e34aaa8573b5_rps:5m rate=2r/s;
	 	limit_req_zone $limit_ZDgtdXNlci1hdXRobl9kZXgtYXV0aF8zZmYwMDVkZS0yZjQwLTRhNGUtODI0My1jODUxZjAxMTU0NmY zone=d8-user-authn_dex-auth_3ff005de-2f40-4a4e-8243-c851f011546f_rpm:5m rate=1000r/m;
	 	limit_req_zone $limit_ZGVmYXVsdF9uZ2lueHhfZGNmYjczOGUtMDg1Mi00Nzg4LTkzMDUtZTM0YWFhODU3M2I1 zone=default_nginxx_dcfb738e-0852-4788-9305-e34aaa8573b5_rpm:5m rate=20r/m;
	+	limit_req_zone $limit_ZGVmYXVsdF9uZ2lueHhfZGNmYjczOGUtMDg1Mi00Nzg4LTkzMDUtZTM0YWFhODU3M2I1 zone=default_nginxx_dcfb738e-0852-4788-9305-e34aaa8573b5_rps:5m rate=2r/s;
```

## Why do we need it in the patch release (if we do)?
It fixes unnecessary nginx config reloads.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: The same order of limit_req_zone statements is maintained when generating new configuration.
impact: The pods of the ingress-nginx module will be restarted.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
