### PR TITLE
[cloud-provider-dvp] Stop preferring fqdn to hostname in cloud-init

### DIFF
--- a/candi/cloud-providers/dvp/terraform-modules/master/templates/cloudinit.tftpl
+++ b/candi/cloud-providers/dvp/terraform-modules/master/templates/cloudinit.tftpl
@@ -2,6 +2,7 @@ ${user_data}
 
 #cloud-config
 hostname: ${host_name}
+prefer_fqdn_over_hostname: false
 ssh_authorized_keys:
   - "${ssh_public_key}"
 

--- a/candi/cloud-providers/dvp/terraform-modules/static-node/templates/cloudinit.tftpl
+++ b/candi/cloud-providers/dvp/terraform-modules/static-node/templates/cloudinit.tftpl
@@ -2,6 +2,7 @@ ${user_data}
 
 #cloud-config
 hostname: ${host_name}
+prefer_fqdn_over_hostname: false
 ssh_authorized_keys:
   - "${ssh_public_key}"
 

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -7,6 +7,7 @@
 mounts:
 - [ ephemeral0, /mnt/resource ]
   {{- end }}
+prefer_fqdn_over_hostname: false
 package_update: false
 package_upgrade: false
 manage_etc_hosts: localhost

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -7,7 +7,6 @@
 mounts:
 - [ ephemeral0, /mnt/resource ]
   {{- end }}
-prefer_fqdn_over_hostname: false
 package_update: false
 package_upgrade: false
 manage_etc_hosts: localhost
@@ -41,7 +40,9 @@ runcmd:
 
 ssh_authorized_keys:
 - {{ $context.Values.nodeManager.internal.cloudProvider.sshPublicKey| default "" | quote }}
+{{- if ($context.Values.global.enabledModules | has "cloud-provider-dvp") }}
 prefer_fqdn_over_hostname: false
+{{- end }}
 package_update: false
 package_upgrade: false
 manage_etc_hosts: localhost

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -40,9 +40,6 @@ runcmd:
 
 ssh_authorized_keys:
 - {{ $context.Values.nodeManager.internal.cloudProvider.sshPublicKey| default "" | quote }}
-{{- if ($context.Values.global.enabledModules | has "cloud-provider-dvp") }}
-prefer_fqdn_over_hostname: false
-{{- end }}
 package_update: false
 package_upgrade: false
 manage_etc_hosts: localhost

--- a/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
+++ b/modules/040-node-manager/templates/node-group/_cloud_init_cloud_config.tpl
@@ -41,6 +41,7 @@ runcmd:
 
 ssh_authorized_keys:
 - {{ $context.Values.nodeManager.internal.cloudProvider.sshPublicKey| default "" | quote }}
+prefer_fqdn_over_hostname: false
 package_update: false
 package_upgrade: false
 manage_etc_hosts: localhost


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Updated cloud-init configs for cloud-provider-dvp with `prefer_fqdn_over_hostname: false` option.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It's necessary for RPM-based OSs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Stopped preferring FQDN to hostname in cloud-init configurations.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
