### PR TITLE
[node-manager] Change maxPods validation from forbid to warning

### DIFF
--- a/modules/040-node-manager/webhooks/validating/node_group
+++ b/modules/040-node-manager/webhooks/validating/node_group
@@ -164,7 +164,7 @@ EOF
     # every pod can use two IP (one in terminating phase + one in starting phase)
     if (( 2 * maxPods > availableIPs )); then
       cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":".spec.kubelet.maxPods ($maxPods) is too high: each pod may need 2 IPs (one terminating + one starting), but only $availableIPs IPs available in podSubnetNodeCIDRPrefix /$prefix"}
+{"allowed": true, "warnings": [".spec.kubelet.maxPods ($maxPods) is too high: may lead to IP exhaustion"]}
 EOF
       return 0
     fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR changes the validation behavior for `.spec.kubelet.maxPods` in `NodeGroup` resources.

Previously, the validating webhook blocked NodeGroup creation or update when `maxPods` exceeded the recommended value calculated from `podSubnetNodeCIDRPrefix`.
Now, this condition produces a warning:
<img width="611" height="24" alt="image" src="https://github.com/user-attachments/assets/4c90ff7a-7bdc-4e98-a6bf-fe463e150298" />
...instead of a hard rejection, allowing advanced users to apply the configuration while being explicitly informed about the potential risks.

No cluster components are restarted as part of this change.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The current hard validation of `maxPods` is overly restrictive and prevents legitimate configurations in advanced or non-standard networking setups.

While setting `maxPods` higher than the recommended value may lead to pod IP exhaustion, this is not always a misconfiguration and can be an intentional, well-understood trade-off made by cluster operators.

Replacing the hard rejection with a warning:
- improves user experience,
- aligns this validation with other advisory checks in Deckhouse,
- allows power users to proceed while still clearly communicating the risk.

This approach follows Kubernetes best practices by using admission warnings for potentially dangerous but valid configurations instead of enforcing a strict policy.

## Why do we need it in the patch release (if we do)?
This change reduces unnecessary friction for users without introducing breaking behavior or changing defaults.
It is a safe improvement to validation logic and can be beneficial in patch releases to unblock users affected by the overly strict check.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Change NodeGroup maxPods validation from hard rejection to warning.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
