### PR TITLE
[candi] Replacing nc in bashible

### DIFF
--- a/candi/bashible/bootstrap/03-prepare-bashible.sh.tpl
+++ b/candi/bashible/bootstrap/03-prepare-bashible.sh.tpl
@@ -88,7 +88,7 @@ failure_limit=3
 while [ "$patch_pending" = true ] ; do
   for server in {{ .normal.apiserverEndpoints | join " " }} ; do
     server_addr=$(echo $server | cut -f1 -d":")
-    until tcp_endpoint="$(ip ro get ${server_addr} | grep -Po '(?<=src )([0-9\.]+)')"; do
+    until node_ip="$(ip ro get ${server_addr} | grep -Po '(?<=src )([0-9\.]+)')"; do
       echo "The network is not ready for connecting to apiserver yet, waiting..."
       sleep 1
     done
@@ -105,7 +105,7 @@ while [ "$patch_pending" = true ] ; do
       -H "Accept: application/json" \
       -H "Content-Type: application/json-patch+json" \
       --cacert "$BOOTSTRAP_DIR/ca.crt" \
-      --data "[{\"op\":\"add\",\"path\":\"/status/bootstrapStatus\", \"value\": {\"description\": \"Use 'nc ${tcp_endpoint} ${output_log_port}' to get bootstrap logs.\", \"logsEndpoint\": \"${tcp_endpoint}:${output_log_port}\"} }]" \
+      --data "[{\"op\":\"add\",\"path\":\"/status/bootstrapStatus\", \"value\": {\"description\": \"Use curl -N 'http://${node_ip}:${output_log_port}' to get bootstrap logs.\", \"logsEndpoint\": \"http://${node_ip}:${output_log_port}\"} }]" \
       "https://$server/apis/deckhouse.io/v1alpha1/instances/${machine_name}/status" ; then
 
       echo "Successfully patched instance ${machine_name} status."

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -5860,28 +5860,27 @@ alerts:
 
            Look for errors in the `.status.lastMachineFailures` field.
 
-        2. If no Machines stay in the Pending state for more than a couple of minutes, it likely means that Machines are being continuously created and deleted due to an error:
+        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine
+           d8 k get instances
            ```
 
-        3. If logs don’t show errors, and a Machine continues to be Pending, check its bootstrap status:
+        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine <MACHINE_NAME> -o json | jq .status.bootstrapStatus
+           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
            ```
 
-        4. If the output looks like the example below, connect via `nc` to examine bootstrap logs:
+        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
 
-           ```json
-           {
-             "description": "Use 'nc 192.168.199.158 8000' to get bootstrap logs.",
-             "tcpEndpoint": "192.168.199.158"
-           }
+           ```text
+           bootstrapStatus:
+             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+             logsEndpoint: http://192.168.199.158:8000
            ```
 
-          5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
+        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
       summary: |
         NodeGroup {{ $labels.node_group }} has no available instances.
       severity: "7"
@@ -5913,28 +5912,27 @@ alerts:
 
            Look for errors in the `.status.lastMachineFailures` field.
 
-        2. If no Machines stay in the Pending state for more than a couple of minutes, it likely means that Machines are being continuously created and deleted due to an error:
+        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine
+           d8 k get instances
            ```
 
-        3. If logs don’t show errors, and a Machine continues to be Pending, check its bootstrap status:
+        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine <MACHINE_NAME> -o json | jq .status.bootstrapStatus
+           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
            ```
 
-        4. If the output looks like the example below, connect via `nc` to examine bootstrap logs:
+        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
 
-           ```json
-           {
-             "description": "Use 'nc 192.168.199.158 8000' to get bootstrap logs.",
-             "tcpEndpoint": "192.168.199.158"
-           }
+           ```text
+           bootstrapStatus:
+             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+             logsEndpoint: http://192.168.199.158:8000
            ```
 
-          5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
+        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
       summary: |
         Too many unavailable instances in the {{ $labels.node_group }} NodeGroup.
       severity: "8"
@@ -5965,28 +5963,27 @@ alerts:
 
            Look for errors in the `.status.lastMachineFailures` field.
 
-        2. If no Machines stay in the Pending state for more than a couple of minutes, it likely means that Machines are being continuously created and deleted due to an error:
+        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine
+           d8 k get instances
            ```
 
-        3. If logs don’t show errors, and a Machine continues to be Pending, check its bootstrap status:
+        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine <MACHINE_NAME> -o json | jq .status.bootstrapStatus
+           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
            ```
 
-        4. If the output looks like the example below, connect via `nc` to examine bootstrap logs:
+        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
 
-           ```json
-           {
-             "description": "Use 'nc 192.168.199.158 8000' to get bootstrap logs.",
-             "tcpEndpoint": "192.168.199.158"
-           }
+           ```text
+           bootstrapStatus:
+             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+             logsEndpoint: http://192.168.199.158:8000
            ```
 
-          5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
+        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
       summary: |
         NodeGroup {{ $labels.node_group }} has unavailable instances.
       severity: "8"

--- a/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADDING_NODE_RU.md
+++ b/docs/site/pages/stronghold/documentation/admin/platform-management/node-management/ADDING_NODE_RU.md
@@ -375,11 +375,11 @@ d8 k label node <node_name> node-role.kubernetes.io/<old_node_group_name>-
    d8 k get instances dev-worker-2a6158ff-6764d-nrtbj -o yaml | grep 'bootstrapStatus' -B0 -A2
 
    # bootstrapStatus:
-   #   description: Use 'nc 192.168.199.178 8000' to get bootstrap logs.
+   #   description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
    #   logsEndpoint: 192.168.199.178:8000
    ```
 
-1. Выполните полученную команду (в примере выше — `nc 192.168.199.178 8000`), чтобы получить логи `cloud-init` для последующей диагностики.
+1. Выполните полученную команду (в примере выше — `curl -N http://192.168.199.158:8000`), чтобы получить логи `cloud-init` для последующей диагностики.
 
 Логи первоначальной настройки узла находятся в `/var/log/cloud-init-output.log`.
 

--- a/modules/040-node-manager/crds/doc-ru-instance.yaml
+++ b/modules/040-node-manager/crds/doc-ru-instance.yaml
@@ -77,7 +77,7 @@ spec:
                   properties:
                     logsEndpoint:
                       type: string
-                      description: IP-адрес для получения логов начальной настройки узла.
+                      description: http эндпоинт для получения логов начальной настройки узла.
                     description:
                       type: string
                       description: Описание процесса получения логов начальной настройки узла.

--- a/modules/040-node-manager/crds/instance.yaml
+++ b/modules/040-node-manager/crds/instance.yaml
@@ -110,7 +110,7 @@ spec:
                   properties:
                     logsEndpoint:
                       type: string
-                      description: IP address for getting bootstrap logs.
+                      description: http endpoint for getting bootstrap logs.
                     description:
                       type: string
                       description: Description about getting logs.

--- a/modules/040-node-manager/docs/FAQ.md
+++ b/modules/040-node-manager/docs/FAQ.md
@@ -348,11 +348,11 @@ You can analyze `cloud-init` to find out what's happening on a node during the b
    ```shell
    d8 k get instances dev-worker-2a6158ff-6764d-nrtbj -o yaml | grep 'bootstrapStatus' -B0 -A2
    bootstrapStatus:
-     description: Use 'nc 192.168.199.178 8000' to get bootstrap logs.
-     logsEndpoint: 192.168.199.178:8000
+     description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+     logsEndpoint: http://192.168.199.158:8000
    ```
 
-1. Run the command you got (`nc 192.168.199.115 8000` according to the example above) to see `cloud-init` logs and determine the cause of the problem on the node.
+1. Run the command you got (`curl -N http://192.168.199.158:8000` according to the example above) to see `cloud-init` logs and determine the cause of the problem on the node.
 
 The logs of the initial node configuration are located at `/var/log/cloud-init-output.log`.
 

--- a/modules/040-node-manager/docs/FAQ_RU.md
+++ b/modules/040-node-manager/docs/FAQ_RU.md
@@ -346,11 +346,11 @@ May 25 04:39:16 kube-master-0 systemd[1]: bashible.service: Succeeded.
    ```shell
    d8 k get instances dev-worker-2a6158ff-6764d-nrtbj -o yaml | grep 'bootstrapStatus' -B0 -A2
    bootstrapStatus:
-     description: Use 'nc 192.168.199.178 8000' to get bootstrap logs.
-     logsEndpoint: 192.168.199.178:8000
+     description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+     logsEndpoint: http://192.168.199.158:8000
    ```
 
-1. Выполните полученную команду (в примере выше — `nc 192.168.199.178 8000`), чтобы просмотреть логи `cloud-init` и определить, на каком этапе остановилась настройка узла.
+1. Выполните полученную команду (в примере выше — `curl -N http://192.168.199.158:8000`), чтобы просмотреть логи `cloud-init` и определить, на каком этапе остановилась настройка узла.
 
 Логи первоначальной настройки узла находятся в `/var/log/cloud-init-output.log`.
 

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-group.tpl
@@ -18,28 +18,27 @@
 
            Look for errors in the `.status.lastMachineFailures` field.
 
-        2. If no Machines stay in the Pending state for more than a couple of minutes, it likely means that Machines are being continuously created and deleted due to an error:
+        2. If no Instances stay in the Pending state for more than a couple of minutes, it likely means that Instances are being continuously created and deleted due to an error:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine
+           d8 k get instances
            ```
 
-        3. If logs don’t show errors, and a Machine continues to be Pending, check its bootstrap status:
+        3. If logs don’t show errors, and an Instance continues to be Pending, check its bootstrap status:
 
            ```shell
-           d8 k -n d8-cloud-instance-manager get machine <MACHINE_NAME> -o json | jq .status.bootstrapStatus
+           d8 k get instances <INSTANCE_NAME> -o yaml | grep 'bootstrapStatus' -B0 -A2
            ```
 
-        4. If the output looks like the example below, connect via `nc` to examine bootstrap logs:
+        4. If the output looks like the example below, use the `logsEndpoint` (or the command in `description`) to examine bootstrap logs:
 
-           ```json
-           {
-             "description": "Use 'nc 192.168.199.158 8000' to get bootstrap logs.",
-             "tcpEndpoint": "192.168.199.158"
-           }
+           ```text
+           bootstrapStatus:
+             description: Use 'curl -N http://192.168.199.158:8000' to get bootstrap logs.
+             logsEndpoint: http://192.168.199.158:8000
            ```
 
-          5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
+        5. If there's no bootstrap log endpoint, `cloudInit` may not be working correctly. This could indicate a misconfigured instance class in the cloud provider.
 {{- end }}
 
 - name: d8.node-group

--- a/modules/040-node-manager/templates/node-group/_bootstrap.tpl
+++ b/modules/040-node-manager/templates/node-group/_bootstrap.tpl
@@ -27,10 +27,14 @@ exec >"${TMPDIR}/bootstrap.log" 2>&1
 
   {{- if or (eq $ng.nodeType "CloudEphemeral") (hasKey $ng "staticInstances") }}
 function run_log_output() {
-  if type nc >/dev/null 2>&1; then
-    tail -n 100 -f ${TMPDIR}/bootstrap.log | nc -l -p 8000 &
-    bootstrap_job_log_pid=$!
-  fi
+  check_python
+
+  cat - <<'PY' > "${TMPDIR}/tail-log.py"
+{{- include "node_group_tail_log_py" . | nindent 0 }}
+PY
+
+  "${python_binary}" "${TMPDIR}/tail-log.py" "${TMPDIR}/bootstrap.log" &
+  bootstrap_job_log_pid=$!
 }
   {{- end }}
 

--- a/modules/040-node-manager/templates/node-group/_tail_log.tpl
+++ b/modules/040-node-manager/templates/node-group/_tail_log.tpl
@@ -1,0 +1,50 @@
+{{- define "node_group_tail_log_py" -}}
+import os
+import sys
+import time
+
+try:
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from socketserver import ThreadingMixIn
+except ImportError:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+    from SocketServer import ThreadingMixIn
+
+LOG_FILE = sys.argv[1]
+HOST = "0.0.0.0"
+PORT = 8000
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer): pass
+
+class LogStreamHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.end_headers()
+        try:
+            with open(LOG_FILE, "rb") as f:
+                self.wfile.write(b"".join(f.read().splitlines(True)[-100:]))
+                self.wfile.flush()
+                f.seek(0, 2)
+
+                while True:
+                    curr_pos = f.tell()
+                    line = f.readline()
+                    if line:
+                        self.wfile.write(line)
+                        self.wfile.flush()
+                    else:
+                        try:
+                            if os.stat(LOG_FILE).st_size < curr_pos:
+                                f.seek(0)
+                        except OSError:
+                            pass
+                        time.sleep(0.1)
+        except Exception:
+            pass
+
+if __name__ == "__main__":
+    print("Streaming {} on 0.0.0.0:{}".format(LOG_FILE, PORT))
+    server = ThreadedHTTPServer(("0.0.0.0", PORT), LogStreamHandler)
+    server.serve_forever()
+{{ end }}


### PR DESCRIPTION
## Description

Refusal to use nc in bashible for security reasons. In particular:
- Previously, server bootstrap logs were transmitted via nc, now Python is used for this.
- Previously, nc was used to check Kubernetes API availability in one of the functions, now this is done via kubectl (temporary solution).

## Why do we need it, and what problem does it solve?

Refusal to use nc in bashible for security reasons.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Server bootstrap logs are no longer transmitted via nc; Python is used instead.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
