### PR TITLE
[admission-policy-engine] Preserve explicit empty arrays in SecurityPolicy/OperationPolicy values

### DIFF
--- a/modules/015-admission-policy-engine/hooks/handle_operation_policies.go
+++ b/modules/015-admission-policy-engine/hooks/handle_operation_policies.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
@@ -30,31 +29,6 @@ import (
 
 	v1alpha1 "github.com/deckhouse/deckhouse/modules/015-admission-policy-engine/hooks/internal/apis"
 )
-
-type operationPolicyFilterResult struct {
-	Policy                 *operationPolicy `json:"policy"`
-	ExplicitEmptySliceKeys []string         `json:"explicitEmptySliceKeys,omitempty"`
-}
-
-// operationPolicyEmptySlicePaths enumerates slice fields where explicit empty list ([]) must be
-// preserved in Values so Helm `hasKey`-guards can distinguish "omitted" vs "explicitly empty".
-//
-// We keep it strictly to fields that participate in constraint rendering logic.
-var operationPolicyEmptySlicePaths = []string{
-	"spec.policies.allowedRepos",
-	"spec.policies.requiredResources.limits",
-	"spec.policies.requiredResources.requests",
-	"spec.policies.disallowedImageTags",
-	"spec.policies.disallowedTolerations",
-	"spec.policies.requiredProbes",
-	"spec.policies.priorityClassNames",
-	"spec.policies.ingressClassNames",
-	"spec.policies.storageClassNames",
-	"spec.policies.requiredLabels.labels",
-	"spec.policies.requiredLabels.watchKinds",
-	"spec.policies.requiredAnnotations.annotations",
-	"spec.policies.requiredAnnotations.watchKinds",
-}
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/admission-policy-engine/operation_policies",
@@ -69,38 +43,12 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, handleOP)
 
 func handleOP(_ context.Context, input *go_hook.HookInput) error {
-	items, err := sdkobjectpatch.UnmarshalToStruct[operationPolicyFilterResult](input.Snapshots, "operation-policies")
+	ops, err := sdkobjectpatch.UnmarshalToStruct[operationPolicy](input.Snapshots, "operation-policies")
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal operation-policies snapshot: %w", err)
 	}
 
-	// We intentionally convert typed structs to map before putting them into Values to preserve
-	// the semantic difference between:
-	// - field omitted        => no key in Values (templates guarded by hasKey won't render)
-	// - field set to []      => key exists in Values with empty array
-	//
-	// This is needed for selected fields (see filterOP) where explicitly empty list must not be
-	// dropped by `omitempty` during JSON serialization.
-	opsForValues := make([]map[string]any, 0, len(items))
-	for _, item := range items {
-		b, err := json.Marshal(item.Policy)
-		if err != nil {
-			return fmt.Errorf("failed to marshal OperationPolicy for Values: %w", err)
-		}
-		var m map[string]any
-		if err := json.Unmarshal(b, &m); err != nil {
-			return fmt.Errorf("failed to unmarshal OperationPolicy to map for Values: %w", err)
-		}
-		for _, key := range item.ExplicitEmptySliceKeys {
-			path := strings.Split(key, ".")
-			if err := unstructured.SetNestedField(m, []any{}, path...); err != nil {
-				return fmt.Errorf("failed to force empty slice %q in Values: %w", key, err)
-			}
-		}
-		opsForValues = append(opsForValues, m)
-	}
-
-	data, err := json.Marshal(opsForValues)
+	data, err := json.Marshal(ops)
 	if err != nil {
 		return err
 	}
@@ -117,15 +65,7 @@ func filterOP(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 		return nil, err
 	}
 
-	explicitEmpty, err := detectExplicitEmptySliceKeys(obj.Object, operationPolicyEmptySlicePaths)
-	if err != nil {
-		return nil, err
-	}
-
-	return &operationPolicyFilterResult{
-		Policy:                 &op,
-		ExplicitEmptySliceKeys: explicitEmpty,
-	}, nil
+	return &op, nil
 }
 
 type operationPolicy struct {

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -55,47 +55,47 @@ type SecurityPolicy struct {
 type SecurityPolicySpec struct {
 	EnforcementAction string `json:"enforcementAction"`
 	Policies          struct {
-		AllowedHostPaths []struct {
+		AllowedHostPaths *[]struct {
 			PathPrefix string `json:"pathPrefix"`
 			ReadOnly   bool   `json:"readOnly"`
 		} `json:"allowedHostPaths,omitempty"`
-		AllowHostIPC             *bool     `json:"allowHostIPC,omitempty"`
-		AllowHostPID             *bool     `json:"allowHostPID,omitempty"`
-		AllowPrivileged          *bool     `json:"allowPrivileged,omitempty"`
-		AllowPrivilegeEscalation *bool     `json:"allowPrivilegeEscalation,omitempty"`
-		AllowRbacWildcards       *bool     `json:"allowRbacWildcards,omitempty"`
-		AllowedProcMount         string    `json:"allowedProcMount,omitempty"`
-		AllowedCapabilities      []string  `json:"allowedCapabilities,omitempty"`
-		AllowedAppArmor          []string  `json:"allowedAppArmor,omitempty"`
-		RequiredDropCapabilities []string  `json:"requiredDropCapabilities,omitempty"`
-		AllowHostNetwork         *bool     `json:"allowHostNetwork,omitempty"`
-		AllowedHostPorts         []IDRange `json:"allowedHostPorts,omitempty"`
-		AllowedFlexVolumes       []struct {
+		AllowHostIPC             *bool      `json:"allowHostIPC,omitempty"`
+		AllowHostPID             *bool      `json:"allowHostPID,omitempty"`
+		AllowPrivileged          *bool      `json:"allowPrivileged,omitempty"`
+		AllowPrivilegeEscalation *bool      `json:"allowPrivilegeEscalation,omitempty"`
+		AllowRbacWildcards       *bool      `json:"allowRbacWildcards,omitempty"`
+		AllowedProcMount         string     `json:"allowedProcMount,omitempty"`
+		AllowedCapabilities      *[]string  `json:"allowedCapabilities,omitempty"`
+		AllowedAppArmor          *[]string  `json:"allowedAppArmor,omitempty"`
+		RequiredDropCapabilities *[]string  `json:"requiredDropCapabilities,omitempty"`
+		AllowHostNetwork         *bool      `json:"allowHostNetwork,omitempty"`
+		AllowedHostPorts         *[]IDRange `json:"allowedHostPorts,omitempty"`
+		AllowedFlexVolumes       *[]struct {
 			Driver string `json:"driver"`
 		} `json:"allowedFlexVolumes,omitempty"`
-		AllowedVolumes               []string           `json:"allowedVolumes,omitempty"`
-		AllowedServiceTypes          []string           `json:"allowedServiceTypes,omitempty"`
+		AllowedVolumes               *[]string          `json:"allowedVolumes,omitempty"`
+		AllowedServiceTypes          *[]string          `json:"allowedServiceTypes,omitempty"`
 		BlockWildcardDomains         bool               `json:"blockWildcardDomains,omitempty"`
 		ReadOnlyRootFilesystem       bool               `json:"readOnlyRootFilesystem,omitempty"`
 		AutomountServiceAccountToken *bool              `json:"automountServiceAccountToken,omitempty"`
-		AllowedClusterRoles          []string           `json:"allowedClusterRoles,omitempty"`
+		AllowedClusterRoles          *[]string          `json:"allowedClusterRoles,omitempty"`
 		FsGroup                      *SelectUIDStrategy `json:"fsGroup,omitempty"`
 		RunAsUser                    *SelectUIDStrategy `json:"runAsUser,omitempty"`
 		RunAsGroup                   *SelectUIDStrategy `json:"runAsGroup,omitempty"`
 		SupplementalGroups           *SelectUIDStrategy `json:"supplementalGroups,omitempty"`
-		AllowedUnsafeSysctls         []string           `json:"allowedUnsafeSysctls,omitempty"`
-		ForbiddenSysctls             []string           `json:"forbiddenSysctls,omitempty"`
+		AllowedUnsafeSysctls         *[]string          `json:"allowedUnsafeSysctls,omitempty"`
+		ForbiddenSysctls             *[]string          `json:"forbiddenSysctls,omitempty"`
 		SeccompProfiles              struct {
-			AllowedProfiles       []string `json:"allowedProfiles,omitempty"`
-			AllowedLocalhostFiles []string `json:"allowedLocalhostFiles,omitempty"`
+			AllowedProfiles       *[]string `json:"allowedProfiles,omitempty"`
+			AllowedLocalhostFiles *[]string `json:"allowedLocalhostFiles,omitempty"`
 		} `json:"seccompProfiles,omitempty"`
-		SeLinux []struct {
+		SeLinux *[]struct {
 			Level string `json:"level,omitempty"`
 			Role  string `json:"role,omitempty"`
 			Type  string `json:"type,omitempty"`
 			User  string `json:"user,omitempty"`
 		} `json:"seLinux,omitempty"`
-		VerifyImageSignatures []ImageReference `json:"verifyImageSignatures,omitempty"`
+		VerifyImageSignatures *[]ImageReference `json:"verifyImageSignatures,omitempty"`
 	} `json:"policies"`
 	Match struct {
 		NamespaceSelector NamespaceSelector    `json:"namespaceSelector,omitempty"`
@@ -123,35 +123,35 @@ type IDRange struct {
 type OperationPolicySpec struct {
 	EnforcementAction string `json:"enforcementAction"`
 	Policies          struct {
-		AllowedRepos      []string `json:"allowedRepos,omitempty"`
+		AllowedRepos      *[]string `json:"allowedRepos,omitempty"`
 		RequiredResources struct {
-			Limits   []string `json:"limits,omitempty"`
-			Requests []string `json:"requests,omitempty"`
+			Limits   *[]string `json:"limits,omitempty"`
+			Requests *[]string `json:"requests,omitempty"`
 		} `json:"requiredResources,omitempty"`
-		DisallowedImageTags   []string     `json:"disallowedImageTags,omitempty"`
-		DisallowedTolerations []Toleration `json:"disallowedTolerations,omitempty"`
-		RequiredProbes        []string     `json:"requiredProbes,omitempty"`
+		DisallowedImageTags   *[]string     `json:"disallowedImageTags,omitempty"`
+		DisallowedTolerations *[]Toleration `json:"disallowedTolerations,omitempty"`
+		RequiredProbes        *[]string     `json:"requiredProbes,omitempty"`
 		RequiredLabels        struct {
-			Labels []struct {
+			Labels *[]struct {
 				Key          string `json:"key,omitempty"`
 				AllowedRegex string `json:"allowedRegex,omitempty"`
 			} `json:"labels,omitempty"`
-			WatchKinds []string `json:"watchKinds,omitempty"`
+			WatchKinds *[]string `json:"watchKinds,omitempty"`
 		} `json:"requiredLabels,omitempty"`
 		RequiredAnnotations struct {
-			Annotations []struct {
+			Annotations *[]struct {
 				Key          string `json:"key,omitempty"`
 				AllowedRegex string `json:"allowedRegex,omitempty"`
 			} `json:"annotations,omitempty"`
-			WatchKinds []string `json:"watchKinds,omitempty"`
+			WatchKinds *[]string `json:"watchKinds,omitempty"`
 		} `json:"requiredAnnotations,omitempty"`
-		MaxRevisionHistoryLimit   *int     `json:"maxRevisionHistoryLimit,omitempty"`
-		ImagePullPolicy           string   `json:"imagePullPolicy,omitempty"`
-		PriorityClassNames        []string `json:"priorityClassNames,omitempty"`
-		IngressClassNames         []string `json:"ingressClassNames,omitempty"`
-		StorageClassNames         []string `json:"storageClassNames,omitempty"`
-		CheckHostNetworkDNSPolicy bool     `json:"checkHostNetworkDNSPolicy,omitempty"`
-		CheckContainerDuplicates  bool     `json:"checkContainerDuplicates,omitempty"`
+		MaxRevisionHistoryLimit   *int      `json:"maxRevisionHistoryLimit,omitempty"`
+		ImagePullPolicy           string    `json:"imagePullPolicy,omitempty"`
+		PriorityClassNames        *[]string `json:"priorityClassNames,omitempty"`
+		IngressClassNames         *[]string `json:"ingressClassNames,omitempty"`
+		StorageClassNames         *[]string `json:"storageClassNames,omitempty"`
+		CheckHostNetworkDNSPolicy bool      `json:"checkHostNetworkDNSPolicy,omitempty"`
+		CheckContainerDuplicates  bool      `json:"checkContainerDuplicates,omitempty"`
 		ReplicaLimits             struct {
 			MinReplicas int `json:"minReplicas,omitempty"`
 			MaxReplicas int `json:"maxReplicas,omitempty"`


### PR DESCRIPTION
## Description

- Preserve **explicitly set empty arrays (`[]`)** from `SecurityPolicy` / `OperationPolicy` when hooks store objects into module `Values`, so Helm can distinguish **“field omitted” vs “field set to []”**.

- Expand preservation to **slice fields that affect constraint rendering** (including nested `seccompProfiles` arrays), keeping existing semantics for non-slice and unrelated fields.

- Add/extend **unit tests** to cover tri-state behavior (omitted / empty / non-empty) and nested empty-array cases for both hooks.

- Backward-compatible: behavior changes only for fields explicitly set to `[]` in CRs; fields not specified remain absent in `Values`.

No restarts of control-plane/ingress-controllers/Prometheus are induced by this fix. Module behavior changes only in generated Gatekeeper constraints.

## Why do we need it, and what problem does it solve?

- Fixes a bug where `[]` in CRs was lost during hook processing, causing corresponding Gatekeeper constraints **not to render** (due to Helm `hasKey` checks) and policies **not to be enforced** (e.g., `allowedHostPaths: []` failing to block `/proc`).

- Restores correct tri-state semantics for relevant list fields, ensuring constraints are generated and enforcement works as documented.

## Why do we need it in the patch release (if we do)?

Yes: this is a **security enforcement correctness fix**. In affected configurations, policies that should deny workloads may silently not apply.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Added and extend unit tests to cover tri-state behavior (omitted / empty / non-empty) and nested empty-array cases for both hooks.
impact_level: default
```