### PR TITLE
Fix scan dhctl additional image

### DIFF
--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -259,7 +259,7 @@ for d8_tag in "${d8_tags[@]}"; do
       echo ""
       if [ "${additional_image_detected}" == true ]; then
         # CVE Scan
-        image_to_scan="${d8_image}${IMAGE_NAME/deckhouse-oss/""}:${d8_tag}" # replace deckhouse-oss with an empty string, but keep any other image_name for additional_image.
+        image_to_scan="${d8_image}/${IMAGE_NAME/deckhouse-oss/""}:${d8_tag}" # replace deckhouse-oss with an empty string, but keep any other image_name for additional_image.
         trivy_scan "--scanners vuln" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "${image_to_scan/"/:"/:}"
         # License scan
         trivy_scan "--scanners license --license-full" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report_license.json" "${image_to_scan/"/:"/:}"

--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -259,9 +259,10 @@ for d8_tag in "${d8_tags[@]}"; do
       echo ""
       if [ "${additional_image_detected}" == true ]; then
         # CVE Scan
-        trivy_scan "--scanners vuln" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "${d8_image}:${d8_tag}"
+        image_to_scan="${d8_image}${IMAGE_NAME/deckhouse-oss/""}" # replace deckhouse-oss with an empty string, but keep any other image_name for additional_image.
+        trivy_scan "--scanners vuln" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "${image_to_scan/"/:":"}:${d8_tag}"
         # License scan
-        trivy_scan "--scanners license --license-full" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report_license.json" "${d8_image}:${d8_tag}"
+        trivy_scan "--scanners license --license-full" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report_license.json" "${image_to_scan/"/:":"}:${d8_tag}"
       else
         # CVE Scan
         trivy_scan "--scanners vuln" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "${d8_image}@${IMAGE_HASH}"

--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -259,10 +259,10 @@ for d8_tag in "${d8_tags[@]}"; do
       echo ""
       if [ "${additional_image_detected}" == true ]; then
         # CVE Scan
-        image_to_scan="${d8_image}${IMAGE_NAME/deckhouse-oss/""}" # replace deckhouse-oss with an empty string, but keep any other image_name for additional_image.
-        trivy_scan "--scanners vuln" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "${image_to_scan/"/:":"}:${d8_tag}"
+        image_to_scan="${d8_image}${IMAGE_NAME/deckhouse-oss/""}:${d8_tag}" # replace deckhouse-oss with an empty string, but keep any other image_name for additional_image.
+        trivy_scan "--scanners vuln" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "${image_to_scan/"/:"/:}"
         # License scan
-        trivy_scan "--scanners license --license-full" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report_license.json" "${image_to_scan/"/:":"}:${d8_tag}"
+        trivy_scan "--scanners license --license-full" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report_license.json" "${image_to_scan/"/:"/:}"
       else
         # CVE Scan
         trivy_scan "--scanners vuln" "${module_reports}/d8_${MODULE_NAME}_${IMAGE_NAME}_report.json" "${d8_image}@${IMAGE_HASH}"


### PR DESCRIPTION
## Description

Fixes a bug with scanning the same additional image for deckhouse-controller and dhctl by replacing deckhouse-oss in the variable with an empty string

## Why do we need it, and what problem does it solve?

Previously, only deckhouse-oss:main was scanned from additional images, and the same image was checked on dhctl. The fix allows you to send a valid dhctl image for scanning and any other additional image that will be added to the array of additional images in the future.

## Why do we need it in the patch release (if we do)?

Not required.
This is a CI improvement that fixes an error when scanning a dhctl cve image and can be safely included in a regular release cycle.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix CVE scans
impact: The correct image for dhctl will be scanned.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
