### PR TITLE
[candi] Added Linux kernel versions with CVE-2025-37999 fix to the bashible step

### DIFF
--- a/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
+++ b/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
@@ -28,7 +28,45 @@ can_load_erofs() {
 
 # CVE-2025-37999 impacts Linux kernels 6.12.0–6.12.28 and 6.14.0–6.14.6
 is_kernel_erofs_cve_vulnerable() {
-  local kv=$(uname -r | cut -d- -f1)
+  local full_kv=$(uname -r)
+
+  # Exception for generic Ubuntu kernels: CVE fixed starting 6.14.0-28.28
+  if [[ "$full_kv" == *-generic ]] && [[ "$full_kv" =~ ^6\.14\.0-([0-9]+) ]]; then
+    local build="${BASH_REMATCH[1]}"
+    (( build >= 28 )) && return 1
+  fi
+
+  # Exception for AWS kernels: CVE fixed starting 6.14.0-1011.11
+  if [[ "$full_kv" == *-aws ]] && [[ "$full_kv" =~ ^6\.14\.0-([0-9]+) ]]; then
+    local build="${BASH_REMATCH[1]}"
+    (( build >= 1011 )) && return 1
+  fi
+
+  # Exception for Azure kernels: CVE fixed starting 6.14.0-1010.10
+  if [[ "$full_kv" == *-azure ]] && [[ "$full_kv" =~ ^6\.14\.0-([0-9]+) ]]; then
+    local build="${BASH_REMATCH[1]}"
+    (( build >= 1010 )) && return 1
+  fi
+
+  # Exception for GCP kernels: CVE fixed starting 6.14.0-1014.15
+  if [[ "$full_kv" == *-gcp ]] && [[ "$full_kv" =~ ^6\.14\.0-([0-9]+) ]]; then
+    local build="${BASH_REMATCH[1]}"
+    (( build >= 1014 )) && return 1
+  fi
+
+  # Exception for Oracle kernels: CVE fixed starting 6.14.0-1011.11
+  if [[ "$full_kv" == *-oracle ]] && [[ "$full_kv" =~ ^6\.14\.0-([0-9]+) ]]; then
+    local build="${BASH_REMATCH[1]}"
+    (( build >= 1011 )) && return 1
+  fi
+
+  # Exception for OEM kernels: CVE fixed starting 6.14.0-1010.10
+  if [[ "$full_kv" == *-oem ]] && [[ "$full_kv" =~ ^6\.14\.0-([0-9]+) ]]; then
+    local build="${BASH_REMATCH[1]}"
+    (( build >= 1010 )) && return 1
+  fi
+
+  local kv=$(echo "$full_kv" | cut -d- -f1)
   if version_ge "$kv" "6.12.0" && ! version_ge "$kv" "6.12.29"; then
     return 0
   fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Exclusions for the most popular kernels, which already contain fixes for this vulnerability, have been added to the kernel check for CVE-2025-37999.

`linux-azure` older than `6.14.0-1010.10`
`linux-gcp` older than `6.14.0-1014.15`
`linux` older than `6.14.0-28.28`
`linux-aws` older than `6.14.0-1011.11`
`linux-oracle` older than `6.14.0-1011.11`
`linux-oem` older than `6.14.0-1010.10`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Our bashible step [000_check_containerd_v2_support.sh.tpl](https://github.com/deckhouse/deckhouse/blob/main/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl#L29-L39) verifies the kernel for CVE-2025-37999. It meticulously excludes versions 6.12.0–6.12.28 and 6.14.0–6.14.6.

However, kernel 6.14.0 already contains a fix for CVE-2025-37999.
https://ubuntu.com/security/CVE-2025-37999

## Why do we need it in the patch release (if we do)?

The issue is currently relevant and is blocking node updates in some clusters.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Updated the bashible step to include Linux kernel versions that address CVE-2025-37999
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
