### PR TITLE
Add immediate job link to CVE scan start comment for better visibility and faster debugging.

### DIFF
--- a/.github/workflow_templates/cve-pr.yml
+++ b/.github/workflow_templates/cve-pr.yml
@@ -55,6 +55,7 @@ jobs:
       WORKDIR: "cve_scan"
     steps:
 {!{ tmpl.Exec "checkout_full_step"           $ctx | strings.Indent 6 }!}
+{!{ tmpl.Exec "update_comment_on_start" "Trivy scan dev images" | strings.Indent 6 }!}
 {!{ tmpl.Exec "link_bin_step"                     | strings.Indent 6 }!}
 {!{ tmpl.Exec "exctract_pr_number"                | strings.Indent 6 }!}
 {!{ tmpl.Exec "cve_scan_deckhouse_images"         | strings.Indent 6 }!}

--- a/.github/workflows/cve-pr.yml
+++ b/.github/workflows/cve-pr.yml
@@ -114,6 +114,20 @@ jobs:
         with:
           fetch-depth: 0
       # </template: checkout_full_step>
+      # <template: update_comment_on_start>
+      - name: Update comment on start
+        if: ${{ github.event_name == 'workflow_dispatch' && !!github.event.inputs.issue_number }}
+        uses: actions/github-script@v6.4.1
+        with:
+          github-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          retries: 3
+          script: |
+            const name = 'Trivy scan dev images';
+
+            const ci = require('./.github/scripts/js/ci');
+            return await ci.updateCommentOnStart({github, context, core, name})
+
+      # </template: update_comment_on_start>
 
       # <template: link_bin_step>
       - name: Link binary cache


### PR DESCRIPTION
## Description

This PR improves the behavior of the CVE scan job when the `security/cve` label is added to a pull request. Previously, the comment only stated that the scan was started, **without including a link** to the running GitHub Actions job.

Now, the comment **immediately includes a direct link to the scan job** at the moment it starts, allowing developers to track its status and logs right away.

## Why do we need it, and what problem does it solve?

Currently, developers cannot access the running scan job until it completes — the link is only posted in a follow-up comment. This delays debugging and slows down the feedback loop in case of failures or timeouts.

This PR solves the issue by **publishing the GitHub Actions job link right at the start** of the scan, improving visibility and developer experience in secure CI workflows.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Add immediate job link to CVE scan start comment for better visibility and faster debugging.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
