### PR TITLE
[dhctl] Fix parallel bootstrap cloud permanent nodes

### DIFF
--- a/dhctl/pkg/infrastructure/terraform/cmd.go
+++ b/dhctl/pkg/infrastructure/terraform/cmd.go
@@ -28,6 +28,23 @@ import (
 type RunExecutorParams struct {
 	RootDir          string
 	TerraformBinPath string
+	ExecutorID       string
+}
+
+func (p *RunExecutorParams) validateRunParams() error {
+	if p.RootDir == "" {
+		return fmt.Errorf("RootDir is required for terraform executor")
+	}
+
+	if p.TerraformBinPath == "" {
+		return fmt.Errorf("TerraformBinPath is required for terraform executor")
+	}
+
+	if p.ExecutorID == "" {
+		return fmt.Errorf("ExecutorID is required for terraform executor")
+	}
+
+	return nil
 }
 
 func terraformCmd(ctx context.Context, params RunExecutorParams, args ...string) *exec.Cmd {
@@ -37,10 +54,12 @@ func terraformCmd(ctx context.Context, params RunExecutorParams, args ...string)
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
 	}
 
+	dataDir := filepath.Join(params.RootDir, fmt.Sprintf("tf_%s", params.ExecutorID))
+
 	cmd.Env = append(
 		os.Environ(),
 		"TF_IN_AUTOMATION=yes",
-		"TF_DATA_DIR="+filepath.Join(params.RootDir, "tf_dhctl"),
+		fmt.Sprintf("TF_DATA_DIR=%s", dataDir),
 	)
 
 	// always use dug log for write its to debug log file

--- a/dhctl/pkg/infrastructure/terraform/executor.go
+++ b/dhctl/pkg/infrastructure/terraform/executor.go
@@ -21,6 +21,8 @@ import (
 	"os/exec"
 	"syscall"
 
+	"github.com/name212/govalue"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	infraexec "github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/exec"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
@@ -33,7 +35,27 @@ type ExecutorParams struct {
 	WorkingDir     string
 	PluginsDir     string
 	Step           infrastructure.Step
-	VmChangeTester plan.VMChangeTester
+	VMChangeTester plan.VMChangeTester
+}
+
+func (p *ExecutorParams) validate() error {
+	if err := p.RunExecutorParams.validateRunParams(); err != nil {
+		return err
+	}
+
+	if p.PluginsDir == "" {
+		return fmt.Errorf("PluginsDir is required for terraform executor")
+	}
+
+	if p.WorkingDir == "" {
+		return fmt.Errorf("WorkingDir is required for terraform executor")
+	}
+
+	if p.Step == "" {
+		return fmt.Errorf("Step is required for terraform executor")
+	}
+
+	return nil
 }
 
 type Executor struct {
@@ -43,15 +65,27 @@ type Executor struct {
 	cmd    *exec.Cmd
 }
 
-func NewExecutor(params ExecutorParams, logger log.Logger) *Executor {
+func NewExecutor(params ExecutorParams, logger log.Logger) (*Executor, error) {
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	if govalue.IsNil(logger) {
+		logger = log.GetDefaultLogger()
+	}
+
 	return &Executor{
 		params: params,
 		logger: logger,
-	}
+	}, nil
 }
 
 func (e *Executor) IsVMChange(rc plan.ResourceChange) bool {
-	return e.params.VmChangeTester(rc)
+	if e.params.VMChangeTester == nil {
+		return false
+	}
+
+	return e.params.VMChangeTester(rc)
 }
 
 func (e *Executor) Step() infrastructure.Step {

--- a/dhctl/pkg/infrastructure/terraform/output_executor.go
+++ b/dhctl/pkg/infrastructure/terraform/output_executor.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/name212/govalue"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
@@ -32,11 +34,19 @@ type OutputExecutor struct {
 	logger log.Logger
 }
 
-func NewOutputExecutor(params OutputExecutorParams, logger log.Logger) *OutputExecutor {
+func NewOutputExecutor(params OutputExecutorParams, logger log.Logger) (*OutputExecutor, error) {
+	if err := params.validateRunParams(); err != nil {
+		return nil, err
+	}
+
+	if govalue.IsNil(logger) {
+		logger = log.GetDefaultLogger()
+	}
+
 	return &OutputExecutor{
 		params: params,
 		logger: logger,
-	}
+	}, nil
 }
 
 func (e *OutputExecutor) Output(ctx context.Context, statePath string, outFielda ...string) (result []byte, err error) {

--- a/dhctl/pkg/infrastructure/tofu/executor.go
+++ b/dhctl/pkg/infrastructure/tofu/executor.go
@@ -21,6 +21,8 @@ import (
 	"os/exec"
 	"syscall"
 
+	"github.com/name212/govalue"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	infraexec "github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/exec"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
@@ -36,6 +38,26 @@ type ExecutorParams struct {
 	VMChangeTester plan.VMChangeTester
 }
 
+func (p *ExecutorParams) validate() error {
+	if err := p.RunExecutorParams.validateRunParams(); err != nil {
+		return err
+	}
+
+	if p.PluginsDir == "" {
+		return fmt.Errorf("PluginsDir is required for tofu executor")
+	}
+
+	if p.WorkingDir == "" {
+		return fmt.Errorf("WorkingDir is required for tofu executor")
+	}
+
+	if p.Step == "" {
+		return fmt.Errorf("Step is required for tofu executor")
+	}
+
+	return nil
+}
+
 type Executor struct {
 	params ExecutorParams
 
@@ -43,14 +65,26 @@ type Executor struct {
 	cmd    *exec.Cmd
 }
 
-func NewExecutor(params ExecutorParams, logger log.Logger) *Executor {
+func NewExecutor(params ExecutorParams, logger log.Logger) (*Executor, error) {
+	if err := params.validate(); err != nil {
+		return nil, err
+	}
+
+	if govalue.IsNil(logger) {
+		logger = log.GetDefaultLogger()
+	}
+
 	return &Executor{
 		params: params,
 		logger: logger,
-	}
+	}, nil
 }
 
 func (e *Executor) IsVMChange(rc plan.ResourceChange) bool {
+	if e.params.VMChangeTester == nil {
+		return false
+	}
+
 	return e.params.VMChangeTester(rc)
 }
 

--- a/dhctl/pkg/infrastructure/tofu/output_executor.go
+++ b/dhctl/pkg/infrastructure/tofu/output_executor.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/name212/govalue"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
@@ -32,11 +34,19 @@ type OutputExecutor struct {
 	logger log.Logger
 }
 
-func NewOutputExecutor(params OutputExecutorParams, logger log.Logger) *OutputExecutor {
+func NewOutputExecutor(params OutputExecutorParams, logger log.Logger) (*OutputExecutor, error) {
+	if err := params.validateRunParams(); err != nil {
+		return nil, err
+	}
+
+	if govalue.IsNil(logger) {
+		logger = log.GetDefaultLogger()
+	}
+
 	return &OutputExecutor{
 		params: params,
 		logger: logger,
-	}
+	}, nil
 }
 
 func (e *OutputExecutor) Output(ctx context.Context, statePath string, outFielda ...string) (result []byte, err error) {

--- a/dhctl/pkg/infrastructureprovider/cloud_provider_test.go
+++ b/dhctl/pkg/infrastructureprovider/cloud_provider_test.go
@@ -1620,10 +1620,37 @@ type executorTestInitParams struct {
 	pluginVersion string
 }
 
+func testFindDirWithPrefix(t *testing.T, root, prefix string) string {
+	found := ""
+	err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if found != "" {
+			return nil
+		}
+
+		require.NoError(t, err, p)
+
+		// Process only dirs
+		if !info.IsDir() {
+			return nil
+		}
+
+		if strings.HasPrefix(path.Base(p), prefix) {
+			found = p
+		}
+
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	return found
+}
+
 func asserProviderDirContainsWorkingFilesAndSourcesNotContainsLock(t *testing.T, params executorTestInitParams) {
 	t.Helper()
 
 	require.False(t, govalue.IsNil(params.provider))
+	require.False(t, govalue.IsNil(params.params.Logger))
 	require.NotEmpty(t, params.step)
 	require.NotEmpty(t, params.layout)
 	require.NotEmpty(t, params.pluginsDir)
@@ -1632,7 +1659,10 @@ func asserProviderDirContainsWorkingFilesAndSourcesNotContainsLock(t *testing.T,
 
 	infraRoot := filepath.Join(params.provider.RootDir(), params.pluginVersion)
 
-	tmp := filepath.Join(infraRoot, "tf_dhctl")
+	tmp := testFindDirWithPrefix(t, infraRoot, "tf_")
+	require.NotEmpty(t, tmp)
+
+	params.params.Logger.LogInfoF("Found tmp dir %s\n", tmp)
 
 	assertIsNotEmptyDir(t, tmp)
 	assertPluginsPresent(t, path.Join(tmp, "providers"), params.pluginsDir, params.params.FSDIParams.PluginsDir)

--- a/dhctl/pkg/util/stringsutil/strings.go
+++ b/dhctl/pkg/util/stringsutil/strings.go
@@ -18,12 +18,26 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"math/rand"
+	"strconv"
 )
 
 func RandomStrElement(list []string) (string, int) {
 	indx := rand.Intn(len(list)) // this call is thread safe
 
 	return list[indx], indx
+}
+
+func FirstLetters(s string, count int) string {
+	l := len(s)
+	if l == 0 || count < 1 || count >= l {
+		return s
+	}
+
+	runesCountStr := strconv.Itoa(count)
+
+	// "%.8s"
+	f := `%.` + runesCountStr + "s"
+	return fmt.Sprintf(f, s)
 }
 
 func Index(list []string, elem string) int {
@@ -59,6 +73,11 @@ func Sha256Encode(input string) string {
 	hasher.Write([]byte(input))
 
 	return fmt.Sprintf("%x", hasher.Sum(nil))
+}
+
+func Sha256EncodeWithFirstLettersOfHash(input string, count int) string {
+	hash := Sha256Encode(input)
+	return FirstLetters(hash, count)
 }
 
 func Sha256EncodeBytes(input []byte) string {

--- a/dhctl/pkg/util/stringsutil/strings_test.go
+++ b/dhctl/pkg/util/stringsutil/strings_test.go
@@ -21,6 +21,71 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFirstLetters(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		count    int
+		name     string
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			expected: "",
+			count:    2,
+		},
+
+		{
+			name:     "zero count",
+			input:    "aaaa",
+			expected: "aaaa",
+			count:    0,
+		},
+
+		{
+			name:     "negative count",
+			input:    "aaaa",
+			expected: "aaaa",
+			count:    -1,
+		},
+
+		{
+			name:     "all string",
+			input:    "aaaa",
+			expected: "aaaa",
+			count:    4,
+		},
+
+		{
+			name:     "count > string len",
+			input:    "aaaa",
+			expected: "aaaa",
+			count:    10,
+		},
+
+		{
+			name:     "2 count",
+			input:    "aaaa",
+			expected: "aa",
+			count:    2,
+		},
+
+		{
+			name:     "1 count",
+			input:    "aaaa",
+			expected: "a",
+			count:    1,
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			res := FirstLetters(tst.input, tst.count)
+			require.Equal(t, res, tst.expected)
+		})
+	}
+}
+
 // This test will fail at the original implementation of RandomStrElement with the message such as:
 // "strings_test.go:56: RandomStrElement produces 100 consecutive repetitions out of 100 elements"
 func TestRandomStrElement(t *testing.T) {


### PR DESCRIPTION
## Description
We have parallel bootstrap cloud permanent nodes when create cluster. We using TF_DATA_DIR env for running terraform/tofu commands. But `terraform/tofu` can remove all content in TF_DATA_DIR and we got next error:
```
Error: Failed to install provider

Error while installing hashicorp/kubernetes v2.35.1: after installing  
[registry.opentofu.org/hashicorp/kubernetes](http://registry.opentofu.org/hashicorp/kubernetes) it is still not detected in  
/tmp/dhctl/infra/46afc1422ebd49ff/2.35.1/tf\_dhctl/providers; this is a bug in 
```

For fix it we added special id for every get terraform/tofu executor. We cannot use different directory beetwen `init/plan/apply` so we add one id for one executor. Executor only use in pipline functions with  chain of operations `init/plan/apply`.

## Why do we need it, and what problem does it solve?
User cannot bootstrap cluster with multiple cloud-permanent nodes in node groups.

## Why do we need it in the patch release (if we do)?

User cannot bootstrap cluster with multiple cloud-permanent nodes in node groups.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix parallel bootstrap cloud permanent nodes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
