### PR TITLE
[cloud-provider-dvp] Try to find node by name

### DIFF
--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/instance.go
@@ -100,20 +100,13 @@ func (c *Cloud) getVMByNodeName(ctx context.Context, nodeName types.NodeName) (*
 
 	vm, err := c.dvpService.ComputeService.GetVMByHostname(ctx, vmHostname)
 	if err != nil {
-
-		if errors.Is(err, api.ErrNotFound) {
-			vm, err = c.dvpService.ComputeService.GetVMByName(ctx, vmHostname)
-			if err != nil && errors.Is(err, api.ErrNotFound) {
-				return nil, cloudprovider.InstanceNotFound
-			} else if err != nil {
-				return nil, err
-			}
-
-		} else {
+		vm, err = c.dvpService.ComputeService.GetVMByName(ctx, vmHostname)
+		if err != nil && errors.Is(err, api.ErrNotFound) {
+			return nil, cloudprovider.InstanceNotFound
+		} else if err != nil {
 			return nil, err
 		}
 	}
-
 	return vm, nil
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

We're trying to search node by name if search by hostname label `dvp.deckhouse.io/hostname` is failed.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

This pull request enhances the clarity of the CloudStatic node bootstrap process.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We don't.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: try to search nodes in ccm by name if search with hostname is failed
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
