### PR TITLE
Backport: [admission-policy-engine] Fix template, fix tests 

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/constraint-allowed-admin.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/allowed-cluster-roles/constraint-allowed-admin.yaml
@@ -8,9 +8,6 @@ spec:
     kinds:
       - apiGroups: ["rbac.authorization.k8s.io"]
         kinds: ["RoleBinding"]
-    namespaceSelector:
-      matchLabels:
-        enforce: deny-all
     scope: Namespaced
   parameters:
     allowedClusterRoles:

--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package template_tests
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
 )
@@ -28,7 +31,7 @@ const (
 )
 
 var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation policies", func() {
-	f := SetupHelmConfig(`{global: {discovery: {kubernetesVersion: "1.30"}},admissionPolicyEngine: {denyVulnerableImages: {}, podSecurityStandards: {}, internal: {"bootstrapped": true, "ratify": {"webhook": {"key": "YjY0ZW5jX3N0cmluZwo=", "crt": "YjY0ZW5jX3N0cmluZwo=" , "ca": "YjY0ZW5jX3N0cmluZwo="}}, "podSecurityStandards": {"enforcementActions": ["deny"]}, "operationPolicies": [
+	f := SetupHelmConfig(`{global: {discovery: {kubernetesVersion: "1.30"}},admissionPolicyEngine: {podSecurityStandards: {}, internal: {"bootstrapped": true, "ratify": {"webhook": {"key": "YjY0ZW5jX3N0cmluZwo=", "crt": "YjY0ZW5jX3N0cmluZwo=" , "ca": "YjY0ZW5jX3N0cmluZwo="}}, "podSecurityStandards": {"enforcementActions": ["deny"]}, "operationPolicies": [
 {
 	"metadata":{"name":"genpolicy"},
 	"spec":{
@@ -97,6 +100,27 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: operation 
 			Expect(f.KubernetesGlobalResource("D8ContainerDuplicates", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8ReplicaLimits", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8DisallowedTolerations", testPolicyName).Exists()).To(BeTrue())
+		})
+
+		It("All operation policy constraints must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			operationConstraints := getOperationConstraintNames()
+			Expect(operationConstraints).NotTo(BeEmpty(), "No operation constraints found in templates")
+
+			for _, constraintKind := range operationConstraints {
+				constraint := f.KubernetesGlobalResource(constraintKind, testPolicyName)
+				if constraint.Exists() {
+					// Get the resource as a map to validate YAML structure
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s: %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, constraintKind)
+				}
+			}
 		})
 	})
 })

--- a/modules/015-admission-policy-engine/template_tests/policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/policies_test.go
@@ -20,10 +20,14 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
 )
@@ -49,7 +53,6 @@ admissionPolicyEngine:
       key: YjY0ZW5jX3N0cmluZwo=
     trackedConstraintResources: []
     trackedMutateResources: []
-  denyVulnerableImages: {}
   podSecurityStandards:
     policies:
       hostPorts:
@@ -74,7 +77,7 @@ admissionPolicyEngine:
 		It("Rego policy test must have passed", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 			gatorCLI := exec.Command(gatorPath, "verify", "-v", "../charts/constraint-templates/tests/...")
-			res, err := gatorCLI.Output()
+			res, err := gatorCLI.CombinedOutput()
 			if err != nil {
 				output := strings.ReplaceAll(string(res), "modules/015-admission-policy-engine/charts/constraint-templates", "...")
 				fmt.Println(output)
@@ -82,6 +85,231 @@ admissionPolicyEngine:
 			}
 		})
 	})
+
+	Context("Pod security standards constraints YAML validation", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("All pod security standards baseline constraints must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			baselineConstraints := getBaselineConstraintNames()
+			Expect(baselineConstraints).NotTo(BeEmpty(), "No baseline constraints found in templates")
+
+			for _, constraintKind := range baselineConstraints {
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-baseline-deny-default")
+				if constraint.Exists() {
+					// Get the resource as a map to validate YAML structure
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s: %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, constraintKind)
+				}
+			}
+		})
+
+		It("All pod security standards restricted constraints must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			restrictedConstraints := getRestrictedConstraintNames()
+			Expect(restrictedConstraints).NotTo(BeEmpty(), "No restricted constraints found in templates")
+
+			for _, constraintKind := range restrictedConstraints {
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-restricted-deny-default")
+				if constraint.Exists() {
+					// Get the resource as a map to validate YAML structure
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s: %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, constraintKind)
+				}
+			}
+		})
+	})
+
+	Context("Pod security standards with explicit defaultPolicy: Privileged and enforcementAction: Deny", func() {
+		BeforeEach(func() {
+			f.ValuesSet("admissionPolicyEngine.podSecurityStandards.defaultPolicy", "Privileged")
+			f.ValuesSet("admissionPolicyEngine.podSecurityStandards.enforcementAction", "Deny")
+			f.ValuesSetFromYaml("admissionPolicyEngine.internal.podSecurityStandards.enforcementActions", `["deny"]`)
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("All pod security standards baseline constraints must have valid YAML with defaultPolicy: Privileged", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			baselineConstraints := getBaselineConstraintNames()
+			Expect(baselineConstraints).NotTo(BeEmpty(), "No baseline constraints found in templates")
+
+			for _, constraintKind := range baselineConstraints {
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-baseline-deny-default")
+				if constraint.Exists() {
+					// Get the resource as a map to validate YAML structure
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s: %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, constraintKind)
+				}
+			}
+		})
+
+		It("All pod security standards restricted constraints must have valid YAML with defaultPolicy: Privileged", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			restrictedConstraints := getRestrictedConstraintNames()
+			Expect(restrictedConstraints).NotTo(BeEmpty(), "No restricted constraints found in templates")
+
+			for _, constraintKind := range restrictedConstraints {
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-restricted-deny-default")
+				if constraint.Exists() {
+					// Get the resource as a map to validate YAML structure
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s: %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, constraintKind)
+				}
+			}
+		})
+	})
+
+	// ============================================================================
+	// TODO: REMOVE THIS SECTION AFTER REMOVING d8-prefixed constraints from templates
+	// ============================================================================
+	// This section tests constraints with "-d8" suffix that are generated
+	// when defaultPolicy != "privileged" (for baseline) or != "restricted" (for restricted).
+	// These constraints are marked for removal in templates/_helpers.tpl with TODO comment.
+	// After removing the template code that generates these constraints, this test section
+	// should be deleted as well.
+	// ============================================================================
+	Context("Pod security standards constraints with -d8 suffix (temporary, for removal)", func() {
+		BeforeEach(func() {
+			// Set defaultPolicy to Baseline to trigger generation of -d8 constraints for baseline
+			// Set defaultPolicy to Privileged to trigger generation of -d8 constraints for restricted
+			f.ValuesSet("admissionPolicyEngine.podSecurityStandards.defaultPolicy", "Baseline")
+			f.ValuesSet("admissionPolicyEngine.podSecurityStandards.enforcementAction", "Deny")
+			f.ValuesSetFromYaml("admissionPolicyEngine.internal.podSecurityStandards.enforcementActions", `["deny"]`)
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("All pod security standards baseline constraints with -d8-default suffix must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			baselineConstraints := getBaselineConstraintNames()
+			Expect(baselineConstraints).NotTo(BeEmpty(), "No baseline constraints found in templates")
+
+			for _, constraintKind := range baselineConstraints {
+				// Check constraint with -d8-default suffix (when policyAction matches default enforcement action)
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-baseline-deny-d8-default")
+				if constraint.Exists() {
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s (d8-default): %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, fmt.Sprintf("%s (d8-default)", constraintKind))
+				}
+			}
+		})
+
+		It("All pod security standards restricted constraints with -d8-default suffix must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			restrictedConstraints := getRestrictedConstraintNames()
+			Expect(restrictedConstraints).NotTo(BeEmpty(), "No restricted constraints found in templates")
+
+			for _, constraintKind := range restrictedConstraints {
+				// Check constraint with -d8-default suffix (when policyAction matches default enforcement action)
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-restricted-deny-d8-default")
+				if constraint.Exists() {
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s (d8-default): %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, fmt.Sprintf("%s (d8-default)", constraintKind))
+				}
+			}
+		})
+	})
+
+	Context("Pod security standards constraints with -d8 suffix (non-default action, temporary, for removal)", func() {
+		BeforeEach(func() {
+			// Set defaultPolicy to Baseline to trigger generation of -d8 constraints for baseline
+			// Set enforcementAction to "warn" (non-default) to test -d8 suffix (without -default)
+			f.ValuesSet("admissionPolicyEngine.podSecurityStandards.defaultPolicy", "Baseline")
+			f.ValuesSet("admissionPolicyEngine.podSecurityStandards.enforcementAction", "Deny")
+			f.ValuesSetFromYaml("admissionPolicyEngine.internal.podSecurityStandards.enforcementActions", `["deny", "warn"]`)
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("All pod security standards baseline constraints with -d8 suffix (non-default) must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			baselineConstraints := getBaselineConstraintNames()
+			Expect(baselineConstraints).NotTo(BeEmpty(), "No baseline constraints found in templates")
+
+			for _, constraintKind := range baselineConstraints {
+				// Check constraint with -d8 suffix (when policyAction doesn't match default enforcement action)
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-baseline-warn-d8")
+				if constraint.Exists() {
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s (d8): %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, fmt.Sprintf("%s (d8)", constraintKind))
+				}
+			}
+		})
+
+		It("All pod security standards restricted constraints with -d8 suffix (non-default) must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// Dynamically extract constraint names from template files
+			restrictedConstraints := getRestrictedConstraintNames()
+			Expect(restrictedConstraints).NotTo(BeEmpty(), "No restricted constraints found in templates")
+
+			for _, constraintKind := range restrictedConstraints {
+				// Check constraint with -d8 suffix (when policyAction doesn't match default enforcement action)
+				constraint := f.KubernetesGlobalResource(constraintKind, "d8-pod-security-restricted-warn-d8")
+				if constraint.Exists() {
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s (d8): %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, fmt.Sprintf("%s (d8)", constraintKind))
+				}
+			}
+		})
+	})
+	// ============================================================================
+	// END OF TEMPORARY SECTION - REMOVE AFTER REMOVING d8-prefixed constraints
+	// ============================================================================
 })
 
 func gatorAvailable() (string, bool) {
@@ -91,5 +319,136 @@ func gatorAvailable() (string, bool) {
 	}
 
 	info, err := os.Lstat(gatorPath)
-	return gatorPath, err == nil && (info.Mode().Perm()&0111 != 0)
+	return gatorPath, err == nil && (info.Mode().Perm()&0o111 != 0)
+}
+
+// validateYAML checks if the constraint resource has valid YAML structure
+// by attempting to marshal it back to YAML
+func validateYAML(constraint interface{}, resourceName string) {
+	// Try to marshal the resource to YAML to validate its structure
+	yamlBytes, err := yaml.Marshal(constraint)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to marshal resource %s to YAML: %v", resourceName, err))
+	}
+
+	// Try to unmarshal it back to validate it's valid YAML
+	var result interface{}
+	err = yaml.Unmarshal(yamlBytes, &result)
+	if err != nil {
+		Fail(fmt.Sprintf("Invalid YAML for resource %s: %v\nYAML content:\n%s", resourceName, err, string(yamlBytes)))
+	}
+}
+
+// extractConstraintNamesFromTemplate parses template file and extracts constraint kind names
+// from include statements like: include "pod_security_standard_baseline" (list $context "D8HostNetwork" ...)
+// or include "pod_security_standard_restricted" (list $context "D8AllowedCapabilities" ...)
+func extractConstraintNamesFromTemplate(templatePath string, helperName string) []string {
+	content, err := os.ReadFile(templatePath)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to read template file %s: %v", templatePath, err))
+	}
+
+	// Pattern to match: include "pod_security_standard_baseline" (list $context "D8XXX" ...)
+	// or include "pod_security_standard_restricted" (list $context "D8XXX" ...)
+	// The pattern looks for the helper name followed by a list that contains a quoted string starting with D8
+	pattern := fmt.Sprintf(`include\s+"%s"\s+\([^)]*list[^)]*"([D8][^"]+)"`, regexp.QuoteMeta(helperName))
+	re := regexp.MustCompile(pattern)
+
+	matches := re.FindAllStringSubmatch(string(content), -1)
+	constraintNames := make(map[string]bool)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			constraintName := match[1]
+			// Only include names that start with D8 (constraint kinds)
+			if strings.HasPrefix(constraintName, "D8") {
+				constraintNames[constraintName] = true
+			}
+		}
+	}
+
+	result := make([]string, 0, len(constraintNames))
+	for name := range constraintNames {
+		result = append(result, name)
+	}
+
+	return result
+}
+
+// findTemplatePath finds the template file by trying multiple possible paths
+func findTemplatePath(relativePath string) string {
+	// Get the directory where this test file is located
+	_, testFile, _, _ := runtime.Caller(0)
+	testDir := filepath.Dir(testFile)
+	
+	// Try different possible paths
+	possiblePaths := []string{
+		// Relative to test file (when running from module root)
+		filepath.Join(testDir, "..", relativePath),
+		// Relative to current working directory
+		relativePath,
+		// From workspace root
+		filepath.Join("modules", "015-admission-policy-engine", relativePath),
+	}
+
+	for _, path := range possiblePaths {
+		absPath, _ := filepath.Abs(path)
+		if _, err := os.Stat(absPath); err == nil {
+			return absPath
+		}
+		// Also try the relative path as-is
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+	}
+
+	Fail(fmt.Sprintf("Could not find template file %s. Tried paths: %v (test file: %s)", relativePath, possiblePaths, testFile))
+	return ""
+}
+
+// getBaselineConstraintNames extracts constraint names from baseline template
+func getBaselineConstraintNames() []string {
+	templatePath := findTemplatePath(filepath.Join("templates", "policies", "pod-security-standards", "baseline", "constraint.yaml"))
+	return extractConstraintNamesFromTemplate(templatePath, "pod_security_standard_baseline")
+}
+
+// getRestrictedConstraintNames extracts constraint names from restricted template
+func getRestrictedConstraintNames() []string {
+	templatePath := findTemplatePath(filepath.Join("templates", "policies", "pod-security-standards", "restricted", "constraint.yaml"))
+	return extractConstraintNamesFromTemplate(templatePath, "pod_security_standard_restricted")
+}
+
+// getOperationConstraintNames extracts constraint names from operation-policy template
+// by parsing "kind: D8XXX" lines in define blocks
+func getOperationConstraintNames() []string {
+	templatePath := findTemplatePath(filepath.Join("templates", "policies", "operation-policy", "constraint.yaml"))
+	content, err := os.ReadFile(templatePath)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to read template file %s: %v", templatePath, err))
+	}
+
+	// Pattern to match: kind: D8XXX (where XXX is the constraint name)
+	// This appears in define blocks like: kind: D8AllowedRepos
+	pattern := `kind:\s+(D8[A-Za-z0-9]+)`
+	re := regexp.MustCompile(pattern)
+
+	matches := re.FindAllStringSubmatch(string(content), -1)
+	constraintNames := make(map[string]bool)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			constraintName := match[1]
+			// Only include names that start with D8 (constraint kinds)
+			if strings.HasPrefix(constraintName, "D8") {
+				constraintNames[constraintName] = true
+			}
+		}
+	}
+
+	result := make([]string, 0, len(constraintNames))
+	for name := range constraintNames {
+		result = append(result, name)
+	}
+
+	return result
 }

--- a/modules/015-admission-policy-engine/template_tests/security_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/security_policies_test.go
@@ -17,14 +17,17 @@ limitations under the License.
 package template_tests
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
 )
 
 var _ = Describe("Module :: admissionPolicyEngine :: helm template :: security policies", func() {
-	f := SetupHelmConfig(`{admissionPolicyEngine: {denyVulnerableImages: {}, podSecurityStandards: {}, internal: {"bootstrapped": true, "ratify": {"webhook": {"key": "YjY0ZW5jX3N0cmluZwo=", "crt": "YjY0ZW5jX3N0cmluZwo=" , "ca": "YjY0ZW5jX3N0cmluZwo="}}, "podSecurityStandards": {"enforcementActions": ["deny"]}, "securityPolicies": [
+	f := SetupHelmConfig(`{admissionPolicyEngine: {podSecurityStandards: {}, internal: {"bootstrapped": true, "ratify": {"webhook": {"key": "YjY0ZW5jX3N0cmluZwo=", "crt": "YjY0ZW5jX3N0cmluZwo=" , "ca": "YjY0ZW5jX3N0cmluZwo="}}, "podSecurityStandards": {"enforcementActions": ["deny"]}, "securityPolicies": [
 {
 	"metadata":{"name":"genpolicy"},
 	"spec":{
@@ -87,6 +90,45 @@ var _ = Describe("Module :: admissionPolicyEngine :: helm template :: security p
 			Expect(f.KubernetesGlobalResource("D8AppArmor", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8VerifyImageSignatures", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8AllowRbacWildcards", testPolicyName).Exists()).To(BeTrue())
+		})
+
+		It("All security policy constraints must have valid YAML", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			securityConstraints := []string{
+				"D8AllowedCapabilities",
+				"D8AllowedFlexVolumes",
+				"D8AllowedHostPaths",
+				"D8AllowedProcMount",
+				"D8AllowedSeccompProfiles",
+				"D8AllowedSysctls",
+				"D8AllowedUsers",
+				"D8AllowedVolumeTypes",
+				"D8AllowPrivilegeEscalation",
+				"D8HostNetwork",
+				"D8HostProcesses",
+				"D8PrivilegedContainer",
+				"D8ReadOnlyRootFilesystem",
+				"D8AllowedClusterRoles",
+				"D8AutomountServiceAccountTokenPod",
+				"D8SeLinux",
+				"D8AppArmor",
+				"D8VerifyImageSignatures",
+				"D8AllowRbacWildcards",
+			}
+
+			for _, constraintKind := range securityConstraints {
+				constraint := f.KubernetesGlobalResource(constraintKind, testPolicyName)
+				if constraint.Exists() {
+					// Get the resource as a map to validate YAML structure
+					var resourceMap map[string]interface{}
+					err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resourceMap)
+					if err != nil {
+						Fail(fmt.Sprintf("Invalid YAML for resource %s: %v\nYAML content:\n%s", constraintKind, err, constraint.ToYaml()))
+					}
+					validateYAML(resourceMap, constraintKind)
+				}
+			}
 		})
 	})
 })

--- a/modules/015-admission-policy-engine/templates/_helpers.tpl
+++ b/modules/015-admission-policy-engine/templates/_helpers.tpl
@@ -138,13 +138,13 @@ spec:
       matchExpressions:
     {{- if eq $standard "baseline" }}
       {{- if ne $defaultPolicy "privileged" }}
-      - { key: heritage, operator: In, values: [ deckhouse ] }
-      - { key: security.deckhouse.io/enable-security-policy-check, operator: In, values: [ "true" ] }
+        - { key: heritage, operator: In, values: [ deckhouse ] }
+        - { key: security.deckhouse.io/enable-security-policy-check, operator: In, values: [ "true" ] }
       {{- end }}
     {{- else if eq $standard "restricted" }}
       {{- if ne $defaultPolicy "restricted" }}
-      - { key: heritage, operator: In, values: [ deckhouse ] }
-      - { key: security.deckhouse.io/enable-security-policy-check, operator: In, values: [ "true" ] }
+        - { key: heritage, operator: In, values: [ deckhouse ] }
+        - { key: security.deckhouse.io/enable-security-policy-check, operator: In, values: [ "true" ] }
       {{- end }}
     {{- end }}
       # matches default enforcement action


### PR DESCRIPTION
## Description
Bugs in `_helpers.tpl` added in #17344 were found that interfere with object rendering.
It was also discovered that existing template tests do not support these checks.
The bug has been fixed, and tests for this case have been added.

## Why do we need it, and what problem does it solve?
Bug fix, tests improvements

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: admission-policy-engine
type: fix 
summary: Fix constraint templates, add additional tests
impact_level: low
```
