### PR TITLE
[candi] Enable feature gates for Dynamic Resource Allocation

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -313,6 +313,9 @@ featureGates:
 {{- if eq $topologyManagerEnabled true }}
   MemoryManager: true
 {{- end }}
+{{- if semverCompare ">=1.32 <1.34" .kubernetesVersion }}
+  DynamicResourceAllocation: true
+{{- end }}
 {{- range .allowedKubeletFeatureGates }}
   {{ . }}: true
 {{- end }}

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -3,6 +3,9 @@ RotateKubeletServerCertificate default is true, but CIS benchmark wants it to be
 https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 */ -}}
 {{- $baseFeatureGates := list "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" -}}
+{{- if semverCompare ">=1.32 <1.34" .clusterConfiguration.kubernetesVersion }}
+  {{- $baseFeatureGates = append $baseFeatureGates "DynamicResourceAllocation=true" -}}
+{{- end }}
 {{- $apiserverFeatureGates := $baseFeatureGates -}}
 {{- $controllerManagerFeatureGates := $baseFeatureGates -}}
 {{- $schedulerFeatureGates := $baseFeatureGates -}}
@@ -20,6 +23,11 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 {{- $apiserverFeatureGatesStr := $apiserverFeatureGates | uniq | join "," -}}
 {{- $controllerManagerFeatureGatesStr := $controllerManagerFeatureGates | uniq | join "," -}}
 {{- $schedulerFeatureGatesStr := $schedulerFeatureGates | uniq | join "," -}}
+{{- $runtimeConfig := list "admissionregistration.k8s.io/v1beta1=true" "admissionregistration.k8s.io/v1alpha1=true" -}}
+{{- if semverCompare ">=1.32 <1.34" .clusterConfiguration.kubernetesVersion }}
+  {{- $runtimeConfig = append $runtimeConfig "resource.k8s.io/v1beta1=true" -}}
+{{- end }}
+{{- $runtimeConfig := join "," $runtimeConfig -}}
 {{- $nodesCount := .nodesCount | default 0 | int }}
 {{- $gcThresholdCount := 1000 }}
 {{- if lt $nodesCount 100 }}
@@ -150,7 +158,7 @@ apiServer:
     - name: feature-gates
       value: {{ $apiserverFeatureGatesStr | quote }}
     - name: runtime-config
-      value: admissionregistration.k8s.io/v1beta1=true,admissionregistration.k8s.io/v1alpha1=true
+      value: {{ $runtimeConfig }}
     {{ if .apiserver.webhookURL }}
     - name: authorization-mode
       value: Node,Webhook,RBAC
@@ -178,7 +186,7 @@ apiServer:
     - name: request-timeout
       value: 60s
     - name: tls-cipher-suites
-      value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256    
+      value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
     {{- if .apiserver.oidcIssuerURL }}
     - name: authentication-config
       value: /etc/kubernetes/deckhouse/extra-files/authentication-config.yaml


### PR DESCRIPTION
## Description
This PR enables the necessary feature gates to support [`Dynamic Resource Allocation`](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) for `1.32 >= K8s < 1.34`
It ensures that Kubernetes components are properly configured to handle dynamic resource requests and allocations across supported versions

## Why do we need it, and what problem does it solve?
`Dynamic Resource Allocation` is a Kubernetes mechanism that allows workloads to request and manage non-standard or device-specific resources dynamically
Without the required feature gates `(DynamicResourceAllocation=true)`, the cluster cannot fully utilize DRA functionality

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: candi
type: feature
summary: Enabled feature gates for Dynamic Resource Allocation.
impact_level: default
impact: Kubelet, api-server, and scheduler will be restarted.
```

