### PR TITLE
[candi] d8-shutdown-inhibitor systemd enable fix

### DIFF
--- a/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
+++ b/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
@@ -34,7 +34,7 @@ extra_logind_conf="/etc/systemd/logind.conf.d/99-node-d8-shutdown-inhibitor.conf
 bb-event-on 'inhibitor-unit-changed' '_inhibitor-unit-changed'
 _inhibitor-unit-changed() {
 systemctl daemon-reload
-systemctl enable $inhibitor_service_name
+systemctl is-enabled --quiet $inhibitor_service_name || systemctl enable $inhibitor_service_name
 systemctl restart $inhibitor_service_name
 }
 


### PR DESCRIPTION
## Description

d8-shutdown-inhibitor systemd enable fix.
added is-enabled check

## Why do we need it, and what problem does it solve?

in some very specific OS there is a problem with systemctl enable 
```
systemctl enable d8-shutdown-inhibitor
Failed to execute operation: File exists
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: d8-shutdown-inhibitor systemd enable fix.
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
