### PR TITLE
[cloud-provider-dvp] add LoadBalancerClass discovery and auto-selection

### DIFF
--- a/candi/cloud-providers/dvp/openapi/cloud_discovery_data.yaml
+++ b/candi/cloud-providers/dvp/openapi/cloud_discovery_data.yaml
@@ -42,3 +42,24 @@ apiVersions:
                 type: boolean
               isDefault:
                 type: boolean
+        loadBalancerClasses:
+          type: array
+          description: |
+            A list of load balancer classes in the cloud.
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              addressPool:
+                type: array
+                items:
+                  type: string
+              interfaces:
+                type: array
+                items:
+                  type: string
+              isEnabled:
+                type: boolean
+              isDefault:
+                type: boolean

--- a/go_lib/cloud-data/apis/v1/dvp_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1/dvp_cloud_provider_discovery_data.go
@@ -15,11 +15,12 @@
 package v1
 
 type DVPCloudProviderDiscoveryData struct {
-	APIVersion       string            `json:"apiVersion,omitempty"`
-	Kind             string            `json:"kind,omitempty"`
-	Layout           string            `json:"layout,omitempty"`
-	Zones            []string          `json:"zones,omitempty"`
-	StorageClassList []DVPStorageClass `json:"storageClasses,omitempty"`
+	APIVersion            string                 `json:"apiVersion,omitempty"`
+	Kind                  string                 `json:"kind,omitempty"`
+	Layout                string                 `json:"layout,omitempty"`
+	Zones                 []string               `json:"zones,omitempty"`
+	StorageClassList      []DVPStorageClass      `json:"storageClasses,omitempty"`
+	LoadBalancerClassList []DVPLoadBalancerClass `json:"loadBalancerClasses,omitempty"`
 }
 
 type DVPStorageClass struct {
@@ -29,4 +30,12 @@ type DVPStorageClass struct {
 	AllowVolumeExpansion bool   `json:"allowVolumeExpansion,omitempty"`
 	IsEnabled            bool   `json:"isEnabled,omitempty"`
 	IsDefault            bool   `json:"isDefault,omitempty"`
+}
+
+type DVPLoadBalancerClass struct {
+	Name        string   `json:"name,omitempty"`
+	AddressPool []string `json:"addressPool,omitempty"`
+	Interfaces  []string `json:"interfaces,omitempty"`
+	IsEnabled   bool     `json:"isEnabled,omitempty"`
+	IsDefault   bool     `json:"isDefault,omitempty"`
 }

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -91,7 +91,6 @@ func applyStorageClassFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 	return storageClass, nil
 }
 
-
 func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.HookInput) error {
 	if len(input.Snapshots.Get("cloud_provider_discovery_data")) == 0 {
 		input.Logger.Warn("failed to find secret 'd8-cloud-provider-discovery-data' in namespace 'kube-system'")
@@ -148,10 +147,7 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 		return fmt.Errorf("failed to handle discovery data storage classes: %v", err)
 	}
 
-	err = handleDiscoveryDataLoadBalancerClasses(input, discoveryData.LoadBalancerClassList)
-	if err != nil {
-		return fmt.Errorf("failed to handle discovery data load balancer classes: %v", err)
-	}
+	handleDiscoveryDataLoadBalancerClasses(input, discoveryData.LoadBalancerClassList)
 
 	return nil
 }
@@ -242,7 +238,7 @@ func setStorageClassesValues(input *go_hook.HookInput, storageClasses []storageC
 func handleDiscoveryDataLoadBalancerClasses(
 	input *go_hook.HookInput,
 	dvpLoadBalancerClassList []cloudDataV1.DVPLoadBalancerClass,
-) error {
+) {
 	dvpLoadBalancerClass := make(map[string]cloudDataV1.DVPLoadBalancerClass, len(dvpLoadBalancerClassList))
 
 	for _, lbc := range dvpLoadBalancerClassList {
@@ -282,7 +278,6 @@ func handleDiscoveryDataLoadBalancerClasses(
 	input.Logger.Info("Found DVP load balancer classes: %v", loadBalancerClasses)
 
 	setLoadBalancerClassesValues(input, loadBalancerClasses)
-	return nil
 }
 
 func setLoadBalancerClassesValues(input *go_hook.HookInput, loadBalancerClasses []metalLoadBalancerClass) {

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -275,6 +275,8 @@ func handleDiscoveryDataLoadBalancerClasses(
 		return loadBalancerClasses[i].Name < loadBalancerClasses[j].Name
 	})
 
+	ensureSingleDefaultLoadBalancerClass(loadBalancerClasses)
+
 	input.Logger.Info("Found DVP load balancer classes: %v", loadBalancerClasses)
 
 	setLoadBalancerClassesValues(input, loadBalancerClasses)
@@ -282,6 +284,27 @@ func handleDiscoveryDataLoadBalancerClasses(
 
 func setLoadBalancerClassesValues(input *go_hook.HookInput, loadBalancerClasses []metalLoadBalancerClass) {
 	input.Values.Set("cloudProviderDvp.internal.loadBalancerClasses", loadBalancerClasses)
+}
+
+func ensureSingleDefaultLoadBalancerClass(classes []metalLoadBalancerClass) {
+	if len(classes) == 0 {
+		return
+	}
+
+	defaultClassIndex := -1
+	for i := range classes {
+		if classes[i].IsDefault {
+			if defaultClassIndex == -1 {
+				defaultClassIndex = i
+			} else {
+				classes[i].IsDefault = false
+			}
+		}
+	}
+
+	if defaultClassIndex == -1 {
+		classes[0].IsDefault = true
+	}
 }
 
 type storageClass struct {

--- a/modules/030-cloud-provider-dvp/openapi/config-values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/config-values.yaml
@@ -1,2 +1,15 @@
 type: object
 properties:
+  loadBalancerClass:
+    type: object
+    description: |
+      Settings for filtering LoadBalancerClass resources.
+    properties:
+      exclude:
+        type: array
+        description: |
+          A list of regular expressions to exclude LoadBalancerClass resources by name.
+        items:
+          type: string
+        x-examples:
+          - ["private-.*", "test-.*"]

--- a/modules/030-cloud-provider-dvp/openapi/doc-ru-config-values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/doc-ru-config-values.yaml
@@ -1,1 +1,10 @@
 properties:
+  loadBalancerClass:
+    description: |
+      Настройки фильтрации LoadBalancerClass ресурсов.
+    properties:
+      exclude:
+        description: |
+          Список регулярных выражений для исключения LoadBalancerClass ресурсов по имени.
+        x-examples:
+          - ["private-.*", "test-.*"]

--- a/modules/030-cloud-provider-dvp/openapi/values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/values.yaml
@@ -477,6 +477,27 @@ properties:
                   type: boolean
                 IsDefault:
                   type: boolean
+          loadBalancerClasses:
+            type: array
+            description: |
+              A list of load balancer classes discovered in the cloud.
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                addressPool:
+                  type: array
+                  items:
+                    type: string
+                interfaces:
+                  type: array
+                  items:
+                    type: string
+                isEnabled:
+                  type: boolean
+                isDefault:
+                  type: boolean
       storageClasses:
         type: array
         items:
@@ -492,3 +513,20 @@ properties:
               type: boolean
             dvpStorageClass:
               type: string
+      loadBalancerClasses:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            addressPool:
+              type: array
+              items:
+                type: string
+            interfaces:
+              type: array
+              items:
+                type: string
+            isDefault:
+              type: boolean


### PR DESCRIPTION
## Description
Implements automatic discovery and selection of LoadBalancerClass for the DVP cloud provider module. The changes add:
- Discovery of LoadBalancerClass resources from cloud provider discovery data
- Automatic filtering based on exclude patterns
- Default class selection logic based on the isDefault flag
- OpenAPI schema updates for LoadBalancerClass configuration
- Structural types for DVPLoadBalancerClass in cloud-data API

## Why do we need it, and what problem does it solve?
Currently, LoadBalancerClass resources need to be manually configured for DVP cloud provider. This PR implements automatic discovery and processing similar to StorageClass discovery. This solves:
- Automatic detection and processing of LoadBalancerClass from discovery data
- Simplified configuration through automatic default class selection
- Flexible filtering by provider using exclude patterns 
- Independent operation without external CRD dependencies

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: feature
summary: add automatic LoadBalancerClass discovery and selection
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
