### PR TITLE
[docs] Expand the warning output area in Getting Started

### DIFF
--- a/docs/site/_includes/getting_started/global/EE_ACCESS.md
+++ b/docs/site/_includes/getting_started/global/EE_ACCESS.md
@@ -7,7 +7,7 @@
 </h3>
 
 <div class="form form--inline">
-  <div class="form__row" style="max-width: 383px;">
+  <div class="form__row">
     <label class="label">
       License key
     </label>

--- a/docs/site/_includes/getting_started/global/EE_ACCESS_RU.md
+++ b/docs/site/_includes/getting_started/global/EE_ACCESS_RU.md
@@ -7,7 +7,7 @@
 </h3>
 
 <div class="form form--inline">
-  <div class="form__row" style="max-width: 383px;">
+  <div class="form__row">
     <label class="label">
       Лицензионный ключ
     </label>

--- a/docs/site/_includes/getting_started/stronghold/global/EE_ACCESS.md
+++ b/docs/site/_includes/getting_started/stronghold/global/EE_ACCESS.md
@@ -7,7 +7,7 @@
 </h3>
 
 <div class="form form--inline">
-  <div class="form__row" style="max-width: 383px;">
+  <div class="form__row">
     <label class="label">
       DKP license key
     </label>

--- a/docs/site/_includes/getting_started/stronghold/global/EE_ACCESS_RU.md
+++ b/docs/site/_includes/getting_started/stronghold/global/EE_ACCESS_RU.md
@@ -7,7 +7,7 @@
 </h3>
 
 <div class="form form--inline">
-  <div class="form__row" style="max-width: 383px;">
+  <div class="form__row">
     <label class="label">
       Лицензионный ключ DKP
     </label>

--- a/docs/site/assets/css/docs.scss
+++ b/docs/site/assets/css/docs.scss
@@ -1797,7 +1797,7 @@ ul .resources__prop_name.deprecated {
 
     & .form__row {
       margin-bottom: 0;
-      flex: 1;
+      min-width: 383px;
     }
 
     & a.button {
@@ -1820,7 +1820,6 @@ ul .resources__prop_name.deprecated {
     color: #dc3545;
     height: 43px;
     margin-left: 30px;
-    max-width: 320px;
   }
 
   &-request {


### PR DESCRIPTION
## Description

Expand the warning output area of the license key input forms in the Getting Started.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Expanded the warning output area of the license key input forms in the Getting Started.
impact_level: low
```
