### PR TITLE
[documentation] Fix a logic bug in the build instructions

### DIFF
--- a/docs/site/werf-docs-builder.inc.yaml
+++ b/docs/site/werf-docs-builder.inc.yaml
@@ -12,7 +12,7 @@ import:
   before: setup
 - image: d8-docs-artifacts
   add: /export/embedded_modules.json
-  to: /app/hugo/data/dkp/embedded_modules.json
+  to: /app/hugo-init/data/dkp/embedded_modules.json
   before: setup
 imageSpec:
   config:


### PR DESCRIPTION
## Description

Fixed a logic bug in the build instructions. The bug was in the `excludePaths:` block, which was incorrecty applied to the mounts instead of docs-builder-template.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: documentation
type: chore
summary: Fixed a logic bug in the build instructions.
impact_level: low
```
