### PR TITLE
[registrypackages] Fix for CVE in kubernetes-cni

### DIFF
--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -531,7 +531,6 @@ var DefaultImagesDigests = map[string]interface{}{
 		"kubelet1335VexArtifact":          "imageHash-registrypackages-kubelet1335VexArtifact",
 		"kubernetesApiProxy":              "imageHash-registrypackages-kubernetesApiProxy",
 		"kubernetesCni162":                "imageHash-registrypackages-kubernetesCni162",
-		"kubernetesCni162VexArtifact":     "imageHash-registrypackages-kubernetesCni162VexArtifact",
 		"lsblk2402":                       "imageHash-registrypackages-lsblk2402",
 		"netcat110481":                    "imageHash-registrypackages-netcat110481",
 		"nfsMount282":                     "imageHash-registrypackages-nfsMount282",


### PR DESCRIPTION
## Description

Fix for CVE:

- CVE-2025-52881

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: registrypackages
type: fix
summary: Fixes CVE in kubernetes-cni
```
