### PR TITLE
[monitoring] Add missing honorLabels where appropriate

### DIFF
--- a/modules/200-operator-prometheus/templates/podmonitor.yaml
+++ b/modules/200-operator-prometheus/templates/podmonitor.yaml
@@ -16,6 +16,7 @@ spec:
       key: "token"
     tlsConfig:
       insecureSkipVerify: true
+    honorLabels: true
     relabelings:
     - regex: endpoint|container
       action: labeldrop

--- a/modules/303-prometheus-pushgateway/templates/service-monitor.yaml
+++ b/modules/303-prometheus-pushgateway/templates/service-monitor.yaml
@@ -16,6 +16,7 @@ spec:
     - kube-{{ .Chart.Name }}
   endpoints:
   - port: http-metrics
+    honorLabels: true
     relabelings:
     - regex: pod|service|endpoint
       action: labeldrop

--- a/modules/340-monitoring-deckhouse/templates/podmonitor.yaml
+++ b/modules/340-monitoring-deckhouse/templates/podmonitor.yaml
@@ -28,6 +28,7 @@ spec:
       action: drop
   - port: self
     path: "/metrics/hooks"
+    honorLabels: true
     relabelings:
     - regex: endpoint|container
       action: labeldrop

--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy-service-monitor.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy-service-monitor.yaml
@@ -59,6 +59,7 @@ spec:
     bearerTokenSecret:
       name: "prometheus-token"
       key: "token"
+    honorLabels: true
     relabelings:
     - regex: endpoint|pod|container
       action: labeldrop

--- a/modules/340-monitoring-kubernetes-control-plane/templates/kube-apiserver-service-monitor.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/kube-apiserver-service-monitor.yaml
@@ -25,6 +25,8 @@ spec:
       action: labeldrop
     - targetLabel: job
       replacement: kube-apiserver
+    - targetLabel: namespace
+      replacement: kube-system
     - targetLabel: tier
       replacement: cluster
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/podmonitor.yaml
@@ -21,6 +21,7 @@ spec:
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -48,6 +49,7 @@ spec:
       name: prometheus-token
     path: /protobuf/metrics
     port: https-metrics
+    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/templates/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/templates/controller/podmonitor.yaml
@@ -16,6 +16,7 @@ spec:
       key: "token"
     tlsConfig:
       insecureSkipVerify: true
+    honorLabels: true
     relabelings:
     - regex: endpoint|pod|container
       action: labeldrop
@@ -44,6 +45,7 @@ spec:
       key: "token"
     tlsConfig:
       insecureSkipVerify: true
+    honorLabels: true
     relabelings:
     - regex: endpoint|pod|container
       action: labeldrop

--- a/modules/402-ingress-nginx/templates/failover/podmonitor.yaml
+++ b/modules/402-ingress-nginx/templates/failover/podmonitor.yaml
@@ -15,6 +15,7 @@ spec:
       key: "token"
     tlsConfig:
       insecureSkipVerify: true
+    honorLabels: true
     relabelings:
     - regex: endpoint|container
       action: labeldrop


### PR DESCRIPTION
## Description
In #12397 the `namespace` label drop was removed in almost every platform's Pod- or Service- Monitors. The `honorLabels: true` option was not set leading to a bug when the metrics `namespace` label was overwritten while scraping, breaking the Ingress Nginx dashboards.

## Why do we need it, and what problem does it solve?
Changes in this PR prioritize metrics labels over the labels added during the scrape process.

## Why do we need it in the patch release (if we do)?
We do, as the crucial ingress controller metrics are affected.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: Fix namespace label value in the Ingress Nginx controller and several other metrics
impact: Ingress Nginx controller dashboards are fixed
impact_level: default
```