### PR TITLE
[dhctl] Expand SSH connect output logs on errors for debug, verbose purposes.

### DIFF
--- a/dhctl/pkg/system/node/ssh/waiting.go
+++ b/dhctl/pkg/system/node/ssh/waiting.go
@@ -50,7 +50,7 @@ func (c *Check) WithDelaySeconds(seconds int) node.Check {
 
 func (c *Check) AwaitAvailability(ctx context.Context) error {
 	if c.Session.Host() == "" {
-		return fmt.Errorf("empty host for connection received")
+		return fmt.Errorf("Empty host for connection received")
 	}
 
 	select {
@@ -81,7 +81,7 @@ func (c *Check) AwaitAvailability(ctx context.Context) error {
 
 func (c *Check) CheckAvailability(ctx context.Context) error {
 	if c.Session.Host() == "" {
-		return fmt.Errorf("empty host for connection received")
+		return fmt.Errorf("Empty host for connection received")
 	}
 
 	log.InfoF("Try to connect to %v host\n", c.Session.Host())


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This pr expand dhctl ssh client connect logs for more debug or verbose information.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
ex. on SSH client connect errors
if target host is not available
```
┌ 🎈 ~ Common: Connect to Kubernetes API
│ ┌ Waiting for SSH connection
│ │ Try to connect to host: 10.12.0.140
│ │ Connection attempt failed to host: 10.12.0.140
│ │ ️⛱️️ Attempt #1 of 50 |
│ │     Waiting for SSH connection check attempt, retry in 5s"
│ │     Status: SSH error: execute command 'echo SUCCESS': exit status 255
│ │ SSH connect failed to 10.12.0.140: Warning: Permanently added '185.11.73.155' (ED25519) to the list of known hosts.
│ │ Connection timed out during banner exchange
│ │ Connection to UNKNOWN port 65535 timed out
```

if bastion host is not available
```
│ │ Try to connect to host: 10.12.0.140
│ │ Connection attempt failed to host: 10.12.0.140
│ │ ️⛱️️ Attempt #1 of 50 |
│ │     Waiting for SSH connection check attempt, retry in 5s"
│ │     Status: SSH error: execute command 'echo SUCCESS': exit status 255
│ │ SSH connect failed to 10.12.0.140: ssh: connect to host 185.11.73.154 port 22: Operation timed out
│ │ Connection closed by UNKNOWN port 65535
```
if some ssh key issues
on bastion host
```
┌ 🎈 ~ Common: Connect to Kubernetes API
│ ┌ Waiting for SSH connection
│ │ Try to connect to host: 10.12.0.140
│ │ Connection attempt failed to host: 10.12.0.140
│ │ ️⛱️️ Attempt #1 of 50 |
│ │     Waiting for SSH connection check attempt, retry in 5s"
│ │     Status: SSH error: execute command 'echo SUCCESS': exit status 255
│ │ SSH connect failed to 10.12.0.140: Warning: Permanently added '185.11.73.155' (ED25519) to the list of known hosts.
│ │ ubuntu@185.11.73.155: Permission denied (publickey).
│ │ Connection closed by UNKNOWN port 65535
```
on target host
```
┌ 🎈 ~ Common: Connect to Kubernetes API
│ ┌ Waiting for SSH connection
│ │ Try to connect to host: 10.12.0.75
│ │ Connection attempt failed to host: 10.12.0.75
│ │ ️⛱️️ Attempt #1 of 50 |
│ │     Waiting for SSH connection check attempt, retry in 5s"
│ │     Status: SSH error: execute command 'echo SUCCESS': exit status 255
│ │ SSH connect failed to 10.12.0.75: Warning: Permanently added '185.11.73.155' (ED25519) to the list of known hosts.
│ │ Warning: Permanently added '10.12.0.75' (ED25519) to the list of known hosts.
│ │ ubuntu@10.12.0.75: Permission denied (publickey).
```
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Expand SSH output logs on errors for debug, verbose purposes.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
