### PR TITLE
[candi] Add bashible 064 step criDir fallback

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -96,6 +96,10 @@ fi
 {{- if not (eq .cri "NotManaged") }}
 # Get CRI directory for eviction thresholds calculation
 criDir=$(crictl info -o json | jq -r '.config.containerdRootDir')
+# fallback
+if [ -z "$criDir" ] || [ "$criDir" = "null" ]; then
+  criDir="/var/lib/containerd"
+fi
 imagefsSize=$(df --output=size "$criDir" | tail -n1)
 imagefsInodes=$(df --output=itotal "$criDir" | tail -n1)
 


### PR DESCRIPTION
## Description

added fallback for criDir variable

## Why do we need it, and what problem does it solve?

There are rare cases when the criDir variable turns out to be empty due to an error. In this case, we fallback to the default value

```
Aug 18 04:23:27 s-worker-0 bash[1032434]: +++ df --output=itotal /var/lib/kubelet
Aug 18 04:23:27 s-worker-0 bash[1032434]: +++ tail -n1
Aug 18 04:23:27 s-worker-0 bash[1032434]: ++ nodefsInodes=13041664
Aug 18 04:23:27 s-worker-0 bash[1032434]: ++ nodefsInodesKFivePercent=652
Aug 18 04:23:27 s-worker-0 bash[1032434]: ++ '[' 652 -gt 1220 ']'
Aug 18 04:23:27 s-worker-0 bash[1032434]: ++ '[' 1304 -gt 2440 ']'
Aug 18 04:23:27 s-worker-0 bash[1032434]: +++ df --output=size # <-- /var/lib/containerd should have been here
Aug 18 04:23:27 s-worker-0 bash[1032434]: +++ tail -n1
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Added bashible 064 step criDir fallback.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
