### PR TITLE
[cloud-provider-azure] fix build image for azure ccm

### DIFF
--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
@@ -64,7 +64,7 @@ shell:
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
   setup:
   - cd /src
-  - go build -a -o bin/azure-cloud-controller-manager ./cmd/cloud-controller-manager
+  - CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o bin/azure-cloud-controller-manager ./cmd/cloud-controller-manager
   - chown 64535:64535 /src/bin/azure-cloud-controller-manager
   - chmod 0755 /src/bin/azure-cloud-controller-manager
   {{- end }}


### PR DESCRIPTION
## Description
Fix build image for azure ccm

## Why do we need it, and what problem does it solve?
Image is broken because binary is dynamically linked. 

## Why do we need it in the patch release (if we do)?

Image is broken because binary is dynamically linked. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-azure
type: fix
summary: fix build image for azure ccm
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
