### PR TITLE
[cloud-provider-dvp] additionalDisks fix in master InstanceClass

### DIFF
--- a/modules/030-cloud-provider-dvp/openapi/values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/values.yaml
@@ -305,6 +305,28 @@ properties:
                         type: string
                         description: |
                           The name of the existing StorageClass will be used to create the ETCD data disk.
+
+                  additionalDisks:
+                    type: array
+                    description: |
+                      Additional data disks settings.
+                    items:
+                      type: object
+                      additionalProperties: false
+                      required:
+                        - size
+                      properties:
+                        size:
+                          type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          description: |
+                            Additional disk size.
+                          example: 10Gi
+                        storageClass:
+                          type: string
+                          description: |
+                            The name of the existing StorageClass will be used to create the additional data disk.
+
                   additionalLabels:
                     type: object
                     description: |
@@ -384,6 +406,27 @@ properties:
                   properties:
                     virtualMachine: *instanceClassVirtualMachine
                     rootDisk: *instanceClassRootDisk
+
+                    additionalDisks:
+                      type: array
+                      description: |
+                        Additional data disks settings.
+                      items:
+                        type: object
+                        additionalProperties: false
+                        required:
+                          - size
+                        properties:
+                          size:
+                            type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            description: |
+                              Additional disk size.
+                            example: 10Gi
+                          storageClass:
+                            type: string
+                            description: |
+                              The name of the existing StorageClass will be used to create the additional data disk.
           layout:
             type: string
             description: |


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Now bootstrap with additionalDisks in master InstanceClass is forbidden. This PR fix this behavior 
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Now bootstrap with additionalDisks in master InstanceClass is forbidden. This PR fix this behavior 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Allowed using `additionalDisks` in master InstanceClasses.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
