### PR TITLE
[multitenancy-manager] Add project name length validation

### DIFF
--- a/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
+++ b/modules/160-multitenancy-manager/crds/doc-ru-projects.yaml
@@ -30,7 +30,6 @@ spec:
     - name: v1alpha2
       schema:
         openAPIV3Schema:
-          description: ""
           properties:
             spec:
               properties:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.
  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR adds validation for the `Project` resource name to ensure it does not exceed **53 characters**.

Project names are used as prefixes when Deckhouse generates Kubernetes resource names. These names later receive an additional hashed suffix. If the original project name is too long, the resulting Kubernetes resource name may exceed the 63-character limit, causing resource creation failures.

This change does **not** affect critical cluster components.

## Why do we need it, and what problem does it solve?
<!---
  Describe the main goal of your feature.
-->
Without this validation, users can create `Project` objects with overly long names.  
Such names cannot be safely used as prefixes for generated Kubernetes resources, which leads to:

- failed resource creation,
- broken or incomplete deployments,
- difficult-to-debug cluster behavior.

The validation prevents this by enforcing a safe maximum length of 53 characters.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: multitenancy-manager
type: fix
summary: Add validation to restrict Project name length to 53 characters.
impact: Prevents creation of Projects with too-long names that would lead to invalid generated Kubernetes resource names.
impact_level: default
