### PR TITLE
DO NOT MERGE [dhctl][1.69]chore(dhctl): update dhctl to use kube-client with in-memory cache option for Commander 1.11 CSE

### DIFF
--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/deckhouse/deckhouse/go_lib/registry-packages-proxy v0.0.0-20240626081445-38c0dcfd3af7
 	github.com/deckhouse/deckhouse/pkg/log v0.0.0
 	github.com/deckhouse/module-sdk v0.2.0
-	github.com/flant/kube-client v1.2.2
+	github.com/flant/kube-client v1.2.3
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-openapi/spec v0.19.8
 	github.com/go-openapi/strfmt v0.19.5

--- a/dhctl/go.sum
+++ b/dhctl/go.sum
@@ -93,6 +93,12 @@ github.com/flant/go-openapi-validate v0.19.12-flant.0 h1:xk6kvc9fHKMgUdB6J7kbpbL
 github.com/flant/go-openapi-validate v0.19.12-flant.0/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.2.2 h1:27LBs+PKJEFnkQXjPU9eIps7a7iyI13AKcSYj897DCU=
 github.com/flant/kube-client v1.2.2/go.mod h1:eMa3aJ6V1PRWSQ/RCROkObDpY4S74uM84SJS4G/LINg=
+github.com/flant/kube-client v1.2.3-0.20251010113940-a5ee3ab51ae7 h1:DyeSB10HH7WtdVIuRz/BvLb5ww55IcoAUOqzrTKdlIc=
+github.com/flant/kube-client v1.2.3-0.20251010113940-a5ee3ab51ae7/go.mod h1:eMa3aJ6V1PRWSQ/RCROkObDpY4S74uM84SJS4G/LINg=
+github.com/flant/kube-client v1.2.3-0.20251010120358-6d59508d68da h1:QTK//RIoqdsUq3h0LLtd/+GKHZK5h/nGHW5wE2MCOnU=
+github.com/flant/kube-client v1.2.3-0.20251010120358-6d59508d68da/go.mod h1:kuIr5aVjXzJaMRth/wEHYwLXz9qt28B6M+zhidk7S04=
+github.com/flant/kube-client v1.2.3 h1:cmS4FktyBdM65xNT71CW/sS3gaJatANqGOHySNCNbio=
+github.com/flant/kube-client v1.2.3/go.mod h1:kuIr5aVjXzJaMRth/wEHYwLXz9qt28B6M+zhidk7S04=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/flant/addon-operator v1.6.6
-	github.com/flant/kube-client v1.2.3-0.20250320122654-cc319665c656
+	github.com/flant/kube-client v1.2.3
 	github.com/flant/shell-operator v1.6.2
 	github.com/go-openapi/spec v0.19.8
 	github.com/gojuno/minimock/v3 v3.4.5

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,12 @@ github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AW
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.2.3-0.20250320122654-cc319665c656 h1:4KJJsnfhb9a6Vym7RtwxEYm+lid4GpApsWMxr31kHkw=
 github.com/flant/kube-client v1.2.3-0.20250320122654-cc319665c656/go.mod h1:kuIr5aVjXzJaMRth/wEHYwLXz9qt28B6M+zhidk7S04=
+github.com/flant/kube-client v1.2.3-0.20251010113940-a5ee3ab51ae7 h1:DyeSB10HH7WtdVIuRz/BvLb5ww55IcoAUOqzrTKdlIc=
+github.com/flant/kube-client v1.2.3-0.20251010113940-a5ee3ab51ae7/go.mod h1:eMa3aJ6V1PRWSQ/RCROkObDpY4S74uM84SJS4G/LINg=
+github.com/flant/kube-client v1.2.3-0.20251010120358-6d59508d68da h1:QTK//RIoqdsUq3h0LLtd/+GKHZK5h/nGHW5wE2MCOnU=
+github.com/flant/kube-client v1.2.3-0.20251010120358-6d59508d68da/go.mod h1:kuIr5aVjXzJaMRth/wEHYwLXz9qt28B6M+zhidk7S04=
+github.com/flant/kube-client v1.2.3 h1:cmS4FktyBdM65xNT71CW/sS3gaJatANqGOHySNCNbio=
+github.com/flant/kube-client v1.2.3/go.mod h1:kuIr5aVjXzJaMRth/wEHYwLXz9qt28B6M+zhidk7S04=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee h1:evii83J+/6QGNvyf6tjQ/p27DPY9iftxIBb37ALJRTg=
 github.com/flant/libjq-go v1.6.3-0.20201126171326-c46a40ff22ee/go.mod h1:f+REaGl/+pZR97rbTcwHEka/MAipoQQ2Mc0iQUj4ak0=
 github.com/flant/shell-operator v1.6.2 h1:YNj4u0PZ8T82n31Zwyu2DUaiXbQghEfT97NvOu4en1M=


### PR DESCRIPTION
## Description

Update dhctl to use kube-client with in-memory cache option for Commander 1.11 CSE
This PR uses kube-client  v1.2.3.

## Why do we need it, and what problem does it solve?

Commander 1.11 uses 1.69 dhctl-lib. So we need to actualize 1.69 codebase by adding necessary fix from the flant/kube-client 1.2.3.