### PR TITLE
fix: return error when module.yaml name doesn't match registry name

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader.go
@@ -52,6 +52,19 @@ const (
 	tracerName = "downloader"
 )
 
+// ErrModuleNameMismatch indicates that the module name in module.yaml doesn't match the expected registry module name
+var ErrModuleNameMismatch = errors.New("module name mismatch")
+
+// validateModuleDefinitionName checks that the name in module.yaml matches the expected registry name.
+// Empty definition names are allowed for backward compatibility (the registry name is used as default).
+func validateModuleDefinitionName(definitionName, expectedName string) error {
+	definitionName = strings.TrimSpace(definitionName)
+	if definitionName != "" && definitionName != expectedName {
+		return fmt.Errorf("%w: module.yaml contains name %q but expected %q (registry module name)", ErrModuleNameMismatch, definitionName, expectedName)
+	}
+	return nil
+}
+
 type ModuleDownloader struct {
 	dc                   dependency.Container
 	downloadedModulesDir string
@@ -134,6 +147,12 @@ func (md *ModuleDownloader) DownloadMetadataFromReleaseChannel(ctx context.Conte
 		return nil, err
 	}
 
+	if releaseImageInfo.Metadata.ModuleDefinition != nil {
+		if err := validateModuleDefinitionName(releaseImageInfo.Metadata.ModuleDefinition.Name, moduleName); err != nil {
+			return nil, err
+		}
+	}
+
 	res := &ModuleDownloadResult{
 		Checksum:         releaseImageInfo.Digest.String(),
 		ModuleVersion:    "v" + releaseImageInfo.Metadata.Version.String(),
@@ -158,6 +177,9 @@ func (md *ModuleDownloader) DownloadReleaseImageInfoByVersion(ctx context.Contex
 		Changelog:     releaseImageInfo.Metadata.Changelog,
 	}
 	if releaseImageInfo.Metadata.ModuleDefinition != nil {
+		if err := validateModuleDefinitionName(releaseImageInfo.Metadata.ModuleDefinition.Name, moduleName); err != nil {
+			return nil, err
+		}
 		res.ModuleDefinition = releaseImageInfo.Metadata.ModuleDefinition
 		return res, nil
 	}
@@ -459,6 +481,10 @@ func (md *ModuleDownloader) fetchModuleDefinitionFromModuleImage(moduleName stri
 		err = yaml.NewDecoder(rr.moduleReader).Decode(def)
 		if err != nil {
 			return nil, fmt.Errorf("yaml decode: %w", err)
+		}
+
+		if err := validateModuleDefinitionName(def.Name, moduleName); err != nil {
+			return nil, err
 		}
 	}
 

--- a/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/downloader/downloader_test.go
@@ -83,3 +83,55 @@ func TestDownloadMetadataByVersion(t *testing.T) {
 	require.Equal(t, "v1.2.3", meta.ModuleVersion)
 	require.Equal(t, map[string]any{"feat": []any{"Added new feature"}}, meta.Changelog)
 }
+
+func TestValidateModuleDefinitionName(t *testing.T) {
+	tests := []struct {
+		name           string
+		definitionName string
+		expectedName   string
+		wantErr        bool
+	}{
+		{
+			name:           "matching names",
+			definitionName: "my-module",
+			expectedName:   "my-module",
+			wantErr:        false,
+		},
+		{
+			name:           "empty definition name",
+			definitionName: "",
+			expectedName:   "my-module",
+			wantErr:        false,
+		},
+		{
+			name:           "whitespace-only definition name",
+			definitionName: "   ",
+			expectedName:   "my-module",
+			wantErr:        false,
+		},
+		{
+			name:           "definition name with leading/trailing whitespace",
+			definitionName: "  my-module  ",
+			expectedName:   "my-module",
+			wantErr:        false,
+		},
+		{
+			name:           "mismatched names",
+			definitionName: "wrong-name",
+			expectedName:   "my-module",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateModuleDefinitionName(tt.definitionName, tt.expectedName)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrModuleNameMismatch)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Added validation in the module downloader to check that the module name in `module.yaml` matches the expected registry module name. When a mismatch is detected, the download fails with a clear error message instead of silently hanging.

The validation is performed in three places:
- `DownloadMetadataFromReleaseChannel()` - when downloading via release channel
- `DownloadReleaseImageInfoByVersion()` - when downloading by specific version
- `fetchModuleDefinitionFromModuleImage()` - when extracting definition from module image

This change doesn't affect critical cluster components - it only changes the error handling behavior during module downloads.

## Why do we need it, and what problem does it solve?

When downloading a module from the registry, if the module name in `module.yaml` didn't match the registry module name, Deckhouse wouldn't throw any errors and just left the module stuck in "Phase Downloading" forever.

This made debugging very difficult because there was no indication of what was wrong. Users had to figure out the name mismatch on their own.

Now when there's a mismatch, users get a clear error:
```
module name mismatch: module.yaml contains name "wrong-name" but expected "my-module" (registry module name)
```

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Module download now fails with a clear error when module.yaml name doesn't match the registry module name
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
