### PR TITLE
[docs] Fix Module CR description rendering

### DIFF
--- a/deckhouse-controller/crds/doc-ru-module.yaml
+++ b/deckhouse-controller/crds/doc-ru-module.yaml
@@ -49,9 +49,9 @@ spec:
                       description: Требование к статусу установки кластера (только для встроенных модулей DKP).
                     modules:
                       description: Список других включенных модулей, которые необходимы для работы модуля.
-              accessibility:
-                type: object
-                description: Настройки доступности модуля.
-                properties:
-                  editions:
-                    description: Настройки работы модуля в редакциях Deckhouse.
+                accessibility:
+                  type: object
+                  description: Настройки доступности модуля.
+                  properties:
+                    editions:
+                      description: Настройки работы модуля в редакциях Deckhouse.


### PR DESCRIPTION
## Description

This PR fixes an issue when the Module CR description wasn't rendered properly in Russian.

## Changelog entries

```changes
section: docs
type: chore
summary: Fixed Module CR description rendering.
impact_level: low
```