### PR TITLE
[candi] Fix dhctl skipping errors when it's fetching packages

### DIFF
--- a/candi/bashible/bashbooster/50_registrypackages.sh
+++ b/candi/bashible/bashbooster/50_registrypackages.sh
@@ -60,12 +60,12 @@ bb-package-fetch-blob() {
   local REPOSITORY_PATH="${REPOSITORY_PATH:-}"
   local no_proxy=${PACKAGES_PROXY_ADDRESSES}
   local NO_PROXY=${PACKAGES_PROXY_ADDRESSES}
-  
-  if [[ -z "$1" || "$1" == "<no value>" ]]; then
+
+  if [[ -z "$1" || "$1" == "<no value>:" ]]; then
     echo "Error: Digest is incorrect. Probably we pass incorrect package name and we cannot get correct digest"
     return 1
   fi
-  
+
   check_python
 
   cat - <<EOF | $python_binary

--- a/candi/bashible/bb_package_install.sh.tpl
+++ b/candi/bashible/bb_package_install.sh.tpl
@@ -92,7 +92,7 @@ bb-package-fetch-blob() {
   local no_proxy=${PACKAGES_PROXY_ADDRESSES}
   local NO_PROXY=${PACKAGES_PROXY_ADDRESSES}
 
-  if [[ -z "$1" || "$1" == "<no value>" ]]; then
+  if [[ -z "$1" || "$1" == "<no value>:" ]]; then
     echo "Error: Digest is incorrect. Probably we pass incorrect package name and we cannot get correct digest"
     return 1
   fi


### PR DESCRIPTION
## Description
Fix dhctl skipping errors when it's fetching packages
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fix dhctl skipping errors when it's fetching packages

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
You don't

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed dhctl skipping errors when it's fetching packages.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
