### PR TITLE
[deckhouse] fix runtime package values

### DIFF
--- a/deckhouse-controller/internal/packages/manager/apps/app.go
+++ b/deckhouse-controller/internal/packages/manager/apps/app.go
@@ -141,15 +141,13 @@ func (a *Application) addHooks(found ...*addonhooks.ModuleHook) error {
 	return nil
 }
 
-// GetMetaValues returns values that is not part of schema(name, namespace, version)
-func (a *Application) GetMetaValues() addonutils.Values {
+// GetRuntimeValues returns values that is not part of schema(name, namespace, version)
+func (a *Application) GetRuntimeValues() addonutils.Values {
 	return addonutils.Values{
 		"Name":      a.instance,
 		"Namespace": a.namespace,
 		"Digests":   a.digests,
 		"Registry":  a.registry,
-		"Package":   a.definition.Name,
-		"Version":   a.definition.Version,
 	}
 }
 


### PR DESCRIPTION
## Description
It fixes runtime package values

## Why do we need it, and what problem does it solve?
To access runtime values in helm chart:
```
.Runtime.Instance
```

Available fields:
```
Name - application
Namespace - application namespace
Digests - package digests 
Registry - application registry
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Fix runtime package values.
impact_level: low
```
