### PR TITLE
[docs] Add note about tunnelMode in yandex cloud static setup

### DIFF
--- a/modules/021-cni-cilium/openapi/config-values.yaml
+++ b/modules/021-cni-cilium/openapi/config-values.yaml
@@ -49,7 +49,7 @@ properties:
 
       > Note! VXLAN mode is not compatible with following bpfLBMode modes: Hybrid, DSR. bpfLBMode will be overriden to SNAT if the tunnelMode is VXLAN.
       
-      > Note! Disabled mode is not compatible with clouds that have limitations in the operation of OSI Layer 2 (L2) networking technologies. Such clouds include Yandex Cloud, AWS, and GCP.
+      > Note! The Disabled mode is not compatible with cloud providers such as Yandex Cloud, AWS, and GCP, which have limitations in the operation of network technologies of the second level of the OSI model (L2).
   svcSourceRangeCheck:
     type: boolean
     default: false

--- a/modules/021-cni-cilium/openapi/doc-ru-config-values.yaml
+++ b/modules/021-cni-cilium/openapi/doc-ru-config-values.yaml
@@ -36,7 +36,7 @@ properties:
 
       > Внимание! Режим VXLAN не совместим со следующими режимами bpfLBMode: Hybrid, DSR. Если tunnelMode настроен на VXLAN, то bpfLBMode будет переопределён на SNAT автоматически.
 
-      > Внимание! Режим Disabled не совместим с облаками, которые имеют ограничения работы сетевых технологий второго уровня модели OSI(L2). К таким облакам относятся Yandex Cloud, AWS, GCP.
+      > Внимание! Режим Disabled не совместим с такими облачными провайдерами как Yandex Cloud, AWS, GCP, которые имеют ограничения работы сетевых технологий второго уровня модели OSI(L2).
   svcSourceRangeCheck:
     description: |
       Для сервисов с типом `loadBalancer` включает проверку source IP на его соответствие [loadBalancer.sourceRanges](../ingress-nginx/cr.html#ingressnginxcontroller-v1-spec-loadbalancer-sourceranges).


### PR DESCRIPTION
## Description
Added a note about using cilium direct tunnel mode in Yandex Cloud

## Why do we need it, and what problem does it solve?
This note describes important points for setting up Cilium in Yandex Cloud.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Add note about tunnelMode in yandex cloud static setup.
impact_level: low
```

<!---
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
-->
