### PR TITLE
[node-manager] Fix mig-manager disruption approval

### DIFF
--- a/ee/modules/040-node-manager/templates/nvidia-gpu/nvidia-mig-config.yml
+++ b/ee/modules/040-node-manager/templates/nvidia-gpu/nvidia-mig-config.yml
@@ -652,6 +652,11 @@ data:
         fi
           echo "Disruption required, asking for approval."
           echo "Annotating Node with annotation 'update.node.deckhouse.io/disruption-required='."
+          # To get approve from update_approvel hook, two conditions must be satisfied:
+          # - update.node.deckhouse.io/approved= annotation exists (needed by approveDisruptions func)
+          # - node checksum must be differemt from nodegroup checksum or empty (to not unset annotations listed above)
+          # and we cannot run it as ngc inside bashible, because this action must be triggered by node labels change, and mig-manager/partition-manager
+          # are not present on the node
           kubectl \
             --resource-version="$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
             annotate node ${NODE_NAME} update.node.deckhouse.io/disruption-required= node.deckhouse.io/configuration-checksum= update.node.deckhouse.io/approved= --overwrite \


### PR DESCRIPTION
## Description

Fix mig-manager reconfigure script to make it works with auto approval node groups

## Why do we need it, and what problem does it solve?

If node group has auto approve for disruptive changes, it still waiting for manual approve with annotation. To fix it, we should set additional annotation and change node checksum 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fixed `mig-manager` reconfigure script to correctly handle auto-approved disruptive node group changes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
