### PR TITLE
Add ignore capability to Svace template

### DIFF
--- a/.werf/defines/image-build.tmpl
+++ b/.werf/defines/image-build.tmpl
@@ -7,6 +7,7 @@
 #   - Commit.Hash - build commit hash, which is used to distinct artifacts on the analyze server and to add into import custom field
 #   - SvaceBuildOptions - optional parameter; might be used for javascript and python svacing
 #   - SvaceImportSettings - dict, which can contain ProjectName and Branch fields, to override default behavior of the futher analysis job
+#   - SvaceIgnore - list of regexps to exclude folders from analysis
 # Svace build uploads gathered artifacts to the analyze server
 
 {{- define "image-build.build" }}
@@ -23,6 +24,16 @@ cat > .svace-dir/import-settings <<EOF
 {{ trim $content }}
 EOF
 {{- end }}
+{{- if hasKey . "SvaceIgnore" }}
+  {{- $Root := . }}
+  {{- $content := "" }}
+  {{- range $value := .SvaceIgnore }}
+    {{- $content = (printf "%s%s\n" $content $value) }}
+  {{- end }}
+cat >> .svace-dir/svace.ignore <<EOF
+{{ trim $content }}
+EOF
+{{- end }}
 attempt=0
 retries=5
 success=0
@@ -35,6 +46,7 @@ while [[ $attempt -lt $retries ]]; do
 done
 set -e
 [[ $success == 1 ]] && rm -rf .svace-dir || exit 1
-{{-   end }}
+{{-   else }}
 {{ .BuildCommand }}
+{{-   end }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add ignore capability to Svace template
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This change allows to specify directories and files in which warnings will not be issued after analysis.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
- [ ] Changes were tested manually

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add ignore capability to Svace template
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
