### PR TITLE
[kube-dns] Added test remove_old_coredns_rbac_and_cm_test.go

### DIFF
--- a/modules/042-kube-dns/hooks/remove_old_coredns_rbac_and_cm_test.go
+++ b/modules/042-kube-dns/hooks/remove_old_coredns_rbac_and_cm_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+const kubeDNSResources = `
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:coredns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:coredns
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+`
+
+var _ = Describe("KubeDns hooks :: removeKubeDNSRBACAndConfigMap", func() {
+	f := HookExecutionConfigInit("", "")
+
+	Context("All kube-dns RBAC and ConfigMap exist", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(kubeDNSResources), f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Hook executes successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("All resources are marked for deletion", func() {
+			expectResourcesDeleted(f)
+		})
+	})
+
+	Context("All kube-dns RBAC and ConfigMap do not exist", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.RunHook()
+		})
+
+		It("Hook executes successfully", func() {
+			Expect(f).To(ExecuteSuccessfully())
+		})
+
+		It("All resources are marked for deletion", func() {
+			expectResourcesDeleted(f)
+		})
+	})
+})
+
+func expectResourcesDeleted(f *HookExecutionConfig) {
+	Expect(f.KubernetesResource("ClusterRole", "", "system:coredns").Exists()).To(BeFalse())
+	Expect(f.KubernetesResource("ClusterRoleBinding", "", "system:coredns").Exists()).To(BeFalse())
+	Expect(f.KubernetesResource("ServiceAccount", "kube-system", "coredns").Exists()).To(BeFalse())
+	Expect(f.KubernetesResource("ConfigMap", "kube-system", "coredns").Exists()).To(BeFalse())
+}


### PR DESCRIPTION
## Description
This pull request adds a new test for the `remove_old_coredns_rbac_and_cm.go hook`. The test verifies the hook’s behavior and ensures it works as expected under defined conditions.

## Why do we need it, and what problem does it solve?
Previously, this hook was not covered by any tests, which made it harder to ensure its correctness and prevent regressions. By adding this test, we improve test coverage, increase confidence in future changes, and reduce the risk of unnoticed breaking changes.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: kube-dns
type: chore
summary: Added test remove_old_coredns_rbac_and_cm_test.go
impact_level: low
```
