### PR TITLE
[cloud-provider-dvp] VM deletion timeout and improve memory validation

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +40,11 @@ const (
 	attachmentDiskNameLabel    = "virtualMachineDiskName"
 	attachmentMachineNameLabel = "virtualMachineName"
 	DVPLoadBalancerLabelPrefix = "dvp.deckhouse.io/"
+)
+
+const (
+	// DefaultVMDeletionTimeout is the maximum time to wait for VM deletion
+	DefaultVMDeletionTimeout = 10 * time.Minute
 )
 
 type ComputeService struct {
@@ -164,11 +170,32 @@ func (c *ComputeService) DeleteVM(ctx context.Context, name string) error {
 		return fmt.Errorf("delete VirtualMachine resource: %w", err)
 	}
 
-	err = c.Wait(ctx, name, vm, func(obj client.Object) (bool, error) { return obj == nil, nil })
+	// Create context with timeout for waiting
+	waitCtx, cancel := context.WithTimeout(ctx, DefaultVMDeletionTimeout)
+	defer cancel()
+
+	klog.Infof("Waiting for VirtualMachine %s deletion (timeout: %v)", name, DefaultVMDeletionTimeout)
+
+	// Wait for VM to be deleted with timeout
+	err = c.Wait(waitCtx, name, vm, func(obj client.Object) (bool, error) {
+		return obj == nil, nil
+	})
+
 	if err != nil {
+		// Check if timeout exceeded
+		if errors.Is(err, context.DeadlineExceeded) {
+			klog.Warningf("VirtualMachine %s deletion timed out after %v, VM may still be terminating in parent DVP cluster", name, DefaultVMDeletionTimeout)
+			return fmt.Errorf("VM deletion timeout after %v, VM may still be terminating in parent DVP cluster: %w", DefaultVMDeletionTimeout, err)
+		}
+		// Check if operation was canceled
+		if errors.Is(err, context.Canceled) {
+			return fmt.Errorf("VM deletion was canceled: %w", err)
+		}
+		// Other errors
 		return fmt.Errorf("await VirtualMachine deletion: %w", err)
 	}
 
+	klog.Infof("VirtualMachine %s deleted successfully", name)
 	return nil
 }
 


### PR DESCRIPTION
## Description

Fixed two critical issues in cloud-provider-dvp module:

1. **VM deletion timeout issue**: VM deletion could hang indefinitely (up to 1 hour) when VM was forcefully deleted in the external DVP cluster, blocking DeckhouseMachine resource deletion.

2. **Missing error reporting for memory limits**: When ephemeral nodes failed to start due to memory/CPU limit violations, errors were not properly reported, making it difficult to diagnose the root cause.

## Why do we need it, and what problem does it solve?
**Problem 1 - VM Deletion Hanging:**
When a VM is forcefully deleted in the parent DVP cluster (e.g., manual cleanup, infrastructure issues), the DeckhouseMachine resource could remain in "deleting" state indefinitely because the deletion reconciliation loop waited forever for the VM to disappear from the API. This blocked cluster scale-down and node cleanup operations.

**Problem 2 - Silent Memory Limit Failures:**
When creating ephemeral nodes with memory/CPU requests exceeding VirtualMachineClass limits, the error was generic ("create VM: forbidden") without context. Operators couldn't easily identify that the issue was related to resource limits, leading to prolonged troubleshooting time.

**Solution Impact:**
- VM deletion now completes within 10 minutes maximum, allowing DeckhouseMachine cleanup to proceed
- Resource limit violations are now clearly identified in logs and status messages
- Orphaned VMs are tracked via annotations for manual cleanup
- Significantly improved observability and debuggability

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Fixed VM deletion timeout and improved memory validation error reporting
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
