### PR TITLE
[docs] DeckhouseRelease documentation review

### DIFF
--- a/deckhouse-controller/crds/deckhouse-release.yaml
+++ b/deckhouse-controller/crds/deckhouse-release.yaml
@@ -21,7 +21,11 @@ spec:
         openAPIV3Schema:
           type: object
           description: |
-            Defines the state and parameters for applying Deckhouse Kubernetes Platform (DKP) releases in the cluster. Current DKP versions by update channel are available at [releases.deckhouse.io](https://releases.deckhouse.io).
+            Determines the state and parameters for applying a specific release (version) of the Deckhouse Kubernetes Platform (DKP) in the cluster.
+
+            DeckhouseRelease objects are automatically created by DKP upon the discovery of new DKP versions on the selected [release channel](/products/kubernetes-platform/documentation/latest/reference/release-channels.html). Modifying DeckhouseRelease enables the management of the process for applying the corresponding DKP version. More details about configuring DKP updates can be found in the [documentation](../../admin/configuration/update/configuration.html).
+
+            The current versions of DKP and modules by release channels can be found at [releases.deckhouse.ru](https://releases.deckhouse.ru).
           required:
             - spec
           properties:
@@ -31,9 +35,9 @@ spec:
               description: |
                 Allows or disables manual updates.
 
-                Used only if the `deckhouse` module is configured for `Manual` update mode (`update.mode: Manual`). Ignored if the update mode is set to `Auto` or `AutoPatch`.
+                Used only if the [`deckhouse` module](/modules/deckhouse/) is configured for manual update mode ([update.mode](/modules/deckhouse/configuration.html#parameters-update-mode) parameter is set to `Manual`). Ignored if the update mode is set to `Auto` or `AutoPatch`.
 
-                For more information on confirming manual updates, refer to the [`deckhouse` module documentation](/modules/deckhouse/usage.html#manual-update-confirmation).
+                For more information on confirming manual updates, refer to the [documentation](../../admin/configuration/update/configuration.html#manual-update-approval).
             spec:
               type: object
               required:
@@ -42,15 +46,19 @@ spec:
                 version:
                   type: string
                   description: DKP version.
-                  x-doc-examples: ['v1.24.20']
+                  x-doc-examples: ['v1.73.2']
                 applyAfter:
                   type: string
-                  description: Marks release as a part of [canary-release](../../user/network/canary-deployment.html). This release will be delayed until the specified time. If the release is waiting to be applied, check [`.status.message`](../../admin/configuration/update/notifications.html#notification-format) for the reason.
+                  description: |
+                    Marks release as a part of [canary-release](../../user/network/canary-deployment.html). This release will be delayed until the specified time. If the release is waiting to be applied, check [`.status.message`](../../admin/configuration/update/notifications.html#notification-format) for the reason.
                 requirements:
                   type: object
                   additionalProperties:
                     type: string
-                  description: DKP release requirements. If the requirements are not met, the release may be skipped or blocked. Check [`.status.message`](../../admin/configuration/update/notifications.html#notification-format) for details (for example, requirements of active modules or the Kubernetes version).
+                  description: |
+                    A structure containing a list of requirements for installing the release. It is used by the DKP core. If the requirements are not met, the release may be skipped or blocked from installation.
+
+                    Reports on unmet requirements can be found in the field [`.status.message`](../../admin/configuration/update/notifications.html#notification-format) of the DeckhouseRelease object.
                 disruptions:
                   type: array
                   items:
@@ -59,7 +67,10 @@ spec:
                   description: Disruptive changes in the release.
                 changelog:
                   type: object
-                  description: Release's changelog for enabled modules. For more information about DKP release changelogs, refer to [Updating](../../architecture/updating.html#retrieving-the-changelog).
+                  description: |
+                    A structure containing a list of DKP changes (and modules included in the DKP) of the release.
+
+                    For more information about DKP release changelogs, refer to [Updating](../../architecture/updating.html#retrieving-the-changelog).
                   x-kubernetes-preserve-unknown-fields: true
                 changelogLink:
                   type: string
@@ -103,7 +114,7 @@ spec:
             - `Superseded`: The release is outdated and no longer used.
             - `Suspended`: The release has been canceled (typically before it was applied).
             - `Skipped`: The release was skipped because the requirements were not satisfied.
-            
+
             For more information about DKP and modules release statuses, refer to the [`deckhouse` module documentation](/modules/deckhouse/#deckhouse-releases-update).
         - name: transitionTime
           jsonPath: .status.transitionTime

--- a/deckhouse-controller/crds/doc-ru-deckhouse-release.yaml
+++ b/deckhouse-controller/crds/doc-ru-deckhouse-release.yaml
@@ -4,39 +4,43 @@ spec:
       schema:
         openAPIV3Schema:
           description: |
-            Определяет состояние и параметры применения релизов Deckhouse Kubernetes Platform (DKP) в кластере.
+            Определяет состояние и параметры применения конкретного релиза (версии) Deckhouse Kubernetes Platform (DKP) в кластере.
 
-            Актуальные версии DKP и модулей по каналам обновлений — [releases.deckhouse.ru](https://releases.deckhouse.ru).
+            Объекты DeckhouseRelease создаются DKP автоматически, при обнаружении новых версий DKP на выбранном [канале обновлений](/products/kubernetes-platform/documentation/latest/reference/release-channels.html). Изменение DeckhouseRelease позволяет управлять процессом применения соответствующей версии DKP. Подробнее о настройке обновлений DKP можно почитать в [документации](../../admin/configuration/update/configuration.html).
+
+            Актуальные версии DKP и модулей по каналам обновлений можно узнать на [releases.deckhouse.ru](https://releases.deckhouse.ru).
           properties:
             approved:
               description: |
                 Разрешает или запрещает ручное обновление.
 
-                Используется только если в конфигурации модуля `deckhouse` установлен ручной режим обновлений (`update.mode: Manual`).
+                Используется только если в конфигурации [модуля `deckhouse`](/modules/deckhouse/) установлен ручной режим обновлений (параметр [update.mode](/modules/deckhouse/configuration.html#parameters-update-mode) установлен в `Manual`).
                 Игнорируется, если установлен режим обновления `Auto` или `AutoPatch`.
 
-                Подробнее о ручном подтверждении обновлений можно почитать в [документации модуля `deckhouse`](/modules/deckhouse/usage.html#ручное-подтверждение-обновлений).
+                Подробнее о ручном подтверждении обновлений можно почитать [в документации](../../admin/configuration/update/configuration.html#ручное-подтверждение-обновлений).
             spec:
               properties:
                 version:
                   description: Версия DKP.
                 applyAfter:
-                  description: Время, до которого отложено обновление, если релиз является частью [canary-release](../../user/network/canary-deployment.html). Если релиз ожидает применения, уточняйте причину в [`.status.message`](../../admin/configuration/update/notifications.html#формат-уведомлений).
+                  description: Время, до которого отложено обновление, если релиз является частью [canary-release](../../user/network/canary-deployment.html). Если релиз ожидает применения, уточнить причину можно в поле [`.status.message`](../../admin/configuration/update/notifications.html#формат-уведомлений) объекта DeckhouseRelease.
                 requirements:
-                  description: Требования для установки релиза. Если требования не выполняются, релиз может быть пропущен или заблокирован.
-                    Причины смотрите в [`.status.message`](../../admin/configuration/update/notifications.html#формат-уведомлений) (например, требования активных модулей или версии Kubernetes).
+                  description: |
+                    Структура, содержащая список требований для установки релиза. Используется ядром DKP. Если требования не выполняются, релиз может быть пропущен или заблокирован для установки.
+
+                    Сообщения о невыполненных требованиях, можно найти в поле [`.status.message`](../../admin/configuration/update/notifications.html#формат-уведомлений) объекта DeckhouseRelease.
                 disruptions:
                   x-doc-deprecated: true
                   description: Изменения в релизе, которые могут привести к кратковременному простою в работе системных компонентов.
                 changelog:
-                  description: Изменения включенных модулей в данном релизе. Подробнее об истории изменений в релизах DKP можно почитать в [разделе «Обновление»](../../architecture/updating.html#получение-истории-изменений-changelog).
+                  description: Структура, содержащая список изменений DKP (и модулей, входящих в состав DKP) данного релиза. Подробнее об истории изменений в релизах DKP можно почитать в [разделе «Обновление»](../../architecture/updating.html#получение-истории-изменений-changelog).
                 changelogLink:
                   description: Ссылка на страницу со всеми изменениями данного релиза.
             status:
               properties:
                 phase:
-                  description: |                
-                    Текущий статус релиза. 
+                  description: |
+                    Текущий статус релиза.
 
                     Типичные значения:
 


### PR DESCRIPTION
## Description
DeckhouseRelease documentation review.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: DeckhouseRelease documentation review.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
