### PR TITLE
[deckhouse-controller] rename package fiels to struct and make imutable

### DIFF
--- a/deckhouse-controller/crds/application.yaml
+++ b/deckhouse-controller/crds/application.yaml
@@ -23,11 +23,11 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
-    - jsonPath: .spec.packageVersion
+    - jsonPath: .spec.version
       name: Version
       type: string
-    - jsonPath: .spec.packageRepositoryName
-      name: Repository
+    - jsonPath: .spec.packageRepository
+      name: Registry
       priority: 1
       type: string
     - jsonPath: .status.conditions[?(@.type=='Ready')].status
@@ -39,7 +39,7 @@ spec:
     - jsonPath: .status.resourceConditions[?(@.type=='Processed')].status
       name: Processed
       type: string
-    - jsonPath: .status.conditions[?(@.type=='Ready')].message
+    - jsonPath: .status.resourceConditions[?(@.type=='Processed')].message
       name: Message
       type: string
     name: v1alpha1

--- a/deckhouse-controller/crds/applicationpackageversion.yaml
+++ b/deckhouse-controller/crds/applicationpackageversion.yaml
@@ -228,15 +228,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              packageName:
-                description: Name of the application package.
-                type: string
-              packageRepositoryName:
-                description: Name of the repository containing the package.
-                type: string
-              packageVersion:
-                description: Version of the application package.
-                type: string
               usedBy:
                 description: Information about applications that are using this package
                   version.

--- a/deckhouse-controller/crds/doc-ru-applicationpackageversion.yaml
+++ b/deckhouse-controller/crds/doc-ru-applicationpackageversion.yaml
@@ -148,15 +148,6 @@ spec:
                             to:
                               description: |
                                 Конечный диапазон версий для совместимости.
-                packageName:
-                  description: |
-                    Название пакета приложения.
-                packageRepositoryName:
-                  description: |
-                    Название репозитория, содержащего пакет.
-                packageVersion:
-                  description: |
-                    Версия пакета приложения.
                 usedBy:
                   description: |
                     Информация о приложениях, которые используют эту версию пакета.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application_package_version.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/application_package_version.go
@@ -87,33 +87,25 @@ type ApplicationPackageVersion struct {
 type ApplicationPackageVersionSpec struct {
 	// Name of the application package.
 	// +optional
+	// +kubebuilder:validation:Immutable
 	PackageName string `json:"packageName,omitempty"`
 
 	// The name of the repository containing the package.
 	// +optional
+	// +kubebuilder:validation:Immutable
 	PackageRepositoryName string `json:"packageRepositoryName,omitempty"`
 
 	// Version of the application package.
 	// +optional
+	// +kubebuilder:validation:Immutable
 	PackageVersion string `json:"packageVersion,omitempty"`
 }
 
 type ApplicationPackageVersionStatus struct {
-	// Name of the application package.
-	// +optional
-	PackageName string `json:"packageName,omitempty"`
-
-	// Name of the repository containing the package.
-	// +optional
-	PackageRepositoryName string `json:"packageRepositoryName,omitempty"`
-
 	// Metadata about the package such as description, requirements, etc.
 	// +optional
 	PackageMetadata *ApplicationPackageVersionStatusMetadata `json:"packageMetadata,omitempty"`
 
-	// Version of the application package.
-	// +optional
-	PackageVersion string `json:"packageVersion,omitempty"`
 	// Conditions represent the latest available observations of the package version's state.
 	// +optional
 	// +patchMergeKey=type

--- a/deckhouse-controller/pkg/controller/packages/application-package-version/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application-package-version/controller.go
@@ -228,9 +228,6 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, apv *v1alpha1.App
 
 	// Patch the status
 	apv = enrichWithPackageDefinition(apv, packageMeta.PackageDefinition)
-	if apv.Status.PackageRepositoryName == "" {
-		apv.Status.PackageRepositoryName = apv.Spec.PackageRepositoryName
-	}
 
 	apv = r.SetConditionTrue(apv, v1alpha1.ApplicationPackageVersionConditionTypeMetadataLoaded)
 
@@ -344,9 +341,6 @@ func enrichWithPackageDefinition(apv *v1alpha1.ApplicationPackageVersion, pd *Pa
 	if pd == nil {
 		return apv
 	}
-
-	apv.Status.PackageName = pd.Name
-	apv.Status.PackageVersion = pd.Version
 
 	apv.Status.PackageMetadata = &v1alpha1.ApplicationPackageVersionStatusMetadata{
 		Category: pd.Category,

--- a/deckhouse-controller/pkg/controller/packages/application-package-version/testdata/golden/error-to-success.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application-package-version/testdata/golden/error-to-success.yaml
@@ -23,9 +23,6 @@ status:
       en: Test package
       ru: Ru Test package
     stage: Preview
-  packageName: test-package
-  packageRepositoryName: deckhouse
-  packageVersion: 1.0.0
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: PackageRepository

--- a/deckhouse-controller/pkg/controller/packages/application-package-version/testdata/golden/successful-reconcile.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application-package-version/testdata/golden/successful-reconcile.yaml
@@ -26,9 +26,6 @@ status:
       en: Test package
       ru: Ru Test package
     stage: Preview
-  packageName: test-package
-  packageRepositoryName: deckhouse
-  packageVersion: 1.0.0
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: PackageRepository

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/golden/successful-reconcile-all-falses.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/golden/successful-reconcile-all-falses.yaml
@@ -57,10 +57,7 @@ metadata:
     packages.deckhouse.io/repository: deckhouse
   name: deckhouse-test-v1.0.3
   resourceVersion: "2"
-spec:
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.3
+spec: {}
 status:
   conditions:
   - lastProbeTime: null
@@ -76,9 +73,6 @@ status:
       deckhouse: '>=1.0.0'
       kubernetes: '>=1.26'
     stage: Preview
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.3
   usedBy:
   - name: test-app
     namespace: foobar

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/golden/successful-reconcile-some-falses.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/golden/successful-reconcile-some-falses.yaml
@@ -76,9 +76,6 @@ status:
       deckhouse: '>=1.0.0'
       kubernetes: '>=1.26'
     stage: Preview
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.2
   usedBy:
   - name: test-app
     namespace: foobar

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/golden/successful-reconcile.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/golden/successful-reconcile.yaml
@@ -76,9 +76,6 @@ status:
       deckhouse: '>=1.0.0'
       kubernetes: '>=1.26'
     stage: Preview
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.1
   usedBy:
   - name: test-app
     namespace: foobar

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/golden/version-is-draft.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/golden/version-is-draft.yaml
@@ -41,8 +41,5 @@ metadata:
     packages.deckhouse.io/repository: deckhouse
   name: deckhouse-test-v1.0.0
   resourceVersion: "1"
-spec:
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.0
+spec: {}
 status: {}

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/successful-reconcile-all-falses.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/successful-reconcile-all-falses.yaml
@@ -16,9 +16,10 @@ metadata:
     packages.deckhouse.io/package: test
     packages.deckhouse.io/repository: deckhouse
 spec:
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.3
+  package:
+    name: test
+    repositoryName: deckhouse
+    version: v1.0.3
 status:
   conditions:
   - lastProbeTime: null
@@ -34,9 +35,6 @@ status:
       deckhouse: '>=1.0.0'
       kubernetes: '>=1.26'
     stage: Preview
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.3
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ApplicationPackage

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/successful-reconcile-some-falses.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/successful-reconcile-some-falses.yaml
@@ -44,9 +44,6 @@ status:
       deckhouse: '>=1.0.0'
       kubernetes: '>=1.26'
     stage: Preview
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.2
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: PackageRepository

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/successful-reconcile.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/successful-reconcile.yaml
@@ -44,9 +44,6 @@ status:
       deckhouse: '>=1.0.0'
       kubernetes: '>=1.26'
     stage: Preview
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.1
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: PackageRepository

--- a/deckhouse-controller/pkg/controller/packages/application/testdata/version-is-draft.yaml
+++ b/deckhouse-controller/pkg/controller/packages/application/testdata/version-is-draft.yaml
@@ -27,7 +27,8 @@ metadata:
     packages.deckhouse.io/repository: deckhouse
     packages.deckhouse.io/draft: "true"
 spec:
-  packageName: test
-  packageRepositoryName: deckhouse
-  packageVersion: v1.0.0
+  package:
+    name: test
+    repositoryName: deckhouse
+    version: v1.0.0
 status: {}

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
@@ -247,8 +247,8 @@ func (s *OperationService) getLastProcessedVersion(ctx context.Context, packageN
 	switch list := versionList.(type) {
 	case *v1alpha1.ApplicationPackageVersionList:
 		for _, item := range list.Items {
-			if item.Status.PackageVersion != "" {
-				versionTags = append(versionTags, item.Status.PackageVersion)
+			if item.Status.PackageMetadata != nil {
+				versionTags = append(versionTags, item.Spec.PackageVersion)
 			}
 		}
 	default:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR adds the `// +kubebuilder:validation:Immutable` annotation to all fields in the `ApplicationPackageVersionSpec` struct and its nested `ApplicationPackageVersionSpecPackage` struct. This ensures that once an `ApplicationPackageVersion` resource is created, its spec fields cannot be modified, which is appropriate for version-specific resources.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: rename package fields to struct and make immutable
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
