### PR TITLE
[dashboard] Fixing CVE-2025-30204

### DIFF
--- a/modules/500-dashboard/images/api/werf.inc.yaml
+++ b/modules/500-dashboard/images/api/werf.inc.yaml
@@ -1,7 +1,7 @@
 # #####################################################################
 # Based on https://github.com/kubernetes/dashboard/blob/kubernetes-dashboard-7.10.4/modules/api/Dockerfile
 # #####################################################################
-{{- $version := "1.10.2" }}
+{{- $version := "1.14.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless

--- a/modules/500-dashboard/images/auth/werf.inc.yaml
+++ b/modules/500-dashboard/images/auth/werf.inc.yaml
@@ -1,7 +1,7 @@
 # #####################################################################
 # Based on https://github.com/kubernetes/dashboard/blob/kubernetes-dashboard-7.10.4/modules/auth/Dockerfile
 # #####################################################################
-{{- $version := "1.2.3" }}
+{{- $version := "1.4.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless

--- a/modules/500-dashboard/images/web/werf.inc.yaml
+++ b/modules/500-dashboard/images/web/werf.inc.yaml
@@ -1,7 +1,7 @@
 # #####################################################################
 # Based on https://github.com/kubernetes/dashboard/blob/kubernetes-dashboard-7.10.4/modules/web/Dockerfile
 # #####################################################################
-{{- $version := "1.6.1" }}
+{{- $version := "1.7.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless


### PR DESCRIPTION
## Why do we need it, and what problem does it solve?

This PR fix CVE in golang-jwt (CVE-2025-30204)
https://github.com/golang-jwt/jwt/security/advisories/GHSA-mh63-6h87-95cp

## Why do we need it in the patch release (if we do)?

It blocks clients to use Deckhouse 1.73 in production

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dashboard
type: fix
summary: Fixed CVE-2025-30204 by updating dashboard components
```
