### PR TITLE
[docs][DVP] Sync updates to the VM traffic redirection manual

### DIFF
--- a/docs/site/pages/virtualization-platform/documentation/FAQ.md
+++ b/docs/site/pages/virtualization-platform/documentation/FAQ.md
@@ -350,36 +350,51 @@ spec:
 
 ## Redirecting traffic to a virtual machine
 
-The virtual machine runs in a Kubernetes cluster, so directing network traffic is similar to directing traffic to pods.
+The virtual machine operates within a Kubernetes cluster, so directing network traffic to it is similar to routing traffic to pods. To route network traffic to a virtual machine, Kubernetes uses a standard mechanism — the Service resource, which selects target objects using labels selectors.
 
-1. Create a service with the required settings. As an example, here is a virtual machine with an HTTP service published on port 80 and the following set of labels:
+1. Create a Service with the required settings:
 
-    ```yaml
-    apiVersion: virtualization.deckhouse.io/v1alpha2
-    kind: VirtualMachine
-    metadata:
-    name: web
-    labels:
-    vm: web
-    spec: ...
-    ```
+   For example, consider a virtual machine with the label `vm: frontend-0`, an HTTP service exposed on ports 80 and 443, and SSH access on port 22:
 
-1. To forward network traffic to port 80 of the virtual machine, create a service:
+   ```yaml
+   apiVersion: virtualization.deckhouse.io/v1alpha2
+   kind: VirtualMachine
+   metadata:
+     name: frontend-0
+     namespace: dev
+     labels:
+       vm: frontend-0
+   spec: ...
+   ```
 
-    ```yaml
-    apiVersion: v1
-    kind: Service
-    metadata:
-    name: svc-1
-    spec:
-    ports:
-    - name: http
-    port: 8080
-    protocol: TCP
-    targetPort: 80
-    selector:
-    app: old
-    ```
+1. To route network traffic to the virtual machine's ports, create the following Service:
+
+   This Service listens on ports 80 and 443 and forwards traffic to the target virtual machine’s ports 80 and 443. SSH access from outside the cluster is provided on port 2211.
+
+   ```yaml
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: frontend-0-svc
+     namespace: dev
+   spec:
+     type: LoadBalancer
+     ports:
+     - name: ssh
+       port: 2211
+       protocol: TCP
+       targetPort: 22
+     - name: http
+       port: 80
+       protocol: TCP
+       targetPort: 80
+     - name: https
+       port: 443
+       protocol: TCP
+       targetPort: 443
+     selector:
+       vm: frontend-0
+   ```
 
 ## Changing virtual machine labels without having to restart
 

--- a/docs/site/pages/virtualization-platform/documentation/FAQ_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/FAQ_RU.md
@@ -346,38 +346,51 @@ spec:
 
 ## Перенаправление трафика на виртуальную машину
 
-Виртуальная машина функционирует в кластере Kubernetes, поэтому направление сетевого трафика осуществляется аналогично направлению трафика на поды.
+Виртуальная машина функционирует в кластере Kubernetes, поэтому направление сетевого трафика к ней осуществляется аналогично направлению трафика к подам. Для маршрутизации сетевого трафика на виртуальную машину применяется стандартный механизм Kubernetes — ресурс Service, который выбирает целевые объекты по меткам (label selector).
 
-В качестве примера приведена виртуальная машина с HTTP-сервисом, опубликованным на порте 80, и следующим набором меток:
+1. Создайте сервис с требуемыми настройками.
 
-1. Создайте сервис с требуемыми настройками. В качестве примера приведена виртуальная машина с HTTP-сервисом, опубликованным на порте 80, и следующим набором меток:
+   В качестве примера приведена виртуальная машина с меткой `vm: frontend-0`, HTTP-сервисом, опубликованным на портах 80 и 443, и открытым SSH на порту 22:
 
-    ```yaml
-    apiVersion: virtualization.deckhouse.io/v1alpha2
-    kind: VirtualMachine
-    metadata:
-      name: web
-      labels:
-        vm: web
-    spec: ...
-    ```
+   ```yaml
+   apiVersion: virtualization.deckhouse.io/v1alpha2
+   kind: VirtualMachine
+   metadata:
+     name: frontend-0
+     namespace: dev
+     labels:
+       vm: frontend-0
+   spec: ...
+   ```
 
-1. Чтобы направить сетевой трафик на 80-й порт виртуальной машины, создайте сервис:
+1. Чтобы направить сетевой трафик на порты виртуальной машины, создайте Service:
 
-    ```yaml
-    apiVersion: v1
-    kind: Service
-    metadata:
-      name: svc-1
-    spec:
-      ports:
-        - name: http
-          port: 8080
-          protocol: TCP
-          targetPort: 80
-      selector:
-        app: old
-    ```
+   Следующий Service обеспечивает доступ к виртуальной машине: он слушает порты 80 и 443 и перенаправляет трафик на соответствующие порты целевой виртуальной машины. SSH-доступ извне предоставляется по порту 2211:
+
+   ```yaml
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: frontend-0-svc
+     namespace: dev
+   spec:
+     type: LoadBalancer
+     ports:
+     - name: ssh
+       port: 2211
+       protocol: TCP
+       targetPort: 22
+     - name: http
+       port: 80
+       protocol: TCP
+       targetPort: 80
+     - name: https
+       port: 443
+       protocol: TCP
+       targetPort: 443
+     selector:
+       vm: frontend-0
+   ```
 
 ## Изменение меток виртуальной машины без необходимости перезапуска
 


### PR DESCRIPTION
## Description
Sync documentation updates for the VM traffic redirection manual from the `virtualization` module ([PR #1646](https://github.com/deckhouse/virtualization/pull/1646)).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Sync documentation updates for the VM traffic redirection manual.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
