### PR TITLE
[istio] the option to enter an ip address or fqdn in the advertise

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -90,11 +90,11 @@ properties:
                 address:
                   anyOf:
                   - type: string
+                    example: "somehost.example.com"
+                    pattern: '^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$'
+                  - type: string
                     example: "172.16.0.5"
                     pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'
-                  - type: string
-                    example: "somehost.example.com"
-                    pattern: '^(?=.{1,253}\.?$)(([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.?)$'
                 port:
                   type: integer
                   minimum: 1024


### PR DESCRIPTION
## Description
The `address` option in the `ingressGateway.advertise` API has been expanded with the ability to specify the FQDN of the local cluster.

## Why do we need it, and what problem does it solve?
In the case when the public address of the cluster can change, the FQDN option has been added, which allows you to specify the address of the local server to be transmitted to the remote server. If the IP address is changed, the remote cluster will update the DNS record of the remote server's FQDN.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Added FQDN support to the `alliance.ingressGateway.advertise` section.
impact_level: default
```
