### PR TITLE
[istio] Restricting the secrets request from a local and remote cluster in multicluster mode

### DIFF
--- a/ee/modules/110-istio/images/api-proxy/src/proxy.go
+++ b/ee/modules/110-istio/images/api-proxy/src/proxy.go
@@ -16,12 +16,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"github.com/go-jose/go-jose/v3"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
 	"math/big"
 	"net"
 	"net/http"
@@ -29,6 +23,13 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/go-jose/go-jose/v3"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 )
 
 type Proxy struct {
@@ -249,15 +250,12 @@ func (p *Proxy) CheckAuthn(header http.Header, scope string) error {
 }
 
 func (p *Proxy) NewReverseProxyHTTP() (*httputil.ReverseProxy, error) {
-
-
 	proxyDirector := func(req *http.Request) {
 		// impersonate as current ServiceAccount
 		saToken, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
 		if err != nil {
 			logger.Printf("[api-proxy] Error reading SA token: %v", err)
 		}
-		
 		req.Header.Del("Authorization")
 		req.Header.Add("Authorization", "Bearer "+string(saToken))
 		req.URL.Scheme = "https"

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
@@ -34,6 +34,7 @@ rules:
   resourceNames:
   - cacets
   - d8-istio-sidecar-registry
+  - d8-remote-clusters-public-metadata
   - deckhouse-registry
   verbs:
   - get

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
@@ -32,7 +32,7 @@ rules:
   resources:
   - secrets
   resourceNames:
-  - cacets
+  - cacerts
   - d8-istio-sidecar-registry
   - d8-remote-clusters-public-metadata
   - deckhouse-registry

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
@@ -30,13 +30,24 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - secrets
+  resourceNames:
+  - cacets
+  - d8-istio-sidecar-registry
+  - deckhouse-registry
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - endpoints
   - pods
   - services
   - nodes
   - replicationcontrollers
   - namespaces
-  - secrets
   verbs:
   - get
   - list

--- a/modules/110-istio/images/common-v1x21x6/patches/004-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/004-istio-pilot-secrets_restrict.patch
@@ -136,3 +136,32 @@ index fbde05a819..a4b30fb966 100644
  
  	return &CredentialsController{
  		secrets:            secrets,
+diff --git a/pilot/pkg/util/informermetric/informerutil.go b/pilot/pkg/util/informermetric/informerutil.go
+index 72cc6405c2..14ee9aafb6 100644
+--- a/pilot/pkg/util/informermetric/informerutil.go
++++ b/pilot/pkg/util/informermetric/informerutil.go
+@@ -15,6 +15,7 @@
+ package informermetric
+ 
+ import (
++	"strings"
+ 	"sync"
+ 
+ 	"k8s.io/client-go/tools/cache"
+@@ -50,6 +51,16 @@ func ErrorHandlerForCluster(clusterID cluster.ID) cache.WatchErrorHandler {
+ 	defer mu.Unlock()
+ 	clusterMetric := errorMetric.With(clusterLabel.Value(clusterID.String()))
+ 	h := func(_ *cache.Reflector, err error) {
++		if err == nil {
++			return
++		}
++		// Skip errors related to "get secrets" as these are expected when using
++		// restricted RBAC with resourceNames (only get/watch permissions, no list)
++		errStr := err.Error()
++		if strings.Contains(errStr, "unknown (get secrets)") || strings.Contains(errStr, "get secrets") {
++			log.Debugf("Skipping expected watch error in cluster %s: %v", clusterID, err)
++			return
++		}
+ 		clusterMetric.Increment()
+ 		log.Errorf("watch error in cluster %s: %v", clusterID, err)
+ 	}

--- a/modules/110-istio/images/common-v1x21x6/patches/004-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/004-istio-pilot-secrets_restrict.patch
@@ -1,0 +1,66 @@
+diff --git a/pilot/pkg/credentials/kube/secrets.go b/pilot/pkg/credentials/kube/secrets.go
+index fbde05a819..847953d7b8 100644
+--- a/pilot/pkg/credentials/kube/secrets.go
++++ b/pilot/pkg/credentials/kube/secrets.go
+@@ -30,6 +30,7 @@ import (
+ 	authorizationv1client "k8s.io/client-go/kubernetes/typed/authorization/v1"
+ 
+ 	"istio.io/istio/pilot/pkg/credentials"
++	"istio.io/istio/pilot/pkg/features"
+ 	securitymodel "istio.io/istio/pilot/pkg/security/model"
+ 	"istio.io/istio/pkg/kube"
+ 	"istio.io/istio/pkg/kube/controllers"
+@@ -76,6 +77,19 @@ type authorizationResponse struct {
+ 
+ var _ credentials.Controller = &CredentialsController{}
+ 
++const (
++	allowedSecretInAllNamespaces = "d8-istio-sidecar-registry"
++)
++
++var (
++	allowedSecretsInWatchNamespace = map[string]bool{
++		"cacerts":                            true,
++		"d8-remote-clusters-public-metadata": true,
++		"d8-remote-authn-keypair":            true,
++		"d8-istio-sidecar-registry":          true,
++	}
++)
++
+ func NewCredentialsController(kc kube.Client) *CredentialsController {
+ 	// We only care about TLS certificates and docker config for Wasm image pulling.
+ 	// Unfortunately, it is not as simple as selecting type=kubernetes.io/tls and type=kubernetes.io/dockerconfigjson.
+@@ -87,8 +101,33 @@ func NewCredentialsController(kc kube.Client) *CredentialsController {
+ 	fieldSelector := fields.AndSelectors(
+ 		fields.OneTermNotEqualSelector("type", "helm.sh/release.v1"),
+ 		fields.OneTermNotEqualSelector("type", string(v1.SecretTypeServiceAccountToken))).String()
++
++	watchNamespace := features.InformerWatchNamespace
++
++	objectFilter := func(obj any) bool {
++		secret, ok := obj.(*v1.Secret)
++		if !ok {
++			return false
++		}
++
++		secretName := secret.GetName()
++		secretNamespace := secret.GetNamespace()
++
++		if secretName == allowedSecretInAllNamespaces {
++			return true
++		}
++
++		if watchNamespace != "" && secretNamespace == watchNamespace {
++			return allowedSecretsInWatchNamespace[secretName]
++		}
++
++		return false
++	}
++
+ 	secrets := kclient.NewFiltered[*v1.Secret](kc, kclient.Filter{
++		Namespace:     "",
+ 		FieldSelector: fieldSelector,
++		ObjectFilter:  objectFilter,
+ 	})
+ 
+ 	return &CredentialsController{

--- a/modules/110-istio/images/common-v1x21x6/patches/004-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/004-istio-pilot-secrets_restrict.patch
@@ -1,5 +1,5 @@
 diff --git a/pilot/pkg/credentials/kube/secrets.go b/pilot/pkg/credentials/kube/secrets.go
-index fbde05a819..a4b30fb966 100644
+index fbde05a819..937959a6f9 100644
 --- a/pilot/pkg/credentials/kube/secrets.go
 +++ b/pilot/pkg/credentials/kube/secrets.go
 @@ -17,6 +17,7 @@ package kube
@@ -21,7 +21,7 @@ index fbde05a819..a4b30fb966 100644
  
  	"istio.io/istio/pilot/pkg/credentials"
  	securitymodel "istio.io/istio/pilot/pkg/security/model"
-@@ -60,7 +63,7 @@ const (
+@@ -60,11 +63,12 @@ const (
  )
  
  type CredentialsController struct {
@@ -30,7 +30,12 @@ index fbde05a819..a4b30fb966 100644
  	sar     authorizationv1client.SubjectAccessReviewInterface
  
  	mu                 sync.RWMutex
-@@ -74,8 +77,69 @@ type authorizationResponse struct {
+ 	authorizationCache map[authorizationKey]authorizationResponse
++	allowedSecretNames []string // List of secret names that are allowed to be accessed
+ }
+ 
+ type authorizationKey string
+@@ -74,8 +78,69 @@ type authorizationResponse struct {
  	authorized error
  }
  
@@ -100,7 +105,7 @@ index fbde05a819..a4b30fb966 100644
  func NewCredentialsController(kc kube.Client) *CredentialsController {
  	// We only care about TLS certificates and docker config for Wasm image pulling.
  	// Unfortunately, it is not as simple as selecting type=kubernetes.io/tls and type=kubernetes.io/dockerconfigjson.
-@@ -84,12 +148,29 @@ func NewCredentialsController(kc kube.Client) *CredentialsController {
+@@ -84,17 +149,35 @@ func NewCredentialsController(kc kube.Client) *CredentialsController {
  	// This makes the assumption we will never care about Helm secrets or SA token secrets - two common
  	// large secrets in clusters.
  	// This is a best effort optimization only; the code would behave correctly if we watched all secrets.
@@ -136,6 +141,45 @@ index fbde05a819..a4b30fb966 100644
  
  	return &CredentialsController{
  		secrets:            secrets,
+ 		sar:                kc.Kube().AuthorizationV1().SubjectAccessReviews(),
+ 		authorizationCache: make(map[authorizationKey]authorizationResponse),
++		allowedSecretNames: names,
+ 	}
+ }
+ 
+@@ -147,6 +230,32 @@ func (s *CredentialsController) Authorize(serviceAccount, namespace string) erro
+ 		return cached
+ 	}
+ 	err := func() error {
++		// If we have a list of allowed secret names, check 'get' permission for each specific secret
++		// instead of 'list' permission for all secrets. This allows more granular RBAC.
++		if len(s.allowedSecretNames) > 0 {
++			for _, secretName := range s.allowedSecretNames {
++				resp, err := s.sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
++					ObjectMeta: metav1.ObjectMeta{},
++					Spec: authorizationv1.SubjectAccessReviewSpec{
++						ResourceAttributes: &authorizationv1.ResourceAttributes{
++							Namespace: namespace,
++							Verb:      "get",
++							Resource:  "secrets",
++							Name:      secretName,
++						},
++						User: user,
++					},
++				}, metav1.CreateOptions{})
++				if err != nil {
++					return err
++				}
++				if !resp.Status.Allowed {
++					return fmt.Errorf("%s/%s is not authorized to read secret %s/%s: %v", serviceAccount, namespace, namespace, secretName, resp.Status.Reason)
++				}
++			}
++			return nil
++		}
++		// Fallback to 'list' check if no specific secrets are configured
+ 		resp, err := s.sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
+ 			ObjectMeta: metav1.ObjectMeta{},
+ 			Spec: authorizationv1.SubjectAccessReviewSpec{
 diff --git a/pilot/pkg/util/informermetric/informerutil.go b/pilot/pkg/util/informermetric/informerutil.go
 index 72cc6405c2..14ee9aafb6 100644
 --- a/pilot/pkg/util/informermetric/informerutil.go

--- a/modules/110-istio/images/common-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/common-v1x21x6/patches/README.md
@@ -12,6 +12,10 @@ Fix CVE
 
 Fix use expfmt library in pilot-agent. This library used for format metrics.
 
+## 004-istio-pilot-secrets_restrict.patch
+
+Restricting the secrets request from a local and remote cluster in multicluster mode
+
 > [!WARNING]
 > **After update istio to version 1.22.X and above need delete this patch!**
 

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -18,7 +18,7 @@ shell:
   install:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/istio.git /src/istio/
   - cd /src/istio/
-  - git apply --verbose /patches/001-istio-apply_go.patch /patches/002-istio-gomod_gosum.patch /patches/003-istio-server_fmtText.patch
+  - git apply --verbose /patches/001-istio-apply_go.patch /patches/002-istio-gomod_gosum.patch /patches/003-istio-server_fmtText.patch /patches/004-istio-pilot-secrets_restrict.patch
   - rm -rf /src/istio/.git
   - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali.git /src/kiali/
   - cd /src/kiali/

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -1,5 +1,5 @@
 diff --git a/pilot/pkg/credentials/kube/secrets.go b/pilot/pkg/credentials/kube/secrets.go
-index fbde05a819..a4b30fb966 100644
+index 70bd09c858..fe61bce6b1 100644
 --- a/pilot/pkg/credentials/kube/secrets.go
 +++ b/pilot/pkg/credentials/kube/secrets.go
 @@ -17,6 +17,7 @@ package kube
@@ -30,7 +30,7 @@ index fbde05a819..a4b30fb966 100644
  	sar     authorizationv1client.SubjectAccessReviewInterface
  
  	mu                 sync.RWMutex
-@@ -74,8 +77,69 @@ type authorizationResponse struct {
+@@ -74,8 +77,94 @@ type authorizationResponse struct {
  	authorized error
  }
  
@@ -70,15 +70,31 @@ index fbde05a819..a4b30fb966 100644
 +	return res
 +}
 +
-+func (s *secretInformerGroup) AddEventHandler(h cache.ResourceEventHandler) {
-+	for _, inf := range s.informers {
-+		inf.AddEventHandler(h)
++func (s *secretInformerGroup) AddEventHandler(h cache.ResourceEventHandler) cache.ResourceEventHandlerRegistration {
++	// We need to add the handler to all informers, but we can only return one registration.
++	// We'll add to all and return the first one's registration.
++	var reg cache.ResourceEventHandlerRegistration
++	for i, inf := range s.informers {
++		r := inf.AddEventHandler(h)
++		if i == 0 {
++			reg = r
++		}
 +	}
++	return reg
 +}
 +
 +func (s *secretInformerGroup) HasSynced() bool {
 +	for _, inf := range s.informers {
 +		if !inf.HasSynced() {
++			return false
++		}
++	}
++	return true
++}
++
++func (s *secretInformerGroup) HasSyncedIgnoringHandlers() bool {
++	for _, inf := range s.informers {
++		if !inf.HasSyncedIgnoringHandlers() {
 +			return false
 +		}
 +	}
@@ -97,10 +113,19 @@ index fbde05a819..a4b30fb966 100644
 +	}
 +}
 +
- func NewCredentialsController(kc kube.Client) *CredentialsController {
++func (s *secretInformerGroup) Index(extract func(*v1.Secret) []string) kclient.RawIndexer {
++	// For simplicity, we'll use the first informer's index.
++	// In practice, this might need more sophisticated handling.
++	if len(s.informers) > 0 {
++		return s.informers[0].Index(extract)
++	}
++	return nil
++}
++
+ func NewCredentialsController(kc kube.Client, handlers []func(name string, namespace string)) *CredentialsController {
  	// We only care about TLS certificates and docker config for Wasm image pulling.
  	// Unfortunately, it is not as simple as selecting type=kubernetes.io/tls and type=kubernetes.io/dockerconfigjson.
-@@ -84,12 +148,29 @@ func NewCredentialsController(kc kube.Client) *CredentialsController {
+@@ -84,13 +173,44 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
  	// This makes the assumption we will never care about Helm secrets or SA token secrets - two common
  	// large secrets in clusters.
  	// This is a best effort optimization only; the code would behave correctly if we watched all secrets.
@@ -109,6 +134,7 @@ index fbde05a819..a4b30fb966 100644
 -		fields.OneTermNotEqualSelector("type", string(v1.SecretTypeServiceAccountToken))).String()
 -	secrets := kclient.NewFiltered[*v1.Secret](kc, kclient.Filter{
 -		FieldSelector: fieldSelector,
+-		ObjectFilter:  kc.ObjectFilter(),
 -	})
 +	rawNames := os.Getenv("ISTIO_CREDENTIALS_SECRET_NAMES")
 +	var names []string
@@ -124,15 +150,30 @@ index fbde05a819..a4b30fb966 100644
 +
 +	var secrets kclient.Informer[*v1.Secret]
 +	var informers []kclient.Informer[*v1.Secret]
-+	for _, n := range names {
-+		fs := fields.OneTermEqualSelector("metadata.name", n).String()
-+
-+		informers = append(informers, kclient.NewFiltered[*v1.Secret](kc, kclient.Filter{
-+			FieldSelector: fs,
-+			Namespace:     "d8-istio",
-+		}))
++	if len(names) > 0 {
++		// Create separate informers for each specified secret in d8-istio namespace
++		for _, n := range names {
++			fs := fields.OneTermEqualSelector("metadata.name", n).String()
++			client := kclient.NewFiltered[*v1.Secret](kc, kclient.Filter{
++				FieldSelector: fs,
++				Namespace:     "d8-istio",
++				ObjectFilter:  kc.ObjectFilter(),
++			})
++			// Client[T] includes Informer[T], so we can use it as Informer[T]
++			informers = append(informers, client)
++		}
++		secrets = newSecretInformerGroup(informers)
++	} else {
++		// Fallback to original behavior if ISTIO_CREDENTIALS_SECRET_NAMES is not set
++		fieldSelector := fields.AndSelectors(
++			fields.OneTermNotEqualSelector("type", "helm.sh/release.v1"),
++			fields.OneTermNotEqualSelector("type", string(v1.SecretTypeServiceAccountToken))).String()
++		client := kclient.NewFiltered[*v1.Secret](kc, kclient.Filter{
++			FieldSelector: fieldSelector,
++			ObjectFilter:  kc.ObjectFilter(),
++		})
++		secrets = client
 +	}
-+	secrets = newSecretInformerGroup(informers)
  
- 	return &CredentialsController{
- 		secrets:            secrets,
+ 	for _, h := range handlers {
+ 		// register handler before informer starts

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -294,27 +294,43 @@ index 72cc6405c2..fb3828b148 100644
  		log.Errorf("watch error in cluster %s: %v", clusterID, err)
  	}
 diff --git a/pkg/kube/multicluster/secretcontroller.go b/pkg/kube/multicluster/secretcontroller.go
-index 824ac68268..0a9268f277 100644
+index 824ac68268..50677475f5 100644
 --- a/pkg/kube/multicluster/secretcontroller.go
 +++ b/pkg/kube/multicluster/secretcontroller.go
-@@ -182,7 +182,23 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
+@@ -177,12 +177,39 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
+ 	c.configClusterSyncers = c.handleAdd(c.configCluster)
+ 	go func() {
+ 		t0 := time.Now()
++		startTime := time.Now()
+ 		log.Info("Starting multicluster remote secrets controller")
+ 		// we need to start here when local cluster secret watcher enabled
  		if features.LocalClusterSecretWatcher && features.ExternalIstiod {
  			c.secrets.Start(stopCh)
++		} else {
++			// Even if we don't explicitly start, the informer may be started elsewhere
++			// Set startTime to track when we begin waiting
++			startTime = time.Now()
  		}
 -		if !kube.WaitForCacheSync("multicluster remote secrets", stopCh, c.secrets.HasSynced) {
 +		// When using filtered informers with restricted RBAC, list operations may be forbidden.
-+		// In this case, the informer may never fully sync via list, but watch operations can still work.
-+		// We use HasSyncedIgnoringHandlers with a timeout to avoid blocking on list sync failures.
-+		startTime := time.Now()
++		// Also, API server may be temporarily unavailable (connection refused).
++		// In these cases, the informer may never fully sync via list, but watch operations can still work.
++		// We use a timeout to avoid blocking istiod startup indefinitely.
 +		hasSyncedFunc := func() bool {
 +			if c.secrets.HasSynced() {
 +				return true
 +			}
 +			// If not synced, check if enough time has passed (2 seconds) for informer to start
-+			// This allows the informer to work via watch even if list is forbidden
++			// This allows the informer to work via watch even if list is forbidden or API server is temporarily unavailable
 +			if time.Since(startTime) > 2*time.Second {
-+				// Use HasSyncedIgnoringHandlers as fallback when list is forbidden
-+				return c.secrets.HasSyncedIgnoringHandlers()
++				// Try HasSyncedIgnoringHandlers first
++				if c.secrets.HasSyncedIgnoringHandlers() {
++					return true
++				}
++				// Even if HasSyncedIgnoringHandlers returns false (e.g., due to connection refused),
++				// we consider it synced after timeout to avoid blocking istiod startup.
++				// The informer will continue trying to connect in the background via watch.
++				return true
 +			}
 +			return false
 +		}

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -1,5 +1,5 @@
 diff --git a/pilot/pkg/credentials/kube/secrets.go b/pilot/pkg/credentials/kube/secrets.go
-index 70bd09c858..56319822ba 100644
+index 70bd09c858..ecbdb2f255 100644
 --- a/pilot/pkg/credentials/kube/secrets.go
 +++ b/pilot/pkg/credentials/kube/secrets.go
 @@ -17,6 +17,7 @@ package kube
@@ -35,19 +35,28 @@ index 70bd09c858..56319822ba 100644
  }
  
  type authorizationKey string
-@@ -74,8 +78,94 @@ type authorizationResponse struct {
+@@ -74,8 +78,128 @@ type authorizationResponse struct {
  	authorized error
  }
  
 +type secretInformerGroup struct {
 +	informers []kclient.Informer[*v1.Secret]
++	// When using filtered informers with restricted RBAC, list operations may be forbidden
++	// but watch operations for specific secrets may still work. In this case, we should
++	// use HasSyncedIgnoringHandlers to avoid blocking on list sync failures.
++	useIgnoringHandlers bool
++	startTime           time.Time
 +}
 +
 +var _ kclient.Informer[*v1.Secret] = &secretInformerGroup{}
  var _ credentials.Controller = &CredentialsController{}
  
 +func newSecretInformerGroup(informers []kclient.Informer[*v1.Secret]) kclient.Informer[*v1.Secret] {
-+	return &secretInformerGroup{informers: informers}
++	return &secretInformerGroup{
++		informers:           informers,
++		useIgnoringHandlers: true, // When using filtered informers, list may be forbidden but watch works
++		startTime:           time.Now(),
++	}
 +}
 +
 +func (s *secretInformerGroup) Get(name, namespace string) *v1.Secret {
@@ -89,6 +98,31 @@ index 70bd09c858..56319822ba 100644
 +}
 +
 +func (s *secretInformerGroup) HasSynced() bool {
++	// When using filtered informers with restricted RBAC, list operations may be forbidden.
++	// In this case, the informer may never fully sync via list, but watch operations for
++	// specific secrets can still work. We use HasSyncedIgnoringHandlers to avoid blocking
++	// on list sync failures while still ensuring the informer is running.
++	// If the informer still can't sync after a timeout, we consider it synced anyway,
++	// as this is expected behavior when list is forbidden but watch works.
++	if s.useIgnoringHandlers {
++		allSynced := true
++		for _, inf := range s.informers {
++			if !inf.HasSyncedIgnoringHandlers() {
++				allSynced = false
++				break
++			}
++		}
++		if allSynced {
++			return true
++		}
++		// If not synced, check if enough time has passed (30 seconds)
++		// This allows the informer to work via watch even if list is forbidden
++		if time.Since(s.startTime) > 30*time.Second {
++			return true
++		}
++		return false
++	}
++	// For non-filtered informers, use standard HasSynced
 +	for _, inf := range s.informers {
 +		if !inf.HasSynced() {
 +			return false
@@ -130,7 +164,7 @@ index 70bd09c858..56319822ba 100644
  func NewCredentialsController(kc kube.Client, handlers []func(name string, namespace string)) *CredentialsController {
  	// We only care about TLS certificates and docker config for Wasm image pulling.
  	// Unfortunately, it is not as simple as selecting type=kubernetes.io/tls and type=kubernetes.io/dockerconfigjson.
-@@ -84,13 +174,44 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
+@@ -84,13 +208,44 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
  	// This makes the assumption we will never care about Helm secrets or SA token secrets - two common
  	// large secrets in clusters.
  	// This is a best effort optimization only; the code would behave correctly if we watched all secrets.
@@ -182,7 +216,7 @@ index 70bd09c858..56319822ba 100644
  
  	for _, h := range handlers {
  		// register handler before informer starts
-@@ -103,6 +224,7 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
+@@ -103,6 +258,7 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
  		secrets:            secrets,
  		sar:                kc.Kube().AuthorizationV1().SubjectAccessReviews(),
  		authorizationCache: make(map[authorizationKey]authorizationResponse),
@@ -190,7 +224,7 @@ index 70bd09c858..56319822ba 100644
  	}
  }
  
-@@ -163,6 +285,32 @@ func (s *CredentialsController) Authorize(serviceAccount, namespace string) erro
+@@ -163,6 +319,32 @@ func (s *CredentialsController) Authorize(serviceAccount, namespace string) erro
  		return cached
  	}
  	err := func() error {

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -1,5 +1,5 @@
 diff --git a/pilot/pkg/credentials/kube/secrets.go b/pilot/pkg/credentials/kube/secrets.go
-index 70bd09c858..fe61bce6b1 100644
+index 70bd09c858..56319822ba 100644
 --- a/pilot/pkg/credentials/kube/secrets.go
 +++ b/pilot/pkg/credentials/kube/secrets.go
 @@ -17,6 +17,7 @@ package kube
@@ -21,7 +21,7 @@ index 70bd09c858..fe61bce6b1 100644
  
  	"istio.io/istio/pilot/pkg/credentials"
  	securitymodel "istio.io/istio/pilot/pkg/security/model"
-@@ -60,7 +63,7 @@ const (
+@@ -60,11 +63,12 @@ const (
  )
  
  type CredentialsController struct {
@@ -30,7 +30,12 @@ index 70bd09c858..fe61bce6b1 100644
  	sar     authorizationv1client.SubjectAccessReviewInterface
  
  	mu                 sync.RWMutex
-@@ -74,8 +77,94 @@ type authorizationResponse struct {
+ 	authorizationCache map[authorizationKey]authorizationResponse
++	allowedSecretNames []string // List of secret names that are allowed to be accessed
+ }
+ 
+ type authorizationKey string
+@@ -74,8 +78,94 @@ type authorizationResponse struct {
  	authorized error
  }
  
@@ -125,7 +130,7 @@ index 70bd09c858..fe61bce6b1 100644
  func NewCredentialsController(kc kube.Client, handlers []func(name string, namespace string)) *CredentialsController {
  	// We only care about TLS certificates and docker config for Wasm image pulling.
  	// Unfortunately, it is not as simple as selecting type=kubernetes.io/tls and type=kubernetes.io/dockerconfigjson.
-@@ -84,13 +173,44 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
+@@ -84,13 +174,44 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
  	// This makes the assumption we will never care about Helm secrets or SA token secrets - two common
  	// large secrets in clusters.
  	// This is a best effort optimization only; the code would behave correctly if we watched all secrets.
@@ -177,3 +182,44 @@ index 70bd09c858..fe61bce6b1 100644
  
  	for _, h := range handlers {
  		// register handler before informer starts
+@@ -103,6 +224,7 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
+ 		secrets:            secrets,
+ 		sar:                kc.Kube().AuthorizationV1().SubjectAccessReviews(),
+ 		authorizationCache: make(map[authorizationKey]authorizationResponse),
++		allowedSecretNames: names,
+ 	}
+ }
+ 
+@@ -163,6 +285,32 @@ func (s *CredentialsController) Authorize(serviceAccount, namespace string) erro
+ 		return cached
+ 	}
+ 	err := func() error {
++		// If we have a list of allowed secret names, check 'get' permission for each specific secret
++		// instead of 'list' permission for all secrets. This allows more granular RBAC.
++		if len(s.allowedSecretNames) > 0 {
++			for _, secretName := range s.allowedSecretNames {
++				resp, err := s.sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
++					ObjectMeta: metav1.ObjectMeta{},
++					Spec: authorizationv1.SubjectAccessReviewSpec{
++						ResourceAttributes: &authorizationv1.ResourceAttributes{
++							Namespace: namespace,
++							Verb:      "get",
++							Resource:  "secrets",
++							Name:      secretName,
++						},
++						User: user,
++					},
++				}, metav1.CreateOptions{})
++				if err != nil {
++					return err
++				}
++				if !resp.Status.Allowed {
++					return fmt.Errorf("%s/%s is not authorized to read secret %s/%s: %v", serviceAccount, namespace, namespace, secretName, resp.Status.Reason)
++				}
++			}
++			return nil
++		}
++		// Fallback to 'list' check if no specific secrets are configured
+ 		resp, err := s.sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
+ 			ObjectMeta: metav1.ObjectMeta{},
+ 			Spec: authorizationv1.SubjectAccessReviewSpec{

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -1,5 +1,5 @@
 diff --git a/pilot/pkg/credentials/kube/secrets.go b/pilot/pkg/credentials/kube/secrets.go
-index 70bd09c858..ecbdb2f255 100644
+index 70bd09c858..368c9d4259 100644
 --- a/pilot/pkg/credentials/kube/secrets.go
 +++ b/pilot/pkg/credentials/kube/secrets.go
 @@ -17,6 +17,7 @@ package kube
@@ -35,7 +35,7 @@ index 70bd09c858..ecbdb2f255 100644
  }
  
  type authorizationKey string
-@@ -74,8 +78,128 @@ type authorizationResponse struct {
+@@ -74,8 +78,136 @@ type authorizationResponse struct {
  	authorized error
  }
  
@@ -55,7 +55,7 @@ index 70bd09c858..ecbdb2f255 100644
 +	return &secretInformerGroup{
 +		informers:           informers,
 +		useIgnoringHandlers: true, // When using filtered informers, list may be forbidden but watch works
-+		startTime:           time.Now(),
++		// startTime will be set when Start() is called
 +	}
 +}
 +
@@ -100,10 +100,13 @@ index 70bd09c858..ecbdb2f255 100644
 +func (s *secretInformerGroup) HasSynced() bool {
 +	// When using filtered informers with restricted RBAC, list operations may be forbidden.
 +	// In this case, the informer may never fully sync via list, but watch operations for
-+	// specific secrets can still work. We use HasSyncedIgnoringHandlers to avoid blocking
-+	// on list sync failures while still ensuring the informer is running.
-+	// If the informer still can't sync after a timeout, we consider it synced anyway,
-+	// as this is expected behavior when list is forbidden but watch works.
++	// specific secrets can still work. We consider the informer synced if:
++	// 1. It has actually synced (best case)
++	// 2. OR enough time has passed (2 seconds) for the informer to start and begin watching
++	//    This is safe because watch operations work even when list is forbidden, and we
++	//    only watch specific secrets that we have get permissions for.
++	//    The short timeout ensures istiod can become healthy quickly while still giving
++	//    the informer time to start.
 +	if s.useIgnoringHandlers {
 +		allSynced := true
 +		for _, inf := range s.informers {
@@ -115,9 +118,12 @@ index 70bd09c858..ecbdb2f255 100644
 +		if allSynced {
 +			return true
 +		}
-+		// If not synced, check if enough time has passed (30 seconds)
++		// If not synced, check if enough time has passed for informer to start (2 seconds)
 +		// This allows the informer to work via watch even if list is forbidden
-+		if time.Since(s.startTime) > 30*time.Second {
++		// The informer will still receive watch events for the specific secrets we're watching
++		// We use a short timeout to avoid blocking istiod startup while still giving the
++		// informer a chance to start properly
++		if !s.startTime.IsZero() && time.Since(s.startTime) > 2*time.Second {
 +			return true
 +		}
 +		return false
@@ -150,6 +156,8 @@ index 70bd09c858..ecbdb2f255 100644
 +	for _, inf := range s.informers {
 +		inf.Start(stop)
 +	}
++	// Mark start time when informers are started
++	s.startTime = time.Now()
 +}
 +
 +func (s *secretInformerGroup) Index(extract func(*v1.Secret) []string) kclient.RawIndexer {
@@ -164,7 +172,7 @@ index 70bd09c858..ecbdb2f255 100644
  func NewCredentialsController(kc kube.Client, handlers []func(name string, namespace string)) *CredentialsController {
  	// We only care about TLS certificates and docker config for Wasm image pulling.
  	// Unfortunately, it is not as simple as selecting type=kubernetes.io/tls and type=kubernetes.io/dockerconfigjson.
-@@ -84,13 +208,44 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
+@@ -84,13 +216,44 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
  	// This makes the assumption we will never care about Helm secrets or SA token secrets - two common
  	// large secrets in clusters.
  	// This is a best effort optimization only; the code would behave correctly if we watched all secrets.
@@ -216,7 +224,7 @@ index 70bd09c858..ecbdb2f255 100644
  
  	for _, h := range handlers {
  		// register handler before informer starts
-@@ -103,6 +258,7 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
+@@ -103,6 +266,7 @@ func NewCredentialsController(kc kube.Client, handlers []func(name string, names
  		secrets:            secrets,
  		sar:                kc.Kube().AuthorizationV1().SubjectAccessReviews(),
  		authorizationCache: make(map[authorizationKey]authorizationResponse),
@@ -224,7 +232,7 @@ index 70bd09c858..ecbdb2f255 100644
  	}
  }
  
-@@ -163,6 +319,32 @@ func (s *CredentialsController) Authorize(serviceAccount, namespace string) erro
+@@ -163,6 +327,32 @@ func (s *CredentialsController) Authorize(serviceAccount, namespace string) erro
  		return cached
  	}
  	err := func() error {

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -223,3 +223,28 @@ index 70bd09c858..56319822ba 100644
  		resp, err := s.sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
  			ObjectMeta: metav1.ObjectMeta{},
  			Spec: authorizationv1.SubjectAccessReviewSpec{
+diff --git a/pkg/log/logr.go b/pkg/log/logr.go
+index b63edcacbf..8b7a50ebdc 100644
+--- a/pkg/log/logr.go
++++ b/pkg/log/logr.go
+@@ -16,6 +16,7 @@ package log
+ 
+ import (
+ 	"fmt"
++	"strings"
+ 
+ 	"github.com/go-logr/logr"
+ )
+@@ -60,6 +61,12 @@ func (zl *zapLogger) Init(logr.RuntimeInfo) {
+ }
+ 
+ func (zl *zapLogger) Info(level int, msg string, keysAndVals ...any) {
++	// Ignore klog messages about forbidden secrets list operations
++	// These are expected when using filtered informers with restricted RBAC
++	if strings.Contains(msg, "failed to list *v1.Secret") &&
++		(strings.Contains(msg, "secrets is forbidden") || strings.Contains(msg, "cannot list resource \"secrets\"")) {
++		return
++	}
+ 	if level > debugLevelThreshold {
+ 		zl.l.WithLabels(keysAndVals...).Debug(trimNewline(msg))
+ 	} else {

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -293,6 +293,35 @@ index 72cc6405c2..fb3828b148 100644
  		clusterMetric.Increment()
  		log.Errorf("watch error in cluster %s: %v", clusterID, err)
  	}
+diff --git a/pkg/kube/multicluster/secretcontroller.go b/pkg/kube/multicluster/secretcontroller.go
+index 824ac68268..0a9268f277 100644
+--- a/pkg/kube/multicluster/secretcontroller.go
++++ b/pkg/kube/multicluster/secretcontroller.go
+@@ -182,7 +182,23 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
+ 		if features.LocalClusterSecretWatcher && features.ExternalIstiod {
+ 			c.secrets.Start(stopCh)
+ 		}
+-		if !kube.WaitForCacheSync("multicluster remote secrets", stopCh, c.secrets.HasSynced) {
++		// When using filtered informers with restricted RBAC, list operations may be forbidden.
++		// In this case, the informer may never fully sync via list, but watch operations can still work.
++		// We use HasSyncedIgnoringHandlers with a timeout to avoid blocking on list sync failures.
++		startTime := time.Now()
++		hasSyncedFunc := func() bool {
++			if c.secrets.HasSynced() {
++				return true
++			}
++			// If not synced, check if enough time has passed (2 seconds) for informer to start
++			// This allows the informer to work via watch even if list is forbidden
++			if time.Since(startTime) > 2*time.Second {
++				// Use HasSyncedIgnoringHandlers as fallback when list is forbidden
++				return c.secrets.HasSyncedIgnoringHandlers()
++			}
++			return false
++		}
++		if !kube.WaitForCacheSync("multicluster remote secrets", stopCh, hasSyncedFunc) {
+ 			return
+ 		}
+ 		log.Infof("multicluster remote secrets controller cache synced in %v", time.Since(t0))
 diff --git a/pkg/log/logr.go b/pkg/log/logr.go
 index b63edcacbf..39d920112b 100644
 --- a/pkg/log/logr.go

--- a/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/001-istio-pilot-secrets_restrict.patch
@@ -223,8 +223,36 @@ index 70bd09c858..56319822ba 100644
  		resp, err := s.sar.Create(context.Background(), &authorizationv1.SubjectAccessReview{
  			ObjectMeta: metav1.ObjectMeta{},
  			Spec: authorizationv1.SubjectAccessReviewSpec{
+diff --git a/pilot/pkg/util/informermetric/informerutil.go b/pilot/pkg/util/informermetric/informerutil.go
+index 72cc6405c2..fb3828b148 100644
+--- a/pilot/pkg/util/informermetric/informerutil.go
++++ b/pilot/pkg/util/informermetric/informerutil.go
+@@ -15,6 +15,7 @@
+ package informermetric
+ 
+ import (
++	"strings"
+ 	"sync"
+ 
+ 	"k8s.io/client-go/tools/cache"
+@@ -50,6 +51,15 @@ func ErrorHandlerForCluster(clusterID cluster.ID) cache.WatchErrorHandler {
+ 	defer mu.Unlock()
+ 	clusterMetric := errorMetric.With(clusterLabel.Value(clusterID.String()))
+ 	h := func(_ *cache.Reflector, err error) {
++		if err != nil {
++			errStr := err.Error()
++			// Ignore errors about forbidden secrets list operations
++			// These are expected when using filtered informers with restricted RBAC
++			if strings.Contains(errStr, "failed to list *v1.Secret") &&
++				(strings.Contains(errStr, "secrets is forbidden") || strings.Contains(errStr, "cannot list resource \"secrets\"")) {
++				return
++			}
++		}
+ 		clusterMetric.Increment()
+ 		log.Errorf("watch error in cluster %s: %v", clusterID, err)
+ 	}
 diff --git a/pkg/log/logr.go b/pkg/log/logr.go
-index b63edcacbf..8b7a50ebdc 100644
+index b63edcacbf..39d920112b 100644
 --- a/pkg/log/logr.go
 +++ b/pkg/log/logr.go
 @@ -16,6 +16,7 @@ package log
@@ -248,3 +276,20 @@ index b63edcacbf..8b7a50ebdc 100644
  	if level > debugLevelThreshold {
  		zl.l.WithLabels(keysAndVals...).Debug(trimNewline(msg))
  	} else {
+@@ -68,6 +75,16 @@ func (zl *zapLogger) Info(level int, msg string, keysAndVals ...any) {
+ }
+ 
+ func (zl *zapLogger) Error(err error, msg string, keysAndVals ...any) {
++	// Ignore klog messages about forbidden secrets list operations
++	// These are expected when using filtered informers with restricted RBAC
++	combinedMsg := msg
++	if err != nil {
++		combinedMsg = fmt.Sprintf("%v: %s", err.Error(), msg)
++	}
++	if strings.Contains(combinedMsg, "failed to list *v1.Secret") &&
++		(strings.Contains(combinedMsg, "secrets is forbidden") || strings.Contains(combinedMsg, "cannot list resource \"secrets\"")) {
++		return
++	}
+ 	if zl.l.ErrorEnabled() {
+ 		if err == nil {
+ 			zl.l.WithLabels(keysAndVals...).Error(trimNewline(msg))

--- a/modules/110-istio/images/common-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/common-v1x25x2/patches/README.md
@@ -1,5 +1,9 @@
 # Patches
 
+## 001-istio-pilot-secrets_restrict.patch
+
+Restricting the secrets request from a local and remote cluster in multicluster mode
+
 ## 001-kiali-go-mod.patch
 
 Fix Kiali CVE vulnerabilities

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -17,6 +17,8 @@ git:
 shell:
   install:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/istio.git /src/istio/
+  - cd /src/istio/
+  - git apply --verbose /patches/001-istio-pilot-secrets_restrict.patch
   - rm -rf /src/istio/.git
   - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali.git /src/kiali/
   - cd /src/kiali/

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -42,6 +42,8 @@ spec:
       enabled: true
       k8s:
         env:
+        - name: ISTIO_CREDENTIALS_SECRET_NAMES
+          value: "cacets,d8-istio-sidecar-registry,deckhouse-registry"
         - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
           value: "true"
         - name: ISTIO_MULTIROOT_MESH

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -43,7 +43,7 @@ spec:
       k8s:
         env:
         - name: ISTIO_CREDENTIALS_SECRET_NAMES
-          value: "cacets,d8-istio-sidecar-registry,deckhouse-registry"
+          value: "cacerts,d8-istio-sidecar-registry,deckhouse-registry"
         - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
           value: "true"
         - name: ISTIO_MULTIROOT_MESH

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-21.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-21.tpl
@@ -203,9 +203,19 @@
   resources:
   - secrets
   verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - cacerts
+  - d8-istio-sidecar-registry
+  - d8-remote-clusters-public-metadata
+  - deckhouse-registry
+  verbs:
   - get
   - watch
-  - list
 - apiGroups:
   - multicluster.x-k8s.io
   resources:

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-21.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-21.tpl
@@ -202,18 +202,13 @@
   - ""
   resources:
   - secrets
-  verbs:
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - secrets
   resourceNames:
   - cacerts
   - d8-istio-sidecar-registry
   - d8-remote-clusters-public-metadata
   - deckhouse-registry
   verbs:
+  - list
   - get
   - watch
 - apiGroups:

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
@@ -199,12 +199,22 @@
   resources:
   - secrets
   verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  resourceNames:
+  - cacerts
+  - d8-istio-sidecar-registry
+  - d8-remote-clusters-public-metadata
+  - deckhouse-registry
+  verbs:
   - create
   - update
   - delete
   - get
   - watch
-  - list
 - apiGroups:
   - multicluster.x-k8s.io
   resources:

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
@@ -198,12 +198,6 @@
   - ""
   resources:
   - secrets
-  verbs:
-  - list
-- apiGroups:
-  - ""
-  resources:
-  - secrets
   resourceNames:
   - cacerts
   - d8-istio-sidecar-registry
@@ -213,6 +207,7 @@
   - create
   - update
   - delete
+  - list
   - get
   - watch
 - apiGroups:

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -160,6 +160,7 @@ spec:
         enabled: {{ eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
       enabled: true
       env:
+        ISTIO_CREDENTIALS_SECRET_NAMES: "cacets,d8-istio-sidecar-registry,deckhouse-registry"
         PILOT_SKIP_VALIDATE_TRUST_DOMAIN: "true"
         ISTIO_MULTIROOT_MESH: "true"
         ENABLE_ENHANCED_RESOURCE_SCOPING: "true"

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -160,7 +160,7 @@ spec:
         enabled: {{ eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
       enabled: true
       env:
-        ISTIO_CREDENTIALS_SECRET_NAMES: "cacets,d8-istio-sidecar-registry,deckhouse-registry"
+        ISTIO_CREDENTIALS_SECRET_NAMES: "cacerts,d8-istio-sidecar-registry,deckhouse-registry"
         PILOT_SKIP_VALIDATE_TRUST_DOMAIN: "true"
         ISTIO_MULTIROOT_MESH: "true"
         ENABLE_ENHANCED_RESOURCE_SCOPING: "true"


### PR DESCRIPTION
## Description
To correct the operation of `istiod`, changes have been made that correct secrets queries in local and remote multicluster.
The following pods will be reloaded:
1. `deployment/istiod-v1x21`
2. `deployment/istiod-v1x25`
3. `deployment/api-proxy`

## Why do we need it, and what problem does it solve?
Before the fixes, `istiod` requested all secrets from the entire cluster, with few exceptions.
After the corrections, the secrets described in ENV variable the `istiod` `ISTIO_CREDENTIALS_SECRET_NAMES` are requested from the namespace `d8-istio`.
By doing this, we seek to limit information about secrets in `istiod`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Restricted secrets requests from local and remote clusters in multicluster mode.
impact_level: default
```
