### PR TITLE
[deckhouse-controller] Fixed the default kubectl version selection

### DIFF
--- a/deckhouse-controller/files/bashrc.tpl
+++ b/deckhouse-controller/files/bashrc.tpl
@@ -37,7 +37,10 @@ fi
 if [ -s /tmp/kubectl_version ]; then
  kubernetes_version="$(cat /tmp/kubectl_version)"
 else
- kubernetes_version="{{ index (index . 0) "kubectl" }}"
+{{- /* 
+# if the controller is not running, we select the first acceptable version 
+*/}}
+ kubectl_version="{{ index (index . 0) "kubectl" }}"
 fi
 
 case "$kubernetes_version" in


### PR DESCRIPTION
## Description
If the controller is not running, we select the first valid version.

The edit in https://github.com/deckhouse/deckhouse/pull/15860 breaks the backup selection of the kubectl version in bashrc.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
We correct the error message before starting the controller or in the slave pod.

```
[dev-rnd] root@d8-virt-master-0:~# kubectl -n d8-system exec -ti deployments/deckhouse -- bash
bash: kubectl-: command not found
[deckhouse] root@d8-virt-master-0 /deckhouse # deckhouse-controller module values storage-volume-data-manager
deckhouse-controller: error: debug socket '/tmp/shell-operator-debug.socket' is not exists, try --help
```

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed the default kubectl version selection
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
