### PR TITLE
[monitoring-kubernetes] Rollout changes for resources metrics kubelet

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/kubelet/service-monitor.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kubelet/service-monitor.yaml
@@ -98,23 +98,6 @@ spec:
         replacement: probes
       - targetLabel: tier
         replacement: cluster
-  # Pods resources metrics
-  - port: https-metrics
-    scheme: https
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    tlsConfig:
-      insecureSkipVerify: true
-    path: /metrics/resource
-    honorLabels: true
-    relabelings:
-      - regex: endpoint|namespace|pod|service
-        action: labeldrop
-      - sourceLabels: [__meta_kubernetes_endpointslice_address_target_name]
-        targetLabel: node
-      - targetLabel: scrape_endpoint
-        replacement: resources
-      - targetLabel: tier
-        replacement: cluster
   selector:
     matchLabels:
       k8s-app: kubelet


### PR DESCRIPTION
## Description
Rollout changes for resources metrics kubelet

## Why do we need it, and what problem does it solve?
Due to our changes, some users have started experiencing issues with increased resource consumption because of new additional metrics. 

## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-kubernetes
type: fix
summary: Rollout changes for resources metrics kubelet
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
