### PR TITLE
[cloud-provider-dvp][node-manager] Add sshPublicKey to registration secret and disable update system packages index during boot cloud ephemeral nodes

### DIFF
--- a/modules/030-cloud-provider-dvp/templates/registration.yaml
+++ b/modules/030-cloud-provider-dvp/templates/registration.yaml
@@ -20,6 +20,7 @@ data:
   capiClusterName: {{ b64enc "dvp" | quote }}
   capiMachineTemplateKind: {{ b64enc "DeckhouseMachineTemplate" | quote }}
   capiMachineTemplateAPIVersion: {{ b64enc "infrastructure.cluster.x-k8s.io/v1alpha1" | quote }}
+  sshPublicKey: {{ b64enc $providerClusterConfiguration.sshPublicKey | quote }}
 
   {{- $dvpValues := dict }}
   dvp: {{ $dvpValues | toJson | b64enc | quote }}

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -7,7 +7,8 @@
 mounts:
 - [ ephemeral0, /mnt/resource ]
   {{- end }}
-package_update: True
+package_update: false
+package_upgrade: false
 manage_etc_hosts: localhost
 write_files:
 
@@ -39,7 +40,8 @@ runcmd:
 
 ssh_authorized_keys:
 - {{ $context.Values.nodeManager.internal.cloudProvider.sshPublicKey| default "" | quote }}
-package_update: True
+package_update: false
+package_upgrade: false
 manage_etc_hosts: localhost
 write_files:
 


### PR DESCRIPTION
## Description
Add forget sshPublicKey field for cloud-provider-dvp registration secret. Without it we cannot login via ssh on nodes were creating with CAPI dvp infrastructure provider.

Also disable running `apt/yum/dns update` during first boot via cloud-init of cloud-ephemeral nodes.
We can do it with next reasons:
- if we install package with bb-*-install functions, before install we run `apt/yum/dnf update`
- we do not install packages during bashible bootstrap. If we forget about some packages, see first reason.
- user (or module developer) should use our bb-*-install functions in NGC. otherwise it's your own fault. 

## Why do we need it, and what problem does it solve?
We cannot login via ssh on nodes were creating with CAPI dvp infrastructure provider.
Increase bootstrap cloud-ephemeral nodes. `apt/yum/dnf update` can took long time for downloading indexes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Add sshPublicKey to registration secret.
impact_level: default
---
section: node-manager
type: feature
summary: Disable update system packages index during boot cloud ephemeral nodes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
