### PR TITLE
[docs] Fix example format for a MetalLoadBalancerClass parameter

### DIFF
--- a/ee/se/modules/380-metallb/crds/metalloadbalancerclasses.yaml
+++ b/ee/se/modules/380-metallb/crds/metalloadbalancerclasses.yaml
@@ -58,7 +58,7 @@ spec:
                         - ee
                         - cse-lite
                         - cse-pro
-                      x-doc-examples: ["eth1", "eth2"]
+                      x-doc-examples: [["eth1", "eth2"]]
                       description: |-
                         A list of network interfaces from which the assigned IP addresses will be announced.
                         If this field is not filled in or an empty array is specified, the announcement will occur from all interfaces on the node.


### PR DESCRIPTION
## Description

This PR fixes the example format for `spec.l2.interfaces` in MetalLoadBalancerClass documentation.

## Changelog entries

```changes
section: docs
type: chore
summary: Fixed example format for spec.l2.interfaces in MetalLoadBalancerClass documentation.
impact_level: low
```