### PR TITLE
[operator-trivy] distroless node-collector

### DIFF
--- a/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/node-collector/werf.inc.yaml
@@ -1,19 +1,36 @@
+{{ $requiredCoreUtilsBinaries := list "base64" "basename" "cat" "cut" "coreutils" "echo" "env" "expand" "expr" "head" "ls" "md5sum" "numfmt" "paste" "printf" "readlink" "sha1sum" "sha256sum" "sort" "split" "stat" "tail" "tee" "test" "uname" "uniq" "wc"}}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-    add: /node-collector
-    to: /usr/local/bin/node-collector
-    before: setup
-  - image: tools/procps
-    add: /bin/pgrep
-    to: /usr/bin/pgrep
-    before: setup
-  - image: tools/procps
-    add: /bin/ps
-    to: /usr/bin/ps
-    before: setup
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
+  add: /node-collector
+  to: /usr/local/bin/node-collector
+  before: setup
+- image: tools/procps
+  add: /bin/pgrep
+  to: /usr/bin/pgrep
+  before: setup
+- image: tools/procps
+  add: /bin/ps
+  to: /usr/bin/ps
+  before: setup
+- image: tools/bash
+  add: /usr/bin/bash
+  to: /bin/bash
+  before: setup
+- image: tools/bash
+  add: /usr/bin/bash
+  to: /bin/sh
+  before: setup
+- image: tools/coreutils
+  add: /
+  to: /
+  before: setup
+  includePaths:
+{{- range $binary := $requiredCoreUtilsBinaries }}
+  - usr/bin/{{ $binary }}
+{{ end }}
 git:
 {{- include "image mount points" . }}
 imageSpec:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Moved trivy's `node-collector` image to distroless base

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We want to avoid building alt-based images in our product

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: operator-trivy
type: chore
summary: Distroless-based node-collector in Trivy Operator.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
