### PR TITLE
[cni-cilium] Fix egress-gateway-agent controller logic for deleted resources and disable dev logging

### DIFF
--- a/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/src/cmd/main.go
+++ b/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/src/cmd/main.go
@@ -50,7 +50,7 @@ func main() {
 	var probeAddr string
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":9870", "The address the probe endpoint binds to.")
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/src/internal/controller/egressgateway_controller.go
+++ b/ee/se-plus/modules/021-cni-cilium/images/egress-gateway-agent/src/internal/controller/egressgateway_controller.go
@@ -46,7 +46,9 @@ func (r *EgressGatewayInstanceReconciler) Reconcile(ctx context.Context, req ctr
 	// Get resource
 	var egressGatewayInstance eeInternalCrd.SDNInternalEgressGatewayInstance
 	if err := r.Get(ctx, req.NamespacedName, &egressGatewayInstance); err != nil {
-		logger.Error(err, "unable to fetch egress gateway instance", "name", req.NamespacedName)
+		if client.IgnoreNotFound(err) != nil {
+			logger.Error(err, "unable to fetch egress gateway instance", "name", req.NamespacedName)
+		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 


### PR DESCRIPTION
## Description

Disable development logging mode in the Egress Gateway agent and fix the controller's reconciliation logic to correctly handle "Not Found" errors and resource deletion.

## Why do we need it, and what problem does it solve?

**Logging:** Disabling development mode (`Development: false`) ensures logs are production-ready (likely structured JSON) and less verbose.

**Controller Logic:**
    *   Prevents error logging when an Egress Gateway instance is not found (which is expected during deletion).
    *   Ensures the `Reconcile` loop terminates immediately after successfully cleaning up a deleted resource, preventing unintended execution of subsequent logic.

## Why do we need it in the patch release (if we do)?

It fixes bugs in the controller's operation and improves log quality by removing misleading error messages.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Fixed egress-gateway-agent controller logic for deleted resources and disable dev logging.
impact_level: default

```
