### PR TITLE
temporarily disable Secret scan job failure on findings

### DIFF
--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -223,6 +223,7 @@ jobs:
     steps:
       - name: Run Gitleaks diff scan
         uses: deckhouse/modules-actions/gitleaks@main
+        continue-on-error: true
         with:
           scan_mode: "diff"
           checkout_repo: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -751,6 +751,7 @@ jobs:
     steps:
       - name: Run Gitleaks diff scan
         uses: deckhouse/modules-actions/gitleaks@main
+        continue-on-error: true
         with:
           scan_mode: "diff"
           checkout_repo: ${{ github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Description

Added `continue-on-error: true` for the **Gitleaks diff scan** step in `validation.yml`.  
This is a temporary measure during the initial rollout of secret scanning.

## Why do we need it, and what problem does it solve?

We’ve just introduced **Gitleaks** to the main repository, and at this stage there are many false positives.  
To avoid blocking the CI pipeline and developer workflows, we temporarily allow the job to pass even if potential secrets are found.  
Reports and GitHub summary outputs remain available as before.

Once the configuration and `.gitleaksignore` are fine-tuned, this flag will be removed.

## Checklist
- [x] Gitleaks diff scan no longer blocks the pipeline on findings.  
- [x] Reports and summaries remain unchanged.

## Changelog entries
```changes
section: ci
type: chore
summary: Temporarily allow Gitleaks job to continue on findings (reduce false positives during initial rollout)
impact_level: low