### PR TITLE
[user-authz] cache namespace label checks via informer

### DIFF
--- a/ee/be/modules/140-user-authz/templates/webhook/rbac-for-us.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/rbac-for-us.yaml
@@ -18,7 +18,7 @@ rules:
   verbs: ["get"]
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description

- Switch user-authz webhook namespace label checks to a namespace informer+lister cache instead of per-request `Namespaces().Get`.
- Block server start until the namespace cache is synced; fail fast if sync is not achieved.
- Update webhook RBAC to include `list,watch` on namespaces for informer access; keep existing semantics of authorization.
- Tests adjusted to use a fake namespace lister; `go test` and `-race` pass.

No control-plane components restart; only the user-authz webhook rolls on config changes.

## Why do we need it, and what problem does it solve?

- Eliminates 60–80 per-login namespace GETs to the apiserver when `NamespaceSelector` is used, avoiding rate limits and latency.
- Preserves existing authorization behavior while moving namespace label lookups to an in-memory cache.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: cache namespace label checks in the user-authz webhook via informer to avoid per-request apiserver GETs
impact_level: default
```