### PR TITLE
[docs] Fix VCD Getting Started documentation

### DIFF
--- a/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS.md
+++ b/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS.md
@@ -52,7 +52,7 @@ kruise-controller-manager-78786f57-82wph   3/3     Running   0          16h
 ```
 {%- endofftopic %}
 
-{% if page.platform_type == 'cloud' and page.platform_code != 'vsphere' %}
+{% if page.platform_type == 'cloud' and page.platform_code != 'vsphere' and page.platform_code != 'vcd' %}
 Also wait for the load balancer to be ready:
 
 ```shell

--- a/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS_RU.md
+++ b/docs/site/_includes/getting_started/global/STEP_CLUSTER_ACCESS_RU.md
@@ -52,7 +52,7 @@ kruise-controller-manager-78786f57-82wph   3/3     Running   0          16h
 ```
 {%- endofftopic %}
 
-{% if page.platform_type == 'cloud' and page.platform_code != 'vsphere' %}
+{% if page.platform_type == 'cloud' and page.platform_code != 'vsphere' and page.platform_code != 'vcd' %}
 Также дождитесь готовности балансировщика:
 
 ```shell


### PR DESCRIPTION
## Description
Fixed VCD Getting Started documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: fix
summary: Fixed VCD Getting Started documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
