### PR TITLE
[node-manager] fix CA priority expander fallback 

### DIFF
--- a/modules/040-node-manager/hooks/set_ng_priorities.go
+++ b/modules/040-node-manager/hooks/set_ng_priorities.go
@@ -83,7 +83,7 @@ func handleSetPriorities(_ context.Context, input *go_hook.HookInput) error {
 		}
 
 		if ng.Priority != nil {
-			key := fmt.Sprintf("^%s-%s-[0-9a-zA-Z]+$", prefix, ng.Name)
+			key := fmt.Sprintf(".*%s-%s-[0-9a-zA-Z]+$", prefix, ng.Name)
 			priorities[*ng.Priority] = append(priorities[*ng.Priority], key)
 		}
 	}

--- a/modules/040-node-manager/hooks/set_ng_priorities_test.go
+++ b/modules/040-node-manager/hooks/set_ng_priorities_test.go
@@ -89,7 +89,7 @@ spec:
 		It("Hook must not fail", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			m := f.ValuesGet("nodeManager.internal.clusterAutoscalerPriorities").String()
-			Expect(m).To(Equal(`{"1":[".*"],"20":["^test-ng1-[0-9a-zA-Z]+$"],"50":["^test-ng2-[0-9a-zA-Z]+$"]}`))
+			Expect(m).To(Equal(`{"1":[".*"],"20":[".*test-ng1-[0-9a-zA-Z]+$"],"50":[".*test-ng2-[0-9a-zA-Z]+$"]}`))
 		})
 	})
 

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -99,13 +99,13 @@ internal:
 
   clusterAutoscalerPriorities:
     "50":
-    - ^xxx-staging-[0-9a-zA-Z]+$
+    - .*xxx-staging-[0-9a-zA-Z]+$
     "70":
-    - ^xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
+    - .*xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
     "90":
-    - ^xxx-staging-spot-[0-9a-zA-Z]+$
-    - ^xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
-    - ^xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
+    - .*xxx-staging-spot-[0-9a-zA-Z]+$
+    - .*xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
+    - .*xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
   machineDeployments: {}
   instancePrefix: myprefix
   clusterMasterAddresses: ["10.0.0.1:6443", "10.0.0.2:6443", "10.0.0.3:6443"]
@@ -768,13 +768,13 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 					cm := f.KubernetesResource("ConfigMap", "d8-cloud-instance-manager", "cluster-autoscaler-priority-expander")
 					Expect(cm.Field("data.priorities").String()).To(MatchYAML(`
 50:
-  - ^xxx-staging-[0-9a-zA-Z]+$
+  - .*xxx-staging-[0-9a-zA-Z]+$
 70:
-  - ^xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
+  - .*xxx-staging-spot-m5a-2xlarge-[0-9a-zA-Z]+$
 90:
-  - ^xxx-staging-spot-[0-9a-zA-Z]+$
-  - ^xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
-  - ^xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
+  - .*xxx-staging-spot-[0-9a-zA-Z]+$
+  - .*xxx-staging-spot-m5a.8xlarge-[0-9a-zA-Z]+$
+  - .*xxx-staging-spot-c5.16xlarge-[0-9a-zA-Z]+$
 `))
 
 				})


### PR DESCRIPTION
## Description
Fix priority expander fallback
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
fix https://github.com/deckhouse/deckhouse/pull/16998#pullrequestreview-3594744186

## Why do we need it, and what problem does it solve?
Fix priority expander fallback
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
No need

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Adjusted the regexp used for NodeGroup priority generation in the cluster-autoscaler priority expander fallback.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
