### PR TITLE
[docs] Updating information about the reduction of master nodes in a cloud cluster

### DIFF
--- a/docs/documentation/pages/admin/configuration/platform-scaling/control-plane/SCALING_AND_CHANGING_MASTER_NODES.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/control-plane/SCALING_AND_CHANGING_MASTER_NODES.md
@@ -370,7 +370,7 @@ If your cluster uses the [`stronghold`](/modules/stronghold/) module, make sure 
 
    > For **OpenStack** and **VKCloud(OpenStack)**, after confirming the node deletion, it is extremely important to check the disk deletion `<prefix>kubernetes-data-N` in Openstack itself.
    >
-   > For example, when deleting the `cloud-demo-master-2` node in the Openstack web interface or in the `OpenStack CLI`, it is necessary to check the absence of the `cloud-demo-kubernetes-data-2` disk.
+   > For example, when deleting the `cloud-demo-master-2` node in the Openstack web interface or in the OpenStack CLI, it is necessary to check the absence of the `cloud-demo-kubernetes-data-2` disk.
    >
    > If the kubernetes-data disk remains, there may be problems with ETCD operation as the number of master nodes increases.
 

--- a/docs/documentation/pages/admin/configuration/platform-scaling/control-plane/SCALING_AND_CHANGING_MASTER_NODES_RU.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/control-plane/SCALING_AND_CHANGING_MASTER_NODES_RU.md
@@ -369,13 +369,14 @@ spec:
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
-   > Для **OpenStack** и **VKCloud(OpenStack)** после подтверждении удалении ноды крайне важно проверить удаление диска `<prefix>kubernetes-data-N` в самом Openstack.
+
+   > Для **OpenStack** и **VKCloud(OpenStack)** после подтверждения удаления узла обязательно проверьте удаление диска `<prefix>kubernetes-data-N` в самом Openstack.
    >
-   > Например, при удалении ноды `cloud-demo-master-2` в веб-интерфейсе Openstack или в `OpenStack CLI` необходимо проверить отсутствие диска `cloud-demo-kubernetes-data-2`.
+   > Например, при удалении узла `cloud-demo-master-2` в веб-интерфейсе Openstack или в OpenStack CLI необходимо проверить отсутствие диска `cloud-demo-kubernetes-data-2`.
    >
    > В случае, если диск `kubernetes-data` останется, при увеличении количества master-узлов могут возникнуть проблемы в работе ETCD.
 
-1. Выполните проверку очереди Deckhouse и убедитесь, что отсутствуют ошибки командой:
+1. Выполните проверку очереди Deckhouse и убедитесь, что отсутствуют ошибки, с помощью команды:
 
    ```shell
    d8 system queue list

--- a/modules/040-control-plane-manager/docs/FAQ.md
+++ b/modules/040-control-plane-manager/docs/FAQ.md
@@ -138,7 +138,7 @@ The steps described below must be performed from the first in order of the maste
 If your cluster uses the [`stronghold`](/modules/stronghold/) module, make sure the module is fully operational before adding or removing a master node. We strongly recommend creating a [backup of the module’s data](/modules/stronghold/auto_snapshot.html) before making any changes.
 {% endalert %}
 
-1. Create a [backup of etcd](../../backup/backup-and-restore.html#backing-up-etcd) and the `/etc/kubernetes` directory.
+1. Create a [backup of etcd](/products/kubernetes-platform/documentation/v1/admin/configuration/backup/backup-and-restore.html#backing-up-etcd) and the `/etc/kubernetes` directory.
 1. Copy the resulting archive outside the cluster (e.g., to a local machine).
 1. Ensure there are no alerts in the cluster that may interfere with the master node update process.
 1. Make sure the DKP queue is empty:
@@ -180,7 +180,7 @@ If your cluster uses the [`stronghold`](/modules/stronghold/) module, make sure 
 
    > For **OpenStack** and **VKCloud(OpenStack)**, after confirming the node deletion, it is extremely important to check the disk deletion `<prefix>kubernetes-data-N` in Openstack itself.
    >
-   > For example, when deleting the `cloud-demo-master-2` node in the Openstack web interface or in the `OpenStack CLI`, it is necessary to check the absence of the `cloud-demo-kubernetes-data-2` disk.
+   > For example, when deleting the `cloud-demo-master-2` node in the Openstack web interface or in the OpenStack CLI, it is necessary to check the absence of the `cloud-demo-kubernetes-data-2` disk.
    >
    > If the kubernetes-data disk remains, there may be problems with ETCD operation as the number of master nodes increases.
 

--- a/modules/040-control-plane-manager/docs/FAQ_RU.md
+++ b/modules/040-control-plane-manager/docs/FAQ_RU.md
@@ -140,7 +140,7 @@ spec:
 Если в кластере используется модуль [`stronghold`](/modules/stronghold/), перед добавлением или удалением master-узла убедитесь, что модуль находится в полностью работоспособном состоянии. Перед началом любых изменений настоятельно рекомендуется создать [резервную копию данных модуля](/modules/stronghold/auto_snapshot.html).  
 {% endalert %}
 
-1. Сделайте [резервную копию etcd](../../backup/backup-and-restore.html#резервное-копирование-etcd) и директории `/etc/kubernetes`.
+1. Сделайте [резервную копию etcd](/products/kubernetes-platform/documentation/v1/admin/configuration/backup/backup-and-restore.html#резервное-копирование-etcd) и директории `/etc/kubernetes`.
 1. Скопируйте полученный архив за пределы кластера (например, на локальную машину).
 1. Убедитесь, что в кластере нет алертов, которые могут помешать обновлению master-узлов.
 1. Убедитесь, что очередь DKP пуста:
@@ -179,13 +179,14 @@ spec:
    ```bash
    dhctl converge --ssh-agent-private-keys=/tmp/.ssh/<SSH_KEY_FILENAME> --ssh-user=<USERNAME> --ssh-host <MASTER-NODE-0-HOST>
    ```
-   > Для **OpenStack** и **VKCloud(OpenStack)** после подтверждении удалении ноды крайне важно проверить удаление диска `<prefix>kubernetes-data-N` в самом Openstack.
+
+   > Для **OpenStack** и **VKCloud(OpenStack)** после подтверждения удаления узла обязательно проверьте удаление диска `<prefix>kubernetes-data-N` в самом Openstack.
    >
-   > Например, при удалении ноды `cloud-demo-master-2` в веб-интерфейсе Openstack или в `OpenStack CLI` необходимо проверить отсутствие диска `cloud-demo-kubernetes-data-2`.
+   > Например, при удалении узла `cloud-demo-master-2` в веб-интерфейсе Openstack или в OpenStack CLI необходимо проверить отсутствие диска `cloud-demo-kubernetes-data-2`.
    >
    > В случае, если диск `kubernetes-data` останется, при увеличении количества master-узлов могут возникнуть проблемы в работе ETCD.
 
-1. Выполните проверку очереди Deckhouse и убедитесь, что отсутствуют ошибки командой:
+1. Выполните проверку очереди Deckhouse и убедитесь, что отсутствуют ошибки, с помощью команды:
 
    ```shell
    d8 system queue list


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Outdated instructions for reducing the number of master nodes in cloud clusters have been fixed.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Users will correctly perform the converge of cloud clusters.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix 
summary: Outdated instructions for reducing the number of master nodes in cloud clusters have been fixed. Users will correctly perform the converge of cloud clusters.
impact: The instructions for reducing the number of master nodes have not been updated for a long time, and for a long time now, the conversion to reducing the number of master nodes in clusters in a cloud installation is automatic.
impact_level: low 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
