### PR TITLE
[docs] Fix ClusterLogDestination name in examples

### DIFF
--- a/docs/documentation/pages/admin/configuration/logging/DELIVERY.md
+++ b/docs/documentation/pages/admin/configuration/logging/DELIVERY.md
@@ -346,7 +346,7 @@ Example configuration for converting mixed format records:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -409,7 +409,7 @@ Example configuration for replacing dots with underscores in labels:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: replace-dot
 spec:
@@ -454,7 +454,7 @@ Example configuration with label removal and preliminary `ParseMessage` transfor
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:

--- a/docs/documentation/pages/admin/configuration/logging/DELIVERY_RU.md
+++ b/docs/documentation/pages/admin/configuration/logging/DELIVERY_RU.md
@@ -347,7 +347,7 @@ extraLabels:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -410,7 +410,7 @@ I0505 17:59:40.692994   28133 klog.go:70] hello from klog
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: replace-dot
 spec:
@@ -455,7 +455,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/logging/DELIVERY.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/logging/DELIVERY.md
@@ -341,7 +341,7 @@ Example configuration for converting mixed format records:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -404,7 +404,7 @@ Example configuration for replacing dots with underscores in labels:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: replace-dot
 spec:
@@ -449,7 +449,7 @@ Example configuration with label removal and preliminary `ParseMessage` transfor
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/logging/DELIVERY_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/logging/DELIVERY_RU.md
@@ -346,7 +346,7 @@ extraLabels:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -409,7 +409,7 @@ I0505 17:59:40.692994   28133 klog.go:70] hello from klog
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: replace-dot
 spec:
@@ -454,7 +454,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:

--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -525,7 +525,7 @@ If multiple `ParseMessage` transformations are used, the one that parses the str
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: string-to-json
 spec:
@@ -560,7 +560,7 @@ to parse logs in Klog format and convert them into a structured object.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: klog-to-json
 spec:
@@ -598,7 +598,7 @@ to parse logs in Syslog format and convert them into a structured object.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: syslog-to-json
 spec:
@@ -644,7 +644,7 @@ to parse logs in CLF format and convert them into a structured object.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: clf-to-json
 spec:
@@ -686,7 +686,7 @@ to parse logs in Logfmt format and convert them into a structured object.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: logfmt-to-json
 spec:
@@ -724,7 +724,7 @@ Using the `depth` parameter, you can control the nesting depth.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -759,7 +759,7 @@ The string transformation must be applied last.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -818,7 +818,7 @@ You can use the `ReplaceKeys` transformation to replace `source` with `target` i
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: replace-dot
 spec:
@@ -859,7 +859,7 @@ You can use the `DropLabels` transformation to remove specific labels from log m
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:
@@ -879,7 +879,7 @@ followed by `DropLabels` to remove the specified label.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -525,7 +525,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: string-to-json
 spec:
@@ -560,7 +560,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: klog-to-json
 spec:
@@ -598,7 +598,7 @@ I0505 17:59:40.692994   28133 klog.go:70] hello from klog
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: syslog-to-json
 spec:
@@ -643,7 +643,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: clf-to-json
 spec:
@@ -684,7 +684,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: logfmt-to-json
 spec:
@@ -721,7 +721,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -756,7 +756,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: parse-json
 spec:
@@ -815,7 +815,7 @@ I0505 17:59:40.692994   28133 klog.go:70] hello from klog
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: replace-dot
 spec:
@@ -856,7 +856,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:
@@ -876,7 +876,7 @@ spec:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha2
-kind: ClusterLoggingDestination
+kind: ClusterLogDestination
 metadata:
   name: drop-label
 spec:


### PR DESCRIPTION
## Description

This PR fixes a typo in the name of the ClusterLogDestination resource in configuration examples.

## Changelog entries

```changes
section: docs
type: chore
summary: Fixed a typo in the ClusterLogDestination name in configuration examples.
impact_level: low
```