### PR TITLE
[admission-policy-engine] Fix op/security policy empty fields

### DIFF
--- a/modules/015-admission-policy-engine/hooks/handle_security_policies.go
+++ b/modules/015-admission-policy-engine/hooks/handle_security_policies.go
@@ -186,9 +186,14 @@ func preprocesSecurityPolicy(sp *securityPolicy) {
 		sp.Spec.Policies.AllowedVolumes = nil
 	}
 	// Having all seccomp profiles allowed also isn't worth creating a constraint
-	if hasItemPtr(sp.Spec.Policies.SeccompProfiles.AllowedProfiles, "*") && hasItemPtr(sp.Spec.Policies.SeccompProfiles.AllowedLocalhostFiles, "*") {
-		sp.Spec.Policies.SeccompProfiles.AllowedProfiles = nil
-		sp.Spec.Policies.SeccompProfiles.AllowedLocalhostFiles = nil
+	if sp.Spec.Policies.SeccompProfiles != nil {
+		if hasItemPtr(sp.Spec.Policies.SeccompProfiles.AllowedProfiles, "*") && hasItemPtr(sp.Spec.Policies.SeccompProfiles.AllowedLocalhostFiles, "*") {
+			sp.Spec.Policies.SeccompProfiles.AllowedProfiles = nil
+			sp.Spec.Policies.SeccompProfiles.AllowedLocalhostFiles = nil
+		}
+		if sp.Spec.Policies.SeccompProfiles.AllowedProfiles == nil && sp.Spec.Policies.SeccompProfiles.AllowedLocalhostFiles == nil {
+			sp.Spec.Policies.SeccompProfiles = nil
+		}
 	}
 	// Having rules allowing '*' volumes makes no sense
 	if hasItemPtr(sp.Spec.Policies.AllowedClusterRoles, "*") {

--- a/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
+++ b/modules/015-admission-policy-engine/hooks/internal/apis/v1alpha1.go
@@ -85,7 +85,7 @@ type SecurityPolicySpec struct {
 		SupplementalGroups           *SelectUIDStrategy `json:"supplementalGroups,omitempty"`
 		AllowedUnsafeSysctls         *[]string          `json:"allowedUnsafeSysctls,omitempty"`
 		ForbiddenSysctls             *[]string          `json:"forbiddenSysctls,omitempty"`
-		SeccompProfiles              struct {
+		SeccompProfiles              *struct {
 			AllowedProfiles       *[]string `json:"allowedProfiles,omitempty"`
 			AllowedLocalhostFiles *[]string `json:"allowedLocalhostFiles,omitempty"`
 		} `json:"seccompProfiles,omitempty"`
@@ -124,21 +124,21 @@ type OperationPolicySpec struct {
 	EnforcementAction string `json:"enforcementAction"`
 	Policies          struct {
 		AllowedRepos      *[]string `json:"allowedRepos,omitempty"`
-		RequiredResources struct {
+		RequiredResources *struct {
 			Limits   *[]string `json:"limits,omitempty"`
 			Requests *[]string `json:"requests,omitempty"`
 		} `json:"requiredResources,omitempty"`
 		DisallowedImageTags   *[]string     `json:"disallowedImageTags,omitempty"`
 		DisallowedTolerations *[]Toleration `json:"disallowedTolerations,omitempty"`
 		RequiredProbes        *[]string     `json:"requiredProbes,omitempty"`
-		RequiredLabels        struct {
+		RequiredLabels        *struct {
 			Labels *[]struct {
 				Key          string `json:"key,omitempty"`
 				AllowedRegex string `json:"allowedRegex,omitempty"`
 			} `json:"labels,omitempty"`
 			WatchKinds *[]string `json:"watchKinds,omitempty"`
 		} `json:"requiredLabels,omitempty"`
-		RequiredAnnotations struct {
+		RequiredAnnotations *struct {
 			Annotations *[]struct {
 				Key          string `json:"key,omitempty"`
 				AllowedRegex string `json:"allowedRegex,omitempty"`
@@ -152,7 +152,7 @@ type OperationPolicySpec struct {
 		StorageClassNames         *[]string `json:"storageClassNames,omitempty"`
 		CheckHostNetworkDNSPolicy bool      `json:"checkHostNetworkDNSPolicy,omitempty"`
 		CheckContainerDuplicates  bool      `json:"checkContainerDuplicates,omitempty"`
-		ReplicaLimits             struct {
+		ReplicaLimits             *struct {
 			MinReplicas int `json:"minReplicas,omitempty"`
 			MaxReplicas int `json:"maxReplicas,omitempty"`
 		} `json:"replicaLimits,omitempty"`


### PR DESCRIPTION
## Description

- Switch OperationPolicy object fields (requiredResources, requiredLabels, requiredAnnotations, replicaLimits) to pointers to avoid leaking empty `{}` into Values and rendering unwanted constraints.
- Switch SecurityPolicy seccompProfiles to a pointer; preprocess now skips empty seccompProfiles while still preserving empty slices.
- Extend hook unit tests to cover tri‑state semantics for all policy slices, requiredResources combinations, replicaLimits edge cases, maxRevisionHistoryLimit, imagePullPolicy, booleans, UID strategies, and absence of stray keys.

## Why do we need it, and what problem does it solve?

Explicitly empty arrays in OperationPolicy/SecurityPolicy were collapsing into “field absent”, while missing object fields could appear as empty `{}`. This led to missing constraints (e.g., requiredResources) or extra ones (replicaLimits with `{}`), breaking admission decisions. Pointer fields and expanded tests ensure tri‑state is preserved and empty objects are not emitted.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Fixed tri-state semantics for empty arrays and avoided empty objects in OperationPolicy/SecurityPolicy values.
impact_level: default
```