### PR TITLE
[monitoring-kubernetes] Add ValidatingAdmissionPolicy to the hook

### DIFF
--- a/modules/340-monitoring-kubernetes/hooks/helm.go
+++ b/modules/340-monitoring-kubernetes/hooks/helm.go
@@ -98,9 +98,9 @@ const unsupportedVersionsYAML = `
 
 "1.32":
   "flowcontrol.apiserver.k8s.io/v1beta3": ["FlowSchema", "PriorityLevelConfiguration"]
+  "admissionregistration.k8s.io/v1alpha1": ["ValidatingAdmissionPolicy", "ValidatingAdmissionPolicyBinding"]
 
 "1.34":
-  "admissionregistration.k8s.io/v1alpha1": ["ValidatingAdmissionPolicy", "ValidatingAdmissionPolicyBinding"]
   "admissionregistration.k8s.io/v1beta1": ["ValidatingAdmissionPolicy", "ValidatingAdmissionPolicyBinding"]
 
 `


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Extended the existing Helm releases compatibility hook with information about unsupported `ValidatingAdmissionPolicy` and `ValidatingAdmissionPolicyBinding` API versions for Kubernetes `1.34`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
On Kubernetes 1.34, Helm releases may contain `ValidatingAdmissionPolicy` resources in API versions that are no longer supported by the API server.
The hook prevents such resources from remaining in Helm releases and avoids apply errors during cluster upgrades.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: Added unsupported ValidatingAdmissionPolicy API versions on Kubernetes 1.34.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
