### PR TITLE
[dhctl] Add NewClientWithOptions to ssh

### DIFF
--- a/dhctl/pkg/system/sshclient/init.go
+++ b/dhctl/pkg/system/sshclient/init.go
@@ -49,19 +49,27 @@ func NewInitClientFromFlagsWithHosts(askPassword bool) (node.SSHClient, error) {
 	return NewInitClientFromFlags(askPassword)
 }
 
+type ClienOptions struct {
+	InitializeNewAgent bool
+}
+
 func NewClient(sess *session.Session, privateKeys []session.AgentPrivateKey) node.SSHClient {
+	return NewClientWithOptions(sess, privateKeys, ClienOptions{})
+}
+
+func NewClientWithOptions(sess *session.Session, privateKeys []session.AgentPrivateKey, clientOptions ClienOptions) node.SSHClient {
 
 	switch {
 	case app.SSHLegacyMode:
 		// if set --ssh-legacy-mode
-		client := clissh.NewClient(sess, privateKeys, false)
+		client := clissh.NewClient(sess, privateKeys, clientOptions.InitializeNewAgent)
 		return client
 	case app.SSHModernMode:
 		// if set --ssh-modern-mode
 		return gossh.NewClient(sess, privateKeys)
 	case len(app.SSHPrivateKeys) > 0:
 		// if flags doesn't set, but we have private keys
-		client := clissh.NewClient(sess, privateKeys, false)
+		client := clissh.NewClient(sess, privateKeys, clientOptions.InitializeNewAgent)
 		return client
 	default:
 		return gossh.NewClient(sess, privateKeys)


### PR DESCRIPTION
## Description

Add NewClientWithOptions to ssh init

## Why do we need it, and what problem does it solve?

To be able to start or not ssh agent by using clissh, we need more flexible create functions

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add NewClientWithOptions to ssh init.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
