### PR TITLE
[deckhouse] fix validation logic for a disabled module

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -173,7 +173,7 @@ func moduleConfigValidationHandler(
 			_, ok = cfg.Annotations[v1alpha1.ModuleConfigAnnotationAllowDisable]
 			_, oldOk := oldModuleMeta.Annotations[v1alpha1.ModuleConfigAnnotationAllowDisable]
 
-			if !ok && !oldOk && cfg.Spec.Enabled != nil && !*cfg.Spec.Enabled {
+			if !ok && !oldOk && oldEnabled && !newEnabled {
 				// we can disable unknown module without any further check
 				if module, err := moduleStorage.GetModuleByName(obj.GetName()); err == nil {
 					if reason, needConfirm := module.GetConfirmationDisableReason(); needConfirm {


### PR DESCRIPTION
## Description

It provides fix for module config validation webhook. 

Check disabling annotation only when module config is disabling(enabled -> disabled).

## Why do we need it, and what problem does it solve?

Currently, `admission webhook "module-configs.deckhouse-webhook.deckhouse.io"` is triggered by any UPDATE in a disabled module:
```
spec:
  enabled: false
```
Because of this, when editing a disabled module with the `confirmation` parameter enabled, the `allow-disabling=true` annotation is requested.

---

Example:

Now, when you enable the `code` module (by default, `confirmation: true`) in a cluster and then disable it with `spec.enabled: false`

If you try to change the `ModuleConfig` parameters afterward, the webhook will trigger.
```
# kubectl get mc code -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: code
spec:
  enabled: false
  source: deckhouse
status:
  message: ""
  version: "1"
```
```
# kubectl patch mc code --type='json' -p='[{"op": "replace", "path": "/spec/source", "value": "deckhouse-oss"}]'
Error from server: admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: Disabling this module will delete all your Code configuration, git data and any secret or configMap owned by operator.Please annotate ModuleConfig with `modules.deckhouse.io/allow-disabling=true` if you're sure that you want to disable the module.
```

With the corrected logic, after disabling a module, editing its `ModuleConfig` will not trigger the webhook.
```
# kubectl get mc code -oyaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: code
spec:
  enabled: false
  source: deckhouse-upstream-ee
status:
  message: ""
  version: "1"
```
```
# kubectl patch mc code --type='json' -p='[{"op": "replace", "path": "/spec/source", "value": "deckhouse"}]'
moduleconfig.deckhouse.io/code patched
```
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix validation logic for a disabled module
```