### PR TITLE
[prometheus] Add configuration reload failed alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2670,8 +2670,8 @@ alerts:
         The Prometheus configuration reload has failed in the `d8-monitoring` namespace.
 
         This usually happens when:
-        - Invalid scrape configuration (e.g., from ServiceMonitor/PodMonitor resources)
-        - Invalid RemoteWrite configuration
+        - Invalid scrape configuration (e.g., from ServiceMonitor/PodMonitor resources).
+        - Invalid RemoteWrite configuration.
 
         Prometheus will continue running with the old configuration, but new rules, targets, or remote write endpoints will not be active.
         Troubleshooting steps:

--- a/modules/300-prometheus/monitoring/prometheus-rules/base.tpl
+++ b/modules/300-prometheus/monitoring/prometheus-rules/base.tpl
@@ -150,8 +150,8 @@
           The Prometheus configuration reload has failed in the `d8-monitoring` namespace.
 
           This usually happens when:
-          - Invalid scrape configuration (e.g., from ServiceMonitor/PodMonitor resources)
-          - Invalid RemoteWrite configuration
+          - Invalid scrape configuration (e.g., from ServiceMonitor/PodMonitor resources).
+          - Invalid RemoteWrite configuration.
 
           Prometheus will continue running with the old configuration, but new rules, targets, or remote write endpoints will not be active.
           Troubleshooting steps:


### PR DESCRIPTION
## Description
Add `D8PrometheusConfigReloadFailed` alert. 

## Why do we need it, and what problem does it solve?
Sometimes the Prometheus Operator accepts invalid Prometheus custom resources that result in a broken configuration file. This causes Prometheus configuration reloads to fail silently. This alert addresses this issue.
 
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: feature
summary: Add prometheus configuration reload failed alert
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
