### PR TITLE
[monitoring-kubernetes] Remove docker traces from the module code

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/mount-points.yaml
+++ b/modules/340-monitoring-kubernetes/images/kubelet-eviction-thresholds-exporter/mount-points.yaml
@@ -2,7 +2,5 @@ dirs:
 - /host/
 - /var/run/node-exporter-textfile
 - /run/node-exporter-textfile
-- /var/run/docker.sock
-- /run/docker.sock
 - /etc/containerd
 - /root/.kube

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -138,8 +138,6 @@ spec:
           mountPath: /host/
         - name: textfile-kubelet-eviction-thresholds-exporter
           mountPath: /var/run/node-exporter-textfile
-        - name: dockersock
-          mountPath: /var/run/docker.sock
         - name: containerddir
           mountPath: /etc/containerd
         - name: kube
@@ -204,9 +202,6 @@ spec:
       - name: root
         hostPath:
           path: /
-      - name: dockersock
-        hostPath:
-          path: /var/run/docker.sock
       - name: containerddir
         hostPath:
           path: /etc/containerd


### PR DESCRIPTION
## Description
Remove all the Docker traces from the module

## Why do we need it, and what problem does it solve?
There are several confirmed cases where the node-exporter enters CrashLoopBackoff state due to the presence of a hostPath mount of the Docker socket with the following message:
```
Message:      failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/var/run/docker.sock" to rootfs at "/var/run/docker.sock": mount src=/var/run/docker.sock, dst=/var/run/docker.sock, dstFd=/proc/thread-self/fd/8, flags=MS_BIND|MS_REC: not a directory: unknown
```
Since the Deckhouse no longer supports Docker as a container runtime, we are free to remove all the Docker traces left in this module, effectively fixing the issue

## Why do we need it in the patch release (if we do)?
We do, as there are several clusters on a 1.73 release affected by this issue

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-kubernetes
type: fix
summary: remove the Docker traces from the module code
impact: node-exporter pods will be rollout restarted during upgrade
impact_level: default
```
