### PR TITLE
[control-plane] Add logging before kubeadm cmd in controller contol plane

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
@@ -174,7 +174,6 @@ func prepareConverge(componentName string, isTemp bool) error {
 	log.Info("run kubeadm",
 		slog.String("phase", "prepare-converge"),
 		slog.String("component", componentName),
-		slog.String("path", kubeadmPath),
 		slog.Any("args", args),
 		slog.Bool("temp_rootfs", isTemp),
 	)

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/etcd.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/etcd.go
@@ -61,7 +61,6 @@ func EtcdJoinConverge() error {
 	log.Info("run kubeadm",
 		slog.String("phase", "etcd-join-converge"),
 		slog.String("component", "etcd"),
-		slog.String("path", kubeadmPath),
 		slog.Any("args", args),
 	)
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/kubeconfig.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/kubeconfig.go
@@ -180,7 +180,6 @@ func prepareKubeconfig(componentName string, isTemp bool) error {
 	log.Info("run kubeadm",
 		slog.String("phase", "prepare-kubeconfig"),
 		slog.String("component", componentName),
-		slog.String("path", kubeadmPath),
 		slog.Any("args", args),
 		slog.Bool("temp_rootfs", isTemp),
 	)

--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/pki.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/pki.go
@@ -251,7 +251,6 @@ func prepareCerts(componentName string, isTemp bool) error {
 	log.Info("run kubeadm",
 		slog.String("phase", "prepare-certs"),
 		slog.String("component", componentName),
-		slog.String("path", kubeadmPath),
 		slog.Any("args", args),
 		slog.Bool("temp_rootfs", isTemp),
 	)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add logging before running the kubeadm command in control-plane-manager:

```bash
{
  "level": "info",
  "msg": "run kubeadm",
  "args": [
    "init",
    "phase",
    "certs",
    "apiserver",
    "--config",
    "/etc/kubernetes/deckhouse/kubeadm/config.yaml",
    "--rootfs",
    "/tmp/a9f795d5d3c6165f8cc77d9efb98caf85aa4c5e6b13d17a0f5009587d40000b8"
  ],
  "component": "apiserver",
  "phase": "prepare-certs",
  "temp_rootfs": true,
  "time": "2025-10-17T11:34:41Z"
}
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
It makes it easier to troubleshoot issues related to kubeadm execution.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
No need

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Added logging before running the kubeadm command to make troubleshooting easier
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
