### PR TITLE
[dhctl] Allow updating master images

### DIFF
--- a/dhctl/pkg/config/validation_rules.go
+++ b/dhctl/pkg/config/validation_rules.go
@@ -136,33 +136,9 @@ func UpdateMasterImageRule(oldRaw, newRaw json.RawMessage) error {
 		return err
 	}
 
-	for _, images := range []struct {
-		old   string
-		new   string
-		field string
-	}{
-		{old: oldConfig.InstanceClass.AMI, new: newConfig.InstanceClass.AMI, field: "ami"},
-		{old: oldConfig.InstanceClass.URN, new: newConfig.InstanceClass.URN, field: "urn"},
-		{old: oldConfig.InstanceClass.Image, new: newConfig.InstanceClass.Image, field: "image"},
-		{old: oldConfig.InstanceClass.ImageID, new: newConfig.InstanceClass.ImageID, field: "imageID"},
-		{old: oldConfig.InstanceClass.ImageName, new: newConfig.InstanceClass.ImageName, field: "imageName"},
-		{old: oldConfig.InstanceClass.Template, new: newConfig.InstanceClass.Template, field: "template"},
-	} {
-		if images.new != "" && images.old != images.new {
-			if oldConfig.Replicas > 1 && newConfig.Replicas > 1 {
-				return fmt.Errorf(
-					"%w: can't update .masterNodeGroup.%s in multi-master cluster, functionality will be available in future versions",
-					ErrValidationRuleFailed, images.field,
-				)
-			}
-
-			return fmt.Errorf(
-				"%w: can't update .masterNodeGroup.%s in single-master cluster, functionality will be available in future versions",
-				ErrValidationRuleFailed, images.field,
-			)
-		}
-	}
-
+	// Image update is now allowed for both single-master and multi-master clusters.
+	// dhctl converge handles image updates correctly by automatically scaling to 3 replicas
+	// and back to 1 for single-master clusters if needed.
 	return nil
 }
 

--- a/dhctl/pkg/config/validation_rules_test.go
+++ b/dhctl/pkg/config/validation_rules_test.go
@@ -208,7 +208,7 @@ masterNodeGroup:
 			schema:      testSchemaStore(t),
 			errContains: `ChangesValidationFailed: validation rule failed: can't delete zone if .masterNodeGroup.replicas < 3 (1)`,
 		},
-		"unsafe rule, failed: updateMasterImage 1": {
+		"unsafe rule, ok: updateMasterImage multi-master": {
 			phase: phases.FinalizationPhase,
 			oldConfig: `
 apiVersion: deckhouse.io/v1
@@ -226,10 +226,9 @@ masterNodeGroup:
   replicas: 3
   instanceClass:
     imageID: bar`,
-			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: validation rule failed: can't update .masterNodeGroup.imageID in multi-master cluster, functionality will be available in future versions`,
+			schema: testSchemaStore(t),
 		},
-		"unsafe rule, failed: updateMasterImage 2": {
+		"unsafe rule, ok: updateMasterImage single-master": {
 			phase: phases.FinalizationPhase,
 			oldConfig: `
 apiVersion: deckhouse.io/v1
@@ -247,8 +246,7 @@ masterNodeGroup:
   replicas: 1
   instanceClass:
     urn: bar`,
-			schema:      testSchemaStore(t),
-			errContains: `ChangesValidationFailed: validation rule failed: can't update .masterNodeGroup.urn in single-master cluster, functionality will be available in future versions`,
+			schema: testSchemaStore(t),
 		},
 		"change number of docs": {
 			phase: phases.FinalizationPhase,


### PR DESCRIPTION
## Description
Allowed updating master images.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
allow updating master images
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
no need

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Allowed updating master images.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
