### PR TITLE
[docs] Update getting-started guide for bare metal

### DIFF
--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE.md
@@ -344,7 +344,7 @@ sudo -i d8 k create -f $PWD/user.yml
 <li><strong>Create DNS records</strong> to organize access to the cluster web-interfaces:
   <ul><li>Identify the public IP address of the node where the Ingress Controller is running:
   <div class="highlight">
-  <pre class="highlight"><code>kubectl get pods -n d8-ingress-nginx -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.hostIP}{"\n"}{end}' | grep '^controller' | awk '{print $2}'</code></pre>
+  <pre class="highlight"><code>sudo -i d8 k get pods -n d8-ingress-nginx -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.hostIP}{"\n"}{end}' | grep '^controller' | awk '{print $2}'</code></pre>
   </div>
   </li>
   <li>If you have the DNS server and you can add a DNS records:

--- a/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
+++ b/docs/site/_includes/getting_started/bm/STEP_FINALIZE_RU.md
@@ -352,7 +352,7 @@ sudo -i d8 k create -f $PWD/user.yml
 <li><strong>Создание DNS-записи</strong>, для доступа в веб-интерфейсы кластера
   <ul><li>Выясните публичный IP-адрес узла, на котором работает Ingress-контроллер:
   <div class="highlight">
-  <pre class="highlight"><code>kubectl get pods -n d8-ingress-nginx -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.hostIP}{"\n"}{end}' | grep '^controller' | awk '{print $2}'</code></pre>
+  <pre class="highlight"><code>sudo -i d8 k get pods -n d8-ingress-nginx -o=jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.hostIP}{"\n"}{end}' | grep '^controller' | awk '{print $2}'</code></pre>
   </div>
   </li>
   <li>Если у вас есть возможность добавить DNS-запись используя DNS-сервер:


### PR DESCRIPTION
## Description

This PR adds a command to the bare metal getting-started guide that is required to identify an Ingress Controller's node IP address.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated getting-started guide for bare metal.
impact_level: low
```