### PR TITLE
[metallb] Fix D8MetallbBGPSessionDown alert

### DIFF
--- a/ee/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
+++ b/ee/modules/380-metallb/monitoring/prometheus-rules/metallb.yaml
@@ -43,6 +43,8 @@
         summary: MetalLB is running on a stale configuration.
 
     - alert: D8MetallbBGPSessionDown
+      # TODO: After updating to a version higher than 0.15.3, change the expression
+      # Fixed in upstream: https://github.com/metallb/metallb/issues/2806
       expr: metallb_bgp_session_up{peer=~".+:.+"} == 0
       for: 5m
       labels:


### PR DESCRIPTION
## Description

The `D8MetallbBGPSessionDown` alert was incorrectly triggering due to duplicate metrics exported by MetalLB. One metric series labels the peer with just the IP address (reporting status **Down**), while the other includes both IP and Port (reporting status **Up**). 

This commit adds a label selector to the alert expression to strictly match peers with a port defined, effectively ignoring the incorrect metric series that lacks port information.

This PR implements a workaround for [the issue](https://github.com/metallb/metallb/issues/2806), which has already been fixed upstream.

---

```txt
metallb_bgp_session_up{container="kube-rbac-proxy", instance="172.17.17.1:4220", job="speaker", namespace="d8-metallb", peer="172.17.17.0", pod="speaker-hskxt", tier="cluster"}
0
metallb_bgp_session_up{container="kube-rbac-proxy", instance="172.17.17.1:4220", job="speaker", namespace="d8-metallb", peer="172.17.17.0:179", pod="speaker-hskxt", tier="cluster"}
1
metallb_bgp_session_up{container="kube-rbac-proxy", instance="172.17.17.2:4220", job="speaker", namespace="d8-metallb", peer="172.17.17.0", pod="speaker-pvqvh", tier="cluster"}
0
metallb_bgp_session_up{container="kube-rbac-proxy", instance="172.17.17.2:4220", job="speaker", namespace="d8-metallb", peer="172.17.17.0:179", pod="speaker-pvqvh", tier="cluster"}
1
```

Before:

<img width="1562" height="262" alt="2026-01-20 at 18 08 51@2x" src="https://github.com/user-attachments/assets/6c4c87d3-858f-443d-9764-3140b4fe4e33" />

After:

<img width="1962" height="348" alt="2026-01-20 at 18 12 24@2x" src="https://github.com/user-attachments/assets/fcd6e5df-491b-429e-aaa5-892cad6ff761" />

## Why do we need it, and what problem does it solve?

To fix false positive alerts for BGP sessions. MetalLB exports two metrics for the same peer, and the one missing the port information incorrectly reports the session as down, causing the alert to fire even when the session is actually up (as shown by the metric with the port).

## Why do we need it in the patch release (if we do)?

Yes, to eliminate noise from false positive alerts in existing installations.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: fix
summary: Fixed D8MetallbBGPSessionDown alert false positives caused by duplicate metrics without port information.
impact_level: default 
