### PR TITLE
[docs] Update documentation pages layout to better use on a small screen

### DIFF
--- a/docs/site/assets/css/docs.scss
+++ b/docs/site/assets/css/docs.scss
@@ -32,7 +32,7 @@
   }
 
   .breadcrumbs__container {
-    min-width: calc(1000px - 260px - 40px);
+    min-width: calc(1000px - 150px - 260px - 40px);
   }
 
   .searchV3 {
@@ -458,7 +458,7 @@
 }
 
 .layout-sidebar__content {
-    min-width: calc(1000px - 260px - 40px);
+    min-width: calc(1000px - 150px - 260px - 40px);
     flex: 1;
 
     @media screen and (max-width: 1000px) {


### PR DESCRIPTION
## Description

This pull request makes minor adjustments to the minimum width calculations for certain layout elements in the documentation site's CSS. The changes ensure that both the breadcrumbs container and the sidebar content account for an additional 150px in their minimum width formulas.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update documentation pages layout to better use on a small screen.
impact_level: low
```
