### PR TITLE
fix prometheus rules and test

### DIFF
--- a/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_prometheus_rules.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_monitoring_prometheus_rules.tpl
@@ -51,9 +51,10 @@
     {{- $useObservabilityRules := has "observability.deckhouse.io/v1alpha1/ClusterObservabilityMetricsRulesGroup" $context.Values.global.discovery.apiVersions }}
     {{- if and $hasObservabilityModule $useObservabilityRules }}
       {{- range $idx, $group := $definitionStruct.Rules }}
-        {{- $_ := unset $group "name" }}
-        {{- $resourceName = $resourceName | replace "propagated-" "" }}
-        {{- $groupResourceName := printf "%s-%d" $resourceName $idx }}
+        {{- if $group.rules }}
+          {{- $_ := unset $group "name" }}
+          {{- $resourceName = $resourceName | replace "propagated-" "" }}
+          {{- $groupResourceName := printf "%s-%d" $resourceName $idx }}
 ---
 apiVersion: observability.deckhouse.io/v1alpha1
 kind: {{ $propagated | ternary "ClusterObservabilityPropagatedMetricsRulesGroup" "ClusterObservabilityMetricsRulesGroup" }}
@@ -62,8 +63,10 @@ metadata:
   {{- include "helm_lib_module_labels" (list $context (dict "app" "prometheus" "prometheus" "main" "component" "rules")) | nindent 2 }}
 spec:
   {{- $group | toYaml | nindent 2 }}
+        {{- end }}
       {{- end }}
     {{- else }}
+      {{- if $definitionStruct.Rules }}
         {{- $definition := $definitionStruct.Rules | toYaml }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -75,6 +78,7 @@ metadata:
 spec:
   groups:
     {{- $definition | nindent 4 }}
+      {{- end }}
     {{- end }}
   {{- end }}
 

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -745,12 +745,12 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 					f.HelmRender()
 				})
 
-				It("spec.groups should be empty array", func() {
+				It("PrometheusRule should not exist", func() {
 					Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 					rule := f.KubernetesResource("PrometheusRule", "d8-cloud-instance-manager", "node-manager-cluster-autoscaler")
 
-					assertSpecDotGroupsArray(rule, true)
+					Expect(rule.Exists()).To(BeFalse())
 				})
 			})
 
@@ -789,12 +789,12 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 					f.HelmRender()
 				})
 
-				It("spec.groups should be empty array", func() {
+				It("PrometheusRule should not exist", func() {
 					Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 					rule := f.KubernetesResource("PrometheusRule", "d8-cloud-instance-manager", "node-manager-machine-controller-manager")
 
-					assertSpecDotGroupsArray(rule, true)
+					Expect(rule.Exists()).To(BeFalse())
 				})
 			})
 


### PR DESCRIPTION
## Description

Add check values not null in prometheusRule or ClusterObservabilityPropagatedMetricsRulesGroup

## Why do we need it, and what problem does it solve?

Create object with null values broke deckhouse queue

## Why do we need it in the patch release (if we do)?

Fix problem with create wrong object

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: Add check values not null in prometheusRule or ClusterObservabilityPropagatedMetricsRulesGroup
impact: deckhouse queue 
impact_level: high 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
