### PR TITLE
Add project name length validation

### DIFF
--- a/modules/160-multitenancy-manager/crds/projects.yaml
+++ b/modules/160-multitenancy-manager/crds/projects.yaml
@@ -85,6 +85,9 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          x-kubernetes-validations:
+            - rule: "size(self.metadata.name) <= 53"
+              message: "Project name must be no longer than 53 characters."
           properties:
             spec:
               type: object


### PR DESCRIPTION
## Description
This PR adds validation for the Project resource name to ensure it does not exceed 53 characters.
Project names are used as prefixes for generated Kubernetes resource names. These names later get a hashed suffix, and exceeding the Kubernetes 63-character limit would cause resource creation failures.

## Why do we need this:
Without this validation, users can create Project objects with names too long to be safely used as base names for generated resources. This results in broken deployments and hard-to-debug errors.

## What was changed:
- Added x-kubernetes-validations rule to CRD projects.deckhouse.io (v1alpha2).
- Validation rule: size(self.metadata.name) <= 53.
- Added user-facing message explaining the restriction.