### PR TITLE
[docs] Fix version menu item URLs for modules without a channel

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/module-version-badge.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/module-version-badge.html
@@ -36,4 +36,15 @@
 {{- end }}
     </ul>
 </div>
+<script>
+  // Fix version menu item URLs for cases where the URL lacks a channel (e.g., /modules/MODULE/).
+  const currentUrl = window.location.pathname;
+
+  if (!currentUrl.match(/\/modules\/[^\/]+\/(alpha|beta|early-access|stable|rock-solid|latest)\//)
+      && currentUrl.includes('/modules/')) {
+    document.querySelectorAll('#doc-versions-menu a.submenu-item-link').forEach(link => {
+        link.href = link.href.replace(/.*\/(alpha|beta|early-access|stable|rock-solid|latest)\//, `$1/`);
+    });
+  }
+</script>
 {{- end }}


### PR DESCRIPTION
## Description

Fixed version menu item URLs on the site for modules from sources without a channel.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fixed version menu item URLs on the site for modules from sources without a channel.
impact_level: low
```
