### PR TITLE
[control-plane-manager] Add logging removeList

### DIFF
--- a/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
@@ -139,15 +139,14 @@ func handleRecicleEtcdMembers(_ context.Context, input *go_hook.HookInput, dc de
 	}
 
 	removeListIDs := make([]uint64, 0)
-	removeListNames := make([]string, 0)
 	for _, mem := range etcdMembersResp.Members {
 		if _, ok := discoveredMasterMap[mem.Name]; !ok {
 			removeListIDs = append(removeListIDs, mem.ID)
-			removeListNames = append(removeListNames, mem.Name)
+			input.Logger.Warn("added etcd member to remove list", slog.Uint64("memberID", mem.ID), slog.String("memberName", mem.Name))
 		}
 	}
 
-	input.Logger.Warn("etcd members to remove", slog.Any("removeListIDs", removeListIDs), slog.Any("removeListNames", removeListNames))
+	input.Logger.Warn("etcd members to remove", slog.Any("removeListIDs", removeListIDs))
 
 	if len(removeListIDs) == len(etcdMembersResp.Members) {
 		return fmt.Errorf("attempting do delete every single member from etcd cluster. Exiting")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added logging for etcd member removals to track cluster membership changes.

Example:
```bash
{
  "level": "warn",
  "logger": "auto-hook-logger",
  "msg": "added etcd member to remove list",
  "binding": "kubernetes",
  "binding.name": "master_nodes",
  "event.id": "81764282-1456-45da-ac6a-9e1fa4764871",
  "hook": "040-control-plane-manager/hooks/reconcile_etcd_members.go",
  "hook.type": "module",
  "memberID": 15300627357424665000,
  "memberName": "kube-test-master-2",
  "module": "control-plane-manager",
  "output": "gohook",
  "path": "/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go",
  "queue": "/modules/control-plane-manager/reconcile_etcd_members",
  "task.id": "7a28fd6d-7b93-46bf-a16e-b323a41f71c4",
  "watchEvent": "Deleted",
  "time": "2025-11-14T07:40:21Z"
}
{
  "level": "warn",
  "logger": "auto-hook-logger",
  "msg": "etcd members to remove",
  "binding": "kubernetes",
  "binding.name": "master_nodes",
  "event.id": "81764282-1456-45da-ac6a-9e1fa4764871",
  "hook": "040-control-plane-manager/hooks/reconcile_etcd_members.go",
  "hook.type": "module",
  "module": "control-plane-manager",
  "output": "gohook",
  "path": "/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go",
  "queue": "/modules/control-plane-manager/reconcile_etcd_members",
  "removeListIDs": [
    15300627357424665000
  ],
  "task.id": "7a28fd6d-7b93-46bf-a16e-b323a41f71c4",
  "watchEvent": "Deleted",
  "time": "2025-11-14T07:40:21Z"
}
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Helps debug etcd issues by providing visibility into when and which members are removed from the cluster.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Add logging for etcd member removals
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->