### PR TITLE
[monitoring-kubernetes] Add kube-summary-exporter

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_basic_targets_generated.go
@@ -137,6 +137,7 @@ var auditPolicyBasicServiceAccounts = []string{
 	"system:serviceaccount:d8-monitoring:grafana",
 	"system:serviceaccount:d8-monitoring:image-availability-exporter",
 	"system:serviceaccount:d8-monitoring:kube-state-metrics",
+	"system:serviceaccount:d8-monitoring:kube-summary-exporter",
 	"system:serviceaccount:d8-monitoring:loki",
 	"system:serviceaccount:d8-monitoring:monitoring-ping",
 	"system:serviceaccount:d8-monitoring:node-exporter",

--- a/modules/340-monitoring-kubernetes/images/kube-summary-exporter/werf.inc.yaml
+++ b/modules/340-monitoring-kubernetes/images/kube-summary-exporter/werf.inc.yaml
@@ -1,0 +1,44 @@
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+fromImage: common/src-artifact
+final: false
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
+shell:
+  install:
+  - cd /src
+  - git clone --branch=v0.4.7 --depth=1 $(cat /run/secrets/SOURCE_REPO)/utilitywarehouse/kube-summary-exporter.git .
+  - rm -rf .git
+---
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+fromImage: builder/golang-alpine
+final: false
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
+  add: /src
+  to: /src
+  before: install
+mount:
+{{ include "mount points for golang builds" . }}
+secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
+shell:
+  install:
+  - cd /src
+  - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+  - go build -ldflags="-s -w" -o kube-summary-exporter main.go
+  - chown -R 64535:64535 /src/
+  - chmod 0700 /src/kube-summary-exporter
+---
+image: {{ .ModuleName }}/{{ .ImageName }}
+fromImage: common/distroless
+import:
+- image: {{ .ModuleName }}/{{ .ImageName }}-artifact
+  add: /src/kube-summary-exporter
+  to: /bin/kube-summary-exporter
+  before: setup
+imageSpec:
+  config:
+    entrypoint: ["/bin/kube-summary-exporter"]

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/propagated-namespaces.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/propagated-namespaces.json
@@ -24,7 +24,7 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 24,
+  "id": 30,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -565,7 +565,7 @@
         "showHeader": true
       },
       "pageSize": 50,
-      "pluginVersion": "10.4.5",
+      "pluginVersion": "10.4.19",
       "scroll": true,
       "showHeader": true,
       "sort": {
@@ -2181,7 +2181,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 35
+            "y": 51
           },
           "id": 352,
           "links": [],
@@ -2374,7 +2374,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 36
+            "y": 52
           },
           "id": 14,
           "links": [],
@@ -3337,7 +3337,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 54
+            "y": 70
           },
           "id": 44,
           "links": [],
@@ -4386,6 +4386,220 @@
         }
       ],
       "title": "PVC Used in % (except local storage classes)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 88
+      },
+      "id": 565,
+      "panels": [],
+      "title": "Disk Usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 89
+      },
+      "id": 566,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(30,\n  sum by(namespace) (\n      kube_summary_pod_ephemeral_storage_used_bytes{namespace=~\"$namespace\", container!=\"POD\", node=~\"$node\"}\n  )\n)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{ namespace }} ",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Consumers by Namespace",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 89
+      },
+      "id": 567,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "topk(30,\n  sum by(namespace) (\n    kube_summary_container_logs_used_bytes{namespace=~\"$namespace\", container!=\"POD\", node=~\"$node\"}\n  )\n)",
+          "instant": false,
+          "legendFormat": "{{ namespace }}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Log Producers ",
       "type": "timeseries"
     }
   ],

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/propagated-controller.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/propagated-controller.json
@@ -24,7 +24,7 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 29,
+  "id": 40,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -635,7 +635,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "10.4.5",
+      "pluginVersion": "10.4.19",
       "targets": [
         {
           "datasource": {
@@ -2066,7 +2066,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 42
+            "y": 50
           },
           "id": 62,
           "links": [],
@@ -2262,7 +2262,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 51
           },
           "id": 11,
           "links": [],
@@ -3257,7 +3257,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 63
+            "y": 71
           },
           "id": 19,
           "links": [],
@@ -3975,6 +3975,161 @@
     },
     {
       "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 109,
+      "panels": [],
+      "title": "Disk Usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 83
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(pod) (\n  kube_summary_pod_ephemeral_storage_used_bytes{namespace=\"$namespace\"}\n  * on(pod, namespace)\n  group_right()\n  max(kube_controller_pod{node=~\"$node\", namespace=\"$namespace\", controller=\"$controller\", pod=~\"$pod\"}) by(pod, namespace)\n)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{ container }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ephemeral storage usage by pod",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {}
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "$ds_prometheus"
@@ -3983,7 +4138,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 92
       },
       "id": 81,
       "panels": [],
@@ -4088,7 +4243,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 83
+        "y": 93
       },
       "id": 82,
       "options": {
@@ -4222,7 +4377,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 83
+        "y": 93
       },
       "id": 84,
       "options": {
@@ -4308,8 +4463,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -4358,7 +4512,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 100
       },
       "id": 83,
       "options": {
@@ -4404,7 +4558,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 98
+        "y": 108
       },
       "id": 88,
       "panels": [],
@@ -4434,8 +4588,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4693,7 +4846,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 99
+        "y": 109
       },
       "id": 86,
       "options": {
@@ -4865,8 +5018,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -4882,7 +5034,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 108
+        "y": 118
       },
       "id": 89,
       "options": {

--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/propagated-pod.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/propagated-pod.json
@@ -24,7 +24,7 @@
   "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 10,
+  "id": 39,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -2177,8 +2177,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -2255,7 +2254,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 46
+            "y": 62
           },
           "id": 102,
           "options": {
@@ -3416,7 +3415,7 @@
             "h": 9,
             "w": 12,
             "x": 0,
-            "y": 75
+            "y": 91
           },
           "id": 19,
           "links": [],
@@ -4112,6 +4111,301 @@
     },
     {
       "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 92
+      },
+      "id": 171,
+      "panels": [],
+      "title": "Disk Usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 93
+      },
+      "id": 170,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(container) (\n  kube_summary_container_logs_used_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"} +\n  kube_summary_container_rootfs_used_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"}\n)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{ container }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ephemeral storage usage by container",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {}
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "bytes",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 93
+      },
+      "id": 174,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(container) (\n  kube_summary_container_logs_used_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"}\n)",
+          "format": "time_series",
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{ container }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Log storage usage by container",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {}
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
       "datasource": {
         "type": "prometheus",
         "uid": "$ds_prometheus"
@@ -4120,7 +4414,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 92
+        "y": 102
       },
       "id": 150,
       "panels": [],
@@ -4224,7 +4518,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 93
+        "y": 103
       },
       "id": 148,
       "options": {
@@ -4361,7 +4655,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 93
+        "y": 103
       },
       "id": 151,
       "options": {
@@ -4460,7 +4754,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 101
+        "y": 111
       },
       "id": 152,
       "options": {
@@ -4500,7 +4794,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 119
       },
       "id": 156,
       "panels": [
@@ -4527,8 +4821,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4763,7 +5056,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 110
+            "y": 126
           },
           "id": 154,
           "options": {
@@ -4931,8 +5224,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -4948,7 +5240,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 119
+            "y": 135
           },
           "id": 157,
           "options": {

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/deployment.yaml
@@ -1,0 +1,143 @@
+{{- define "kube_summary_exporter_resources" }}
+cpu: 10m
+memory: 25Mi
+{{- end }}
+
+{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: kube-summary-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: kube-summary-exporter
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: "kube-summary-exporter"
+      minAllowed:
+        {{- include "kube_summary_exporter_resources" . | nindent 8 }}
+      maxAllowed:
+        cpu: 500m
+        memory: 512Mi
+    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-summary-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: kube-summary-exporter
+  template:
+    metadata:
+      labels:
+        app: kube-summary-exporter
+    spec:
+      imagePullSecrets:
+      - name: deckhouse-registry
+      serviceAccountName: kube-summary-exporter
+      automountServiceAccountToken: true
+      {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
+      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      containers:
+      - name: kube-summary-exporter
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
+        image: {{ include "helm_lib_module_image" (list . "kubeSummaryExporter") }}
+        ports:
+        - name: http-metrics
+          containerPort: 9779
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 9779
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: 9779
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+            {{- include "kube_summary_exporter_resources" . | nindent 12 }}
+{{- end }}
+      - name: kube-rbac-proxy
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
+        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
+        args:
+        - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8080"
+        - "--v=2"
+        - "--logtostderr=true"
+        - "--stale-cache-interval=1h30m"
+        - "--livez-path=/livez"
+        ports:
+        - containerPort: 8080
+          name: https-metrics
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /livez
+            port: 8080
+            scheme: HTTPS
+        env:
+        - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: KUBE_RBAC_PROXY_CONFIG
+          value: |
+            excludePaths:
+            - /livez
+            upstreams:
+            - upstream: http://127.0.0.1:9779/
+              path: /
+              authorization:
+                resourceAttributes:
+                  namespace: d8-monitoring
+                  apiGroup: apps
+                  apiVersion: v1
+                  resource: deployments
+                  subresource: prometheus-main-metrics
+                  name: kube-summary-exporter
+        resources:
+          requests:
+            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+{{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
+            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
+{{- end }}

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/deployment.yaml
@@ -24,8 +24,8 @@ spec:
       minAllowed:
         {{- include "kube_summary_exporter_resources" . | nindent 8 }}
       maxAllowed:
-        cpu: 500m
-        memory: 512Mi
+        cpu: 100m
+        memory: 200Mi
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
 ---

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/deployment.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     kind: Deployment
     name: kube-summary-exporter
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     - containerName: "kube-summary-exporter"

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/pdb.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/pdb.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-summary-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+spec:
+  minAvailable: {{ include "helm_lib_is_ha_to_value" (list . 1 0) }}
+  selector:
+    matchLabels:
+      app: kube-summary-exporter

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/podmonitor.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/podmonitor.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kube-summary-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter" "prometheus" "main")) | nindent 2 }}
+spec:
+  jobLabel: app
+  selector:
+    matchLabels:
+      app: kube-summary-exporter
+  namespaceSelector:
+    matchNames:
+    - d8-monitoring
+  podMetricsEndpoints:
+  - port: https-metrics
+    path: /nodes
+    scheme: https
+    interval: 30s
+    scrapeTimeout: 25s
+    bearerTokenSecret:
+      name: "prometheus-token"
+      key: "token"
+    tlsConfig:
+      insecureSkipVerify: true
+    honorLabels: true
+    relabelings:
+    - regex: endpoint|namespace|pod|service
+      action: labeldrop
+    metricRelabelings:
+    - sourceLabels: [name]
+      targetLabel: container
+      action: replace
+    - regex: name
+      action: labeldrop

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/rbac-for-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/rbac-for-us.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-summary-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:monitoring-kubernetes:kube-summary-exporter
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources:
+  - nodes/proxy
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:monitoring-kubernetes:kube-summary-exporter
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:monitoring-kubernetes:kube-summary-exporter
+subjects:
+- kind: ServiceAccount
+  name: kube-summary-exporter
+  namespace: d8-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:monitoring-kubernetes:kube-summary-exporter:rbac-proxy
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: kube-summary-exporter
+  namespace: d8-monitoring

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/rbac-to-us.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/rbac-to-us.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: access-to-kube-summary-exporter-prometheus-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+rules:
+- apiGroups: ["apps"]
+  resources:
+  - "deployments/prometheus-main-metrics"
+  resourceNames: ["kube-summary-exporter"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: access-to-kube-summary-exporter-prometheus-metrics
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: access-to-kube-summary-exporter-prometheus-metrics
+subjects:
+- kind: User
+  name: d8-monitoring:scraper
+- kind: ServiceAccount
+  name: prometheus
+  namespace: d8-monitoring

--- a/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/service.yaml
+++ b/modules/340-monitoring-kubernetes/templates/kube-summary-exporter/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-summary-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "kube-summary-exporter")) | nindent 2 }}
+spec:
+  type: ClusterIP
+  selector:
+    app: kube-summary-exporter
+  ports:
+    - name: https-metrics
+      protocol: TCP
+      port: 8080
+      targetPort: https-metrics

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -375,6 +375,7 @@ var DefaultImagesDigests = map[string]interface{}{
 	"monitoringKubernetes": map[string]interface{}{
 		"ebpfExporter":                      "imageHash-monitoringKubernetes-ebpfExporter",
 		"kubeStateMetrics":                  "imageHash-monitoringKubernetes-kubeStateMetrics",
+		"kubeSummaryExporter":               "imageHash-monitoringKubernetes-kubeSummaryExporter",
 		"kubeletEvictionThresholdsExporter": "imageHash-monitoringKubernetes-kubeletEvictionThresholdsExporter",
 		"nodeExporter":                      "imageHash-monitoringKubernetes-nodeExporter",
 	},


### PR DESCRIPTION
## Description
This PR introduces `kube-summary-exporter` as a temporary solution to replace missing ephemeral/rootfs/logs storage metrics from cAdvisor.
The exporter takes information from handler `/api/v1/nodes/{$node-name}/proxy/stats/summary"`,  which kubelet populates directly from CRI.

Adds new panels for node/pod dashboards.

## Why do we need it, and what problem does it solve?
- cAdvisor can't get storage metrics from contrainerd CRI.  The issue is caused by an upstream cAdvisor limitation documented in https://github.com/google/cadvisor/issues/2785.  


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: feature
summary: Add kube-summary-exporter as temporary replacement for missing cAdvisor storage metrics
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
