### PR TITLE
[registrypackages] add vex for d8

### DIFF
--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -1,0 +1,66 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 4,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2024-9675"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/containers/buildah@v1.37.6"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта уязвимость не может быть эксплуатирована при использовании бекенда Docker, который включён по умолчанию в Delivery Kit. В этом режиме Docker-демон запрещает произвольное монтирование директорий, исключая возможность эксплуатации уязвимости. Уязвимость актуальна только при использовании бекенда Buildah, который включается установкой переменной окружения WERF_BUILDAH_MODE=on.",
+      "timestamp": "2025-10-09T14:21:14.710165495Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-0495"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/buildx@v0.13.0-rc2"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта уязвимость не может быть эксплуатирована при использовании Delivery Kit, так как он не использует сборочный бекенд Docker BuildKit, в котором проявляется уязвимость. Delivery Kit форсирует Docker использовать бекенд по умолчанию. Уязвимость актуальна только при использовании бекенда Docker Buildkit, который включается установкой переменной окружения DOCKER_BUILDKIT=1.",
+      "timestamp": "2025-10-09T14:21:14.78894747Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-54410"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/docker@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта уязвимость не эксплуатируется в Delivery Kit. Она проявляется только в работе демона Docker (dockerd), который является внешней зависимостью и не входит в состав Delivery Kit. Delivery Kit взаимодействует с Docker через его API и использует пакет github.com/docker/docker исключительно как клиентскую библиотеку. Внутренние компоненты Delivery Kit не управляют сетевыми правилами и не выполняют операций, связанных с Firewalld, в котором и проявляется уязвимость.",
+      "timestamp": "2025-10-09T14:21:14.86863865Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-8869"
+      },
+      "products": [
+        {
+          "@id": "pip:25.0.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Функционал извлечения tar-архивов с использованием уязвимого fallback-кода pip версии 25.0.1 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Все используемые версии Python соответствуют требованиям PEP 706, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2025-10-09T14:31:32.069712443Z"
+    }
+  ],
+  "timestamp": "2025-10-09T14:21:14Z",
+  "last_updated": "2025-10-09T14:21:14Z"
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: add vex to registrypackages d8
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
