### PR TITLE
[docs] Fix rendering of objectkeeper controller docs

### DIFF
--- a/deckhouse-controller/crds/doc-ru-objectkeeper.yaml
+++ b/deckhouse-controller/crds/doc-ru-objectkeeper.yaml
@@ -11,7 +11,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: |
-          Определяет конфигурацию ресурса ObjectKeeper.
+          Определяет конфигурацию единого механизма отложенного и каскадного удаления ресурсов кластера.
         properties:
           apiVersion:
             type: string
@@ -23,9 +23,9 @@ spec:
             properties:
               followObjectRef:
                 description: |-
-                  FollowObjectRef — параметры отслеживаемого объекта.
-                  Параметр обязателен, если mode = FollowObject или FollowObjectWithTTL.
-                  Объект ObjectKeeper будет удалён после удаления отслеживаемого объекта.
+                  `FollowObjectRef` — параметры отслеживаемого объекта.
+                  Параметр обязателен, если `mode` = `FollowObject` или `FollowObjectWithTTL`.
+                  Объект `ObjectKeeper` будет удалён после удаления отслеживаемого объекта.
                 properties:
                   apiVersion:
                     description: Версия API отслеживаемого объекта.
@@ -51,7 +51,7 @@ spec:
                 - uid
                 type: object
               mode:
-                description: Режим управления временем жизни объекта
+                description: Режим управления временем жизни объекта.
                 enum:
                 - FollowObject
                 - TTL
@@ -59,10 +59,10 @@ spec:
                 type: string
               ttl:
                 description: |-
-                  TTL — продолжительность жизни ObjectKeeper.
-                  Обязательно, если mode = TTL или FollowObjectWithTTL.
+                  `TTL` — продолжительность жизни `ObjectKeeper`.
+                  Обязательно, если `mode = TTL` или `FollowObjectWithTTL`.
                   Объект будет удалён после указанного времени.
-                  При FollowObjectWithTTL — отсчёт начинается после удаления связанного объекта.
+                  При `FollowObjectWithTTL` — отсчёт начинается после удаления связанного объекта.
                 type: string
             required:
             - mode

--- a/deckhouse-controller/crds/objectkeeper.yaml
+++ b/deckhouse-controller/crds/objectkeeper.yaml
@@ -31,12 +31,8 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: |-
-              APIVersion defines the versioned schema of this representation of an object.
             type: string
           kind:
-            description: |-
-              Kind is a string value representing the REST resource this object represents.
             type: string
           metadata:
             type: object
@@ -45,9 +41,9 @@ spec:
               followObjectRef:
                 description: |-
                   References the namespaced object that controls retention.
-                  Required when mode = FollowObject or FollowObjectWithTTL.
+                  Required when `mode` = `FollowObject` or `FollowObjectWithTTL`.
                   The ObjectKeeper will be automatically deleted when the referenced object is deleted
-                  (or after TTL expires if mode = FollowObjectWithTTL).
+                  (or after TTL expires if `mode` = `FollowObjectWithTTL`).
                 properties:
                   apiVersion:
                     description: APIVersion of the object to follow.
@@ -64,7 +60,7 @@ spec:
                   uid:
                     description: |-
                       UID of the object to follow (required for verification).
-                      Used by ObjectKeeperController to detect object deletion or recreation.
+                      Used by `ObjectKeeperController` to detect object deletion or recreation.
                     type: string
                 required:
                 - apiVersion
@@ -82,10 +78,10 @@ spec:
                 type: string
               ttl:
                 description: |-
-                  TTL specifies how long the ObjectKeeper must live
-                  Required when mode = TTL or FollowObjectWithTTL
-                  The ObjectKeeper will expire after this duration
-                  For FollowObjectWithTTL: TTL starts counting from object deletion time
+                  TTL specifies how long the `ObjectKeeper` must live
+                  Required when `mode` = `TTL` or `FollowObjectWithTTL`
+                  The `ObjectKeeper` will expire after this duration
+                  For `FollowObjectWithTTL`: TTL starts counting from object deletion time
                 type: string
             required:
             - mode
@@ -104,33 +100,31 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions represent the latest available observations
-                  of the objectkeeper state.
+                description: Conditions represent the latest available observations of the `ObjectKeeper` state.
                 items:
-                  description: Condition contains details for one aspect of the current
-                    state of this API Resource.
+                  description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
-                        lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        `lastTransitionTime` is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        message is a human readable message indicating details about the transition.
+                        `message` is a human readable message indicating details about the transition.
                         This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
                       description: |-
-                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        `observedGeneration` represents the `.metadata.generation` that the condition was set based upon.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
                       description: |-
-                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        `reason` contains a programmatic identifier indicating the reason for the condition's last transition.
                         Producers of specific condition types may define expected values and meanings for this field,
                         and whether the values are considered a guaranteed API.
                       maxLength: 1024
@@ -138,14 +132,14 @@ spec:
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
-                      description: status of the condition, one of True, False, Unknown.
+                      description: Status of the condition, one of True, False, Unknown.
                       enum:
                       - "True"
                       - "False"
                       - "Unknown"
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      description: Type of condition in CamelCase or in `foo.example.com/CamelCase`.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -161,7 +155,7 @@ spec:
                 description: Message provides additional information about the status.
                 type: string
               phase:
-                description: Phase of the objectkeeper
+                description: Phase of the ObjectKeeper.
                 enum:
                 - Pending
                 - Tracking
@@ -176,7 +170,19 @@ spec:
         - spec
         type: object
         description: |
-          Defines the configuration of an ObjectKeeper resource.
+          Defines the configuration of a single mechanism for deferred and cascaded deletion of cluster resources.
+        x-doc-examples:
+          - apiVersion: deckhouse.io/v1alpha1
+            kind: ObjectKeeper
+            spec:
+              mode: TTL | FollowObject | FollowObjectWithTTL
+              followObjectRef:
+                apiVersion: string
+                kind: string
+                namespace: string
+                name: string
+                uid: string
+              ttl: 24h
     served: true
     storage: true
     subresources:

--- a/docs/documentation/_tools/prepare_resources.sh
+++ b/docs/documentation/_tools/prepare_resources.sh
@@ -22,7 +22,7 @@ if [ -d /src/global ]; then
   cp -f /src/global/config-values.yaml _data/schemas/modules/global/
   echo -e "\ni18n:\n  ru:" >>_data/schemas/modules/global/config-values.yaml
   cat /src/global/doc-ru-config-values.yaml | sed 's/^/    /' >>_data/schemas/modules/global/config-values.yaml
-  for i in /src/global/crds/module* /src/global/crds/ssh_* /src/global/crds/deckhouse-release.yaml /src/global/cluster_configuration.yaml /src/global/init_configuration.yaml /src/global/static_cluster_configuration.yaml; do
+  for i in /src/global/crds/module* /src/global/crds/ssh_* /src/global/crds/deckhouse-release.yaml /src/global/cluster_configuration.yaml /src/global/init_configuration.yaml /src/global/static_cluster_configuration.yaml /src/global/crds/objectkeeper.yaml; do
     cp -v $i /srv/jekyll-data/documentation/_data/schemas/crds/
     echo -e "\ni18n:\n  ru:" >>/srv/jekyll-data/documentation/_data/schemas/crds/$(echo $i | sed -E 's#/src/global(/crds)?/##' )
     cat $(echo $i | sed -E 's#(.+)/([^/]+\.ya?ml)#\1/doc-ru-\2#' ) | sed 's/^/    /' >>_data/schemas/crds/$(echo $i | sed -E 's#/src/global(/crds)?/##' )

--- a/docs/documentation/pages/reference/api/CR.md
+++ b/docs/documentation/pages/reference/api/CR.md
@@ -18,6 +18,8 @@ permalink: en/reference/api/cr.html
 {{ site.data.schemas.crds.module-source | format_crd: "global" }}
 {{ site.data.schemas.crds.module-update-policy | format_crd: "global" }}
 
+{{ site.data.schemas.crds.objectkeeper | format_crd: "global" }}
+
 {{ site.data.schemas.crds.static_cluster_configuration | format_cluster_configuration }}
 
 {{ site.data.schemas.crds.ssh_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/reference/api/CR_RU.md
+++ b/docs/documentation/pages/reference/api/CR_RU.md
@@ -20,6 +20,8 @@ search: global custom resources, global configuration, global parameters, гло
 {{ site.data.schemas.crds.module-source | format_crd: "global" }}
 {{ site.data.schemas.crds.module-update-policy | format_crd: "global" }}
 
+{{ site.data.schemas.crds.objectkeeper | format_crd: "global" }}
+
 {{ site.data.schemas.crds.static_cluster_configuration | format_cluster_configuration }}
 
 {{ site.data.schemas.crds.ssh_configuration | format_cluster_configuration }}


### PR DESCRIPTION
## Description

Fixed rendering of objectkeeper controller docs.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix 
summary: Fixed rendering of objectkeeper controller docs.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
