### PR TITLE
[cni-cilium] Fixed connectivity dashboard

### DIFF
--- a/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
+++ b/modules/021-cni-cilium/monitoring/grafana-dashboards/kubernetes-cluster/cilium-ping-nodes.json
@@ -127,7 +127,7 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"node\",source_node_name=~\"${source_node:regex}\",target_node_name=~\"${destination_node:regex}\"}[$__range]) * 100",
+          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"node\",source_node_name=~\"${source_node}\",target_node_name=~\"${destination_node}\"}[$__range]) * 100",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,
@@ -227,7 +227,7 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"endpoint\",source_node_name=~\"${source_node:regex}\",target_node_name=~\"${destination_node:regex}\"}[$__range]) * 100",
+          "expr": "avg_over_time(cilium_node_connectivity_status{type=\"endpoint\",source_node_name=~\"${source_node}\",target_node_name=~\"${destination_node}\"}[$__range]) * 100",
           "format": "table",
           "legendFormat": "__auto",
           "range": true,


### PR DESCRIPTION
## Description
This PR fixes the issue by ensuring that node names with dots are handled properly, so the connectivity and latency data are accurately visualized for all nodes. It improves the reliability and completeness of the monitoring dashboard

## Why do we need it, and what problem does it solve?
We need this change because the `Node Connectivity Status Matrix` and `Endpoint Connectivity Status Matrix` charts in the `Cilium Nodes Connectivity Status & Latency` dashboard were not displaying correctly when Kubernetes node names contained dots (.)

Before:
<img width="1920" height="1103" alt="image" src="https://github.com/user-attachments/assets/da7ff9b2-36b6-4618-aeaf-09b02a4bef71" />

After:
<img width="866" height="744" alt="image" src="https://github.com/user-attachments/assets/2b3672e0-c660-4b9d-8e63-2c3cd16f54ac" />


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-cilium
type: fix
summary: fixed connectivity dashboard
impact_level: low
```
