### PR TITLE
[documentation] Fix serving rules. Fix 404 when open modules documentation from the web interface

### DIFF
--- a/modules/810-documentation/templates/configmap.yaml
+++ b/modules/810-documentation/templates/configmap.yaml
@@ -153,16 +153,11 @@ data:
             try_files /modules/$1/index.html =404;
         }
 
-        location ~* ^/(?<lang>ru|en)/modules/(?<module>[^/]+)/(?<doc_path>.*)$ {
+        location ~* ^/(?<lang>ru|en)/modules/(?<module>[^/]+)/((alpha|beta|early-access|stable|rock-solid|latest)/)?(?<doc_path>.*)$ {
             set $embedded_module_path "embedded-modules/$lang/modules/$module";
             set $embedded_module_url "/embedded-modules/$lang/modules/$module/$doc_path";
-            set $external_module_path "modules/$lang/$module";
-            set $external_module_url "/external-modules/$lang/$module/$doc_path";
-
-            # Redirect to stable version for module from source TODO
-            #location ~* ^/(?<lang>ru|en)/modules/(?<module>[^/]+)/(?<doc_path>(?!v[0-9]+\.[0-9]+|alpha|beta|early-access|stable|rock-solid|latest).*)$ {
-            #rewrite ^ /$lang/modules/$module/stable/$doc_path redirect;
-            #}
+            set $external_module_path "modules/$lang/$module/stable";
+            set $external_module_url "/external-modules/$lang/$module/stable/$doc_path";
 
             if (-d $document_root/$external_module_path) {
                # Use internal redirect to serve modules from source


### PR DESCRIPTION
## Description

This pull request updates the NGINX configuration for serving documentation for modules from source in the `documentation` module (which serves in-cluster documentation).

The main change is to support version-specific URLs (like `/modules/module/<CHANNEL>/...`) as well as URLs without channel (like `/modules/module/...`).

## Why do we need it, and what problem does it solve?

URLs like `/modules/secrets-store-integration/usage.html` are not available but they are correct and used in the cluster web interface.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: documentation
type: fix
summary: Fixed HTTP/404 error when opening modules documentation from the Web interface.
impact_level: low
```
