### PR TITLE
[dhctl] Add vex to install image

### DIFF
--- a/.werf/defines/vex.tmpl
+++ b/.werf/defines/vex.tmpl
@@ -9,6 +9,8 @@
   {{- $knownVulnPath := "" }}
   {{- if eq $imageName "dev" }}
     {{- $knownVulnPath = "/deckhouse-controller/known_vulnerabilities.vex" }}
+  {{- else if eq $imageName "dev/install" }}
+    {{- $knownVulnPath = "/dhctl/known_vulnerabilities.vex" }}
   {{- else }}
     {{- $knownVulnPath = (printf "/%smodules/%s-%s/images/%s/known_vulnerabilities.vex" $context.ModulePath $context.ModulePriority $context.ModuleName $context.ImageName) }}
   {{- end }}

--- a/.werf/werf-dev-install.yaml
+++ b/.werf/werf-dev-install.yaml
@@ -18,3 +18,6 @@ import:
 {{ include "controller_and_install_image_labels" . }}
     user: "0:0"
     cmd: ["/bin/bash"]
+---
+{{- include "vex mitigation" (list $ "dev/install") }}
+---

--- a/dhctl/known_vulnerabilities.vex
+++ b/dhctl/known_vulnerabilities.vex
@@ -1,0 +1,37 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-819396348420854c54b988d825529cab830b81f6a05730951c9bec690dc551f1",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-1767"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/k8s.io/kubernetes"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость CVE-2025-1767 связана с поведением kubelet при работе с GitRepo volume, terraform-provider-kubernetes не запускает kubelet и не инициирует монтирование gitRepo как исполнение кода - библиотека k8s.io/kubernetes используется только для типов/утилит, уязвимый код не используется в провайдере",
+      "timestamp": "2025-10-10T07:23:24.447174Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-30153"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/getkin/kin-openapi"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость CVE-2025-30153 связана с обработкой сжатых multipart/form-data запросов в компоненте ZipFileBodyDecoder библиотеки kin-openapi. terraform-provider-kubernetes использует kin-openapi только локально для чтения и валидации OpenAPI-схем, при этом прием multipart/form-data не реализован, уязвимый код не используется в провайдере",
+      "timestamp": "2025-10-10T07:23:24.420648Z"
+    }
+  ],
+  "timestamp": "2025-10-10T07:23:24Z"
+}


### PR DESCRIPTION
## Description

Add known_vulnerabilities to install image

## Why do we need it, and what problem does it solve?

To avoid false-positive vulnerabilities detection, we should add known_vulnerabilities.vex to install image

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add vex to install image
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
