### PR TITLE
fix e2e autoclean

### DIFF
--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -26,11 +26,6 @@ env:
   SCRIPT_DIR: ".github/scripts/python/e2e-commander-clean"
   PYTHON_VERSION: '3.13'
 
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: read
-
 jobs:
   skip_tests_repos:
     name: Skip tests repos
@@ -44,6 +39,8 @@ jobs:
     name: Run
     needs:
     - skip_tests_repos
+    permissions:
+      id-token: write
     runs-on: [self-hosted, regular]
     steps:
     {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
@@ -71,6 +68,8 @@ jobs:
     name: Run
     needs:
     - skip_tests_repos
+    permissions:
+      id-token: write
     runs-on: [ self-hosted, regular ]
     steps:
     {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -28,11 +28,6 @@ env:
   SCRIPT_DIR: ".github/scripts/python/e2e-commander-clean"
   PYTHON_VERSION: '3.13'
 
-permissions:
-  contents: read
-  id-token: write
-  pull-requests: read
-
 jobs:
   skip_tests_repos:
     name: Skip tests repos
@@ -46,6 +41,8 @@ jobs:
     name: Run
     needs:
     - skip_tests_repos
+    permissions:
+      id-token: write
     runs-on: [self-hosted, regular]
     steps:
 
@@ -105,6 +102,8 @@ jobs:
     name: Run
     needs:
     - skip_tests_repos
+    permissions:
+      id-token: write
     runs-on: [ self-hosted, regular ]
     steps:
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added necessary permissions for workflow e2e-autoclean.
The changes do not affect the critical components of the cluster, as they only affect CI/CD processes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Without these permissions, workflow e2e-autoclean cannot authenticate correctly to vault

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: fix e2e autoclean
impact: low
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
