### PR TITLE
[docs] Fix the description for the 4239 port in the reference table

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -236,7 +236,7 @@ groups:
     protocol: TCP
     description:
       en: "`storage-status` agent healthcheck"
-      ru: "Healthcheck агента модуля `sds-node-configurator`"
+      ru: "Healthcheck агента модуля `storage-status`"
   - ports: "4240"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description

Fixed the description for the 4239 port in the reference table.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary: Fixed the description for the 4239 port in the reference table.
impact_level: low
```
