### PR TITLE
[log-shipper] Fix typo in D8LogShipperDestinationErrors alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1888,7 +1888,7 @@ alerts:
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        d8 k -n d8-log-shipper logs {{ $labels.host }}` -c vector
+        d8 k -n d8-log-shipper logs {{ $labels.host }} -c vector
         ```
       summary: |
         The log-shipper-agent pods can't send logs to {{ $labels.component_id }} on the {{ $labels.node }} node.

--- a/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
+++ b/modules/460-log-shipper/monitoring/prometheus-rules/log-shipper-agent.yaml
@@ -90,7 +90,7 @@
         To resolve this, check the pod logs or follow advanced instructions:
 
         ```bash
-        d8 k -n d8-log-shipper logs {{ $labels.host }}` -c vector
+        d8 k -n d8-log-shipper logs {{ $labels.host }} -c vector
         ```
 
   - alert: D8LogShipperCollectLogErrors


### PR DESCRIPTION
## Description

Fix typo in D8LogShipperDestinationErrors alert


## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: log-shipper
type: fix
summary: Fix typo in D8LogShipperDestinationErrors alert.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
