### PR TITLE
[dhctl] Default port for ssh

### DIFF
--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -228,12 +228,12 @@ func (p *ConnectionConfigParser) ParseConnectionConfigFromFile() error {
 		hosts = append(hosts, session.Host{Host: host.Host, Name: strconv.Itoa(i)})
 	}
 
-	bastionPort := ""
+	bastionPort := "22"
 	if cfg.SSHConfig.SSHBastionPort != nil {
 		bastionPort = strconv.Itoa(int(*cfg.SSHConfig.SSHBastionPort))
 	}
 
-	port := ""
+	port := "22"
 	if cfg.SSHConfig.SSHPort != nil {
 		port = strconv.Itoa(int(*cfg.SSHConfig.SSHPort))
 	}

--- a/dhctl/pkg/server/pkg/util/util.go
+++ b/dhctl/pkg/server/pkg/util/util.go
@@ -53,7 +53,7 @@ func ErrToString(err error) string {
 
 func PortToString(p *int32) string {
 	if p == nil {
-		return ""
+		return "22"
 	}
 	return strconv.Itoa(int(*p))
 }


### PR DESCRIPTION
## Description

Set default ssh port to 22, to backward compatibility with cli ssh behavior

## Why do we need it, and what problem does it solve?

While using gossh with SSHConfig with unset sshPort field, we're receiving an error:

```
Status: strconv.ParseUint: parsing "": invalid syntax
```
To fix it, we must set ssh port/bastion port to 22 if it not set directly.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Set default ssh port to 22, to backward compatibility with cli ssh behavior in dhctl.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
