### PR TITLE
[deckhouse] fix module restoring

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -162,7 +162,7 @@ func (l *Loader) restoreModulesByOverrides(ctx context.Context) error {
 			return fmt.Errorf("restore the module '%s': %w", moduleName, err)
 		}
 
-		l.registries[mpo.GetModuleName()] = utils.BuildRegistryValue(source)
+		l.registries[moduleName] = utils.BuildRegistryValue(source)
 	}
 
 	return nil


### PR DESCRIPTION
## Description
It provides fix for module restoring process.

## Why do we need it, and what problem does it solve?
A module might not exist, so we cannot rely on its name.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: deckhouse
type: fix
summary: Fix module restoring
impact_level: low
```
