### PR TITLE
[candi] bb-detect-bundle fix

### DIFF
--- a/candi/bashible/bashbooster/56_detect_bundle.sh.tpl
+++ b/candi/bashible/bashbooster/56_detect_bundle.sh.tpl
@@ -40,9 +40,10 @@ _bb_detect_os_context() {
 {{- range $familyName, $family := $families }}
   {{- $pkg := $family.packageManager }}
   {{- range $distribution := $family.distributions }}
+    {{- $bundle := default $distribution.name $distribution.bundle }}
     {{ join "|" $distribution.ids }})
       BB_DETECTED_FAMILY="{{ $familyName }}"
-      BB_DETECTED_BUNDLE="{{ $distribution.name }}"
+      BB_DETECTED_BUNDLE="{{ $bundle }}"
       BB_DETECTED_PKG_MGR="{{ $pkg }}"
       return 0
       ;;

--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -5,6 +5,7 @@ bashible: &bashible
       distributions:
         - name: ubuntu
           ids: [ubuntu]
+          bundle: ubuntu-lts
         - name: debian
           ids: [debian]
         - name: astra


### PR DESCRIPTION
## Description

fix 16459

Added the ability to explicitly specify a bundle name in `version_map.yaml`, for example:

```
bashible: &bashible
  os:
    debian:
      packageManager: apt
      distributions:
        - name: ubuntu
          ids: [ubuntu]
          bundle: ubuntu-lts
```

For Ubuntu, the bundle name `ubuntu-lts` will be used.


## Why do we need it, and what problem does it solve?

backward compatibility is broken

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: version_map.yaml fix
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
