### PR TITLE
[docs] Update supported versions table, K8s version and d8 version extraction

### DIFF
--- a/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
+++ b/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
@@ -71,7 +71,7 @@
     {%- for k8sItem in k8sVersions %}
     {%- assign k8sStatus = k8sItem[1].status | default: 'preview' %}
     {%- assign iconStatus = k8sStatus| append: '.svg' | prepend: '/images/icons/' %}
-    <tr {%- if k8sItem[0] == site.data.version_kubernetes.default %} class="highlight-default"{% endif %}>
+    <tr {%- if k8sItem[1].default %} class="highlight-default"{% endif %}>
       <td style="text-align: center">
         <div class="icon">
           <img src="{{ iconStatus }}" alt="" />

--- a/docs/documentation/werf-documentation-static.inc.yaml
+++ b/docs/documentation/werf-documentation-static.inc.yaml
@@ -28,12 +28,9 @@ shell:
         echo "Render global OpenAPI DKP schemas..."
         bash _tools/prepare_resources.sh
 
-        echo '[] Extracting the default Kubernetes version...'
-        echo "default: \"$(grep "DefaultKubernetesVersion" -m 1 _data/dhctl-base.go | grep -Eo '[0-9.]+')\"" > _data/version_kubernetes.yml
-
         echo '[] Filling in the array of supported OS & K8S versions...'
         cd _data
-        yq eval-all 'select(fileIndex == 0) * {"k8s": select(fileIndex == 1).k8s}' supported_versions.yml version_map.yml > supported_versions.yml.tmp && mv supported_versions.yml.tmp supported_versions.yml && rm version_map.yml
+        yq eval-all -i 'select(fileIndex == 0) * {"k8s": select(fileIndex == 1).k8s, "d8": select(fileIndex == 1).d8}' supported_versions.yml version_map.yml
 
         echo '[] Converting editions structure...'
         yq e -o json editions-repo-data.yaml | jq -M 'reduce .editions[] as $item ({}; .[$item.name | ascii_downcase] = $item)' | jq -Ms '.[0] * .[1]' - modules/editions-addition.json | jq '. as $editions | input as $be | .["be"].excludeModules += $be.excludeModules' - modules/be-addition.json > editions.json

--- a/docs/documentation/werf-git-section.inc.yaml
+++ b/docs/documentation/werf-git-section.inc.yaml
@@ -17,12 +17,6 @@
   group: jekyll
   stageDependencies:
     setup: ['**/*']
-- add: /dhctl/pkg/config/base.go
-  to: /srv/jekyll-data/documentation/_data/dhctl-base.go
-  owner: jekyll
-  group: jekyll
-  stageDependencies:
-    setup: ['**/*']
 - add: /global-hooks/openapi
   to: /src/global
   owner: jekyll


### PR DESCRIPTION
## Description

This pull request updates the handling of default Kubernetes version and Deckhouse CLI information in the documentation build process and fix how supported versions are rendered in the documentation.

Documentation rendering improvements:

* The logic for highlighting the default Kubernetes version in the supported versions table was updated to use the `default` property from the data source instead of matching by version string. (`docs/documentation/_includes/SUPPORTED_VERSIONS.liquid`)
* Fix getting Deckhouse CLI version.
* The step that extracted the default Kubernetes version into a separate YAML file was removed, and the merging of supported versions data now includes both `k8s` and `d8` keys for completeness. (`docs/documentation/werf-documentation-static.inc.yaml`)
* The step that copied `/dhctl/pkg/config/base.go` to the Jekyll data directory was removed, cleaning up unnecessary file operations in the build process. (`docs/documentation/werf-git-section.inc.yaml`)

Fix: #16459

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update supported versions table, K8s version and d8 version extraction.
impact_level: low
```
