### PR TITLE
[candi] kubernetes-api-proxy fix

### DIFF
--- a/candi/bashible/common-steps/all/051_pull_and_configure_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/051_pull_and_configure_kubernetes_api_proxy.sh.tpl
@@ -36,11 +36,11 @@ spec:
   hostNetwork: true
   securityContext:
     fsGroup: 64535
+  shareProcessNamespace: true
   containers:
   - name: kubernetes-api-proxy
     securityContext:
       allowPrivilegeEscalation: false
-      shareProcessNamespace: true
       capabilities:
         drop:
         - ALL
@@ -72,7 +72,6 @@ spec:
     command: ["/kubernetes-api-proxy-reloader"]
     securityContext:
       allowPrivilegeEscalation: false
-      shareProcessNamespace: true
       capabilities:
         drop:
         - ALL

--- a/modules/040-control-plane-manager/images/kubernetes-api-proxy/reloader/src/watcher.go
+++ b/modules/040-control-plane-manager/images/kubernetes-api-proxy/reloader/src/watcher.go
@@ -51,7 +51,10 @@ func nginxReload() error {
 		return nil
 	}
 
-	output, err := exec.Command("nginx", "-t", "-c", nginxNewConf).CombinedOutput()
+	log.Printf("%s differs from %s, validating and reloading nginx...", nginxNewConf, nginxConf)
+
+	// Force nginx to log config test errors to stderr.
+	output, err := exec.Command("nginx", "-t", "-c", nginxNewConf, "-e", "/dev/stderr", "-g", "error_log stderr;").CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("nginx configuration test failed: %s", string(output))
 	}
@@ -67,6 +70,7 @@ func nginxReload() error {
 		return fmt.Errorf("failed to send SIGHUP to nginx process: %s", err)
 	}
 
+	log.Printf("nginx reload finished successfully")
 	return nil
 }
 


### PR DESCRIPTION
## Description

fixed kubernetes-api-proxy-reloader which was broken in  https://github.com/deckhouse/deckhouse/commit/ac9d118245ca244bac236279a55ccfc400be7570

## Why do we need it, and what problem does it solve?

fixes the issue of configuration reloading via kubernetes-api-proxy-reloader

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary:  fixes the issue of configuration reloading via kubernetes-api-proxy-reloader
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
