### PR TITLE
[deckhouse] new application fs layout

### DIFF
--- a/deckhouse-controller/internal/packages/manager/manager.go
+++ b/deckhouse-controller/internal/packages/manager/manager.go
@@ -78,7 +78,7 @@ type Config struct {
 
 // New creates a new package manager with the specified apps directory.
 func New(conf Config, logger *log.Logger) *Manager {
-	appsPath := filepath.Join(d8env.GetDownloadedModulesDir(), "apps")
+	appsPath := filepath.Join(d8env.GetDownloadedModulesDir(), "apps", "deployed")
 	return &Manager{
 		apps: make(map[string]*apps.Application),
 


### PR DESCRIPTION
## Description

Reorganized apps filesystem directory structure for better organization:
- Mounted apps now live under `/apps/deployed/<namespace.name>` instead of `/apps/<namespace.name>`
- Downloaded packages moved to `/apps/<registry>/<package>/<version>` instead of `/<registry>/<package>/<version>`

## Why do we need it, and what problem does it solve?

The previous directory structure mixed deployed apps and downloaded packages at different levels, making it harder to understand the filesystem layout. The new structure groups everything under `/apps`:

```
/downloaded
  /apps
    /deployed
      /<namespace.name>         # mounted apps
    /<registry>
      /<package>
        /<version>.erofs        # downloaded packages
```

This provides clearer separation between deployed applications and their source packages.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: New application fs layout.
impact_level: low
```