### PR TITLE
[dhctl] re-acquire or re-create lease after expiration

### DIFF
--- a/dhctl/pkg/kubernetes/lease/lock.go
+++ b/dhctl/pkg/kubernetes/lease/lock.go
@@ -212,6 +212,35 @@ func (l *LeaseLock) tryAcquire(ctx context.Context, force bool) (*coordinationv1
 				return fmt.Errorf("%s Can't get current lease %v", prefix, err)
 			}
 
+			// If lease is expired, delete it and create a new one
+			if !l.isStillLocked(lease) {
+				log.Warn("Lease expired, deleting expired lease and creating new one",
+					slog.String("identity", l.config.Identity),
+					slog.String("holder", *lease.Spec.HolderIdentity),
+					slog.String("renew_time", lease.Spec.RenewTime.Time.String()))
+
+				// Try to delete expired lease
+				deleteErr := l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Delete(ctx, lease.Name, metav1.DeleteOptions{})
+				if deleteErr != nil && !errors.IsNotFound(deleteErr) {
+					log.Warn("Failed to delete expired lease, will try to create anyway", slog.String("error", deleteErr.Error()))
+				}
+
+				// Try to create new lease
+				lease, err = l.createLease(ctx)
+				if err == nil {
+					return nil
+				}
+				// If creation failed (e.g., another process created it), continue to tryRenew logic
+				if !errors.IsAlreadyExists(err) {
+					return err
+				}
+				// Get the lease again in case it was recreated
+				lease, err = l.getter.KubeClient().CoordinationV1().Leases(l.config.Namespace).Get(ctx, l.config.Name, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("%s Can't get current lease after deletion attempt %v", prefix, err)
+				}
+			}
+
 			lease, err = l.tryRenew(ctx, lease, force)
 			if err != nil {
 				return fmt.Errorf("%s \n%v", prefix, err)


### PR DESCRIPTION
## Description
re-acquire or re-create lease after expiration
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
re-acquire or re-create lease after expiration
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
no need

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: re-acquire or re-create lease after expiration
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
