### PR TITLE
fix: change release apply time notification

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -671,7 +671,7 @@ func (r *deckhouseReleaseReconciler) DeployTimeCalculate(ctx context.Context, dr
 
 	deployTimeResult = timeChecker.CalculateMinorDeployTime(dr, metricLabels)
 
-	notifyErr := releaseNotifier.SendMinorReleaseNotification(ctx, dr, deployTimeResult.ReleaseApplyAfterTime, metricLabels)
+	notifyErr := releaseNotifier.SendMinorReleaseNotification(ctx, dr, deployTimeResult.ReleaseApplyTime, metricLabels)
 	if notifyErr != nil {
 		r.logger.Warn("send minor release notification", log.Err(notifyErr))
 

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller_test.go
@@ -19,6 +19,7 @@ package deckhouse_release
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"io"
@@ -27,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -1624,5 +1626,60 @@ func (suite *ControllerTestSuite) TestWebhookNotifications() {
 		// Should succeed after network errors are resolved
 		require.NoError(suite.T(), err)
 		require.GreaterOrEqual(suite.T(), attemptCount, 3)
+	})
+
+	suite.Run("Notification: minor release uses ReleaseApplyTime instead of ReleaseApplyAfterTime", func() {
+		// This test verifies that notification uses ReleaseApplyTime (the actual deploy time)
+		// instead of ReleaseApplyAfterTime. When canary and window are set,
+		// these times can differ: ReleaseApplyTime is adjusted by window,
+		// while ReleaseApplyAfterTime may retain the notification period time.
+		var httpBody string
+		var webhookData updater.WebhookData
+		svr := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			data, _ := io.ReadAll(r.Body)
+			httpBody = string(data)
+			_ = json.Unmarshal(data, &webhookData)
+		}))
+		defer svr.Close()
+
+		ds := &helpers.DeckhouseSettings{
+			ReleaseChannel: embeddedMUP.ReleaseChannel,
+		}
+		ds.Update.Mode = embeddedMUP.Update.Mode
+		// Set a narrow window to ensure ReleaseApplyTime is adjusted
+		ds.Update.Windows = update.Windows{{From: "08:00", To: "09:00"}}
+		ds.Update.NotificationConfig.WebhookURL = svr.URL
+		ds.Update.NotificationConfig.MinimalNotificationTime = libapi.Duration{Duration: time.Hour}
+
+		suite.setupControllerSettings("notifier-webhook-minor-release-apply-time.yaml", initValues, ds)
+		dr := suite.getDeckhouseRelease("v1.26.0")
+		_, err := suite.ctr.createOrUpdateReconcile(ctx, dr)
+		require.NoError(suite.T(), err)
+
+		// Parse the applyTime from webhook message
+		require.NotEmpty(suite.T(), webhookData.ApplyTime, "ApplyTime should be set in webhook data")
+
+		// Parse the time from the message to verify it matches ApplyTime
+		// The message format is: "Release will be applied at: Friday, 18-Oct-19 08:00:00 UTC"
+		messageTimeMatch := regexp.MustCompile(`Release will be applied at: ([^"]+)`)
+		matches := messageTimeMatch.FindStringSubmatch(httpBody)
+		require.Len(suite.T(), matches, 2, "Message should contain 'Release will be applied at:'")
+
+		// Trim any trailing whitespace or quotes
+		messageTimeStr := strings.TrimSpace(matches[1])
+		messageTime, err := time.Parse(time.RFC850, messageTimeStr)
+		require.NoError(suite.T(), err, "Message time should be parseable")
+
+		applyTime, err := time.Parse(time.RFC3339, webhookData.ApplyTime)
+		require.NoError(suite.T(), err, "ApplyTime should be parseable")
+
+		// Verify that the time in message matches ApplyTime field (ReleaseApplyTime)
+		// The times should be approximately equal (within 1 minute tolerance for formatting differences)
+		require.WithinDuration(suite.T(), applyTime, messageTime, time.Minute,
+			"Message time should match ApplyTime field (ReleaseApplyTime), not ReleaseApplyAfterTime")
+
+		require.Contains(suite.T(), httpBody, "New Deckhouse Release 1.26.0 is available")
+		require.Contains(suite.T(), httpBody, `"version":"1.26.0"`)
+		require.Contains(suite.T(), httpBody, `"subject":"Deckhouse"`)
 	})
 }

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-minor-release-apply-time.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/notifier-webhook-minor-release-apply-time.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  creationTimestamp: null
+  name: v1.25.0
+  resourceVersion: "999"
+spec:
+  version: v1.25.0
+status:
+  approved: false
+  message: ""
+  phase: Deployed
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+approved: false
+kind: DeckhouseRelease
+metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "false"
+    release.deckhouse.io/notification-time-shift: "true"
+    release.deckhouse.io/notified: "true"
+  creationTimestamp: null
+  name: v1.26.0
+  resourceVersion: "1001"
+spec:
+  applyAfter: "2019-10-17T16:33:00Z"
+  version: v1.26.0
+status:
+  approved: false
+  message: Release is postponed by notification until 18 Oct 19 08:00 UTC
+  phase: Pending
+  transitionTime: null
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    app: deckhouse
+  name: deckhouse-6f46df5bd7-nk4j7
+  namespace: d8-system
+  resourceVersion: "999"
+spec:
+  containers:
+  - image: dev-registry.deckhouse.io/sys/deckhouse-oss:v1.2.3
+    name: deckhouse
+    resources: {}
+status:
+  containerStatuses:
+  - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
+    image: ""
+    imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
+    lastState: {}
+    name: ""
+    ready: true
+    restartCount: 0
+    state: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  namespace: d8-system
+  resourceVersion: "999"
+spec:
+  selector: null
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+    spec:
+      containers:
+      - image: my.registry.com/deckhouse:v1.25.0
+        name: deckhouse
+        resources: {}
+status: {}

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/notifier-webhook-minor-release-apply-time.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/notifier-webhook-minor-release-apply-time.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: deckhouse-6f46df5bd7-nk4j7
+  namespace: d8-system
+  labels:
+    app: deckhouse
+spec:
+  containers:
+    - name: deckhouse
+      image: dev-registry.deckhouse.io/sys/deckhouse-oss:v1.2.3
+status:
+  containerStatuses:
+    - containerID: containerd://9990d3eccb8657d0bfe755672308831b6d0fab7f3aac553487c60bf0f076b2e3
+      imageID: dev-registry.deckhouse.io/sys/deckhouse-oss/dev@sha256:d57f01a88e54f863ff5365c989cb4e2654398fa274d46389e0af749090b862d1
+      ready: true
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deckhouse
+  namespace: d8-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: deckhouse
+          image: my.registry.com/deckhouse:v1.25.0
+
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.25.0
+spec:
+  version: "v1.25.0"
+status:
+  phase: Deployed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: DeckhouseRelease
+metadata:
+  name: v1.26.0
+spec:
+  version: "v1.26.0"
+status:
+  phase: Pending
+
+


### PR DESCRIPTION
## Description

Fixed incorrect time value in minor release notification messages. The notification was using `ReleaseApplyAfterTime` instead of `ReleaseApplyTime` when sending webhook notifications for minor releases.

**Changes:**
- Updated `DeployTimeCalculate` method to pass `ReleaseApplyTime` instead of `ReleaseApplyAfterTime` to `SendMinorReleaseNotification`
- Added test coverage to verify that notifications use the correct time value

This fix ensures that notification messages display the actual deployment time (`ReleaseApplyTime`), which may differ from `ReleaseApplyAfterTime` when update windows or other scheduling constraints are applied.

The fix does not affect critical cluster components. It only corrects the time value displayed in notification messages sent to external webhooks.

## Why do we need it, and what problem does it solve?

When minor release notifications were sent via webhook, they displayed incorrect deployment time. The system was using `ReleaseApplyAfterTime` (which represents the notification period deadline) instead of `ReleaseApplyTime` (which represents the actual calculated deployment time).

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Fixed incorrect time value in minor release notification messages.
impact_level: default
```
