### PR TITLE
[node-manager] bashible-apiserver retry on start failed

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/registry/bashible/bashible/storage.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/registry/bashible/bashible/storage.go
@@ -17,6 +17,9 @@ limitations under the License.
 package bashible
 
 import (
+	"bashible-apiserver/pkg/apis/bashible"
+	"bashible-apiserver/pkg/template"
+	"bashible-apiserver/pkg/util"
 	"errors"
 	"fmt"
 	"os"
@@ -25,10 +28,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"bashible-apiserver/pkg/apis/bashible"
-	"bashible-apiserver/pkg/template"
-	"bashible-apiserver/pkg/util"
 )
 
 const templateName = "bashible.sh.tpl"

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/registry/bashible/bootstrap/storage.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/registry/bashible/bootstrap/storage.go
@@ -17,6 +17,9 @@ limitations under the License.
 package bootstrap
 
 import (
+	"bashible-apiserver/pkg/apis/bashible"
+	"bashible-apiserver/pkg/template"
+	"bashible-apiserver/pkg/util"
 	"errors"
 	"fmt"
 	"os"
@@ -25,10 +28,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"bashible-apiserver/pkg/apis/bashible"
-	"bashible-apiserver/pkg/template"
-	"bashible-apiserver/pkg/util"
 )
 
 const templateName = "03-prepare-bashible.sh.tpl"

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/registry/bashible/nodegroupbundle/storage.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/registry/bashible/nodegroupbundle/storage.go
@@ -17,16 +17,15 @@ limitations under the License.
 package nodegroupbundle
 
 import (
+	"bashible-apiserver/pkg/apis/bashible"
+	"bashible-apiserver/pkg/template"
+	"bashible-apiserver/pkg/util"
 	"errors"
 	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-
-	"bashible-apiserver/pkg/apis/bashible"
-	"bashible-apiserver/pkg/template"
-	"bashible-apiserver/pkg/util"
 )
 
 // NewStorage returns a RESTStorage object that will work against API services.

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/requestlog/requestlog.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/requestlog/requestlog.go
@@ -33,8 +33,10 @@ import (
 type contextKey string
 
 const (
-	requestIDKey     contextKey = "bashible-request-id"
-	bashibleAPIGroup            = "bashible.deckhouse.io"
+	requestIDKey       contextKey = "bashible-request-id"
+	checksumAnnotation            = "bashible.deckhouse.io/configuration-checksum"
+	bashibles_uri                 = "/apis/bashible.deckhouse.io"
+	bashibleAPIGroup              = "bashible.deckhouse.io"
 )
 
 func WithRequestLogging(next http.Handler) http.Handler {

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/util/checksum.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/util/checksum.go
@@ -17,9 +17,9 @@ limitations under the License.
 package util
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"bashible-apiserver/pkg/template"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const ConfigurationChecksumAnnotation = "bashible.deckhouse.io/configuration-checksum"

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/util/retry/retry.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/util/retry/retry.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+var DefaultKubeAPIRetryBackoff = wait.Backoff{
+	Duration: 5 * time.Second,
+	Factor:   1.5,
+	Jitter:   0.1,
+	Cap:      1 * time.Minute,
+}
+
+
+func DoWithRetry(ctx context.Context, name string, backoff wait.Backoff, fn func(ctx context.Context) (bool, error)) error {
+	if backoff.Duration <= 0 {
+		backoff.Duration = time.Second
+	}
+	if backoff.Cap <= 0 {
+		backoff.Cap = backoff.Duration
+	}
+
+	delay := backoff.Duration
+	for {
+		syncCtx, cancel := context.WithTimeout(ctx, backoff.Cap)
+		done, err := fn(syncCtx)
+		cancel()
+
+		if done {
+			return nil
+		}
+		if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return fmt.Errorf("%s stopped: %w", name, ctx.Err())
+		}
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			klog.Warningf("%s attempt failed: %v", name, err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s stopped: %w", name, ctx.Err())
+		case <-time.After(delay):
+		}
+
+		nextDelay := time.Duration(float64(delay) * backoff.Factor)
+		if nextDelay > backoff.Cap {
+			nextDelay = backoff.Cap
+		}
+		delay = nextDelay
+	}
+}
+
+
+func RetryWithBackoff(ctx context.Context, name string, backoff wait.Backoff, fn func(ctx context.Context) (bool, error)) error {
+	return DoWithRetry(ctx, name, backoff, fn)
+}
+


### PR DESCRIPTION
## Description

During bootstrap, the control plane may be restarted. If this coincides with the startup of `bashible-apiserver`, it fails with an error when accessing the Kubernetes API. To avoid `bashible-apiserver` crashing during cluster bootstrap, retry logic has been added for these operations.

```
W1224 07:20:32.660193       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.10/tools/cache/reflector.go:229: failed to list *v1.ConfigMap: Get "https://10.223.0.1:443/api/v1/namespaces/kube-system/configmaps?fieldSelector=metadata.name%3Dextension-apiserver-authentication&limit=500&resourceVersion=0": dial tcp 10.223.0.1:443: connect: connection refused
```

## Why do we need it, and what problem does it solve?

It is undesirable for the `bashible-apiserver` Pod to restart during bootstrap, as in some rare cases this negatively affects the bootstrap process.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Added bashible-apiserver retry on start failed.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
