### PR TITLE
[deckhouse] fix packages layout

### DIFF
--- a/deckhouse-controller/internal/packages/operator/tasks/install/task.go
+++ b/deckhouse-controller/internal/packages/operator/tasks/install/task.go
@@ -30,7 +30,7 @@ const (
 
 type installer interface {
 	Download(ctx context.Context, reg registry.Registry, packageName, version string) error
-	Install(ctx context.Context, instance, packageName, version string) error
+	Install(ctx context.Context, registry, instance, packageName, version string) error
 }
 
 type task struct {
@@ -74,7 +74,7 @@ func (t *task) Execute(ctx context.Context) error {
 
 	// Install (mount) package to apps directory
 	logger.Debug("install application")
-	if err := t.installer.Install(ctx, t.instance, t.packageName, t.version); err != nil {
+	if err := t.installer.Install(ctx, t.registry.Name, t.instance, t.packageName, t.version); err != nil {
 		return fmt.Errorf("install application: %w", err)
 	}
 


### PR DESCRIPTION
## Description
It fixes packages layout to support registry in path.

## Why do we need it, and what problem does it solve?
Packages should be placed like that:
```
/downloaded
   /<registry>
     /<package>
       /<version>
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Fix packages layout.
impact_level: low
```
