### PR TITLE
Backport: [cloud-provider-huaweicloud] CSI: fix unpublishValidation for non exist ECS instance

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/004-fix-unpublishValidation.patch
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/004-fix-unpublishValidation.patch
@@ -1,0 +1,40 @@
+Subject: [PATCH] fix unpublishValidation for non exist ECS instance
+---
+Index: pkg/evs/controllerserver.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/evs/controllerserver.go b/pkg/evs/controllerserver.go
+--- a/pkg/evs/controllerserver.go	(revision c070bde369d73794fd73e479217f851211947ca9)
++++ b/pkg/evs/controllerserver.go	(date 1765199790651)
+@@ -379,6 +379,10 @@
+ 		return nil, err
+ 	}
+ 
++	if volume == nil {
++		return &csi.ControllerUnpublishVolumeResponse{}, nil
++	}
++
+ 	if volume.Status == services.EvsAvailableStatus || len(volume.Attachments) == 0 {
+ 		log.Warningf("Warning, the volume %s is not in the server %s attach volume list, skip unpublishing",
+ 			volumeID, instanceID)
+@@ -410,10 +414,18 @@
+ 
+ 	volume, err := services.GetVolume(cc, volumeID)
+ 	if err != nil {
++		if status.Code(err) == codes.NotFound {
++			log.Infof("assuming Volume %s is detached because it does not exist", volumeID)
++			return nil, nil
++		}
+ 		return nil, err
+ 	}
+ 
+ 	if _, err = services.GetServer(cc, instanceID); err != nil {
++		if status.Code(err) == codes.NotFound {
++			log.Infof("assuming Volume %s is detached because ECS instance %s does not exist", volumeID, instanceID)
++			return nil, nil
++		}
+ 		return nil, err
+ 	}
+ 

--- a/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/README.md
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/patches/README.md
@@ -7,3 +7,7 @@ Update dependencies
 ### 002-enterprise-project-id.patch
 
 Add support enterprise-project-id
+
+### 004-fix-unpublishValidation.patch
+
+Fix unpublishValidation for non exist ECS instance


### PR DESCRIPTION
## Description
Fixes unpublishValidation for non exist ECS instance
See https://github.com/deckhouse/deckhouse/pull/16916

## Why do we need it, and what problem does it solve?
See https://github.com/huaweicloud/huaweicloud-csi-driver/issues/171
https://github.com/kubernetes-csi/external-attacher/issues/215

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: fix
summary: fix CSI unpublishValidation for non exist ECS instance
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
