### PR TITLE
[deckhouse] fix module documentation ignorance due to symlink

### DIFF
--- a/deckhouse-controller/internal/module/installer/symlink/installer.go
+++ b/deckhouse-controller/internal/module/installer/symlink/installer.go
@@ -119,12 +119,8 @@ func (i *Installer) Install(ctx context.Context, module, version, tempModulePath
 		}
 	}
 
-	// Compute relative path: ../<module>/<version>
-	// IT IS VERY IMPORTANT TO USE RELATIVE
-	relativeTarget := filepath.Join("..", module, version)
-
 	// Create new symlink pointing to permanent location
-	if err := os.Symlink(relativeTarget, symlinkPoint); err != nil {
+	if err := os.Symlink(versionPath, symlinkPoint); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("create symlink '%s': %w", symlinkPoint, err)
 	}
@@ -232,12 +228,8 @@ func (i *Installer) Restore(ctx context.Context, ms *v1alpha1.ModuleSource, modu
 		}
 	}
 
-	// Compute relative path: ../<module>/<version>
-	// IT IS VERY IMPORTANT TO USE RELATIVE
-	relativeTarget := filepath.Join("..", module, version)
-
 	// Create symlink pointing to permanent location
-	if err := os.Symlink(relativeTarget, symlinkPoint); err != nil {
+	if err := os.Symlink(versionPath, symlinkPoint); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("create symlink '%s': %w", modulePath, err)
 	}


### PR DESCRIPTION
## Description
It fixes module documentation ignorance due to symlink.

## Why do we need it, and what problem does it solve?
`filepath.Walk` cant work with symlink, we should evolve it before walking 

After fix:
```
...
{"level":"debug","logger":"deckhouse-controller.module-documentation-controller","msg":"copy file","source":"deckhouse/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go:405","path":"/deckhouse/downloaded/console/v1.42.9/docs/README_RU.md","time":"2025-12-23T00:06:52Z"}
{"level":"debug","logger":"deckhouse-controller.module-documentation-controller","msg":"copy file","source":"deckhouse/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go:405","path":"/deckhouse/downloaded/console/v1.42.9/docs/RELEASE_NOTES.md","time":"2025-12-23T00:06:52Z"}
{"level":"debug","logger":"deckhouse-controller.module-documentation-controller","msg":"copy file","source":"deckhouse/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go:405","path":"/deckhouse/downloaded/console/v1.42.9/docs/RELEASE_NOTES.ru.md","time":"2025-12-23T00:06:52Z"}
{"level":"debug","logger":"deckhouse-controller.module-documentation-controller","msg":"copy file","source":"deckhouse/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go:405","path":"/deckhouse/downloaded/console/v1.42.9/docs/images/screenshot-sys-overview.png","time":"2025-12-23T00:06:52Z"}
...
```

## Why do we need it in the patch release (if we do)?
Without this fix docs not rendered when symlink installer in use.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix module docs rendering.
```
