### PR TITLE
[candi] Add bashible check CVE-2025-37999

### DIFF
--- a/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
+++ b/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
@@ -122,7 +122,7 @@ function fail_fast() {
         fi
 
         if [ "$err" == "kernel_cve_2025_37999" ]; then
-          bb-log-error "Linux kernels 6.12.0–6.12.28 and 6.14.0–6.14.6 are affected by CVE-2025-37999 (EROFS)"
+          bb-log-error "Linux kernels 6.12.0–6.12.28 and 6.14.0–6.14.6 have issues with EROFS functionality (CVE-2025-37999). Kernel upgrade required to proceed."
         fi
     done
     bb-log-error "containerd V2 is not supported"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add kernel compatibility check for containerdV2 during bashible phase.
If the current kernel version is affected by CVE-2025-37999, installation of containerdV2 will be prevented:

```bash
=== Step: /var/lib/bashible/bundle_steps/000_check_containerd_v2_support.sh
===
bash [ERROR] Linux kernels 6.12.0–6.12.28 and 6.14.0–6.14.6 are affected by CVE-2025-37999 (EROFS)
bash [ERROR] containerd V2 is not supported
Failed to execute step /var/lib/bashible/bundle_steps/000_check_containerd_v2_support.sh ... retry in 10 seconds.
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Some kernel versions are incompatible with containerdV2 due to [CVE-2025-37999](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2025-37999).
This prevents Bashible from installing containerdV2 on kernels:
 - 6.12.0 – 6.12.28
 - 6.14.0 – 6.14.6

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
No need

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Add kernel compatibility check for containerdV2 in Bashible
impact: Prevents Bashible from installing containerdV2 on kernel versions 6.12.0–6.12.28 and 6.14.0–6.14.6 due to CVE-2025-37999
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
