### PR TITLE
[vertical-pod-autoscaler]  Add matchConditions to ValidatingAdmissionPolicy  for deny-vpa-in-place-mode

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/admission.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/admission.yaml
@@ -13,6 +13,12 @@ spec:
         apiVersions: ["v1", "v2beta2"]
         operations: ["CREATE", "UPDATE"]
         resources: ["verticalpodautoscalers"]
+  matchConditions:
+    - name: 'exclude-users'
+      expression: |
+        !(
+          request.userInfo.username.startsWith("system:serviceaccount:d8-system")
+        )
   validations:
     - expression: >-
         !has(object.spec.updatePolicy) ||


### PR DESCRIPTION
## Description
Add matchConditions to the ValidatingAdmissionPolicy deny-vpa-in-place-mode to exclude requests made by Deckhouse service accounts from the d8-system namespace.

```
{{- if (semverCompare "< 1.33" .Values.global.discovery.kubernetesVersion) }}
---
apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
kind: ValidatingAdmissionPolicy
metadata:
  name: "deny-vpa-in-place-mode"
  {{- include "helm_lib_module_labels" (list . (dict "app" "vpa-updater")) | nindent 2 }}
spec:
  failurePolicy: Fail
  matchConstraints:
    resourceRules:
      - apiGroups: ["autoscaling.k8s.io"]
        apiVersions: ["v1", "v2beta2"]
        operations: ["CREATE", "UPDATE"]
        resources: ["verticalpodautoscalers"]
  *matchConditions:
    - name: 'exclude-users'
      expression: |
        !(
          request.userInfo.username.startsWith("system:serviceaccount:d8-system")
        )*
  validations:
    - expression: >-
        !has(object.spec.updatePolicy) ||
        !has(object.spec.updatePolicy.updateMode) ||
        object.spec.updatePolicy.updateMode != 'InPlaceOrRecreate'
      message: "VerticalPodAutoscaler with updateMode=InPlaceOrRecreate is not allowed before kubernetes 1.33"
---
```
How to check it

On a Kubernetes cluster < 1.33:

Applying/updating a VPA with updateMode: InPlaceOrRecreate as a “regular” user should still be denied.

Applying/updating the same VPA when performed by Deckhouse (service accounts from d8-system) should succeed and should not block module installation/upgrade.

## Why do we need it, and what problem does it solve?
After the change “Replace VPA’s resources updateMode from Auto to InPlaceOrRecreate” (deckhouse/deckhouse#17011), Deckhouse may update/apply VerticalPodAutoscaler objects with updateMode: InPlaceOrRecreate.

On Kubernetes < 1.33, the deny-vpa-in-place-mode ValidatingAdmissionPolicy blocks such updates, which breaks module installation/upgrade performed by Deckhouse (example error):

verticalpodautoscalers.autoscaling.k8s.io ... is forbidden: ValidatingAdmissionPolicy 'deny-vpa-in-place-mode' ... denied request: VerticalPodAutoscaler with updateMode=InPlaceOrRecreate is not allowed before kubernetes 1.33

This PR fixes the issue by skipping the policy for requests made by Deckhouse service accounts in d8-system, while keeping the restriction in place for regular users/workloads.

This PR fixes the issue by skipping the policy for requests made by Deckhouse service accounts in d8-system, while keeping the restriction in place for regular users/workloads.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Add matchConditions to the ValidatingAdmissionPolicy deny-vpa-in-place-mode to exclude requests made by Deckhouse service accounts from the d8-system namespace.

```changes
section: vertical-pod-autoscaler
type: fix
summary: "Exclude d8-system serviceaccounts from vpa  ValidatingAdmissionPolicy"
impact_level: low
```
