### PR TITLE
[registry] Invalidate checker queue on image list changes

### DIFF
--- a/modules/038-registry/hooks/checker/models.go
+++ b/modules/038-registry/hooks/checker/models.go
@@ -247,8 +247,9 @@ func (state *stateModel) initQueues(log go_hook.Logger, inputs inputsModel) erro
 		}
 
 		q := registryQueue{
-			Items: repoImages,
-			ParamsHash: hash}
+			Items:      repoImages,
+			ParamsHash: hash,
+		}
 
 		state.Queues[name] = q
 		log.Info("Added queue", "queue.name", name, "queue.items", q.total())


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Ensure the registry checker queue is rebuilt when the list of required images (Deckhouse or modules) changes, preventing validation of outdated image tags.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Previously, the registry checker cached the validation queue based solely on registry connection parameters. Changing the Deckhouse version (image tag) or module versions did not trigger a queue rebuild. This caused persistent errors about missing *old* image tags even after a successful update. This fix ensures the checker always validates the actual input image list state

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
This PR fixes validation of input image list changes in the registry checker.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: Fixed validation of input image list changes in the registry checker.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
