### PR TITLE
[ci] Switch svace to secret storage

### DIFF
--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -117,12 +117,12 @@ jobs:
       - build_fe
     steps:
 {!{- $secrets := slice -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACE_ANALYZE_HOST" "SVACE_ANALYZE_HOST" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACE_ANALYZE_SSH_USER" "SVACE_ANALYZE_SSH_USER" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACER_URL" "SVACER_URL" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACER_IMPORT_USER" "SVACER_IMPORT_USER" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACER_IMPORT_PASSWORD" "SVACER_IMPORT_PASSWORD" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACE_ANALYZE_SSH_PRIVATE_KEY" "SVACE_ANALYZE_SSH_PRIVATE_KEY" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACE_ANALYZE_HOST" "SVACE_ANALYZE_HOST" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACE_ANALYZE_SSH_USER" "SVACE_ANALYZE_SSH_USER" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACER_URL" "SVACER_URL" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACER_IMPORT_USER" "SVACER_IMPORT_USER" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACER_IMPORT_PASSWORD" "SVACER_IMPORT_PASSWORD" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACE_ANALYZE_SSH_PRIVATE_KEY" "SVACE_ANALYZE_SSH_PRIVATE_KEY" ) $secrets -}!}
 {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 6 }!}
       - uses: deckhouse/modules-actions/svace_analyze@v4
         with:

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -192,12 +192,12 @@ jobs:
     runs-on: [self-hosted, regular]
     steps:
 {!{- $secrets := slice -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACE_ANALYZE_HOST" "SVACE_ANALYZE_HOST" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACE_ANALYZE_SSH_USER" "SVACE_ANALYZE_SSH_USER" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACER_URL" "SVACER_URL" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACER_IMPORT_USER" "SVACER_IMPORT_USER" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACER_IMPORT_PASSWORD" "SVACER_IMPORT_PASSWORD" ) $secrets -}!}
-{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI" "SVACE_ANALYZE_SSH_PRIVATE_KEY" "SVACE_ANALYZE_SSH_PRIVATE_KEY" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACE_ANALYZE_HOST" "SVACE_ANALYZE_HOST" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACE_ANALYZE_SSH_USER" "SVACE_ANALYZE_SSH_USER" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACER_URL" "SVACER_URL" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACER_IMPORT_USER" "SVACER_IMPORT_USER" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACER_IMPORT_PASSWORD" "SVACER_IMPORT_PASSWORD" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI" "SVACE_ANALYZE_SSH_PRIVATE_KEY" "SVACE_ANALYZE_SSH_PRIVATE_KEY" ) $secrets -}!}
 {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 6 }!}
       - uses: deckhouse/modules-actions/svace_analyze@v4
         with:

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -2124,12 +2124,12 @@ jobs:
           method: jwt
           jwtGithubAudience: github-access-aud
           secrets: |
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACE_ANALYZE_HOST | SVACE_ANALYZE_HOST ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACE_ANALYZE_SSH_USER | SVACE_ANALYZE_SSH_USER ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACER_URL | SVACER_URL ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACER_IMPORT_USER | SVACER_IMPORT_USER ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACER_IMPORT_PASSWORD | SVACER_IMPORT_PASSWORD ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACE_ANALYZE_SSH_PRIVATE_KEY | SVACE_ANALYZE_SSH_PRIVATE_KEY ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_HOST | SVACE_ANALYZE_HOST ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_SSH_USER | SVACE_ANALYZE_SSH_USER ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACER_URL | SVACER_URL ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACER_IMPORT_USER | SVACER_IMPORT_USER ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACER_IMPORT_PASSWORD | SVACER_IMPORT_PASSWORD ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_SSH_PRIVATE_KEY | SVACE_ANALYZE_SSH_PRIVATE_KEY ;
 
       # </template: import_secrets>
       - uses: deckhouse/modules-actions/svace_analyze@v4

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -2437,12 +2437,12 @@ jobs:
           method: jwt
           jwtGithubAudience: github-access-aud
           secrets: |
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACE_ANALYZE_HOST | SVACE_ANALYZE_HOST ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACE_ANALYZE_SSH_USER | SVACE_ANALYZE_SSH_USER ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACER_URL | SVACER_URL ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACER_IMPORT_USER | SVACER_IMPORT_USER ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACER_IMPORT_PASSWORD | SVACER_IMPORT_PASSWORD ;
-            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/github/Svace_CI SVACE_ANALYZE_SSH_PRIVATE_KEY | SVACE_ANALYZE_SSH_PRIVATE_KEY ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_HOST | SVACE_ANALYZE_HOST ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_SSH_USER | SVACE_ANALYZE_SSH_USER ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACER_URL | SVACER_URL ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACER_IMPORT_USER | SVACER_IMPORT_USER ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACER_IMPORT_PASSWORD | SVACER_IMPORT_PASSWORD ;
+            projects/data/24cb1d7c-717a-4f92-8547-26f632916a7a/Svace_CI SVACE_ANALYZE_SSH_PRIVATE_KEY | SVACE_ANALYZE_SSH_PRIVATE_KEY ;
 
       # </template: import_secrets>
       - uses: deckhouse/modules-actions/svace_analyze@v4

--- a/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
+++ b/ee/be/modules/140-user-authz/images/webhook/werf.inc.yaml
@@ -33,7 +33,7 @@ git:
         - '**/go.sum'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-user-authz-webhook-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-user-authz-webhook-src-artifact

--- a/ee/modules/015-admission-policy-engine/images/trivy-provider/werf.inc.yaml
+++ b/ee/modules/015-admission-policy-engine/images/trivy-provider/werf.inc.yaml
@@ -23,7 +23,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
@@ -40,7 +40,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/operator/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/operator/werf.inc.yaml
@@ -44,7 +44,7 @@ shell:
   - mkdir ./local && tar zxvf /bundle.tar.gz -C ./local
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/report-updater/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/report-updater/werf.inc.yaml
@@ -23,7 +23,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
   - rm -rf /src/trivy/.git /src/trivy-db/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
+++ b/ee/se-plus/modules/015-admission-policy-engine/images/ratify/werf.inc.yaml
@@ -30,7 +30,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/000-common/images/kubernetes/werf.inc.yaml
+++ b/modules/000-common/images/kubernetes/werf.inc.yaml
@@ -75,7 +75,7 @@ shell:
   - rm -r .git vendor hack/tools/
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $full_version | replace "." "-" }}
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $full_version | replace "." "-" }}

--- a/modules/015-admission-policy-engine/images/constraint-exporter/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/werf.inc.yaml
@@ -21,7 +21,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
@@ -33,7 +33,7 @@ shell:
   - rm -rf .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
@@ -41,7 +41,7 @@ imageSpec:
     entrypoint: ["/usr/bin/etcd"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}

--- a/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
+++ b/modules/150-user-authn/images/basic-auth-proxy/werf.inc.yaml
@@ -27,7 +27,7 @@ git:
     - '**/go.sum'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-basic-auth-proxy-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-basic-auth-proxy-src-artifact

--- a/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
@@ -41,7 +41,7 @@ shell:
     - rm -rf .git docs
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-oauth2-proxy-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-oauth2-proxy-src-artifact
@@ -80,7 +80,7 @@ git:
     - '**/go.sum'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-url-exec-prober-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-url-exec-prober-src-artifact

--- a/modules/150-user-authn/images/dex/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex/werf.inc.yaml
@@ -10,8 +10,8 @@ import:
     add: /web
     to: /web
     before: setup
-git:    
-{{- include "image mount points" . }}    
+git:
+{{- include "image mount points" . }}
 imageSpec:
   config:
     entrypoint: ["/usr/local/bin/dex", "serve", "/etc/dex/config.docker.yaml"]
@@ -46,7 +46,7 @@ shell:
     - rm -rf examples
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-dex-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-src-artifact

--- a/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
@@ -48,7 +48,7 @@ shell:
     - git apply --whitespace=fix -v /patches/*.patch
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-dex-k8s-authenticator-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-k8s-authenticator-src-artifact

--- a/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
@@ -20,7 +20,7 @@ git:
     to: /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-self-signed-generator-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-self-signed-generator-src-artifact

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
@@ -43,7 +43,7 @@ git:
         - '**/templates/*.yaml'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-multitenancy-manager-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-multitenancy-manager-src-artifact

--- a/modules/300-prometheus/images/alertmanager/werf.inc.yaml
+++ b/modules/300-prometheus/images/alertmanager/werf.inc.yaml
@@ -34,7 +34,7 @@ shell:
   - rm -rf /src/.git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/300-prometheus/images/prometheus/werf.inc.yaml
+++ b/modules/300-prometheus/images/prometheus/werf.inc.yaml
@@ -82,7 +82,7 @@ shell:
   - go build -ldflags="-s -w" -o promu ./main.go
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 mount:
 {{ include "mount points for golang builds" . }}

--- a/modules/300-prometheus/images/promxy/werf.inc.yaml
+++ b/modules/300-prometheus/images/promxy/werf.inc.yaml
@@ -13,7 +13,7 @@ shell:
     - rm -rf .git ./vendor/github.com/prometheus/prometheus/web
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -41,8 +41,8 @@ import:
     add: /src/promxy
     to: /app/promxy
     after: setup
-git:    
-{{- include "image mount points" . }}    
+git:
+{{- include "image mount points" . }}
 imageSpec:
   config:
     entrypoint: ["/app/promxy"]

--- a/modules/300-prometheus/images/trickster/werf.inc.yaml
+++ b/modules/300-prometheus/images/trickster/werf.inc.yaml
@@ -12,8 +12,8 @@ import:
   add: /src/OPATH/trickster
   to: /usr/local/bin/trickster
   before: setup
-git:  
-{{- include "image mount points" . }}  
+git:
+{{- include "image mount points" . }}
 imageSpec:
   config:
     entrypoint: ["entrypoint"]
@@ -51,7 +51,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/trickster

--- a/modules/462-loki/images/loki/werf.inc.yaml
+++ b/modules/462-loki/images/loki/werf.inc.yaml
@@ -20,7 +20,7 @@ shell:
     - rm -r .git vendor
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/alt-go-svace" }}
+fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact


### PR DESCRIPTION
## Description
Update svace workflow to use secret storage.
https://github.com/deckhouse/deckhouse-test-2/actions/runs/18550597829/job/52907082707

## Why do we need it, and what problem does it solve?
Part of CI rework.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Switch svace to secret storage.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
