### PR TITLE
[docs] Translate Prometheus module docs

### DIFF
--- a/modules/200-operator-prometheus/docs/README.md
+++ b/modules/200-operator-prometheus/docs/README.md
@@ -60,58 +60,58 @@ In `scrape_configs`, a set of `scrape job`s is defined — logical descriptions 
 
 ```yaml
 scrape_configs:
-# General settings.
-- job_name: d8-monitoring/custom/0    # Name of the scrape job, shown in the Service Discovery section.
-scrape_interval: 30s                  # How often to scrape data.
-scrape_timeout: 10s                   # Request timeout.
-metrics_path: /metrics                # HTTP path.
-scheme: http                          # HTTP or HTTPS.
-# Service Discovery settings.
-kubernetes_sd_configs:                # Get targets from Kubernetes.
-- api_server: null                    # API server address is taken from environment variables (present in every Pod).
-  role: endpoints                     # Use endpoints as targets.
-  namespaces:
-    names:                            # Restrict the list of namespaces.
-    - foo
-    - baz
-# Filtering settings (which endpoints to include/exclude) and relabeling (which labels to add or remove; applies to all scraped metrics).
-relabel_configs:
-# Filter by the value of the prometheus_custom_target label (taken from the Service associated with the endpoint).
-- source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
-  regex: .+                           # Any non-empty label.
-  action: keep
-# Filter by port name.
-- source_labels: [__meta_kubernetes_endpointslice_port_name]
-  regex: http-metrics                 # Only the port named http-metrics.
-  action: keep
-# Add the job label. Use the value of the prometheus_custom_target label on the Service, prefixed with "custom-".
-#
-# The job label:
-#    * defines the group name under which the target will appear;
-#    * is added to metrics for convenient filtering in rules and dashboards.
-- source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
-  regex: (.*)
-  target_label: job
-  replacement: custom-$1
-  action: replace
-# Add the namespace label.
-- source_labels: [__meta_kubernetes_namespace]
-  regex: (.*)
-  target_label: namespace
-  replacement: $1
-  action: replace
-# Add the service label.
-- source_labels: [__meta_kubernetes_service_name]
-  regex: (.*)
-  target_label: service
-  replacement: $1
-  action: replace
-# Add the instance label (will contain the Pod name).
-- source_labels: [__meta_kubernetes_pod_name]
-  regex: (.*)
-  target_label: instance
-  replacement: $1
-  action: replace
+  # General settings.
+  - job_name: d8-monitoring/custom/0    # Name of the scrape job, shown in the Service Discovery section.
+    scrape_interval: 30s                  # How often to scrape data.
+    scrape_timeout: 10s                   # Request timeout.
+    metrics_path: /metrics                # HTTP path.
+    scheme: http                          # HTTP or HTTPS.
+    # Service Discovery settings.
+    kubernetes_sd_configs:                # Get targets from Kubernetes.
+    - api_server: null                    # API server address is taken from environment variables (present in every Pod).
+      role: endpoints                     # Use endpoints as targets.
+      namespaces:
+        names:                            # Restrict the list of namespaces.
+        - foo
+        - baz
+    # Filtering settings (which endpoints to include/exclude) and relabeling (which labels to add or remove; applies to all scraped metrics).
+    relabel_configs:
+    # Filter by the value of the prometheus_custom_target label (taken from the Service associated with the endpoint).
+    - source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
+      regex: .+                           # Any non-empty label.
+      action: keep
+    # Filter by port name.
+    - source_labels: [__meta_kubernetes_endpointslice_port_name]
+      regex: http-metrics                 # Only the port named http-metrics.
+      action: keep
+    # Add the job label. Use the value of the prometheus_custom_target label on the Service, prefixed with "custom-".
+    #
+    # The job label:
+    #    * defines the group name under which the target will appear;
+    #    * is added to metrics for convenient filtering in rules and dashboards.
+    - source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
+      regex: (.*)
+      target_label: job
+      replacement: custom-$1
+      action: replace
+    # Add the namespace label.
+    - source_labels: [__meta_kubernetes_namespace]
+      regex: (.*)
+      target_label: namespace
+      replacement: $1
+      action: replace
+    # Add the service label.
+    - source_labels: [__meta_kubernetes_service_name]
+      regex: (.*)
+      target_label: service
+      replacement: $1
+      action: replace
+    # Add the instance label (will contain the Pod name).
+    - source_labels: [__meta_kubernetes_pod_name]
+      regex: (.*)
+      target_label: instance
+      replacement: $1
+      action: replace
 ```
 
 Thus, Prometheus automatically tracks the addition and removal of:

--- a/modules/200-operator-prometheus/docs/README_RU.md
+++ b/modules/200-operator-prometheus/docs/README_RU.md
@@ -60,58 +60,58 @@ description: "Установка и управление системой мон
 
 ```yaml
 scrape_configs:
-# Общие настройки.
-- job_name: d8-monitoring/custom/0    # Название scrape job, показывается в разделе Service Discovery.
-scrape_interval: 30s                  # Как часто собирать данные.
-scrape_timeout: 10s                   # Таймаут на запрос.
-metrics_path: /metrics                # HTTP-путь.
-scheme: http                          # HTTP или HTTPS.
-# Настройки Service Discovery.
-kubernetes_sd_configs:                # Брать цели из Kubernetes.
-- api_server: null                    # Адрес API-сервера используется из переменных окружения (переменные есть в каждом поде).
-  role: endpoints                     # Брать цели из эндпоинтов.
-  namespaces:
-    names:                            # Ограничение спика пространств имён.
-    - foo
-    - baz
-# Настройки фильтрации (какие эндпоинты брать, а какие нет) и relabeling'а (какие лейблы добавить или удалить, распостраняется на все получаемые метрики).
-relabel_configs:
-# Фильтр по значению лейбла prometheus_custom_target (полученного из связанного с эндпоинтом сервиса).
-- source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
-  regex: .+                           # Любой не пустой лейбл.
-  action: keep
-# Фильтр по имени порта.
-- source_labels: [__meta_kubernetes_endpointslice_port_name]
-  regex: http-metrics                 # Только порт с именем http-metrics.
-  action: keep
-# Добавление лейбла job. Используйте значение лейбла prometheus_custom_target у сервиса, к которому добавлен префикс "custom-".
-#
-# Лейбл job:
-#    * определяет название группы, в которой будет показываться цель мониторинга;
-#    * добавляется к метрикам для удобной фильтрации в правилах и дашбордах.
-- source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
-  regex: (.*)
-  target_label: job
-  replacement: custom-$1
-  action: replace
-# Добавление лейбла namespace.
-- source_labels: [__meta_kubernetes_namespace]
-  regex: (.*)
-  target_label: namespace
-  replacement: $1
-  action: replace
-# Добавление лейбла service.
-- source_labels: [__meta_kubernetes_service_name]
-  regex: (.*)
-  target_label: service
-  replacement: $1
-  action: replace
-# Добавление лейбла instance (в котором будет имя пода).
-- source_labels: [__meta_kubernetes_pod_name]
-  regex: (.*)
-  target_label: instance
-  replacement: $1
-  action: replace
+  # Общие настройки.
+  - job_name: d8-monitoring/custom/0    # Название scrape job, показывается в разделе Service Discovery.
+    scrape_interval: 30s                  # Как часто собирать данные.
+    scrape_timeout: 10s                   # Таймаут на запрос.
+    metrics_path: /metrics                # HTTP-путь.
+    scheme: http                          # HTTP или HTTPS.
+    # Настройки Service Discovery.
+    kubernetes_sd_configs:                # Брать цели из Kubernetes.
+    - api_server: null                    # Адрес API-сервера используется из переменных окружения (переменные есть в каждом поде).
+      role: endpoints                     # Брать цели из эндпоинтов.
+      namespaces:
+        names:                            # Ограничение спика пространств имён.
+        - foo
+        - baz
+    # Настройки фильтрации (какие эндпоинты брать, а какие нет) и relabeling'а (какие лейблы добавить или удалить, распостраняется на все получаемые метрики).
+    relabel_configs:
+    # Фильтр по значению лейбла prometheus_custom_target (полученного из связанного с эндпоинтом сервиса).
+    - source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
+      regex: .+                           # Любой не пустой лейбл.
+      action: keep
+    # Фильтр по имени порта.
+    - source_labels: [__meta_kubernetes_endpointslice_port_name]
+      regex: http-metrics                 # Только порт с именем http-metrics.
+      action: keep
+    # Добавление лейбла job. Используйте значение лейбла prometheus_custom_target у сервиса, к которому добавлен префикс "custom-".
+    #
+    # Лейбл job:
+    #    * определяет название группы, в которой будет показываться цель мониторинга;
+    #    * добавляется к метрикам для удобной фильтрации в правилах и дашбордах.
+    - source_labels: [__meta_kubernetes_service_label_prometheus_custom_target]
+      regex: (.*)
+      target_label: job
+      replacement: custom-$1
+      action: replace
+    # Добавление лейбла namespace.
+    - source_labels: [__meta_kubernetes_namespace]
+      regex: (.*)
+      target_label: namespace
+      replacement: $1
+      action: replace
+    # Добавление лейбла service.
+    - source_labels: [__meta_kubernetes_service_name]
+      regex: (.*)
+      target_label: service
+      replacement: $1
+      action: replace
+    # Добавление лейбла instance (в котором будет имя пода).
+    - source_labels: [__meta_kubernetes_pod_name]
+      regex: (.*)
+      target_label: instance
+      replacement: $1
+      action: replace
 ```
 
 Таким образом, Prometheus автоматически отслеживает добавление и удаление:


### PR DESCRIPTION
## Description
Translate Prometheus module docs.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Translate Prometheus module docs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
