### PR TITLE
[prometheus] Fix rebuild of trickster

### DIFF
--- a/modules/300-prometheus/images/trickster/werf.inc.yaml
+++ b/modules/300-prometheus/images/trickster/werf.inc.yaml
@@ -45,6 +45,7 @@ shell:
   install:
   - git clone --depth 1 --branch v{{ $TricksterVersion }} $(cat /run/secrets/SOURCE_REPO)/trickstercache/trickster.git /src/trickster
   - cd /src/trickster
+  - git rev-parse HEAD > GITCOMMIT
   - git apply /patches/*.patch --verbose
   - rm -r vendor
   - rm -rf .git
@@ -65,7 +66,7 @@ secrets:
 shell:
   install:
   - cd /src
-  - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64 COMMIT_HASH={{ $.Commit.Hash }}
+  - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64 COMMIT_HASH="$(cat GITCOMMIT)"
   - |
     export LDFLAGS="-X main.applicationBuildTime=$(date +%Y%m%d-%H:%M:%S) \
     -X main.applicationGitCommitID=${COMMIT_HASH} \


### PR DESCRIPTION
## Description
Fix rebuild of trickster
## Why do we need it, and what problem does it solve?
Trickster rebuilds every time because of incorrect declaration of COMMIT_HASH

## Why do we need it in the patch release (if we do)?

Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: fix
summary: Fixed rebuild of trickster.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
