### PR TITLE
[user-authz] Fix SecurityPolicyException usage, added CR presence check

### DIFF
--- a/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -28,6 +28,8 @@ spec:
         cpu: 50m
         memory: 50Mi
   {{- end }}
+
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicyException
@@ -43,7 +45,7 @@ spec:
         description: |
           User Authz Webhook need to run on hostNetwork for fault tolerance. Architectural feature.
           The pod runs on the host network to ensure independence from the state of the "Service" object in k8s.
-          
+{{- end }}   
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
## Description

Currently, a SecurityPolicyException object was attempted to be created without checking whether the corresponding CR was available. A check has been added.
## Why do we need it, and what problem does it solve?

Bug fix

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary:  Fixed SecurityPolicyException usage, added CR presence check.
impact_level: default
```
