### PR TITLE
[docs] Add description for D8ClusterAutoscalerManagerPodIsNotReady alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -636,7 +636,7 @@ alerts:
         To check the Pod's status, run the following command:
 
         ```shell
-        kubectl -n {{$labels.namespace}} get pods {{$labels.pod}} -o json | jq .status
+        d8 k -n {{$labels.namespace}} get pods {{$labels.pod}} -o json | jq .status
         ```
       summary: |
         The {{$labels.pod}} Pod is NOT Ready.

--- a/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/cluster-autoscaler.tpl
@@ -22,7 +22,7 @@
         To check the Pod's status, run the following command:
         
         ```shell
-        kubectl -n {{`{{$labels.namespace}}`}} get pods {{`{{$labels.pod}}`}} -o json | jq .status
+        d8 k -n {{`{{$labels.namespace}}`}} get pods {{`{{$labels.pod}}`}} -o json | jq .status
         ```
 
   - alert: D8ClusterAutoscalerPodIsNotRunning


### PR DESCRIPTION
## Description

Add description for D8ClusterAutoscalerManagerPodIsNotReady alert.

## Why do we need it, and what problem does it solve?

Give more info about alert


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Add description for D8ClusterAutoscalerManagerPodIsNotReady alert. 
impact_level:  low
```
