### PR TITLE
[prometheus-pushgateway] fix CVEs

### DIFF
--- a/modules/303-prometheus-pushgateway/images/pushgateway/patches/001-go-mod.patch
+++ b/modules/303-prometheus-pushgateway/images/pushgateway/patches/001-go-mod.patch
@@ -1,0 +1,77 @@
+diff --git a/go.mod b/go.mod
+index b2e5e40..7e2b689 100644
+--- a/go.mod
++++ b/go.mod
+@@ -1,6 +1,6 @@
+ module github.com/prometheus/pushgateway
+ 
+-go 1.23.0
++go 1.24.0
+ 
+ toolchain go1.24.1
+ 
+@@ -20,9 +20,10 @@ require (
+ 	github.com/mdlayher/socket v0.4.1 // indirect
+ 	github.com/mdlayher/vsock v1.2.1 // indirect
+ 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+-	golang.org/x/crypto v0.35.0 // indirect
+-	golang.org/x/net v0.36.0 // indirect
+-	golang.org/x/oauth2 v0.25.0 // indirect
++	golang.org/x/crypto v0.47.0 // indirect
++	golang.org/x/net v0.49.0 // indirect
++	golang.org/x/oauth2 v0.34.0 // indirect
++	golang.org/x/tools/godoc v0.1.0-deprecated // indirect
+ )
+ 
+ require (
+@@ -37,8 +38,8 @@ require (
+ 	github.com/prometheus/prometheus v0.302.1
+ 	github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c // indirect
+ 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
+-	golang.org/x/sync v0.11.0 // indirect
+-	golang.org/x/sys v0.30.0 // indirect
+-	golang.org/x/text v0.22.0 // indirect
++	golang.org/x/sync v0.19.0 // indirect
++	golang.org/x/sys v0.40.0 // indirect
++	golang.org/x/text v0.33.0 // indirect
+ 	gopkg.in/yaml.v2 v2.4.0 // indirect
+ )
+diff --git a/go.sum b/go.sum
+index 3f2695a..8922094 100644
+--- a/go.sum
++++ b/go.sum
+@@ -72,20 +72,20 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
+ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+ github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+ github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
+-golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
+-golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
+-golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
+-golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
+-golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
+-golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+-golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+-golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+-golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+-golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+-golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+-golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+-golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
+-golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=
++golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
++golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
++golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
++golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
++golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
++golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
++golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
++golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
++golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
++golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
++golang.org/x/text v0.33.0 h1:B3njUFyqtHDUI5jMn1YIr5B0IE2U0qck04r6d4KPAxE=
++golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=
++golang.org/x/tools/godoc v0.1.0-deprecated h1:o+aZ1BOj6Hsx/GBdJO/s815sqftjSnrZZwyYTHODvtk=
++golang.org/x/tools/godoc v0.1.0-deprecated/go.mod h1:qM63CriJ961IHWmnWa9CjZnBndniPt4a3CK0PVB9bIg=
+ google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+ google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/modules/303-prometheus-pushgateway/images/pushgateway/patches/README.md
+++ b/modules/303-prometheus-pushgateway/images/pushgateway/patches/README.md
@@ -1,0 +1,3 @@
+### 001-go-mod.patch
+
+Update dependencies

--- a/modules/303-prometheus-pushgateway/images/pushgateway/werf.inc.yaml
+++ b/modules/303-prometheus-pushgateway/images/pushgateway/werf.inc.yaml
@@ -3,6 +3,12 @@
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
+git:
+- add: /{{ $.ModulePath }}modules/303-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+      - '**/*'
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -10,6 +16,7 @@ shell:
   install:
     - git clone --verbose --depth 1 --branch "v{{ $version }}" $(cat /run/secrets/SOURCE_REPO)/prometheus/pushgateway.git /src
     - cd /src
+    - git apply /patches/*.patch --verbose
     - rm -r .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact


### PR DESCRIPTION
 ## Description

Update go dependencies in prometheus-pushgateway module

## Why do we need it, and what problem does it solve?

Fix CVEs of medium and high severity:

golang.org/x/crypto
  * [CVE-2025-47914](https://github.com/advisories/GHSA-f6x5-jh6r-wrfv)
  * [CVE-2025-58181](https://github.com/advisories/GHSA-j5w8-q4qc-rx2x)

golang.org/x/oauth2
  * [CVE-2025-22868](https://github.com/advisories/GHSA-6v2p-p543-phr9)

golang.org/x/net
  * [CVE-2025-22872](https://github.com/advisories/GHSA-vvgc-356p-c3xw)

## Why do we need it in the patch release (if we do)?

This PR fixes medium and high severity CVEs

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus-pushgateway
type: fix
summary: Fixed CVE-2025-47914, CVE-2025-58181, CVE-2025-22872, CVE-2025-22868
```