### PR TITLE
[deckhouse-controller] Backport 1.73: Fix conversions for external modules

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -1313,50 +1313,43 @@ func (r *reconciler) loadModule(ctx context.Context, release *v1alpha1.ModuleRel
 
 	// get values from module config
 	logger.Debug("get module config")
+
 	config := new(v1alpha1.ModuleConfig)
+	values := make(addonutils.Values)
+	var valuesVersion int
+	var isModuleConfigFound bool
+
 	err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, config)
-	if err != nil {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return nil, fmt.Errorf("get the '%s' module config: %w", release.GetModuleName(), err)
 	}
-	values := make(addonutils.Values)
-	if err == nil {
-		values = addonutils.Values(config.Spec.Settings)
-	}
+	// if module config not found, try to get values from module manager
+	if err != nil {
+		logger.Debug("module config not found, try to get values from module manager")
 
-	// check conversions
-	conversionsDir := filepath.Join(def.Path, "openapi", "conversions")
-	_, err = os.Stat(conversionsDir)
-	if err == nil {
-		logger.Debug("conversions for the module found")
-		values, err = r.applyValuesConversions(def, conversionsDir, config.Spec.Version, values)
-		if err != nil {
-			status := &v1alpha1.ModuleReleaseStatus{
-				Phase:   v1alpha1.ModuleReleasePhaseSuspended,
-				Message: "apply conversions failed: " + err.Error(),
-			}
-
-			if strings.Contains(err.Error(), "is required") || strings.Contains(err.Error(), "is a forbidden property") {
-				r.metricStorage.GaugeSet(metrics.ModuleConfigurationError, 1,
-					map[string]string{
-						"version": release.GetVersion().String(),
-						"module":  release.GetModuleName(),
-						"error":   err.Error(),
-					},
-				)
-
-				status.Phase = v1alpha1.ModuleReleasePhasePending
-			}
-
-			if err = r.updateReleaseStatus(ctx, release, status); err != nil {
-				return nil, fmt.Errorf("update status: the '%s:v%s' module conversion: %w", release.GetModuleName(), release.GetVersion().String(), err)
-			}
-
-			logger.Debug("successfully updated module conditions")
-			return nil, fmt.Errorf("apply conversions: %w", err)
+		module := r.moduleManager.GetModule(release.GetModuleName())
+		if module != nil {
+			values = module.GetConfigValues(false)
 		}
 	}
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("load conversions for the %q module: %w", def.Name, err)
+	if err == nil {
+		isModuleConfigFound = true
+
+		values = addonutils.Values(config.Spec.Settings)
+
+		// try to get the values version from status
+		valuesVersion, err = strconv.Atoi(config.Status.Version)
+		if err != nil {
+			logger.Warn("failed to parse values version from status", slog.String("version", config.Status.Version), log.Err(err))
+		}
+	}
+
+	// if module config not found or default values (version is greater than 0), skip conversions
+	if isModuleConfigFound && valuesVersion > 0 {
+		values, err = r.handleConversions(ctx, def, values, valuesVersion, release)
+		if err != nil {
+			return nil, fmt.Errorf("handle conversions: %w", err)
+		}
 	}
 
 	configConfigurationErrorMetricsLabels := map[string]string{
@@ -1435,6 +1428,51 @@ func (r *reconciler) loadModule(ctx context.Context, release *v1alpha1.ModuleRel
 	}
 
 	return downloadStatistic, nil
+}
+
+func (r *reconciler) handleConversions(ctx context.Context, def *moduletypes.Definition, values addonutils.Values, valuesVersion int, release *v1alpha1.ModuleRelease) (addonutils.Values, error) { // check conversions
+	logger := r.log.With(slog.String("module", release.GetModuleName()), slog.String("release", release.GetName()))
+
+	conversionsDir := filepath.Join(def.Path, "openapi", "conversions")
+	_, err := os.Stat(conversionsDir)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("load conversions for the %q module: %w", def.Name, err)
+	}
+	// no conversions found
+	if err != nil {
+		return values, nil
+	}
+
+	logger.Debug("conversions for the module found")
+
+	newValues, err := r.applyValuesConversions(def, conversionsDir, valuesVersion, values)
+	if err != nil {
+		status := &v1alpha1.ModuleReleaseStatus{
+			Phase:   v1alpha1.ModuleReleasePhaseSuspended,
+			Message: "apply conversions failed: " + err.Error(),
+		}
+
+		if strings.Contains(err.Error(), "is required") || strings.Contains(err.Error(), "is a forbidden property") {
+			r.metricStorage.GaugeSet(metrics.ModuleConfigurationError, 1,
+				map[string]string{
+					"version": release.GetVersion().String(),
+					"module":  release.GetModuleName(),
+					"error":   err.Error(),
+				},
+			)
+
+			status.Phase = v1alpha1.ModuleReleasePhasePending
+		}
+
+		if err = r.updateReleaseStatus(ctx, release, status); err != nil {
+			return nil, fmt.Errorf("update status: the '%s:v%s' module conversion: %w", release.GetModuleName(), release.GetVersion().String(), err)
+		}
+
+		logger.Debug("successfully updated module conditions")
+		return nil, fmt.Errorf("apply conversions: %w", err)
+	}
+
+	return newValues, nil
 }
 
 func (r *reconciler) applyValuesConversions(def *moduletypes.Definition, pathToConversions string, fromVersion int, values addonutils.Values) (addonutils.Values, error) {


### PR DESCRIPTION
## Description
Fixed a behavior where ModuleRelease would get stuck on the "downloading" status if the ModuleConfig was not found. In this case, we now attempt to retrieve values ​​from the ModuleManager and skip the conversions phase.


<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
If ModuleConfig is not found for a release with conversions, we get an error and get stuck in the "downloading" status:
```
{"level":"warn","logger":"deckhouse-controller.module-release-controller","msg":"handle release","source":"deckhouse/deckhouse-controller/pkg/controller/module-controllers/release/controller.go:281","error":"apply predicted release: run release deploy: deploy module: get the 'console' module config: ModuleConfig.deckhouse.io \"console\" not found","time":"2025-12-01T09:21:59Z"}
```

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix conversions for external modules
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
