### PR TITLE
[docs] Update operator-trivy module details

### DIFF
--- a/docs/documentation/_data/modules/embedded_modules_tags.json
+++ b/docs/documentation/_data/modules/embedded_modules_tags.json
@@ -171,9 +171,6 @@
   "operator-prometheus": [
     "observability"
   ],
-  "operator-trivy": [
-    "security"
-  ],
   "pod-reloader": [
     "core"
   ],

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -50,7 +50,7 @@
     ],
     "external": "true",
     "path": "/modules/code/stable/"
-  }, 
+  },
   "managed-postgres": {
     "editions": [
       "ee"
@@ -316,6 +316,15 @@
     },
     "external": "true",
     "path": "/modules/operator-argo/stable/"
+  },
+  "operator-trivy": {
+    "editions": [
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "external": "true",
+    "path": "/modules/operator-trivy/"
   },
   "payload-registry": {
     "editions": [

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -324,6 +324,18 @@
     "external": "true",
     "path": "/modules/operator-argo/stable/"
   },
+  "operator-trivy": {
+    "editions": [
+      "ee",
+      "cse-lite",
+      "cse-pro"
+    ],
+    "external": "true",
+    "path": "/modules/operator-trivy/",
+    "tags": [
+      "security"
+    ],
+  },
   "pod-reloader": {
     "tags": [
       "core"


### PR DESCRIPTION
## Description

This pull request updates the documentation data to add the `operator-trivy` module as an external module, ensuring it is included in the module listings and properly tagged for discoverability. The changes preserve the `security` tag for `operator-trivy` module.

Ref: https://github.com/deckhouse/deckhouse/pull/16328

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update operator-trivy module details.
impact_level: low
```
