### PR TITLE
[dhctl][cloud-provider-yandex] Validate WithNAT layout params only in bootstrap

### DIFF
--- a/dhctl/pkg/infrastructureprovider/cloud/yandex/preparator.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/yandex/preparator.go
@@ -31,7 +31,11 @@ var prefixRegex = regexp.MustCompile("^([a-z]([-a-z0-9]{0,61}[a-z0-9])?)$")
 
 type MetaConfigPreparator struct {
 	validatePrefix bool
-	logger         log.Logger
+	// validateWithNATLayout
+	// todo need migration for validate everywhere not only bootstrap
+	validateWithNATLayout bool
+
+	logger log.Logger
 }
 
 func NewMetaConfigPreparator(validatePrefix bool) *MetaConfigPreparator {
@@ -46,6 +50,11 @@ func (p *MetaConfigPreparator) WithLogger(logger log.Logger) *MetaConfigPreparat
 		p.logger = logger
 	}
 
+	return p
+}
+
+func (p *MetaConfigPreparator) EnableValidateWithNATLayout() *MetaConfigPreparator {
+	p.validateWithNATLayout = true
 	return p
 }
 
@@ -117,6 +126,11 @@ func (p *MetaConfigPreparator) validateWithNATInstanceLayout(metaConfig *config.
 	// layout was prepared with strcase.ToKebab before calling preparator
 	if metaConfig.Layout != "with-nat-instance" {
 		p.logger.LogDebugF("Skip validate WithNATInstance layout. Got layout %v\n", metaConfig.Layout)
+		return nil
+	}
+
+	if !p.validateWithNATLayout {
+		p.logger.LogDebugLn("Skip validate WithNATInstance layout. Validation disabled")
 		return nil
 	}
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
@@ -35,12 +35,12 @@ func (b *ClusterBootstrapper) BaseInfrastructure(ctx context.Context) error {
 		defer restore()
 	}
 
+	preparatorParams := infrastructureprovider.NewPreparatorProviderParams(b.logger)
+	preparatorParams.WithPhaseBootstrap()
 	metaConfig, err := config.ParseConfig(
 		ctx,
 		app.ConfigPaths,
-		infrastructureprovider.MetaConfigPreparatorProvider(
-			infrastructureprovider.NewPreparatorProviderParams(b.logger),
-		),
+		infrastructureprovider.MetaConfigPreparatorProvider(preparatorParams),
 	)
 	if err != nil {
 		return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -223,12 +223,12 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	}
 
 	// first, parse and check cluster config
+	preparatorParams := infrastructureprovider.NewPreparatorProviderParams(b.logger)
+	preparatorParams.WithPhaseBootstrap()
 	metaConfig, err := config.LoadConfigFromFile(
 		ctx,
 		app.ConfigPaths,
-		infrastructureprovider.MetaConfigPreparatorProvider(
-			infrastructureprovider.NewPreparatorProviderParams(b.logger),
-		),
+		infrastructureprovider.MetaConfigPreparatorProvider(preparatorParams),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
In #16100 we moved validation for WithNATInstance layout for Yandex params from preflight checks to MetaConfig preparator.
This preflight check was added when we add multiple interfaces for NAT instance in #12301 for additional validation
But many our client were bootstrapped before #12301 and did not contain required fields and we have situation when converge and auto-converger was failed on MetaConfig validation. In general, we need to migrate Provider cluster configuration and add required fields, but this migration cannot be do in small time. So, we check WithNATInstance params only in bootstrap. In another places we do not  check them.

## Why do we need it, and what problem does it solve?
converge and auto-converger was failed on MetaConfig validation after #16100

## Why do we need it in the patch release (if we do)?
We cannot write migration for WithNATInstance in small time and we revert to old logic.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Validate WithNATInstance Yandex layout params only in bootstrap.
impact_level: default
---
section: cloud-provider-yandex
type: fix
summary: Terraform auto converger was failed for WithNATInstance layout. 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
