### PR TITLE
[node-manager]  Fix panic in registry packages proxy if image not found

### DIFF
--- a/go_lib/registry-packages-proxy/registry/default_client.go
+++ b/go_lib/registry-packages-proxy/registry/default_client.go
@@ -57,6 +57,17 @@ func (c *DefaultClient) GetPackage(ctx context.Context, log log.Logger, config *
 		repository.Digest(digest),
 		remoteOpts...)
 
+	if err != nil {
+		e := &transport.Error{}
+		if errors.As(err, &e) {
+			log.Error(e.Error())
+			if e.StatusCode == http.StatusNotFound {
+				return 0, "", nil, ErrPackageNotFound
+			}
+		}
+		return 0, "", nil, err
+	}
+
 	manifest, err := image.Manifest()
 	if err != nil {
 		return 0, "", nil, err
@@ -70,16 +81,6 @@ func (c *DefaultClient) GetPackage(ctx context.Context, log log.Logger, config *
 		}
 	}
 
-	if err != nil {
-		e := &transport.Error{}
-		if errors.As(err, &e) {
-			log.Error(e.Error())
-			if e.StatusCode == http.StatusNotFound {
-				return 0, "", nil, ErrPackageNotFound
-			}
-		}
-		return 0, "", nil, err
-	}
 
 	layers, err := image.Layers()
 	if err != nil {


### PR DESCRIPTION
## Description

fix panic in rpp after #14685

## Why do we need it, and what problem does it solve?

if the image is missing in the registry, a panic in rpp occurs

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix panic in registry packages proxy if image not found.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
