### PR TITLE
[log-shipper] Fixed incorrect apiVersion in ClusterLogDestination documentation examples

### DIFF
--- a/modules/460-log-shipper/docs/EXAMPLES.md
+++ b/modules/460-log-shipper/docs/EXAMPLES.md
@@ -526,7 +526,7 @@ to convert a string in the `message` field into a structured object.
 If multiple `ParseMessage` transformations are used, the one that parses the string must be applied last.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: string-to-json
@@ -561,7 +561,7 @@ You can use the `ParseMessage` transformation
 to parse logs in Klog format and convert them into a structured object.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: klog-to-json
@@ -599,7 +599,7 @@ You can use the `ParseMessage` transformation
 to parse logs in Syslog format and convert them into a structured object.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: syslog-to-json
@@ -645,7 +645,7 @@ You can use the `ParseMessage` transformation
 to parse logs in CLF format and convert them into a structured object.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: clf-to-json
@@ -687,7 +687,7 @@ You can use the `ParseMessage` transformation
 to parse logs in Logfmt format and convert them into a structured object.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: logfmt-to-json
@@ -725,7 +725,7 @@ You can use the `ParseMessage` transformation to parse log entries in JSON forma
 Using the `depth` parameter, you can control the nesting depth.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: parse-json
@@ -760,7 +760,7 @@ Transformed result:
 The string transformation must be applied last.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: parse-json
@@ -819,7 +819,7 @@ You can use the `ReplaceKeys` transformation to replace `source` with `target` i
 > the log entry must first be parsed into a structured object using the `ParseMessage` transformation.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: replace-dot
@@ -860,7 +860,7 @@ You can use the `DropLabels` transformation to remove specific labels from log m
 > the log entry must first be parsed into a structured object using the `ParseMessage` transformation.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: drop-label
@@ -880,7 +880,7 @@ The `ParseMessage` transformation is applied first to parse the message,
 followed by `DropLabels` to remove the specified label.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: drop-label

--- a/modules/460-log-shipper/docs/EXAMPLES_RU.md
+++ b/modules/460-log-shipper/docs/EXAMPLES_RU.md
@@ -526,7 +526,7 @@ spec:
 При использовании нескольких трансформаций `ParseMessage`, преобразование строки должно выполняться последним.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: string-to-json
@@ -561,7 +561,7 @@ spec:
 чтобы распарсить логи в формате Klog и преобразовать их в структурированный объект.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: klog-to-json
@@ -599,7 +599,7 @@ I0505 17:59:40.692994   28133 klog.go:70] hello from klog
 чтобы распарсить логи в формате Syslog и преобразовать их в структурированный объект.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: syslog-to-json
@@ -644,7 +644,7 @@ spec:
 чтобы распарсить логи в формате CLF и преобразовать их в структурированный объект.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: clf-to-json
@@ -685,7 +685,7 @@ spec:
 чтобы распарсить логи в формате Logfmt и преобразовать их в структурированный объект.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: logfmt-to-json
@@ -722,7 +722,7 @@ spec:
 С помощью параметра `depth` можно контролировать глубину вложенности.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: parse-json
@@ -757,7 +757,7 @@ spec:
 Преобразование строки должно выполняться последним.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: parse-json
@@ -816,7 +816,7 @@ I0505 17:59:40.692994   28133 klog.go:70] hello from klog
 > необходимо преобразовать запись лога в структурированный объект с помощью трансформации `ParseMessage`.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: replace-dot
@@ -857,7 +857,7 @@ spec:
 > необходимо преобразовать запись лога в структурированный объект с помощью трансформации `ParseMessage`.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: drop-label
@@ -877,7 +877,7 @@ spec:
 после чего применяется `DropLabels` для удаления указанного лейбла.
 
 ```yaml
-apiVersion: deckhouse.io/v1alpha2
+apiVersion: deckhouse.io/v1alpha1
 kind: ClusterLogDestination
 metadata:
   name: drop-label


### PR DESCRIPTION
## Description

Fixed incorrect `apiVersion` in ClusterLogDestination examples in log-shipper documentation. Changed from `deckhouse.io/v1alpha2` (unsupported) to `deckhouse.io/v1alpha1` (correct version).

Modified files:
- `modules/460-log-shipper/docs/EXAMPLES.md`
- `modules/460-log-shipper/docs/EXAMPLES_RU.md`

All transformation examples (ParseMessage, ReplaceKeys, DropLabels) now use the correct API version.

## Why do we need it, and what problem does it solve?

Documentation contained non-working examples for ClusterLogDestination with transformations.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: log-shipper
type: fix
summary: Fixed incorrect apiVersion in ClusterLogDestination documentation examples.
impact_level: low
```