### PR TITLE
[prometheus] Add ingressClassName to grafana/prometheus redirect ingress

### DIFF
--- a/modules/300-prometheus/templates/grafana/ingress-grafana-redirect.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress-grafana-redirect.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "grafana-v10")) | nindent 2 }}
   annotations:
-    nginx.ingress.kubernetes.io/permanent-redirect: {{ printf "%s://%s/monitoring/dashboard" (ternary "https" "http" (include "helm_lib_module_https_ingress_tls_enabled" .)) (include "helm_lib_module_public_domain" (list . "console")) | quote }}
+    nginx.ingress.kubernetes.io/permanent-redirect: {{ printf "%s://%s/monitoring/dashboard" (ternary "https" "http" (ne (include "helm_lib_module_https_ingress_tls_enabled" .) "")) (include "helm_lib_module_public_domain" (list . "console")) | quote }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{ include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
 spec:

--- a/modules/300-prometheus/templates/prometheus/ingress-prometheus-redirect.yaml
+++ b/modules/300-prometheus/templates/prometheus/ingress-prometheus-redirect.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: d8-monitoring
   {{- include "helm_lib_module_labels" (list . (dict "app" "grafana-v10")) | nindent 2 }}
   annotations:
-    nginx.ingress.kubernetes.io/permanent-redirect: {{ printf "%s://%s/monitoring/monitoring/pods" (ternary "https" "http" (include "helm_lib_module_https_ingress_tls_enabled" .)) (include "helm_lib_module_public_domain" (list . "console")) | quote }}
+    nginx.ingress.kubernetes.io/permanent-redirect: {{ printf "%s://%s/monitoring/monitoring/pods" (ternary "https" "http" (ne (include "helm_lib_module_https_ingress_tls_enabled" .) "")) (include "helm_lib_module_public_domain" (list . "console")) | quote }}
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       {{ include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}


### PR DESCRIPTION
## Description
Add ingressClassName to grafana/prometheus redirect ingress, add check for tls spec based on https mode, make redirect domain to http if tls disabled.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
When grafana disabled we create redirects from old ingresses to Console domain. But we don't have ingressClassName option in this redirect ingresses.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
I think we don't
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Added `ingressClassName` to the `grafana/prometheus` redirect Ingress.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
