### PR TITLE
[deckhouse-controller] Backport 1.74 fix copy-custom-certificate hook 

### DIFF
--- a/go_lib/hooks/copy_custom_certificate/hook.go
+++ b/go_lib/hooks/copy_custom_certificate/hook.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -130,7 +131,7 @@ func copyCustomCertificatesHandler(moduleName string) func(_ context.Context, in
 		}
 
 		if len(ca) > 0 {
-			vc.CA = string(ca)
+			vc.CA = strings.TrimSpace(string(ca))
 		}
 
 		tlsKey, err := base64.StdEncoding.DecodeString(c.TLSKey)
@@ -139,7 +140,7 @@ func copyCustomCertificatesHandler(moduleName string) func(_ context.Context, in
 		}
 
 		if len(tlsKey) > 0 {
-			vc.TLSKey = string(tlsKey)
+			vc.TLSKey = strings.TrimSpace(string(tlsKey))
 		}
 
 		tlsCert, err := base64.StdEncoding.DecodeString(c.TLSCert)
@@ -148,7 +149,7 @@ func copyCustomCertificatesHandler(moduleName string) func(_ context.Context, in
 		}
 
 		if len(tlsCert) > 0 {
-			vc.TLSCert = string(tlsCert)
+			vc.TLSCert = strings.TrimSpace(string(tlsCert))
 		}
 
 		input.Values.Set(path, vc)
@@ -158,13 +159,13 @@ func copyCustomCertificatesHandler(moduleName string) func(_ context.Context, in
 }
 
 type dataCert struct {
-	CA      string `yaml:"ca.crt,omitempty"`
-	TLSKey  string `yaml:"tls.key,omitempty"`
-	TLSCert string `yaml:"tls.crt,omitempty"`
-}
-
-type valuesCert struct {
 	CA      string `json:"ca.crt,omitempty"`
 	TLSKey  string `json:"tls.key,omitempty"`
 	TLSCert string `json:"tls.crt,omitempty"`
+}
+
+type valuesCert struct {
+	CA      string `json:"ca.crt,omitempty" yaml:"ca.crt,omitempty"`
+	TLSKey  string `json:"tls.key,omitempty" yaml:"tls.key,omitempty"`
+	TLSCert string `json:"tls.crt,omitempty" yaml:"tls.crt,omitempty"`
 }

--- a/modules/000-common/hooks/copy_custom_certificate_test.go
+++ b/modules/000-common/hooks/copy_custom_certificate_test.go
@@ -42,6 +42,8 @@ kind: Secret
 metadata:
   name: d8-tls-cert
   namespace: d8-system
+  labels:
+    owner: deckhouse
 type: kubernetes.io/tls
 `
 	)
@@ -103,8 +105,8 @@ type: kubernetes.io/tls
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("common.internal.customCertificateData").Exists()).To(BeTrue())
 			Expect(f.ValuesGet("common.internal.customCertificateData").String()).To(MatchYAML(`
-tls.crt: Q1JUQ1JUQ1JUCg==
-tls.key: S0VZS0VZS0VZCg==
+tls.crt: CRTCRTCRT
+tls.key: KEYKEYKEY
 `))
 
 		})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backport: https://github.com/deckhouse/deckhouse/pull/17228

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: fix copy-custom-certificate hook
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
