### PR TITLE
[ingress-nginx] Update real-ip-cidr lua patches

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/024-use-proxy-real-ip-cidr-v2.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/024-use-proxy-real-ip-cidr-v2.patch
@@ -34,15 +34,22 @@ index 8628f8090..5a008b18c 100644
  		all.Cfg.GlobalRateLimitMemcachedPort,
  		all.Cfg.GlobalRateLimitMemcachedConnectTimeout,
 diff --git a/rootfs/etc/nginx/lua/lua_ingress.lua b/rootfs/etc/nginx/lua/lua_ingress.lua
-index 49e0f5b05..a8a53e17e 100644
+index 49e0f5b05..998f73cc7 100644
 --- a/rootfs/etc/nginx/lua/lua_ingress.lua
 +++ b/rootfs/etc/nginx/lua/lua_ingress.lua
-@@ -103,6 +103,12 @@ function _M.init_worker()
+@@ -11,6 +11,7 @@ local string = string
+ local original_randomseed = math.randomseed
+ local string_format = string.format
+ local ngx_redirect = ngx.redirect
++local iputils = require("resty.iputils")
+ 
+ local _M = {}
+ 
+@@ -103,6 +104,11 @@ function _M.init_worker()
  end
  
  function _M.set_config(new_config)
 +  if new_config.use_forwarded_headers then
-+    iputils = require("resty.iputils")
 +    iputils.enable_lrucache()
 +    new_config.real_ip_from = iputils.parse_cidrs(new_config.proxy_real_ip_cidr)
 +  end
@@ -55,7 +62,7 @@ index 49e0f5b05..a8a53e17e 100644
    ngx.var.best_http_host = ngx.var.http_host or ngx.var.host
  
 -  if config.use_forwarded_headers then
-+  if config.use_forwarded_headers and iputils.ip_in_cidrs(ngx.var.remote_addr, config.real_ip_from) then
++  if config.use_forwarded_headers and iputils.ip_in_cidrs(ngx.var.realip_remote_addr, config.real_ip_from) then
      -- trust http_x_forwarded_proto headers correctly indicate ssl offloading
      if ngx.var.http_x_forwarded_proto then
        ngx.var.pass_access_scheme = ngx.var.http_x_forwarded_proto

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -132,6 +132,6 @@ Adds a flag to disable TLS verification when downloading from the MaxMind mirror
 
 This patch adds the --status-service-label flag, allowing the controller to define a label selector that is used to match related k8s services. Then, the ip addresses/hostnames from the services' statuses are used to fill in Ingress objects statuses with correct values.
 
-### 024-use-proxy-real-ip-cidr.patch
+### 024-use-proxy-real-ip-cidr-v2.patch
 
 This patch updates lua ingress script to take into account the `proxy-real-ip-cidr` value when deciding if it's ok to accept x-forwarded headers values or not.

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -62,7 +62,7 @@ shell:
   - patch -p1 < /patches/021-geoip-ver-metric.patch
   - patch -p1 < /patches/022-skip-tls-verification-maxmind.patch
   - patch -p1 < /patches/023-ingress-update-status.patch
-  - patch -p1 < /patches/024-use-proxy-real-ip-cidr.patch
+  - patch -p1 < /patches/024-use-proxy-real-ip-cidr-v2.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/022-use-proxy-real-ip-cidr-v2.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/022-use-proxy-real-ip-cidr-v2.patch
@@ -23,15 +23,22 @@ index f6816d70a..86f2c53d5 100644
  
  type LuaListenPorts struct {
 diff --git a/rootfs/etc/nginx/lua/lua_ingress.lua b/rootfs/etc/nginx/lua/lua_ingress.lua
-index a513928cf..81436fdbc 100644
+index a513928cf..5643ebf59 100644
 --- a/rootfs/etc/nginx/lua/lua_ingress.lua
 +++ b/rootfs/etc/nginx/lua/lua_ingress.lua
-@@ -103,6 +103,11 @@ function _M.init_worker()
+@@ -11,6 +11,7 @@ local string = string
+ local original_randomseed = math.randomseed
+ local string_format = string.format
+ local ngx_redirect = ngx.redirect
++local iputils = require("resty.iputils")
+ 
+ local _M = {}
+ 
+@@ -103,6 +104,10 @@ function _M.init_worker()
  end
  
  function _M.set_config(new_config)
 +  if new_config.use_forwarded_headers then
-+    iputils = require("resty.iputils")
 +    iputils.enable_lrucache()
 +    new_config.real_ip_from = iputils.parse_cidrs(new_config.proxy_real_ip_cidr)
 +  end
@@ -43,7 +50,7 @@ index a513928cf..81436fdbc 100644
    ngx.var.best_http_host = ngx.var.http_host or ngx.var.host
  
 -  if config.use_forwarded_headers then
-+  if config.use_forwarded_headers and iputils.ip_in_cidrs(ngx.var.remote_addr, config.real_ip_from) then
++  if config.use_forwarded_headers and iputils.ip_in_cidrs(ngx.var.realip_remote_addr, config.real_ip_from) then
      -- trust http_x_forwarded_proto headers correctly indicate ssl offloading
      if ngx.var.http_x_forwarded_proto then
        ngx.var.pass_access_scheme = ngx.var.http_x_forwarded_proto

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -119,6 +119,6 @@ Adds a flag to disable TLS verification when downloading from the MaxMind mirror
 
 This patch adds the --status-service-label flag, allowing the controller to define a label selector that is used to match related k8s services. Then, the ip addresses/hostnames from the services' statuses are used to fill in Ingress objects statuses with correct values.
 
-### 022-use-proxy-real-ip-cidr.patch
+### 022-use-proxy-real-ip-cidr-v2.patch
 
 This patch updates lua ingress script to take into account the `proxy-real-ip-cidr` value when deciding if it's ok to accept x-forwarded headers values or not.

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/021-use-proxy-real-ip-cidr-v2.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/021-use-proxy-real-ip-cidr-v2.patch
@@ -34,15 +34,22 @@ index 7410ce6e0..aca7d3391 100644
  		all.Cfg.GlobalRateLimitMemcachedPort,
  		all.Cfg.GlobalRateLimitMemcachedConnectTimeout,
 diff --git a/rootfs/etc/nginx/lua/lua_ingress.lua b/rootfs/etc/nginx/lua/lua_ingress.lua
-index 49e0f5b05..a8a53e17e 100644
+index 49e0f5b05..998f73cc7 100644
 --- a/rootfs/etc/nginx/lua/lua_ingress.lua
 +++ b/rootfs/etc/nginx/lua/lua_ingress.lua
-@@ -103,6 +103,12 @@ function _M.init_worker()
+@@ -11,6 +11,7 @@ local string = string
+ local original_randomseed = math.randomseed
+ local string_format = string.format
+ local ngx_redirect = ngx.redirect
++local iputils = require("resty.iputils")
+ 
+ local _M = {}
+ 
+@@ -103,6 +104,11 @@ function _M.init_worker()
  end
  
  function _M.set_config(new_config)
 +  if new_config.use_forwarded_headers then
-+    iputils = require("resty.iputils")
 +    iputils.enable_lrucache()
 +    new_config.real_ip_from = iputils.parse_cidrs(new_config.proxy_real_ip_cidr)
 +  end
@@ -55,7 +62,7 @@ index 49e0f5b05..a8a53e17e 100644
    ngx.var.best_http_host = ngx.var.http_host or ngx.var.host
  
 -  if config.use_forwarded_headers then
-+  if config.use_forwarded_headers and iputils.ip_in_cidrs(ngx.var.remote_addr, config.real_ip_from) then
++  if config.use_forwarded_headers and iputils.ip_in_cidrs(ngx.var.realip_remote_addr, config.real_ip_from) then
      -- trust http_x_forwarded_proto headers correctly indicate ssl offloading
      if ngx.var.http_x_forwarded_proto then
        ngx.var.pass_access_scheme = ngx.var.http_x_forwarded_proto

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
@@ -100,6 +100,6 @@ Adds a flag to disable TLS verification when downloading from the MaxMind mirror
 
 This patch adds the --status-service-label flag, allowing the controller to define a label selector that is used to match related k8s services. Then, the ip addresses/hostnames from the services' statuses are used to fill in Ingress objects statuses with correct values.
 
-### 021-use-proxy-real-ip-cidr.patch
+### 021-use-proxy-real-ip-cidr-v2.patch
 
 This patch updates lua ingress script to take into account the `proxy-real-ip-cidr` value when deciding if it's ok to accept x-forwarded headers values or not.

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -77,7 +77,7 @@ shell:
   - patch -p1 < /patches/ingress-nginx/018-geoip-ver-metric.patch
   - patch -p1 < /patches/ingress-nginx/019-skip-tls-verification-maxmind.patch
   - patch -p1 < /patches/ingress-nginx/020-ingress-update-status.patch
-  - patch -p1 < /patches/ingress-nginx/021-use-proxy-real-ip-cidr.patch
+  - patch -p1 < /patches/ingress-nginx/021-use-proxy-real-ip-cidr-v2.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/rootfs/001-balancer-lua.patch
   - patch -p1 < /patches/rootfs/002-nginx-tmpl.patch


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr updates latest lua [patch](https://github.com/deckhouse/deckhouse/pull/17060), related to accepting X-Forwarded headers only from trusted CIDRs, in the part of using the ngx.var.realip_remote_addr variable instead of the ngx.var.remote_addr variable when detecting clients' source addresses.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It occurred that nginx inits variables in a "lazy" way and if the ngx.var.remote_addr is accessed too early, it breaks the nginx's variable processing chain so that other modifications of the variable is not applied. It's recommended to use the ngx.var.realip_remote_addr variable in case one needs to get clients' source addresses as soon as possible.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: The real-ip-cidr patches are updated to use correct nginx variables.
impact: All ingress-nginx controllers' pods will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
