### PR TITLE
[candi] Remove dead <1.30 StructuredAuthorizationConfiguration feature-gate branch

### DIFF
--- a/candi/control-plane-kubeadm/v1beta3/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta3/config.yaml.tpl
@@ -20,9 +20,6 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
     {{- $schedulerFeatureGates = append $schedulerFeatureGates (printf "%s=true" .) -}}
   {{- end -}}
 {{- end -}}
-{{- if semverCompare "<1.30" .clusterConfiguration.kubernetesVersion -}}
-  {{- $apiserverFeatureGates = append $apiserverFeatureGates "StructuredAuthorizationConfiguration=true" -}}
-{{- end -}}
 {{- $apiserverFeatureGatesStr := $apiserverFeatureGates | uniq | join "," -}}
 {{- $controllerManagerFeatureGatesStr := $controllerManagerFeatureGates | uniq | join "," -}}
 {{- $schedulerFeatureGatesStr := $schedulerFeatureGates | uniq | join "," -}}

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -23,9 +23,6 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
     {{- $schedulerFeatureGates = append $schedulerFeatureGates (printf "%s=true" .) -}}
   {{- end -}}
 {{- end -}}
-{{- if semverCompare "<1.30" .clusterConfiguration.kubernetesVersion -}}
-  {{- $apiserverFeatureGates = append $apiserverFeatureGates "StructuredAuthorizationConfiguration=true" -}}
-{{- end -}}
 {{- $apiserverFeatureGatesStr := $apiserverFeatureGates | uniq | join "," -}}
 {{- $controllerManagerFeatureGatesStr := $controllerManagerFeatureGates | uniq | join "," -}}
 {{- $schedulerFeatureGatesStr := $schedulerFeatureGates | uniq | join "," -}}

--- a/dhctl/pkg/template/kubeadm_config_test.go
+++ b/dhctl/pkg/template/kubeadm_config_test.go
@@ -163,7 +163,7 @@ func testAPIServerConfiguration(t *testing.T) {
 	}{
 		{
 			name:       "v1beta3 configuration",
-			k8sVersion: "1.29",
+			k8sVersion: "1.30",
 		},
 		{
 			name:       "v1beta4 configuration",
@@ -189,10 +189,6 @@ func testAPIServerConfiguration(t *testing.T) {
 					t.Error("Expected authorization-config not found")
 				}
 
-				// For Kubernetes < 1.30, StructuredAuthorizationConfiguration is feature-gated and must be enabled explicitly.
-				if tt.k8sVersion == "1.29" && !strings.Contains(result, "StructuredAuthorizationConfiguration=true") {
-					t.Error("Expected StructuredAuthorizationConfiguration feature gate to be enabled for Kubernetes 1.29")
-				}
 			})
 
 			t.Run("Authentication Webhook", func(t *testing.T) {


### PR DESCRIPTION
## Description

Removed unreachable `semverCompare "<1.30"` branch for `StructuredAuthorizationConfiguration` feature gate from kubeadm `ClusterConfiguration` templates (`v1beta3` and `v1beta4`). Was added in #17183

No runtime behavior change for supported Kubernetes versions (`>= 1.30`). This is a cleanup to avoid misleading/dead code paths.

## Why do we need it, and what problem does it solve?

The `<1.30` feature-gate branch is never triggered in the current Deckhouse support matrix (minimum supported Kubernetes version is `1.30`; kubeadm `v1beta4` is used starting from Kubernetes `1.31`). Keeping such dead branches confuses reviewers and makes templates harder to reason about.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: chore
summary: Remove unreachable (<1.30) StructuredAuthorizationConfiguration logic
impact_level: low
```