### PR TITLE
[registry] Backport 1.74: Omit auth field in dockerConfig for empty credentials

### DIFF
--- a/modules/038-registry/hooks/helpers/docker_cfg.go
+++ b/modules/038-registry/hooks/helpers/docker_cfg.go
@@ -22,72 +22,147 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-
-	"github.com/google/go-containerregistry/pkg/authn"
 )
 
-type dockerCfg struct {
-	Auths map[string]authn.AuthConfig `json:"auths"`
+type authConfig struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+}
+
+func (config *authConfig) decodeAuth() error {
+	if config.Auth != "" {
+		decoded, err := base64.StdEncoding.DecodeString(config.Auth)
+		if err != nil {
+			// Try decoding as if there's no padding
+			decoded, err = base64.RawStdEncoding.DecodeString(config.Auth)
+			if err != nil {
+				return fmt.Errorf("decode base64: %w", err)
+			}
+		}
+
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid format: expected 'username:password'")
+		}
+
+		config.Username = parts[0]
+		config.Password = parts[1]
+	}
+
+	config.encodeAuth()
+	return nil
+}
+
+func (config *authConfig) encodeAuth() {
+	if config.Username != "" && config.Password != "" {
+		auth := fmt.Sprintf("%s:%s", config.Username, config.Password)
+		config.Auth = base64.StdEncoding.EncodeToString([]byte(auth))
+	} else {
+		config.Auth = ""
+	}
+}
+
+func (config *authConfig) deepCopy() *authConfig {
+	if config == nil {
+		return nil
+	}
+	return &authConfig{
+		Username: config.Username,
+		Password: config.Password,
+		Auth:     config.Auth,
+	}
+}
+
+type dockerConfig struct {
+	Auths map[string]authConfig `json:"auths"`
+}
+
+func (config *dockerConfig) getAuth(host string) (*authConfig, error) {
+	host, err := normalizeHost(host)
+	if err != nil {
+		return nil, fmt.Errorf("normalize host: %w", err)
+	}
+
+	for authHost, authConfig := range config.Auths {
+		authHost, err := normalizeHost(authHost)
+		if err != nil {
+			return nil, fmt.Errorf("normalize auth host: %w", err)
+		}
+
+		if authHost == host {
+			return authConfig.deepCopy(), nil
+		}
+	}
+	return nil, nil
 }
 
 func DockerCfgFromCreds(username, password, host string) ([]byte, error) {
-	targetHost, err := normalizeHost(host)
+	host, err := normalizeHost(host)
 	if err != nil {
-		return []byte{}, err
+		return nil, fmt.Errorf("normalize host: %w", err)
 	}
 
-	cfg := dockerCfg{
-		Auths: map[string]authn.AuthConfig{
-			targetHost: {
-				Username: username,
-				Password: password,
-				Auth:     base64.StdEncoding.EncodeToString([]byte(username + ":" + password)),
-			},
+	auth := authConfig{
+		Username: username,
+		Password: password,
+	}
+	auth.encodeAuth()
+
+	config := dockerConfig{
+		Auths: map[string]authConfig{
+			host: auth,
 		},
 	}
-	return json.Marshal(cfg)
+
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return nil, fmt.Errorf("marshal docker config: %w", err)
+	}
+	return configJSON, nil
 }
 
-func CredsFromDockerCfg(rawCfg []byte, host string) (string, string, error) {
-	if len(rawCfg) == 0 {
+func CredsFromDockerCfg(rawConfig []byte, host string) (string, string, error) {
+	if len(rawConfig) == 0 {
 		return "", "", nil
 	}
 
-	// Username and password added by unmarshal
-	// https://github.com/google/go-containerregistry/blob/main/pkg/authn/authn.go#L67-L94
-	var cfg dockerCfg
-	if err := json.Unmarshal(rawCfg, &cfg); err != nil {
-		return "", "", fmt.Errorf("failed to unmarshal docker config: %w", err)
+	var config dockerConfig
+	if err := json.Unmarshal(rawConfig, &config); err != nil {
+		return "", "", fmt.Errorf("unmarshal docker config: %w", err)
 	}
 
-	targetHost, err := normalizeHost(host)
+	auth, err := config.getAuth(host)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("get auth: %w", err)
 	}
 
-	for repoKey, auth := range cfg.Auths {
-		repoHost, err := normalizeHost(repoKey)
-		if err != nil {
-			return "", "", err
-		}
-		if repoHost == targetHost {
-			return auth.Username, auth.Password, nil
-		}
+	if auth == nil {
+		return "", "", nil
 	}
-	return "", "", nil
+
+	err = auth.decodeAuth()
+	if err != nil {
+		return "", "", fmt.Errorf("decode auth: %w", err)
+	}
+
+	return auth.Username, auth.Password, nil
 }
 
 func normalizeHost(host string) (string, error) {
 	targetHost := host
+
 	if !strings.HasPrefix(host, "http://") && !strings.HasPrefix(host, "https://") {
 		targetHost = "//" + host
 	}
+
 	u, err := url.Parse(targetHost)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse input host %q: %w", host, err)
+		return "", fmt.Errorf("parse host %q: %w", host, err)
 	}
-	if u.Host == "" {
-		return "", fmt.Errorf("failed to parse input host %q: host component is empty", host)
+
+	if u.Host == "" || strings.HasPrefix(u.Host, ":") {
+		return "", fmt.Errorf("parse host %q: empty host component", host)
 	}
 	return u.Host, nil
 }


### PR DESCRIPTION
## Description

**Backport** https://github.com/deckhouse/deckhouse/pull/17310

This PR resolves the issue with generating `dockerConfig` when `username` and `password` are empty. If both are empty, the `auth` field in the Docker configuration will now be omitted (previously it was incorrectly set to `":"` which is not valid).

### Example Configuration:

```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: deckhouse
spec:
  settings:
    registry:
      mode: Direct
      direct:
        imagesRepo: <my_anonymous_registry>/sys/deckhouse-oss
        scheme: HTTP
    ---
    registry:
      mode: Unmanaged
      unmanaged:
        imagesRepo: <my_anonymous_registry>/sys/deckhouse-oss
        scheme: HTTP
```


### Switching to Anonymous Docker Registry with Module:

**Before:**

```yaml
# `dechouse-registry` secret (Unmanaged)
.dockerconfigjson: {"auths":{"<my_anonymous_registry>":{"auth":"Og=="}}}
---
# `dechouse-registry` secret (Direct)
.dockerconfigjson: {"auths":{"registry.d8-system.svc:5001":{"auth":"Og=="}}}
```

**After:**

```yaml
# `dechouse-registry` secret (Unmanaged)
.dockerconfigjson: {"auths":{"<my_anonymous_registry>":{}}}
---
# `dechouse-registry` secret (Direct)
.dockerconfigjson: {"auths":{"registry.d8-system.svc:5001":{}}}
---
```

### Cluster Update with the Fix when Registry Module Enabled:

**Before:**

```yaml
# `dechouse-registry` secret (Unmanaged)
.dockerconfigjson: {"auths":{"<my_anonymous_registry>":{"auth":"Og=="}}}
---
# `dechouse-registry` secret (Direct)
.dockerconfigjson: {"auths":{"registry.d8-system.svc:5001":{"auth":"Og=="}}}
```

**After:**

```yaml
# `dechouse-registry` secret (Unmanaged)
.dockerconfigjson: {"auths":{"<my_anonymous_registry>":{}}}
---
# `dechouse-registry` secret (Direct)
.dockerconfigjson: {"auths":{"registry.d8-system.svc:5001":{}}}
---
```


## Why do we need it in the patch release (if we do)?

When users provide an empty `username` and `password` in the registry module, the `dockerConfig` was incorrectly rendered with the `auth` field as `":"`. This invalid configuration could lead to errors when the `dockerConfig` is used in other applications, such as Trivy, resulting in errors like:

```log
failed to download vulnerability DB: database download error: OCI repository error: 1 error occurred:
    * loading config file: /.docker/config.json: : Invalid auth configuration file
```

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: Omitted the auth field in DockerConfig when credentials (username and password) are empty.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
