### PR TITLE
[docs] edit getting started for vcd

### DIFF
--- a/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.with_nat.other.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.ru.yml.with_nat.other.inc
@@ -148,7 +148,7 @@ createDefaultFirewallRules: false
 masterNodeGroup:
   replicas: 1
   instanceClass:
-    sizingPolicy: *!CHANGE_SIZING_POLICY_BASTION*
+    sizingPolicy: *!CHANGE_SIZING_POLICY*
     template: *!CHANGE_TEMPLATE_NAME_WITH_CATALOG*
     storageProfile: *!CHANGE_STORAGE_PROFILE*
     mainNetworkIPAddresses:

--- a/docs/site/_includes/getting_started/vcd/partials/config.yml.with_nat.other.inc
+++ b/docs/site/_includes/getting_started/vcd/partials/config.yml.with_nat.other.inc
@@ -149,7 +149,7 @@ createDefaultFirewallRules: false
 masterNodeGroup:
   replicas: 1
   instanceClass:
-    sizingPolicy: *!CHANGE_SIZING_POLICY_BASTION*
+    sizingPolicy: *!CHANGE_SIZING_POLICY*
     template: *!CHANGE_TEMPLATE_NAME_WITH_CATALOG*
     storageProfile: *!CHANGE_STORAGE_PROFILE*
     mainNetworkIPAddresses:


### PR DESCRIPTION
## Description

Make the order of attributes the same across all InstanceClass objects

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Corrected getting started documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
