### PR TITLE
[ci] Multiline code in e2e test comment

### DIFF
--- a/.github/scripts/js/e2e/cleanup.js
+++ b/.github/scripts/js/e2e/cleanup.js
@@ -69,14 +69,14 @@ function buildFailedE2eTestAdditionalInfo({ needsContext, core, context }){
         }
 
         const splitRunFor = ranFor.replace(';', ' ');
-        const outConnectStr = connectStr ? `\`\`\`ssh -i ~/.ssh/e2e-id-rsa ${bastionPart} ${connectStr}\`\`\` - connect for debugging;` : '';
+        const outConnectStr = connectStr ? `\`\`\`\nssh -i ~/.ssh/e2e-id-rsa ${bastionPart} ${connectStr}\n\`\`\`\n connect for debugging;` : '';
 
         return `
 <!--- failed_clusters_start ${ranFor} -->
-E2E for ${splitRunFor} has failed. Use:
+E2E for ${splitRunFor} has failed. To abort failed cluster, use:
   ${outConnectStr}
 
-  \`\`\`${argv.join(' ')}\`\`\` - to abort failed cluster
+  \`\`\`\n${argv.join(' ')}\n\`\`\`
 <!--- failed_clusters_end ${ranFor} -->
 
 `

--- a/testing/cloud_layouts/script-commander.sh
+++ b/testing/cloud_layouts/script-commander.sh
@@ -1114,7 +1114,7 @@ function update_comment() {
     return 1
   fi
 
-  local connection_str_body="${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION} - Connection string: \`\`\`ssh ${ssh_bastion} ${master_connection}\`\`\`"
+  local connection_str_body="${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION} - Connection string: \`\`\`\nssh ${ssh_bastion} ${master_connection}\n\`\`\`"
   local result_body
 
   if ! result_body="$(echo "$comment" | jq -crM --arg a "$connection_str_body" '{body: (.body + "\r\n\r\n" + $a + "\r\n")}')"; then

--- a/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh
+++ b/testing/cloud_layouts/wait-master-ssh-and-update-comment.sh
@@ -76,7 +76,7 @@ function get_comment(){
   fi
 
   local connection_str="${master_user}@${master_ip}"
-  local connection_str_body="${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION} - Connection string: \`\`\`ssh ${bastion_part} ${connection_str}\`\`\`"
+  local connection_str_body="${PROVIDER}-${LAYOUT}-${CRI}-${KUBERNETES_VERSION} - Connection string: \`\`\`\nssh ${bastion_part} ${connection_str}\n\`\`\`"
   local bbody
   if ! bbody="$(cat "$response_file" | jq -crM --arg a "$connection_str_body" '{body: (.body + "\r\n\r\n" + $a + "\r\n")}')"; then
     return 1


### PR DESCRIPTION
## Description
Switch e2e test comment to multiline code block.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Switch e2e test comment to multiline code block.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
