### PR TITLE
[deckhouse-controller] Fix verifying migrated modules

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_deckhouse_release_test.go
@@ -112,6 +112,46 @@ func createModuleConfig(name string) *v1alpha1.ModuleConfig {
 	}
 }
 
+func createModule(name string) *v1alpha1.Module {
+	return &v1alpha1.Module{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1alpha1.ModuleStatus{
+			Conditions: []v1alpha1.ModuleCondition{
+				{
+					Type:   v1alpha1.ModuleConditionEnabledByModuleManager,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   v1alpha1.ModuleConditionEnabledByModuleConfig,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func createDisabledModule(name string) *v1alpha1.Module {
+	return &v1alpha1.Module{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Status: v1alpha1.ModuleStatus{
+			Conditions: []v1alpha1.ModuleCondition{
+				{
+					Type:   v1alpha1.ModuleConditionEnabledByModuleManager,
+					Status: corev1.ConditionFalse,
+				},
+				{
+					Type:   v1alpha1.ModuleConditionEnabledByModuleConfig,
+					Status: corev1.ConditionFalse,
+				},
+			},
+		},
+	}
+}
+
 func createDisabledModuleConfig(name string) *v1alpha1.ModuleConfig {
 	return &v1alpha1.ModuleConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -197,9 +237,11 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 		},
 		{
 			name:           "reject approved release with migrated modules not found",
-			enabledModules: []string{"module1", "module2"},
+			enabledModules: []string{"module1", "module2", "non-existent-module"},
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
+				createModuleConfig("non-existent-module"),
+				createModule("non-existent-module"),
 			},
 			operation: "CREATE",
 			release: createDeckhouseRelease("test-release", true, map[string]string{
@@ -273,6 +315,8 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 				createClusterConfigSecret("1.28.0"),
 				createModuleConfig("enabled-module"),
 				createDisabledModuleConfig("disabled-module"),
+				createModule("enabled-module"),
+				createDisabledModule("disabled-module"),
 			},
 			operation: "CREATE",
 			release: createDeckhouseRelease("test-release", true, map[string]string{
@@ -288,8 +332,10 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
 				createModuleConfig("cert-manager"),
+				createModule("cert-manager"),
 				createModuleConfig("prometheus"),
-				createModuleSource("test-source", []string{"cert-manager", "prometheus"}),
+				createModule("prometheus"),
+				createModuleSource("test-source", []string{"cert-manager"}),
 			},
 			operation: "CREATE",
 			release: createDeckhouseRelease("test-release", true, map[string]string{
@@ -318,6 +364,7 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
 				createModuleConfig("module-y"),
+				createModule("module-y"),
 				createModuleSource("src", []string{}),
 			},
 			operation:   "CREATE",
@@ -352,7 +399,7 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 			description: "Absent ModuleConfig falls back to ModuleSource and passes",
 		},
 		{
-			name:           "reject when no in ModuleConfig and not in ModuleSource",
+			name:           "allow when no in ModuleConfig and not in ModuleSource",
 			enabledModules: []string{"module-a2"},
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
@@ -360,9 +407,9 @@ func TestDeckhouseReleaseValidationHandler(t *testing.T) {
 			},
 			operation:   "CREATE",
 			release:     createDeckhouseRelease("test-release", true, map[string]string{"migratedModules": "module-a2"}),
-			wantAllowed: false,
-			wantMessage: "requirements not met",
-			description: "Absent ModuleConfig and absence in ModuleSource rejects",
+			wantAllowed: true,
+			wantMessage: "",
+			description: "Absent ModuleConfig and absence in ModuleSource allows",
 		},
 	}
 
@@ -482,6 +529,7 @@ func TestDeckhouseReleaseValidation_RequirementsCoverage(t *testing.T) {
 			kubernetesObjs: []client.Object{
 				createClusterConfigSecret("1.28.0"),
 				createModuleConfig("available-module"),
+				createModule("available-module"),
 			},
 			wantAllowed: false,
 			description: "DeckhouseRelease with partially available migratedModules should be rejected",

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-missing.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/golden/migrated-modules-module-missing.yaml
@@ -5,30 +5,34 @@ kind: DeckhouseRelease
 metadata:
   creationTimestamp: null
   name: v1.49.0
-  resourceVersion: "999"
+  resourceVersion: "1000"
 spec:
   version: v1.49.0
 status:
   approved: true
   message: ""
-  phase: Deployed
-  transitionTime: "2019-10-17T15:32:00Z"
+  phase: Superseded
+  transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: deckhouse.io/v1alpha1
 approved: false
 kind: DeckhouseRelease
 metadata:
+  annotations:
+    release.deckhouse.io/isUpdating: "true"
+    release.deckhouse.io/notified: "false"
+    release.deckhouse.io/update-info: '{"taskCalculation":{"taskType":"process","isPatch":false,"isMajor":false,"isFromTo":false,"isSingle":false,"isLatest":true},"updatePolicy":{"mode":"Auto"},"forceRelease":{"isForced":false},"podReadiness":{"isReady":true},"requirementsCheck":{"requirementsMet":true}}'
   creationTimestamp: null
   name: v1.50.0
-  resourceVersion: "1000"
+  resourceVersion: "1001"
 spec:
   requirements:
     migratedModules: test-module-1, test-module-missing
   version: v1.50.0
 status:
   approved: false
-  message: migrated module 'test-module-missing' not found in any ModuleSource registry
-  phase: Pending
+  message: ""
+  phase: Deployed
   transitionTime: "2019-10-17T15:33:00Z"
 ---
 apiVersion: apps/v1
@@ -37,7 +41,7 @@ metadata:
   creationTimestamp: null
   name: deckhouse
   namespace: d8-system
-  resourceVersion: "999"
+  resourceVersion: "1000"
 spec:
   replicas: 1
   selector:
@@ -51,7 +55,7 @@ spec:
         app: deckhouse
     spec:
       containers:
-      - image: dev-registry.deckhouse.io/deckhouse/deckhouse:v1.49.0
+      - image: my.registry.com/deckhouse:v1.50.0
         name: deckhouse
         resources: {}
 status:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-in-source.yaml
@@ -42,6 +42,10 @@ apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: test-module-1
+status:
+  conditions:
+    - type: EnabledByModuleManager
+      status: "True"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-not-in-source.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-mc-enabled-not-in-source.yaml
@@ -43,6 +43,15 @@ metadata:
 spec:
   enabled: true
 ---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: enabled-module-not-found
+status:
+  conditions:
+    - type: EnabledByModuleManager
+      status: "True"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-missing.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-missing.yaml
@@ -42,6 +42,10 @@ apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: test-module-1
+status:
+  conditions:
+    - type: EnabledByModuleManager
+      status: "True"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-pull-error.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-module-pull-error.yaml
@@ -43,6 +43,10 @@ apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: test-module-1
+status:
+  conditions:
+    - type: EnabledByModuleManager
+      status: "True"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-modules-available.yaml
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/testdata/migrated-modules-modules-available.yaml
@@ -43,6 +43,10 @@ apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: test-module-1
+status:
+  conditions:
+    - type: EnabledByModuleManager
+      status: "True"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig
@@ -55,6 +59,10 @@ apiVersion: deckhouse.io/v1alpha1
 kind: Module
 metadata:
   name: test-module-2
+status:
+  conditions:
+    - type: EnabledByModuleManager
+      status: "True"
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ModuleConfig

--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
@@ -447,8 +447,9 @@ func (c *migratedModulesCheck) Verify(ctx context.Context, dr *v1alpha1.Deckhous
 				if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleManager, corev1.ConditionTrue) {
 					c.logger.Debug("migrated module is enabled", slog.String("module", moduleName))
 					ModuleEnabled = true
+				} else {
+					c.logger.Debug("migrated module is disabled", slog.String("module", moduleName))
 				}
-				c.logger.Debug("migrated module is disabled", slog.String("module", moduleName))
 				break
 			}
 		}


### PR DESCRIPTION
## Description
Fixed behavior where a migrated module was enabled via ModuleManager instead of ModuleConfig and was not verified during the deckhouse release. This behavior could negatively impact the update process.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Checking whether a module is enabled using ModuleConfig is not accurate; Module resource conditions must be used to avoid bugs.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed an issue where modules enabled through ModuleManager after migration bypassed ModuleConfig release validation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
