### PR TITLE
[node-manager] Webhook for validating maxPods depends on podSubnetNodeCIDRPrefix

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -160,11 +160,11 @@ EOF
     if [[ -z "$prefix" || "$prefix" == "null" ]]; then
       prefix=24
     fi
+    availableIPs=$((2**(32 - prefix) - 3))
     # every pod can use two IP (one in terminating phase + one in starting phase)
-    availableIPs=$((2**(32 - prefix - 1) - 3))
-    if [[ "$maxPods" -gt "$availableIPs" ]]; then
+    if (( 2 * maxPods > availableIPs )); then
       cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"it is forbidden to set .spec.kubelet.maxPods ($maxPods) greater than available IPs ($availableIPs) in podSubnetNodeCIDRPrefix /$prefix"}
+{"allowed":false, "message":".spec.kubelet.maxPods ($maxPods) is too high: each pod may need 2 IPs (one terminating + one starting), but only $availableIPs IPs available in podSubnetNodeCIDRPrefix /$prefix"}
 EOF
       return 0
     fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add validation to ensure `.spec.kubelet.maxPods` does not exceed the number of allocatable pod IPs per node:
```bash
availableIPs = 2^(32 - podSubnetNodeCIDRPrefix) - 3
```
Each pod may need 2 IPs (terminating + starting), this is taken into account in the check.

Error example:
```bash
root@master-0:~# kubectl edit ng master
error: nodegroups.deckhouse.io "master" could not be patched: admission webhook "nodegroup-policy.deckhouse.io" denied the request: .spec.kubelet.maxPods (127) is too high: each pod may need 2 IPs (one terminating + one starting), but only 253 IPs available in podSubnetNodeCIDRPrefix /24
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without this validation, maxPods could be set higher than the number of available IPs on a node, which may lead to pod IP allocation failures.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
No need

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Added validation to ensure `.spec.kubelet.maxPods` doesn't exceed the number of available Pod IP capacity per node.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
