### PR TITLE
[docs] Update security event audit documentation

### DIFF
--- a/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT.md
+++ b/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT.md
@@ -307,6 +307,7 @@ kind: ModuleConfig
 metadata:
   name: runtime-audit-engine
 spec:
+  version: 1
   enabled: true
   settings:
     debugLogging: true

--- a/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT_RU.md
+++ b/docs/documentation/pages/admin/configuration/security/RUNTIME-AUDIT_RU.md
@@ -300,7 +300,7 @@ d8 k -n d8-monitoring exec -it prometheus-main-0 prometheus -- \
 В Falco по умолчанию используется отладочный уровень логирования `debug`.
 
 В Falcosidekick по умолчанию отладочное логирование отключено.
-Для включения установите [параметр `spec.settings.debugLogging`](/modules/runtime-audit-engine/configuration.html#parameters-debuglogging) в `true`, следуя примеру
+Для включения установите [параметр `spec.settings.debugLogging`](/modules/runtime-audit-engine/configuration.html#parameters-debuglogging) в `true`, следуя примеру:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -308,6 +308,7 @@ kind: ModuleConfig
 metadata:
   name: runtime-audit-engine
 spec:
+  version: 1
   enabled: true
   settings:
     debugLogging: true

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT.md
@@ -306,6 +306,7 @@ kind: ModuleConfig
 metadata:
   name: runtime-audit-engine
 spec:
+  version: 1
   enabled: true
   settings:
     debugLogging: true

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/security/RUNTIME-AUDIT_RU.md
@@ -299,7 +299,7 @@ d8 k -n d8-monitoring exec -it prometheus-main-0 prometheus -- \
 В Falco по умолчанию используется отладочный уровень логирования `debug`.
 
 В Falcosidekick по умолчанию отладочное логирование отключено.
-Для включения установите [параметр `spec.settings.debugLogging`](/modules/runtime-audit-engine/configuration.html#parameters-debuglogging) в `true`, следуя примеру
+Для включения установите [параметр `spec.settings.debugLogging`](/modules/runtime-audit-engine/configuration.html#parameters-debuglogging) в `true`, следуя примеру:
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -307,6 +307,7 @@ kind: ModuleConfig
 metadata:
   name: runtime-audit-engine
 spec:
+  version: 1
   enabled: true
   settings:
     debugLogging: true


### PR DESCRIPTION
## Description

This PR adds missing version parameter to `runtime-audit-engine` configuration example.

## Changelog entries

```changes
section: docs
type: chore
summary: Added missing version parameter to `runtime-audit-engine` configuration example.
impact_level: low
```