### PR TITLE
[log-shipper] Bump log-shipper version v0.44.0 -> v0.51.1

### DIFF
--- a/modules/460-log-shipper/images/vector/werf.inc.yaml
+++ b/modules/460-log-shipper/images/vector/werf.inc.yaml
@@ -32,7 +32,7 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone --depth 1 --branch v0.44.0 $(cat /run/secrets/SOURCE_REPO)/vectordotdev/vector.git /src/vector
+  - git clone --depth 1 --branch v0.51.1 $(cat /run/secrets/SOURCE_REPO)/vectordotdev/vector.git /src/vector
   - rm -rf /src/vector/website /src/vector/scripts/integration
   - rm -rf /src/vector/.git
 ---


### PR DESCRIPTION
## Description
Bump log-shipper version v0.44.0 -> v0.51.1

## Why do we need it, and what problem does it solve?
Improve security by bumping dependencies versions. No major features added.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: log-shipper
type: chore
summary: Bump log-shipper version v0.44.0 -> v0.51.1
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
