### PR TITLE
[docs] Fix typo at RN 1.73

### DIFF
--- a/CHANGELOG/CHANGELOG-v1.73.0.yml
+++ b/CHANGELOG/CHANGELOG-v1.73.0.yml
@@ -298,7 +298,7 @@ deckhouse:
       pull_request: https://github.com/deckhouse/deckhouse/pull/15911
     - summary: Make deckhouse privileged and run as root.
       pull_request: https://github.com/deckhouse/deckhouse/pull/15664
-      impact: Deckhouse how has privileged mode and runs as root.
+      impact: Deckhouse now has privileged mode and runs as root.
     - summary: Added alert for deprecated modules.
       pull_request: https://github.com/deckhouse/deckhouse/pull/15483
     - summary: Added Deckhouse release information status.

--- a/CHANGELOG/CHANGELOG-v1.73.md
+++ b/CHANGELOG/CHANGELOG-v1.73.md
@@ -4,7 +4,7 @@
 
 
  - ALL pods of the ingress-nginx module will be restarted.
- - Deckhouse how has privileged mode and runs as root.
+ - Deckhouse now has privileged mode and runs as root.
  - Fixed multiple security vulnerabilities that could affect authentication components.
  - The runtime-audit-engine module has been moved to external. All pods of the module will be restarted.
  - This update fixes a security vulnerability in the `user-authn` module (CVE-2025-22868) that could potentially allow bypass of authentication validation.
@@ -30,7 +30,7 @@
  - **[cloud-provider-zvirt]** Added support zvirt cloud provider to cse. [#14683](https://github.com/deckhouse/deckhouse/pull/14683)
  - **[control-plane-manager]** Added extra claim `user-authn.deckhouse.io/dex-provider` (from `federated_claims.connector_id`) Request `federated:id` scope in Dex Authenticator, Basic Auth Proxy, and kubeconfig generator to populate. `federated_claims.connector_id` [#15816](https://github.com/deckhouse/deckhouse/pull/15816)
  - **[deckhouse]** Make deckhouse privileged and run as root. [#15664](https://github.com/deckhouse/deckhouse/pull/15664)
-    Deckhouse how has privileged mode and runs as root.
+    Deckhouse now has privileged mode and runs as root.
  - **[deckhouse]** Added alert for deprecated modules. [#15483](https://github.com/deckhouse/deckhouse/pull/15483)
  - **[deckhouse]** Added Deckhouse release information status. [#15458](https://github.com/deckhouse/deckhouse/pull/15458)
  - **[deckhouse]** Made the module source `deckhouse` the default source. [#15437](https://github.com/deckhouse/deckhouse/pull/15437)


### PR DESCRIPTION
## Description
Fixed typo at RN 1.73.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix
summary: Fixed typo at RN 1.73.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
