### PR TITLE
[cloud-provider-aws] fix ssh access sg creation even with disableDefaultSecurityGroup passed

### DIFF
--- a/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
+++ b/candi/cloud-providers/aws/layouts/with-nat/base-infrastructure/main.tf
@@ -228,6 +228,11 @@ locals {
 
   root_volume_size = lookup(local.instance_class, "diskSizeGb", 20)
   root_volume_type = lookup(local.instance_class, "diskType", "gp2")
+  bastion_sg_from_module = local.disable_default_sg ? [] : compact([
+    coalesce(module.security-groups.security_group_id_node, ""),
+    coalesce(module.security-groups.security_group_id_ssh_accessible, "")
+  ])
+  bastion_vpc_sg_ids = concat(local.bastion_sg_from_module, local.additional_security_groups)
 }
 
 resource "aws_instance" "bastion" {
@@ -236,7 +241,7 @@ resource "aws_instance" "bastion" {
   instance_type          = local.instance_class.instanceType
   key_name               = local.prefix
   subnet_id              = local.subnet_id
-  vpc_security_group_ids = compact(concat([module.security-groups.security_group_id_node, module.security-groups.security_group_id_ssh_accessible], local.additional_security_groups))
+  vpc_security_group_ids = local.bastion_vpc_sg_ids
   source_dest_check      = false
   iam_instance_profile   = "${local.prefix}-node"
 

--- a/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
+++ b/candi/cloud-providers/aws/terraform-modules/security-groups/main.tf
@@ -88,14 +88,14 @@ resource "aws_security_group_rule" "allow-all-outgoing-traffic-to-nodes" {
 }
 
 resource "aws_security_group" "ssh-accessible" {
-  count       = var.disable_default_security_group && length(var.ssh_allow_list) == 0 ? 0 : 1
+  count  = (!var.disable_default_security_group && length(var.ssh_allow_list) > 0) ? 1 : 0
   name        = "${var.prefix}-ssh-accessible"
   vpc_id      = var.vpc_id
   tags        = var.tags
 }
 
 resource "aws_security_group_rule" "allow-ssh-for-everyone" {
-  count             = var.disable_default_security_group && length(var.ssh_allow_list) == 0 ? 0 : 1
+  count             = (!var.disable_default_security_group && length(var.ssh_allow_list) > 0) ? 1 : 0
   type              = "ingress"
   from_port         = 22
   to_port           = 22


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
fix ssh access sg creation even with disableDefaultSecurityGroup passed
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
this is the behavior that users expect
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: fix ssh access sg creation with disableDefaultSecurityGroup passed
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
