### PR TITLE
chore: unify *-src-artifact and *-artifact naming

### DIFF
--- a/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
+++ b/modules/150-user-authn/images/dex-authenticator/werf.inc.yaml
@@ -17,7 +17,7 @@ imageSpec:
     entrypoint: [ "/bin/oauth2_proxy" ]
     cmd: [ "--upstream=http://0.0.0.0:8080/", "--http-address=0.0.0.0:4180" ]
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-oauth2-proxy-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
 git:
@@ -34,6 +34,17 @@ git:
         - '**/*.go'
         - '**/go.mod'
         - '**/go.sum'
+  - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/url-exec-prober
+    to: /src/url-exec-prober
+    includePaths:
+    - '**/*.go'
+    - '**/go.mod'
+    - '**/go.sum'
+    stageDependencies:
+      install:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
 shell:
   install:
     - cd /src
@@ -44,7 +55,7 @@ image: {{ .ModuleName }}/{{ .ImageName }}-oauth2-proxy-artifact
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alt-svace" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-oauth2-proxy-src-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install
@@ -63,28 +74,12 @@ shell:
     - chown 64535:64535 oauth2-proxy
     - chmod 0700 oauth2-proxy
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-url-exec-prober-src-artifact
-fromImage: common/src-artifact
-final: false
-git:
-- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/url-exec-prober
-  to: /src
-  includePaths:
-  - '**/*.go'
-  - '**/go.mod'
-  - '**/go.sum'
-  stageDependencies:
-    install:
-    - '**/*.go'
-    - '**/go.mod'
-    - '**/go.sum'
----
 image: {{ .ModuleName }}/{{ .ImageName }}-url-exec-prober-artifact
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-url-exec-prober-src-artifact
-  add: /src
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+  add: /src/url-exec-prober
   to: /src
   before: install
 mount:

--- a/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/kubeconfig-generator/werf.inc.yaml
@@ -2,19 +2,19 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-k8s-authenticator-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/dex-k8s-authenticator
     to: /app/bin/dex-k8s-authenticator
     before: setup
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-k8s-authenticator-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /etc/nsswitch.conf
     to: /etc/nsswitch.conf
     before: setup
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-k8s-authenticator-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/html
     to: /app/html
     before: setup
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-k8s-authenticator-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/templates
     to: /app/templates
     before: setup
@@ -25,7 +25,7 @@ imageSpec:
     entrypoint: ["/dex-k8s-authenticator"]
     workingDir: "/app"
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-dex-k8s-authenticator-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
 git:
@@ -47,11 +47,11 @@ shell:
     - cd /src
     - git apply --whitespace=fix -v /patches/*.patch
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-dex-k8s-authenticator-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-dex-k8s-authenticator-src-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
+++ b/modules/150-user-authn/images/self-signed-generator/werf.inc.yaml
@@ -2,7 +2,7 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-self-signed-generator-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/self-signed-generator
     to: /self-signed-generator
     before: setup
@@ -12,18 +12,18 @@ imageSpec:
   config:
     entrypoint: [ "/self-signed-generator" ]
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-self-signed-generator-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
 git:
   - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/src
     to: /src
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-self-signed-generator-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-self-signed-generator-src-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/werf.inc.yaml
@@ -2,15 +2,15 @@
 image: {{ .ModuleName }}/{{ .ImageName }}
 fromImage: common/distroless
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-multitenancy-manager-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/multitenancy-manager
     to: /multitenancy-manager
     before: setup
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-multitenancy-manager-src-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src/templates
     to: /templates
     before: setup
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-multitenancy-manager-src-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src/helmlib
     to: /helmlib
     before: setup
@@ -20,7 +20,7 @@ imageSpec:
   config:
     entrypoint: [ "/multitenancy-manager" ]
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-multitenancy-manager-src-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
 git:
@@ -42,11 +42,11 @@ git:
         - '**/helmlib/*.tpl'
         - '**/templates/*.yaml'
 ---
-image: {{ .ModuleName }}/{{ .ImageName }}-multitenancy-manager-artifact
+image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 fromImage: {{ eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" }}
 final: false
 import:
-  - image: {{ $.ModuleName }}/{{ $.ImageName }}-multitenancy-manager-src-artifact
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
     to: /src
     before: install


### PR DESCRIPTION
## Description

Unify internal werf stage naming for `-src-artifact` and `-artifact` images in a few modules (user-authn, multitenancy-manager).

## Why do we need it, and what problem does it solve?

Makes it easier to map image artifacts to their corresponding runtime images by using consistent stage names; no functional changes.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: chore
summary: Unify werf artifact stage naming for easier image-to-source mapping.
impact_level: low
```