### PR TITLE
[registry] 1.74 Backport: invalidate checker queue on image list changes (#17472)

### DIFF
--- a/modules/038-registry/hooks/checker/models.go
+++ b/modules/038-registry/hooks/checker/models.go
@@ -203,6 +203,11 @@ func (state *stateModel) initQueues(log go_hook.Logger, inputs inputsModel) erro
 		state.Queues = make(map[string]registryQueue)
 	}
 
+	imagesFingerprint, err := helpers.ComputeHash(inputs.ImagesInfo)
+	if err != nil {
+		return fmt.Errorf("cannot compute images fingerprint: %w", err)
+	}
+
 	for name := range state.Queues {
 		if _, ok := inputs.Params.Registries[name]; !ok {
 			log.Info("Deleting queue", "queue.name", name)
@@ -212,7 +217,7 @@ func (state *stateModel) initQueues(log go_hook.Logger, inputs inputsModel) erro
 
 	t := time.Now().UTC()
 	for name, registryParams := range inputs.Params.Registries {
-		hash, err := helpers.ComputeHash(registryParams)
+		hash, err := helpers.ComputeHash(registryParams, imagesFingerprint)
 		if err != nil {
 			return fmt.Errorf("cannot compute registry %q params hash: %w", name, err)
 		}


### PR DESCRIPTION
## Description
Ensure the registry checker queue is rebuilt when the list of required images (Deckhouse or modules) changes, preventing validation of outdated image tags.

## Why do we need it, and what problem does it solve?
Previously, the registry checker cached the validation queue based solely on registry connection parameters. Changing the Deckhouse version (image tag) or module versions did not trigger a queue rebuild. This caused persistent errors about missing old image tags even after a successful update. This fix ensures the checker always validates the actual input image list state

## Why do we need it in the patch release (if we do)?
This PR fixes validation of input image list changes in the registry checker.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry
type: fix
summary: Fixed validation of input image list changes in the registry checker.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
