### PR TITLE
[docs] Show related links in the products documentation

### DIFF
--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -96,6 +96,8 @@ defaults:
       lang: en
       showPrevNextButton: true
       feedback: true
+      # Maximum number of related links to display
+      related_links_max: 6
   - scope:
       path: "pages/includes"
       type: "pages"
@@ -104,6 +106,8 @@ defaults:
       searchable: false
       sitemap_include: false
       layout: none
+      # Maximum number of related links to display
+      related_links_max: 0
   - scope:
       path: "pages/guides"
       type: "pages"

--- a/docs/site/_data/i18n.yaml
+++ b/docs/site/_data/i18n.yaml
@@ -248,6 +248,33 @@ common:
   role:
     en: role
     ru: роль
+  related_reference_links:
+    en: Related links to API
+    ru: Ссылки на связанный API
+  related_reference_and_documentation_links:
+    en: Links to related documentation and API
+    ru: Ссылки на связанную документацию и API
+  related_links:
+    en: Related links
+    ru: Связанные ссылки
+  global_parameters:
+    en: Global parameters
+    ru: Глобальные параметры
+  global_crds:
+    en: Global custom resources
+    ru: Глобальные кастомные ресурсы
+  module_x_parameters:
+    en: Module `XXXX` parameters
+    ru: Параметры модуля `XXXX`
+  module_x_crds:
+    en: Module `XXXX` custom resources
+    ru: Кастомные ресурсы модуля `XXXX`
+  module_x_documentation:
+    en: Module `XXXX` documentation
+    ru: Документация модуля `XXXX`
+  module_x_cluster_configuration:
+    en: Module `XXXX` provider configuration
+    ru: Настройки провайдера модуля `XXXX`
   includes_rules_from:
     en: includes all rules from the role
     ru: включает все правила из роли

--- a/docs/site/_layouts/page.html
+++ b/docs/site/_layouts/page.html
@@ -6,6 +6,7 @@ layout: sidebar
         <h1 class="docs__title">{{ page.title }}</h1>
     </div>
 
+    {%- include related_links.liquid %}
     <div class="post-content">
 
     {%- if page.summary %}

--- a/docs/site/werf-web-frontend.inc.yaml
+++ b/docs/site/werf-web-frontend.inc.yaml
@@ -79,10 +79,12 @@ git:
   - _assets/js/search.js
   - _data/rbac/
   - _includes/rbac/
+  - _includes/related_links.liquid
   - _plugins/jekyll_asset_pipeline.rb
   - _plugins/custom_filters.rb
   - _plugins/breadcrumbs_generator.rb
   - _plugins/custom_sidebar.rb
+  - _plugins/related_links.rb
   - _plugins/sidebar_custom.rb
   - _plugins/utils.rb
   - _plugins/offtopic.rb


### PR DESCRIPTION
## Description

Add support for displaying related links on documentation pages for products documentation (DVP, Code, Stronghold, etc).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add support for displaying related links on documentation pages for products documentation
impact_level: low
```
