### PR TITLE
user-authz: Make authz webhook use local apiserver

### DIFF
--- a/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -75,13 +75,15 @@ spec:
       - name: webhook
         {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list $ "webhook") }}
-        # Use local kube-apiserver endpoint (hostNetwork) instead of ClusterIP "kubernetes" service.
+        # Use node-local kube-apiserver endpoint (hostNetwork) instead of ClusterIP "kubernetes" service.
         # Some environments may block access to ClusterIP from hostNetwork pods, which makes the webhook unstable.
         env:
         - name: KUBERNETES_SERVICE_HOST
-          value: "127.0.0.1"
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: KUBERNETES_SERVICE_PORT
-          value: "6445"
+          value: "6443"
         volumeMounts:
         - mountPath: /etc/user-authz-webhook/
           name: user-authz-webhook-config

--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -294,11 +294,10 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			Expect(ds.Exists()).To(BeTrue())
 			Expect(ds.Field("spec.template.spec.hostNetwork").Bool()).To(BeTrue())
 
-			env := ds.Field("spec.template.spec.containers.0.env").String()
-			Expect(env).To(ContainSubstring("KUBERNETES_SERVICE_HOST"))
-			Expect(env).To(ContainSubstring("127.0.0.1"))
-			Expect(env).To(ContainSubstring("KUBERNETES_SERVICE_PORT"))
-			Expect(env).To(ContainSubstring("6445"))
+			Expect(ds.Field("spec.template.spec.containers.0.env.0.name").String()).To(Equal("KUBERNETES_SERVICE_HOST"))
+			Expect(ds.Field("spec.template.spec.containers.0.env.0.valueFrom.fieldRef.fieldPath").String()).To(Equal("status.hostIP"))
+			Expect(ds.Field("spec.template.spec.containers.0.env.1.name").String()).To(Equal("KUBERNETES_SERVICE_PORT"))
+			Expect(ds.Field("spec.template.spec.containers.0.env.1.value").String()).To(Equal("6443"))
 		})
 
 		It("Should deploy permission-browser-apiserver and supporting objects", func() {


### PR DESCRIPTION
## Description

This PR updates the **user-authz-webhook** DaemonSet to use the node-local kube-apiserver endpoint (<node IP>:6443) on control-plane nodes instead of relying on the `kubernetes` ClusterIP service.

### Key changes
- Adds the following environment variables to the `user-authz-webhook` container:
  - `KUBERNETES_SERVICE_HOST` is set from the node IP via `status.hostIP`
  - `KUBERNETES_SERVICE_PORT=6443`
- Forces the in-cluster client to connect to the local kube-apiserve on the same control-plane node.

This keeps the webhook stable in environments where `hostNetwork` pods cannot reach ClusterIP services (for example, `kubernetes.default.svc`).  
In such environments, the webhook may otherwise enter a restart loop and stop listening on `127.0.0.1:40443`.

This change does **not** restart critical cluster components by itself, but it **does** update and restart the authorization webhook DaemonSet.

---

## Why do we need it, and what problem does it solve?

After switching kube-apiserver authorization to **fail-closed** mode (`failurePolicy: Deny`), the authorization webhook must be reliably available at all times.

In some environments, the `user-authz-webhook` (a `hostNetwork` DaemonSet running on control-plane nodes) cannot connect to the API server via the ClusterIP `kubernetes` service (`10.x.x.x:443`) due to networking restrictions. As a result, it:
- fails to initialize its in-cluster client,
- enters a restart loop,
- stops listening on `127.0.0.1:40443`.

When this happens, kube-apiserver cannot authorize requests and the Kubernetes API becomes intermittently unavailable for users (e.g. `kubectl` errors, `Internal Server Error`).

By forcing the webhook to use the local kube-apiserver endpoint (`status.hostIP:6443`), we remove the dependency on ClusterIP service routing (and avoid 127.0.0.1:6445 nginx proxy) ensuring stable webhook operation. This prevents API outages when authorization is configured in fail-closed mode.

---

## Why do we need it in the patch release (if we do)?

Not necessarily.

---

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

---

## Changelog entries
```changes
section: user-authz
type: fix
summary: Made user-authz webhook use node-local kube-apiserver endpoint to avoid ClusterIP connectivity issues.
impact: |
  Improves stability of the user-authz authorization webhook in environments where hostNetwork pods cannot reach ClusterIP services.
  Prevents intermittent Kubernetes API errors when kube-apiserver authorization is configured in fail-closed mode.
impact_level: default
