### PR TITLE
[cni-cilium] Add the ability to configure the mapDynamicSizeRatio parameter for specific nodes using CiliumNodeConfig.

### DIFF
--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -315,7 +315,7 @@ spec:
         command:
         - cilium-dbg
         - build-config
-        - --allow-config-keys=debug,single-cluster-route,mtu
+        - --allow-config-keys=debug,single-cluster-route,mtu,bpf-map-dynamic-size-ratio
         env:
         - name: K8S_NODE_NAME
           valueFrom:


### PR DESCRIPTION
## Description

In cases, for nodes that consistently experience BFP map overflow, you can increase the mapDynamicSizeRatio coefficient through CiliumNodeConfig.

The recommended mapDynamicSizeRatio value should be selected individually based on the specific needs of the cluster.
For example, in the Cilium performance tuning documentation, there is a recommendation to increase mapDynamicSizeRatio up to 0.08, which is equivalent to 8% of the total available RAM.
However, it is important to note that as the size of the BFP cards increases, less RAM will be available for the pods. If this is not considered when planning resources, there is an increased risk of OOM.

## Why do we need it, and what problem does it solve?

By default, the size of BFP maps is automatically determined based on the RAM size on the node and a mapDynamicSizeRatio coefficient. By default is 0.005, which is equivalent to 0.5% of RAM. 
However, if a node has a small amount of RAM but very high traffic intensity, the calculated BFP map size may not be sufficient. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: feature
summary: Added support for configuring the `mapDynamicSizeRatio` parameter for specific nodes using CiliumNodeConfig.
```
