### PR TITLE
[control-plane-manager] Unstarted etcd member processing

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1232,6 +1232,16 @@ alerts:
         etcd cluster database is growing rapidly.
       severity: "4"
       markupFormat: markdown
+    - name: D8EtcdUnstartedMemberDetected
+      sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+      moduleUrl: 040-control-plane-manager
+      module: control-plane-manager
+      edition: ce
+      description: "There is at least one unstarted etcd member in the cluster that has not published its attributes for more than 15 minutes.\n\nAn unstarted etcd member is a member that was added to the etcd cluster but has not yet started and published its name. This can happen during:\n- etcd updates\n- adding new control-plane nodes\n- etcd member recovery\n\n**Recommended actions:**\n\n1. Check the status of etcd members:\n\n```bash\nkubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key member list -w table        \n```\n\n2. Check etcd pod logs on the affected node:\n\n```bash\nkubectl -n kube-system logs $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1)\n```\n\n3. If the member is stuck and should not be in the cluster, it may need to be manually removed.\n\n4. If this is during a planned update, wait for the member to start. If it doesn't start within a reasonable time, investigate the root cause."
+      summary: |
+        Unstarted etcd member detected in the cluster.
+      severity: "3"
+      markupFormat: markdown
     - name: D8GrafanaDeploymentReplicasUnavailable
       sourceFile: modules/300-prometheus/monitoring/prometheus-rules/grafana.tpl
       moduleUrl: 300-prometheus

--- a/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
@@ -155,10 +155,10 @@ func handleRecicleEtcdMembers(_ context.Context, input *go_hook.HookInput, dc de
 	}
 
 	removeListIDs := make([]uint64, 0)
-	var hasUnstartedMember float64
+	var unstartedEtcdMembersCount float64
 	for _, mem := range etcdMembersResp.Members {
 		if mem.Name == "" { // unstarted etcd member
-			hasUnstartedMember = 1.0
+			unstartedEtcdMembersCount += 1.0
 			continue
 		}
 		if _, ok := discoveredEtcdNodesMap[mem.Name]; !ok {
@@ -167,7 +167,7 @@ func handleRecicleEtcdMembers(_ context.Context, input *go_hook.HookInput, dc de
 		}
 	}
 
-	input.MetricsCollector.Set("d8_control_plane_manager_has_unstarted_etcd_member", hasUnstartedMember, nil)
+	input.MetricsCollector.Set("d8_control_plane_manager_unstarted_etcd_members_count", unstartedEtcdMembersCount, nil)
 
 	input.Logger.Warn("etcd members to remove", slog.Any("removeListIDs", removeListIDs))
 

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -166,3 +166,41 @@
         ```
 
         For more information about Kubernetes feature gates, refer to the [official documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).
+
+  - alert: D8EtcdUnstartedMemberDetected
+    for: 15m
+    expr: d8_control_plane_manager_unstarted_etcd_members_count > 0
+    labels:
+      d8_component: control-plane-manager
+      d8_module: control-plane-manager
+      severity_level: "3"
+      tier: cluster
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: Unstarted etcd member detected in the cluster.
+      description: |-
+        There is at least one unstarted etcd member in the cluster that has not published its attributes for more than 15 minutes.
+
+        An unstarted etcd member is a member that was added to the etcd cluster but has not yet started and published its name. This can happen during:
+        - etcd updates
+        - adding new control-plane nodes
+        - etcd member recovery
+
+        **Recommended actions:**
+
+        1. Check the status of etcd members:
+
+        ```bash
+        kubectl -n kube-system exec -ti $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1) -- etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/ca.crt --key /etc/kubernetes/pki/etcd/ca.key member list -w table        
+        ```
+
+        2. Check etcd pod logs on the affected node:
+
+        ```bash
+        kubectl -n kube-system logs $(kubectl -n kube-system get pod -l component=etcd,tier=control-plane -o name | head -n1)
+        ```
+
+        3. If the member is stuck and should not be in the cluster, it may need to be manually removed.
+
+        4. If this is during a planned update, wait for the member to start. If it doesn't start within a reasonable time, investigate the root cause.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
