### PR TITLE
Remove unnecessary Content-Type header from CVE scan API request

### DIFF
--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -57,7 +57,6 @@ send_report() {
     --retry-all-errors \
     https://${DEFECTDOJO_HOST}/api/v2/reimport-scan/ \
     -H "accept: application/json" \
-    -H "Content-Type: multipart/form-data" \
     -H "Authorization: Token ${DEFECTDOJO_API_TOKEN}" \
     -F "auto_create_context=True" \
     -F "minimum_severity=Info" \


### PR DESCRIPTION
## Description

Remove unnecessary `Content-Type: multipart/form-data` header from CVE scan API request to DefectDojo. The curl command with `-F` flag automatically sets the appropriate `Content-Type` header with boundary, and explicitly setting it causes HTTP 400 errors.

This change fixes the CVE scan upload process by allowing curl to handle the content type automatically when using form data uploads.

## Why do we need it, and what problem does it solve?

CVE scans were failing with HTTP 400 errors when uploading Trivy scan results to DefectDojo. The issue was caused by explicitly setting the `Content-Type: multipart/form-data` header without a boundary parameter.

**Root cause analysis:**
- When using curl with `-F` flag for multipart form data, curl automatically sets the `Content-Type` header with the proper boundary
- Explicitly setting `Content-Type: multipart/form-data` without boundary creates a mismatch between the header and actual request body
- DefectDojo API rejects such requests with HTTP 400 error

**Impact before fix:**
- CVE scan uploads to DefectDojo were failing
- Security vulnerability reports were not being properly tracked
- CI/CD pipelines were experiencing failures during security scanning phase

**Solution:**
- Remove the explicit `Content-Type` header declaration
- Let curl handle the content type automatically with proper boundary generation
- This ensures compatibility with DefectDojo API requirements

## Why do we need it in the patch release (if we do)?

This is a critical bug fix that affects the security scanning pipeline. CVE scanning is essential for maintaining security posture, and the current failure prevents proper vulnerability tracking. This should be included in patch releases to ensure security processes work correctly.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: fix
summary: Fix CVE scan uploads to DefectDojo by removing conflicting Content-Type header
impact: CVE scan results will now upload successfully to DefectDojo without HTTP 400 errors
impact_level: default
```