### PR TITLE
[deckhouse-controller] fix: backport addon operator readiness fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flant/addon-operator v1.17.3
+	github.com/flant/addon-operator v1.17.6
 	github.com/flant/kube-client v1.5.0
 	github.com/flant/shell-operator v1.12.2
 	github.com/go-openapi/spec v0.22.0
@@ -303,7 +303,7 @@ require (
 	github.com/werf/kubedog v0.13.1-0.20251110132552-6ffc5a117ada // indirect
 	github.com/werf/lockgate v0.1.1 // indirect
 	github.com/werf/logboek v0.6.1 // indirect
-	github.com/werf/nelm v1.17.2-0.20251113141246-0e0ea9049efe
+	github.com/werf/nelm v1.18.1-0.20251127115054-cb2cde474127
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flant/addon-operator v1.17.3 h1:TO0RvIEQvt23BSOj1bLbISF+kE4HZC7G2j5ZTsilr/Q=
 github.com/flant/addon-operator v1.17.3/go.mod h1:/RqWqQHP00u9qAUe8rMER+8gP20DkGQNqNQfnn5+rkg=
+github.com/flant/addon-operator v1.17.6 h1:7isT3BDc2CpYALaPr1XzyKMpQRMIBQyZdy+D9FgA24M=
+github.com/flant/addon-operator v1.17.6/go.mod h1:l93Qu6Q4QFizR7SPocwChePBVt6t1YsV5wd+Nniu8kY=
 github.com/flant/kube-client v1.5.0 h1:6QZOZy3uk58Bh9YUn4CnhEz13og/cEGXB2uBZ1gWwtM=
 github.com/flant/kube-client v1.5.0/go.mod h1:hpJZ0FnDKHW3r5q5SYQgBrTw9k94q4+dcnJ4uOGYBHc=
 github.com/flant/shell-operator v1.12.2 h1:/B5tB7CfpzRnIFLAkXtQOVKLLdhvaB9h2LTKuWyDj8M=
@@ -741,6 +743,8 @@ github.com/werf/logboek v0.6.1 h1:oEe6FkmlKg0z0n80oZjLplj6sXcBeLleCkjfOOZEL2g=
 github.com/werf/logboek v0.6.1/go.mod h1:Gez5J4bxekyr6MxTmIJyId1F61rpO+0/V4vjCIEIZmk=
 github.com/werf/nelm v1.17.2-0.20251113141246-0e0ea9049efe h1:buWARaRTc8Xlq9rlTsHUrLsrFGstC7nupSCkophOxv4=
 github.com/werf/nelm v1.17.2-0.20251113141246-0e0ea9049efe/go.mod h1:nMH3ZVono+IUvun+RaSCvZCWkGUOfAMhPNkOI+UPeJA=
+github.com/werf/nelm v1.18.1-0.20251127115054-cb2cde474127 h1:MCxrBPACp2KZ7PCtVDc2WtDH1DVeH3VAs3mDhJarYAQ=
+github.com/werf/nelm v1.18.1-0.20251127115054-cb2cde474127/go.mod h1:V3fEi7u60qJvHnMLyXyuKjMDMSFy54vFMgyIgHjBGGU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=


### PR DESCRIPTION
## Description

Bump addon-operator to v1.17.6 with fix for "multiple readiness hooks found" error that occurs on hook registration retry after a previous failure.

## Why do we need it, and what problem does it solve?

**Problem:** When module hook registration fails (e.g., during `AssembleEnvironmentForModule()`), the `hasReadiness` flag remains set to `true` from the search phase, but `hooks.registered` stays `false`. On retry, `RegisterHooks` calls search again, where it sees `hasReadiness=true` from the previous failed attempt and returns error: `"multiple readiness hooks found"`.

This causes modules with readiness hooks to fail permanently after any transient registration error, requiring pod restart to recover.

**Fix:** Remove side effects from hook search functions - `hasReadiness` is now only set after successful registration, preventing stale state from failed attempts.

## Why do we need it in the patch release (if we do)?

Critical bug fix - modules with readiness hooks can get stuck in a failed state after transient errors, requiring manual intervention (pod restart) to recover. This affects production stability.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed "multiple readiness hooks found" error on hook registration retry after a failure.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
