### PR TITLE
[ingress-nginx] Reduced interval of status updates for Ingress resources.

### DIFF
--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --shutdown-grace-period=60
         - --controller-class=ingress-nginx.deckhouse.io/test
         - --maxmind-mirror=https://geoproxy:4250/download

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/controller.yaml
@@ -89,6 +89,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --shutdown-grace-period=0
         - --default-ssl-certificate=default/custom-secret
         - --controller-class=ingress-nginx.deckhouse.io/solid
@@ -408,6 +409,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --shutdown-grace-period=0
         - --default-ssl-certificate=default/custom-secret
         - --controller-class=ingress-nginx.deckhouse.io/solid

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-lbwpp-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/wait-lb-non-default-load-balancer
         - --shutdown-grace-period=333
         - --controller-class=ingress-nginx.deckhouse.io/%!s(<nil>)

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-without-hpa-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/controller.yaml
@@ -74,6 +74,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5
         - --publish-service=d8-ingress-nginx/test-load-balancer
         - --shutdown-grace-period=120
         - --controller-class=ingress-nginx.deckhouse.io/nginx

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -292,6 +292,7 @@ spec:
         - --http-port=80
         - --https-port=443
         - --update-status=true
+        - --status-update-interval=5 # update interval Ingress resources in seconds (Default 60).
         {{- if eq $controllerVersion "1.12" }}
         - --enable-metrics=true
         {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The `status-update-interval` flag for `IngressNginxController` is set, which sets the frequency of updating the status of Ingress resources.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

A reduction in the update interval for the Ingress resource status is requested for the internal d8 utility in order to quickly receive Ingress resource statuses and service information.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: The status update time for Ingress resources has been accelerated.
impact: All controllers was been restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
