### PR TITLE
[deckhouse-controller] fix: can not read modules count from channel mapping editor error

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -218,8 +217,11 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 
 	if len(addrs) == 0 {
 		// no endpoints for doc builder
+		r.logger.Warn("No docs-builder addresses found, skipping documentation update", slog.String("module_name", moduleName))
 		return result, nil
 	}
+
+	r.logger.Debug("Found docs-builder addresses", slog.String("module_name", moduleName), slog.Int("addresses_count", len(addrs)), slog.Any("addresses", addrs))
 
 	b := new(bytes.Buffer)
 
@@ -240,6 +242,7 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 			cond.Checksum == md.Spec.Checksum &&
 			cond.Type == v1alpha1.TypeRendered {
 			// documentation is rendered for this builder
+			r.logger.Debug("Documentation already rendered for builder, skipping", slog.String("module_name", moduleName), slog.String("address", addr), slog.String("version", md.Spec.Version), slog.String("checksum", md.Spec.Checksum))
 			mdCopy.Status.Conditions = append(mdCopy.Status.Conditions, cond)
 			rendered++
 			continue
@@ -253,17 +256,21 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 		}
 
 		if fetchModuleErr != nil {
+			r.logger.Error("Failed to fetch documentation from module directory", slog.String("module_name", moduleName), slog.String("address", addr), slog.String("path", md.Spec.Path), log.Err(fetchModuleErr))
 			cond.Type = v1alpha1.TypeError
 			cond.Message = fmt.Sprintf("Error occurred while fetching the documentation: %s. Please fix the module's docs or restart the Deckhouse to restore the module", fetchModuleErr)
 			mdCopy.Status.Conditions = append(mdCopy.Status.Conditions, cond)
 			continue
 		}
 
+		r.logger.Debug("Sending documentation to builder", slog.String("module_name", moduleName), slog.String("address", addr), slog.String("version", md.Spec.Version), slog.Int("archive_size", b.Len()))
 		err = r.buildDocumentation(ctx, bytes.NewReader(b.Bytes()), addr, moduleName, md.Spec.Version)
 		if err != nil {
+			r.logger.Error("Failed to build documentation", slog.String("module_name", moduleName), slog.String("address", addr), slog.String("version", md.Spec.Version), log.Err(err))
 			cond.Type = v1alpha1.TypeError
 			cond.Message = err.Error()
 		} else {
+			r.logger.Debug("Successfully built documentation", slog.String("module_name", moduleName), slog.String("address", addr), slog.String("version", md.Spec.Version))
 			rendered++
 			cond.Type = v1alpha1.TypeRendered
 			cond.Message = ""
@@ -275,12 +282,15 @@ func (r *reconciler) createOrUpdateReconcile(ctx context.Context, md *v1alpha1.M
 	switch {
 	case rendered == 0:
 		mdCopy.Status.RenderResult = v1alpha1.ResultError
+		r.logger.Warn("No documentation was rendered for any builder", slog.String("module_name", moduleName), slog.Int("total_builders", len(addrs)))
 
 	case rendered == len(addrs):
 		mdCopy.Status.RenderResult = v1alpha1.ResultRendered
+		r.logger.Debug("Documentation rendered successfully for all builders", slog.String("module_name", moduleName), slog.Int("builders_count", len(addrs)))
 
 	default:
 		mdCopy.Status.RenderResult = v1alpha1.ResultPartially
+		r.logger.Warn("Documentation rendered partially", slog.String("module_name", moduleName), slog.Int("rendered", rendered), slog.Int("total_builders", len(addrs)))
 	}
 
 	if err = r.client.Status().Patch(ctx, mdCopy, client.MergeFrom(md)); err != nil {
@@ -327,7 +337,10 @@ func (r *reconciler) getDocsBuilderAddresses(ctx context.Context) ([]string, err
 }
 
 func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes.Buffer) error {
-	moduleDir := path.Join(r.downloadedModulesDir, modulePath) + "/"
+	// modulePath is now in format "/modules/<module>" (e.g., "/modules/stronghold")
+	// Remove leading slash and join with downloadedModulesDir to get full path
+	cleanPath := strings.TrimPrefix(modulePath, "/")
+	moduleDir := filepath.Join(r.downloadedModulesDir, cleanPath)
 
 	dir, err := os.Stat(moduleDir)
 	if err != nil {
@@ -350,7 +363,15 @@ func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes
 			return nil
 		}
 
-		if !module.IsDocsPath(strings.TrimPrefix(file, moduleDir)) {
+		// Get relative path from module directory
+		relPath, err := filepath.Rel(moduleDir, file)
+		if err != nil {
+			return err
+		}
+
+		// Convert to forward slashes for IsDocsPath check (it expects Unix-style paths)
+		relPathUnix := filepath.ToSlash(relPath)
+		if !module.IsDocsPath(relPathUnix) {
 			return nil
 		}
 
@@ -359,7 +380,8 @@ func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes
 			return err
 		}
 
-		header.Name = strings.TrimPrefix(file, moduleDir)
+		// Use forward slashes in tar header (tar format uses forward slashes)
+		header.Name = relPathUnix
 
 		if err = tw.WriteHeader(header); err != nil {
 			return err
@@ -391,10 +413,12 @@ func (r *reconciler) getDocumentationFromModuleDir(modulePath string, buf *bytes
 }
 
 func (r *reconciler) buildDocumentation(ctx context.Context, docsArchive io.Reader, baseAddr, moduleName, moduleVersion string) error {
+	r.logger.Debug("Sending documentation archive", slog.String("module_name", moduleName), slog.String("address", baseAddr), slog.String("version", moduleVersion))
 	if err := r.docsBuilder.SendDocumentation(ctx, baseAddr, moduleName, moduleVersion, docsArchive); err != nil {
 		return fmt.Errorf("send documentation: %w", err)
 	}
 
+	r.logger.Debug("Triggering documentation build", slog.String("module_name", moduleName), slog.String("address", baseAddr))
 	if err := r.docsBuilder.BuildDocumentation(ctx, baseAddr); err != nil {
 		return fmt.Errorf("build documentation: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller_test.go
@@ -98,8 +98,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("with only one builder", func() {
-		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi"), 0777)
-		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi", "config-values.yaml"), []byte("{}"), 0666)
+		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi"), 0777)
+		_ = os.WriteFile(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
 		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
@@ -121,8 +121,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("with two builders", func() {
-		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi"), 0777)
-		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi", "config-values.yaml"), []byte("{}"), 0666)
+		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi"), 0777)
+		_ = os.WriteFile(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
 		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
@@ -144,8 +144,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("one builder cannot render", func() {
-		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi"), 0777)
-		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.0.0", "openapi", "config-values.yaml"), []byte("{}"), 0666)
+		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi"), 0777)
+		_ = os.WriteFile(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
 		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			if strings.HasPrefix(req.Host, "10-111-111-11") {
@@ -171,8 +171,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("render new version", func() {
-		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi"), 0777)
-		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi", "config-values.yaml"), []byte("{}"), 0666)
+		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi"), 0777)
+		_ = os.WriteFile(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
 		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
@@ -194,8 +194,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("render new lease", func() {
-		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi"), 0777)
-		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi", "config-values.yaml"), []byte("{}"), 0666)
+		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi"), 0777)
+		_ = os.WriteFile(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
 		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
@@ -217,8 +217,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("render new checksum", func() {
-		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "dev", "openapi"), 0777)
-		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "dev", "openapi", "config-values.yaml"), []byte("{}"), 0666)
+		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi"), 0777)
+		_ = os.WriteFile(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 
 		dependency.TestDC.HTTPClient.DoMock.Set(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
@@ -240,8 +240,8 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 	})
 
 	suite.Run("keep up-to-date rendered documentation", func() {
-		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi"), 0777)
-		_ = os.WriteFile(filepath.Join(suite.tmpDir, "testmodule", "v1.1.1", "openapi", "config-values.yaml"), []byte("{}"), 0666)
+		_ = os.MkdirAll(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi"), 0777)
+		_ = os.WriteFile(filepath.Join(suite.tmpDir, "modules", "testmodule", "openapi", "config-values.yaml"), []byte("{}"), 0666)
 		dependency.TestDC.GetClock().(clockwork.FakeClock).Advance(1 * time.Hour)
 
 		suite.setupController(string(suite.fetchTestFileData("keep-actual.yaml")))

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/empty-dir.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/empty-dir.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: v1.0.0
   checksum: abc
-  path: /absentmodule/v1.0.0
+  path: /modules/absentmodule
 status:
   conditions:
     - address: http://10-111-111-111.d8-system.pod.cluster.local:8081

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/empty-dir.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/empty-dir.yaml
@@ -7,14 +7,14 @@ metadata:
   resourceVersion: "1000"
 spec:
   checksum: abc
-  path: /absentmodule/v1.0.0
+  path: /modules/absentmodule
   version: v1.0.0
 status:
   conditions:
   - address: http://10-222-222-22.d8-system.pod.cluster.local:8081
     checksum: abc
     lastTransitionTime: "2019-10-17T16:33:00Z"
-    message: 'Error occurred while fetching the documentation: stat /testdir/absentmodule/v1.0.0/:
+    message: 'Error occurred while fetching the documentation: stat /testdir/modules/absentmodule:
       no such file or directory. Please fix the module''s docs or restart the Deckhouse
       to restore the module'
     type: Error

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/keep-actual.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/keep-actual.yaml
@@ -9,7 +9,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   checksum: abc
-  path: /testmodule/v1.1.1
+  path: /modules/testmodule
   version: v1.1.1
 status:
   conditions:

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/no-builders.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/no-builders.yaml
@@ -7,6 +7,6 @@ metadata:
   resourceVersion: "999"
 spec:
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule
   version: v1.0.0
 status: {}

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/one-builder.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/one-builder.yaml
@@ -9,7 +9,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule
   version: v1.0.0
 status:
   conditions:

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/render-new-checksum.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/render-new-checksum.yaml
@@ -9,7 +9,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   checksum: zxc
-  path: /testmodule/dev
+  path: /modules/testmodule
   version: mpo-tag
 status:
   conditions:

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/render-new-lease.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/render-new-lease.yaml
@@ -9,7 +9,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   checksum: abc
-  path: /testmodule/v1.1.1
+  path: /modules/testmodule
   version: v1.1.1
 status:
   conditions:

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/render-new-version.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/render-new-version.yaml
@@ -9,7 +9,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   checksum: dfg
-  path: /testmodule/v1.1.1
+  path: /modules/testmodule
   version: v1.1.1
 status:
   conditions:

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/two-builders-partially.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/two-builders-partially.yaml
@@ -7,7 +7,7 @@ metadata:
   resourceVersion: "1000"
 spec:
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule
   version: v1.0.0
 status:
   conditions:

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/two-builders.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/golden/two-builders.yaml
@@ -9,7 +9,7 @@ metadata:
   resourceVersion: "1001"
 spec:
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule
   version: v1.0.0
 status:
   conditions:

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/keep-actual.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/keep-actual.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: v1.1.1
   checksum: abc
-  path: /testmodule/v1.1.1
+  path: /modules/testmodule
 status:
   conditions:
     - address: http://10-111-111-11.d8-system.pod.cluster.local:8081

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/no-builders.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/no-builders.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   version: v1.0.0
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/one-builder.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/one-builder.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v1.0.0
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule
 ---
 apiVersion: coordination.k8s.io/v1
 kind: Lease

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/render-new-checksum.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/render-new-checksum.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: mpo-tag
   checksum: zxc
-  path: /testmodule/dev
+  path: /modules/testmodule
 status:
   conditions:
     - address: http://10-222-222-22.d8-system.pod.cluster.local:8081

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/render-new-lease.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/render-new-lease.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: v1.1.1
   checksum: abc
-  path: /testmodule/v1.1.1
+  path: /modules/testmodule
 status:
   conditions:
     - address: http://10-222-222-22.d8-system.pod.cluster.local:8081

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/render-new-version.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/render-new-version.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   version: v1.1.1
   checksum: dfg
-  path: /testmodule/v1.1.1
+  path: /modules/testmodule
 status:
   conditions:
     - address: http://10-222-222-22.d8-system.pod.cluster.local:8081

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/two-builders-partially.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/two-builders-partially.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v1.0.0
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule
 ---
 apiVersion: coordination.k8s.io/v1
 kind: Lease

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/two-builders.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/testdata/two-builders.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v1.0.0
   checksum: abc
-  path: /testmodule/v1.0.0
+  path: /modules/testmodule
 ---
 apiVersion: coordination.k8s.io/v1
 kind: Lease

--- a/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
@@ -309,7 +309,8 @@ func (r *reconciler) handleModuleOverride(ctx context.Context, mpo *v1alpha2.Mod
 		_ = r.client.Update(ctx, mpo)
 	}
 
-	modulePath := fmt.Sprintf("/%s/dev", mpo.GetModuleName())
+	// Use mount point path: /modules/<module> (modules are mounted at /deckhouse/downloaded/modules/<module>)
+	modulePath := fmt.Sprintf("/modules/%s", mpo.GetModuleName())
 	ownerRef := metav1.OwnerReference{
 		APIVersion: v1alpha2.ModulePullOverrideGVK.GroupVersion().String(),
 		Kind:       v1alpha2.ModulePullOverrideGVK.Kind,

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -598,7 +598,8 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		return res, nil
 	}
 
-	modulePath := fmt.Sprintf("/%s/v%s", release.GetModuleName(), release.GetVersion().String())
+	// Use mount point path: /modules/<module> (modules are mounted at /deckhouse/downloaded/modules/<module>)
+	modulePath := fmt.Sprintf("/modules/%s", release.GetModuleName())
 	moduleVersion := "v" + release.GetVersion().String()
 
 	moduleChecksum := release.Labels[v1alpha1.ModuleReleaseLabelReleaseChecksum]

--- a/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
@@ -288,7 +288,11 @@ func EnsureModuleDocumentation(
 		}
 	}
 
-	if md.Spec.Version != moduleVersion || md.Spec.Checksum != moduleChecksum {
+	// Check if path needs to be migrated from old format (e.g., "/module/v1.0.0" or "/module/dev")
+	// to new format ("/modules/module")
+	needsPathUpdate := !strings.HasPrefix(md.Spec.Path, "/modules/")
+
+	if md.Spec.Version != moduleVersion || md.Spec.Checksum != moduleChecksum || needsPathUpdate {
 		// update module documentation
 		md.Spec.Path = modulePath
 		md.Spec.Version = moduleVersion

--- a/docs/site/backends/docs-builder/internal/docs/channel_mapping.go
+++ b/docs/site/backends/docs-builder/internal/docs/channel_mapping.go
@@ -155,10 +155,6 @@ func (m *channelMappingEditor) getModulesCount() (int, error) {
 	path := filepath.Join(m.baseDir, modulesDir, "channels.yaml")
 	f, err := os.Open(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			// File doesn't exist yet, return 0 modules count
-			return 0, nil
-		}
 		return -1, fmt.Errorf("open %q: %w", path, err)
 	}
 	defer f.Close()

--- a/docs/site/backends/docs-builder/internal/docs/upload.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload.go
@@ -145,9 +145,9 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 
 	if fileName, ok := strings.CutPrefix(fileName, "docs"); ok {
 		// Skip internal documentation directories that should not be published
-		// if hasBlockedPrefix(fileName) {
-		// 	return "", false
-		// }
+		if hasBlockedPrefix(fileName) {
+			return "", false
+		}
 		return filepath.Join(svc.baseDir, contentDir, moduleName, channel, fileName), true
 	}
 


### PR DESCRIPTION
## Description

Fixed the issue with reading module documentation from EROFS images. Changed the path format in `ModuleDocumentation.Spec.Path` from versioned format (`/module/v1.0.0`) to mount point format (`/modules/module`), as modules are now stored as EROFS images and mounted at `/deckhouse/downloaded/modules/<module>`.

## Why do we need it, and what problem does it solve?

Deckhouse modules are now stored as EROFS images (Enhanced Read-Only File System) instead of regular directories. EROFS images are mounted at `/deckhouse/downloaded/modules/<module>`, not at `/deckhouse/downloaded/<module>/<version>`.

**Problem:** The documentation controller was trying to read documentation from the path `/deckhouse/downloaded/<module>/<version>/`, which no longer exists. Instead, modules are mounted at `/deckhouse/downloaded/modules/<module>`, causing errors: `stat /deckhouse/downloaded/<module>/v1.16.6/: no such file or directory`

**Solution:** Changed the path format in `ModuleDocumentation` to use the EROFS image mount point. The controller now correctly reads documentation from mounted modules.

**Impact:** Critical for module documentation functionality. Without this fix, module documentation cannot be collected and sent to docs-builder.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed module documentation collection from EROFS mounted modules.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
