### PR TITLE
[monitoring-custom] Add clarification to D8ReservedNodeLabelOrTaintFound alert description

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2762,6 +2762,8 @@ alerts:
         - A reserved `metadata.labels` object `node-role.deckhouse.io/`, which doesn't end with `(system|frontend|monitoring|_deckhouse_module_name_)`.
         - A reserved `spec.taints` object `dedicated.deckhouse.io`, with a value other than `(system|frontend|monitoring|_deckhouse_module_name_)`.
 
+        This alert may fire if the corresponding module is missing or disabled in the cluster. It can be safely ignored if you are preparing nodes to enable a module that is currently disabled.
+
         For instructions on how to resolve this issue, refer to the [node allocation guide](https://deckhouse.io/modules/node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).
       summary: |
         Node {{ $labels.name }} is using a reserved label or taint.

--- a/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
+++ b/modules/340-monitoring-custom/monitoring/prometheus-rules/reserved-domain.tpl
@@ -18,4 +18,6 @@
         - A reserved `metadata.labels` object `node-role.deckhouse.io/`, which doesn't end with `(system|frontend|monitoring|_deckhouse_module_name_)`.
         - A reserved `spec.taints` object `dedicated.deckhouse.io`, with a value other than `(system|frontend|monitoring|_deckhouse_module_name_)`.
 
+        This alert may fire if the corresponding module is missing or disabled in the cluster. It can be safely ignored if you are preparing nodes to enable a module that is currently disabled.
+
         For instructions on how to resolve this issue, refer to the [node allocation guide](https://deckhouse.io/modules/node-manager/faq.html#how-do-i-allocate-nodes-to-specific-loads).


### PR DESCRIPTION
## Description
Added clarification that:
- This alert may fire when the corresponding module is missing or disabled in the cluster
- The alert can be safely ignored if nodes are being prepared for a module that will be enabled later

## Why do we need it, and what problem does it solve?
Users were confused when seeing this alert for nodes with labels/taints for modules that are intentionally disabled. The updated description helps users distinguish between:
1. A misconfiguration that needs to be fixed
2. A legitimate scenario where nodes are pre-configured for a module that is not yet enabled

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-custom
type: chore
summary: Add clarification to D8ReservedNodeLabelOrTaintFound alert description.
```
