### PR TITLE
[istio] Correction of the erroneous istiodRemote option in version 1.25

### DIFF
--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -41,8 +41,6 @@ spec:
     global:
       istiod:
         enableAnalysis: false
-      istiodRemote:
-        enabled: false
       defaultPodDisruptionBudget:
         enabled: false
       configValidation: false      # to deploy the ValidatingWebhookConfiguration resources by D8


### PR DESCRIPTION
## Description
When changing the global version of Istio, the queue was blocked with an error:
```
1. ModuleRun:main:istio:KubeConfig-Changed-Modules:failures 1:run helm install: install nelm release "istio": failed release "istio" (namespace: "d8-system"): execute release install plan: wait for operations completion: execute operation: create resource: server-side apply resource "Istio/v1x25 (namespace=d8-istio)": failed to create typed patch object (d8-istio/v1x25; sailoperator.io/v1, Kind=Istio): .spec.values.global.istiodRemote: field not declared in schema
```
This is due to the incorrect location of the `istiodRemote` option in templates for Istio version 1.25.

## Why do we need it, and what problem does it solve?
Due to a non-existent option and queue blocking, the istio module does not switch to the operating state. Resource `istios.sailoperator.io`, where information about the operator's status is stored, is not filled in and `istiod` is not working.

## Why do we need it in the patch release (if we do)?
This configuration error may cause users to disable Istio 1.25 when upgrading from a lower version.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Erroneous option in 1.25 control-plane helm template fixed.
impact_level: default
```