### PR TITLE
[node-manager] Inhibitor re scan event devices

### DIFF
--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/README.md
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/README.md
@@ -33,3 +33,31 @@ systemctl poweroff --check-inhibitors=yes
 systemctl reboot --check-inhibitors=yes
   Use these commands to shutdown/reboot the Node.
 ```
+
+## Tests
+
+### simulate power button device removal
+
+```shell
+ls /sys/bus/acpi/drivers/button
+echo PNP0C0C:00 > /sys/bus/acpi/drivers/button/unbind
+```
+
+### simulate power button press
+
+```shell
+python3 - <<'PY'  
+import libevdev, os
+dev = libevdev.Device()
+dev.name = "d8-shutdown-inhibitor-test"
+dev.enable(libevdev.EV_KEY.KEY_POWER)
+uinput = dev.create_uinput_device()
+uinput.send_events([
+    libevdev.InputEvent(libevdev.EV_KEY.KEY_POWER, 1),
+    libevdev.InputEvent(libevdev.EV_SYN.SYN_REPORT, 0)])
+uinput.send_events([
+    libevdev.InputEvent(libevdev.EV_KEY.KEY_POWER, 0),
+    libevdev.InputEvent(libevdev.EV_SYN.SYN_REPORT, 0)])
+PY
+```
+

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/inputdev/watcher.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/pkg/inputdev/watcher.go
@@ -59,25 +59,26 @@ func (w *Watcher) watch() {
 		}
 	}
 }
+
 func (w *Watcher) readEvents(evCh chan *inputEvent) {
 	var fds []int
-	
+
 	for {
 		if w.shouldStop() {
 			return
 		}
-		
+
 		err := w.processDeviceCycle(evCh, fds)
 		if err == nil {
 			return
 		}
-		
+
 		if errors.Is(err, errDevicesNeedRefresh) {
 			w.refreshDevsOnError()
 			fds = fds[:0]
 			continue
 		}
-		
+
 		dlog.Warn("power button watcher: unexpected error", dlog.Err(err))
 	}
 }
@@ -96,9 +97,9 @@ func (w *Watcher) processDeviceCycle(evCh chan *inputEvent, fds []int) error {
 	if !ok {
 		return nil
 	}
-	
+
 	defer closeFDs(fds)
-	
+
 	return w.handleDeviceEvents(evCh, fds, &fdSet, fdMax, w.stopCh)
 }
 
@@ -195,7 +196,6 @@ func (w *Watcher) refreshDevsOnError() {
 		dlog.Error("power button watcher: refresh devs list", dlog.Err(err))
 		return
 	}
-
 }
 
 type inputEvent struct {


### PR DESCRIPTION
## Description
fix https://github.com/deckhouse/deckhouse/issues/16464


## Why do we need it, and what problem does it solve?

Power button input devices may disappear (e.g. /dev/input/event0 after kernel/udev changes), leaving the shutdown inhibitor stuck on stale descriptors. The watcher now closes descriptors on ENODEV, rescans devices, and continues listening so button presses keep working.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Set to rescan power-button input devices and refreshes stale descriptors, ensuring the shutdown inhibitor continues receiving button-press events.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
