### PR TITLE
fix: update do_not_reactivate flag in CVE scan configuration

### DIFF
--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -65,7 +65,7 @@ send_report() {
     -F "verified=true" \
     -F "scan_type=Trivy Scan" \
     -F "close_old_findings=true" \
-    -F "do_not_reactivate=false" \
+    -F "do_not_reactivate=true" \
     -F "push_to_jira=false" \
     -F "file=@${2}" \
     -F "product_type_name=DKP" \


### PR DESCRIPTION
# Title
DefectDojo: disable reactivation of old findings for CVE re-imports

# Description
Disable reactivation of previously closed findings in DefectDojo during CVE scan re-imports.

# Problem
Current CVE scan configuration reactivates closed findings on re-imports, which confuses developers working on certification tasks.

# Solution
Set `do_not_reactivate=true` in CVE scan templates/scripts so re-imports don’t reopen closed findings.

# Changes
- Update `cve_scan.sh` to pass `do_not_reactivate=true` to DefectDojo importer.

# Why do we need it, and what problem does it solve?
Removes noisy reactivations so teams don’t need manual cleanup to pass CVE certification steps.

# Why do we need it in the patch release (if we do)?
N/A — configuration improvement.

## Changelog entries
```changes
section: deckhouse
type: fix
summary: "Disable reactivation of old findings in DefectDojo for CVE scans."
impact_level: low
```