### PR TITLE
[docs][user-authn] Remove old certSANs instruction from masterURI desc.

### DIFF
--- a/modules/150-user-authn/openapi/config-values.yaml
+++ b/modules/150-user-authn/openapi/config-values.yaml
@@ -75,9 +75,9 @@ properties:
         masterURI:
           type: string
           description: |
-            If you plan to use a TCP proxy, then you must configure a certificate on the API server's side for the TCP proxy address.
+            If you plan to use a TCP proxy, you must configure a certificate for the TCP proxy address on the API server side.
 
-            Suppose your API servers use three different addresses (`192.168.0.10`, `192.168.0.11`, and `192.168.0.12`) while the client uses a TCP load balancer (say, `192.168.0.15`). In this case, you need to add the new address (`192.168.0.15`) to [apiserver.certSANs](/modules/control-plane-manager/configuration.html#parameters-apiserver-certsans) parameter in `control-plane-manager` configuration.
+            For example, if the API server is available via three addresses (`192.168.0.10`, `192.168.0.11`, and `192.168.0.12`) while the client accesses the API server through a TCP load balancer (for example, `192.168.0.15`), you must add the TCP load balancer address to the [`apiserver.certSANs`](/modules/control-plane-manager/configuration.html#parameters-apiserver-certsans) parameter in the `control-plane-manager` configuration.
         description:
           type: string
           description: |

--- a/modules/150-user-authn/openapi/config-values.yaml
+++ b/modules/150-user-authn/openapi/config-values.yaml
@@ -75,13 +75,9 @@ properties:
         masterURI:
           type: string
           description: |
-            If you plan to use a TCP proxy, then you must configure a certificate on the API server's side for the TCP proxy address. Suppose your API servers use three different addresses (`192.168.0.10`, `192.168.0.11`, and `192.168.0.12`) while the client uses a TCP load balancer (say, `192.168.0.15`). In this case, you have to re-generate the API server certificates:
-            * edit `kubeadm-config`: `d8 k -n kube-system edit configmap kubeadm-config` and add `192.168.0.15` to `.apiServer.certSANs`;
-            * save the resulting config: `kubeadm config view > kubeadmconf.yaml`;
-            * delete old API server certificates: `mv /etc/kubernetes/pki/apiserver.* /tmp/`;
-            * reissue new certificates: `kubeadm init phase certs apiserver --config=kubeadmconf.yaml`;
-            * restart the API server's container: `docker ps -a | grep 'kube-apiserver' | grep -v pause| awk '{print $1}' | xargs docker restart`;
-            * repeat this step for all master nodes.
+            If you plan to use a TCP proxy, then you must configure a certificate on the API server's side for the TCP proxy address.
+
+            Suppose your API servers use three different addresses (`192.168.0.10`, `192.168.0.11`, and `192.168.0.12`) while the client uses a TCP load balancer (say, `192.168.0.15`). In this case, you need to add the new address (`192.168.0.15`) to [apiserver.certSANs](/modules/control-plane-manager/configuration.html#parameters-apiserver-certsans) parameter in `control-plane-manager` configuration.
         description:
           type: string
           description: |

--- a/modules/150-user-authn/openapi/doc-ru-config-values.yaml
+++ b/modules/150-user-authn/openapi/doc-ru-config-values.yaml
@@ -46,7 +46,7 @@ properties:
           description: |
             Если планируется использовать TCP-прокси, для адреса TCP-прокси должен быть сконфигурирован сертификат на стороне API-сервера.
 
-            Например, в случае, если API-сервер доступен по трем адресам (`192.168.0.10`, `192.168.0.11` и `192.168.0.12`), а ходить к API-серверу клиент будет через TCP-балансер (например, `192.168.0.15`), необходимо добавить новый адрес в параметр [apiserver.certSANs](/modules/control-plane-manager/configuration.html#parameters-apiserver-certsans) в настройках `control-plane-manager`.
+            Например, если API-сервер доступен по трем адресам (`192.168.0.10`, `192.168.0.11` и `192.168.0.12`), а клиент обращается к API-серверу через TCP-балансер (например, `192.168.0.15`), необходимо добавить адрес TCP-балансера в [параметр `apiserver.certSANs`](/modules/control-plane-manager/configuration.html#parameters-apiserver-certsans) в настройках модуля `control-plane-manager`.
         masterCA:
           description: |
             CA для доступа к API-серверу.

--- a/modules/150-user-authn/openapi/doc-ru-config-values.yaml
+++ b/modules/150-user-authn/openapi/doc-ru-config-values.yaml
@@ -44,13 +44,9 @@ properties:
           description: 'Имя способа доступа к API-серверу (без пробелов, маленькими буквами).'
         masterURI:
           description: |
-            Если планируется использовать TCP-прокси, для адреса TCP-прокси должен быть сконфигурирован сертификат на стороне API-сервера. Например, в случае, если API-сервер доступен по трем адресам (`192.168.0.10`, `192.168.0.11` и `192.168.0.12`), а ходить к API-серверу клиент будет через TCP-балансер (например, `192.168.0.15`), необходимо перегенерировать сертификаты для API-серверов:
-            * отредактировать `kubeadm-config`: `d8 k -n kube-system edit configmap kubeadm-config`, добавив в `.apiServer.certSANs` адрес `192.168.0.15`;
-            * сохранить получившийся конфиг: `kubeadm config view > kubeadmconf.yaml`;
-            * удалить старые сертификаты API-сервера: `mv /etc/kubernetes/pki/apiserver.* /tmp/`;
-            * перевыпустить новые сертификаты: `kubeadm init phase certs apiserver --config=kubeadmconf.yaml`;
-            * перезапустить контейнер с API-сервером: `docker ps -a | grep 'kube-apiserver' | grep -v pause| awk '{print $1}' | xargs docker restart`;
-            * повторить данное действие для всех master-узлов.
+            Если планируется использовать TCP-прокси, для адреса TCP-прокси должен быть сконфигурирован сертификат на стороне API-сервера.
+
+            Например, в случае, если API-сервер доступен по трем адресам (`192.168.0.10`, `192.168.0.11` и `192.168.0.12`), а ходить к API-серверу клиент будет через TCP-балансер (например, `192.168.0.15`), необходимо добавить новый адрес в параметр [apiserver.certSANs](/modules/control-plane-manager/configuration.html#parameters-apiserver-certsans) в настройках `control-plane-manager`.
         masterCA:
           description: |
             CA для доступа к API-серверу.


### PR DESCRIPTION
## Description
Remove old certSANs instruction from masterURI description

## Why do we need it, and what problem does it solve?
Now we don't have to edit CMs or manually invoke kubeadm, we have [control-plane-mananger parameter](https://deckhouse.io/modules/control-plane-manager/configuration.html#parameters-apiserver-certsans) for that.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: chore
summary: Remove old certSANs instruction from masterURI description
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
