### PR TITLE
[user-authn] fix error: auth request does not have an identity for approval

### DIFF
--- a/modules/150-user-authn/images/dex/patches/004-2fa.patch
+++ b/modules/150-user-authn/images/dex/patches/004-2fa.patch
@@ -137,7 +137,7 @@ index 463751ed..a4a1f2cb 100644
  github.com/prometheus/client_golang v1.23.0/go.mod h1:i/o0R9ByOnHX0McrTMTyhYvKE4haaf2mW08I+jGAjEE=
  github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 diff --git a/server/handlers.go b/server/handlers.go
-index 93266b8d..17688448 100644
+index 93266b8d..1474c49b 100644
 --- a/server/handlers.go
 +++ b/server/handlers.go
 @@ -11,7 +11,6 @@ import (
@@ -160,7 +160,7 @@ index 93266b8d..17688448 100644
  		return a, nil
  	}
  	if err := s.storage.UpdateAuthRequest(ctx, authReq.ID, updater); err != nil {
-@@ -558,63 +562,81 @@ func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity,
+@@ -558,52 +562,52 @@ func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity,
  		"connector_id", authReq.ConnectorID, "username", claims.Username,
  		"preferred_username", claims.PreferredUsername, "email", email, "groups", claims.Groups)
  
@@ -233,6 +233,8 @@ index 93266b8d..17688448 100644
  		}
  	}
  
+-	// we can skip the redirect to /approval and go ahead and send code if it's not required
+-	if s.skipApproval && !authReq.ForceApprovalPrompt {
 +	// Update existing OfflineSession obj with new RefreshTokenRef.
 +	if err := s.storage.UpdateOfflineSessions(ctx, identity.UserID, authReq.ConnectorID, func(old storage.OfflineSessions) (storage.OfflineSessions, error) {
 +		if len(identity.ConnectorData) > 0 {
@@ -244,19 +246,12 @@ index 93266b8d..17688448 100644
 +		return "", false, err
 +	}
 +
- 	// we can skip the redirect to /approval and go ahead and send code if it's not required
- 	if s.skipApproval && !authReq.ForceApprovalPrompt {
++	// we can skip the redirect to /approval and /totp and go ahead and send code if it's not required
++	if s.skipApproval && !authReq.ForceApprovalPrompt && !s.totp.enabledForConnector(authReq.ConnectorID) {
  		return "", true, nil
  	}
  
-+	// we can skip the redirect to /approval and /totp and go ahead and send code if it's not required
-+	if s.skipApproval && !authReq.ForceApprovalPrompt && !s.totp.enabledForConnector(authReq.ConnectorID) {
-+		return "", true, nil
-+	}
-+
- 	// an HMAC is used here to ensure that the request ID is unpredictable, ensuring that an attacker who intercepted the original
- 	// flow would be unable to poll for the result at the /approval endpoint
- 	h := hmac.New(sha256.New, authReq.HMACKey)
+@@ -613,8 +617,21 @@ func (s *Server) finalizeLogin(ctx context.Context, identity connector.Identity,
  	h.Write([]byte(authReq.ID))
  	mac := h.Sum(nil)
  
@@ -280,7 +275,7 @@ index 93266b8d..17688448 100644
  }
  
  func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
-@@ -636,7 +658,7 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
+@@ -636,7 +653,7 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
  		s.renderError(r, w, http.StatusInternalServerError, "Database error.")
  		return
  	}
@@ -2343,3 +2338,5 @@ index 00000000..2a77b8d3
 +</div>
 +
 +{{ template "footer.html" . }}
+
+


### PR DESCRIPTION
## Description
fix error: auth request does not have an identity for approval
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
Not necessarily.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: skipApproval no longer bypasses TOTP. When 2FA is enabled, users are sent to /totp before approval, so “auth request does not have an identity for approval” no longer occurs
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
