### PR TITLE
Add retry to commander script

### DIFF
--- a/testing/cloud_layouts/script-commander.sh
+++ b/testing/cloud_layouts/script-commander.sh
@@ -1005,21 +1005,32 @@ function wait_upmeter_green() {
 }
 
 function check_resources_state_results() {
+  local testRunAttempts=20
   echo "Check applied resource status..."
-  response=$(get_cluster_status)
-  errors=$(jq -c '
-    .resources_state_results[]
-    | select(.errors)
-    | .errors |= map(select(test("vstaticinstancev1alpha1.deckhouse.io") | not))
-    | select(.errors | length > 0)
-    | .errors
-  ' <<< "$response")
-  if [ -n "$errors" ]; then
-    echo "  Errors found:"
-    echo "${errors}"
-    return 1
-  fi
-  echo "Check applied resource status... Passed"
+  for ((i=1; i<=testRunAttempts; i++)); do
+    response=$(get_cluster_status)
+    errors=$(jq -c '
+      .resources_state_results[]
+      | select(.errors)
+      | .errors |= map(select(test("vstaticinstancev1alpha1.deckhouse.io") | not))
+      | select(.errors | length > 0)
+      | .errors
+    ' <<< "$response")
+    if [ -n "$errors" ]; then
+      if [[ $i -lt $testRunAttempts ]]; then
+        echo "  Errors found. Attempt $i/$testRunAttempts failed. Sleep for 30 seconds..."
+        sleep 30
+        continue
+      else
+        echo "  Attempt $i/$testRunAttempts failed."
+        echo "${errors}"
+        return 1
+      fi
+    else
+      echo "Check applied resource status... Passed"
+      return 0
+    fi
+  done
 }
 
 function change_deckhouse_image() {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added the retry mechanism to the check_resources_state_results() function. Now, when errors are detected in the resource status, the function performs up to 20 attempts with an interval of 30 seconds between them.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously, the check_resources_state_results() function was terminated immediately when errors were first detected in the status of cluster resources. In some scenarios, this led to false positives.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Added repeated attempts when checking the status of cluster resources
impact: low
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
