### PR TITLE
[docs-builder] fix: prevent folders from passing the internal documentation filter

### DIFF
--- a/docs/site/backends/docs-builder/internal/docs/upload.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload.go
@@ -144,6 +144,10 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 	}
 
 	if fileName, ok := strings.CutPrefix(fileName, "docs"); ok {
+		// Skip internal documentation directories that should not be published
+		if hasBlockedPrefix(fileName) {
+			return "", false
+		}
 		return filepath.Join(svc.baseDir, contentDir, moduleName, channel, fileName), true
 	}
 
@@ -156,6 +160,30 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 	}
 
 	return "", false
+}
+
+func hasBlockedPrefix(path string) bool {
+	blockedDocPathPrefixes := []string{
+		"/internal",
+		"/internals",
+		"/development",
+		"/dev",
+	}
+	for _, prefix := range blockedDocPathPrefixes {
+		if !strings.HasPrefix(path, prefix) {
+			continue
+		}
+
+		if len(path) == len(prefix) {
+			return true
+		}
+
+		if path[len(prefix)] == '/' {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (svc *Service) cleanModulesFiles(moduleName string, channels []string) error {

--- a/docs/site/backends/docs-builder/internal/docs/upload_test.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload_test.go
@@ -102,6 +102,43 @@ func TestLoadHandlerGetLocalPath(t *testing.T) {
 			"/app/hugo/data/modules/moduleName/stable/openapi",
 			true,
 		},
+		// Test cases for internal directories exclusion
+		{
+			"docs/internal/README.md",
+			"",
+			false,
+		},
+		{
+			"docs/internals/development.md",
+			"",
+			false,
+		},
+		{
+			"docs/development/HOWTO.md",
+			"",
+			false,
+		},
+		{
+			"docs/dev/debug.md",
+			"",
+			false,
+		},
+		{
+			"docs/internal/subfolder/file.md",
+			"",
+			false,
+		},
+		// Test that regular docs files still work
+		{
+			"docs/public/README.md",
+			"/app/hugo/content/modules/moduleName/stable/public/README.md",
+			true,
+		},
+		{
+			"docs/configuration.md",
+			"/app/hugo/content/modules/moduleName/stable/configuration.md",
+			true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description
Fix docs-builder to exclude internal documentation directories.

## Why do we need it, and what problem does it solve?
The docs-builder service was processing all files from the docs/ directory, including internal documentation that should not be published.

Solution - exclude files from internal directories.
Files from these directories are now ignored during documentation processing.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fix docs-builder to exclude internal documentation directories
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
