### PR TITLE
[keepalived] remove readOnlyRootFilesystem from pod security context

### DIFF
--- a/ee/modules/450-keepalived/templates/statefulset.yaml
+++ b/ee/modules/450-keepalived/templates/statefulset.yaml
@@ -52,7 +52,6 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple $ "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_root" $ | nindent 6 }}
-        readOnlyRootFilesystem: true
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR corrects the module's template removing erroneous readOnlyRootFilesystem setting from the pod security context.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
An issue with the template was found after implementing Nelm in Deckhouse:
```
 1. ModuleRun:parallel_queue_0:keepalived:doStartup:OperatorStartup:failures 13:run helm install: install nelm release "keepalived": failed release "keepalived" (namespace: "d8-system"): execute release install plan: wait for operations completion: execute operation: apply resource: server-side apply resource "StatefulSet/keepalived-front (namespace=d8-keepalived)": failed to create typed patch object (d8-keepalived/keepalived-front; apps/v1, Kind=StatefulSet): .spec.template.spec.securityContext.readOnlyRootFilesystem: field not declared in schema
 ```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: keepalived
type: chore
summary: Erroneous readOnlyRootFilesystem setting is removed from the pod security context.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
