### PR TITLE
[node-manager] add new fencing-agent CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,71 +1,73 @@
-.github/                        @Nikolay1224 @himax1991
-000-common/                     @name212 @sprait
-002-deckhouse/                  @ldmonster
-007-registrypackages/           @RomanenkoDenys @name212 @sprait
-015-admission-policy-engine/    @nabokihms
-021-cni-cilium/                 @AndreyPavlovFlant @apolovov
-025-static-routing-manager/     @AndreyPavlovFlant @apolovov
-030-cloud-provider-*/           @aleksey-su
-031-local-path-provisioner/     @AleksZimin @duckhawk
-035-cni-flannel/                @AndreyPavlovFlant @apolovov
-035-cni-simple-bridge/          @AndreyPavlovFlant @apolovov
-036-kube-proxy/                 @AndreyPavlovFlant @apolovov
-038-registry/                   @RaveNoX
-039-registry-packages-proxy/    @RomanenkoDenys @name212 @sprait
-040-control-plane-manager/      @name212 @sprait
-040-node-manager/               @name212
-040-terraform-manager/          @name212 @aleksey-su
-042-kube-dns/                   @AndreyPavlovFlant @apolovov
-050-network-policy-engine/      @AndreyPavlovFlant @apolovov
-101-cert-manager/               @Suselz
-110-istio/                      @skurbatov @apolovov
-140-user-authz/                 @nabokihms
-150-user-authn/                 @nabokihms
-160-multitenancy-manager/       @nabokihms
-200-operator-prometheus/        @vladimirGuryanov @lazovskiy
-300-prometheus/                 @vladimirGuryanov @lazovskiy
-301-prometheus-*/               @vladimirGuryanov @lazovskiy
-302-vertical-pod-autoscaler/    @yalosev
-303-prometheus-*/               @vladimirGuryanov @lazovskiy
-340-extended-monitoring/        @vladimirGuryanov @lazovskiy
-340-monitoring-*/               @vladimirGuryanov @lazovskiy
-350-node-local-dns/             @AndreyPavlovFlant @apolovov
-380-metallb/                    @AndreyPavlovFlant @apolovov
-400-descheduler/                @yalosev
-402-ingress-nginx/              @miklezzzz @apolovov
-450-keepalived/                 @AndreyPavlovFlant @apolovov
-450-network-gateway/            @AndreyPavlovFlant @apolovov
-460-log-shipper/                @nabokihms @vladimirGuryanov @lazovskiy
-462-loki/                       @nabokihms @vladimirGuryanov @lazovskiy
-470-chrony/                     @name212
-491-containerized-data-importer @fl64
-500-basic-auth/                 @nabokihms
-500-openvpn/                    @AndreyPavlovFlant @apolovov
-500-cilium-hubble/              @AndreyPavlovFlant @apolovov
-500-dashboard/                  @shvgn
-500-upmeter/                    @vladimirGuryanov @lazovskiy
-500-okmeter/                    @vladimirGuryanov @lazovskiy
-500-operator-trivy/             @nabokihms
-600-secret-copier/              @nabokihms
-600-namespace-configurator/     @yalosev @ldmonster
-610-service-with-healthchecks   @AndreyPavlovFlant @apolovov
-800-deckhouse-tools/            @RomanenkoDenys @name212
-810-documentation/              @z9r5
-bashible-apiserver/             @name212 @sprait
-candi/                          @name212
-candi/version_map.yml           @sprait
-candi/cloud-providers/          @aleksey-su
-candi/terraform_versions.yml    @aleksey-su
-cloud-controller-manager/       @aleksey-su
-csi/                            @AleksZimin @duckhawk
-deckhouse-controller/           @ldmonster
-dhctl/                          @name212
-docs/                           @z9r5
-helm_lib/                       @name212 @sprait
-crds/                           @nabokihms @z9r5
-openapi/                        @nabokihms @z9r5
-/pkg/                           @ldmonster
-testing/cloud_layouts/          @Nikolay1224 @KraMorK @Taior @himax1991
-/monitoring/prometheus-rules/   @sudoroot-null
-/release.yaml                   @yalosev @nabokihms
-go_lib/registry/                @RaveNoX
+.github/                                 @Nikolay1224 @himax1991
+000-common/                              @name212 @sprait
+002-deckhouse/                           @ldmonster
+007-registrypackages/                    @RomanenkoDenys @name212 @sprait
+015-admission-policy-engine/             @nabokihms
+021-cni-cilium/                          @AndreyPavlovFlant @apolovov
+025-static-routing-manager/              @AndreyPavlovFlant @apolovov
+030-cloud-provider-*/                    @aleksey-su
+031-local-path-provisioner/              @AleksZimin @duckhawk
+035-cni-flannel/                         @AndreyPavlovFlant @apolovov
+035-cni-simple-bridge/                   @AndreyPavlovFlant @apolovov
+036-kube-proxy/                          @AndreyPavlovFlant @apolovov
+038-registry/                            @RaveNoX
+039-registry-packages-proxy/             @RomanenkoDenys @name212 @sprait
+040-control-plane-manager/               @name212 @sprait
+040-node-manager/                        @name212
+040-node-manager/templates/fencing-agent @yalosev @Evgeniy-Bondarenko
+040-node-manager/images/fencing-agent    @yalosev @Evgeniy-Bondarenko
+040-terraform-manager/                   @name212 @aleksey-su
+042-kube-dns/                            @AndreyPavlovFlant @apolovov
+050-network-policy-engine/               @AndreyPavlovFlant @apolovov
+101-cert-manager/                        @Suselz
+110-istio/                               @skurbatov @apolovov
+140-user-authz/                          @nabokihms
+150-user-authn/                          @nabokihms
+160-multitenancy-manager/                @nabokihms
+200-operator-prometheus/                 @vladimirGuryanov @lazovskiy
+300-prometheus/                          @vladimirGuryanov @lazovskiy
+301-prometheus-*/                        @vladimirGuryanov @lazovskiy
+302-vertical-pod-autoscaler/             @yalosev
+303-prometheus-*/                        @vladimirGuryanov @lazovskiy
+340-extended-monitoring/                 @vladimirGuryanov @lazovskiy
+340-monitoring-*/                        @vladimirGuryanov @lazovskiy
+350-node-local-dns/                      @AndreyPavlovFlant @apolovov
+380-metallb/                             @AndreyPavlovFlant @apolovov
+400-descheduler/                         @yalosev
+402-ingress-nginx/                       @miklezzzz @apolovov
+450-keepalived/                          @AndreyPavlovFlant @apolovov
+450-network-gateway/                     @AndreyPavlovFlant @apolovov
+460-log-shipper/                         @nabokihms @vladimirGuryanov @lazovskiy
+462-loki/                                @nabokihms @vladimirGuryanov @lazovskiy
+470-chrony/                              @name212
+491-containerized-data-importer          @fl64
+500-basic-auth/                          @nabokihms
+500-openvpn/                             @AndreyPavlovFlant @apolovov
+500-cilium-hubble/                       @AndreyPavlovFlant @apolovov
+500-dashboard/                           @shvgn
+500-upmeter/                             @vladimirGuryanov @lazovskiy
+500-okmeter/                             @vladimirGuryanov @lazovskiy
+500-operator-trivy/                      @nabokihms
+600-secret-copier/                       @nabokihms
+600-namespace-configurator/              @yalosev @ldmonster
+610-service-with-healthchecks            @AndreyPavlovFlant @apolovov
+800-deckhouse-tools/                     @RomanenkoDenys @name212
+810-documentation/                       @z9r5
+bashible-apiserver/                      @name212 @sprait
+candi/                                   @name212
+candi/version_map.yml                    @sprait
+candi/cloud-providers/                   @aleksey-su
+candi/terraform_versions.yml             @aleksey-su
+cloud-controller-manager/                @aleksey-su
+csi/                                     @AleksZimin @duckhawk
+deckhouse-controller/                    @ldmonster
+dhctl/                                   @name212
+docs/                                    @z9r5
+helm_lib/                                @name212 @sprait
+crds/                                    @nabokihms @z9r5
+openapi/                                 @nabokihms @z9r5
+/pkg/                                    @ldmonster
+testing/cloud_layouts/                   @Nikolay1224 @KraMorK @Taior @himax1991
+/monitoring/prometheus-rules/            @sudoroot-null
+/release.yaml                            @yalosev @nabokihms
+go_lib/registry/                         @RaveNoX


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add yalosev and Evgeniy-Bondarenko as CODEOWNERS for fencing-agent
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: change CODEOWNERS for fencing-agent
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
