### PR TITLE
[docs] Update page metadata

### DIFF
--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -95,15 +95,11 @@
 
 {%- if page.product_code == 'stronghold' or page.product_code == "virtualization-platform" or page.product_code == "code" or page.product_code == "delivery-kit" or page.product_code == "kubernetes-platform" or page.product_code == "observability-platform" or page.product_code == "prompp" %}
 <meta property="og:image" content="{{ site.urls[page.lang] }}/images/og/{{ page.product_code }}.png">
+<meta property="og:site_name" content="Deckhouse">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">
 <meta property="og:image:type" content="image/png">
 {%- endif %}
 
 <!-- Twitter -->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:url" content="{{ site.urls[page.lang] }}{{ page_meta_url }}">
-<meta name="twitter:title" content="{{ generated_title }} | {{ site.site_title }}">
-<meta name="twitter:description" content="{{ description }}">
-<meta name="twitter:image" content="{{ site.urls[page.lang] }}/images/favicon/logo-180.png" />
-<meta name="twitter:image:alt" content="{{ site.Title }}">
+<meta name="twitter:card" content="summary_large_image">

--- a/docs/site/backends/docs-builder-template/layouts/_partials/head.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/head.html
@@ -23,9 +23,4 @@
 <meta property="og:image:type" content="image/png">
 
 <!-- Twitter -->
-<meta name="twitter:card" content="summary">
-<meta name="twitter:url" content="{{ strings.TrimSuffix "readme.html" .Permalink }}">
-<meta name="twitter:title" content="{{ .Title }} | {{ .Site.Title }}">
-<meta name="twitter:description" content="{{ $description }}">
-<meta name="twitter:image" content="{{ if eq site.Params.mode "module" }}/{{ else }}{{ site.BaseURL }}{{ end }}images/favicon/logo-180.png" />
-<meta name="twitter:image:alt" content="{{ site.Title }}">
+<meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
## Description

This pull request updates the Open Graph and Twitter meta tags in the documentation site's HTML templates to improve social media sharing. The main focus is to enhance how links appear when shared, especially on Twitter, by switching to a larger image preview and adding a site name for Open Graph.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update page metadata.
impact_level: low
```
