### PR TITLE
[deckhouse] default settings check

### DIFF
--- a/deckhouse-controller/internal/packages/manager/apps/app.go
+++ b/deckhouse-controller/internal/packages/manager/apps/app.go
@@ -215,6 +215,9 @@ func (a *Application) ValidateSettings(ctx context.Context, settings addonutils.
 		return settingscheck.Result{}, err
 	}
 
+	// apply defaults from config values spec
+	settings = a.values.ApplyDefaultsConfigValues(settings)
+
 	// no need to call the settings check if nothing changed
 	if a.values.GetConfigChecksum() == settings.Checksum() {
 		return settingscheck.Result{Valid: true}, nil
@@ -354,7 +357,7 @@ func (a *Application) runHook(ctx context.Context, h *addonhooks.ModuleHook, bct
 	}
 
 	if valuesPatch, has := hookResult.Patches[addonutils.MemoryValuesPatch]; has && valuesPatch != nil {
-		if err = a.values.ApplyPatch(*valuesPatch); err != nil {
+		if err = a.values.ApplyValuesPatch(*valuesPatch); err != nil {
 			return fmt.Errorf("apply hook values patch: %w", err)
 		}
 	}

--- a/deckhouse-controller/internal/queue/queue.go
+++ b/deckhouse-controller/internal/queue/queue.go
@@ -232,7 +232,7 @@ func (q *queue) processOne() bool {
 	// Check for parent context cancellation
 	select {
 	case <-t.ctx.Done():
-		q.logger.Debug("context canceled", slog.String("id", t.id), slog.String("name", t.task.String()))
+		q.logger.Debug("task context canceled", slog.String("id", t.id), slog.String("name", t.task.String()))
 		if t.wg != nil {
 			t.wg.Done()
 		}


### PR DESCRIPTION
## Description
It applies defaults for settings before checking.

## Why do we need it, and what problem does it solve?
Settings check should check settings with its defaults.

Example:
Package has such config spec:
```
$schema: http://json-schema.org/schema#
type: object
properties:
  replicas:
    type: integer
    default: 1
```

But settings without replicas cant be applied:
```
for: "packages/app.yaml": error when patching "packages/app.yaml": admission webhook "applicationss.deckhouse-webhook.deckhouse.io" denied the request: replicas cannot be 0
```

After PR:
```
root@paksashvili-master-0:~# k apply -f packages/app.yaml
application.deckhouse.io/test configured
root@paksashvili-master-0:~# k get app
NAME   PACKAGE    AGE   VERSION   READY   INSTALLED   PROCESSED   MESSAGE
test   m-s-test   22h   v0.0.4    True    True        True
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type:  chore
summary: Default settings check.
impact_level: low
```