### PR TITLE
[deckhouse] module and path to loading error

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -565,7 +565,7 @@ func (l *Loader) parseModulesDir(modulesDir string) ([]*moduletypes.Definition, 
 
 		definition, err := l.moduleDefinitionByDir(name, absPath)
 		if err != nil {
-			return nil, fmt.Errorf("parse module definition by dir: %w", err)
+			return nil, fmt.Errorf("parse module definition '%s' from dir '%s': %w", name, absPath, err)
 		}
 
 		definitions = append(definitions, definition)


### PR DESCRIPTION
## Description
It adds module name and path to loading error

## Why do we need it, and what problem does it solve?
To know what module can not be loaded.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Add module name and path to loading error.
impact_level: low
```