### PR TITLE
[monitoring-kubernetes] Filter unbound PVCs

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/propagated-kube-state-metrics.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/propagated-kube-state-metrics.yaml
@@ -19,6 +19,6 @@
         or
           (kube_persistentvolume_info - 1)
       ) * on(persistentvolume) group_left(namespace) max by (namespace, persistentvolume) (
-        label_replace(kube_persistentvolumeclaim_info, "persistentvolume", "$1", "volumename", "(.+)")
+        label_replace(kube_persistentvolumeclaim_info{volumename!=""}, "persistentvolume", "$1", "volumename", "(.+)")
       )
     record: kube_persistentvolume_is_local


### PR DESCRIPTION
## Description
In #17329, the `kube_persistentvolume_is_local` recording rule was changed to have a `namespace` label to be usable on propagated dashboards. However, if the PV is not yet provisioned (e.g., in the Pending state), the `kube_persistentvolumeclaim_info` metric has series without a volumename, leading to a many-to-many operation in the expression. This change filters out `kube_persistentvolumeclaim_info` series without a volume name. If the PV is not bound (thus, not used by any payload in the cluster), we can safely skip it.

## Why do we need it, and what problem does it solve?
Presence of PVCs in the Pending state leads to rule evaluation failures.

## Why do we need it in the patch release (if we do)?
It would be nice to have this change in the next patch release

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-kubernetes
type: fix
summary: fix kube_persistentvolume_is_local recording rule for not-bound PVCs
impact_level: default
```
