### PR TITLE
[150-user-authn] Remove email_verified claim when insecureSkipEmailVerified enabled

### DIFF
--- a/modules/150-user-authn/images/dex/patches/008-insecure-skip-email-verified.patch
+++ b/modules/150-user-authn/images/dex/patches/008-insecure-skip-email-verified.patch
@@ -1,0 +1,61 @@
+diff --git a/connector/oidc/oidc.go b/connector/oidc/oidc.go
+index 1cf2b62a..26118490 100644
+--- a/connector/oidc/oidc.go
++++ b/connector/oidc/oidc.go
+@@ -531,12 +531,33 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
+ 		return identity, fmt.Errorf("missing email claim, not found \"%s\" key", emailKey)
+ 	}
+ 
+-	emailVerified, found := claims["email_verified"].(bool)
+-	if !found {
+-		if c.insecureSkipEmailVerified {
+-			emailVerified = true
+-		} else if hasEmailScope {
+-			return identity, errors.New("missing \"email_verified\" claim")
++	var emailVerified bool
++	var skipEmailVerifiedClaim bool
++
++	if c.insecureSkipEmailVerified {
++		// Skip email verification entirely; warn because this is insecure.
++		c.logger.Warn("insecureSkipEmailVerified enabled: removing email_verified claim from identity (insecure)")
++		// Don't set emailVerified and mark to skip the claim entirely
++		skipEmailVerifiedClaim = true
++		// Remove the claim from the original claims map to prevent downstream usage
++		delete(claims, "email_verified")
++	} else {
++		v, ok := claims["email_verified"]
++		if !ok {
++			if hasEmailScope {
++				return identity, errors.New("missing \"email_verified\" claim")
++			}
++			// no email scope, default to false
++			emailVerified = false
++		} else {
++			switch t := v.(type) {
++			case bool:
++				emailVerified = t
++			case string:
++				emailVerified = strings.EqualFold(t, "true")
++			default:
++				return identity, fmt.Errorf("malformed \"email_verified\" claim: %T", v)
++			}
+ 		}
+ 	}
+ 
+@@ -632,11 +653,15 @@ func (c *oidcConnector) createIdentity(ctx context.Context, identity connector.I
+ 		Username:          name,
+ 		PreferredUsername: preferredUsername,
+ 		Email:             email,
+-		EmailVerified:     emailVerified,
+ 		Groups:            groups,
+ 		ConnectorData:     connData,
+ 	}
+ 
++	// Only set EmailVerified if we're not skipping the claim
++	if !skipEmailVerifiedClaim {
++		identity.EmailVerified = emailVerified
++	}
++
+ 	if c.userIDKey != "" {
+ 		userID, found := claims[c.userIDKey].(string)
+ 		if !found {

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -43,3 +43,7 @@ This patch changes the Internal Error message to a human-readable 'Access Denied
 In the latest go versions (1.25.2, 1.24.8) the bug was fixed, and without this patch Dex fails with an error
 
 Upstream PR: https://github.com/dexidp/dex/pull/4363
+
+### 008-insecure-skip-email-verified.patch
+
+This patch fixes the behavior of `insecureSkipEmailVerified` flag in OIDC connector to completely remove the `email_verified` claim from identity when the flag is enabled.


### PR DESCRIPTION
## Description

Change Dex OIDC connector behavior when `insecureSkipEmailVerified` is enabled: instead of propagating an explicit `email_verified:false` claim downstream (which causes kube-apiserver and other consumers to reject tokens when email is used as username), Dex will now **remove the `email_verified` claim entirely** and will **not set** `identity.EmailVerified`. A WARN log is emitted when the insecure option is active. The PR includes unit tests covering missing/false/true/malformed claim scenarios and documentation updates explaining the behavior and security implications.

This change affects token/identity content emitted by Dex (potentially observable by downstream services), but does not restart cluster control-plane components. Deployments that include Dex may roll due to config/arg changes if applied.

## Why do we need it, and what problem does it solve?

Problem: some upstream IdPs (Keycloak, Azure AD configurations) include `email_verified: false` in tokens. Kubernetes apiserver (and other consumers) reject authentication when the username is an email and `email_verified == false`. The existing `insecureSkipEmailVerified` flag only helped when the claim was **absent**; it did not override explicit `false`. That made the flag ineffective for many real-world setups.

Solution: when `insecureSkipEmailVerified` is enabled Dex removes the `email_verified` claim instead. A WARN log makes the insecure usage visible to operators.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

* [x] The code is covered by unit tests.
* [ ] e2e tests passed.
* [x] Documentation updated according to the changes.
* [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: When insecureSkipEmailVerified is enabled remove the email_verified claim from identity.
impact: When enabled, Dex will remove email_verified from emitted identity/claims.
impact_level: default
```
