### PR TITLE
[cilium-hubble] Fixed affinity in HA cluster mode

### DIFF
--- a/modules/500-cilium-hubble/templates/relay/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/relay/deployment.yaml
@@ -116,6 +116,14 @@ spec:
                 matchLabels:
                   app: agent
                   module: cni-cilium
+        {{- if (include "helm_lib_ha_enabled" .) }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: hubble-relay
+              topologyKey: kubernetes.io/hostname
+        {{- end }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
       volumes:

--- a/modules/500-cilium-hubble/templates/ui/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/ui/deployment.yaml
@@ -67,6 +67,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "monitoring") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "hubble-ui")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs" . | nindent 6 }}
       automountServiceAccountToken: true
       serviceAccountName: "ui"


### PR DESCRIPTION
## Description
This PR improves the scheduling policy for the `hubble-ui` and `hubble-relay` pods in clusters running in Deckhouse `High Availability` mode.
It added the anti-affinity rules to ensure that multiple replicas of these components are properly distributed across different nodes, increasing overall reliability and resilience.

## Why do we need it, and what problem does it solve?
We need this change to ensure proper pod distribution when running Deckhouse in `High Availability` mode.
Without explicit anti-affinity rules, multiple replicas of `hubble-ui` or `hubble-relay` may be scheduled onto the same node. This creates a single point of failure: if that node goes down, all replicas of the component become unavailable.

By adding the correct affinity and anti-affinity policies, we ensure that the replicas are spread across different nodes. This improves fault tolerance, prevents service disruption during node failures, and aligns the deployment with HA best practices.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cilium-hubble
type: fix
summary: Fix affinity in HA mode
impact: In HA cluster mode hubble-ui and hubble-relay will be restarted
impact_level: default
```
