### PR TITLE
[docs] Add shortcodes for tabbed content and update readme

### DIFF
--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -587,3 +587,88 @@ Hugo:
 ```html
 data-search-context="{{ T "search_context" }}"
 ```
+
+## Markup (external modules documentation)
+
+[Hugo](gohugo.io) SSG is used for rendering.
+
+The documentation content is written in Markdown with some custom shortcodes.
+
+### OpenAPI Specifications rendering
+
+TODO
+
+### Page parameters (front matter)
+
+#### Related links
+
+```yaml
+params:
+  relatedLinks:
+    - title: "Link"
+      url: link.html
+    - title: "External link"
+      url: "http://domain/external/link.html"
+    - url: /modules/monitoring-kubernetes/
+```
+
+### Shortcodes
+
+<div id="alert-details"></div>
+
+#### Alert
+
+There are following levels of alerts: `info`, `warning`, `danger`. The default level is `info`.
+
+```go
+{{< alert level="warning" >}}
+The warning message...
+{{< /alert >}}
+```
+
+#### Tabs
+
+```go
+{{< tabs name="tabs_uniq_name" >}}
+{{% tab name="Tab caption 1" %}}Tab 1 Content {{% /tab %}}
+{{% tab name="Tab caption 2" %}}Tab 2 Content {{% /tab %}}
+{{< /tabs >}}
+```
+
+#### Translate
+
+Translates content based on the current language using the translations defined in the `i18n` folder.
+
+```go
+{{< translate "version_of_module" >}}
+```
+
+<div id="shortcode-details"></div>
+
+#### Details
+
+```go
+{{% details "Summary..."%}}
+## Markdown content
+
+Markdown content...
+{{% /details %}}
+```
+
+### Partials
+
+#### Details
+
+The same as the [details shortcode](#user-content-shortcode-details), but used in templates.
+
+```
+{{ partial "details" ( dict "summary" "Summary..." "content" "Markdown content..." ) }}
+```
+
+#### Alert
+
+The same as the [alert shortcode](#user-content-alert-details), but used in templates.
+
+```
+{{ partial "alert" ( dict "level" "warning" "content" "Markdown content..." ) }}
+```

--- a/docs/site/backends/docs-builder-template/layouts/_shortcodes/tab.html
+++ b/docs/site/backends/docs-builder-template/layouts/_shortcodes/tab.html
@@ -1,0 +1,10 @@
+{{ if .Parent }}
+  {{ $name := trim (.Get "name") " " }}
+  {{ $content := .Inner }}
+  {{ if not (.Parent.Scratch.Get "tabs") }}
+    {{ .Parent.Scratch.Set "tabs" slice }}
+  {{ end }}
+  {{ $.Parent.Scratch.Add "tabs" (dict "name" $name "content" $content ) }}
+{{ else }}
+  {{- errorf "[%s] %q: tab shortcode missing parent" site.Language.Lang .Page.Path -}}
+{{ end}}

--- a/docs/site/backends/docs-builder-template/layouts/_shortcodes/tabs.html
+++ b/docs/site/backends/docs-builder-template/layouts/_shortcodes/tabs.html
@@ -1,0 +1,19 @@
+{{- .Page.Scratch.Add "tabset-counter" 1 -}}
+{{- $tabs_name := .Get "name" | default (printf "%s-%d" (.Page.RelPermalink) (.Page.Scratch.Get "tabset-counter") ) | anchorize -}}
+{{- $tabs := .Scratch.Get "tabs" -}}
+{{- if .Inner -}}{{- /* We don't use the inner content, but Hugo will complain if we don't reference it. */ -}}{{- end -}}
+<div class="tabs">
+  {{- range $i, $e := $tabs -}}
+    {{- $id := printf "%s_%d" $tabs_name $i -}}
+    <a id="tab_{{ $id }}" href="javascript:void(0)" class="tabs__btn tabs__btn_{{ $tabs_name }}{{ if (eq $i 0) }} active{{ end }}"
+       onclick="openTabAndSaveStatus(event, 'tabs__btn_{{ $tabs_name }}', 'tabs__content_{{ $tabs_name }}', 'block_{{ $id }}');" >
+      {{- trim .name " " -}}
+    </a>
+  {{- end -}}
+</div>
+{{- range $i, $e := $tabs -}}
+{{- $id := printf "%s_%d" $tabs_name $i -}}
+<div id='block_{{ $id }}' class="tabs__content tabs__content_{{ $tabs_name }}{{ if (eq $i 0) }} active{{ end }}">
+  {{ .content | $.Page.RenderString | safeHTML }}
+</div>
+{{- end -}}


### PR DESCRIPTION
## Description

- Updated documentation for the markup in documentation for external modules.
- Added shortcodes for tabbed content.

  Example:

  ```go
  {{< tabs name="tabs_uniq_name" >}}
  {{% tab name="Tab caption 1" %}}Tab 1 Content {{% /tab %}}
  {{% tab name="Tab caption 2" %}}Tab 2 Content {{% /tab %}}
  {{< /tabs >}}
  ```

## Changelog entries
```changes
section: docs
type: chore
summary: Added shortcodes for tabbed content and updated readme.
impact_level: low
```
