### PR TITLE
[candi] fix netplan 2 eth

### DIFF
--- a/candi/cloud-providers/yandex/bashible/bootstrap-networks.sh.tpl
+++ b/candi/cloud-providers/yandex/bashible/bootstrap-networks.sh.tpl
@@ -91,6 +91,10 @@ network:
         use-routes: false
       match:
         macaddress: $mac
+      routing-policy:
+        - from: "$ip"
+          table: 0
+          priority: 100
       $route_settings
 BOOTSTRAP_NETWORK_EOF
 
@@ -104,5 +108,4 @@ if which netplan 2>/dev/null 1>&2; then
 fi
 
 shopt -u extglob
-
 


### PR DESCRIPTION
## Description
fix https://github.com/deckhouse/deckhouse/issues/12243
Added a netplan override that forces traffic from the node’s secondary interface to use the main routing table and bypass cloud-init’s auto-generated policy-based routing.

## Why do we need it, and what problem does it solve?

Cloud-init creates PBR rules (table 101) for multi-NIC nodes, causing asymmetric routing and blocking pod access to Service (ClusterIP) networks. The override removes this routing conflict and restores pod-to-Service connectivity.

```
cat /etc/netplan/50-cloud-init.yaml  | tail -n11
      set-name: "eth1"
      routes:
      - table: 101
        to: "0.0.0.0/0"
        via: "10.241.32.1"
      - scope: "link"
        table: 101
        to: "10.241.32.0/22"
      routing-policy:
      - table: 101
        from: "10.241.32.32"

cat /etc/netplan/999-cim-eth1.yaml  | tail -n7
      routing-policy:
        - from: "10.241.32.32"
          table: 0
          priority: 100
      routes:
      - to: 10.241.32.0/20
        scope: link
```


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Added a Netplan override to force the secondary NIC to use the main routing table, fixing cloud-init PBR conflicts.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
