### PR TITLE
[candi][k8s] Disable kernel.panic parameter check

### DIFF
--- a/candi/bashible/common-steps/all/063_install_kubelet_forker.sh.tpl
+++ b/candi/bashible/common-steps/all/063_install_kubelet_forker.sh.tpl
@@ -21,9 +21,6 @@ if [ -x /opt/deckhouse/bin/sysctl-tuner ]; then
   /opt/deckhouse/bin/sysctl-tuner
 fi
 
-# Hack, which is necessary for correct start of kubelet service. Since for the enabled fencing feature the value 0 is required, which can be set with sysctl-tuner
-sysctl -w kernel.panic=10
-
 $@ &
 CHILDREN_PID="$!"
 
@@ -44,10 +41,6 @@ until ss -nltp4 | grep -qE "127.0.0.1:10248.*pid=$CHILDREN_PID" && /opt/deckhous
   echo "d8-kubelet-forker [INFO] Waiting for HTTP 200 response from /healthz endpoing of kubelet with PID $CHILDREN_PID (attempt $attempt of $max_attempts)..."
   sleep 1
 done
-
-{{- if eq (dig "fencing" "mode" "" .nodeGroup) "Watchdog" }}
-  sysctl -w kernel.panic=0
-{{- end }}
 
 EOF
 chmod +x /opt/deckhouse/bin/d8-kubelet-forker

--- a/modules/000-common/images/kubernetes/patches/1.30/006-kubelet-disable-k-panic-check.patch
+++ b/modules/000-common/images/kubernetes/patches/1.30/006-kubelet-disable-k-panic-check.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
+index 4ed1aa7b591..994b96320a0 100644
+--- a/pkg/kubelet/cm/container_manager_linux.go
++++ b/pkg/kubelet/cm/container_manager_linux.go
+@@ -403,7 +403,6 @@ func setupKernelTunables(option KernelTunableBehavior) error {
+ 	desiredState := map[string]int{
+ 		utilsysctl.VMOvercommitMemory: utilsysctl.VMOvercommitMemoryAlways,
+ 		utilsysctl.VMPanicOnOOM:       utilsysctl.VMPanicOnOOMInvokeOOMKiller,
+-		utilsysctl.KernelPanic:        utilsysctl.KernelPanicRebootTimeout,
+ 		utilsysctl.KernelPanicOnOops:  utilsysctl.KernelPanicOnOopsAlways,
+ 		utilsysctl.RootMaxKeys:        utilsysctl.RootMaxKeysSetting,
+ 		utilsysctl.RootMaxBytes:       utilsysctl.RootMaxBytesSetting,

--- a/modules/000-common/images/kubernetes/patches/1.31/006-kubelet-disable-k-panic-check.patch
+++ b/modules/000-common/images/kubernetes/patches/1.31/006-kubelet-disable-k-panic-check.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
+index 29be9d202b8..11f3d76f0d8 100644
+--- a/pkg/kubelet/cm/container_manager_linux.go
++++ b/pkg/kubelet/cm/container_manager_linux.go
+@@ -402,7 +402,6 @@ func setupKernelTunables(option KernelTunableBehavior) error {
+ 	desiredState := map[string]int{
+ 		utilsysctl.VMOvercommitMemory: utilsysctl.VMOvercommitMemoryAlways,
+ 		utilsysctl.VMPanicOnOOM:       utilsysctl.VMPanicOnOOMInvokeOOMKiller,
+-		utilsysctl.KernelPanic:        utilsysctl.KernelPanicRebootTimeout,
+ 		utilsysctl.KernelPanicOnOops:  utilsysctl.KernelPanicOnOopsAlways,
+ 		utilsysctl.RootMaxKeys:        utilsysctl.RootMaxKeysSetting,
+ 		utilsysctl.RootMaxBytes:       utilsysctl.RootMaxBytesSetting,

--- a/modules/000-common/images/kubernetes/patches/1.32/005-kubelet-disable-k-panic-check.patch
+++ b/modules/000-common/images/kubernetes/patches/1.32/005-kubelet-disable-k-panic-check.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
+index efbd90c1d5f..d8b58c9e726 100644
+--- a/pkg/kubelet/cm/container_manager_linux.go
++++ b/pkg/kubelet/cm/container_manager_linux.go
+@@ -405,7 +405,6 @@ func setupKernelTunables(option KernelTunableBehavior) error {
+ 	desiredState := map[string]int{
+ 		utilsysctl.VMOvercommitMemory: utilsysctl.VMOvercommitMemoryAlways,
+ 		utilsysctl.VMPanicOnOOM:       utilsysctl.VMPanicOnOOMInvokeOOMKiller,
+-		utilsysctl.KernelPanic:        utilsysctl.KernelPanicRebootTimeout,
+ 		utilsysctl.KernelPanicOnOops:  utilsysctl.KernelPanicOnOopsAlways,
+ 		utilsysctl.RootMaxKeys:        utilsysctl.RootMaxKeysSetting,
+ 		utilsysctl.RootMaxBytes:       utilsysctl.RootMaxBytesSetting,

--- a/modules/000-common/images/kubernetes/patches/1.33/006-kubelet-disable-k-panic-check.patch
+++ b/modules/000-common/images/kubernetes/patches/1.33/006-kubelet-disable-k-panic-check.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
+index 51536010663..a0d3494a830 100644
+--- a/pkg/kubelet/cm/container_manager_linux.go
++++ b/pkg/kubelet/cm/container_manager_linux.go
+@@ -413,7 +413,6 @@ func setupKernelTunables(option KernelTunableBehavior) error {
+ 	desiredState := map[string]int{
+ 		utilsysctl.VMOvercommitMemory: utilsysctl.VMOvercommitMemoryAlways,
+ 		utilsysctl.VMPanicOnOOM:       utilsysctl.VMPanicOnOOMInvokeOOMKiller,
+-		utilsysctl.KernelPanic:        utilsysctl.KernelPanicRebootTimeout,
+ 		utilsysctl.KernelPanicOnOops:  utilsysctl.KernelPanicOnOopsAlways,
+ 		utilsysctl.RootMaxKeys:        utilsysctl.RootMaxKeysSetting,
+ 		utilsysctl.RootMaxBytes:       utilsysctl.RootMaxBytesSetting,

--- a/modules/000-common/images/kubernetes/patches/1.34/006-kubelet-disable-k-panic-check.patch
+++ b/modules/000-common/images/kubernetes/patches/1.34/006-kubelet-disable-k-panic-check.patch
@@ -1,0 +1,12 @@
+diff --git a/pkg/kubelet/cm/container_manager_linux.go b/pkg/kubelet/cm/container_manager_linux.go
+index c65053cd678..5d1cb33510f 100644
+--- a/pkg/kubelet/cm/container_manager_linux.go
++++ b/pkg/kubelet/cm/container_manager_linux.go
+@@ -451,7 +451,6 @@ func setupKernelTunables(option KernelTunableBehavior) error {
+ 	desiredState := map[string]int{
+ 		utilsysctl.VMOvercommitMemory: utilsysctl.VMOvercommitMemoryAlways,
+ 		utilsysctl.VMPanicOnOOM:       utilsysctl.VMPanicOnOOMInvokeOOMKiller,
+-		utilsysctl.KernelPanic:        utilsysctl.KernelPanicRebootTimeout,
+ 		utilsysctl.KernelPanicOnOops:  utilsysctl.KernelPanicOnOopsAlways,
+ 		utilsysctl.RootMaxKeys:        utilsysctl.RootMaxKeysSetting,
+ 		utilsysctl.RootMaxBytes:       utilsysctl.RootMaxBytesSetting,

--- a/modules/000-common/images/kubernetes/patches/README.md
+++ b/modules/000-common/images/kubernetes/patches/README.md
@@ -6,11 +6,12 @@ directory.
 ### local-init-configuration.patch
 
 We want to include in join data the following:
+
 ```yaml
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 localAPIEndpoint:
-  advertiseAddress: {{ .nodeIP | quote }}
+  advertiseAddress: { { .nodeIP | quote } }
   bindPort: 6443
 ```
 
@@ -25,6 +26,7 @@ Supports DaemonSets in disruption controller by adding /scale subresource to dae
 ### fix-mount-hostaliases.patch
 
 Fixes a bug where pods with hostNetwork ignored host aliases (k8s < 1.32):
+
 > https://github.com/kubernetes/kubernetes/pull/126460
 
 ### resource-quota-ignore-mechanism.patch
@@ -37,3 +39,7 @@ This patch ensures that the Memory Manager state file is removed during a gracef
 
 The Memory Manager stores the node memory state in a file. After a reboot, the amount of used memory may slightly differ from the previous state, which can make the stored state invalid and prevent the kubelet from starting. Removing the state file before shutdown ensures that the Memory Manager starts with a clean state after the reboot.
 See issue: https://github.com/kubernetes/kubernetes/issues/131253
+
+### kubelet-disable-k-panic-check
+
+Kubelet strictly checks that the `kernel.panic` parameter equals 10, now, regardless of kubelet settings, only a warning is used. The `kernel.panic` parameter itself is strictly controlled by the DKP platform


### PR DESCRIPTION
## Description

Kubelet strictly checks that the `kernel.panic` parameter equals 10, now, regardless of kubelet settings, this check is skipped. The `kernel.panic` parameter itself is strictly controlled by the DKP platfor

## Why do we need it, and what problem does it solve?

We use kernel.panic for our fencing module; previously, we had to implement special measures to prevent kubelet from crashing when values were changed. This hack created a race condition that, in rare cases, led to issues during kubelet startup.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Disabled kernel.panic parameter check in kubelet.
impact:
impact_level: default
---
section: candi
type: fix
summary: Disabled kernel.panic parameter check in kubelet.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
