### PR TITLE
[istio] Added reports on Non-exploitable vulnerabilities

### DIFF
--- a/modules/110-istio/images/kiali-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/kiali-v1x21x6/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-66e96be7a37a2401f73b2b4101609d939e0e295634605433389159f40bf70b22",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-28180"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/gopkg.in/square/go-jose.v2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "в рамках платформы не передаются скомпрессированные данные, поэтому данная уязвимость не может быть эксплуатирована",
+      "timestamp": "2025-10-10T15:25:19.178028674Z"
+    }
+  ],
+  "timestamp": "2025-10-10T15:25:19Z"
+}

--- a/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
@@ -1,0 +1,115 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-4a1e88df7c6c8f81542a2b158759e29d57a19a408fb82c88470f633bb7d5d65c",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-53547"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Helm Chart Code Execution - Функционал, связанный с обновлением зависимостей helm chart, в программном продукте helm версии 3.14.2 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Все необходимые зависимости включаются непосредственно в состав чарта, что исключает возможность эксплуатации уязвимости.",
+      "timestamp": "2025-10-10T15:29:44.644944464Z"
+    }
+  ],
+  "timestamp": "2025-10-10T15:29:44Z"
+}
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1027bb9708316a925f7c01d588ba61989c7402802702e4795f09249e6dbd6728",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32386"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Helm specially crafted chart archive causing out of memory - Функционал скачивания и распаковки helm chart архивов в программном продукте helm версии 3.14.2 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Все необходимые чарты предоставляются в готовом виде, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2025-10-10T15:32:08.129204108Z"
+    }
+  ],
+  "timestamp": "2025-10-10T15:32:08Z"
+}
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-a31baefa686daf2254a1a46a9cfd3ad0b93d7a522460309421737ff9b1b4c859",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-32387"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Helm specially crafted JSON schema causing stack overflow - Функционал обработки JSON схем с произвольной глубиной вложенности в программном продукте helm версии 3.14.2 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Величина вложенности схем контролируется на этапе проверки линтером, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2025-10-10T15:33:13.264855875Z"
+    }
+  ],
+  "timestamp": "2025-10-10T15:33:13Z"
+}
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8099493f35d0f646e271364c458516100e4a951182c5d08558bd18852e39c8e8",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-55198"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Helm YAML parsing panic vulnerability - Функционал разбора YAML-файлов в программном продукте helm версии 3.14.2 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы без предварительной проверки линтером. Все чарты проходят обязательную валидацию, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2025-10-10T15:34:40.216094508Z"
+    }
+  ],
+  "timestamp": "2025-10-10T15:34:40Z"
+}
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-2cb510013d32cb4eda9bf24d33a36bd4787bb1eebfb8a4e0463d5bc8d4c88153",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-55199"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Helm Chart JSON Schema denial of service - Функционал обработки JSON схем в программном продукте helm версии 3.14.2 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы без предварительной проверки линтером. Все чарты проходят обязательную валидацию на отсутствие ссылок , указывающих на /dev/zero, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2025-10-10T15:35:45.218482198Z"
+    }
+  ],
+  "timestamp": "2025-10-10T15:35:45Z"
+}


### PR DESCRIPTION
## Description
To automate scanning for vulnerabilities in Istio code and binary files, openVex descriptions of non-exploitable vulnerabilities have been added.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Added reports on Non-exploitable vulnerabilities
impact_level: low
```
