### PR TITLE
updated rules to enable hashi/openbao/werf tokens detection

### DIFF
--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -30,3 +30,20 @@ regexes = [
     '''AKIAIOSFODNN7EXAMPLE''',
     '''wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY''',
 ]
+
+# Custom rules for hashi/openbao/werf tokens
+[[rules]]
+id = "werf-secret-key"
+description = "Identified a Werf Secret Key."
+regex = '''\b([a-f0-9]{32})\b'''
+path = '''\.werf_secret_key$'''
+
+[[rules]]
+id = "hashicorp-vault-token"
+description = "Identified a HashiCorp Vault token (hvs, hvb, or hvr prefix)."
+regex = '''\b(hv[sbr]\.[A-Za-z0-9_-]{20,})\b'''
+
+[[rules]]
+id = "openbao-token"
+description = "Identified an OpenBao token (S. prefix)."
+regex = '''\b(S\.[A-Za-z0-9_-]{20,})\b'''


### PR DESCRIPTION
## Description

This PR enhances the Gitleaks secret scanning configuration by adding custom detection rules for project-specific secrets:

1. **Werf Secret Key detection**: Added rule to detect 32-character hexadecimal Werf secret keys in `.werf_secret_key` files with path-based filtering to reduce false positives.

2. **HashiCorp Vault token detection**: Added rule to detect HashiCorp Vault tokens with prefixes `hvs.`, `hvb.`, and `hvr.` (previously only `hvs.` tokens were detected).

3. **OpenBao token detection**: Added rule to detect OpenBao tokens with `S.` prefix format.

## Why do we need it, and what problem does it solve?

Previously, Gitleaks was missing several types of secrets used in our infrastructure:
- Werf secret keys in `.werf_secret_key` files were not being detected
- HashiCorp Vault tokens with `hvb` and `hvr` prefixes were not detected (only `hvs` tokens were found)
- OpenBao tokens with `S.` prefix format were completely undetected

This enhancement improves our security posture by ensuring all relevant secret types are properly scanned and detected during code reviews and CI/CD pipeline runs.

## Why do we need it in the patch release (if we do)?

Not necessarily. This is a security improvement that can be included in the next regular release.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: feature
summary: Enhanced Gitleaks secret scanning with custom rules for Werf, HashiCorp Vault, and OpenBao tokens
impact: Gitleaks now detects Werf secret keys in `.werf_secret_key` files, all HashiCorp Vault token types (hvs, hvb, hvr), and OpenBao tokens (S. prefix). This improves security by catching previously undetected secrets during code reviews and CI scans.
impact_level: low
```