### PR TITLE
[cni-cilium][ingress-nginx] Added reports on Non-exploitable vulnerabilities

### DIFF
--- a/modules/021-cni-cilium/images/kube-rbac-proxy/known_vulnerabilities.vex
+++ b/modules/021-cni-cilium/images/kube-rbac-proxy/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-8e6d3533386852e2c517539fda233328ae5d160590273cc5a5bcc7698dcbbe9a",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-28180"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/gopkg.in/square/go-jose.v2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "CVE-2024-28180 описывает переполнение ресурсов в go-jose, возникающее при попытке распаковать зашифрованные сообщения JWE (JSON Web Encryption - формат JOSE для шифрования полезной нагрузки). Kubernetes не создает и не обрабатывает JWE, используя библиотеку только для подписанных JWT, что подтверждено в обсуждении: https://github.com/kubernetes/kubernetes/pull/123253#issuecomment-1940379993 https://github.com/kubernetes/sig-security/issues/116#issuecomment-2197995745",
+      "timestamp": "2025-10-13T12:24:00.293353Z"
+    }
+  ],
+  "timestamp": "2025-10-13T12:24:00Z"
+}

--- a/modules/402-ingress-nginx/images/kube-rbac-proxy/known_vulnerabilities.vex
+++ b/modules/402-ingress-nginx/images/kube-rbac-proxy/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-c40f4f4051bff9ec536f80909979b4edbbe1fe5d1231cf8e1bf39d0ff815fe97",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-28180"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/gopkg.in/square/go-jose.v2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "CVE-2024-28180 описывает переполнение ресурсов в go-jose, возникающее при попытке распаковать зашифрованные сообщения JWE (JSON Web Encryption - формат JOSE для шифрования полезной нагрузки). Kubernetes не создает и не обрабатывает JWE, используя библиотеку только для подписанных JWT, что подтверждено в обсуждении: https://github.com/kubernetes/kubernetes/pull/123253#issuecomment-1940379993 https://github.com/kubernetes/sig-security/issues/116#issuecomment-2197995745",
+      "timestamp": "2025-10-13T12:29:16.580589Z"
+    }
+  ],
+  "timestamp": "2025-10-13T12:29:16Z"
+}


### PR DESCRIPTION
## Description

To automate scanning for vulnerabilities in code and binary files, openVex descriptions of non-exploitable vulnerabilities have been added.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: chore
summary: vex files have been added.
impact_level: low
---
section: ingress-nginx
type: chore
summary: vex files have been added.
impact_level: low
```
