### PR TITLE
[kubelet] Pod status manager state fix

### DIFF
--- a/candi/bashible/common-steps/all/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/069_start_kubelet.sh.tpl
@@ -35,15 +35,14 @@ if bb-flag? kubelet-need-restart; then
   bb-log-warning "'kubelet-need-restart' flag was set, restarting kubelet."
   if [ -f /var/lib/kubelet/cpu_manager_state ]; then rm /var/lib/kubelet/cpu_manager_state; fi
   if [ -f /var/lib/kubelet/memory_manager_state ]; then rm /var/lib/kubelet/memory_manager_state; fi
+  {{ $kubernetesVersion := .kubernetesVersion | toString }}
+  {{ if eq $kubernetesVersion "1.32" }}
   # https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#no-really-you-must-read-this-before-you-upgrade
   if [ -f /var/lib/kubelet/pod_status_manager_state ]; then
-    {{ $kubernetesVersion := .kubernetesVersion | toString }}
-    desiredVersion="{{ $kubernetesVersion }}"
-    if [[ "${desiredVersion}" = "1.32" ]]; then
-      bb-log-info "Removing /var/lib/kubelet/pod_status_manager_state for Kubernetes 1.32 upgrade"
-      rm -f /var/lib/kubelet/pod_status_manager_state
-    fi
+    bb-log-info "Removing /var/lib/kubelet/pod_status_manager_state for Kubernetes 1.32 upgrade"
+    rm -f /var/lib/kubelet/pod_status_manager_state
   fi
+  {{ end }}
   
   systemctl restart "kubelet.service"
   {{ if ne .runType "ClusterBootstrap" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This change adds deletion of the kubelet checkpoint file `/var/lib/kubelet/pod_status_manager_state` immediately before kubelet restart.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When upgrading Kubernetes (notably 1.31 → 1.32), kubelet may fail to start with a panic caused by an incompatible or corrupted checkpoint file:
```
root@borovets-133-master-0:~# journalctl -xeu kubelet.service
...
Jan 12 14:11:06 borovets-133-master-0 d8-kubelet-forker[139206]: E0112 14:11:06.296987  139206 allocation_manager.go:86] "Failed to initialize allocation checkpoint manager" err="could not restore state from check>
Jan 12 14:11:06 borovets-133-master-0 d8-kubelet-forker[139206]: panic: could not restore state from checkpoint: checkpoint is corrupted, please drain this node and delete pod resource information checkpoint file >
```
See changelog: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#no-really-you-must-read-this-before-you-upgrade

This change automates the required cleanup step, ensuring kubelet starts successfully.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
No need

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Added deletion of the kubelet checkpoint file `/var/lib/kubelet/pod_status_manager_state` immediately before kubelet restart.
impact: Prevents kubelet startup panic caused by incompatible or corrupted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
