### PR TITLE
[admission-policy-engine] Prohibit only creation or modification for objects with vulnerable images

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/vulnerable-images.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/vulnerable-images.yaml
@@ -14,14 +14,14 @@ spec:
         kind: D8VulnerableImages
   targets:
     - target: admission.k8s.gatekeeper.sh
-      rego: |
+      rego: |-
         package d8.vulnerableimages
 
         violation[{"msg": msg}] {
           images := [img | img = retrieve_images[_]]
           response := external_data({"provider": "trivy-provider", "keys": images})
 
-          response_deny_request(response)
+          response_deny_request(response, input.review.operation)
           msg := sprintf("request denied: %v", [response])
         }
 
@@ -45,10 +45,12 @@ spec:
           imgs := input.review.object.spec.template.spec.initContainers[_].image
         }
 
-        response_deny_request(response) {
+        response_deny_request(response, operation) {
+          not operation == "DELETE"
           count(response.errors) > 0
         }
 
-        response_deny_request(response) {
+        response_deny_request(response, operation) {
+          not operation == "DELETE"
           count(response.system_error) > 0
         }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Allowed to delete vulnerable pods from namespaces controlled with admission-policy-engine's `security.deckhouse.io/trivy-provider` label.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This fixes bad ux where, if `denyVulnerableImages` is enabled in settings, you are completely losing control over workloads with vulnerable image references as webhook would deny any request touching them. We make an exeption for deletions now.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Prohibit only creation or modification for objects with vulnerable images
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
