### PR TITLE
[registrypackages] power commands wrapper fix

### DIFF
--- a/modules/007-registrypackages/images/systemctl-power-commands-wrapper/src/go.mod
+++ b/modules/007-registrypackages/images/systemctl-power-commands-wrapper/src/go.mod
@@ -3,3 +3,7 @@ module systemctl-power-commands-wrapper
 go 1.24.0
 
 toolchain go1.24.6
+
+require github.com/godbus/dbus/v5 v5.2.0
+
+require golang.org/x/sys v0.27.0 // indirect

--- a/modules/007-registrypackages/images/systemctl-power-commands-wrapper/src/go.sum
+++ b/modules/007-registrypackages/images/systemctl-power-commands-wrapper/src/go.sum
@@ -1,0 +1,4 @@
+github.com/godbus/dbus/v5 v5.2.0 h1:3WexO+U+yg9T70v9FdHr9kCxYlazaAXUhx2VMkbfax8=
+github.com/godbus/dbus/v5 v5.2.0/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
## Description

fix https://github.com/deckhouse/deckhouse/pull/16187

## Why do we need it, and what problem does it solve?

Fix after refactoring the systemctl power commands wrapper. The previous implementation did not support `shutdown -r -t 5`, since `systemctl` does not provide a built‑in delay option, so a dedicated D-Bus call was introduced for this case.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: power commands wrapper fix
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
