### PR TITLE
[docs] Update redirects for module channels in configuration files

### DIFF
--- a/docs/site/.helm/templates/10-cm-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/10-cm-moduleslibrary.yaml
@@ -82,6 +82,7 @@ data:
 
         rewrite ^/modules$ /modules/ redirect;
         rewrite ^/modules/(?<module>[^/.]+)$ /modules/$module/ redirect;
+        rewrite ^/modules/(?<module>[^/.]+)/(?<channel>alpha|beta|early-access|stable|rock-solid)$ /modules/$module/$channel/ redirect;
 
         location /link_test_report.txt {
             deny all;

--- a/modules/810-documentation/templates/configmap.yaml
+++ b/modules/810-documentation/templates/configmap.yaml
@@ -103,6 +103,7 @@ data:
         rewrite ^/$ /$redirection_lang/$is_args$args redirect;
         rewrite ^/(ru/|en/)?modules$ /$redirection_lang/modules/$is_args$args redirect;
         rewrite ^/(ru/|en/)?modules/(?<module>[^/.]+)$ /$redirection_lang/modules/$module/$is_args$args redirect;
+        rewrite ^/(ru/|en/)?modules/(?<module>[^/.]+)/(?<channel>alpha|beta|early-access|stable|rock-solid)$ /modules/$module/$channel/ redirect;
         rewrite ^/?!(ru/|en/|assets/|css/|js/|images/|presentations/|includes/|[a-z0-9]+\.[a-z0-9]+).*$ /$redirection_lang/$uri$is_args$args redirect;
         rewrite ^/modules/.+$ /$redirection_lang$uri$is_args$args redirect;
         rewrite ^/(products/kubernetes-platform/)?documentation/v[\d]+[^\/]*/(?<path>.*)?$ /$redirection_lang/$path$is_args$args redirect;


### PR DESCRIPTION
## Description

This pull request updates the URL rewriting rules in two configuration files to improve support for module channels (such as alpha, beta, early-access, stable, and rock-solid) in module URLs. The changes ensure that requests to these channel-specific module URLs are properly redirected.

Updates: https://github.com/deckhouse/deckhouse/pull/17202

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update redirects for module channels in configuration files.
impact_level: low
```
