### PR TITLE
[deckhouse] values unchanged after enabling

### DIFF
--- a/deckhouse-controller/pkg/controller/confighandler/handler.go
+++ b/deckhouse-controller/pkg/controller/confighandler/handler.go
@@ -82,6 +82,11 @@ func (h *Handler) HandleEvent(moduleConfig *v1alpha1.ModuleConfig, op config.Op)
 			Checksum:     addonOperatorModuleConfig.Checksum(),
 		}
 
+		// it is needed to trigger kube config apply after enabling
+		if moduleConfig.Spec.Enabled != nil && !*moduleConfig.Spec.Enabled {
+			kubeConfig.Modules[moduleConfig.Name].Checksum = ""
+		}
+
 		// update deckhouse settings
 		if moduleConfig.Name == moduleDeckhouse {
 			h.deckhouseConfigCh <- values


### PR DESCRIPTION
## Description
It provides fix for bug when module config values unchanged after enabling

The bug happens due to [this pr](https://github.com/flant/addon-operator/pull/653). 
Module`s config values clear but checksum in kube config manager not, so [here](https://github.com/flant/addon-operator/blob/63b2a171d56d4d1c87679e12544d5c48e6e8fb45/pkg/kube_config_manager/kube_config_manager.go#L282) it does not create an event to apply config values. 

My solution is to clear config values checksum at module disabling. 

## Why do we need it, and what problem does it solve?

To reproduce the bug:
1. Create a module config with some settings
```
root@paksashvili-master-0:~# dcm values s-p-test
internal:
  apiServers:
    - kube-apiserver-paksashvili-master-0
registry:
  base: dev-registry.deckhouse.io/deckhouse/foxtrot/external-modules
  dockercfg: 
  scheme: HTTPS
replicas: 3
```
3. Then disable the module - values reset
```
root@paksashvili-master-0:~# dcm values s-p-test
internal:
  apiServers: []
registry:
  base: dev-registry.deckhouse.io/deckhouse/foxtrot/external-modules
  dockercfg:
  scheme: HTTPS
replicas: 1
```

4. Then enable and check the config values - they remain unchanged(config values not applied) 
```
root@paksashvili-master-0:~# dcme s-p-test
Module s-p-test enabled
root@paksashvili-master-0:~# dcm values s-p-test
internal:
  apiServers:
    - kube-apiserver-paksashvili-master-0
registry:
  base: dev-registry.deckhouse.io/deckhouse/foxtrot/external-modules
  dockercfg:
  scheme: HTTPS
replicas: 1
```

After:
0. Check values:
```
root@paksashvili-master-0:~# dcm values s-p-test
internal:
  apiServers: []
registry:
  base: dev-registry.deckhouse.io/deckhouse/foxtrot/external-modules
  dockercfg: 
  scheme: HTTPS
replicas: 1
```
1. Enable
```
root@paksashvili-master-0:~# dcme s-p-test
Module s-p-test enabled
```
2. Check values
```
root@paksashvili-master-0:~# dcm values s-p-test
internal:
  apiServers: []
registry:
  base: dev-registry.deckhouse.io/deckhouse/foxtrot/external-modules
  dockercfg: 
  scheme: HTTPS
replicas: 3
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fixes bug when module`s config values unchanged after enabling.
```
