### PR TITLE
[docs] Fix BGP port description in the network ports list

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -514,8 +514,8 @@ groups:
   - ports: "179"
     protocol: TCP
     description:
-      en: BGP for routing operations (metallb module)
-      ru: BGP для работы маршрутизации (модуль metallb)
+      en: BGP peering with the infrastructure router for network traffic balancing (metallb module)
+      ru: BGP-стык с роутером инфраструктуры для балансировки сетевого трафика (модуль metallb)
   - ports: "443"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description
Fixed BGP port description in the network ports list.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fixed BGP port description in the network ports list.
impact_level: low
```
