### PR TITLE
[candi] Add bashible events generateName

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -123,11 +123,11 @@ function bb-event-error-create() {
     if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
       indent="            " # 12 spaces
       logs="$(bb-indent-text "$indent" <<<"${eventNote}")"
-      bb-kubectl-exec apply -f - <<EOF || true
+      bb-kubectl-exec create -f - <<EOF || true
           apiVersion: events.k8s.io/v1
           kind: Event
           metadata:
-            name: bashible-error-${eventName}
+            generateName: bashible-error-${eventName}-
           regarding:
             apiVersion: v1
             kind: Node
@@ -146,14 +146,14 @@ EOF
 }
 
 function bb-event-info-create() {
-    eventName="$(echo -n "$(bb-d8-node-name)")-$1"
+    eventName="$(echo -n "$(bb-d8-node-name)")-$(echo $1 | sed 's#.*/##; s/_/-/g')"
     nodeName="$(bb-d8-node-name)"
     if type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf ; then
-      bb-kubectl-exec apply -f - <<EOF || true
+      bb-kubectl-exec create -f - <<EOF || true
           apiVersion: events.k8s.io/v1
           kind: Event
           metadata:
-            name: bashible-info-${eventName}-update-$(date -u +"%Y-%m-%dt%H-%M-%S-%6N")
+            generateName: bashible-info-${eventName}-update-
           regarding:
             apiVersion: v1
             kind: Node


### PR DESCRIPTION
## Description

Use generateName and kubectl create for bashible events so each emission gets a unique name.

## Why do we need it, and what problem does it solve?

Prevents reapplying Events with the same name, avoiding eventTime immutability errors like `The Event "bashible-error-bob" is invalid: eventTime: Invalid value: 2025-12-01 08:54:54.438241 +0000 UTC: field is immutable`

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Added bashible events generateName.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
