### PR TITLE
[deckhouse-controller] fix: backport addon operator readiness fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flant/addon-operator v1.15.11
+	github.com/flant/addon-operator v1.15.12
 	github.com/flant/kube-client v1.4.0
 	github.com/flant/shell-operator v1.11.4
 	github.com/go-openapi/spec v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.15.11 h1:wxNcaUJGNPI46inlbzie/+pV1CUiL0iGXZ7c1EO0nyw=
 github.com/flant/addon-operator v1.15.11/go.mod h1:/Snmis6fr5+NlOYVXfaRjpUhXlxWULYH4icKRZ/ToHM=
+github.com/flant/addon-operator v1.15.12 h1:GHSKJg8bZZoxyWtFxZXzzolYGSbyElyUi2QN6TIM+6I=
+github.com/flant/addon-operator v1.15.12/go.mod h1:/Snmis6fr5+NlOYVXfaRjpUhXlxWULYH4icKRZ/ToHM=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.4.0 h1:1m/Hyf4KMaYi6rGyfHz0Coh44MJz2nUiitvMmrBwXwg=


### PR DESCRIPTION
## Description

Bump addon-operator to v1.15.12 with fix for "multiple readiness hooks found" error that occurs on hook registration retry after a previous failure.

## Why do we need it, and what problem does it solve?

**Problem:** When module hook registration fails (e.g., during `AssembleEnvironmentForModule()`), the `hasReadiness` flag remains set to `true` from the search phase, but `hooks.registered` stays `false`. On retry, `RegisterHooks` calls search again, where it sees `hasReadiness=true` from the previous failed attempt and returns error: `"multiple readiness hooks found"`.

This causes modules with readiness hooks to fail permanently after any transient registration error, requiring pod restart to recover.

**Fix:** Remove side effects from hook search functions - `hasReadiness` is now only set after successful registration, preventing stale state from failed attempts.

## Why do we need it in the patch release (if we do)?

Critical bug fix - modules with readiness hooks can get stuck in a failed state after transient errors, requiring manual intervention (pod restart) to recover. This affects production stability.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix "multiple readiness hooks found" error on hook registration retry after failure.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
