### PR TITLE
[user-authz] Add securityPolicyException for webhook daemonset

### DIFF
--- a/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -41,8 +41,9 @@ spec:
       allowedValue: true
       metadata:
         description: |
-          User Authz Webhook need to run on hostNetwork for communication with apiserver
-
+          User Authz Webhook need to run on hostNetwork for fault tolerance. Architectural feature.
+          The pod runs on the host network to ensure independence from the state of the "Service" object in k8s.
+          
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
## Description
When implementing feature in #16738, a webhook service was missed that requires a securityPolicyException object.
This PR adds this object.

## Why do we need it, and what problem does it solve?
Bug fix


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix 
summary: Add securityPolicyException for webhook daemonset
impact_level:  low
```
