### PR TITLE
[user-authn] Add D8DexAuthRequestsQuotaHigh alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1137,6 +1137,39 @@ alerts:
         Prometheus is unable to scrape Dex metrics.
       severity: "6"
       markupFormat: markdown
+    - name: D8DexAuthRequestsQuotaExhausted
+      sourceFile: modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
+      moduleUrl: 150-user-authn
+      module: user-authn
+      edition: ce
+      description: |-
+        The ResourceQuota for `authrequests.dex.coreos.com` objects in namespace `d8-user-authn` has been fully exhausted.
+
+        Dex is currently unable to create new AuthRequest custom resources, which will cause:
+        * Dex health checks to fail immediately.
+        * Authentication through external identity providers to stop working.
+        * Users unable to log in via OAuth/OIDC flows.
+
+        **Immediate actions required:**
+
+        1. Check current AuthRequest objects and clean up stale ones:
+           ```bash
+           d8 k get authrequests.dex.coreos.com -n d8-user-authn --no-headers | wc -l
+           d8 k delete authrequests.dex.coreos.com --all -n d8-user-authn
+           ```
+
+        2. Temporarily increase the ResourceQuota limit:
+           ```bash
+           d8 k patch resourcequota authrequest-quota -n d8-user-authn --type='json' -p='[{"op": "replace", "path": "/spec/hard/count\/authrequests.dex.coreos.com", "value": "20000"}]'
+           ```
+
+        3. Investigate why Dex is not cleaning up AuthRequest objects automatically.
+
+        4. Review Dex configuration for AuthRequest TTL settings.
+      summary: |
+        Dex AuthRequest objects ResourceQuota is exhausted in namespace &quot;d8-user-authn&quot;.
+      severity: "3"
+      markupFormat: markdown
     - name: D8DexAuthRequestsQuotaHigh
       sourceFile: modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
       moduleUrl: 150-user-authn
@@ -1164,39 +1197,6 @@ alerts:
       summary: |
         Dex AuthRequest objects quota usage is higher than 80% in namespace &quot;d8-user-authn&quot;.
       severity: "4"
-      markupFormat: markdown
-    - name: D8DexAuthRequestsQuotaExhausted
-      sourceFile: modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
-      moduleUrl: 150-user-authn
-      module: user-authn
-      edition: ce
-      description: |-
-        The ResourceQuota for `authrequests.dex.coreos.com` objects in namespace `d8-user-authn` has been fully exhausted.
-
-        Dex is currently unable to create new AuthRequest CRs, which will cause:
-        * Dex health checks to fail immediately
-        * Authentication through external identity providers to stop working
-        * Users unable to log in via OAuth/OIDC flows
-
-        **Immediate actions required:**
-
-        1. Check current AuthRequest objects and clean up stale ones:
-           ```bash
-           d8 k get authrequests.dex.coreos.com -n d8-user-authn --no-headers | wc -l
-           d8 k delete authrequests.dex.coreos.com --all -n d8-user-authn
-           ```
-
-        2. Temporarily increase the ResourceQuota limit:
-           ```bash
-           d8 k patch resourcequota authrequest-quota -n d8-user-authn --type='json' -p='[{"op": "replace", "path": "/spec/hard/count\/authrequests.dex.coreos.com", "value": "20000"}]'
-           ```
-
-        3. Investigate why Dex is not cleaning up AuthRequest objects automatically
-
-        4. Review Dex configuration for AuthRequest TTL settings
-      summary: |
-        Dex AuthRequest objects ResourceQuota is exhausted in namespace &quot;d8-user-authn&quot;.
-      severity: "3"
       markupFormat: markdown
     - name: D8EtcdDatabaseHighFragmentationRatio
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml

--- a/modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
+++ b/modules/150-user-authn/monitoring/prometheus-rules/dex.yaml
@@ -70,7 +70,7 @@
 
         2. Review Dex configuration for AuthRequest TTL settings.
 
-        3. Consider temporarily increasing the ResourceQuota limit if needed
+        3. Consider temporarily increasing the ResourceQuota limit if needed.
 
   - alert: D8DexAuthRequestsQuotaExhausted
     expr: |
@@ -112,10 +112,10 @@
       description: |-
         The ResourceQuota for `authrequests.dex.coreos.com` objects in namespace `d8-user-authn` has been fully exhausted.
 
-        Dex is currently unable to create new AuthRequest CRs, which will cause:
-        * Dex health checks to fail immediately
-        * Authentication through external identity providers to stop working
-        * Users unable to log in via OAuth/OIDC flows
+        Dex is currently unable to create new AuthRequest custom resources, which will cause:
+        * Dex health checks to fail immediately.
+        * Authentication through external identity providers to stop working.
+        * Users unable to log in via OAuth/OIDC flows.
 
         **Immediate actions required:**
 
@@ -130,6 +130,6 @@
            d8 k patch resourcequota authrequest-quota -n d8-user-authn --type='json' -p='[{"op": "replace", "path": "/spec/hard/count\/authrequests.dex.coreos.com", "value": "20000"}]'
            ```
 
-        3. Investigate why Dex is not cleaning up AuthRequest objects automatically
+        3. Investigate why Dex is not cleaning up AuthRequest objects automatically.
 
-        4. Review Dex configuration for AuthRequest TTL settings
+        4. Review Dex configuration for AuthRequest TTL settings.


### PR DESCRIPTION
## Description

Added a new Prometheus alert `D8DexAuthRequestsQuotaHigh` to monitor the ResourceQuota usage for `authrequests.dex.coreos.com` objects in the `d8-user-authn` namespace.

The alert triggers when the quota usage exceeds 80% and provides guidance for investigating and resolving potential issues with stale AuthRequest objects.

## Why do we need it, and what problem does it solve?

Dex creates `authrequests.dex.coreos.com` custom resources for each OAuth/OIDC authentication flow. These objects are stored in a ResourceQuota with a hard limit of 10,000 objects by default. When the quota is exhausted, Dex cannot create new AuthRequest objects, which causes authentication failures for external identity providers (GitLab, GitHub, etc.).

The new alert provides early warning when the quota usage approaches the limit (80%), giving administrators time to investigate and clean up stale AuthRequest objects before authentication stops working completely.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: feature
summary: Added Prometheus alert for Dex AuthRequest ResourceQuota monitoring.
impact_level: default
```