### PR TITLE
[monitoring-kubernetes] Add missing severity level label to the PodStatusIsIncorrect alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -6294,7 +6294,7 @@ alerts:
            ```
       summary: |
         Incorrect state of Pod {{ $labels.namespace }}/{{ $labels.pod }} running on node {{ $labels.node }}.
-      severity: undefined
+      severity: "6"
       markupFormat: markdown
     - name: PrometheusDirectAccessDeprecated
       sourceFile: modules/300-prometheus/monitoring/prometheus-rules/deprecation.yaml

--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/pod-status.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/pod-status.yaml
@@ -10,6 +10,8 @@
           (count by (namespace, pod) (kube_pod_container_status_ready==0) * on (namespace, pod) group_left(node) (max by (namespace, node, pod) (kube_pod_info)))
         )
       for: 10m
+      labels:
+        severity_level: "6"
       annotations:
         plk_markup_format: markdown
         plk_protocol_version: "1"


### PR DESCRIPTION
## Description
The severity_level label for the PodStatusIsIncorrect is missing. Set to 6.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-kubernetes
type: chore
summary: Added missing severity_level label to the PodStatusIsIncorrect alert.
```