### PR TITLE
[docs][getting-started] Update SHA512 for trdl repo on the GUI installer page

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
+++ b/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
@@ -57,7 +57,7 @@ docker run --rm --pull always -v $HOME/.d8installer:$HOME/.d8installer -v /var/r
 ```bash
 URL=https://deckhouse.ru/downloads/deckhouse-installer-trdl
 ROOT_VERSION=1
-ROOT_SHA512=4f2323bdda2bef5c15df2b1cd129d4514c46c963e889bfaf1924dd3e7f4cfcedf80798c83dfb7b2a6a3fd310f37c30236b456b9b16282e0e708ec2cd874789a6
+ROOT_SHA512=62e4b351bd06ee962dca92c0650ecbd2bceca9a78c125836fa62186b046f07257015929c853eb8a6241d90d59b2995bb028389cdb30bfa9c0991b10ddc2c57bc
 REPO=d8-installer
 trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
 ```
@@ -116,7 +116,7 @@ docker run --rm --pull always -v $HOME/.d8installer:$HOME/.d8installer -v /var/r
 ```bash
 URL=https://deckhouse.ru/downloads/deckhouse-installer-trdl
 ROOT_VERSION=1
-ROOT_SHA512=4f2323bdda2bef5c15df2b1cd129d4514c46c963e889bfaf1924dd3e7f4cfcedf80798c83dfb7b2a6a3fd310f37c30236b456b9b16282e0e708ec2cd874789a6
+ROOT_SHA512=62e4b351bd06ee962dca92c0650ecbd2bceca9a78c125836fa62186b046f07257015929c853eb8a6241d90d59b2995bb028389cdb30bfa9c0991b10ddc2c57bc
 REPO=d8-installer
 trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
 ```


### PR DESCRIPTION
## Description

Updated SHA512 for trdl repo on the GUI installer page

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix 
summary: Updated SHA512 for trdl repo on the GUI installer page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
