### PR TITLE
[docs] Add conditional rendering for product version menu in navigation breadcrumbs

### DIFF
--- a/docs/site/_includes/nav-breadcrumbs.html
+++ b/docs/site/_includes/nav-breadcrumbs.html
@@ -1,5 +1,5 @@
 <div class="navigation__container">
-  {%- if page.product_code == kubernetes-platform %}
+  {%- if page.product_code == 'kubernetes-platform' %}
   <div style="display: flex; justify-content: start; margin-right: 135px; padding-top: 20px; padding-bottom: 25px; gap: 25px;">
     <div>
       {%- if site.mode == 'module' %}


### PR DESCRIPTION
## Description

This pull request makes a small adjustment to the navigation breadcrumbs in the documentation site to conditionally display the module version badge only for pages related to the Kubernetes platform.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Added conditional rendering for product version menu in navigation breadcrumbs.
impact_level: low
```
