### PR TITLE
[common] Enrich debug-container image with nsenter and /bin/sh symlink

### DIFF
--- a/modules/000-common/images/debug-container/werf.inc.yaml
+++ b/modules/000-common/images/debug-container/werf.inc.yaml
@@ -241,9 +241,14 @@ import:
   add: /scripts/entrypoint.sh
   to: /opt/entrypoint.sh
   before: install
+- image: tools/util-linux
+  add: /usr/bin/nsenter
+  to: /usr/bin/nsenter
+  before: install
 shell:
   install:
   - ln -s /var/run /run
+  - ln -s /bin/bash /bin/sh
 imageSpec:
   config:
     env: { "LANG": "C.UTF-8", "LANGUAGE": "C.UTF-8", "LC_ALL": "C.UTF-8", "CRYPTOGRAPHY_OPENSSL_NO_LEGACY": "true", "EDITOR": "/usr/bin/vim" }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR enhances the `debug-container` image by adding the `nsenter` utility and creating a `/bin/sh` symlink pointing to `/bin/bash`.

The `nsenter` binary allows entering host namespaces from the debug container, enabling effective node-level troubleshooting without SSH access.  
The `/bin/sh` symlink improves compatibility with common debugging workflows and scripts that expect `/bin/sh` to be present.

The changes affect only the debug container image and do not trigger restarts of cluster components or control plane services.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The debug container is commonly used for on-node troubleshooting in Kubernetes clusters, especially when SSH access is unavailable or restricted.

Adding `nsenter` enables operators to enter the host's namespaces (mount, PID, network, etc.) directly from the debug container, which is essential for diagnosing issues related to:
- node filesystem and mounts,
- kubelet and container runtime processes,
- networking and iptables configuration.

Without `nsenter`, many real-world troubleshooting scenarios require alternative access methods or additional tooling.

The `/bin/sh` symlink to `/bin/bash` improves usability and compatibility, as many standard commands, scripts, and tools assume the presence of `/bin/sh`. This avoids unnecessary friction during interactive debugging sessions.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Request from architects team.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: feature
summary: Enrich debug-container image with nsenter and /bin/sh symlink.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
