### PR TITLE
[dhctl] Add preflight tests

### DIFF
--- a/dhctl/go.mod
+++ b/dhctl/go.mod
@@ -158,6 +158,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/vbatts/tar-split v0.12.1 // indirect
 	github.com/weppos/publicsuffix-go v0.30.3-0.20240510084413-5f1d03393b3d // indirect

--- a/dhctl/pkg/preflight/check_time_test.go
+++ b/dhctl/pkg/preflight/check_time_test.go
@@ -1,0 +1,203 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+)
+
+func TestChecker_CheckTimeDrift(t *testing.T) {
+	now := time.Now().Unix()
+
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		setupMock     func(*mockNodeInterface, *mockCommand)
+		expectedError string
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:     "time drift within acceptable range",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// Remote time is 5 minutes ahead (300 seconds)
+				remoteTime := now + 300
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte(strconv.FormatInt(remoteTime, 10)+"\n"), []byte(""), nil)
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+		},
+		{
+			name:     "time drift exceeds acceptable range",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// Remote time is 15 minutes ahead (900 seconds)
+				remoteTime := now + 900
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte(strconv.FormatInt(remoteTime, 10)+"\n"), []byte(""), nil)
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+		},
+		{
+			name:     "time drift exceeds acceptable range - remote behind",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// Remote time is 15 minutes behind (-900 seconds)
+				remoteTime := now - 900
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte(strconv.FormatInt(remoteTime, 10)+"\n"), []byte(""), nil)
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+		},
+		{
+			name:     "error getting remote timestamp",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte(""), []byte(""), errors.New("command failed"))
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+		},
+		{
+			name:     "invalid timestamp format",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte("invalid-timestamp\n"), []byte(""), nil)
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipTimeDrift
+			defer func() {
+				app.PreflightSkipTimeDrift = originalSkipFlag
+			}()
+
+			app.PreflightSkipTimeDrift = tt.skipFlag
+
+			mockNode := &mockNodeInterface{}
+			mockCmd := &mockCommand{}
+			tt.setupMock(mockNode, mockCmd)
+
+			checker := &Checker{
+				nodeInterface: mockNode,
+			}
+
+			err := checker.CheckTimeDrift(context.Background())
+
+			// Time drift check should never return an error, it only logs warnings
+			assert.NoError(t, err)
+
+			mockNode.AssertExpectations(t)
+			mockCmd.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetRemoteTimeStamp(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*mockNodeInterface, *mockCommand)
+		expectedTime  int64
+		expectedError string
+	}{
+		{
+			name: "successful timestamp retrieval",
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte("1640995200\n"), []byte(""), nil)
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+			expectedTime: 1640995200,
+		},
+		{
+			name: "command execution failed",
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte(""), []byte(""), errors.New("command failed"))
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+			expectedError: "failed to execute date command:",
+		},
+		{
+			name: "invalid timestamp format",
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte("not-a-timestamp\n"), []byte(""), nil)
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+			expectedError: "invalid timestamp format received",
+		},
+		{
+			name: "timestamp parsing failed",
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Output", mock.MatchedBy(func(ctx context.Context) bool { return ctx != nil })).Return(
+					[]byte("99999999999999999999999999999\n"), []byte(""), nil)
+				mni.On("Command", "date", []string{"+%s"}).Return(mc)
+			},
+			expectedError: "failed to parse timestamp:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockNode := &mockNodeInterface{}
+			mockCmd := &mockCommand{}
+			tt.setupMock(mockNode, mockCmd)
+
+			timestamp, err := getRemoteTimeStamp(context.Background(), mockNode)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Zero(t, timestamp)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedTime, timestamp)
+			}
+
+			mockNode.AssertExpectations(t)
+			mockCmd.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetLocalTimeStamp(t *testing.T) {
+	before := time.Now().Unix()
+	timestamp := getLocalTimeStamp()
+	after := time.Now().Unix()
+
+	// Timestamp should be within a reasonable range
+	assert.GreaterOrEqual(t, timestamp, before)
+	assert.LessOrEqual(t, timestamp, after)
+}

--- a/dhctl/pkg/preflight/deckhouse_user_test.go
+++ b/dhctl/pkg/preflight/deckhouse_user_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+)
+
+func TestChecker_CheckDeckhouseUser(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		executeError  error
+		executeOutput []byte
+		expectedError string
+		setupMock     func(*mockNodeInterface, *mockScript)
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:          "deckhouse user check successful",
+			skipFlag:      false,
+			executeError:  nil,
+			executeOutput: []byte("deckhouse user and group are not present\n"),
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				msc.On("Execute", mock.Anything).Return([]byte("deckhouse user and group are not present\n"), nil)
+			},
+		},
+		{
+			name:          "deckhouse user check failed with exit error",
+			skipFlag:      false,
+			executeError:  &exec.ExitError{Stderr: []byte("deckhouse user exists")},
+			executeOutput: []byte("User check failed"),
+			expectedError: "Deckhouse user existence check failed:",
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				exitErr := &exec.ExitError{Stderr: []byte("deckhouse user exists")}
+				msc.On("Execute", mock.Anything).Return([]byte("User check failed"), exitErr)
+			},
+		},
+		{
+			name:          "generic execution error",
+			skipFlag:      false,
+			executeError:  errors.New("network error"),
+			executeOutput: []byte(""),
+			expectedError: "Could not execute a script to check deckhouse user and group aren't present on the node:",
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				msc.On("Execute", mock.Anything).Return([]byte(""), errors.New("network error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipDeckhouseUserCheck
+			defer func() {
+				app.PreflightSkipDeckhouseUserCheck = originalSkipFlag
+			}()
+
+			app.PreflightSkipDeckhouseUserCheck = tt.skipFlag
+
+			mockNode := &mockNodeInterface{}
+			mockScript := &mockScript{}
+			tt.setupMock(mockNode, mockScript)
+
+			checker := &Checker{
+				nodeInterface: mockNode,
+			}
+
+			err := checker.CheckDeckhouseUser(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockNode.AssertExpectations(t)
+			mockScript.AssertExpectations(t)
+		})
+	}
+}

--- a/dhctl/pkg/preflight/domain_test.go
+++ b/dhctl/pkg/preflight/domain_test.go
@@ -1,0 +1,238 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+func TestChecker_CheckLocalhostDomain(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		executeError  error
+		executeOutput []byte
+		expectedError string
+		setupMock     func(*mockNodeInterface, *mockScript)
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:          "successful localhost resolution",
+			skipFlag:      false,
+			executeError:  nil,
+			executeOutput: []byte("localhost resolves correctly\n"),
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				msc.On("Execute", mock.Anything).Return([]byte("localhost resolves correctly\n"), nil)
+			},
+		},
+		{
+			name:          "localhost resolution failed with exit error",
+			skipFlag:      false,
+			executeError:  &exec.ExitError{Stderr: []byte("localhost resolution failed")},
+			executeOutput: []byte("Resolution failed"),
+			expectedError: "Localhost domain resolving check failed:",
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				exitErr := &exec.ExitError{Stderr: []byte("localhost resolution failed")}
+				msc.On("Execute", mock.Anything).Return([]byte("Resolution failed"), exitErr)
+			},
+		},
+		{
+			name:          "generic execution error",
+			skipFlag:      false,
+			executeError:  errors.New("network error"),
+			executeOutput: []byte(""),
+			expectedError: "Could not execute a script to check for localhost domain resolution:",
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				msc.On("Execute", mock.Anything).Return([]byte(""), errors.New("network error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipResolvingLocalhost
+			defer func() {
+				app.PreflightSkipResolvingLocalhost = originalSkipFlag
+			}()
+
+			app.PreflightSkipResolvingLocalhost = tt.skipFlag
+
+			mockNode := &mockNodeInterface{}
+			mockScript := &mockScript{}
+			tt.setupMock(mockNode, mockScript)
+
+			checker := &Checker{
+				nodeInterface: mockNode,
+			}
+
+			err := checker.CheckLocalhostDomain(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockNode.AssertExpectations(t)
+			mockScript.AssertExpectations(t)
+		})
+	}
+}
+
+func TestChecker_CheckPublicDomainTemplate(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		metaConfig    *config.MetaConfig
+		expectedError string
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+		},
+		{
+			name:     "no global module config",
+			skipFlag: false,
+			metaConfig: &config.MetaConfig{
+				ModuleConfigs: []*config.ModuleConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-module",
+						},
+					},
+				},
+				ClusterConfig: map[string]json.RawMessage{
+					"clusterDomain": []byte(`"cluster.local"`),
+				},
+			},
+		},
+		{
+			name:     "valid public domain template",
+			skipFlag: false,
+			metaConfig: &config.MetaConfig{
+				ModuleConfigs: []*config.ModuleConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "global",
+						},
+						Spec: config.ModuleConfigSpec{
+							Settings: map[string]interface{}{
+								"modules": map[string]interface{}{
+									"publicDomainTemplate": "example.com",
+								},
+							},
+						},
+					},
+				},
+				ClusterConfig: map[string]json.RawMessage{
+					"clusterDomain": []byte(`"cluster.local"`),
+				},
+			},
+		},
+		{
+			name:     "invalid public domain template - matches cluster domain",
+			skipFlag: false,
+			metaConfig: &config.MetaConfig{
+				ModuleConfigs: []*config.ModuleConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "global",
+						},
+						Spec: config.ModuleConfigSpec{
+							Settings: map[string]interface{}{
+								"modules": map[string]interface{}{
+									"publicDomainTemplate": "cluster.local",
+								},
+							},
+						},
+					},
+				},
+				ClusterConfig: map[string]json.RawMessage{
+					"clusterDomain": []byte(`"cluster.local"`),
+				},
+			},
+			expectedError: "The publicDomainTemplate \"cluster.local\" MUST NOT match the one specified in the clusterDomain parameter",
+		},
+		{
+			name:     "invalid public domain template - contains cluster domain",
+			skipFlag: false,
+			metaConfig: &config.MetaConfig{
+				ModuleConfigs: []*config.ModuleConfig{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "global",
+						},
+						Spec: config.ModuleConfigSpec{
+							Settings: map[string]interface{}{
+								"modules": map[string]interface{}{
+									"publicDomainTemplate": "test.cluster.local",
+								},
+							},
+						},
+					},
+				},
+				ClusterConfig: map[string]json.RawMessage{
+					"clusterDomain": []byte(`"cluster.local"`),
+				},
+			},
+			expectedError: "The publicDomainTemplate \"test.cluster.local\" MUST NOT match the one specified in the clusterDomain parameter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipPublicDomainTemplateCheck
+			defer func() {
+				app.PreflightSkipPublicDomainTemplateCheck = originalSkipFlag
+			}()
+
+			app.PreflightSkipPublicDomainTemplateCheck = tt.skipFlag
+
+			checker := &Checker{
+				metaConfig: tt.metaConfig,
+			}
+
+			err := checker.CheckPublicDomainTemplate(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/dhctl/pkg/preflight/mocks_test.go
+++ b/dhctl/pkg/preflight/mocks_test.go
@@ -1,0 +1,348 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+)
+
+type mockNodeInterface struct {
+	mock.Mock
+}
+
+func (m *mockNodeInterface) Command(name string, arg ...string) node.Command {
+	args := m.Called(name, arg)
+	return args.Get(0).(node.Command)
+}
+
+func (m *mockNodeInterface) File() node.File {
+	args := m.Called()
+	return args.Get(0).(node.File)
+}
+
+func (m *mockNodeInterface) UploadScript(scriptPath string, args ...string) node.Script {
+	mockArgs := m.Called(scriptPath, args)
+	return mockArgs.Get(0).(node.Script)
+}
+
+type mockScript struct {
+	mock.Mock
+}
+
+func (m *mockScript) Execute(ctx context.Context) ([]byte, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *mockScript) ExecuteBundle(ctx context.Context, parentDir, bundleDir string) ([]byte, error) {
+	args := m.Called(ctx, parentDir, bundleDir)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *mockScript) Sudo() {
+	m.Called()
+}
+
+func (m *mockScript) WithStdoutHandler(handler func(string)) {
+	m.Called(handler)
+}
+
+func (m *mockScript) WithTimeout(timeout time.Duration) {
+	m.Called(timeout)
+}
+
+func (m *mockScript) WithEnvs(envs map[string]string) {
+	m.Called(envs)
+}
+
+func (m *mockScript) WithCleanupAfterExec(doCleanup bool) {
+	m.Called(doCleanup)
+}
+
+func (m *mockScript) WithCommanderMode(enabled bool) {
+	m.Called(enabled)
+}
+
+func (m *mockScript) WithExecuteUploadDir(dir string) {
+	m.Called(dir)
+}
+
+type mockCommand struct {
+	mock.Mock
+}
+
+func (m *mockCommand) Run(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockCommand) Cmd(ctx context.Context) {
+	m.Called(ctx)
+}
+
+func (m *mockCommand) Sudo(ctx context.Context) {
+	m.Called(ctx)
+}
+
+func (m *mockCommand) StdoutBytes() []byte {
+	args := m.Called()
+	return args.Get(0).([]byte)
+}
+
+func (m *mockCommand) StderrBytes() []byte {
+	args := m.Called()
+	return args.Get(0).([]byte)
+}
+
+func (m *mockCommand) Output(ctx context.Context) ([]byte, []byte, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]byte), args.Get(1).([]byte), args.Error(2)
+}
+
+func (m *mockCommand) CombinedOutput(ctx context.Context) ([]byte, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *mockCommand) OnCommandStart(fn func()) {
+	m.Called(fn)
+}
+
+func (m *mockCommand) WithEnv(env map[string]string) {
+	m.Called(env)
+}
+
+func (m *mockCommand) WithTimeout(timeout time.Duration) {
+	m.Called(timeout)
+}
+
+func (m *mockCommand) WithStdoutHandler(h func(line string)) {
+	m.Called(h)
+}
+
+func (m *mockCommand) WithStderrHandler(h func(line string)) {
+	m.Called(h)
+}
+
+func (m *mockCommand) WithSSHArgs(args ...string) {
+	m.Called(args)
+}
+
+type mockSSHClient struct {
+	mock.Mock
+}
+
+func (m *mockSSHClient) OnlyPreparePrivateKeys() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockSSHClient) Start() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockSSHClient) Tunnel(address string) node.Tunnel {
+	args := m.Called(address)
+	return args.Get(0).(node.Tunnel)
+}
+
+func (m *mockSSHClient) ReverseTunnel(address string) node.ReverseTunnel {
+	args := m.Called(address)
+	return args.Get(0).(node.ReverseTunnel)
+}
+
+func (m *mockSSHClient) Command(name string, arg ...string) node.Command {
+	args := m.Called(name, arg)
+	return args.Get(0).(node.Command)
+}
+
+func (m *mockSSHClient) KubeProxy() node.KubeProxy {
+	args := m.Called()
+	return args.Get(0).(node.KubeProxy)
+}
+
+func (m *mockSSHClient) File() node.File {
+	args := m.Called()
+	return args.Get(0).(node.File)
+}
+
+func (m *mockSSHClient) UploadScript(scriptPath string, args ...string) node.Script {
+	mockArgs := m.Called(scriptPath, args)
+	return mockArgs.Get(0).(node.Script)
+}
+
+func (m *mockSSHClient) Check() node.Check {
+	args := m.Called()
+	return args.Get(0).(node.Check)
+}
+
+func (m *mockSSHClient) Stop() {
+	m.Called()
+}
+
+func (m *mockSSHClient) Loop(fn node.SSHLoopHandler) error {
+	args := m.Called(fn)
+	return args.Error(0)
+}
+
+func (m *mockSSHClient) Session() *session.Session {
+	args := m.Called()
+	return args.Get(0).(*session.Session)
+}
+
+func (m *mockSSHClient) PrivateKeys() []session.AgentPrivateKey {
+	args := m.Called()
+	return args.Get(0).([]session.AgentPrivateKey)
+}
+
+func (m *mockSSHClient) RefreshPrivateKeys() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+type mockCheck struct {
+	mock.Mock
+}
+
+func (m *mockCheck) WithDelaySeconds(seconds int) node.Check {
+	args := m.Called(seconds)
+	return args.Get(0).(node.Check)
+}
+
+func (m *mockCheck) AwaitAvailability(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockCheck) CheckAvailability(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *mockCheck) ExpectAvailable(ctx context.Context) ([]byte, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *mockCheck) String() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+type mockSession struct {
+	mock.Mock
+}
+
+func (m *mockSession) AvailableHosts() []string {
+	args := m.Called()
+	return args.Get(0).([]string)
+}
+
+type mockReverseTunnel struct {
+	mock.Mock
+}
+
+func (m *mockReverseTunnel) Up() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockReverseTunnel) StartHealthMonitor(ctx context.Context, checker node.ReverseTunnelChecker, killer node.ReverseTunnelKiller) {
+	m.Called(ctx, checker, killer)
+}
+
+func (m *mockReverseTunnel) Stop() {
+	m.Called()
+}
+
+func (m *mockReverseTunnel) String() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+type mockNodeInterfaceWrapper struct {
+	mock.Mock
+	client node.SSHClient
+}
+
+func (m *mockNodeInterfaceWrapper) Command(name string, arg ...string) node.Command {
+	args := m.Called(name, arg)
+	return args.Get(0).(node.Command)
+}
+
+func (m *mockNodeInterfaceWrapper) File() node.File {
+	args := m.Called()
+	return args.Get(0).(node.File)
+}
+
+func (m *mockNodeInterfaceWrapper) UploadScript(scriptPath string, args ...string) node.Script {
+	mockArgs := m.Called(scriptPath, args)
+	return mockArgs.Get(0).(node.Script)
+}
+
+func (m *mockNodeInterfaceWrapper) Client() node.SSHClient {
+	return m.client
+}
+
+type mockState struct {
+	mock.Mock
+}
+
+func (m *mockState) SetGlobalPreflightchecksWasRan() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockState) GlobalPreflightchecksWasRan() (bool, error) {
+	args := m.Called()
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockState) SetCloudPreflightchecksWasRan() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockState) SetPostCloudPreflightchecksWasRan() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockState) CloudPreflightchecksWasRan() (bool, error) {
+	args := m.Called()
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockState) PostCloudPreflightchecksWasRan() (bool, error) {
+	args := m.Called()
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockState) SetStaticPreflightchecksWasRan() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockState) StaticPreflightchecksWasRan() (bool, error) {
+	args := m.Called()
+	return args.Bool(0), args.Error(1)
+}

--- a/dhctl/pkg/preflight/ports_test.go
+++ b/dhctl/pkg/preflight/ports_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+)
+
+func TestChecker_CheckAvailabilityPorts(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		executeError  error
+		executeOutput []byte
+		expectedError string
+		setupMock     func(*mockNodeInterface, *mockScript)
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:          "successful port check",
+			skipFlag:      false,
+			executeError:  nil,
+			executeOutput: []byte("All ports are available\n"),
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				msc.On("Execute", mock.Anything).Return([]byte("All ports are available\n"), nil)
+			},
+		},
+		{
+			name:          "port check failed with exit error",
+			skipFlag:      false,
+			executeError:  &exec.ExitError{Stderr: []byte("Port 6443 is already in use")},
+			executeOutput: []byte("Port check failed"),
+			expectedError: "Required ports check failed:",
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				exitErr := &exec.ExitError{Stderr: []byte("Port 6443 is already in use")}
+				msc.On("Execute", mock.Anything).Return([]byte("Port check failed"), exitErr)
+			},
+		},
+		{
+			name:          "generic execution error",
+			skipFlag:      false,
+			executeError:  errors.New("network error"),
+			executeOutput: []byte(""),
+			expectedError: "Could not execute a script to check if all necessary ports are open on the node:",
+			setupMock: func(mni *mockNodeInterface, msc *mockScript) {
+				mni.On("UploadScript", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(msc)
+				msc.On("Execute", mock.Anything).Return([]byte(""), errors.New("network error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipAvailabilityPorts
+			defer func() {
+				app.PreflightSkipAvailabilityPorts = originalSkipFlag
+			}()
+
+			app.PreflightSkipAvailabilityPorts = tt.skipFlag
+
+			mockNode := &mockNodeInterface{}
+			mockScript := &mockScript{}
+			tt.setupMock(mockNode, mockScript)
+
+			checker := &Checker{
+				nodeInterface: mockNode,
+			}
+
+			err := checker.CheckAvailabilityPorts(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockNode.AssertExpectations(t)
+			mockScript.AssertExpectations(t)
+		})
+	}
+}

--- a/dhctl/pkg/preflight/preflight_test.go
+++ b/dhctl/pkg/preflight/preflight_test.go
@@ -1,0 +1,340 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+func TestNewChecker(t *testing.T) {
+	nodeInterface := &mockNodeInterface{}
+	installConfig := &config.DeckhouseInstaller{}
+	metaConfig := &config.MetaConfig{}
+	bootstrapState := &mockState{}
+
+	checker := NewChecker(nodeInterface, installConfig, metaConfig, bootstrapState)
+
+	assert.Equal(t, nodeInterface, checker.nodeInterface)
+	assert.Equal(t, installConfig, checker.installConfig)
+	assert.Equal(t, metaConfig, checker.metaConfig)
+	assert.Equal(t, bootstrapState, checker.bootstrapState)
+	assert.NotNil(t, checker.imageDescriptorProvider)
+}
+
+func TestChecker_Global(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipAll       bool
+		wasRan        bool
+		wasRanError   error
+		setRanError   error
+		expectedError string
+		setupMock     func(*mockState)
+	}{
+		{
+			name:    "checks already ran",
+			wasRan:  true,
+			skipAll: false,
+			setupMock: func(ms *mockState) {
+				ms.On("GlobalPreflightchecksWasRan").Return(true, nil)
+			},
+		},
+		{
+			name:        "error getting state",
+			wasRan:      false,
+			wasRanError: errors.New("state error"),
+			skipAll:     false,
+			setupMock: func(ms *mockState) {
+				ms.On("GlobalPreflightchecksWasRan").Return(false, errors.New("state error"))
+			},
+			expectedError: "Cannot get state for global preflight checks from cache:",
+		},
+		{
+			name:    "skip all checks enabled",
+			wasRan:  false,
+			skipAll: true,
+			setupMock: func(ms *mockState) {
+				ms.On("GlobalPreflightchecksWasRan").Return(false, nil)
+				ms.On("SetGlobalPreflightchecksWasRan").Return(nil)
+			},
+		},
+		{
+			name:        "error setting state after checks",
+			wasRan:      false,
+			skipAll:     true,
+			setRanError: errors.New("set state error"),
+			setupMock: func(ms *mockState) {
+				ms.On("GlobalPreflightchecksWasRan").Return(false, nil)
+				ms.On("SetGlobalPreflightchecksWasRan").Return(errors.New("set state error"))
+			},
+			expectedError: "set state error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipAll := app.PreflightSkipAll
+			originalSkipPublicDomain := app.PreflightSkipPublicDomainTemplateCheck
+			originalSkipRegistry := app.PreflightSkipRegistryCredentials
+			originalSkipEdition := app.PreflightSkipDeckhouseEditionCheck
+			originalSkipCIDR := app.PreflightSkipCIDRIntersection
+
+			defer func() {
+				app.PreflightSkipAll = originalSkipAll
+				app.PreflightSkipPublicDomainTemplateCheck = originalSkipPublicDomain
+				app.PreflightSkipRegistryCredentials = originalSkipRegistry
+				app.PreflightSkipDeckhouseEditionCheck = originalSkipEdition
+				app.PreflightSkipCIDRIntersection = originalSkipCIDR
+			}()
+
+			app.PreflightSkipAll = tt.skipAll
+			app.PreflightSkipPublicDomainTemplateCheck = true
+			app.PreflightSkipRegistryCredentials = true
+			app.PreflightSkipDeckhouseEditionCheck = true
+			app.PreflightSkipCIDRIntersection = true
+
+			mockState := &mockState{}
+			tt.setupMock(mockState)
+
+			checker := &Checker{
+				bootstrapState: mockState,
+			}
+
+			err := checker.Global(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockState.AssertExpectations(t)
+		})
+	}
+}
+
+func TestChecker_Static(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipAll       bool
+		wasRan        bool
+		wasRanError   error
+		setRanError   error
+		expectedError string
+		setupMock     func(*mockState)
+	}{
+		{
+			name:    "checks already ran",
+			wasRan:  true,
+			skipAll: false,
+			setupMock: func(ms *mockState) {
+				ms.On("StaticPreflightchecksWasRan").Return(true, nil)
+			},
+		},
+		{
+			name:        "error getting state",
+			wasRan:      false,
+			wasRanError: errors.New("state error"),
+			skipAll:     false,
+			setupMock: func(ms *mockState) {
+				ms.On("StaticPreflightchecksWasRan").Return(false, errors.New("state error"))
+			},
+			expectedError: "Cannot get state for static preflight checks from cache:",
+		},
+		{
+			name:    "skip all checks enabled",
+			wasRan:  false,
+			skipAll: true,
+			setupMock: func(ms *mockState) {
+				ms.On("StaticPreflightchecksWasRan").Return(false, nil)
+				ms.On("SetStaticPreflightchecksWasRan").Return(nil)
+			},
+		},
+		{
+			name:        "error setting state after checks",
+			wasRan:      false,
+			skipAll:     true,
+			setRanError: errors.New("set state error"),
+			setupMock: func(ms *mockState) {
+				ms.On("StaticPreflightchecksWasRan").Return(false, nil)
+				ms.On("SetStaticPreflightchecksWasRan").Return(errors.New("set state error"))
+			},
+			expectedError: "set state error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipAll := app.PreflightSkipAll
+			originalSkipStaticIP := app.PreflightSkipStaticInstancesIPDuplication
+			originalSkipOneSSH := app.PreflightSkipOneSSHHost
+			originalSkipSSHCred := app.PreflightSkipSSHCredentialsCheck
+			originalSkipSSHForward := app.PreflightSkipSSHForward
+			originalSkipDeckhouseUser := app.PreflightSkipDeckhouseUserCheck
+			originalSkipSystemReq := app.PreflightSkipSystemRequirementsCheck
+			originalSkipPython := app.PreflightSkipPythonChecks
+			originalSkipRegistry := app.PreflightSkipRegistryThroughProxy
+			originalSkipPorts := app.PreflightSkipAvailabilityPorts
+			originalSkipLocalhost := app.PreflightSkipResolvingLocalhost
+			originalSkipSudo := app.PreflightSkipSudoIsAllowedForUserCheck
+			originalSkipTime := app.PreflightSkipTimeDrift
+			originalSkipCIDR := app.PreflightSkipCIDRIntersection
+
+			defer func() {
+				app.PreflightSkipAll = originalSkipAll
+				app.PreflightSkipStaticInstancesIPDuplication = originalSkipStaticIP
+				app.PreflightSkipOneSSHHost = originalSkipOneSSH
+				app.PreflightSkipSSHCredentialsCheck = originalSkipSSHCred
+				app.PreflightSkipSSHForward = originalSkipSSHForward
+				app.PreflightSkipDeckhouseUserCheck = originalSkipDeckhouseUser
+				app.PreflightSkipSystemRequirementsCheck = originalSkipSystemReq
+				app.PreflightSkipPythonChecks = originalSkipPython
+				app.PreflightSkipRegistryThroughProxy = originalSkipRegistry
+				app.PreflightSkipAvailabilityPorts = originalSkipPorts
+				app.PreflightSkipResolvingLocalhost = originalSkipLocalhost
+				app.PreflightSkipSudoIsAllowedForUserCheck = originalSkipSudo
+				app.PreflightSkipTimeDrift = originalSkipTime
+				app.PreflightSkipCIDRIntersection = originalSkipCIDR
+			}()
+
+			app.PreflightSkipAll = tt.skipAll
+			app.PreflightSkipStaticInstancesIPDuplication = true
+			app.PreflightSkipOneSSHHost = true
+			app.PreflightSkipSSHCredentialsCheck = true
+			app.PreflightSkipSSHForward = true
+			app.PreflightSkipDeckhouseUserCheck = true
+			app.PreflightSkipSystemRequirementsCheck = true
+			app.PreflightSkipPythonChecks = true
+			app.PreflightSkipRegistryThroughProxy = true
+			app.PreflightSkipAvailabilityPorts = true
+			app.PreflightSkipResolvingLocalhost = true
+			app.PreflightSkipSudoIsAllowedForUserCheck = true
+			app.PreflightSkipTimeDrift = true
+			app.PreflightSkipCIDRIntersection = true
+
+			mockState := &mockState{}
+			tt.setupMock(mockState)
+
+			checker := &Checker{
+				bootstrapState: mockState,
+			}
+
+			err := checker.Static(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockState.AssertExpectations(t)
+		})
+	}
+}
+
+func TestChecker_StaticSudo(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipAll       bool
+		wasRanError   error
+		expectedError string
+		setupMock     func(*mockState)
+	}{
+		{
+			name:    "successful static sudo check",
+			skipAll: true,
+			setupMock: func(ms *mockState) {
+				ms.On("StaticPreflightchecksWasRan").Return(false, nil)
+			},
+		},
+		{
+			name:        "error getting state",
+			wasRanError: errors.New("state error"),
+			skipAll:     false,
+			setupMock: func(ms *mockState) {
+				ms.On("StaticPreflightchecksWasRan").Return(false, errors.New("state error"))
+			},
+			expectedError: "Cannot get state for static sudo preflight checks from cache:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipAll := app.PreflightSkipAll
+			originalSkipSSHCred := app.PreflightSkipSSHCredentialsCheck
+			originalSkipSSHForward := app.PreflightSkipSSHForward
+			originalSkipSudo := app.PreflightSkipSudoIsAllowedForUserCheck
+
+			defer func() {
+				app.PreflightSkipAll = originalSkipAll
+				app.PreflightSkipSSHCredentialsCheck = originalSkipSSHCred
+				app.PreflightSkipSSHForward = originalSkipSSHForward
+				app.PreflightSkipSudoIsAllowedForUserCheck = originalSkipSudo
+			}()
+
+			app.PreflightSkipAll = tt.skipAll
+			app.PreflightSkipSSHCredentialsCheck = true
+			app.PreflightSkipSSHForward = true
+			app.PreflightSkipSudoIsAllowedForUserCheck = true
+
+			mockState := &mockState{}
+			tt.setupMock(mockState)
+
+			checker := &Checker{
+				bootstrapState: mockState,
+			}
+
+			err := checker.StaticSudo(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockState.AssertExpectations(t)
+		})
+	}
+}
+
+func TestChecker_do_DuplicatedSkipFlag(t *testing.T) {
+	checker := &Checker{}
+
+	// This should panic due to duplicated skip flags
+	assert.Panics(t, func() {
+		checker.do(context.Background(), "Test", []checkStep{
+			{
+				fun:            func(ctx context.Context) error { return nil },
+				successMessage: "test1",
+				skipFlag:       "duplicate-flag",
+			},
+			{
+				fun:            func(ctx context.Context) error { return nil },
+				successMessage: "test2",
+				skipFlag:       "duplicate-flag", // Same flag as above
+			},
+		})
+	})
+}

--- a/dhctl/pkg/preflight/python_test.go
+++ b/dhctl/pkg/preflight/python_test.go
@@ -1,0 +1,246 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+)
+
+func TestChecker_CheckPythonAndItsModules(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		setupMock     func(*mockNodeInterface)
+		expectedError string
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(mni *mockNodeInterface) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:     "python3 available with all modules",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface) {
+				// Mock python3 detection
+				cmdPython3 := &mockCommand{}
+				cmdPython3.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "command", []string{"-v", "python3"}).Return(cmdPython3)
+
+				// Mock module checks - all modules available
+				modules := []string{
+					"urllib.request", "urllib.error", "configparser", "http.server", "http.server",
+				}
+				for _, module := range modules {
+					cmdModule := &mockCommand{}
+					cmdModule.On("Run", mock.Anything).Return(nil)
+					mni.On("Command", "python3", []string{"-c", "import " + module}).Return(cmdModule)
+				}
+			},
+		},
+		{
+			name:     "python2 available with fallback modules",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface) {
+				// Mock python3 not available
+				cmdPython3 := &mockCommand{}
+				cmdPython3.On("Run", mock.Anything).Return(&exec.ExitError{})
+				mni.On("Command", "command", []string{"-v", "python3"}).Return(cmdPython3)
+
+				// Mock python2 available
+				cmdPython2 := &mockCommand{}
+				cmdPython2.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "command", []string{"-v", "python2"}).Return(cmdPython2)
+
+				// Mock module checks - python3 modules fail, python2 modules succeed
+				python3Modules := []string{"urllib.request", "urllib.error", "configparser", "http.server"}
+				python2Modules := []string{"urllib2", "urllib2", "ConfigParser", "SimpleHTTPServer", "SocketServer"}
+
+				for i, module := range python3Modules {
+					cmdModule := &mockCommand{}
+					cmdModule.On("Run", mock.Anything).Return(&exec.ExitError{})
+					mni.On("Command", "python2", []string{"-c", "import " + module}).Return(cmdModule)
+
+					// Add fallback module
+					if i < len(python2Modules) {
+						cmdFallback := &mockCommand{}
+						cmdFallback.On("Run", mock.Anything).Return(nil)
+						mni.On("Command", "python2", []string{"-c", "import " + python2Modules[i]}).Return(cmdFallback)
+					}
+				}
+
+				// Handle the duplicate http.server case
+				cmdModule := &mockCommand{}
+				cmdModule.On("Run", mock.Anything).Return(&exec.ExitError{})
+				mni.On("Command", "python2", []string{"-c", "import http.server"}).Return(cmdModule)
+
+				cmdFallback := &mockCommand{}
+				cmdFallback.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "python2", []string{"-c", "import SocketServer"}).Return(cmdFallback)
+			},
+		},
+		{
+			name:     "no python available",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface) {
+				// Mock all python binaries not available
+				for _, binary := range []string{"python3", "python2", "python"} {
+					cmd := &mockCommand{}
+					cmd.On("Run", mock.Anything).Return(&exec.ExitError{})
+					mni.On("Command", "command", []string{"-v", binary}).Return(cmd)
+				}
+			},
+			expectedError: "Python was not found under any of expected names",
+		},
+		{
+			name:     "python available but missing required modules",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface) {
+				// Mock python3 available
+				cmdPython3 := &mockCommand{}
+				cmdPython3.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "command", []string{"-v", "python3"}).Return(cmdPython3)
+
+				// Mock first module set missing
+				cmdModule1 := &mockCommand{}
+				cmdModule1.On("Run", mock.Anything).Return(&exec.ExitError{})
+				mni.On("Command", "python3", []string{"-c", "import urllib.request"}).Return(cmdModule1)
+
+				cmdModule2 := &mockCommand{}
+				cmdModule2.On("Run", mock.Anything).Return(&exec.ExitError{})
+				mni.On("Command", "python3", []string{"-c", "import urllib2"}).Return(cmdModule2)
+			},
+			expectedError: "Please install at least one of the following python modules",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipPythonChecks
+			defer func() {
+				app.PreflightSkipPythonChecks = originalSkipFlag
+			}()
+
+			app.PreflightSkipPythonChecks = tt.skipFlag
+
+			mockNode := &mockNodeInterface{}
+			tt.setupMock(mockNode)
+
+			checker := &Checker{
+				nodeInterface: mockNode,
+			}
+
+			err := checker.CheckPythonAndItsModules(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockNode.AssertExpectations(t)
+		})
+	}
+}
+
+func TestDetectPythonBinary(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*mockNodeInterface)
+		expectedBin   string
+		expectedError string
+	}{
+		{
+			name: "python3 available",
+			setupMock: func(mni *mockNodeInterface) {
+				cmd := &mockCommand{}
+				cmd.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "command", []string{"-v", "python3"}).Return(cmd)
+			},
+			expectedBin: "python3",
+		},
+		{
+			name: "python2 available (python3 not available)",
+			setupMock: func(mni *mockNodeInterface) {
+				cmdPython3 := &mockCommand{}
+				cmdPython3.On("Run", mock.Anything).Return(&exec.ExitError{})
+				mni.On("Command", "command", []string{"-v", "python3"}).Return(cmdPython3)
+
+				cmdPython2 := &mockCommand{}
+				cmdPython2.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "command", []string{"-v", "python2"}).Return(cmdPython2)
+			},
+			expectedBin: "python2",
+		},
+		{
+			name: "python available (python3 and python2 not available)",
+			setupMock: func(mni *mockNodeInterface) {
+				cmdPython3 := &mockCommand{}
+				cmdPython3.On("Run", mock.Anything).Return(&exec.ExitError{})
+				mni.On("Command", "command", []string{"-v", "python3"}).Return(cmdPython3)
+
+				cmdPython2 := &mockCommand{}
+				cmdPython2.On("Run", mock.Anything).Return(&exec.ExitError{})
+				mni.On("Command", "command", []string{"-v", "python2"}).Return(cmdPython2)
+
+				cmdPython := &mockCommand{}
+				cmdPython.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "command", []string{"-v", "python"}).Return(cmdPython)
+			},
+			expectedBin: "python",
+		},
+		{
+			name: "no python available",
+			setupMock: func(mni *mockNodeInterface) {
+				for _, binary := range []string{"python3", "python2", "python"} {
+					cmd := &mockCommand{}
+					cmd.On("Run", mock.Anything).Return(&exec.ExitError{})
+					mni.On("Command", "command", []string{"-v", binary}).Return(cmd)
+				}
+			},
+			expectedError: "Python was not found under any of expected names",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockNode := &mockNodeInterface{}
+			tt.setupMock(mockNode)
+
+			binary, err := detectPythonBinary(context.Background(), mockNode)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Empty(t, binary)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedBin, binary)
+			}
+
+			mockNode.AssertExpectations(t)
+		})
+	}
+}

--- a/dhctl/pkg/preflight/ssh_test.go
+++ b/dhctl/pkg/preflight/ssh_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+)
+
+func TestChecker_CheckSSHCredential(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		nodeInterface node.Interface
+		setupMock     func(*mockSSHClient, *mockCheck)
+		expectedError string
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(msc *mockSSHClient, msch *mockCheck) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:          "local run - not SSH wrapper",
+			skipFlag:      false,
+			nodeInterface: &mockNodeInterface{},
+			setupMock: func(msc *mockSSHClient, msch *mockCheck) {
+				// No mock setup needed as function should return early for local run
+			},
+		},
+		{
+			name:     "SSH credentials check successful",
+			skipFlag: false,
+			setupMock: func(msc *mockSSHClient, msch *mockCheck) {
+				msc.On("Check").Return(msch)
+				msch.On("CheckAvailability", mock.Anything).Return(nil)
+			},
+		},
+		{
+			name:     "SSH credentials check failed",
+			skipFlag: false,
+			setupMock: func(msc *mockSSHClient, msch *mockCheck) {
+				msc.On("Check").Return(msch)
+				msch.On("CheckAvailability", mock.Anything).Return(errors.New("authentication failed"))
+			},
+			expectedError: "ssh authentication failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipSSHCredentialsCheck
+			defer func() {
+				app.PreflightSkipSSHCredentialsCheck = originalSkipFlag
+			}()
+
+			app.PreflightSkipSSHCredentialsCheck = tt.skipFlag
+
+			mockSSHClient := &mockSSHClient{}
+			mockSSHCheck := &mockCheck{}
+			tt.setupMock(mockSSHClient, mockSSHCheck)
+
+			var nodeInterface node.Interface
+			if tt.nodeInterface != nil {
+				nodeInterface = tt.nodeInterface
+			} else {
+				wrapper := &mockNodeInterfaceWrapper{client: mockSSHClient}
+				nodeInterface = wrapper
+			}
+
+			checker := &Checker{
+				nodeInterface: nodeInterface,
+			}
+
+			err := checker.CheckSSHCredential(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockSSHClient.AssertExpectations(t)
+			mockSSHCheck.AssertExpectations(t)
+		})
+	}
+}
+
+func TestChecker_CheckSingleSSHHostForStatic(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		nodeInterface node.Interface
+		setupMock     func(*mockSSHClient, *mockSession)
+		expectedError string
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(msc *mockSSHClient, mss *mockSession) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:          "local run - not SSH wrapper",
+			skipFlag:      false,
+			nodeInterface: &mockNodeInterface{},
+			setupMock: func(msc *mockSSHClient, mss *mockSession) {
+				// No mock setup needed as function should return early for local run
+			},
+		},
+		{
+			name:     "single SSH host - valid",
+			skipFlag: false,
+			setupMock: func(msc *mockSSHClient, mss *mockSession) {
+				sessionObj := session.NewSession(session.Input{
+					AvailableHosts: []session.Host{{Host: "host1", Name: "host1"}},
+				})
+				msc.On("Session").Return(sessionObj)
+			},
+		},
+		{
+			name:     "multiple SSH hosts - invalid",
+			skipFlag: false,
+			setupMock: func(msc *mockSSHClient, mss *mockSession) {
+				sessionObj := session.NewSession(session.Input{
+					AvailableHosts: []session.Host{{Host: "host1", Name: "host1"}, {Host: "host2", Name: "host2"}},
+				})
+				msc.On("Session").Return(sessionObj)
+			},
+			expectedError: "during the bootstrap of the first static master node, only one --ssh-host parameter is allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipOneSSHHost
+			defer func() {
+				app.PreflightSkipOneSSHHost = originalSkipFlag
+			}()
+
+			app.PreflightSkipOneSSHHost = tt.skipFlag
+
+			mockSSHClient := &mockSSHClient{}
+			mockSSHSession := &mockSession{}
+			tt.setupMock(mockSSHClient, mockSSHSession)
+
+			var nodeInterface node.Interface
+			if tt.nodeInterface != nil {
+				nodeInterface = tt.nodeInterface
+			} else {
+				wrapper := &mockNodeInterfaceWrapper{client: mockSSHClient}
+				nodeInterface = wrapper
+			}
+
+			checker := &Checker{
+				nodeInterface: nodeInterface,
+			}
+
+			err := checker.CheckSingleSSHHostForStatic(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockSSHClient.AssertExpectations(t)
+			mockSSHSession.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetTunnelPreflightCheckFailedError(t *testing.T) {
+	originalErr := errors.New("connection failed")
+	stdout := "some output"
+
+	err := getTunnelPreflightCheckFailedError(originalErr, stdout)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot establish working tunnel to control-plane host")
+	assert.Contains(t, err.Error(), "connection failed")
+	assert.Contains(t, err.Error(), "AllowTcpForwarding")
+}
+
+func TestHealthUrl(t *testing.T) {
+	port := 8080
+	expected := "http://127.0.0.1:8080/healthz"
+	actual := healthUrl(port)
+	assert.Equal(t, expected, actual)
+}

--- a/dhctl/pkg/preflight/sudoers_test.go
+++ b/dhctl/pkg/preflight/sudoers_test.go
@@ -1,0 +1,191 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+)
+
+func TestChecker_CheckSudoIsAllowedForUser(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipFlag      bool
+		setupMock     func(*mockNodeInterface, *mockCommand)
+		expectedError string
+	}{
+		{
+			name:     "skip flag enabled",
+			skipFlag: true,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// No mock setup needed as function should return early
+			},
+		},
+		{
+			name:     "sudo allowed successfully",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Sudo", mock.Anything)
+				mc.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "echo", []string(nil)).Return(mc)
+			},
+		},
+		{
+			name:     "sudo not allowed - exit error",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// Create ExitError with exit code != 255 to test "sudo not allowed" path
+				// Note: &exec.ExitError{} has exit code 0 by default, which != 255
+				exitErr := &exec.ExitError{}
+				mc.On("Sudo", mock.Anything)
+				mc.On("Run", mock.Anything).Return(exitErr)
+				mni.On("Command", "echo", []string(nil)).Return(mc)
+			},
+			expectedError: "Provided SSH user is not allowed to sudo",
+		},
+		{
+			name:     "unexpected error during sudo check",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// Use a regular error (not ExitError) to test the unexpected error path
+				mc.On("Sudo", mock.Anything)
+				mc.On("Run", mock.Anything).Return(errors.New("connection timeout"))
+				mni.On("Command", "echo", []string(nil)).Return(mc)
+			},
+			expectedError: "Unexpected error when checking sudoers permissions for SSH user:",
+		},
+		{
+			name:     "generic error during sudo check",
+			skipFlag: false,
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Sudo", mock.Anything)
+				mc.On("Run", mock.Anything).Return(errors.New("network error"))
+				mni.On("Command", "echo", []string(nil)).Return(mc)
+			},
+			expectedError: "Unexpected error when checking sudoers permissions for SSH user:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalSkipFlag := app.PreflightSkipSudoIsAllowedForUserCheck
+			defer func() {
+				app.PreflightSkipSudoIsAllowedForUserCheck = originalSkipFlag
+			}()
+
+			app.PreflightSkipSudoIsAllowedForUserCheck = tt.skipFlag
+
+			mockNode := &mockNodeInterface{}
+			mockCmd := &mockCommand{}
+			tt.setupMock(mockNode, mockCmd)
+
+			checker := &Checker{
+				nodeInterface: mockNode,
+			}
+
+			err := checker.CheckSudoIsAllowedForUser(context.Background())
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockNode.AssertExpectations(t)
+			mockCmd.AssertExpectations(t)
+		})
+	}
+}
+
+type mockProcessState struct {
+	exitCode int
+}
+
+func (m *mockProcessState) ExitCode() int {
+	return m.exitCode
+}
+
+func (m *mockProcessState) String() string {
+	return ""
+}
+
+func (m *mockProcessState) Success() bool {
+	return m.exitCode == 0
+}
+
+func (m *mockProcessState) Sys() interface{} {
+	return nil
+}
+
+func (m *mockProcessState) SysUsage() interface{} {
+	return nil
+}
+
+func TestCallSudo(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func(*mockNodeInterface, *mockCommand)
+		expectedError string
+	}{
+		{
+			name: "sudo successful",
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				mc.On("Sudo", mock.Anything)
+				mc.On("Run", mock.Anything).Return(nil)
+				mni.On("Command", "echo", []string(nil)).Return(mc)
+			},
+		},
+		{
+			name: "sudo not allowed",
+			setupMock: func(mni *mockNodeInterface, mc *mockCommand) {
+				// Create ExitError with exit code != 255 to test "sudo not allowed" path
+				// Note: &exec.ExitError{} has exit code 0 by default, which != 255
+				exitErr := &exec.ExitError{}
+				mc.On("Sudo", mock.Anything)
+				mc.On("Run", mock.Anything).Return(exitErr)
+				mni.On("Command", "echo", []string(nil)).Return(mc)
+			},
+			expectedError: "Provided SSH user is not allowed to sudo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockNode := &mockNodeInterface{}
+			mockCmd := &mockCommand{}
+			tt.setupMock(mockNode, mockCmd)
+
+			err := callSudo(context.Background(), mockNode)
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockNode.AssertExpectations(t)
+			mockCmd.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
## Description
Added preflight tests.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?


<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Added preflight tests.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
