### PR TITLE
[cloud-provider-yandex] Add fallback to nat_instance_internal_address_calculated

### DIFF
--- a/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
+++ b/candi/cloud-providers/yandex/terraform-modules/vpc-components/nat_instance.tf
@@ -55,7 +55,7 @@ locals {
 
   # if user passes nat instance internal address directly (deprecated, keep for backward compatibility) use passed address,
   # else get 10 host address from cidr which got in previous step
-  nat_instance_internal_address_calculated = var.nat_instance_internal_address != null ? var.nat_instance_internal_address : cidrhost(local.nat_instance_internal_cidr, 10)
+  nat_instance_internal_address_calculated = var.nat_instance_internal_address != null ? var.nat_instance_internal_address : try(cidrhost(local.nat_instance_internal_cidr, 10), "")
 
   assign_external_ip_address = var.nat_instance_external_subnet_id == null ? true : false
 


### PR DESCRIPTION
## Description
Add fallback to `nat_instance_internal_address_calculated`

## Why do we need it, and what problem does it solve?
Terraform returns error on this variable if user has invalid config, user sees NAT-related error, even when his layout is not `WithNAT`

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Added fallback to `nat_instance_internal_address_calculated`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
