### PR TITLE
[docs][node-manager] Clear node removal way in the static cluster

### DIFF
--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -191,16 +191,16 @@ To decommission a node from the cluster and clean up the server (VM), run the fo
 
 ### For control-plane nodes
 
-1. Remove the label control-plane and master:
+1. Remove the labels `node-role.kubernetes.io/control-plane`, `node-role.kubernetes.io/master`, and `node.deckhouse.io/group` from the node:
 
    ```shell
    d8 k label node <node> node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master- node.deckhouse.io/group-
    ```
 
-1. Make sure that the node being deleted by the control-plane is missing from the list of etcd cluster nodes:
+1. Make sure the removed node with control-plane has disappeared from the list of etcd cluster members:
 
    ```shell
-   d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- \ etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \ --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \ --endpoints https://127.0.0.1:2379/ member list -w table
+   d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
 1. Delete a node from the Kubernetes cluster:
@@ -220,11 +220,11 @@ To decommission a node from the cluster and clean up the server (VM), run the fo
 
 1. After restarting the node [run](#how-do-i-add-a-static-node-to-a-cluster) the script `bootstrap.sh`.
 
-1. Wait for the Deckhouse queues to pass and make sure that the etcd cluster member is back online:
+1. Wait for the Deckhouse queues to be processed and ensure that the etcd cluster member has reappeared in the list:
   
-  ```shell
-  d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- \ etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \ --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \ --endpoints https://127.0.0.1:2379/ member list -w table
-  ```
+   ```shell
+   d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
+   ```
 
 ### Can I delete a StaticInstance?
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -265,16 +265,16 @@ d8 k label node <node_name> node-role.kubernetes.io/<old_node_group_name>-
 
 ### Для узлов control-plane
 
-1. Снимите label control-plane и master:
+1. Снимите лейблы `node-role.kubernetes.io/control-plane`, `node-role.kubernetes.io/master` и `node.deckhouse.io/group` с узла:
 
    ```shell
    d8 k label node <node> node-role.kubernetes.io/control-plane- node-role.kubernetes.io/master- node.deckhouse.io/group-
    ```
 
-1. Убедитесь, что удаляемый control-plane узел пропал из списка узлов кластера etcd:
+1. Убедитесь, что удаляемый узел с control-plane пропал из списка членов кластера etcd:
 
    ```shell
-   d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- \ etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \ --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \ --endpoints https://127.0.0.1:2379/ member list -w table
+   d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
    ```
 
 1. Удалите узел из кластера Kubernetes:
@@ -294,11 +294,11 @@ d8 k label node <node_name> node-role.kubernetes.io/<old_node_group_name>-
 
 1. После перезагрузки узла [запустите](#как-добавить-статический-узел-в-кластер) скрипт `bootstrap.sh`.
 
-1. Дождитесь прохождения очередей Deckhouse и убедитесь, что член кластера etcd снова в строю:
+1. Дождитесь прохождения очередей Deckhouse и убедитесь, что член кластера etcd снова появился в списке:
   
-  ```shell
-  d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- \ etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt \ --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key \ --endpoints https://127.0.0.1:2379/ member list -w table
-  ```
+   ```shell
+   d8 k -n kube-system exec -ti $(d8 k -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key --endpoints https://127.0.0.1:2379/ member list -w table
+   ```
 
 ## Как понять, что что-то пошло не так?
 


### PR DESCRIPTION
## Description
Added documentation for the static node removal procedure from the Kubernetes cluster based on numerous requests from customers and internal teams. The documentation now provides clear guidance on how to properly remove any node from the Kubernetes cluster for subsequent re-introduction.

## Why do we need it, and what problem does it solve?
This documentation update addresses the common challenge faced by users when they need to properly remove static nodes from their Kubernetes cluster. Previously, there was no clear, official guidance on the correct procedure for node removal, leading to potential cluster instability and configuration issues. The new documentation provides step-by-step instructions ensuring safe node removal and subsequent re-introduction.

## Why do we need it in the patch release (if we do)?

Recently, we have received many requests for an explanation of this functionality, and the current path described in the documentation sometimes leads to various malfunctions in the cluster.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Added documentation for proper static node removal procedure.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
