### PR TITLE
[dhctl] Fix initconfiguration generation logic

### DIFF
--- a/dhctl/pkg/config/base_test.go
+++ b/dhctl/pkg/config/base_test.go
@@ -811,6 +811,100 @@ func createTestParseConfigFromCluster(t *testing.T, p testParseConfigFromCluster
 	}
 }
 
+func TestParseConfigFromData_MergedDocuments(t *testing.T) {
+	t.Run("Should detect missing separator between InitConfiguration and ModuleConfig", func(t *testing.T) {
+		// This reproduces the issue from https://github.com/deckhouse/deckhouse/issues/14009
+		// When --- separator is commented out, documents get merged
+		configWithCommentedSeparator := `
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+  imagesRepo: test:EE
+  registryDockerCfg: test
+# ---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+  settings:
+    bundle: Default
+    releaseChannel: Alpha
+    logLevel: Info
+    update:
+      mode: Manual
+---
+`
+
+		_, err := ParseConfigFromData(context.TODO(), configWithCommentedSeparator, DummyPreparatorProvider())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing '---' separator")
+		require.Contains(t, err.Error(), "InitConfiguration")
+		require.Contains(t, err.Error(), "ModuleConfig")
+	})
+
+	t.Run("Should detect missing separator with multiple apiVersion fields", func(t *testing.T) {
+		configWithoutSeparator := `
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+  imagesRepo: test:EE
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+---
+`
+
+		_, err := ParseConfigFromData(context.TODO(), configWithoutSeparator, DummyPreparatorProvider())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing '---' separator")
+	})
+
+	t.Run("Should allow valid config with proper separators", func(t *testing.T) {
+		validConfig := `
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+  imagesRepo: registry.deckhouse.io/deckhouse/ee
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: deckhouse
+spec:
+  version: 1
+  enabled: true
+---
+`
+
+		metaConfig, err := ParseConfigFromData(context.TODO(), validConfig, DummyPreparatorProvider())
+		require.NoError(t, err)
+		require.NotNil(t, metaConfig)
+		require.NotEmpty(t, metaConfig.InitClusterConfig)
+	})
+
+	t.Run("Should allow comments with kind in them", func(t *testing.T) {
+		configWithComment := `
+---
+apiVersion: deckhouse.io/v1
+kind: InitConfiguration
+deckhouse:
+  imagesRepo: registry.deckhouse.io/deckhouse/ee
+  # This is a comment with kind: something
+---
+`
+
+		metaConfig, err := ParseConfigFromData(context.TODO(), configWithComment, DummyPreparatorProvider())
+		require.NoError(t, err)
+		require.NotNil(t, metaConfig)
+	})
+}
+
 func testCreateKubeSystemSecret(t *testing.T, kubeCl *client.KubernetesClient, name string, data map[string][]byte) {
 	t.Helper()
 


### PR DESCRIPTION
## Description
fix initconfiguration generation logic
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
fix initconfiguration generation logic
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
No need
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed initconfiguration generation logic.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
