### PR TITLE
[istio] fixing the CVE in Kiali

### DIFF
--- a/candi/base_images.yml
+++ b/candi/base_images.yml
@@ -15,6 +15,7 @@ base/ruby-v3_4_7: "sha256:e95e692539498f322e5f0eb47160c85491f3f6c41e8d411f428695
 base/scratch: "sha256:cfac1c6b53f9365ee59ffe94c90211253f2a85ece372a6a9dfad61f4e0ab0bea" # from: builder/scratch
 base/shell-operator: "sha256:9f098e8149812ea28d51c0e9d70a2ccdea9e859f13dbcc91b098002163d466d1" # from: builder/scratch
 base/shell-operator-v1.9.3: "sha256:9f098e8149812ea28d51c0e9d70a2ccdea9e859f13dbcc91b098002163d466d1" # from: builder/scratch
+builder/alpine-3.20: "sha256:b55c3d5bf9ba4c245496a1f7b38ee0ae2174a90496b4fe6f8937d6f3feff6f26" # from: alpine:3.20.7
 builder/alpine-3.21: "sha256:7b5050553bf256aec2c8c8e67179e689f13f6877e45a036755c6bc3113be7239" # from: alpine:3.21.5
 builder/alpine-3.22: "sha256:2ffd38fd342a64e79ed28cf52d71216bf119b28d96b9871184acfea672a7acc8" # from: alpine:3.22.2
 builder/alpine: "sha256:2ffd38fd342a64e79ed28cf52d71216bf119b28d96b9871184acfea672a7acc8" # from: alpine:3.22.2

--- a/modules/000-common/images/redis-static/werf.inc.yaml
+++ b/modules/000-common/images/redis-static/werf.inc.yaml
@@ -12,7 +12,7 @@ shell:
   - rm -r /src/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-fromImage: builder/alpine-3.21
+fromImage: builder/alpine-3.20
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/007-registrypackages/images/netcat/werf.inc.yaml
+++ b/modules/007-registrypackages/images/netcat/werf.inc.yaml
@@ -40,7 +40,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-fromImage: builder/alpine-3.21
+fromImage: builder/alpine-3.20
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src


### PR DESCRIPTION
## Description
This PR fix CVE in Kiali v1.81.0 for Istio version 1.21.6.
Fixed CVE:

- [CVE-2025-47914](defectdojo.flant.ru/finding/3068305)
- [CVE-2025-61729](https://defectdojo.flant.ru/finding/3068307)

## Why do we need it, and what problem does it solve?
This is done to improve the security of the Kiali v1.81.0 component.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: fixing the CVE in Kiali
impact_level: default
```
