### PR TITLE
[candi] bb-event-error-create function fix

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -75,6 +75,14 @@ bb-label-node-bashible-first-run-finished() {
 export -f bb-kubectl-exec
 export -f bb-label-node-bashible-first-run-finished
 
+bb-indent-text() {
+    local indent="$1"
+    local line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        printf '%s%s\n' "$indent" "$line"
+    done
+}
+
 function bb-event-error-create() {
     # This function is used for creating event in the default namespace with reference of
     # bashible step and used events.k8s.io/v1 apiVersion.
@@ -90,7 +98,14 @@ function bb-event-error-create() {
     eventName="$(echo -n $(bb-d8-node-name))-$(echo $step | sed 's#.*/##; s/_/-/g')"
     nodeName=$(bb-d8-node-name)
     eventLog="/var/lib/bashible/step.log"
+    if [[ -f "${eventLog}" ]]; then
+      eventNote="$(tail -c 500 "${eventLog}")"
+    else
+      eventNote="bashible step log is not available."
+    fi
     if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
+      indent="            " # 12 spaces
+      logs="$(bb-indent-text "$indent" <<<"${eventNote}")"
       bb-kubectl-exec apply -f - <<EOF || true
           apiVersion: events.k8s.io/v1
           kind: Event
@@ -101,7 +116,8 @@ function bb-event-error-create() {
             kind: Node
             name: ${nodeName}
             uid: ${nodeName}
-          note: '$(tail -c 500 ${eventLog})'
+          note: |
+${logs}
           reason: BashibleStepFailed
           type: Warning
           reportingController: bashible

--- a/candi/bashible/common-steps/all/001_waiting_approval_annotations.sh.tpl
+++ b/candi/bashible/common-steps/all/001_waiting_approval_annotations.sh.tpl
@@ -12,36 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-get_node_json() {
-  local node_json
-  node_json="$(bb-kubectl-exec get node $(bb-d8-node-name) -o json 2>&1)"
-  
-  if [ -z "$node_json" ]; then
-    bb-log-error "Failed to get node: empty response"
-    exit 1
-  fi
-  
-  if ! echo "$node_json" | jq empty 2>/dev/null; then
-    bb-log-error "Failed to get node: invalid JSON"
-    exit 1
-  fi
-  
-  echo "$node_json"
-}
-
 {{ if eq .runType "Normal" }}
 if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   >&2 echo "Setting update.node.deckhouse.io/waiting-for-approval= annotation on our Node..."
   attempt=0
   until
-    node_json="$(get_node_json)"
-    node_data="$(echo "$node_json" | jq '{
-        resourceVersion: .metadata.resourceVersion,
-        isApproved: .metadata.annotations | has("update.node.deckhouse.io/approved"),
-        isWaitingForApproval: .metadata.annotations | has("update.node.deckhouse.io/waiting-for-approval")
-      }')"
-    jq -ne --argjson n "$node_data" '(($n.isApproved | not) and ($n.isWaitingForApproval)) or ($n.isApproved)' >/dev/null
+    node_data="$(
+      bb-kubectl-exec get node $(bb-d8-node-name) -o json | jq '
+      {
+        "resourceVersion": .metadata.resourceVersion,
+        "isApproved": (.metadata.annotations | has("update.node.deckhouse.io/approved")),
+        "isWaitingForApproval": (.metadata.annotations | has("update.node.deckhouse.io/waiting-for-approval"))
+      }
+    ')" &&
+     jq -ne --argjson n "$node_data" '(($n.isApproved | not) and ($n.isWaitingForApproval)) or ($n.isApproved)' >/dev/null
   do
     attempt=$(( attempt + 1 ))
     if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
@@ -57,8 +41,8 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   >&2 echo "Waiting for update.node.deckhouse.io/approved= annotation on our Node..."
   attempt=0
   until
-    node_json="$(get_node_json)"
-    echo "$node_json" | jq -e '.metadata.annotations | has("update.node.deckhouse.io/approved")' >/dev/null
+    bb-kubectl-exec get node $(bb-d8-node-name) -o json | \
+    jq -e '.metadata.annotations | has("update.node.deckhouse.io/approved")' >/dev/null
   do
     attempt=$(( attempt + 1 ))
     if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then


### PR DESCRIPTION
## Description

bb-event-error-create function fix

## Why do we need it, and what problem does it solve?

bb-event-error-create is a function for creating k8s events about a bashible step failure. 
The event includes the latest data from the log. A problem was fixed where some logs could not be sent

```
printf "ERROR: Can't set annotation update.node.deckhouse.io/waiting-for-approval\n" > /var/lib/bashible/step.log
bb-event-error-create "/var/lib/bashible/bundle_steps/001_waiting_approval_annotations"

error: error parsing STDIN: error converting YAML to JSON: yaml: line 9: did not find expected key
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed an issue in `bb-event-error-create` that prevented some logs from sending.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
