### PR TITLE
[candi] auditd may cause node freeze fix

### DIFF
--- a/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
+++ b/candi/bashible/common-steps/all/041_configure_sysctl_tuner.sh.tpl
@@ -99,9 +99,9 @@ echo 0 | tee /sys/kernel/mm/transparent_hugepage/use_zero_page >/dev/null
 echo 0 | tee /sys/kernel/mm/transparent_hugepage/khugepaged/defrag >/dev/null
 echo 0 | tee /proc/sys/net/ipv4/conf/*/rp_filter >/dev/null # disable reverse-path filtering on all interfaces
 
-# auditd: do not block the system when the auditd backlog is full.
+# auditd: increase kernel backlog
 if command -v auditctl &>/dev/null; then
-  auditctl --backlog_wait_time 0 -b 65536 || echo "auditctl backlog configuration failed, continuing without it" >&2
+  auditctl -b 65536 || echo "auditctl backlog configuration failed, continuing without it"
 fi
 EOF
 chmod +x /opt/deckhouse/bin/sysctl-tuner

--- a/candi/bashible/common-steps/all/098_configure_auditd.sh.tpl
+++ b/candi/bashible/common-steps/all/098_configure_auditd.sh.tpl
@@ -46,13 +46,12 @@ if [ -d /etc/audit/rules.d ]; then
 EOF
   bb-sync-file /etc/audit/rules.d/z99-deckhouse.rules - << "EOF"
 -b 65536
---backlog_wait_time 0
 EOF
 fi
 if command -v auditctl &>/dev/null; then
-  auditctl --backlog_wait_time 0 -b 65536 || bb-log-warning "failed to configure auditctl backlog; continuing with defaults"
+  auditctl -b 65536 || bb-log-warning "failed to configure auditctl backlog, continuing with defaults"
 else
-  bb-log-info "auditctl is not installed; skipping backlog configuration"
+  bb-log-info "auditctl is not installed, skipping backlog configuration"
 fi
 
 {{- end }}


### PR DESCRIPTION
## Description

follow https://github.com/deckhouse/deckhouse/pull/15986

Some distributions build `auditctl` without support for `--backlog_wait_time`.
Therefore, we simply rely on:
a) an increased backlog and a reduced number of audit events, and
b) Linux 6.x kernels, where this issue no longer exists.

## Why do we need it, and what problem does it solve?

In some legacy os, bootstrap crashes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: auditd may cause node freeze fix, now without --backlog_wait_time
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
