### PR TITLE
[docs] Update guide about DKP in air-gapped environment

### DIFF
--- a/docs/site/pages/guides/AIRGAPPED_UPDATE.md
+++ b/docs/site/pages/guides/AIRGAPPED_UPDATE.md
@@ -255,6 +255,7 @@ Vulnerability database images in [DKP EE](/modules/operator-trivy/) have fixed n
 registry.deckhouse.io/deckhouse/ee/security/trivy-db:2
 registry.deckhouse.io/deckhouse/ee/security/trivy-java-db:1
 registry.deckhouse.io/deckhouse/ee/security/trivy-checks:0
+registry.deckhouse.io/deckhouse/ee/security/trivy-bdu:1
 ```
 
 To configure periodic updates of vulnerability database images, run the command in the following format:

--- a/docs/site/pages/guides/AIRGAPPED_UPDATE_RU.md
+++ b/docs/site/pages/guides/AIRGAPPED_UPDATE_RU.md
@@ -232,6 +232,7 @@ crane export registry.deckhouse.ru/deckhouse/ee/modules/console/release:alpha | 
 registry.deckhouse.ru/deckhouse/ee/security/trivy-db:2
 registry.deckhouse.ru/deckhouse/ee/security/trivy-java-db:1
 registry.deckhouse.ru/deckhouse/ee/security/trivy-checks:0
+registry.deckhouse.ru/deckhouse/ee/security/trivy-bdu:1
 ```
 
 Для настройки периодического обновления образов баз данных уязвимостей используйте конструкцию вида:


### PR DESCRIPTION
## Description

This PR updates the list of vulnerability database images in the guide about DKP in air-gapped environment.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated guide on DKP in air-gapped environment.
impact_level: low
```