### PR TITLE
[extended-monitoring] Fix enabled label handling

### DIFF
--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/watcher/helpers.go
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/watcher/helpers.go
@@ -32,9 +32,23 @@ func boolToFloat64(b bool) float64 {
 	return 0
 }
 
-func enabledLabel(labels map[string]string) bool {
+func enabledOnNamespace(labels map[string]string) bool {
 	_, ok := labels[namespacesEnabledLabel]
 	return ok
+}
+
+func enabledLabel(labels map[string]string) bool {
+	val, ok := labels[namespacesEnabledLabel]
+
+	if !ok {
+		return true
+	}
+
+	if b, err := strconv.ParseBool(val); err == nil {
+		return b
+	}
+
+	return true
 }
 
 func thresholdLabel(labels map[string]string, threshold string, def float64) float64 {

--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/watcher/watcher.go
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/watcher/watcher.go
@@ -95,7 +95,7 @@ func (w *Watcher) StartNamespaceWatcher(ctx context.Context) {
 }
 
 func (w *Watcher) addNamespace(ctx context.Context, ns *v1.Namespace) {
-	enabled := enabledLabel(ns.Labels)
+	enabled := enabledOnNamespace(ns.Labels)
 	w.metrics.NamespacesEnabled.WithLabelValues(ns.Name).Set(boolToFloat64(enabled))
 	log.Printf("[NS ADD] %s", ns.Name)
 


### PR DESCRIPTION
## Description
A regression was introduced while rewriting the extended monitoring exporter into Golang. Invalid enable label handling enabled extending monitoring by default
## Why do we need it, and what problem does it solve?
Extended monitoring should be enabled explicitly by setting a label on the namespace.

## Why do we need it in the patch release (if we do)?
We do, due to excessive alerting.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: extended-monitoring
type: fix
summary: Fix extended-monitoring.deckhouse.io/enabled label handling
impact: the extended monitoring will only be enabled when the label is explicitly set on a namespace
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
