### PR TITLE
[candi] Add capability version check to check_gpu step

### DIFF
--- a/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
+++ b/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
@@ -61,7 +61,7 @@ version=$(egrep -E -o "[0-9]{3,4}[.][0-9]{1,3}[.][0-9]{1,3}" /proc/driver/nvidia
 compare $version $required_version
 
 got_capability=$(nvidia-smi --query-gpu="compute_cap" --format=csv,noheader)
-if is_valid_greater_than "$version" "$threshold"; then
+if is_valid_greater_than "$got_capability" "6.0"; then
     echo "compute_cap ${got_capability} is valid"
 else
     echo "compute_cap ${got_capability} is invalid"


### PR DESCRIPTION
## Description

Add capability version check to check_gpu step

## Why do we need it, and what problem does it solve?

If GPU node was prepared wrong, e.g. drivers w/o CUDA support was installed,  node bootstrap succeeded, but CRI cannot run any container what needs GPU. To avoid it, we should add compute capability check to bootstrap process.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Added GPU compute capability check to `check_gpu` bootstrap step.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
