### PR TITLE
[ci] Move changelog back to public runner

### DIFF
--- a/.github/workflows/changelog-by-milestone.yml
+++ b/.github/workflows/changelog-by-milestone.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   condition_check:
     name: Check conditions
-    runs-on: "regular"
+    runs-on: ubuntu-latest
     steps:
       - name: Check PR
         id: pr
@@ -88,7 +88,7 @@ jobs:
     needs: condition_check
     if: needs.condition_check.outputs.ok == 'ok'
     name: Open Milestones
-    runs-on: "regular"
+    runs-on: ubuntu-latest
     steps:
       - name: Find Open Milestones
         id: milestones
@@ -110,7 +110,7 @@ jobs:
   changelogs:
     if: needs.milestones.outputs.count > 0
     name: Changelog ${{ matrix.milestone.title }}
-    runs-on: "regular"
+    runs-on: ubuntu-latest
     needs: milestones
     strategy:
       max-parallel: 1


### PR DESCRIPTION
## Description
Move changelog back to public runner.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Move changelog back to public runner.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
