### PR TITLE
[candi] Add configuration of maxPods

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -332,7 +332,7 @@ maxOpenFiles: 1000000
 {{- if (((.nodeGroup).kubelet).maxPods) }}
   {{- $max_pods = .nodeGroup.kubelet.maxPods | int }}
 {{- else }}
-  {{- $prefix := .normal.podSubnetNodeCIDRPrefix | default 24 }}
+  {{- $prefix := .normal.podSubnetNodeCIDRPrefix | default "24" | int }}
   {{- if ge $prefix 24 }}
     {{- $max_pods = 120 }}
   {{- else if eq $prefix 23 }}

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
@@ -449,7 +449,7 @@ type bundleK8sVersionContext struct {
 }
 
 type normal struct {
-	PodSubnetNodeCIDRPrefix int               `json:"podSubnetNodeCIDRPrefix" yaml:"podSubnetNodeCIDRPrefix"`
+	PodSubnetNodeCIDRPrefix string            `json:"podSubnetNodeCIDRPrefix" yaml:"podSubnetNodeCIDRPrefix"`
 	ClusterDomain           string            `json:"clusterDomain" yaml:"clusterDomain"`
 	ClusterDNSAddress       string            `json:"clusterDNSAddress" yaml:"clusterDNSAddress"`
 	BootstrapTokens         map[string]string `json:"bootstrapTokens" yaml:"bootstrapTokens"`
@@ -459,7 +459,7 @@ type normal struct {
 }
 
 type inputData struct {
-	PodSubnetNodeCIDRPrefix    int                    `json:"podSubnetNodeCIDRPrefix" yaml:"podSubnetNodeCIDRPrefix"`
+	PodSubnetNodeCIDRPrefix    string                 `json:"podSubnetNodeCIDRPrefix" yaml:"podSubnetNodeCIDRPrefix"`
 	ClusterDomain              string                 `json:"clusterDomain" yaml:"clusterDomain"`
 	ClusterDNSAddress          string                 `json:"clusterDNSAddress" yaml:"clusterDNSAddress"`
 	CloudProvider              interface{}            `json:"cloudProvider,omitempty" yaml:"cloudProvider,omitempty"`

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -114,7 +114,7 @@ spec:
 
 
 {{- define "bashible_input_data" }}
-    podSubnetNodeCIDRPrefix: {{ $.Values.global.clusterConfiguration.podSubnetNodeCIDRPrefix | int }}
+    podSubnetNodeCIDRPrefix: {{ $.Values.global.clusterConfiguration.podSubnetNodeCIDRPrefix | quote }}
     clusterDomain: {{ $.Values.global.discovery.clusterDomain | toYaml }}
     clusterDNSAddress: {{ $.Values.global.discovery.clusterDNSAddress | toYaml }}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add dynamic default value for `maxPods` based on `podSubnetNodeCIDRPrefix`.
Defaults: ≥/24 → 120, /23 → 250, /22 → 500, ≤/21 → 1000.
If `nodeGroup.kubelet.maxPods` is explicitly set, it overrides the default.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Removes manual configuration and aligns maxPods with the node CIDR size, reducing misconfigurations.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
No need

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Added dynamic default for `maxPods` based on `podSubnetNodeCIDRPrefix`.
impact: Kubelet will restart. The maximum default number of pods per node now automatically depends on the node CIDR size.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
