### PR TITLE
[istio] reduce RAM for regenerate multicluster JWT token (#15328)

### DIFF
--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -6,6 +6,8 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package ee
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -13,6 +15,10 @@ import (
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/square/go-jose/v3"
+	"gopkg.in/yaml.v3"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
@@ -125,6 +131,148 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	}, nil
 }
 
+// Simplified struct for storing only essential token data
+type IstioRemoteSecretToken struct {
+	MultiClusterName string `json:"multiClusterName"`
+	Token            string `json:"token"`
+}
+
+// Kubeconfig represents the structure of a kubeconfig file
+type Kubeconfig struct {
+	Users []struct {
+		User struct {
+			Token string `yaml:"token"`
+		} `yaml:"user"`
+	} `yaml:"users"`
+}
+
+// TokenValidationResult represents the result of token validation
+type TokenValidationResult struct {
+	IsExpired bool      `json:"isExpired"`
+	ExpiresAt time.Time `json:"expiresAt"`
+	Error     string    `json:"error,omitempty"`
+}
+
+// validateJWTToken validates a JWT token and checks if it's expired
+func validateJWTToken(tokenString string) TokenValidationResult {
+	if tokenString == "" {
+		return TokenValidationResult{
+			IsExpired: true,
+			Error:     "token is empty",
+		}
+	}
+
+	// Parse the JWT token
+	token, err := jose.ParseSigned(tokenString)
+	if err != nil {
+		return TokenValidationResult{
+			IsExpired: true,
+			Error:     fmt.Sprintf("failed to parse token: %v", err),
+		}
+	}
+
+	// Check expiration time
+	payload := token.UnsafePayloadWithoutVerification()
+
+	// Parse the payload to get claims
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return TokenValidationResult{
+			IsExpired: true,
+			Error:     fmt.Sprintf("failed to unmarshal claims: %v", err),
+		}
+	}
+
+	expTime := int64(claims["exp"].(float64))
+
+	if expTime < time.Now().UTC().Unix() {
+		return TokenValidationResult{
+			IsExpired: true,
+			Error:     "JWT token expired",
+			ExpiresAt: time.Unix(expTime, 0),
+		}
+	}
+
+	return TokenValidationResult{
+		IsExpired: false,
+		ExpiresAt: time.Unix(expTime, 0),
+	}
+}
+
+func applyIstioRemoteSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &v1.Secret{}
+	err := sdk.FromUnstructured(obj, secret)
+	if err != nil {
+		return nil, fmt.Errorf("cannot convert k8s secret to struct: %v", err)
+	}
+
+	secretName := secret.GetName()
+	if !strings.HasPrefix(secretName, "istio-remote-secret-") {
+		return nil, fmt.Errorf("secret %s is not an istio remote secret", secretName)
+	}
+
+	// Extract cluster name from annotation instead of parsing from secret name
+	annotations := secret.GetAnnotations()
+	clusterName, exists := annotations["networking.istio.io/cluster"]
+	if !exists {
+		return nil, fmt.Errorf("secret %s does not have required annotation 'networking.istio.io/cluster'", secretName)
+	}
+
+	// Get the base64-encoded kubeconfig from the field named after the cluster
+	secData, exists := secret.Data[clusterName]
+	if !exists {
+		return nil, fmt.Errorf("secret %s does not contain '%s' field", secretName, clusterName)
+	}
+
+	var kubeconfigBytes []byte
+
+	// parse the data directly as YAML
+	var testKubeconfig Kubeconfig
+	if yaml.Unmarshal(secData, &testKubeconfig) == nil {
+		kubeconfigBytes = secData
+	} else {
+		// If direct YAML parsing failed, try base64 decoding
+		// Remove all whitespace characters first
+		cleanBase64 := strings.Map(func(r rune) rune {
+			if strings.ContainsRune(" \t\n\r\v\f", r) {
+				return -1
+			}
+			return r
+		}, string(secData))
+
+		var decodeErr error
+		kubeconfigBytes, decodeErr = base64.StdEncoding.DecodeString(cleanBase64)
+		if decodeErr != nil {
+			return nil, fmt.Errorf("cannot decode base64 kubeconfig from secret %s: %v (also tried direct YAML parsing)", secretName, decodeErr)
+		}
+	}
+
+	// Extract token from kubeconfig directly
+	var kubeconfig Kubeconfig
+	err = yaml.Unmarshal(kubeconfigBytes, &kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal kubeconfig from secret %s: %v", secretName, err)
+	}
+
+	// Look for the first user with a token
+	var token string
+	for _, user := range kubeconfig.Users {
+		if user.User.Token != "" {
+			token = user.User.Token
+			break
+		}
+	}
+
+	if token == "" {
+		return nil, fmt.Errorf("token not found in kubeconfig from secret %s", secretName)
+	}
+
+	return IstioRemoteSecretToken{
+		MultiClusterName: clusterName,
+		Token:            token,
+	}, nil
+}
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: lib.Queue("alliance"),
 	Kubernetes: []go_hook.KubernetesConfig{
@@ -139,6 +287,18 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ApiVersion: "deckhouse.io/v1alpha1",
 			Kind:       "IstioMulticlusters",
 			FilterFunc: applyMulticlusterMergeFilter,
+		},
+		{
+			Name:       "istioRemoteSecrets",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			FilterFunc: applyIstioRemoteSecretFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"istio/multiCluster": "true",
+				},
+			},
+			NamespaceSelector: lib.NsSelector(),
 		},
 	},
 	Schedule: []go_hook.ScheduleConfig{
@@ -157,6 +317,14 @@ func metadataMerge(input *go_hook.HookInput) error {
 	var remotePublicMetadata = make(map[string]eeCrd.AlliancePublicMetadata)
 
 	var myTrustDomain = input.Values.Get("global.discovery.clusterDomain").String()
+
+	// Create a map of cluster names to tokens from remote secrets for quick lookup
+	secretTokens := make(map[string]string)
+	for _, secretInfo := range input.Snapshots["istioRemoteSecrets"] {
+		if tokenInfo, ok := secretInfo.(IstioRemoteSecretToken); ok {
+			secretTokens[tokenInfo.MultiClusterName] = tokenInfo.Token
+		}
+	}
 
 federationsLoop:
 	for federationInfo, err := range sdkobjectpatch.SnapshotIter[IstioFederationMergeCrdInfo](input.NewSnapshots.Get("federations")) {
@@ -216,19 +384,45 @@ multiclustersLoop:
 			continue multiclustersLoop
 		}
 
-		privKey := []byte(input.Values.Get("istio.internal.remoteAuthnKeypair.priv").String())
-		claims := map[string]string{
-			"iss":   "d8-istio",
-			"aud":   multiclusterInfo.Public.ClusterUUID,
-			"sub":   input.Values.Get("global.discovery.clusterUUID").String(),
-			"scope": "api",
-		}
-		// until the bug won't be solved https://github.com/istio/istio/issues/37925
-		// multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*25)
-		multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*24*366)
-		if err != nil {
-			input.Logger.Warn("can't generate auth token for remote api of IstioMulticluster", slog.String("name", multiclusterInfo.Name), log.Err(err))
-			continue multiclustersLoop
+		// Check existing token from remote secrets and validate it
+		existingToken := secretTokens[multiclusterInfo.Name]
+
+		input.Logger.Info("validating existing token",
+			slog.String("name", multiclusterInfo.Name))
+
+		validationResult := validateJWTToken(existingToken)
+		input.Logger.Info("token validation result",
+			slog.String("name", multiclusterInfo.Name),
+			slog.Bool("isExpired", validationResult.IsExpired),
+			slog.String("error", validationResult.Error),
+			slog.String("expiresAt", validationResult.ExpiresAt.Format(time.RFC3339)))
+
+		if !validationResult.IsExpired {
+			// Token is still valid, reuse it
+			multiclusterInfo.APIJWT = existingToken
+			input.Logger.Info("reusing existing valid token for multicluster",
+				slog.String("name", multiclusterInfo.Name),
+				slog.String("expiresAt", validationResult.ExpiresAt.Format(time.RFC3339)))
+		} else {
+			input.Logger.Info("existing token is invalid or expired, generating new token",
+				slog.String("name", multiclusterInfo.Name),
+				slog.String("error", validationResult.Error),
+				slog.Bool("isExpired", validationResult.IsExpired))
+
+			privKey := []byte(input.Values.Get("istio.internal.remoteAuthnKeypair.priv").String())
+			claims := map[string]string{
+				"iss":   "d8-istio",
+				"aud":   multiclusterInfo.Public.ClusterUUID,
+				"sub":   input.Values.Get("global.discovery.clusterUUID").String(),
+				"scope": "api",
+			}
+			// until the bug won't be solved https://github.com/istio/istio/issues/37925
+			// multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*25)
+			multiclusterInfo.APIJWT, err = jwt.GenerateJWT(privKey, claims, time.Hour*24*366)
+			if err != nil {
+				input.Logger.Warn("can't generate auth token for remote api of IstioMulticluster", slog.String("name", multiclusterInfo.Name), log.Err(err))
+				continue multiclustersLoop
+			}
 		}
 
 		multiclusterInfo.Public = nil


### PR DESCRIPTION
## Description
Implementation for reusing The JWT token to establish a connection between Istio Multiclusters.

Before fix:
<img width="1118" height="759" alt="image" src="https://github.com/user-attachments/assets/ab6fdeb8-af7b-44cc-8b02-dde1aa30b79f" />

After fix:
<img width="1118" height="759" alt="image" src="https://github.com/user-attachments/assets/e07fbed3-8399-4c8b-b00c-62618cce9b82" />

## Why do we need it, and what problem does it solve?

Hook, in order to establish communication between Istio Multiclusters, reissued the JWT token every minute, which led to high RAM consumption. It is now being verified that the token is valid and is not being reissued, but is being reused.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary:  Reduce RAM for regenerate multicluster JWT token
impact_level: default
```