### PR TITLE
[docs] Fix Makefile Docker registry check condition

### DIFF
--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -6,7 +6,7 @@ endif
 .DEFAULT_GOAL := help
 
 registry: ## Start local Docker registry
-		@if ! docker ps | grep -q registry ; then \
+		@if [ -z "$$(docker ps --filter name=registry --format '{{.Names}}')" ]; then \
 			docker rm -f registry 2>/dev/null 1>/dev/null; \
 			docker run -d -p 4999:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true --restart=always --name registry registry:2 ; \
 		fi


### PR DESCRIPTION
## Description

This pull request makes a minor improvement to the Docker registry startup logic in the `docs/site/Makefile`. The change updates the check for an existing `registry` container to be more robust and reliable.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix Makefile Docker registry check condition.
impact_level: low
```
