### PR TITLE
[admission-policy-engine] deny_vulnerable_images webhook must use module status instead of moduleconfig

### DIFF
--- a/modules/015-admission-policy-engine/webhooks/validating/deny_vulnerable_images
+++ b/modules/015-admission-policy-engine/webhooks/validating/deny_vulnerable_images
@@ -16,14 +16,14 @@
 
 source /shell_lib.sh
 
-function __config__(){
+function __config__() {
   cat <<EOF
 configVersion: v1
 kubernetes:
   - name: operator_trivy_module_config
     apiVersion: deckhouse.io/v1alpha1
-    kind: ModuleConfig
-    queue: operator_trivy_module_config
+    kind: Module
+    queue: operator_trivy_module
     group: main
     executeHookOnEvent: []
     executeHookOnSynchronization: false
@@ -33,7 +33,7 @@ kubernetes:
       - operator-trivy
     jqFilter: |
       {
-        "enabled": .spec.enabled,
+        "enabled": .status.conditions[] | select(.type == "EnabledByModuleManager") | .status,
       }
 kubernetesValidating:
 - name: ape-moduleconfig.deckhouse.io
@@ -51,16 +51,16 @@ function __main__() {
   mcName=$(context::jq -r '.review.request.object.metadata.name')
   if [[ "$mcName" == "admission-policy-engine" ]]; then
     denyVulnerableImagesEnabled="$(context::jq -r '.review.request.object.spec.settings.denyVulnerableImages.enabled')"
-    operatorTrivyEnabled="$(context::jq -r '.snapshots.operator_trivy_module_config[].filterResult.enabled')"
-    if [[ "$denyVulnerableImagesEnabled" == "true" ]] && [[ "$operatorTrivyEnabled" != "true" ]]; then
-      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"moduleconfigs.deckhouse.io \"$mcName\", .spec.settings.denyVulnerableImages can't be enabled when operator-trivy module is disabled" }
+    operatorTrivyEnabled="$(context::jq -r '.snapshots.operator_trivy_module[].filterResult.enabled')"
+    if [[ "$denyVulnerableImagesEnabled" == "true" ]] && [[ "$operatorTrivyEnabled" != "True" ]]; then
+      cat <<EOF >"$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"module \"admission-policy-engine\", .spec.settings.denyVulnerableImages can't be enabled when operator-trivy module is disabled" }
 EOF
       return 0
     fi
   fi
 
-  cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+  cat <<EOF >"$VALIDATING_RESPONSE_PATH"
 {"allowed":true}
 EOF
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Changed webhook logic to rely on module status instead of ModuleConfig parameter to detect if module is enabled.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In cases where `operator-trivy` module is implicitly enabled, current logic breaks and prevents use of some of `admission-policy-engine` features that rely on presence of `operator-trivy`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: deny_vulnerable_images webhook must use module status instead of moduleconfig
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
