### PR TITLE
[candi] d8-shutdown-inhibitor permissions fix

### DIFF
--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/install
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/scripts/install
@@ -8,6 +8,9 @@ set -Eeo pipefail
 mkdir -p /opt/deckhouse/bin
 cp -f d8-shutdown-inhibitor /opt/deckhouse/bin
 
+chown 0:0 /opt/deckhouse/bin/d8-shutdown-inhibitor
+chmod 700 /opt/deckhouse/bin/d8-shutdown-inhibitor
+
 # Install systemd unit.
 cp -f d8-shutdown-inhibitor.service /lib/systemd/system
 chmod 600 /lib/systemd/system/d8-shutdown-inhibitor.service

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/werf.inc.yaml
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/werf.inc.yaml
@@ -47,4 +47,6 @@ shell:
   setup:
   - cd /src/inhibitor
   - GOPROXY={{ .GOPROXY }} CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /d8-shutdown-inhibitor ./cmd/d8-shutdown-inhibitor
+  - chown 64535:64535 /d8-shutdown-inhibitor
+  - chmod 0755 /d8-shutdown-inhibitor
   - mv /src/scripts/* /


### PR DESCRIPTION
## Description

d8-shutdown-inhibitor permissions fix

## Why do we need it, and what problem does it solve?



## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: d8-shutdown-inhibitor permissions fix
impact: d8-shutdown-inhibitor permissions fix
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
