### PR TITLE
[deckhouse] No use proxy for boostrap phase

### DIFF
--- a/helm_lib/charts/deckhouse_lib_helm/templates/_envs_for_proxy.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_envs_for_proxy.tpl
@@ -1,17 +1,8 @@
-{{- /* Usage: {{ include "helm_lib_envs_for_proxy" . }} or {{ include "helm_lib_envs_for_proxy" (list . "extra.ip1,extra.ip2") }} */ -}}
-{{- /* Add HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables for container, use extra for list additional no_proxy hosts  */ -}}
+{{- /* Usage: {{ include "helm_lib_envs_for_proxy" . }} */ -}}
+{{- /* Add HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables for container */ -}}
 {{- /* depends on [proxy settings](https://deckhouse.io/products/kubernetes-platform/documentation/v1/deckhouse-configure-global.html#parameters-modules-proxy) */ -}}
 {{- define "helm_lib_envs_for_proxy" }}
   {{- $context := . -}} {{- /* Template context with .Values, .Chart, etc */ -}}
-  {{- $extraNoProxy := "" -}}
-
-  {{- if kindIs "slice" . }}
-    {{- $context = index . 0 -}}
-    {{- if gt (len .) 1 }}
-      {{- $extraNoProxy = index . 1 -}}
-    {{- end }}
-  {{- end }}
-
   {{- if $context.Values.global.clusterConfiguration }}
     {{- if $context.Values.global.clusterConfiguration.proxy }}
       {{- if $context.Values.global.clusterConfiguration.proxy.httpProxy }}
@@ -26,17 +17,10 @@
 - name: https_proxy
   value: {{ $context.Values.global.clusterConfiguration.proxy.httpsProxy | quote }}
       {{- end }}
-
       {{- $noProxy := list "127.0.0.1" "169.254.169.254" $context.Values.global.clusterConfiguration.clusterDomain $context.Values.global.clusterConfiguration.podSubnetCIDR $context.Values.global.clusterConfiguration.serviceSubnetCIDR }}
       {{- if $context.Values.global.clusterConfiguration.proxy.noProxy }}
         {{- $noProxy = concat $noProxy $context.Values.global.clusterConfiguration.proxy.noProxy }}
       {{- end }}
-
-      {{- if $extraNoProxy }}
-        {{- $extraList := splitList "," $extraNoProxy }}
-        {{- $noProxy = concat $noProxy $extraList }}
-      {{- end }}
-
 - name: NO_PROXY
   value: {{ $noProxy | join "," | quote }}
 - name: no_proxy

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -162,6 +162,7 @@ spec:
               valueFrom: null # a hack for explicit wiping valueFrom field, helm has problems with arrays merge patching
             - name: KUBERNETES_SERVICE_PORT
               value: "6445"
+            {{- include "helm_lib_envs_for_proxy" . | nindent 12 }}
   {{- else }}
   # bootstrap phase: use direct connection
             - name: KUBERNETES_SERVICE_HOST
@@ -171,6 +172,11 @@ spec:
                   fieldPath: status.hostIP
             - name: KUBERNETES_SERVICE_PORT
               value: "6443"
+            {{- $bootstrapContext := deepCopy . }}
+            {{- if and $bootstrapContext.Values.global.clusterConfiguration $bootstrapContext.Values.global.clusterConfiguration.proxy }}
+            {{- $_ := set $bootstrapContext.Values.global.clusterConfiguration.proxy "noProxy" (append ($bootstrapContext.Values.global.clusterConfiguration.proxy.noProxy | default list) "$(KUBERNETES_SERVICE_HOST)") }}
+            {{- end }}
+            {{- include "helm_lib_envs_for_proxy" $bootstrapContext | nindent 12 }}
   {{- end }}
 {{- end }}
             - name: LOG_LEVEL
@@ -246,7 +252,6 @@ spec:
               value: /tmp/.bash_history
             - name: DEBUG_HTTP_SERVER_ADDR
               value: "127.0.0.1:9652"
-            {{- include "helm_lib_envs_for_proxy" (list . "$(KUBERNETES_SERVICE_HOST)") | nindent 12 }}
 {{- if .Values.deckhouse.internal.chrootMode }}
             - name: ADDON_OPERATOR_SHELL_CHROOT_DIR
               value: "/chroot"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
There is a situation when during the initial bootrstrap phase (when kubernetes-api-proxy is not running yet) deckhouse pod can access the apiserver (on its node) using the proxies specified in the ClusterConfiguration. 
This is often not necessary, at least because all components are located on the same node.
We fixed this by automatically adding the node ip address where deckhouse pod to NoProxy(during bootrstrap phase).
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Deckhouse initial converge may be affected by proxy server settings(port blocked), when it's not necessary
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Automatically set node ip to deckhouse pod during bootstrap phase to no_proxy env.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
