### PR TITLE
[deckhouse] 1.73 module enabling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cloudflare/cfssl v1.6.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/flant/addon-operator v1.15.12
+	github.com/flant/addon-operator v1.15.13
 	github.com/flant/kube-client v1.4.0
 	github.com/flant/shell-operator v1.11.4
 	github.com/go-openapi/spec v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/flant/addon-operator v1.15.11 h1:wxNcaUJGNPI46inlbzie/+pV1CUiL0iGXZ7c
 github.com/flant/addon-operator v1.15.11/go.mod h1:/Snmis6fr5+NlOYVXfaRjpUhXlxWULYH4icKRZ/ToHM=
 github.com/flant/addon-operator v1.15.12 h1:GHSKJg8bZZoxyWtFxZXzzolYGSbyElyUi2QN6TIM+6I=
 github.com/flant/addon-operator v1.15.12/go.mod h1:/Snmis6fr5+NlOYVXfaRjpUhXlxWULYH4icKRZ/ToHM=
+github.com/flant/addon-operator v1.15.13 h1:d9fk7xLbrPZKbqMWSLdPaqOTQXlLtSWCSQBmiDeihBE=
+github.com/flant/addon-operator v1.15.13/go.mod h1:/Snmis6fr5+NlOYVXfaRjpUhXlxWULYH4icKRZ/ToHM=
 github.com/flant/go-openapi-validate v0.19.12-flant.1 h1:GuB9XEfiLHq3M7fafRLq1AWkndSY/+/5MX7ad1xJ/8A=
 github.com/flant/go-openapi-validate v0.19.12-flant.1/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
 github.com/flant/kube-client v1.4.0 h1:1m/Hyf4KMaYi6rGyfHz0Coh44MJz2nUiitvMmrBwXwg=


### PR DESCRIPTION
## Description
It fixes module enabling. 

If values not changed, enabling changing ignored.

[PR in addon-operator](https://github.com/flant/addon-operator/pull/712)

## Why do we need it, and what problem does it solve?
We can not enable a module if it had module config with disabled at start.

Disable a module
```
root@paksashvili-master-0:~# dcmd keepalived
Module keepalived disabled

root@paksashvili-master-0:~# k get module keepalived
NAME         STAGE                  SOURCE     PHASE        ENABLED   READY
keepalived   General Availability   Embedded   Downloaded   False     False
```

Restart deckhouse
```
root@paksashvili-master-0:~# restartdc
deployment.apps/deckhouse restarted
```

Enable the module
```
root@paksashvili-master-0:~# dcme keepalived
Module keepalived enabled
```

Wait until converge starts(its normal that its disabled for now)
```
root@paksashvili-master-0:~# k get module keepalived
NAME         STAGE                  SOURCE     PHASE        ENABLED   READY
keepalived   General Availability   Embedded   Downloaded   False     False
```

Check the module
```
root@paksashvili-master-0:~# k get module keepalived
NAME         STAGE                  SOURCE     PHASE         ENABLED   READY
keepalived   General Availability   Embedded   Reconciling   True      False
```

## Why do we need it in the patch release (if we do)?
It fixes module enabling.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module enabling.
```
