### PR TITLE
[docs] remove `/` symbol for podSubnetNodeCIDRPrefix

### DIFF
--- a/modules/040-node-manager/crds/doc-ru-node_group.yaml
+++ b/modules/040-node-manager/crds/doc-ru-node_group.yaml
@@ -213,10 +213,10 @@ spec:
                     maxPods:
                       description: |
                         Максимальное количество подов на узлах данной `NodeGroup`. Если явно не задан, по умолчанию задается в зависимости от значения параметра [podSubnetNodeCIDRPrefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-podsubnetnodecidrprefix) ClusterConfiguration:
-                        - `120`  подов для `podSubnetNodeCIDRPrefix` ≥ `/24`;
-                        - `250`  подов для `podSubnetNodeCIDRPrefix` = `/23`;
-                        - `500`  подов для `podSubnetNodeCIDRPrefix` = `/22`;
-                        - `1000` подов для `podSubnetNodeCIDRPrefix` ≤ `/21`.
+                        - `120`  подов для `podSubnetNodeCIDRPrefix` ≥ `24`;
+                        - `250`  подов для `podSubnetNodeCIDRPrefix` = `23`;
+                        - `500`  подов для `podSubnetNodeCIDRPrefix` = `22`;
+                        - `1000` подов для `podSubnetNodeCIDRPrefix` ≤ `21`.
                     rootDir:
                       description: |
                         Путь к каталогу для файлов kubelet (volume mounts и т. д.).
@@ -441,10 +441,10 @@ spec:
                     maxPods:
                       description: |
                         Максимальное количество подов на узлах данной `NodeGroup`. Если явно не задан, по умолчанию задается в зависимости от значения параметра [podSubnetNodeCIDRPrefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-podsubnetnodecidrprefix) ClusterConfiguration:
-                        - `120`  подов для `podSubnetNodeCIDRPrefix` ≥ `/24`;
-                        - `250`  подов для `podSubnetNodeCIDRPrefix` = `/23`;
-                        - `500`  подов для `podSubnetNodeCIDRPrefix` = `/22`;
-                        - `1000` подов для `podSubnetNodeCIDRPrefix` ≤ `/21`.
+                        - `120`  подов для `podSubnetNodeCIDRPrefix` ≥ `24`;
+                        - `250`  подов для `podSubnetNodeCIDRPrefix` = `23`;
+                        - `500`  подов для `podSubnetNodeCIDRPrefix` = `22`;
+                        - `1000` подов для `podSubnetNodeCIDRPrefix` ≤ `21`.
                     rootDir:
                       description: |
                         Путь к каталогу для файлов kubelet (volume mounts и т. д.).
@@ -788,10 +788,10 @@ spec:
                     maxPods:
                       description: |
                         Максимальное количество подов на узлах данной `NodeGroup`. Если явно не задан, по умолчанию задается в зависимости от значения параметра [podSubnetNodeCIDRPrefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-podsubnetnodecidrprefix) ClusterConfiguration:
-                        - `120`  подов для `podSubnetNodeCIDRPrefix` ≥ `/24`;
-                        - `250`  подов для `podSubnetNodeCIDRPrefix` = `/23`;
-                        - `500`  подов для `podSubnetNodeCIDRPrefix` = `/22`;
-                        - `1000` подов для `podSubnetNodeCIDRPrefix` ≤ `/21`.
+                        - `120`  подов для `podSubnetNodeCIDRPrefix` ≥ `24`;
+                        - `250`  подов для `podSubnetNodeCIDRPrefix` = `23`;
+                        - `500`  подов для `podSubnetNodeCIDRPrefix` = `22`;
+                        - `1000` подов для `podSubnetNodeCIDRPrefix` ≤ `21`.
                     rootDir:
                       description: |
                         Путь к каталогу для файлов kubelet (volume mounts и т. д.).

--- a/modules/040-node-manager/crds/node_group.yaml
+++ b/modules/040-node-manager/crds/node_group.yaml
@@ -609,10 +609,10 @@ spec:
                       type: integer
                       description: |
                         Set the max count of pods per node for given `NodeGroup`. When left unspecified, the system automatically determines this limit according to the value of the [podSubnetNodeCIDRPrefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-podsubnetnodecidrprefix) ClusterConfiguration parameter:
-                        - `120`  pods for `podSubnetNodeCIDRPrefix` ≥ `/24`;
-                        - `250`  pods for `podSubnetNodeCIDRPrefix` = `/23`;
-                        - `500`  pods for `podSubnetNodeCIDRPrefix` = `/22`;
-                        - `1000` pods for `podSubnetNodeCIDRPrefix` ≤ `/21`.
+                        - `120`  pods for `podSubnetNodeCIDRPrefix` ≥ `24`;
+                        - `250`  pods for `podSubnetNodeCIDRPrefix` = `23`;
+                        - `500`  pods for `podSubnetNodeCIDRPrefix` = `22`;
+                        - `1000` pods for `podSubnetNodeCIDRPrefix` ≤ `21`.
                     rootDir:
                       type: string
                       x-doc-default: /var/lib/kubelet
@@ -1223,10 +1223,10 @@ spec:
                       type: integer
                       description: |
                         Set the max count of pods per node for given `NodeGroup`. When left unspecified, the system automatically determines this limit according to the value of the [podSubnetNodeCIDRPrefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-podsubnetnodecidrprefix) ClusterConfiguration parameter:
-                        - `120`  pods for `podSubnetNodeCIDRPrefix` ≥ `/24`;
-                        - `250`  pods for `podSubnetNodeCIDRPrefix` = `/23`;
-                        - `500`  pods for `podSubnetNodeCIDRPrefix` = `/22`;
-                        - `1000` pods for `podSubnetNodeCIDRPrefix` ≤ `/21`.
+                        - `120`  pods for `podSubnetNodeCIDRPrefix` ≥ `24`;
+                        - `250`  pods for `podSubnetNodeCIDRPrefix` = `23`;
+                        - `500`  pods for `podSubnetNodeCIDRPrefix` = `22`;
+                        - `1000` pods for `podSubnetNodeCIDRPrefix` ≤ `21`.
                     rootDir:
                       type: string
                       x-doc-default: /var/lib/kubelet
@@ -2115,10 +2115,10 @@ spec:
                       type: integer
                       description: |
                         Set the max count of pods per node for given `NodeGroup`. When left unspecified, the system automatically determines this limit according to the value of the [podSubnetNodeCIDRPrefix](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-podsubnetnodecidrprefix) ClusterConfiguration parameter:
-                        - `120`  pods for `podSubnetNodeCIDRPrefix` ≥ `/24`;
-                        - `250`  pods for `podSubnetNodeCIDRPrefix` = `/23`;
-                        - `500`  pods for `podSubnetNodeCIDRPrefix` = `/22`;
-                        - `1000` pods for `podSubnetNodeCIDRPrefix` ≤ `/21`.
+                        - `120`  pods for `podSubnetNodeCIDRPrefix` ≥ `24`;
+                        - `250`  pods for `podSubnetNodeCIDRPrefix` = `23`;
+                        - `500`  pods for `podSubnetNodeCIDRPrefix` = `22`;
+                        - `1000` pods for `podSubnetNodeCIDRPrefix` ≤ `21`.
                     rootDir:
                       type: string
                       x-doc-default: /var/lib/kubelet


### PR DESCRIPTION
## Description

Removed `/` symbol for podSubnetNodeCIDRPrefix in docs, correction of #16818

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`/` is not needed for `podSubnetNodeCIDRPrefix`
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Removed symbol `/` to avoid misunderstanding.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
