### PR TITLE
[ingress-nginx] fix vulnerabilities

### DIFF
--- a/modules/000-common/images/alt-p11/werf.inc.yaml
+++ b/modules/000-common/images/alt-p11/werf.inc.yaml
@@ -1,8 +1,6 @@
 {{- define "alt archive repos" }}
-{{- $date := "2025-10-08" }}
-- sed -i "s|http://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/x86_64 classic|http://ftp.altlinux.org/pub/distributions/archive/p11/date/{{ $date | replace "-" "/" }}/ x86_64 classic|g" /etc/apt/sources.list.d/alt.list
-- sed -i "s|http://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/x86_64-i586 classic|http://ftp.altlinux.org/pub/distributions/archive/p11/date/{{ $date | replace "-" "/" }}/ x86_64-i586 classic|g" /etc/apt/sources.list.d/alt.list
-- sed -i "s|http://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/noarch classic|http://ftp.altlinux.org/pub/distributions/archive/p11/date/{{ $date | replace "-" "/" }}/ noarch classic|g" /etc/apt/sources.list.d/alt.list
+{{- $date := "2025-10-12" }}
+- sed -i -E "s|http://ftp.altlinux.org/pub/distributions/archive/p11/date/[0-9]{4}/[0-9]{2}/[0-9]{2}/|http://ftp.altlinux.org/pub/distributions/archive/p11/date/{{ $date | replace "-" "/" }}/|g" /etc/apt/sources.list.d/alt.list
 {{- end }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact


### PR DESCRIPTION
## Description

This PR fixes several security vulnerabilities in the project.

These changes allow you to update the alt linux distribution to the date specified in the configuration. Since the URL lists were changed, `sed` did not work properly.

State of the file BEFORE applying the `sed` command:

```
# ftp.altlinux.org (ALT Linux, Moscow)

# ALT Platform 11
#rpm [p11] ftp://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/x86_64 classic
#rpm [p11] ftp://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/x86_64-i586 classic
#rpm [p11] ftp://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/noarch classic

rpm [p11] http://ftp.altlinux.org/pub/distributions/archive/p11/date/2025/09/24/ x86_64 classic
rpm [p11] http://ftp.altlinux.org/pub/distributions/archive/p11/date/2025/09/24/ x86_64-i586 classic
rpm [p11] http://ftp.altlinux.org/pub/distributions/archive/p11/date/2025/09/24/ noarch classic

#rpm [p11] rsync://ftp.altlinux.org/ALTLinux p11/branch/x86_64 classic
#rpm [p11] rsync://ftp.altlinux.org/ALTLinux p11/branch/x86_64-i586 classic
#rpm [p11] rsync://ftp.altlinux.org/ALTLinux p11/branch/noarch classic
```

The state of the file AFTER applying the `sed` command:

```
# ftp.altlinux.org (ALT Linux, Moscow)

# ALT Platform 11
#rpm [p11] ftp://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/x86_64 classic
#rpm [p11] ftp://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/x86_64-i586 classic
#rpm [p11] ftp://ftp.altlinux.org/pub/distributions/ALTLinux p11/branch/noarch classic

rpm [p11] http://ftp.altlinux.org/pub/distributions/archive/p11/date/2025/10/12/ x86_64 classic
rpm [p11] http://ftp.altlinux.org/pub/distributions/archive/p11/date/2025/10/12/ x86_64-i586 classic
rpm [p11] http://ftp.altlinux.org/pub/distributions/archive/p11/date/2025/10/12/ noarch classic

#rpm [p11] rsync://ftp.altlinux.org/ALTLinux p11/branch/x86_64 classic
#rpm [p11] rsync://ftp.altlinux.org/ALTLinux p11/branch/x86_64-i586 classic
#rpm [p11] rsync://ftp.altlinux.org/ALTLinux p11/branch/noarch classic
```

## Why do we need it, and what problem does it solve?

This update addresses the following vulnerabilities:

- ALT-PU-2025-12177
- BDU:2025-06694
- CVE-2025-4598 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ingress-nginx
type: fix 
summary: Fixed vulnerabilities.
impact_level: low
```
