### PR TITLE
[docs] Fix permalinks in getting started documentation

### DIFF
--- a/docs/site/pages/getting_started/getting_started.html
+++ b/docs/site/pages/getting_started/getting_started.html
@@ -1,6 +1,6 @@
 ---
 title: "Getting started — Selecting infrastructure"
-permalink: en/gs/index.html
+permalink: en/gs/
 description: Step-by-step walkthroughs for installing Deckhouse Kubernetes Platform on top of any infrastructure.
 layout: page-nosidebar
 toc: false

--- a/docs/site/pages/getting_started/getting_started_ru.html
+++ b/docs/site/pages/getting_started/getting_started_ru.html
@@ -1,6 +1,6 @@
 ---
 title: "Быстрый старт — выбор инфраструктуры"
-permalink: ru/gs/index.html
+permalink: ru/gs/
 description: Пошаговый процесс установки Deckhouse Kubernetes Platform поверх любой инфраструктуры.
 layout: page-nosidebar
 lang: ru

--- a/docs/site/pages/stronghold/documentation/user/secrets-engines/index.md
+++ b/docs/site/pages/stronghold/documentation/user/secrets-engines/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-permalink: en/stronghold/documentation/user/secrets-engines/index.html
+permalink: en/stronghold/documentation/user/secrets-engines/
 lang: en
 description: Secrets engines are mountable engines that store or generate secrets in Stronghold.
 ---

--- a/docs/site/pages/stronghold/gs/getting_started.html
+++ b/docs/site/pages/stronghold/gs/getting_started.html
@@ -1,6 +1,6 @@
 ---
 title: "Selecting infrastructure"
-permalink: en/stronghold/gs/index.html
+permalink: en/stronghold/gs/
 layout: page-nosidebar
 toc: false
 ---

--- a/docs/site/pages/stronghold/gs/getting_started_ru.html
+++ b/docs/site/pages/stronghold/gs/getting_started_ru.html
@@ -1,6 +1,6 @@
 ---
 title: "Выбор инфраструктуры"
-permalink: ru/stronghold/gs/index.html
+permalink: ru/stronghold/gs/
 layout: page-nosidebar
 lang: ru
 toc: false


### PR DESCRIPTION
## Description

Updated the permalink structure for several documentation pages to remove the trailing `index.html` and use directory-style permalinks instead. This change helps standardize URLs and makes them cleaner and more consistent across the documentation site.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix permalinks in getting started documentation.
impact_level: low
```
