### PR TITLE
[node-local-dns] Bump version and fix vulnerabilities (1.73)

### DIFF
--- a/modules/000-common/images/coredns/patches/go-mod.patch
+++ b/modules/000-common/images/coredns/patches/go-mod.patch
@@ -1,0 +1,28 @@
+diff --git a/go.mod b/go.mod
+index b83633d22..7583d06ef 100644
+--- a/go.mod
++++ b/go.mod
+@@ -18,7 +18,7 @@ require (
+ 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.40.4
+ 	github.com/coredns/caddy v1.1.4-0.20250930002214-15135a999495
+ 	github.com/dnstap/golang-dnstap v0.4.0
+-	github.com/expr-lang/expr v1.17.6
++	github.com/expr-lang/expr v1.17.7
+ 	github.com/farsightsec/golang-framestream v0.3.0
+ 	github.com/go-logr/logr v1.4.3
+ 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
+diff --git a/go.sum b/go.sum
+index 59fe8a0bb..70d30d072 100644
+--- a/go.sum
++++ b/go.sum
+@@ -138,8 +138,8 @@ github.com/ebitengine/purego v0.8.4 h1:CF7LEKg5FFOsASUj0+QwaXf8Ht6TlFxg09+S9wz0o
+ github.com/ebitengine/purego v0.8.4/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+ github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
+ github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+-github.com/expr-lang/expr v1.17.6 h1:1h6i8ONk9cexhDmowO/A64VPxHScu7qfSl2k8OlINec=
+-github.com/expr-lang/expr v1.17.6/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
++github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
++github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+ github.com/farsightsec/golang-framestream v0.3.0 h1:/spFQHucTle/ZIPkYqrfshQqPe2VQEzesH243TjIwqA=
+ github.com/farsightsec/golang-framestream v0.3.0/go.mod h1:eNde4IQyEiA5br02AouhEHCu3p3UzrCdFR4LuQHklMI=
+ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/modules/000-common/images/coredns/werf.inc.yaml
+++ b/modules/000-common/images/coredns/werf.inc.yaml
@@ -4,6 +4,12 @@
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ .ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -12,6 +18,7 @@ shell:
     - git clone --depth 1 -b v{{ $coredns_version }} $(cat /run/secrets/SOURCE_REPO)/coredns/coredns.git /src
     - git clone --depth 1 -b v{{ $kubeforward_version }} -v "$(cat /run/secrets/SOURCE_REPO)/deckhouse/coredns-kubeforward" /src/coredns-kubeforward
     - cd /src
+    - git apply /patches/*.patch --verbose
     - touch /src/coredns-kubeforward/go.mod # need for go build
     - echo "kubeforward:github.com/deckhouse/coredns-kubeforward" >> plugin.cfg
     - rm -rf /src/.git


### PR DESCRIPTION
## Description

This PR fixes several security vulnerabilities in the project.

## Why do we need it, and what problem does it solve?

This update addresses the following vulnerabilities:

- CVE-2025-64702
- CVE-2025-47914
- CVE-2025-58181
- CVE-2025-68156

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-local-dns
type: fix
summary: Bump version and fixed vulnerabilities.
impact_level: low
```