### PR TITLE
[documentation] Fix building the search index. Fix the builder build instruction

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_default/page.json
+++ b/docs/site/backends/docs-builder-template/layouts/_default/page.json
@@ -11,7 +11,8 @@
       {{- $moduleData := index $modulesData $moduleName -}}
       {{- $moduleSection := printf "modules/%s/%s" $moduleName $moduleChannel }}
       {{- range $.Site.Pages }}
-        {{- if and (hasPrefix .RelPermalink (printf "/%s/" $moduleSection)) (eq .Section "modules") (ne .Kind "section") (ne .Kind "home") (not (hasSuffix .RelPermalink "/configuration.html")) (not (hasSuffix .RelPermalink "/cr.html")) }}
+        {{ $relPermalinkWithoutLang := replaceRE `/(ru/|en/)` "/" .RelPermalink }}
+        {{- if and (hasPrefix $relPermalinkWithoutLang (printf "/%s/" $moduleSection)) (eq .Section "modules") (ne .Kind "section") (ne .Kind "home") (not (hasSuffix $relPermalinkWithoutLang "/configuration.html")) (not (hasSuffix $relPermalinkWithoutLang "/cr.html")) }}
           {{- if .File }}
             {{- if not $first -}},{{- end -}}
             {{- $first = false -}}
@@ -42,8 +43,8 @@
   {{- $modulesStablestList := partial "get-stablest-modules-list.html" . }}
   {{- $allParameters := slice }}
   {{- range $modulesStablestList }}
-    {{- $moduleChannel := index . "channel" }}
     {{- $moduleName := index . "name" }}
+    {{- $moduleChannel := index . "channel" }}
     {{- $moduleData := index (index $.Site.Data.modules $moduleName) $moduleChannel }}
     {{- if not $moduleData }}
       {{- continue -}}

--- a/docs/site/werf-docs-builder.inc.yaml
+++ b/docs/site/werf-docs-builder.inc.yaml
@@ -27,7 +27,7 @@ git:
     - config/production/
     - data/dkp/embedded_modules.json
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/modules-docs/hugo.yaml
-    to: /app/hugo/config/production/hugo.yaml
+    to: /app/hugo-init/config/production/hugo.yaml
 {{ end }}
 
 ---


### PR DESCRIPTION
## Description

* Updated the permalink handling in `page.json` to strip language prefixes when build documentation for modules from sources in the cluster.
* Fix the builder, to handle Hugo config file `hugo.yaml`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Fix build search index. Fix builder build instruction.
impact_level: low
```
