### PR TITLE
[ci] Remove release channel branches

### DIFF
--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -346,20 +346,6 @@ is used if DECKHOUSE_REGISTRY_HOST is not set.
 
 {!{- end }!}
 
-      - name: Update release branch
-        if: ${{ success() }}
-        continue-on-error: true
-        env:
-          RELEASE_BRANCH_NAME: {!{ .channel }!}
-        run: |
-          echo "Update branch ${RELEASE_BRANCH_NAME} to SHA:${{ needs.git_info.outputs.github_sha }}. Actor is ${GITHUB_ACTOR}."
-
-          git config --global user.name ${GITHUB_ACTOR}
-          git config --global user.email ${GITHUB_ACTOR}'@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{secrets.BOATSWAIN_GITHUB_TOKEN}}@github.com/${{ github.repository }}
-          git checkout -b "${RELEASE_BRANCH_NAME}"
-          git push --force origin "${RELEASE_BRANCH_NAME}"
-
       - name: Send failure report
         if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
         env:

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -1177,20 +1177,6 @@ jobs:
           echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
           echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
-      - name: Update release branch
-        if: ${{ success() }}
-        continue-on-error: true
-        env:
-          RELEASE_BRANCH_NAME: alpha
-        run: |
-          echo "Update branch ${RELEASE_BRANCH_NAME} to SHA:${{ needs.git_info.outputs.github_sha }}. Actor is ${GITHUB_ACTOR}."
-
-          git config --global user.name ${GITHUB_ACTOR}
-          git config --global user.email ${GITHUB_ACTOR}'@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{secrets.BOATSWAIN_GITHUB_TOKEN}}@github.com/${{ github.repository }}
-          git checkout -b "${RELEASE_BRANCH_NAME}"
-          git push --force origin "${RELEASE_BRANCH_NAME}"
-
       - name: Send failure report
         if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
         env:

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -1177,20 +1177,6 @@ jobs:
           echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
           echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
-      - name: Update release branch
-        if: ${{ success() }}
-        continue-on-error: true
-        env:
-          RELEASE_BRANCH_NAME: beta
-        run: |
-          echo "Update branch ${RELEASE_BRANCH_NAME} to SHA:${{ needs.git_info.outputs.github_sha }}. Actor is ${GITHUB_ACTOR}."
-
-          git config --global user.name ${GITHUB_ACTOR}
-          git config --global user.email ${GITHUB_ACTOR}'@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{secrets.BOATSWAIN_GITHUB_TOKEN}}@github.com/${{ github.repository }}
-          git checkout -b "${RELEASE_BRANCH_NAME}"
-          git push --force origin "${RELEASE_BRANCH_NAME}"
-
       - name: Send failure report
         if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
         env:

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -1177,20 +1177,6 @@ jobs:
           echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
           echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
-      - name: Update release branch
-        if: ${{ success() }}
-        continue-on-error: true
-        env:
-          RELEASE_BRANCH_NAME: early-access
-        run: |
-          echo "Update branch ${RELEASE_BRANCH_NAME} to SHA:${{ needs.git_info.outputs.github_sha }}. Actor is ${GITHUB_ACTOR}."
-
-          git config --global user.name ${GITHUB_ACTOR}
-          git config --global user.email ${GITHUB_ACTOR}'@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{secrets.BOATSWAIN_GITHUB_TOKEN}}@github.com/${{ github.repository }}
-          git checkout -b "${RELEASE_BRANCH_NAME}"
-          git push --force origin "${RELEASE_BRANCH_NAME}"
-
       - name: Send failure report
         if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
         env:

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -1177,20 +1177,6 @@ jobs:
           echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
           echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
-      - name: Update release branch
-        if: ${{ success() }}
-        continue-on-error: true
-        env:
-          RELEASE_BRANCH_NAME: rock-solid
-        run: |
-          echo "Update branch ${RELEASE_BRANCH_NAME} to SHA:${{ needs.git_info.outputs.github_sha }}. Actor is ${GITHUB_ACTOR}."
-
-          git config --global user.name ${GITHUB_ACTOR}
-          git config --global user.email ${GITHUB_ACTOR}'@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{secrets.BOATSWAIN_GITHUB_TOKEN}}@github.com/${{ github.repository }}
-          git checkout -b "${RELEASE_BRANCH_NAME}"
-          git push --force origin "${RELEASE_BRANCH_NAME}"
-
       - name: Send failure report
         if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
         env:

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -1177,20 +1177,6 @@ jobs:
           echo "  Source: ${SOURCE_RELEASE_VERSION_IMAGE}"
           echo "  Prod: ${PROD_RELEASE_VERSION_IMAGE}"
 
-      - name: Update release branch
-        if: ${{ success() }}
-        continue-on-error: true
-        env:
-          RELEASE_BRANCH_NAME: stable
-        run: |
-          echo "Update branch ${RELEASE_BRANCH_NAME} to SHA:${{ needs.git_info.outputs.github_sha }}. Actor is ${GITHUB_ACTOR}."
-
-          git config --global user.name ${GITHUB_ACTOR}
-          git config --global user.email ${GITHUB_ACTOR}'@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{secrets.BOATSWAIN_GITHUB_TOKEN}}@github.com/${{ github.repository }}
-          git checkout -b "${RELEASE_BRANCH_NAME}"
-          git push --force origin "${RELEASE_BRANCH_NAME}"
-
       - name: Send failure report
         if: ${{ failure() && github.repository == 'deckhouse/deckhouse' }}
         env:


### PR DESCRIPTION
## Description
Remove release channel branches (`alpha`, `beta`) update step.

## Why do we need it, and what problem does it solve?
Deprecated.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Remove release channel branches.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
