### PR TITLE
Add create trivy-db with date tag with manual start

### DIFF
--- a/.github/scripts/trivy-db-update-vulnerability-references.sh
+++ b/.github/scripts/trivy-db-update-vulnerability-references.sh
@@ -77,4 +77,11 @@ case "$host" in
     exit 1
     ;;
 esac
-perform_oras_command "./oras push -d -v $auth --artifact-type application/octet-stream ${1} export.tar.gz:application/deckhouse.io.bdu.layer.v1.tar+gzip"
+
+
+perform_oras_command "./oras push -d -v $auth --artifact-type application/octet-stream ${1}/security/trivy-bdu:1 export.tar.gz:application/deckhouse.io.bdu.layer.v1.tar+gzip"
+
+if [ -n "${TRIVY_DB_UPDATE_WITH_DATE}" ]; then
+  date=$(date +%Y%m%d)
+  perform_oras_command "./oras push -d -v $auth --artifact-type application/octet-stream ${1}/security/trivy-bdu:${date} export.tar.gz:application/deckhouse.io.bdu.layer.v1.tar+gzip"
+fi

--- a/.github/scripts/trivy-db-update.sh
+++ b/.github/scripts/trivy-db-update.sh
@@ -208,3 +208,11 @@ esac
 perform_oras_command "../../oras push -d -v $auth --artifact-type application/vnd.aquasec.trivy.config.v1+json ${1}/security/trivy-db:2 db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
 perform_oras_command "../../oras push -d -v $auth --artifact-type application/octet-stream ${1}/security/trivy-checks:0 bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip"
 perform_oras_command "../../oras push -d -v $auth --artifact-type application/vnd.aquasec.trivy.config.v1+json ${1}/security/trivy-java-db:1 javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+
+
+if [ -n "${TRIVY_DB_UPDATE_WITH_DATE}" ]; then
+  date=$(date +%Y%m%d)
+  perform_oras_command "../../oras push -d -v $auth --artifact-type application/vnd.aquasec.trivy.config.v1+json ${1}/security/trivy-db:${date} db.tar.gz:application/vnd.aquasec.trivy.db.layer.v1.tar+gzip"
+  perform_oras_command "../../oras push -d -v $auth --artifact-type application/octet-stream ${1}/security/trivy-checks:${date} bundle.tar.gz:application/vnd.cncf.openpolicyagent.layer.v1.tar+gzip"
+  perform_oras_command "../../oras push -d -v $auth --artifact-type application/vnd.aquasec.trivy.config.v1+json ${1}/security/trivy-java-db:${date} javadb.tar.gz:application/vnd.aquasec.trivy.javadb.layer.v1.tar+gzip"
+fi

--- a/.github/workflow_templates/trivy-db-schedule.yml
+++ b/.github/workflow_templates/trivy-db-schedule.yml
@@ -17,6 +17,11 @@ on:
   schedule:
   - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      trivy_version:
+        description: Trivy Version Tag
+        required: true
+        default: v0.63.0
 
 # Always run a single job at a time.
 # Note: Concurrency is currently in beta and subject to change.
@@ -29,11 +34,11 @@ permissions:
   id-token: write
 
 jobs:
-{!{ tmpl.Exec "skip_tests_repos" . | strings.Indent 2 }!}
+# {!{ tmpl.Exec "skip_tests_repos" . | strings.Indent 2 }!}
   download-and-repush-images:
     name: Download and repush images
-    needs:
-      - skip_tests_repos
+    # needs:
+    #   - skip_tests_repos
     runs-on: [self-hosted, regular]
     permissions:
       contents: read
@@ -54,7 +59,7 @@ jobs:
 {!{ tmpl.Exec "add_ssh_keys" . | strings.Indent 6 }!}
       - name: Download custom trivy-db binary and copy image
         env:
-          TRIVY_VERSION: v0.63.0
+          TRIVY_VERSION: ${{ github.event.inputs.trivy_version }}
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           DECKHOUSE_REGISTRY_USER: ${{secrets.DECKHOUSE_REGISTRY_USER}}
           DECKHOUSE_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_REGISTRY_PASSWORD}}
@@ -82,14 +87,17 @@ jobs:
           git apply --verbose --whitespace=fix ../trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
           cp ../.github/scripts/trivy-db-update-vulnerability-references.sh ./update-vulnerability-references.sh
           cp ../.github/scripts/trivy-db-update.sh ./update.sh
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            export TRIVY_DB_UPDATE_WITH_DATE=true
+          fi
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe
           ./update.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse
           ./update.sh ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss
           ./update.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse/security/trivy-bdu:1
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse
+          ./update-vulnerability-references.sh ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse
 {!{ tmpl.Exec "send_fail_report" . | strings.Indent 6 }!}

--- a/.github/workflows/trivy-db-schedule.yml
+++ b/.github/workflows/trivy-db-schedule.yml
@@ -21,6 +21,11 @@ on:
   schedule:
   - cron: '0 */6 * * *'
   workflow_dispatch:
+    inputs:
+      trivy_version:
+        description: Trivy Version Tag
+        required: true
+        default: v0.63.0
 
 # Always run a single job at a time.
 # Note: Concurrency is currently in beta and subject to change.
@@ -33,7 +38,7 @@ permissions:
   id-token: write
 
 jobs:
-
+# 
   # <template: skip_tests_repos>
   skip_tests_repos:
     name: Skip tests repos
@@ -45,8 +50,8 @@ jobs:
   # </template: skip_tests_repos>
   download-and-repush-images:
     name: Download and repush images
-    needs:
-      - skip_tests_repos
+    # needs:
+    #   - skip_tests_repos
     runs-on: [self-hosted, regular]
     permissions:
       contents: read
@@ -222,7 +227,7 @@ jobs:
       # </template: add_ssh_keys>
       - name: Download custom trivy-db binary and copy image
         env:
-          TRIVY_VERSION: v0.63.0
+          TRIVY_VERSION: ${{ github.event.inputs.trivy_version }}
           DECKHOUSE_REGISTRY_HOST: ${{secrets.DECKHOUSE_REGISTRY_HOST}}
           DECKHOUSE_REGISTRY_USER: ${{secrets.DECKHOUSE_REGISTRY_USER}}
           DECKHOUSE_REGISTRY_PASSWORD: ${{secrets.DECKHOUSE_REGISTRY_PASSWORD}}
@@ -250,16 +255,19 @@ jobs:
           git apply --verbose --whitespace=fix ../trivy-db-patch/patches/${TRIVY_VERSION}/*.patch
           cp ../.github/scripts/trivy-db-update-vulnerability-references.sh ./update-vulnerability-references.sh
           cp ../.github/scripts/trivy-db-update.sh ./update.sh
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            export TRIVY_DB_UPDATE_WITH_DATE=true
+          fi
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee
           ./update.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe
           ./update.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse
           ./update.sh ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss
           ./update.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss/security/trivy-bdu:1
-          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse/security/trivy-bdu:1
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/ee
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_REGISTRY_HOST}}/deckhouse/fe
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_CSE_REGISTRY_HOST}}/deckhouse/cse
+          ./update-vulnerability-references.sh ${{steps.secrets.outputs.DECKHOUSE_DEV_REGISTRY_HOST}}/sys/deckhouse-oss
+          ./update-vulnerability-references.sh ${{secrets.DECKHOUSE_DEV_CSE_REGISTRY_HOST}}/sys/deckhouse-cse
 
       # <template: send_fail_report>
       - name: Send fail report


### PR DESCRIPTION
## Description
Add build trivy-db with date tag with manual start

## Why do we need it, and what problem does it solve?
Add build trivy-db with date tag with manual start

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Add build trivy-db with date tag with manual start
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
