### PR TITLE
[extended-monitoring] Bump image-availability-exporter from 0.13.0 to 0.14.0

### DIFF
--- a/modules/340-extended-monitoring/images/image-availability-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{ $imageAvailabilityExporterVersion := "0.13.0" }}
+{{ $imageAvailabilityExporterVersion := "0.14.0" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact


### PR DESCRIPTION
## Description

This PR bumps the `image-availability-exporter` version from `0.13.0` to `0.14.0` in the `extended-monitoring` module.



## Why do we need it, and what problem does it solve?

Fixes CVE-2025-22868

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: extended-monitoring
type: chore
summary: Bump image-availability-exporter from 0.13.0 to 0.14.0
impact_level: low