### PR TITLE
[docs] Fix links in getting started guides for private environment

### DIFF
--- a/docs/site/_includes/getting_started/dvp/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/dvp/global/step_cluster_setup.html
@@ -18,7 +18,7 @@
       This template is used for system apps domains within the cluster, e.g., Grafana for <code>%s.domain.my</code> will be available as <code>grafana.domain.my</code>.<br />
       This tutorial assumes the use of a public domain pointing to a public cluster address.
       It is necessary to obtain <a href="https://letsencrypt.org/">Let's Encrypt</a> certificates for Deckhouse services.
-      If the existing certificates (including Self-Signed ones) are used, you need to change the <a href="/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters">global settings</a> in the <code>modules.https</code> section.<br />
+      If the existing certificates (including self-signed ones) are used, you need to adjust the <a href="/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-https"><code>modules.https</code></a> section in the global settings.<br />
       We recommend using the <a href="https://sslip.io/">sslip.io</a> service (or similar) for testing if wildcard DNS records are unavailable to you for some reason.
     </span>
   </div>
@@ -94,7 +94,7 @@
 <div markdown="1">
 ### Parameters for accessing the container image registry (or proxy registry)
 
-> Read more about [configuring a container image storage](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#tips-for-configuring-the-third-party-registry), if necessary.
+> Read more about [configuring an external container registry](/products/kubernetes-platform/documentation/v1/installing/#installing-deckhouse-kubernetes-platform-from-an-external-registry), if necessary.
 </div>
 
   <div class="form__row">
@@ -121,7 +121,7 @@
       name="registryDockerCfg" placeholder=""
       autocomplete="off" />
     <span class="info">
-      It is a string from the Docker client configuration file (in Linux it is usually <code>$HOME/.docker/config.json</code>), Base64-encoded.<br />Read more about the parameter <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">in the documentation</a>.
+      It is a string from the Docker client configuration file (in Linux it is usually <code>$HOME/.docker/config.json</code>), Base64-encoded.<br />Read more about the parameter in the <a href="/products/kubernetes-platform/documentation/v1/reference/api/cr.html#initconfiguration-deckhouse-registrydockercfg">InitConfiguration documentation</a>.
     </span>
     <span class="info">
       If using anonymous access to the container registry, do not fill in this field.

--- a/docs/site/_includes/getting_started/dvp/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/dvp/global/step_cluster_setup_ru.html
@@ -18,7 +18,7 @@
       Используется для формирования доменов системных приложений в кластере. Например, Grafana для шаблона <code>%s.domain.my</code> будет доступна как <code>grafana.domain.my</code>.<br />
       В данном руководстве предполагается использование публичного домена, направленного на публичный адрес кластера.
       Это необходимо для получения сертификатов <a href="https://letsencrypt.org/">Let's Encrypt</a> сервисам Deckhouse.
-      В случае использования уже имеющихся сертификатов (включая Self-Signed), необходимо изменить <a href="/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#параметры">глобальные настройки</a> в секции <code>modules.https</code>.<br />
+      В случае использования уже имеющихся сертификатов (в том числе самоподписанных) необходимо изменить параметры <a href="/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-https">секции <code>modules.https</code></a> в глобальных настройках.<br />
       Если у вас нет возможности завести wildcard-записи DNS, для тестирования вы можете воспользоваться, например, сервисом <a href="https://sslip.io/">sslip.io</a> или аналогами.
     </span>
   </div>
@@ -94,7 +94,7 @@
 <div markdown="1">
 ### Параметры доступа к хранилищу образов контейнеров (или проксирующему registry)
 
-> При необходимости ознакомьтесь [с особенностями настройки хранилища образов контейнеров](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#особенности-настройки-сторонних-registry).
+> При необходимости ознакомьтесь с [особенностями настройки стороннего container registry](/products/kubernetes-platform/documentation/v1/installing/#установка-deckhouse-kubernetes-platform-из-стороннего-registry).
 </div>
 
   <div class="form__row">
@@ -121,7 +121,7 @@
       name="registryDockerCfg" placeholder=""
       autocomplete="off" />
     <span class="info">
-      Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">в документации</a>.
+      Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте в <a href="/products/kubernetes-platform/documentation/v1/reference/api/cr.html#initconfiguration-deckhouse-registrydockercfg">документации ресурса InitConfiguration</a>.
     </span>
     <span class="info">
       В случае использования анонимного доступа к хранилищу образов контейнеров не заполняйте это поле.

--- a/docs/site/_includes/getting_started/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup.html
@@ -18,7 +18,7 @@
       This template is used for system apps domains within the cluster, e.g., Grafana for <code>%s.domain.my</code> will be available as <code>grafana.domain.my</code>.<br />
       This tutorial assumes the use of a public domain pointing to a public cluster address.
       It is necessary to obtain <a href="https://letsencrypt.org/">Let's Encrypt</a> certificates for Deckhouse services.
-      If the existing certificates (including Self-Signed ones) are used, you need to change the <a href="/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters">global settings</a> in the <code>modules.https</code> section.<br />
+      If the existing certificates (including self-signed ones) are used, you need to adjust the <a href="/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-https"><code>modules.https</code></a> section in the global settings.<br />
       We recommend using the <a href="https://sslip.io/">sslip.io</a> service (or similar) for testing if wildcard DNS records are unavailable to you for some reason.
     </span>
   </div>
@@ -94,7 +94,7 @@
 <div markdown="1">
 ### Parameters for accessing the container image registry (or proxy registry)
 
-> Read more about [configuring a container image storage](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#tips-for-configuring-the-third-party-registry), if necessary.
+> Read more about [configuring an external container registry](/products/kubernetes-platform/documentation/v1/installing/#installing-deckhouse-kubernetes-platform-from-an-external-registry), if necessary.
 </div>
 
   <div class="form__row">
@@ -121,7 +121,7 @@
       name="registryDockerCfg" placeholder=""
       autocomplete="off" />
     <span class="info">
-      It is a string from the Docker client configuration file (in Linux it is usually <code>$HOME/.docker/config.json</code>), Base64-encoded.<br />Read more about the parameter <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">in the documentation</a>.
+      It is a string from the Docker client configuration file (in Linux it is usually <code>$HOME/.docker/config.json</code>), Base64-encoded.<br />Read more about the parameter in the <a href="/products/kubernetes-platform/documentation/v1/reference/api/cr.html#initconfiguration-deckhouse-registrydockercfg">InitConfiguration documentation</a>.
     </span>
     <span class="info">
       If using anonymous access to the container registry, do not fill in this field.

--- a/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/global/step_cluster_setup_ru.html
@@ -18,7 +18,7 @@
       Используется для формирования доменов системных приложений в кластере. Например, Grafana для шаблона <code>%s.domain.my</code> будет доступна как <code>grafana.domain.my</code>.<br />
       В данном руководстве предполагается использование публичного домена, направленного на публичный адрес кластера.
       Это необходимо для получения сертификатов <a href="https://letsencrypt.org/">Let's Encrypt</a> сервисам Deckhouse.
-      В случае использования уже имеющихся сертификатов (включая Self-Signed), необходимо изменить <a href="/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#параметры">глобальные настройки</a> в секции <code>modules.https</code>.<br />
+      В случае использования уже имеющихся сертификатов (в том числе самоподписанных) необходимо изменить параметры <a href="/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-https">секции <code>modules.https</code></a> в глобальных настройках.<br />
       Если у вас нет возможности завести wildcard-записи DNS, для тестирования вы можете воспользоваться, например, сервисом <a href="https://sslip.io/">sslip.io</a> или аналогами.
     </span>
   </div>
@@ -94,7 +94,7 @@
 <div markdown="1">
 ### Параметры доступа к хранилищу образов контейнеров (или проксирующему registry)
 
-> При необходимости ознакомьтесь [с особенностями настройки хранилища образов контейнеров](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#особенности-настройки-сторонних-registry).
+> При необходимости ознакомьтесь с [особенностями настройки стороннего container registry](/products/kubernetes-platform/documentation/v1/installing/#установка-deckhouse-kubernetes-platform-из-стороннего-registry).
 </div>
 
   <div class="form__row">
@@ -121,7 +121,7 @@
       name="registryDockerCfg" placeholder=""
       autocomplete="off" />
     <span class="info">
-      Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">в документации</a>.
+      Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте в <a href="/products/kubernetes-platform/documentation/v1/reference/api/cr.html#initconfiguration-deckhouse-registrydockercfg">документации ресурса InitConfiguration</a>.
     </span>
     <span class="info">
       В случае использования анонимного доступа к хранилищу образов контейнеров не заполняйте это поле.

--- a/docs/site/_includes/getting_started/stronghold/global/step_cluster_setup.html
+++ b/docs/site/_includes/getting_started/stronghold/global/step_cluster_setup.html
@@ -18,7 +18,7 @@
       This template is used for system apps domains within the cluster, e.g., Grafana for <code>%s.domain.my</code> will be available as <code>grafana.domain.my</code>.<br />
       This tutorial assumes the use of a public domain pointing to a public cluster address.
       It is necessary to obtain <a href="https://letsencrypt.org/">Let's Encrypt</a> certificates for Deckhouse services.
-      If the existing certificates (including Self-Signed ones) are used, you need to change the <a href="/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters">global settings</a> in the <code>modules.https</code> section.<br />
+      If the existing certificates (including self-signed ones) are used, you need to adjust the <a href="/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-https"><code>modules.https</code></a> section in the global settings.<br />
       We recommend using the <a href="https://sslip.io/">sslip.io</a> service (or similar) for testing if wildcard DNS records are unavailable to you for some reason.
     </span>
   </div>
@@ -94,7 +94,7 @@
 <div markdown="1">
 ### Parameters for accessing the container image registry (or proxy registry)
 
-> Read more about [configuring a container image storage](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#tips-for-configuring-the-third-party-registry), if necessary.
+> Read more about [configuring an external container registry](/products/kubernetes-platform/documentation/v1/installing/#installing-deckhouse-kubernetes-platform-from-an-external-registry), if necessary.
 </div>
 
   <div class="form__row">
@@ -121,7 +121,7 @@
       name="registryDockerCfg" placeholder=""
       autocomplete="off" />
     <span class="info">
-      It is a string from the Docker client configuration file (in Linux it is usually <code>$HOME/.docker/config.json</code>), Base64-encoded.<br />Read more about the parameter <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">in the documentation</a>.
+      It is a string from the Docker client configuration file (in Linux it is usually <code>$HOME/.docker/config.json</code>), Base64-encoded.<br />Read more about the parameter in the <a href="/products/kubernetes-platform/documentation/v1/reference/api/cr.html#initconfiguration-deckhouse-registrydockercfg">InitConfiguration documentation</a>.
     </span>
     <span class="info">
       If using anonymous access to the container registry, do not fill in this field.

--- a/docs/site/_includes/getting_started/stronghold/global/step_cluster_setup_ru.html
+++ b/docs/site/_includes/getting_started/stronghold/global/step_cluster_setup_ru.html
@@ -18,7 +18,7 @@
       Используется для формирования доменов системных приложений в кластере. Например, Grafana для шаблона <code>%s.domain.my</code> будет доступна как <code>grafana.domain.my</code>.<br />
       В данном руководстве предполагается использование публичного домена, направленного на публичный адрес кластера.
       Это необходимо для получения сертификатов <a href="https://letsencrypt.org/">Let's Encrypt</a> сервисам Deckhouse.
-      В случае использования уже имеющихся сертификатов (включая Self-Signed), необходимо изменить <a href="/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#параметры">глобальные настройки</a> в секции <code>modules.https</code>.<br />
+      В случае использования уже имеющихся сертификатов (в том числе самоподписанных) необходимо изменить параметры <a href="/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-https">секции <code>modules.https</code></a> в глобальных настройках.<br />
       Если у вас нет возможности завести wildcard-записи DNS, для тестирования вы можете воспользоваться, например, сервисом <a href="https://sslip.io/">sslip.io</a> или аналогами.
     </span>
   </div>
@@ -94,7 +94,7 @@
 <div markdown="1">
 ### Параметры доступа к хранилищу образов контейнеров (или проксирующему registry)
 
-> При необходимости ознакомьтесь [с особенностями настройки хранилища образов контейнеров](/products/kubernetes-platform/documentation/v1/deckhouse-faq.html#особенности-настройки-сторонних-registry).
+> При необходимости ознакомьтесь с [особенностями настройки стороннего container registry](/products/kubernetes-platform/documentation/v1/installing/#установка-deckhouse-kubernetes-platform-из-стороннего-registry).
 </div>
 
   <div class="form__row">
@@ -121,7 +121,7 @@
       name="registryDockerCfg" placeholder=""
       autocomplete="off" />
     <span class="info">
-      Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте <a href="/products/kubernetes-platform/documentation/v1/installing/configuration.html#initconfiguration-deckhouse-registrydockercfg">в документации</a>.
+      Строка авторизации из файла конфигурации Docker-клиента (в Linux обычно это <code>$HOME/.docker/config.json</code>), закодированная в Base64.<br />Подробнее про этот параметр читайте в <a href="/products/kubernetes-platform/documentation/v1/reference/api/cr.html#initconfiguration-deckhouse-registrydockercfg">документации ресурса InitConfiguration</a>.
     </span>
     <span class="info">
       В случае использования анонимного доступа к хранилищу образов контейнеров не заполняйте это поле.


### PR DESCRIPTION
## Description

This PR fixes a number of links in the getting started guides for when DKP, DVP, or Stronghold are installed in a private environment.

## Changelog entries

```changes
section: docs
type: chore
summary: Fixed links in getting started guides for private environment.
impact_level: low
```