### PR TITLE
Fix/user authz webhook local apiserver

### DIFF
--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -946,9 +946,10 @@ apiserver:
 				// Ensure authz webhook is fail-closed but bypasses core control-plane identities to avoid deadlocks.
 				Expect(authzConfigYaml).To(ContainSubstring("failurePolicy: Deny"))
 				Expect(authzConfigYaml).To(ContainSubstring("matchConditions:"))
-				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user in ["system:aggregator", "system:kube-aggregator", "system:kube-controller-manager", "system:kube-scheduler", "kubernetes-admin"])'`))
+				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user in ["system:aggregator", "system:kube-aggregator", "system:kube-controller-manager", "system:kube-scheduler", "kubernetes-admin", "kube-apiserver-kubelet-client", "capi-controller-manager", "system:volume-scheduler"])'`))
 				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user.startsWith("system:node:"))'`))
 				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user.startsWith("system:serviceaccount:kube-system:"))'`))
+				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user.startsWith("system:serviceaccount:d8-"))'`))
 
 				kubeadmConfigData, err := base64.StdEncoding.DecodeString(secret.Field("data.kubeadm-config\\.yaml").String())
 				Expect(err).ShouldNot(HaveOccurred())
@@ -1005,9 +1006,10 @@ apiserver:
 				Expect(authzConfigYaml).To(ContainSubstring("kind: AuthorizationConfiguration"))
 				Expect(authzConfigYaml).To(ContainSubstring("failurePolicy: Deny"))
 				Expect(authzConfigYaml).To(ContainSubstring("matchConditions:"))
-				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user in ["system:aggregator", "system:kube-aggregator", "system:kube-controller-manager", "system:kube-scheduler", "kubernetes-admin"])'`))
+				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user in ["system:aggregator", "system:kube-aggregator", "system:kube-controller-manager", "system:kube-scheduler", "kubernetes-admin", "kube-apiserver-kubelet-client", "capi-controller-manager", "system:volume-scheduler"])'`))
 				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user.startsWith("system:node:"))'`))
 				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user.startsWith("system:serviceaccount:kube-system:"))'`))
+				Expect(authzConfigYaml).To(ContainSubstring(`expression: '!(request.user.startsWith("system:serviceaccount:d8-"))'`))
 
 				kubeadmConfigData, err := base64.StdEncoding.DecodeString(secret.Field("data.kubeadm-config\\.yaml").String())
 				Expect(err).ShouldNot(HaveOccurred())

--- a/modules/040-control-plane-manager/templates/_authorization_config.tpl
+++ b/modules/040-control-plane-manager/templates/_authorization_config.tpl
@@ -14,11 +14,22 @@ authorizers:
       subjectAccessReviewVersion: v1
       matchConditionSubjectAccessReviewVersion: v1
       matchConditions:
-        # Bypass authz webhook for core control-plane identities to avoid deadlocks
-        # and reduce blast radius if webhook becomes unavailable.
-        - expression: '!(request.user in ["system:aggregator", "system:kube-aggregator", "system:kube-controller-manager", "system:kube-scheduler", "kubernetes-admin"])'
+        # Exclude core control-plane identities from authz-webhook to avoid deadlocks:
+        # if kube-apiserver cannot authorize these components, the cluster may not be able to recover.
+        # Includes CAPI controllers observed in SubjectAccessReview logs (e.g. "capi-controller-manager").
+        - expression: '!(request.user in ["system:aggregator", "system:kube-aggregator", "system:kube-controller-manager", "system:kube-scheduler", "kubernetes-admin", "kube-apiserver-kubelet-client", "capi-controller-manager", "system:volume-scheduler"])'
+
+        # Nodes should not depend on the webhook: kubelet requests go via Node authorizer and are required
+        # for node registration/heartbeats; blocking them may break the cluster.
         - expression: '!(request.user.startsWith("system:node:"))'
+
+        # kube-system contains core in-cluster serviceaccounts (controllers, DNS, etc.);
+        # exclude them to avoid self-blocking during bootstrap/upgrade.
         - expression: '!(request.user.startsWith("system:serviceaccount:kube-system:"))'
+
+        # Deckhouse modules run under d8-* namespaces; exclude their serviceaccounts so Deckhouse can
+        # always reconcile and restore the webhook if it becomes unhealthy.
+        - expression: '!(request.user.startsWith("system:serviceaccount:d8-"))'
       authorizedTTL: 5m
       unauthorizedTTL: 30s
       timeout: 3s


### PR DESCRIPTION
## Description

This PR updates the structured authorization configuration generated by `control-plane-manager`.
It extends authz-webhook `matchConditions` (CEL) to explicitly bypass the webhook for a limited set of
critical control-plane identities, preventing authorization deadlocks when fail-closed mode is enabled.

### Key changes

- Extend the `matchConditions` list in kube-apiserver `AuthorizationConfiguration` for the
  `user-authz-webhook` authorizer:
  - Bypass core control-plane users:
    - aggregator
    - kube-aggregator
    - controller-manager
    - scheduler
    - admin
  - Add explicit bypass for:
    - `kube-apiserver-kubelet-client`
    - `capi-controller-manager` (observed in `SubjectAccessReview` logs)
    - `system:volume-scheduler`
  - Keep existing bypass for:
    - `system:node:*`
    - `system:serviceaccount:kube-system:*`
  - Add bypass for:
    - `system:serviceaccount:d8-*`
- Add and update template tests to assert that the generated authorization configuration contains
  the expected CEL expressions.
- Force the in-cluster client to connect to the node-local kube-apiserver endpoint
  on the same control-plane node.

This keeps the authorization webhook stable in environments where `hostNetwork` pods cannot reach
ClusterIP services (for example, `kubernetes.default.svc`).

In such environments, the webhook may otherwise fail to initialize, enter a restart loop,
and stop listening on `127.0.0.1:40443`.

This change does **not** restart critical cluster components by itself, but it **does**
update and restart the authorization webhook DaemonSet.

---

## Why do we need it, and what problem does it solve?

When kube-apiserver authorization is configured in **fail-closed** mode (`failurePolicy: Deny`),
any authorization webhook instability can directly impact cluster availability.

In practice, several core control-plane identities must not depend on the authorization webhook.
If they do, they can become blocked during bootstrap, upgrades, or while the webhook itself is unhealthy,
leading to self-deadlocks and loss of control-plane recoverability.

We observed such cases in logs (for example, `capi-controller-manager` performing
`SubjectAccessReview` requests) where webhook involvement is unnecessary and unsafe.

The added `matchConditions` exclusions reduce blast radius and ensure that the control-plane
remains functional, while still enforcing fail-closed authorization for regular users
and workloads.

---

## Why do we need it in the patch release (if we do)?

Potentially yes.

The issue can lead to control-plane degradation or Kubernetes API unavailability
in clusters with fail-closed authorization enabled, which makes it relevant
for a patch release.

---

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested manually in a Kubernetes cluster.

---

## Changelog entries

```changes
section: control-plane-manager
type: fix
summary: Extended authz webhook matchConditions to bypass critical control-plane identities and avoid deadlocks.
impact: |
  Prevents control-plane components (including CAPI controllers) and Deckhouse service accounts
  from being blocked by the authorization webhook.
  Reduces the risk of cluster deadlocks and improves recoverability when fail-closed authorization is enabled.
impact_level: default
