### PR TITLE
[dhctl] Fix TestConcurrentExec test

### DIFF
--- a/dhctl/pkg/infrastructure/runner_test.go
+++ b/dhctl/pkg/infrastructure/runner_test.go
@@ -17,7 +17,6 @@ package infrastructure
 import (
 	"context"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
@@ -273,7 +272,7 @@ func TestConcurrentExec(t *testing.T) {
 		})
 	}()
 
-	runtime.Gosched()
+	time.Sleep(500 * time.Millisecond)
 	_, err := runner.execInfrastructureUtility(ctx, func(ctx context.Context) (int, error) {
 		return exec.Plan(ctx, PlanOpts{})
 	})


### PR DESCRIPTION
## Description

Fix TestConcurrentExec test

## Why do we need it, and what problem does it solve?

Test TestConcurrentExec tries to run simultaneous `execInfrastructureUtility`, to check that second run will cause an error. Sometimes it gets stuck forever. To fix it, we'd add a sleep instead of `runtime.Gosched()`, got an expected result:

```
go test -timeout 30m -count 100 -run ^TestConcurrentExec$ github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure
ok      github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure 51.094s
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Fix TestConcurrentExec test.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
