### PR TITLE
[cloud-provider-dvp] Fix healthCheckNodePort collisions

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/loadbalancer.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/loadbalancer.go
@@ -141,7 +141,6 @@ func (lb *LoadBalancerService) updateLoadBalancerService(
 	svc.Spec.ExternalIPs = []string{}
 	svc.Spec.LoadBalancerClass = nil
 	svc.Spec.LoadBalancerIP = ""
-	svc.Spec.HealthCheckNodePort = 0
 
 	if len(serviceLabels) > 0 {
 		svc.Labels = serviceLabels
@@ -157,9 +156,6 @@ func (lb *LoadBalancerService) updateLoadBalancerService(
 	}
 	if service.Spec.LoadBalancerIP != "" {
 		svc.Spec.LoadBalancerIP = service.Spec.LoadBalancerIP
-	}
-	if service.Spec.HealthCheckNodePort > 0 {
-		svc.Spec.HealthCheckNodePort = service.Spec.HealthCheckNodePort
 	}
 
 	err := lb.client.Update(ctx, svc)
@@ -224,9 +220,6 @@ func (lb *LoadBalancerService) createLoadBalancerService(
 	}
 	if service.Spec.LoadBalancerIP != "" {
 		svc.Spec.LoadBalancerIP = service.Spec.LoadBalancerIP
-	}
-	if service.Spec.HealthCheckNodePort > 0 {
-		svc.Spec.HealthCheckNodePort = service.Spec.HealthCheckNodePort
 	}
 
 	err := lb.client.Create(ctx, svc)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix healthCheckNodePort collisions
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We don't have to set healthCheckNodePort manually. It can be delegated to kube-proxy, which will allocate and manage it automatically

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Fix healthCheckNodePort collisions
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
