### PR TITLE
[docs] Add BGP port to the network ports list

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -511,6 +511,11 @@ groups:
     description:
       en: NTP for synchronization with external time servers
       ru: NTP для синхронизации с внешними серверами точного времени
+  - ports: "179"
+    protocol: TCP
+    description:
+      en: BGP for routing operations (metallb module)
+      ru: BGP для работы маршрутизации (модуль metallb)
   - ports: "443"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description
Added BGP port to the network ports list in the documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Added BGP port to the network ports list in the documentation.
impact_level: low
```
