### PR TITLE
[extended-monitoring] Fix CronJobFailed alert for job with retries

### DIFF
--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
@@ -7,17 +7,19 @@
     # - Have been scheduled more recently than their last success
     - record: extended_monitoring:cronjob:recent_schedule_not_successful
       expr: |
-        label_replace(
-          (
-            kube_cronjob_status_last_schedule_time
-            >= on(namespace, cronjob)
+        max by (namespace, owner_name) (
+          label_replace(
             (
-              kube_cronjob_status_last_successful_time
-              or on(namespace, cronjob)
-              (kube_cronjob_status_last_schedule_time * 0)
-            )
-          ),
-          "owner_name", "$1", "cronjob", "(.*)"
+              kube_cronjob_status_last_schedule_time
+              >= on(namespace, cronjob)
+              (
+                kube_cronjob_status_last_successful_time
+                or on(namespace, cronjob)
+                (kube_cronjob_status_last_schedule_time * 0)
+              )
+            ),
+            "owner_name", "$1", "cronjob", "(.*)"
+          )
         )
 
     # Identify Jobs that are from the latest CronJob execution
@@ -28,12 +30,16 @@
         kube_job_status_start_time
         >= on (namespace, job_name) group_left(owner_name)
         (
-          label_replace(
-            kube_cronjob_status_last_schedule_time,
-            "owner_name", "$1", "cronjob", "(.*)"
+          max by (namespace, owner_name) (
+            label_replace(
+              kube_cronjob_status_last_schedule_time,
+              "owner_name", "$1", "cronjob", "(.*)"
+            )
           )
           * on (namespace, owner_name) group_right(job_name)
-          kube_job_owner{owner_kind="CronJob"}
+          max by (namespace, owner_name, job_name) (
+            kube_job_owner{owner_kind="CronJob"}
+          )
         )
 
     # Combine all conditions into a single metric

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
@@ -7,19 +7,17 @@
     # - Have been scheduled more recently than their last success
     - record: extended_monitoring:cronjob:recent_schedule_not_successful
       expr: |
-        max by (namespace, owner_name) (
-          label_replace(
+        label_replace(
+          (
+            kube_cronjob_status_last_schedule_time
+            >= on(namespace, cronjob)
             (
-              kube_cronjob_status_last_schedule_time
-              >= on(namespace, cronjob)
-              (
-                kube_cronjob_status_last_successful_time
-                or on(namespace, cronjob)
-                (kube_cronjob_status_last_schedule_time * 0)
-              )
-            ),
-            "owner_name", "$1", "cronjob", "(.*)"
-          )
+              kube_cronjob_status_last_successful_time
+              or on(namespace, cronjob)
+              (kube_cronjob_status_last_schedule_time * 0)
+            )
+          ),
+          "owner_name", "$1", "cronjob", "(.*)"
         )
 
     # Identify Jobs that are from the latest CronJob execution
@@ -30,15 +28,15 @@
         kube_job_status_start_time
         >= on (namespace, job_name) group_left(owner_name)
         (
-          max by (namespace, owner_name) (
+          max by (owner_name, namespace) (
             label_replace(
               kube_cronjob_status_last_schedule_time,
               "owner_name", "$1", "cronjob", "(.*)"
             )
           )
-          * on (namespace, owner_name) group_right(job_name)
-          max by (namespace, owner_name, job_name) (
-            kube_job_owner{owner_kind="CronJob"}
+          * on (namespace, owner_name) group_right()
+          max by (owner_name, namespace, job_name) (
+            kube_job_owner{owner_kind="cronjob"}
           )
         )
 

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
@@ -20,15 +20,6 @@
           "owner_name", "$1", "cronjob", "(.*)"
         )
 
-    # Pre-filter CronJobs with extended monitoring enabled
-    # Normalizes the label name from 'cronjob' to 'owner_name' for easier joins
-    - record: extended_monitoring:cronjob:enabled
-      expr: |
-        label_replace(
-          extended_monitoring_cronjob_enabled == 1,
-          "owner_name", "$1", "cronjob", "(.*)"
-        )
-
     # Identify Jobs that are from the latest CronJob execution
     # A Job is "latest" if its start_time >= parent CronJob's last_schedule_time
     # This prevents alerting on historical failed jobs that are still in history

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob-rules.yaml
@@ -1,0 +1,61 @@
+- name: extended_monitoring.cronjob.records
+  interval: 30s
+  rules:
+    # Identify CronJobs where the most recent schedule hasn't succeeded yet
+    # This captures CronJobs that either:
+    # - Have never succeeded (last_successful_time doesn't exist)
+    # - Have been scheduled more recently than their last success
+    - record: extended_monitoring:cronjob:recent_schedule_not_successful
+      expr: |
+        label_replace(
+          (
+            kube_cronjob_status_last_schedule_time
+            >= on(namespace, cronjob)
+            (
+              kube_cronjob_status_last_successful_time
+              or on(namespace, cronjob)
+              (kube_cronjob_status_last_schedule_time * 0)
+            )
+          ),
+          "owner_name", "$1", "cronjob", "(.*)"
+        )
+
+    # Pre-filter CronJobs with extended monitoring enabled
+    # Normalizes the label name from 'cronjob' to 'owner_name' for easier joins
+    - record: extended_monitoring:cronjob:enabled
+      expr: |
+        label_replace(
+          extended_monitoring_cronjob_enabled == 1,
+          "owner_name", "$1", "cronjob", "(.*)"
+        )
+
+    # Identify Jobs that are from the latest CronJob execution
+    # A Job is "latest" if its start_time >= parent CronJob's last_schedule_time
+    # This prevents alerting on historical failed jobs that are still in history
+    - record: extended_monitoring:job:is_latest_for_cronjob
+      expr: |
+        kube_job_status_start_time
+        >= on (namespace, job_name) group_left(owner_name)
+        (
+          label_replace(
+            kube_cronjob_status_last_schedule_time,
+            "owner_name", "$1", "cronjob", "(.*)"
+          )
+          * on (namespace, owner_name) group_right(job_name)
+          kube_job_owner{owner_kind="CronJob"}
+        )
+
+    # Combine all conditions into a single metric
+    # This identifies Jobs that are:
+    # 1. Failed (kube_job_status_failed > 0)
+    # 2. From the latest CronJob execution
+    # 3. Belong to a CronJob whose recent execution hasn't succeeded
+    - record: extended_monitoring:job:failed_latest_from_pending_cronjob
+      expr: |
+        max by (namespace, job_name, owner_kind, owner_name) (
+          (kube_job_status_failed > 0)
+          * on (namespace, job_name) group_right()
+          extended_monitoring:job:is_latest_for_cronjob
+        )
+        >= on (namespace, owner_name) group_right()
+        extended_monitoring:cronjob:recent_schedule_not_successful

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -2,22 +2,29 @@
   rules:
   - alert: CronJobFailed
     expr: |
-      (
-        max by (namespace, job_name, owner_kind, owner_name) (
-          # Job has failed attempts AND no successful completions
-          (kube_job_status_failed > 0)
-          * on (namespace, job_name)
-          (kube_job_status_succeeded == 0)
-          * on (namespace, job_name) group_right()
-          # compare start time of a Job with the last schedule time of a CronJob
+      label_replace(
+        (
+          kube_cronjob_status_last_schedule_time
+          >= on(namespace, cronjob)
           (
-            kube_job_status_start_time
-            >= on (namespace, job_name) group_left(owner_name)
-            (
-              max by (owner_name, namespace) (label_replace(kube_cronjob_status_last_schedule_time, "owner_name", "$1", "cronjob", "(.*)"))
-              * on (namespace, owner_name) group_right()
-              max by (owner_name, namespace, job_name) (kube_job_owner{owner_kind="CronJob"})
-            )
+            kube_cronjob_status_last_successful_time
+            or on(namespace, cronjob)
+            kube_cronjob_status_last_schedule_time * 0
+          )
+        ), "owner_name", "$1", "cronjob", "(.*)"
+      )
+      >= on (namespace, owner_name) group_right()
+      max by (namespace, job_name, owner_kind, owner_name) (
+        (kube_job_status_failed > 0)
+        * on (namespace, job_name) group_right()
+        # compare start time of a Job with the last schedule time of a CronJob
+        (
+          kube_job_status_start_time
+          >= on (namespace, job_name) group_left(owner_name)
+          (
+            max by (owner_name, namespace) (label_replace(kube_cronjob_status_last_schedule_time, "owner_name", "$1", "cronjob", "(.*)"))
+            * on (namespace, owner_name) group_right()
+            max by (owner_name, namespace, job_name) (kube_job_owner{owner_kind="CronJob"})
           )
         )
       )
@@ -27,7 +34,6 @@
           label_replace((extended_monitoring_cronjob_enabled == 1), "owner_name", "$1", "cronjob", "(.*)")
         ) > 0
       )
-    for: 2m
     labels:
       severity_level: "5"
     annotations:

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -4,7 +4,10 @@
     expr: |
       (
         max by (namespace, job_name, owner_kind, owner_name) (
+          # Job has failed attempts AND no successful completions
           (kube_job_status_failed > 0)
+          * on (namespace, job_name)
+          (kube_job_status_succeeded == 0)
           * on (namespace, job_name) group_right()
           # compare start time of a Job with the last schedule time of a CronJob
           (
@@ -15,7 +18,7 @@
               * on (namespace, owner_name) group_right()
               max by (owner_name, namespace, job_name) (kube_job_owner{owner_kind="CronJob"})
             )
-          ) ^ 0
+          )
         )
       )
       * on (namespace, owner_name) group_left()
@@ -24,6 +27,7 @@
           label_replace((extended_monitoring_cronjob_enabled == 1), "owner_name", "$1", "cronjob", "(.*)")
         ) > 0
       )
+    for: 2m
     labels:
       severity_level: "5"
     annotations:

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -2,29 +2,22 @@
   rules:
   - alert: CronJobFailed
     expr: |
-      label_replace(
-        (
-          kube_cronjob_status_last_schedule_time
-          >= on(namespace, cronjob)
+      (
+        max by (namespace, job_name, owner_kind, owner_name) (
+          # Job has failed attempts AND no successful completions
+          (kube_job_status_failed > 0)
+          * on (namespace, job_name)
+          (kube_job_status_succeeded == 0)
+          * on (namespace, job_name) group_right()
+          # compare start time of a Job with the last schedule time of a CronJob
           (
-            kube_cronjob_status_last_successful_time
-            or on(namespace, cronjob)
-            kube_cronjob_status_last_schedule_time * 0
-          )
-        ), "owner_name", "$1", "cronjob", "(.*)"
-      )
-      >= on (namespace, owner_name) group_right()
-      max by (namespace, job_name, owner_kind, owner_name) (
-        (kube_job_status_failed > 0)
-        * on (namespace, job_name) group_right()
-        # compare start time of a Job with the last schedule time of a CronJob
-        (
-          kube_job_status_start_time
-          >= on (namespace, job_name) group_left(owner_name)
-          (
-            max by (owner_name, namespace) (label_replace(kube_cronjob_status_last_schedule_time, "owner_name", "$1", "cronjob", "(.*)"))
-            * on (namespace, owner_name) group_right()
-            max by (owner_name, namespace, job_name) (kube_job_owner{owner_kind="CronJob"})
+            kube_job_status_start_time
+            >= on (namespace, job_name) group_left(owner_name)
+            (
+              max by (owner_name, namespace) (label_replace(kube_cronjob_status_last_schedule_time, "owner_name", "$1", "cronjob", "(.*)"))
+              * on (namespace, owner_name) group_right()
+              max by (owner_name, namespace, job_name) (kube_job_owner{owner_kind="CronJob"})
+            )
           )
         )
       )
@@ -34,6 +27,7 @@
           label_replace((extended_monitoring_cronjob_enabled == 1), "owner_name", "$1", "cronjob", "(.*)")
         ) > 0
       )
+    for: 2m
     labels:
       severity_level: "5"
     annotations:

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -1,39 +1,15 @@
 - name: cronjob.rules
   rules:
   - alert: CronJobFailed
+      # The alert fires when:
+      # 1. A Job has failed (kube_job_status_failed > 0)
+      # 2. The Job is from the latest CronJob execution (not a historical failure)
+      # 3. The CronJob's recent execution hasn't succeeded yet
+      # 4. Extended monitoring is enabled for the CronJob
     expr: |
-      label_replace(
-        (
-          kube_cronjob_status_last_schedule_time
-          >= on(namespace, cronjob)
-          (
-            kube_cronjob_status_last_successful_time
-            or on(namespace, cronjob)
-            kube_cronjob_status_last_schedule_time * 0
-          )
-        ), "owner_name", "$1", "cronjob", "(.*)"
-      )
-      >= on (namespace, owner_name) group_right()
-      max by (namespace, job_name, owner_kind, owner_name) (
-        (kube_job_status_failed > 0)
-        * on (namespace, job_name) group_right()
-        # compare start time of a Job with the last schedule time of a CronJob
-        (
-          kube_job_status_start_time
-          >= on (namespace, job_name) group_left(owner_name)
-          (
-            max by (owner_name, namespace) (label_replace(kube_cronjob_status_last_schedule_time, "owner_name", "$1", "cronjob", "(.*)"))
-            * on (namespace, owner_name) group_right()
-            max by (owner_name, namespace, job_name) (kube_job_owner{owner_kind="CronJob"})
-          )
-        )
-      )
+      extended_monitoring:job:failed_latest_from_pending_cronjob
       * on (namespace, owner_name) group_left()
-      (
-        max by (namespace, owner_name) (
-          label_replace((extended_monitoring_cronjob_enabled == 1), "owner_name", "$1", "cronjob", "(.*)")
-        ) > 0
-      )
+      extended_monitoring:cronjob:enabled
     labels:
       severity_level: "5"
     annotations:

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/cronjob.yaml
@@ -6,10 +6,14 @@
       # 2. The Job is from the latest CronJob execution (not a historical failure)
       # 3. The CronJob's recent execution hasn't succeeded yet
       # 4. Extended monitoring is enabled for the CronJob
+      #
     expr: |
       extended_monitoring:job:failed_latest_from_pending_cronjob
       * on (namespace, owner_name) group_left()
-      extended_monitoring:cronjob:enabled
+      label_replace(
+        extended_monitoring_cronjob_enabled == 1,
+        "owner_name", "$1", "cronjob", "(.*)"
+      )
     labels:
       severity_level: "5"
     annotations:


### PR DESCRIPTION
## Description
Fix CronJobFailed alert for job with retries

## Why do we need it, and what problem does it solve?
The alert will no longer fire for Jobs that eventually succeed after pod retries. The alert will only fire when a Job completely fails (has failed attempts but no successful completions).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  extended-monitoring
type: fix 
summary: Fix CronJobFailed alert for job with retries
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
