### PR TITLE
[user-authn] Login bug fix

### DIFF
--- a/modules/150-user-authn/images/dex/patches/005-password-policy.patch
+++ b/modules/150-user-authn/images/dex/patches/005-password-policy.patch
@@ -411,10 +411,10 @@ index 00000000..49280860
 +	return time.Duration(d), nil
 +}
 diff --git a/server/handlers.go b/server/handlers.go
-index 17688448..0dd2a990 100644
+index 17688448..5ba3cf8e 100644
 --- a/server/handlers.go
 +++ b/server/handlers.go
-@@ -373,6 +373,34 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
+@@ -373,6 +373,39 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
  		password := r.FormValue("password")
  		scopes := parseScopes(authReq.Scopes)
  
@@ -425,36 +425,42 @@ index 17688448..0dd2a990 100644
 +		}
 +
 +		var p storage.Password
++		var passwordFound bool
 +		// Fetch local password in case of local connector for the further password policies validation
 +		if localConnector && s.passwordPolicy != nil {
 +			p, err = s.storage.GetPassword(ctx, username)
 +			if err != nil {
-+				s.logger.ErrorContext(r.Context(), "failed to get password", "err", err)
-+				s.renderError(r, w, http.StatusInternalServerError, "Login error.")
-+				return
-+			}
-+
-+			if s.passwordPolicy.IsPasswordLocked(p) {
-+				s.logger.WarnContext(r.Context(),
-+					"login attempt for locked account",
-+					"username", username,
-+					"locked_until", p.LockedUntil,
-+				)
-+				// TODO: maybe need to render error field in the login page (like incorrect pass error)
-+				s.renderError(r, w, http.StatusTooManyRequests, "Account temporarily locked")
-+				return
++				if err != storage.ErrNotFound {
++					s.logger.ErrorContext(r.Context(), "failed to get password", "err", err)
++					s.renderError(r, w, http.StatusInternalServerError, "Login error.")
++					return
++				}
++				// User not found - will be handled as invalid credentials by pwConn.Login
++			} else {
++				passwordFound = true
++				if s.passwordPolicy.IsPasswordLocked(p) {
++					s.logger.WarnContext(r.Context(),
++						"login attempt for locked account",
++						"username", username,
++						"locked_until", p.LockedUntil,
++					)
++					// TODO: maybe need to render error field in the login page (like incorrect pass error)
++					s.renderError(r, w, http.StatusTooManyRequests, "Account temporarily locked")
++					return
++				}
 +			}
 +		}
 +
  		identity, ok, err := pwConn.Login(r.Context(), scopes, username, password)
  		if err != nil {
  			s.logger.ErrorContext(r.Context(), "failed to login user", "err", err)
-@@ -380,12 +408,68 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
+@@ -380,12 +413,69 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
  			return
  		}
  		if !ok {
 +			// Validate login incorrect attempts for local connector with configured password policy
-+			if localConnector && s.passwordPolicy != nil && s.passwordPolicy.IsMaxLoginAttemptsExeeded(p.IncorrectPasswordLoginAttempts+1) {
++			// Only apply lockout logic for existing users (passwordFound == true)
++			if localConnector && s.passwordPolicy != nil && passwordFound && s.passwordPolicy.IsMaxLoginAttemptsExeeded(p.IncorrectPasswordLoginAttempts+1) {
 +				lockedUntil := time.Now().Add(s.passwordPolicy.lockout.lockDuration)
 +				updader := func(p storage.Password) (storage.Password, error) {
 +					p.LockedUntil = &lockedUntil
@@ -518,6 +524,72 @@ index 17688448..0dd2a990 100644
  		redirectURL, canSkipApproval, err := s.finalizeLogin(r.Context(), identity, authReq, conn.Connector)
  		if err != nil {
  			s.logger.ErrorContext(r.Context(), "failed to finalize login", "err", err)
+diff --git a/server/handlers_test.go b/server/handlers_test.go
+index 114712ba..00d7f2d8 100644
+--- a/server/handlers_test.go
++++ b/server/handlers_test.go
+@@ -555,6 +555,61 @@ func TestHandlePasswordLoginWithSkipApproval(t *testing.T) {
+ 	}
+ }
+ 
++func TestHandlePasswordLoginWithPasswordPolicyNonExistingUser(t *testing.T) {
++	ctx := t.Context()
++
++	connID := "local"
++	authReqID := "test"
++	expiry := time.Now().Add(100 * time.Second)
++	resTypes := []string{responseTypeCode}
++
++	// Create a password policy
++	passwordPolicy, err := NewPasswordPolicy("test-policy", WithComplexityLevel("low"))
++	require.NoError(t, err)
++
++	httpServer, s := newTestServer(t, func(c *Config) {
++		c.SkipApprovalScreen = true
++		c.Now = time.Now
++		c.PasswordPolicy = passwordPolicy
++	})
++	defer httpServer.Close()
++
++	// Create a local connector
++	sc := storage.Connector{
++		ID:              connID,
++		Type:            "local",
++		Name:            "Local",
++		ResourceVersion: "1",
++	}
++	if err := s.storage.CreateConnector(ctx, sc); err != nil {
++		t.Fatalf("create connector: %v", err)
++	}
++	if _, err := s.OpenConnector(sc); err != nil {
++		t.Fatalf("open connector: %v", err)
++	}
++
++	authReq := storage.AuthRequest{
++		ID:                  authReqID,
++		ConnectorID:         connID,
++		RedirectURI:         "cb",
++		Expiry:              expiry,
++		ResponseTypes:       resTypes,
++		ForceApprovalPrompt: false,
++	}
++	if err := s.storage.CreateAuthRequest(ctx, authReq); err != nil {
++		t.Fatalf("failed to create AuthRequest: %v", err)
++	}
++
++	rr := httptest.NewRecorder()
++
++	// Login with non-existing user - should NOT return 500
++	path := fmt.Sprintf("/auth/%s/login?state=%s&back=&login=nonexistent@example.com&password=somepassword", connID, authReqID)
++	s.handlePasswordLogin(rr, httptest.NewRequest("POST", path, nil))
++
++	// Should return 401 (invalid credentials form), not 500
++	require.Equal(t, http.StatusUnauthorized, rr.Code, "expected 401 for non-existing user, got %d", rr.Code)
++}
++
+ func TestHandleConnectorCallbackWithSkipApproval(t *testing.T) {
+ 	ctx := t.Context()
+ 
 diff --git a/server/passwordchangehandler.go b/server/passwordchangehandler.go
 new file mode 100644
 index 00000000..3614bd18
@@ -699,7 +771,7 @@ index 00000000..3614bd18
 +}
 diff --git a/server/passwordpolicy.go b/server/passwordpolicy.go
 new file mode 100644
-index 00000000..322d6584
+index 00000000..ea87beb5
 --- /dev/null
 +++ b/server/passwordpolicy.go
 @@ -0,0 +1,352 @@
@@ -1661,7 +1733,7 @@ index 00000000..1e945371
 +{{ template "footer.html" . }}
 \ No newline at end of file
 diff --git a/web/themes/dark/styles.css b/web/themes/dark/styles.css
-index edf30412..6965823a 100644
+index edf30412..28f76280 100644
 --- a/web/themes/dark/styles.css
 +++ b/web/themes/dark/styles.css
 @@ -120,3 +120,9 @@
@@ -1674,9 +1746,8 @@ index edf30412..6965823a 100644
 +  border-color: #ddd;
 +  cursor: not-allowed;
 +}
-\ No newline at end of file
 diff --git a/web/themes/light/styles.css b/web/themes/light/styles.css
-index 2d920571..22bfeb3a 100644
+index 2d920571..ae4552e3 100644
 --- a/web/themes/light/styles.css
 +++ b/web/themes/light/styles.css
 @@ -111,3 +111,9 @@


### PR DESCRIPTION
## Description

Login bug fix
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

Not necessarily.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Fix login error 500 with password policy enabled.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
