### PR TITLE
[docs] Add the enableNote display to the external modules configuration page

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/module-resources.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/module-resources.html
@@ -6,11 +6,13 @@ Context:
 .data — module data (usually, it is .Site.Data.modules.<MODULE_NAME> structure)
 .type — resource to render. Can be: "crds" or "configuration"
 .lang — language to use for rendering
+.pageParams — the page parameters (.Page.Params)
 */}}
 
 {{- $moduleName := .name }}
 {{- $moduleChannel := .channel }}
 {{- $moduleData := .data }}
+{{- $pageParams := .pageParams }}
 {{- $lang := .lang }}
 
 {{- if and (eq .type "crds") $moduleData.crds }}
@@ -24,6 +26,6 @@ Context:
     {{- $cfgConversions := index $moduleData.openapi "conversions" }}
     {{ if $cfgData }}
       {{- $langData := index $moduleData.openapi (printf "doc-%s-config-values" $lang ) }}
-      {{- partial "openapi/format-configuration" ( dict "name" $moduleName "channel" $moduleChannel "data" $cfgData "conversions" $cfgConversions "langData" $langData "page" .page ) }}
+      {{- partial "openapi/format-configuration" ( dict "name" $moduleName "channel" $moduleChannel "data" $cfgData "conversions" $cfgConversions "langData" $langData "pageParams" $pageParams ) }}
     {{ end }}
 {{- end }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -1,10 +1,10 @@
 {{/* Renders a module configuration.
-
-  Context:
-  .name — module name
-  .channel — module channel
-  .data — a map, containing the JSON schema.
-  .langData — map, containing the preferable language data. Can be empty.
+Context:
+.name — module name
+.channel — module channel
+.data — a map, containing the JSON schema.
+.langData — map, containing the preferable language data. Can be empty.
+.pageParams — the page parameters (.Page.Params)
 */}}
 
 {{- $moduleName := .name }}
@@ -12,6 +12,7 @@
 {{- $data := .data }}
 {{- $conversions := .conversions }}
 {{- $langData := .langData }}
+{{- $pageParams := .pageParams }}
 
 {{- $configVersion := 1 }}
 {{- if index $data "x-config-version" }}
@@ -20,8 +21,8 @@
 
 {{/*  Rendering info about module enabling and setting up */}}
 
-{{- partial "openapi/module-enable" (dict "Page" .page "ModuleName" $moduleName "configVersion" $configVersion) }}
-{{- partial "openapi/module-settings" (dict "Page" .page "ModuleName" $moduleName "configVersion" $configVersion) }}
+{{- partial "openapi/module-enable" (dict "pageParams" $pageParams "ModuleName" $moduleName "configVersion" $configVersion) }}
+{{- partial "openapi/module-settings" (dict "ModuleName" $moduleName "configVersion" $configVersion) }}
 
 {{/* Show module requirements */}}
 {{- template "module-requirements" (dict "module" $moduleName "channel" $moduleChannel) }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/module-enable.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/module-enable.html
@@ -1,17 +1,12 @@
 {{- $moduleName := .ModuleName }}
 {{- $configVersion := .configVersion}}
+{{- $pageParams := .pageParams }}
 
 {{- $content := replace (T "module_enabling_details_content") "<ModuleName>" .ModuleName }}
 
-{{- if and .Page .Page.Params.enablingNote }}
-  {{- $enablingNote := .Page.Params.enablingNote | markdownify }}
-  {{- $enablingNoteHtml := printf `<div class="info alert__wrap">
-  <svg class="alert__icon icon--info">
-    <use xlink:href="/images/sprite.svg#info-icon"></use>
-  </svg>
-  <div><p>%s</p></div>
-</div>` $enablingNote }}
-  {{- $content = printf "%s\n\n%s" $enablingNoteHtml $content }}
+{{- if and $pageParams $pageParams.enablingNote }}
+  {{- $enablingNote := $pageParams.enablingNote | markdownify }}
+  {{- $content = printf "%s%s" (partial "alert" ( dict "level" "info" "content" $enablingNote )) $content }}
 {{- end }}
 
 {{- partial "details" (dict "summary" (T "module_enabling_details_title") "content" $content) }}

--- a/docs/site/backends/docs-builder-template/layouts/modules/single.html
+++ b/docs/site/backends/docs-builder-template/layouts/modules/single.html
@@ -112,7 +112,7 @@
               {{- else if eq .File.ContentBaseName "CONFIGURATION" }} {{/* Render module configuration JSONschema */}}
                 {{- $type = "configuration" }}
               {{- end }}
-              {{- partial "module-resources" (dict "name" $moduleName "channel" $moduleChannel "data" (index $moduleData $moduleChannel) "type" $type "lang" .Language.Lang "page" $ )}}
+              {{- partial "module-resources" (dict "name" $moduleName "channel" $moduleChannel "data" (index $moduleData $moduleChannel) "type" $type "lang" .Language.Lang "pageParams" $.Page.Params ) }}
             {{- end }}
           {{- end }}
         {{- end }}


### PR DESCRIPTION
## Description

This pull request updates the way module documentation pages are rendered, to allow custom "enabling notes" to be injected into the module enabling section based on page parameters. 

Read more about using the feature [in the wiki](https://github.com/deckhouse/deckhouse/wiki/Documentation-development#notes-about-module-enabling).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Add the enableNote display to the external modules configuration page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
