### PR TITLE
[testing] fix test output not showing stderr on failure

### DIFF
--- a/modules/015-admission-policy-engine/template_tests/policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/policies_test.go
@@ -73,11 +73,10 @@ admissionPolicyEngine:
 		It("Rego policy test must have passed", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 			gatorCLI := exec.Command(gatorPath, "verify", "-v", "../charts/constraint-templates/tests/...")
-			res, err := gatorCLI.Output()
+			res, err := gatorCLI.CombinedOutput()
 			if err != nil {
 				output := strings.ReplaceAll(string(res), "modules/015-admission-policy-engine/charts/constraint-templates", "...")
-				fmt.Println(output)
-				Fail("Gatekeeper policy tests failed:" + err.Error())
+				Fail(fmt.Sprintf("Gatekeeper policy tests failed: %s\nOutput:\n%s", err.Error(), output))
 			}
 		})
 	})


### PR DESCRIPTION
## Description

Changed `Output()` to `CombinedOutput()` in gator test execution so stderr is captured alongside stdout. Moved the output directly into the `Fail()` message instead of printing separately.

## Why do we need it, and what problem does it solve?

When gator policy tests fail, the test wasn't showing the actual error details. `exec.Command.Output()` only captures stdout, but gator writes failure information to stderr. This made debugging failing tests difficult since the error output was silently discarded.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: testing
type: fix
summary: Fixed gator policy test output not showing error details on failure
impact_level: low
```
