### PR TITLE
[docs] Fix yaml manifests apply commands at documentation

### DIFF
--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM.md
@@ -92,7 +92,7 @@ Example of creating a virtual machine with Ubuntu 22.04.
    Create a virtual machine from the following specification:
 
    ```yaml
-   d8 k apply -f - <<EOF
+   d8 k apply -f - <<'EOF'
    apiVersion: virtualization.deckhouse.io/v1alpha2
    kind: VirtualMachine
    metadata:
@@ -241,7 +241,7 @@ The password in the example was generated using the command `mkpasswd --method=S
 Create a virtual machine with the disk created [previously](/products/virtualization-platform/documentation/user/resource-management/disks.html#creating-a-disk-from-an-image):
 
 ```yaml
-d8 k apply -f - <<EOF
+d8 k apply -f - <<'EOF'
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine
 metadata:

--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/VM_RU.md
@@ -93,7 +93,7 @@ lang: ru
    Создайте виртуальную машину из следующей спецификации:
 
    ```yaml
-   d8 k apply -f - <<EOF
+   d8 k apply -f - <<'EOF'
    apiVersion: virtualization.deckhouse.io/v1alpha2
    kind: VirtualMachine
    metadata:
@@ -243,7 +243,7 @@ lang: ru
 Создайте виртуальную машину с диском созданным [ранее](/products/virtualization-platform/documentation/user/resource-management/disks.html#создание-диска-из-образа):
 
 ```yaml
-d8 k apply -f - <<"EOF"
+d8 k apply -f - <<'EOF'
 apiVersion: virtualization.deckhouse.io/v1alpha2
 kind: VirtualMachine
 metadata:


### PR DESCRIPTION
## Description
Fixed yaml manifests apply commands at documentation.

The change ensures that the heredoc delimiter in the `d8 k apply` command is quoted, preventing variable interpolation and potential errors when copying and pasting the example commands.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix
summary: Fixed yaml manifests apply commands at documentation.
impact_level: low
```
