### PR TITLE
[user-authn] fix-password-change-error

### DIFF
--- a/modules/150-user-authn/images/dex/patches/005-password-policy.patch
+++ b/modules/150-user-authn/images/dex/patches/005-password-policy.patch
@@ -411,7 +411,7 @@ index 00000000..49280860
 +	return time.Duration(d), nil
 +}
 diff --git a/server/handlers.go b/server/handlers.go
-index 17688448..5ba3cf8e 100644
+index 17688448..72f58d7a 100644
 --- a/server/handlers.go
 +++ b/server/handlers.go
 @@ -373,6 +373,39 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
@@ -454,7 +454,7 @@ index 17688448..5ba3cf8e 100644
  		identity, ok, err := pwConn.Login(r.Context(), scopes, username, password)
  		if err != nil {
  			s.logger.ErrorContext(r.Context(), "failed to login user", "err", err)
-@@ -380,12 +413,69 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
+@@ -380,12 +413,70 @@ func (s *Server) handlePasswordLogin(w http.ResponseWriter, r *http.Request) {
  			return
  		}
  		if !ok {
@@ -505,6 +505,7 @@ index 17688448..5ba3cf8e 100644
 +				}
 +				http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 +				s.logger.InfoContext(r.Context(), "user was forced to change password due to password complexity policy settings", "user", username)
++				return
 +			}
 +
 +			// Validate password expiry with configured password policy
@@ -592,10 +593,10 @@ index 114712ba..00d7f2d8 100644
  
 diff --git a/server/passwordchangehandler.go b/server/passwordchangehandler.go
 new file mode 100644
-index 00000000..3614bd18
+index 00000000..040a33d6
 --- /dev/null
 +++ b/server/passwordchangehandler.go
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,174 @@
 +package server
 +
 +import (
@@ -682,6 +683,7 @@ index 00000000..3614bd18
 +			}); err != nil {
 +				s.logger.ErrorContext(r.Context(), "server template error", "err", err)
 +			}
++			return
 +		}
 +
 +		if s.passwordPolicy != nil {


### PR DESCRIPTION
## Description

fix-password-change-error
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

Not necessarily.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Fix BadRequest after the change password redirect when password policy is enabled
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
