### PR TITLE
[candi] Ensure etcd dir has permissions 700 on all master nodes

### DIFF
--- a/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
+++ b/candi/bashible/common-steps/all/098_set_permissions.sh.tpl
@@ -20,3 +20,7 @@ chmod 700 /var/lib/kubelet/
 if [[ -d /etc/containerd ]]; then
     chmod 700 /etc/containerd
 fi
+
+if [[ -d /var/lib/etcd ]]; then
+    chmod 700 /var/lib/etcd
+fi


### PR DESCRIPTION
## Description
Add additional permission change `chmod 700 /var/lib/etcd` to `098_set_permissions.sh.tpl`

## Why do we need it, and what problem does it solve?
If `/var/lib/etcd` is created from control-plane-manager (on secondary master nodes), permissions are too open (`drwxr-xr-x.`) https://github.com/deckhouse/deckhouse/blob/b3f73bd85c60c2d21a0fa424a70792dbe525f65f/modules/040-control-plane-manager/templates/daemonset.yaml#L310C1-L312C34

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Ensure etcd dir has permissions 700 on all masters.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
