### PR TITLE
[dhctl] add dhctl and cluster version validation

### DIFF
--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -62,6 +62,10 @@ func DefineTestControlPlaneManagerReadyCommand(cmd *kingpin.CmdClause) *kingpin.
 			return fmt.Errorf("open kubernetes connection: %v", err)
 		}
 
+		if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+			return err
+		}
+
 		checker := controlplane.NewManagerReadinessChecker(kubernetes.NewSimpleKubeClientGetter(kubeCl))
 		ready, err := checker.IsReady(ctx, app.ControlPlaneHostname)
 		if err != nil {
@@ -107,6 +111,10 @@ func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 		err = kubeCl.Init(client.AppKubernetesInitParams())
 		if err != nil {
 			return fmt.Errorf("open kubernetes connection: %v", err)
+		}
+
+		if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+			return err
 		}
 
 		nodeToHostForChecks := map[string]string{app.ControlPlaneHostname: app.ControlPlaneIP}

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -24,6 +24,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -60,6 +61,10 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			err = kubeCl.Init(client.AppKubernetesInitParams())
 			if err != nil {
 				return fmt.Errorf("open kubernetes connection: %v", err)
+			}
+
+			if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+				return err
 			}
 
 			err = deckhouse.DeleteDeckhouseDeployment(ctx, kubeCl)

--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -59,6 +59,10 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 			return err
 		}
 
+		if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+			return err
+		}
+
 		return operations.SecretEdit(kubeCl, name, "kube-system", secret, dataKey, map[string]string{
 			"name": name,
 		})

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -112,6 +113,10 @@ func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			err = kubeCl.Init(client.AppKubernetesInitParams())
 			if err != nil {
 				return fmt.Errorf("open kubernetes connection: %v", err)
+			}
+
+			if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+				return err
 			}
 
 			err = deckhouse.WaitForReadiness(ctx, kubeCl)

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -89,6 +89,10 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			return err
 		}
 
+		if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+			return err
+		}
+
 		metaConfig, err := config.ParseConfigInCluster(
 			ctx,
 			kubeCl,

--- a/dhctl/pkg/app/kube.go
+++ b/dhctl/pkg/app/kube.go
@@ -23,6 +23,8 @@ var (
 	KubeConfigContext = ""
 
 	KubeConfigInCluster = false
+
+	SkipDhctlVersionCheck = false
 )
 
 func DefineKubeFlags(cmd *kingpin.CmdClause) {
@@ -35,4 +37,7 @@ func DefineKubeFlags(cmd *kingpin.CmdClause) {
 	cmd.Flag("kube-client-from-cluster", "Use in-cluster Kubernetes API access.").
 		Envar(configEnvName("KUBE_CLIENT_FROM_CLUSTER")).
 		BoolVar(&KubeConfigInCluster)
+	cmd.Flag("skip-dhctl-version-check", "Skip dhctl version check with cluster deckhouse version.").
+		Envar(configEnvName("SKIP_DHCTL_VERSION_CHECK")).
+		BoolVar(&SkipDhctlVersionCheck)
 }

--- a/dhctl/pkg/kubernetes/version_check.go
+++ b/dhctl/pkg/kubernetes/version_check.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	gcr "github.com/google/go-containerregistry/pkg/name"
+
+	deckhousev1alpha1 "github.com/deckhouse/deckhouse/dhctl/pkg/apis/deckhouse/v1alpha1"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+var ErrDeckhouseVersionNotFound = errors.New("deckhouse version not found in cluster")
+
+type VersionCheckOptions struct {
+	AllowAnyError         bool
+	SkipDhctlVersionCheck bool
+}
+
+// DefaultVersionCheckOptions returns VersionCheckOptions with values from app flags.
+func DefaultVersionCheckOptions() VersionCheckOptions {
+	return VersionCheckOptions{
+		SkipDhctlVersionCheck: app.SkipDhctlVersionCheck,
+	}
+}
+
+func CheckDeckhouseVersionCompatibility(ctx context.Context, kubeCl *client.KubernetesClient, opts VersionCheckOptions) error {
+	if app.AppVersion == "local" || app.AppVersion == "dev" {
+		log.InfoLn("Deckhouse version check is skipped for local/dev builds")
+		return nil
+	}
+	if opts.SkipDhctlVersionCheck {
+		log.WarnF("⚠️  WARNING: Deckhouse version check is skipped manually. This may lead to cluster instability, data corruption, or complete cluster failure. We do NOT guarantee cluster operability when version check is skipped!")
+		return nil
+	}
+
+	deckhouseVersion, err := getDeckhouseVersionFromCluster(ctx, kubeCl)
+	if err != nil {
+		if opts.AllowAnyError {
+			log.WarnF("Deckhouse version check is skipped: %v\n", err)
+			return nil
+		}
+		return fmt.Errorf("Deckhouse and dhctl version check failed: %w. You may use \"--skip-dhctl-version-check\" flag to skip this check. ⚠️  WARNING: Using \"--skip-dhctl-version-check\" flag may lead to cluster instability, data corruption, or complete cluster failure. We do NOT guarantee cluster operability when version check is skipped!", err)
+	}
+
+	if !versionsMatch(app.AppVersion, deckhouseVersion) {
+		return fmt.Errorf("Deckhouse and dhctl version mismatch: dhctl=%s, cluster=%s. Use dhctl with tag \"%s\" or use \"--skip-dhctl-version-check\" flag to skip this check. WARNING: Using \"--skip-dhctl-version-check\" flag may lead to cluster instability, data corruption, or complete cluster failure. We do NOT guarantee cluster operability when version check is skipped!",
+			app.AppVersion, deckhouseVersion, deckhouseVersion)
+	}
+
+	return nil
+}
+
+func getDeckhouseVersionFromCluster(ctx context.Context, kubeCl *client.KubernetesClient) (string, error) {
+	releaseVersion, found, err := deckhouseVersionFromRelease(ctx, kubeCl)
+	if err != nil {
+		return "", err
+	}
+	if found {
+		return releaseVersion, nil
+	}
+
+	deployVersion, err := deckhouseVersionFromDeployment(ctx, kubeCl)
+	if err != nil {
+		return "", err
+	}
+	if deployVersion == "" {
+		return "", ErrDeckhouseVersionNotFound
+	}
+
+	return deployVersion, nil
+}
+
+func deckhouseVersionFromRelease(ctx context.Context, kubeCl *client.KubernetesClient) (string, bool, error) {
+	list, err := kubeCl.Dynamic().Resource(deckhousev1alpha1.DeckhouseReleaseGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+
+	for _, item := range list.Items {
+		phase, _, _ := unstructured.NestedString(item.Object, "status", "phase")
+		if phase != deckhousev1alpha1.PhaseDeployed {
+			continue
+		}
+		version, _, _ := unstructured.NestedString(item.Object, "spec", "version")
+		if version == "" {
+			version = item.GetName()
+		}
+		if version == "" {
+			continue
+		}
+		return version, true, nil
+	}
+
+	return "", false, nil
+}
+
+func deckhouseVersionFromDeployment(ctx context.Context, kubeCl *client.KubernetesClient) (string, error) {
+	deployment, err := kubeCl.AppsV1().Deployments("d8-system").Get(ctx, "deckhouse", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", ErrDeckhouseVersionNotFound
+		}
+		return "", err
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers) == 0 {
+		return "", fmt.Errorf("deckhouse deployment has no containers")
+	}
+
+	image := ""
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == "deckhouse" {
+			image = container.Image
+			break
+		}
+	}
+	if image == "" {
+		return "", fmt.Errorf("deckhouse container not found in deployment")
+	}
+
+	imageTag, err := gcr.NewTag(image)
+	if err != nil {
+		return "", fmt.Errorf("deckhouse image has no tag: %s: %w", image, err)
+	}
+
+	return imageTag.TagStr(), nil
+}
+
+// versionsMatch compares two version strings using semver, handling different formats
+// (e.g., "v1.73.0" vs "v1.73" vs "1.73.0")
+func versionsMatch(v1, v2 string) bool {
+	ver1, err := semver.NewVersion(strings.TrimPrefix(v1, "v"))
+	if err != nil {
+		return false
+	}
+	ver2, err := semver.NewVersion(strings.TrimPrefix(v2, "v"))
+	if err != nil {
+		return false
+	}
+
+	return ver1.Equal(ver2)
+}

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -159,6 +159,10 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 		}
 	}
 
+	if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+		return err
+	}
+
 	if !c.CommanderMode {
 		cacheIdentity := ""
 		if app.KubeConfigInCluster {
@@ -287,6 +291,10 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("unable to connect to Kubernetes over ssh tunnel: %w", err)
 		}
+	}
+
+	if err := kubernetes.CheckDeckhouseVersionCompatibility(ctx, kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+		return nil, err
 	}
 
 	if !c.CommanderMode {
@@ -504,6 +512,10 @@ func (c *Converger) AutoConverge(listenAddress string, checkInterval time.Durati
 		if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 			return err
 		}
+	}
+
+	if err := kubernetes.CheckDeckhouseVersionCompatibility(context.Background(), kubeCl, kubernetes.DefaultVersionCheckOptions()); err != nil {
+		return err
 	}
 
 	convergeCtx := convergectx.NewContext(context.Background(), convergectx.Params{


### PR DESCRIPTION
## Description
add dhctl and cluster version validation
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
add dhctl and cluster version validation
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
no need

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Added dhctl and cluster version validation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->