### PR TITLE
[istio] Improve federation discovery observability by logging published services count

### DIFF
--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -228,6 +229,11 @@ func federationDiscovery(_ context.Context, input *go_hook.HookInput, dc depende
 		if err != nil {
 			return err
 		}
+		var countServices = 0
+		if privateMetadata.PublicServices != nil {
+			countServices = len(*privateMetadata.PublicServices)
+		}
+		input.Logger.Info(fmt.Sprintf("Cluster name: %s connected successfully, published services: %s", myTrustDomain, strconv.Itoa(countServices)))
 	}
 	return nil
 }

--- a/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery_test.go
@@ -222,7 +222,7 @@ status:
 
 		It("Hook must execute successfully", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(string(f.LoggerOutput.Contents())).To(HaveLen(0))
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("\"msg\":\"Cluster name: my.cluster connected successfully, published services: 2\""))
 
 			tPub0, err := time.Parse(time.RFC3339, f.KubernetesGlobalResource("IstioFederation", "proper-federation-0").Field("status.metadataCache.publicLastFetchTimestamp").String())
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
## Description
Added published services count to the federation discovery log messages to improve observability in Federation mode. The message is emitted примерно раз в минуту and written to the federation discovery hook log.

To get the log run `kubectl -n d8-system logs deploy/deckhouse`
Example of the message: `{"level":"info","logger":"auto-hook-logger","msg":"Cluster name: cluster.local connected successfully, published services: 0","binding":"schedule","binding.name":"cron","event.id":"8561f429-4e13-408b-b5e3-ea5d682fd060","hook":"110-istio/hooks/ee/federation_discovery.go","h
ook.type":"module","module":"istio","output":"gohook","path":"/modules/110-istio/hooks/ee/federation_discovery.go","queue":"/modules/istio/federation","task.id":"17706e44-80a1-4fd8-963f-2cdb524787d0","time":"2026-01-14T08:58:00Z"}`

## Why do we need it, and what problem does it solve?
Initialization starts with connect to a cluster and publishes some services.
Before current fixes we don't see info about published services.
After the current fixes have done its shown in the hook of log of federation discovery.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Improved federation discovery observability by logging published services count.
impact_level: default
```
