### PR TITLE
[docs] More accurate and visually appealing page meta descriptions

### DIFF
--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -3,6 +3,7 @@
 <meta name="viewport" content="width=1100">
 
 <!-- title/descriptions -->
+{%- assign description_maxlength = 199 -%}
 {%- assign page_url_parts = page.url | split: '/' -%}
 {%- assign max_ind = page_url_parts.size | minus: 1 -%}
 {%- assign title_parts = "" | split: "" -%}
@@ -52,17 +53,34 @@
 <title>{{ generated_title }} | {{ site.site_title }} {{ additional_title }}</title>
 
 {%- if page.description %}
-    {%- assign description = page.description | strip_html | strip_newlines | strip | truncate: 200 %}
+    {%- assign raw_description = page.description | strip_html | strip_newlines | strip %}
 {%- else %}
     {%- assign pageCommonName = page.name | replace: '_RU.md', '' | replace: '.md', '' | downcase %}
     {%- if pageCommonName == "configuration" or pageCommonName == "cr" or pageCommonName == "examples" or pageCommonName == "usage" or pageCommonName == "faq"  %}
         {%- assign i18nKey = 'description_' | append: pageCommonName %}
-        {%- assign description = site.data.i18n.common[i18nKey][page.lang] | replace: '<MODULENAME>', page['module-kebab-name'] %}
+        {%- assign raw_description = site.data.i18n.common[i18nKey][page.lang] | replace: '<MODULENAME>', page['module-kebab-name'] %}
     {%- elsif page.platform_type %}
-        {%- assign description = site.data.i18n.common['gs_description'][page.lang] | replace: '<TITLE>', page.title_main | replace: '<STEP>', page.step_name %}
+        {%- assign raw_description = site.data.i18n.common['gs_description'][page.lang] | replace: '<TITLE>', page.title_main | replace: '<STEP>', page.step_name %}
     {%- else %}
-        {%- assign description = page.content | markdownify | strip_html | normalizeSearchContent | strip_newlines | strip | truncate: 200 %}
+        {%- assign raw_description = page.content | markdownify | strip_html | normalizeSearchContent | strip_newlines | strip %}
     {%- endif %}
+{%- endif %}
+{%- if raw_description.size > description_maxlength %}
+    {%- assign truncated = raw_description | truncate: description_maxlength, '' %}
+    {%- assign boundary_char = raw_description | slice: description_maxlength, 1 %}
+    {%- if boundary_char != ' ' %}
+        {%- assign words = truncated | split: ' ' %}
+        {%- if words.size > 1 %}
+            {%- assign last_index = words.size | minus: 1 %}
+            {%- assign description = words | slice: 0, last_index | join: ' ' %}
+        {%- else %}
+            {%- assign description = truncated %}
+        {%- endif %}
+    {%- else %}
+        {%- assign description = truncated | strip %}
+    {%- endif %}
+{%- else %}
+    {%- assign description = raw_description %}
 {%- endif %}
 
 {%- if page.sidebar == 'embedded-modules' %}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/get-description-from-content.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/get-description-from-content.html
@@ -1,0 +1,14 @@
+{{- $content := .content }}
+{{/* Remove all shortcode blocks including their content */}}
+{{- $content = replaceRE `(?s)\{\{<[^}]*?>.*?\{\{<[^}]*?>\}\}` "" $content }}
+{{/* Replace ALL newlines with spaces */}}
+{{- $content = replaceRE `\r?\n` " " $content }}
+{{/* Collapse multiple spaces (including tabs) to single space */}}
+{{- $content = replaceRE `[ \t]+` " " $content }}
+{{/* Remove leading/trailing spaces */}}
+{{- $content = strings.TrimSpace $content }}
+{{/* Trancate to 199 characters */}}
+{{- $content = $content | truncate 199 "…" }}
+{{- return $content }}
+
+

--- a/docs/site/backends/docs-builder-template/layouts/_partials/head.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/head.html
@@ -1,5 +1,9 @@
 {{- $description := "" }}
-{{- if .Description }}{{ $description = .Description | strings.TrimSpace }}{{ else }}{{ $description = .Summary | strings.TrimSpace }}{{ end }}
+{{- if .Description }}
+  {{- $description = .Description }}
+{{- else }}
+  {{- $description = partial "get-description-from-content" (dict "content" .RawContent) }}
+{{- end }}
 {{- if lt ( $description | len ) 20 }}{{ $description = .Site.Params.description }}{{ end }}
 {{- $canonicalURL := strings.TrimSuffix "readme.html" .RelPermalink }}
 {{- $canonicalURL = replaceRE "^(/modules/[a-zA-Z0-9-]+)/(alpha|beta|early-access|stable|rock-solid)/(.*)$" "$1/$3" $canonicalURL 1 }}

--- a/docs/site/backends/docs-builder-template/layouts/modules/single.html
+++ b/docs/site/backends/docs-builder-template/layouts/modules/single.html
@@ -11,7 +11,6 @@
 {{- $_pathElements := index ( findRESubmatch  `^modules/([a-zA-Z0-9-]+)/([a-zA-Z0-9-]+)/*$` .File.Dir 1 ) 0 }}
 {{- $currentModuleName := index $_pathElements 1 }}
 {{- $currentModuleChannel := index $_pathElements 2 }}
-
 <div class="navigation__container">
   <div class="navigation__container--versions">
     <div>


### PR DESCRIPTION
## Description

This pull request improves how page descriptions are generated and truncated for documentation pages, ensuring more accurate and visually appealing meta descriptions for SEO and sharing. The changes primarily focus on refining the logic for extracting, cleaning, and truncating descriptions in both the Jekyll and Hugo-based documentation sites.

Ref: https://github.com/deckhouse/deckhouse/pull/17521

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Trim whitespaces for description in the page metadata for modules from sources.
impact_level: low
```
