### PR TITLE
[admission-policy-engine] Add a filter that allows vulnerable images with only specified severity levels to run

### DIFF
--- a/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
+++ b/ee/modules/015-admission-policy-engine/templates/trivy-provider/statefulset.yaml
@@ -3,6 +3,8 @@ cpu: 100m
 memory: 128Mi
 {{- end }}
 
+{{ $allowedSeverityLevels := dig "denyVulnerableImages" "allowedSeverityLevels" nil .Values.admissionPolicyEngine }}
+
 {{- if include "trivy.provider.enabled" $ }}
   {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -66,6 +68,10 @@ spec:
           - --client-ca-file=/client-cert/ca.crt
           - --timeout=25
         env:
+       {{ if $allowedSeverityLevels }}
+        - name: ALLOWED_SEVERITIES
+          value: {{ $allowedSeverityLevels | join "," }}
+       {{ end }}
         - name: TRIVY_REMOTE_URL
           value: "http://trivy-server.d8-operator-trivy:4954"
         - name: TRIVY_JAVA_DB_IMAGE

--- a/modules/015-admission-policy-engine/openapi/config-values.yaml
+++ b/modules/015-admission-policy-engine/openapi/config-values.yaml
@@ -63,6 +63,13 @@ properties:
     description: |
       Trivy provider will deny creation of the `Pod`/`Deployment`/`StatefulSet`/`DaemonSet` with vulnerable images in namespaces with `security.deckhouse.io/trivy-provider: ""` label.
     properties:
+      allowedSeverityLevels:
+        type: array
+        description: |
+          Images containing only vulnerabilities of specified severities will not be denied.
+        items:
+          type: string
+          enum: ["UNKNOWN", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
       storageClass:
         type: string
         x-examples: ["ceph-ssd", "false"]

--- a/modules/015-admission-policy-engine/openapi/doc-ru-config-values.yaml
+++ b/modules/015-admission-policy-engine/openapi/doc-ru-config-values.yaml
@@ -34,14 +34,17 @@ properties:
 
       Trivy-провайдер запрещает создание `Pod`/`Deployment`/`StatefulSet`/`DaemonSet` с образами, которые имеют уязвимости в пространствах имен с лейблом `security.deckhouse.io/trivy-provider: ""`.
     properties:
+      allowedSeverityLevels:
+        description: |-
+          Образы контейнеров, содержащие только уязвимости указанных уровней критичности, не будут запрещены.
       storageClass:
         description: |-
           Имя StorageClass для использования `trivy_provider`.
-          
+
           Если значение не указано, то будет использоваться StorageClass, согласно настройке [глобального параметра storageClass](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-storageclass).
-         
+
           Настройка глобального параметра `storageClass` учитывается только при включении модуля. Изменение глобального параметра `storageClass` при включенном модуле не приведет к перезаказу диска.
-          
+
           **Внимание.** Если указать значение, отличное от текущего (используемого в существующей PVC), диск будет перезаказан, и все данные удалятся.
 
           Если указать `false`, будет принудительно использоваться `emptyDir`.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Implemented a feature that allows to run images that are vulnerable only to some specific severity levels

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Per user request

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: feature
summary: Added a filter that allows vulnerable images with only specified severity levels to run.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
