### PR TITLE
[cloud-provider-dvp] Refactor hasDiskAttachedToVM method

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -463,18 +463,34 @@ func (c *ComputeService) RemoveVMLabelByHostname(ctx context.Context, hostname, 
 
 func (c *ComputeService) WaitDiskAttaching(ctx context.Context, vmBDAName string) error {
 	klog.Infof("WaitDiskAttaching vmBDA %s", vmBDAName)
+
 	return c.Wait(ctx, vmBDAName, &v1alpha2.VirtualMachineBlockDeviceAttachment{}, func(obj client.Object) (bool, error) {
+		if obj == nil {
+			klog.Infof("vmBDA %s not found yet; still waiting for creation", vmBDAName)
+			return false, nil
+		}
+
 		vmBDA, ok := obj.(*v1alpha2.VirtualMachineBlockDeviceAttachment)
-		if !ok {
+		if !ok || vmBDA == nil {
 			return false, fmt.Errorf("expected a VirtualMachineBlockDeviceAttachment but got a %T", obj)
 		}
-		klog.Infof("Phase vmBDA %s: %s", vmBDAName, vmBDA.Status.Phase)
 
-		if vmBDA.Status.Phase == v1alpha2.BlockDeviceAttachmentPhaseFailed {
-			return false, fmt.Errorf("disk attaching error to the vm, please check status VirtualMachineBlockDeviceAttachment %s in the parent cluster", vmBDAName)
+		phase := vmBDA.Status.Phase
+
+		if phase == v1alpha2.BlockDeviceAttachmentPhaseAttached {
+			klog.Infof("vmBDA %s is Attached", vmBDAName)
+		} else {
+			klog.Infof("vmBDA %s exists but still not attached: phase=%s", vmBDAName, phase)
 		}
 
-		return vmBDA.Status.Phase == v1alpha2.BlockDeviceAttachmentPhaseAttached, nil
+		if phase == v1alpha2.BlockDeviceAttachmentPhaseFailed {
+			return false, fmt.Errorf(
+				"disk attaching error to the vm, please check status VirtualMachineBlockDeviceAttachment %s in the parent cluster",
+				vmBDAName,
+			)
+		}
+
+		return phase == v1alpha2.BlockDeviceAttachmentPhaseAttached, nil
 	})
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR gives a lot more informational errors and messages to user
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Now It's hard to understand what module of Deckhouse is really cause the error in VMBDA

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: this PR gives a lot more informational errors and messages to user
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
