### PR TITLE
[docs][getting-started] Fix commands on the GUI installer page

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
+++ b/docs/site/_includes/getting_started/global/partials/installer/installer_block_ru.html
@@ -68,11 +68,11 @@ trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
                   <p>Установите последний выпуск установщика с канала early-access и проверьте его работоспособность:</p>
 {% capture command %}
 ```bash
-. $(trdl use -d d8-installer 0 ea) && version
+. $(trdl use -d d8-installer 0 ea) && d8install version
 ```
 {% endcapture %}
 {{ command | markdownify }}
-                <p>Если вы не хотите вызывать <code>. $(trdl use -d d8-installer 0 ea)</code> перед каждым использованием установщика, добавьте строку <code>alias d8-installer='trdl exec d8-installer 0 ea -- "$@"'</code> в RC-файл вашей командной оболочки.</p>
+                <p>Если вы не хотите вызывать <code>. $(trdl use -d d8-installer 0 ea)</code> перед каждым использованием установщика, добавьте строку <code>source $(trdl use -d d8-installer 0 ea)</code> в RC-файл вашей командной оболочки.</p>
                 </li>
               </ol>
             </div>
@@ -127,11 +127,11 @@ trdl add $REPO $URL $ROOT_VERSION $ROOT_SHA512
                   <p>Установите последний выпуск установщика с канала early-access и проверьте его работоспособность:</p>
 {% capture command %}
 ```bash
-. $(trdl use -d d8-installer 0 ea) && version
+. $(trdl use -d d8-installer 0 ea) && d8install version
 ```
 {% endcapture %}
 {{ command | markdownify }}
-                <p>Если вы не хотите вызывать <code>. $(trdl use -d d8-installer 0 ea)</code> перед каждым использованием установщика, добавьте строку <code>alias d8-installer='trdl exec d8-installer 0 ea -- "$@"'</code> в RC-файл вашей командной оболочки.</p>
+                <p>Если вы не хотите вызывать <code>. $(trdl use -d d8-installer 0 ea)</code> перед каждым использованием установщика, добавьте строку <code>source $(trdl use -d d8-installer 0 ea)</code> в RC-файл вашей командной оболочки.</p>
                 </li>
               </ol>
             </div>


### PR DESCRIPTION
## Description

Fixed commands on the GUI installer page.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fixed commands on the GUI installer page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
