### PR TITLE
[ingress-nginx] add a symlink to the correct new opentelemetry path

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -341,8 +341,7 @@ shell:
   - mkdir -p /chroot/lib /chroot/proc /chroot/usr /chroot/bin /chroot/dev /chroot/run /chroot/lib64 /chroot/usr/local/modsecurity /chroot/usr/local/share
   - cp /etc/passwd /etc/group /etc/hosts /chroot/etc/
   - touch /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
-  - ln -sf /chroot/etc/ingress-controller/telemetry/opentelemetry.toml /chroot/etc/nginx/opentelemetry.toml
-  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /chroot/etc/nginx/opentelemetry.toml /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
+  - chown -R {{ $controllerUser }}:{{ $controllerUser }} /chroot/etc/ingress-controller/telemetry/opentelemetry.toml
   - cp -a /etc/pki /chroot/etc/pki
   - cp -a /usr/share/ca-certificates /chroot/usr/share/ca-certificates
   - cp -a /usr/bin/curl /chroot/usr/bin/curl
@@ -441,6 +440,7 @@ shell:
   - rm -rf /tmp
   - ln -sf /chroot/tmp /tmp
   - ln -sf /chroot/etc/ingress-controller /etc/ingress-controller
+  - ln -sf /etc/ingress-controller/telemetry/opentelemetry.toml /etc/nginx/opentelemetry.toml
   # a hack to let the controller update the /etc/nginx/lua/cfg.json file via a symlink on a read-only file system
   - mkdir /etc/ingress-controller/lua/ -p && touch /etc/ingress-controller/lua/cfg.json
   - ln -s /etc/ingress-controller/lua/cfg.json /chroot/etc/nginx/lua/cfg.json


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR updates the image of the ingress-nginx controller of v1.9 so that the old telemetry config file (/chroot/etc/nginx/opentelemetry.toml) is replaced by the symlink leading to the new opentelemetry config file (/chroot/etc/ingress-controller/telemetry/opentelemetry.toml).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We need it because if a user explicitly sets opentelemetry-config setting to /etc/nginx/opentelemetry.toml (from older ingress-nginx installations), the ingress-nginx controller is still able to write data to the telemetry config at the start (only /chroot/etc/ingress-controller/telemetry/opentelemetry.toml is writable because of readOnlyRootFilesystem setting).

## Why do we need it in the patch release (if we do)?

We need it in the patch release because we've already had one occurrence when opentelemetry-config setting was explicitly set to /etc/nginx/opentelemetry.toml.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: A symlink to the new opentelemetry config path is added.
impact: Ingress-Nginx controller's pods of 1.9 version will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
