### PR TITLE
Remove Andrey Kolashtov from codeowners from module okmeter and upmeter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,8 +44,8 @@
 500-openvpn/                    @apolovov
 500-cilium-hubble/              @apolovov
 500-dashboard/                  @shvgn
-500-upmeter/                    @vladimirGuryanov @lazovskiy @kolashtov
-500-okmeter/                    @vladimirGuryanov @lazovskiy @kolashtov
+500-upmeter/                    @vladimirGuryanov @lazovskiy
+500-okmeter/                    @vladimirGuryanov @lazovskiy
 500-operator-trivy/             @yalosev @ldmonster
 600-secret-copier/              @nabokihms
 600-namespace-configurator/     @yalosev @ldmonster


### PR DESCRIPTION
## Description
Remove Andrey Kolashtov from the CODEOWNERS file for the okmeter and upmeter modules.

## Why do we need it and what problem does it solve?

This change is made at the request of Andrey Kolashtov.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: chore
summary: Removed Andrey Kolashtov from codeowners from module okmeter and upmeter.
impact_level:  low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
