### PR TITLE
Fix nc shutdown inhibitor backport 1.74

### DIFF
--- a/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
+++ b/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
@@ -76,7 +76,6 @@ Wants=network-online.target kubelet.service containerd-deckhouse.service
 After=network-online.target kubelet.service containerd-deckhouse.service
 [Service]
 Environment="PATH=/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
-ExecStartPre=/bin/bash -c 'until /opt/deckhouse/bin/nc -z 127.0.0.1 6445; do sleep 1; done'
 ExecStart=/opt/deckhouse/bin/d8-shutdown-inhibitor{{ if $noCordon }} --no-cordon{{ end }}
 Restart=always
 StartLimitInterval=0

--- a/candi/bashible/common-steps/all/098_cleanup.sh.tpl
+++ b/candi/bashible/common-steps/all/098_cleanup.sh.tpl
@@ -28,3 +28,5 @@ rm -f "$BB_YUM_UNHANDLED_PACKAGES_STORE"
 find /.kubeadm.checksum -mmin +120 -delete >/dev/null 2>&1 || true
 
 rm -f /var/lib/bashible/first_run
+
+bb-package-remove "netcat"

--- a/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/cmd/d8-shutdown-inhibitor/main.go
+++ b/ee/modules/040-node-manager/images/d8-shutdown-inhibitor/src/cmd/d8-shutdown-inhibitor/main.go
@@ -12,11 +12,13 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"d8_shutdown_inhibitor/pkg/app"
 	"d8_shutdown_inhibitor/pkg/kubernetes"
 
 	dlog "github.com/deckhouse/deckhouse/pkg/log"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func run(cordonEnabled bool) error {
@@ -25,11 +27,40 @@ func run(cordonEnabled bool) error {
 		dlog.Fatal("failed to get hostname", dlog.Err(err))
 	}
 
-	// Start application.
-	kubeClient, err := kubernetes.NewClientFromKubeconfig(kubernetes.KubeConfigPath)
-	if err != nil {
-		dlog.Fatal("failed to create kubernetes client", dlog.Err(err))
+	// Wait for kube-apiserver to be available before creating client
+	var kubeClient *kubernetes.Klient
+	dlog.Info("waiting for kube-apiserver to be available")
+
+	backoff := wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   1.5,
+		Jitter:   0.1,
+		Steps:    20, // ~5 minutes total
 	}
+
+	err = wait.ExponentialBackoff(backoff, func() (bool, error) {
+		client, err := kubernetes.NewClientFromKubeconfig(kubernetes.KubeConfigPath)
+		if err != nil {
+			dlog.Warn("failed to create kubernetes client, retrying", dlog.Err(err))
+			return false, nil
+		}
+
+		// Test connectivity by making a simple API call
+		_, err = client.Clientset().Discovery().ServerVersion()
+		if err != nil {
+			dlog.Warn("kube-apiserver not ready, retrying", dlog.Err(err))
+			return false, nil
+		}
+
+		kubeClient = client
+		return true, nil
+	})
+
+	if err != nil {
+		dlog.Fatal("failed to connect to kube-apiserver after retries", dlog.Err(err))
+	}
+
+	dlog.Info("successfully connected to kube-apiserver")
 	a := app.NewApp(app.AppConfig{
 		PodLabel:              app.InhibitNodeShutdownLabel,
 		InhibitDelayMax:       app.InhibitDelayMaxSec,


### PR DESCRIPTION
## Description
Fix nc shutdown inhibitor backport 1.74 https://github.com/deckhouse/deckhouse/pull/17153
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Fix nc shutdown inhibitor backport 1.74 https://github.com/deckhouse/deckhouse/pull/17153

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
No need

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: remove excessive netcat calls from d8-shutdown-inhibitor
impact_level: default 
```

```changes
section: node-manager
type: fix
summary: remove excessive netcat calls from d8-shutdown-inhibitor
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
