### PR TITLE
[cloud-providers] update lifecycle stage for multiple providers

### DIFF
--- a/ee/modules/030-cloud-provider-dynamix/module.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/module.yaml
@@ -4,7 +4,7 @@ weight: 30
 subsystems:
   - infrastructure
 namespace: d8-cloud-provider-dynamix
-stage: Experimental
+stage: Preview
 descriptions:
   en: Manages interaction with Dynamix resources. Allows to use Dynamix resources for provisioning nodes.
   ru: Управляет взаимодействием с облачными ресурсами Базис.DynamiX. Позволяет использовать ресурсы Базис.DynamiX при создании узлов.

--- a/ee/modules/030-cloud-provider-huaweicloud/module.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/module.yaml
@@ -4,7 +4,7 @@ weight: 30
 subsystems:
   - infrastructure
 namespace: d8-cloud-provider-huaweicloud
-stage: Experimental
+stage: General Availability
 descriptions:
   en: Manages interaction with Huawei Cloud resources. Allows to use Huawei Cloud resources for provisioning nodes.
   ru: Управляет взаимодействием с облачными ресурсами Huawei Cloud. Позволяет использовать ресурсы Huawei Cloud при создании узлов.

--- a/ee/modules/030-cloud-provider-vcd/module.yaml
+++ b/ee/modules/030-cloud-provider-vcd/module.yaml
@@ -4,7 +4,7 @@ weight: 30
 subsystems:
   - infrastructure
 namespace: d8-cloud-provider-vcd
-stage: Experimental
+stage: General Availability
 descriptions:
   en: Manages interaction with VMware Cloud Director resources. Allows to use VMware Cloud Director resources for provisioning nodes.
   ru: Управляет взаимодействием с облачными ресурсами VMware Cloud Director. Позволяет использовать ресурсы VMware Cloud Director при создании узлов.

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/module.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/module.yaml
@@ -4,7 +4,7 @@ weight: 30
 subsystems:
   - infrastructure
 namespace: d8-cloud-provider-zvirt
-stage: Experimental
+stage: General Availability
 descriptions:
   en: Manages interaction with zVirt resources. Allows to use zVirt resources for provisioning nodes.
   ru: Управляет взаимодействием с облачными ресурсами zVirt. Позволяет использовать ресурсы zVirt при создании узлов.

--- a/modules/030-cloud-provider-dvp/module.yaml
+++ b/modules/030-cloud-provider-dvp/module.yaml
@@ -4,7 +4,7 @@ weight: 30
 subsystems:
   - infrastructure
 namespace: d8-cloud-provider-dvp
-stage: Experimental
+stage: General Availability
 descriptions:
   en: Manages interaction with Deckhouse Virtualization Platform resources. Allows to use DVP resources for provisioning nodes.
   ru: Управляет взаимодействием с ресурсами Deckhouse Virtualization Platform. Позволяет использовать ресурсы DVP при создании узлов.


### PR DESCRIPTION
## Description
Update lifecycle stage for cloud provider modules:
- `cloud-provider-dynamix`: Experimental → Preview
- `cloud-provider-dvp`: Experimental → General Availability
- `cloud-provider-vcd`: Experimental → General Availability
- `cloud-provider-huaweicloud`: Experimental → General Availability
- `cloud-provider-zvirt`: Experimental → General Availability

## Why do we need it, and what problem does it solve?
Update cloud provider lifecycle stages according to their current state.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dynamix
type: feature
summary: Update lifecycle stage from Experimental to Preview.
impact_level: low
```
```changes
section: cloud-provider-dvp
type: feature
summary: Update lifecycle stage from Experimental to General Availability.
impact_level: low
```
```changes
section: cloud-provider-vcd
type: feature
summary: Update lifecycle stage from Experimental to General Availability.
impact_level: low
```
```changes
section: cloud-provider-huaweicloud
type: feature
summary: Update lifecycle stage from Experimental to General Availability.
impact_level: low
```
```changes
section: cloud-provider-zvirt
type: feature
summary: Update lifecycle stage from Experimental to General Availability.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
