### PR TITLE
[ci] Add summary for compare_internal_modules

### DIFF
--- a/.github/scripts/python/compare_internal_modules.py
+++ b/.github/scripts/python/compare_internal_modules.py
@@ -20,6 +20,7 @@ import sys
 import re
 
 whitelist = [
+    ".*-vex-artifact",
     "base-for-go",
     "common-base",
     "common/shell-operator",
@@ -61,7 +62,7 @@ for edition in editions:
         unique_images.update(reports[edition].keys())
 
 # Find which images have more than one unique digest
-found = False
+found = []
 for image in unique_images:
     digests = set()
     for edition in editions:
@@ -69,13 +70,15 @@ for image in unique_images:
             digests.add(reports[edition][image]['DockerImageDigest'])
     if len(digests) > 1:
         if not [image for pattern in whitelist if re.fullmatch(pattern, image)]:
-            found = True
+            found.append(image)
             print(f'Found differing image digests for image {image}:')
         else:
             print(f'Found differing image digests for image {image} (allowed to differ):')
         for edition in editions:
             if image in reports[edition]:
                 print(f'\t{edition} digest: {reports[edition][image]['DockerImageDigest']}')
-
-if found:
+if len(found) > 0:
+    print("Found possibly dangerous differing images:")
+    for image in found:
+        print(image)
     sys.exit(1)


### PR DESCRIPTION
## Description
Add summary for internal modules compare script.

## Why do we need it, and what problem does it solve?
This change increases output readability.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add summary for internal modules compare script.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
