### PR TITLE
[upmeter] Add UpmeterHookProbe garbage cleaner

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3541,27 +3541,6 @@ alerts:
         Unnecessary smoke-mini PersistentVolumes detected in the cluster.
       severity: "9"
       markupFormat: markdown
-    - name: D8UpmeterTooManyHookProbeObjects
-      sourceFile: modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
-      moduleUrl: 500-upmeter
-      module: upmeter
-      edition: ce
-      description: |
-        The average number of `UpmeterHookProbe` objects per `upmeter-agent` Pod is {{ $value }}, but it should always be exactly 1 per agent.
-
-        This likely happened because older `upmeter-agent` Pods left behind their `UpmeterHookProbe` objects during an Upmeter update or downscale.
-
-        Once the cause has been investigated, remove outdated objects and leave only the ones corresponding to currently running `upmeter-agent` Pods.
-
-        To view all `UpmeterHookProbe` objects, run the following command:
-
-        ```shell
-        d8 k get upmeterhookprobes.deckhouse.io
-        ```
-      summary: |
-        Too many UpmeterHookProbe objects in the cluster.
-      severity: "9"
-      markupFormat: markdown
     - name: D8UsingFeatureGateWillBeDeprecated
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
       moduleUrl: 040-control-plane-manager

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/d8_clusterconfiguration_cleanup_test.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/d8_clusterconfiguration_cleanup_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checker
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	kube "github.com/flant/kube-client/client"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"d8.io/upmeter/pkg/probe/run"
+)
+
+func TestCleanupExtraHookProbesChecker(t *testing.T) {
+	ctx := context.TODO()
+	fakeClient := kube.NewFake(nil)
+	access := NewFake(fakeClient)
+
+	gvr := schema.GroupVersionResource{
+		Group:    "deckhouse.io",
+		Version:  "v1",
+		Resource: "upmeterhookprobes",
+	}
+	dynamicClient := fakeClient.Dynamic().Resource(gvr)
+
+	if err := createAgentPod(ctx, fakeClient, "agent-1", "master-1"); err != nil {
+		t.Fatalf("create agent pod 1: %v", err)
+	}
+	if err := createAgentPod(ctx, fakeClient, "agent-2", "master-2"); err != nil {
+		t.Fatalf("create agent pod 2: %v", err)
+	}
+
+	oldTime := time.Now().Add(-10 * time.Minute)
+	newTime := time.Now().Add(-2 * time.Minute)
+
+	expected := []string{
+		run.NodeNameHash("master-1"),
+		run.NodeNameHash("master-2"),
+	}
+	for _, name := range expected {
+		if err := createHookProbe(ctx, dynamicClient, name, oldTime); err != nil {
+			t.Fatalf("create expected hook probe %q: %v", name, err)
+		}
+	}
+
+	staleExtra := run.NodeNameHash("old-master")
+	if err := createHookProbe(ctx, dynamicClient, staleExtra, oldTime); err != nil {
+		t.Fatalf("create stale hook probe: %v", err)
+	}
+
+	recentExtra := run.NodeNameHash("new-master")
+	if err := createHookProbe(ctx, dynamicClient, recentExtra, newTime); err != nil {
+		t.Fatalf("create recent hook probe: %v", err)
+	}
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	checker := &cleanupExtraHookProbesChecker{
+		access:        access,
+		dynamicClient: dynamicClient,
+		logger:        logrus.NewEntry(logger),
+	}
+
+	if err := checker.Check(); err != nil {
+		t.Fatalf("cleanup checker error: %v", err)
+	}
+
+	list, err := dynamicClient.List(ctx, metav1.ListOptions{LabelSelector: "heritage=upmeter"})
+	if err != nil {
+		t.Fatalf("list hook probes: %v", err)
+	}
+
+	got := make(map[string]struct{})
+	for i := range list.Items {
+		got[list.Items[i].GetName()] = struct{}{}
+	}
+
+	for _, name := range expected {
+		if _, ok := got[name]; !ok {
+			t.Fatalf("expected hook probe %q to remain", name)
+		}
+	}
+	if _, ok := got[recentExtra]; !ok {
+		t.Fatalf("expected recent hook probe %q to remain", recentExtra)
+	}
+	if _, ok := got[staleExtra]; ok {
+		t.Fatalf("expected stale hook probe %q to be deleted", staleExtra)
+	}
+}
+
+func createAgentPod(ctx context.Context, client kube.Client, name, nodeName string) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "d8-upmeter",
+			Labels: map[string]string{
+				"app": "upmeter-agent",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+	}
+	_, err := client.CoreV1().Pods("d8-upmeter").Create(ctx, pod, metav1.CreateOptions{})
+	return err
+}
+
+func createHookProbe(ctx context.Context, client dynamic.ResourceInterface, name string, createdAt time.Time) error {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("deckhouse.io/v1")
+	obj.SetKind("UpmeterHookProbe")
+	obj.SetName(name)
+	obj.SetLabels(map[string]string{
+		"heritage": "upmeter",
+	})
+	obj.SetCreationTimestamp(metav1.NewTime(createdAt))
+
+	_, err := client.Create(ctx, obj, metav1.CreateOptions{})
+	return err
+}

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/run/id.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/run/id.go
@@ -43,12 +43,12 @@ var id string
 
 func ID() string {
 	if id == "" {
-		id = nodeNameHash(os.Getenv("NODE_NAME"))
+		id = NodeNameHash(os.Getenv("NODE_NAME"))
 	}
 	return id
 }
 
-func nodeNameHash(nodeName string) string {
+func NodeNameHash(nodeName string) string {
 	h32 := murmur3.New32WithSeed(seed)
 	_, _ = h32.Write([]byte(nodeName))
 	return strconv.FormatInt(int64(h32.Sum32()), 16)

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/run/id_test.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/run/id_test.go
@@ -35,7 +35,7 @@ func Test_RandomIdentifier(t *testing.T) {
 	}
 }
 
-func Test_nodeNameHash(t *testing.T) {
+func Test_NodeNameHash(t *testing.T) {
 	tests := []struct {
 		nodeName string
 		want     string
@@ -51,8 +51,8 @@ func Test_nodeNameHash(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.nodeName, func(t *testing.T) {
-			if got := nodeNameHash(tt.nodeName); got != tt.want {
-				t.Errorf("nodeNameHash(%q) = %v, want %v", tt.nodeName, got, tt.want)
+			if got := NodeNameHash(tt.nodeName); got != tt.want {
+				t.Errorf("NodeNameHash(%q) = %v, want %v", tt.nodeName, got, tt.want)
 			}
 		})
 	}

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -439,39 +439,6 @@
              d8 k -n d8-upmeter delete ns -l heritage=upmeter
              ```
 
-    - alert: D8UpmeterTooManyHookProbeObjects
-      expr: |
-        (
-          sum (d8_upmeter_upmeterhookprobe_count)
-          /
-          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
-        ) > 1
-      for: 10m
-      labels:
-        severity_level: "9"
-        tier: cluster
-        d8_module: upmeter
-        d8_component: upmeter-agent
-      annotations:
-        plk_protocol_version: "1"
-        plk_markup_format: "markdown"
-        plk_create_group_if_not_exists__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_grouped_by__d8_upmeter_resources_garbage: "D8UpmeterProbeGarbage,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-        plk_labels_as_annotations: "upmeterhookprobe"
-        summary: Too many UpmeterHookProbe objects in the cluster.
-        description: |
-          The average number of `UpmeterHookProbe` objects per `upmeter-agent` Pod is {{ $value }}, but it should always be exactly 1 per agent.
-
-          This likely happened because older `upmeter-agent` Pods left behind their `UpmeterHookProbe` objects during an Upmeter update or downscale.
-
-          Once the cause has been investigated, remove outdated objects and leave only the ones corresponding to currently running `upmeter-agent` Pods.
-
-          To view all `UpmeterHookProbe` objects, run the following command:
-
-          ```shell
-          d8 k get upmeterhookprobes.deckhouse.io
-          ```
-
     - alert: D8UpmeterSmokeMiniMoreThanOnePVxPVC
       expr: |
         count(


### PR DESCRIPTION
## Description
Add UpmeterHookProbe garbage cleaner

## Why do we need it, and what problem does it solve?
Sometimes there can be situations when UpmeterHookProbe can spawn more resources than master nodes. This is not expected behavior.

## Why do we need it in the patch release (if we do)?

Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: fix
summary: Add UpmeterHookProbe garbage cleaner
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
