### PR TITLE
fix cve scan for dkp main image

### DIFF
--- a/.github/scripts/cve_scan.sh
+++ b/.github/scripts/cve_scan.sh
@@ -236,9 +236,9 @@ for d8_tag in "${d8_tags[@]}"; do
     a_module_name=""
     a_image_name=$(echo "${additional_image}" | grep -o '[^/]*$')
     # if it is deckhouse-oss - add it as deckhouse-controller module
-    if [ "${a_image_name}" == "deckhouse-oss" ]; then
+    if [ "${additional_image}" == "${d8_image}" ]; then
       a_module_name="deckhouseController"
-    elif [ "${a_image_name}" == "install" ]; then
+    elif [ "${additional_image}" == "${d8_image}/install" ]; then
       a_module_name="dhctl"
     fi
     echo "----------------------------------------------"


### PR DESCRIPTION
## Description
main image have different name in different registries, so scan for it not working for release tags
Tested prod: https://github.com/deckhouse/deckhouse/actions/runs/20306030955/job/58323594257
Tested dev: https://github.com/deckhouse/deckhouse/actions/runs/20306697731/job/58325995040

## Why do we need it, and what problem does it solve?
Now main image scans correctly for release tags

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: fix cve scan for dkp main image
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
