### PR TITLE
[docs] Fix displaying OpenAPI schemas

### DIFF
--- a/docs/documentation/_includes/toc_in_sidebar.html
+++ b/docs/documentation/_includes/toc_in_sidebar.html
@@ -89,7 +89,7 @@
                     const scrollOffset = targetElement.offset().top - headerHeight;
 
                     $('html, body').animate({
-                        scrollTop: scrollOffse - 10
+                        scrollTop: scrollOffset - 10
                     }, 0);
                 }
             }

--- a/docs/site/_includes/toc_in_sidebar.html
+++ b/docs/site/_includes/toc_in_sidebar.html
@@ -89,7 +89,7 @@
                     const scrollOffset = targetElement.offset().top - headerHeight;
 
                     $('html, body').animate({
-                        scrollTop: scrollOffse - 10
+                        scrollTop: scrollOffset - 10
                     }, 0);
                 }
             }

--- a/docs/site/backends/docs-builder-template/layouts/_partials/toc.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/toc.html
@@ -90,7 +90,7 @@
                 const scrollOffset = targetElement.offset().top - headerHeight;
 
                 $('html, body').animate({
-                    scrollTop: scrollOffse - 10
+                    scrollTop: scrollOffset - 10
                 }, 0);
             }
         }


### PR DESCRIPTION
## Description

This pull request updates the logic for handling sidebar navigation highlighting in the documentation table of contents for OpenAPI schemas.

Fixed a typo in the scroll animation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix displaying OpenAPI schemas
impact_level: low
```
