### PR TITLE
[deckhouse] fix mpo cleanup

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/sync.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/sync.go
@@ -305,7 +305,8 @@ func (l *Loader) deleteOrphanModules(ctx context.Context) error {
 		}
 
 		if !apierrors.IsNotFound(err) {
-			return fmt.Errorf("get module pull override '%s': %w", module, err)
+			l.logger.Warn("get module pull override", slog.String("name", module), log.Err(err))
+			continue
 		}
 
 		l.logger.Debug("uninstall orphan module", slog.String("module", module))


### PR DESCRIPTION
## Description
It fixes MPO cleanup.

## Why do we need it, and what problem does it solve?

Assumed flow:
1. The tag is present in the registry.
2. The MPO functions correctly (the annotation set).
3. The tag is removed from the registry.
4. The MPO gets degraded (Message: Downloaded error), but the module remains in the cluster.
5. A new main image triggers a restart.
6. Module restoring passes because it only checks for the existence of files.
7. Deleting orphan modules checks the MPO for readiness, but the MPO is not ready, so the current working module is uninstalled.

Fix:
Now, deleting orphan modules does not uninstall MPOs that are not ready, it preserves the current working version of the module.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix mpo cleanup.
impact_level: low
```
