### PR TITLE
[deckhouse] refactor: minimize lock contention in app manager

### DIFF
--- a/deckhouse-controller/internal/packages/manager/apps/app.go
+++ b/deckhouse-controller/internal/packages/manager/apps/app.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/flant/addon-operator/pkg"
 	"github.com/flant/addon-operator/pkg/hook/types"
@@ -64,6 +65,8 @@ type Application struct {
 	hooks         *hooks.Storage      // Hook storage with indices
 	values        *values.Storage     // Values storage with layering
 	settingsCheck *kind.SettingsCheck // Hook to validate settings
+
+	deleting atomic.Bool
 }
 
 // ApplicationConfig holds configuration for creating a new Application instance.
@@ -181,6 +184,16 @@ func (a *Application) GetVersion() string {
 // GetPath returns path to the package dir
 func (a *Application) GetPath() string {
 	return a.path
+}
+
+// IsDeleting returns true if the application is being deleted.
+func (a *Application) IsDeleting() bool {
+	return a.deleting.Load()
+}
+
+// TryMarkDeleting atomically marks the application as being deleted.
+func (a *Application) TryMarkDeleting() bool {
+	return a.deleting.CompareAndSwap(false, true)
 }
 
 // GetValuesChecksum returns a checksum of the current values.


### PR DESCRIPTION
## Description

Refactored the packages manager to reduce lock contention by holding locks only for map lookups, not for long-running operations like validation. Added atomic deletion flag to prevent race conditions during package deletion. Enabled race detection in the build script to catch concurrency issues during development.

## Why do we need it, and what problem does it solve?

The manager was holding locks during slow operations like JSON schema validation, which blocked other operations unnecessarily. This caused contention when multiple packages were being validated or settings were applied concurrently. The atomic deletion flag prevents concurrent deletion attempts from interfering with each other, and race detection helps catch any remaining concurrency bugs during testing.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Get rid of global lock in package manager.
impact_level: low
```