### PR TITLE
[cloud-providers-dvp] remove duplicate disk_hashes

### DIFF
--- a/candi/cloud-providers/dvp/terraform-modules/static-node/main.tf
+++ b/candi/cloud-providers/dvp/terraform-modules/static-node/main.tf
@@ -40,9 +40,6 @@ locals {
     }
   ])
 
-  additional_disks_hashes = [
-    for d in var.additional_disks : d.hash
-  ]
 
   spec = merge(
     {


### PR DESCRIPTION
## Description
Remove duplicate definition of additional_disks_hashes local variable in DVP static-node Terraform module. The variable was accidentally duplicated in both main.tf and variables.tf during implementation of runPolicy and liveMigrationPolicy features. This PR removes the duplicate from main.tf, keeping only the definition in variables.tf.
## Why do we need it, and what problem does it solve?

Terraform may fail or behave unexpectedly when the same local variable is defined in multiple files within a module. This fix ensures there's only one definition of additional_disks_hashes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Remove duplicate `additional_disks_hashes` definition in static-node Terraform module.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
