### PR TITLE
[docs] Sync DVP documentation with `virtualization` module docs (PR#1545)

### DIFF
--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM.md
@@ -1819,26 +1819,12 @@ spec:
       name: user-net # Network name
 ```
 
-It is allowed to connect a VM to the same network multiple times. Example:
-
-```yaml
-spec:
-  networks:
-    - type: Main # Must always be specified first
-    - type: Network
-      name: user-net # Network name
-    - type: Network
-      name: user-net # Network name
-```
-
 Example of connecting to the cluster network `corp-net`:
 
 ```yaml
 spec:
   networks:
     - type: Main # Must always be specified first
-    - type: Network
-      name: user-net
     - type: Network
       name: user-net
     - type: ClusterNetwork
@@ -1854,12 +1840,9 @@ status:
     - type: Network
       name: user-net
       macAddress: aa:bb:cc:dd:ee:01
-    - type: Network
-      name: user-net
-      macAddress: aa:bb:cc:dd:ee:02
     - type: ClusterNetwork
       name: corp-net
-      macAddress: aa:bb:cc:dd:ee:03
+      macAddress: aa:bb:cc:dd:ee:02
 ```
 
 For each additional network interface, a unique MAC address is automatically generated and reserved to avoid collisions. The following resources are used for this: `VirtualMachineMACAddress` (`vmmac`) and `VirtualMachineMACAddressLease` (`vmmacl`).

--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM_RU.md
@@ -1843,26 +1843,12 @@ spec:
       name: user-net # Название сети
 ```
 
-Допускается подключать одну ВМ к одной и той же сети несколько раз. Пример:
-
-```yaml
-spec:
-  networks:
-    - type: Main # Обязательно указывать первым
-    - type: Network
-      name: user-net # Название сети
-    - type: Network
-      name: user-net # Название сети
-```
-
 Пример подключения кластерной сети `corp-net`:
 
 ```yaml
 spec:
   networks:
     - type: Main # Обязательно указывать первым
-    - type: Network
-      name: user-net
     - type: Network
       name: user-net
     - type: ClusterNetwork
@@ -1878,12 +1864,9 @@ status:
     - type: Network
       name: user-net
       macAddress: aa:bb:cc:dd:ee:01
-    - type: Network
-      name: user-net
-      macAddress: aa:bb:cc:dd:ee:02
     - type: ClusterNetwork
       name: corp-net
-      macAddress: aa:bb:cc:dd:ee:03
+      macAddress: aa:bb:cc:dd:ee:02
 ```
 
 Для каждого дополнительного сетевого интерфейса автоматически создается и резервируется уникальный MAC-адрес, что обеспечивает отсутствие коллизий MAC-адресов. Для этих целей используются ресурсы: `VirtualMachineMACAddress` (`vmmac`) и `VirtualMachineMACAddressLease` (`vmmacl`).


### PR DESCRIPTION
## Description
Synchronized DVP documentation with `virtualization` module docs ([PR#1545](https://github.com/deckhouse/virtualization/pull/1545)).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Synchronized DVP documentation with `virtualization` module docs (PR#1545).
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
