### PR TITLE
[global-hooks] prevent HA mode when destructively converging single-master cluster

### DIFF
--- a/dhctl/pkg/operations/converge/controller/master_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/master_node_group.go
@@ -124,10 +124,10 @@ func (c *MasterNodeGroupController) run(ctx *context.Context) (err error) {
 
 		err = c.runWithReplicas(ctx, replicas)
 		if err != nil {
-			return fmt.Errorf("failed to converge with 3 replicas: %w", err)
+			return fmt.Errorf("failed to converge with %d replicas: %w", replicas, err)
 		}
 
-		log.DebugF("to multi master scaled. saving state...\n")
+		log.DebugF("scaled to multi master. saving state...\n")
 
 		c.convergeState.Phase = phases.ScaleToSingleMasterPhase
 

--- a/global-hooks/discovery/cluster_ha.go
+++ b/global-hooks/discovery/cluster_ha.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Flant JSC
+// Copyright 2026 Flant JSC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,12 +16,25 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 )
+
+const masterNodeGroupName = "master"
+
+// masterNodeGroupReplicas represents desired replicas count from NodeGroup
+type masterNodeGroupReplicas struct {
+	DesiredReplicas int32
+}
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Kubernetes: []go_hook.KubernetesConfig{
@@ -37,19 +50,135 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: applyMasterNodeFilter,
 		},
 	},
-}, isHighAvailabilityCluster)
+}, dependency.WithExternalDependencies(isHighAvailabilityCluster))
 
 func applyMasterNodeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	return obj.GetName(), nil
 }
 
-func isHighAvailabilityCluster(_ context.Context, input *go_hook.HookInput) error {
-	masterNodesSnap := input.Snapshots.Get("master_node_names")
+func applyMasterNodeGroupFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	// Extract desired replicas from NodeGroup spec
+	// For cloud clusters: minPerZone * number of zones
+	// For static clusters: staticInstances.count
 
+	var ng struct {
+		Spec struct {
+			CloudInstances struct {
+				MinPerZone *int32   `json:"minPerZone"`
+				Zones      []string `json:"zones"`
+			} `json:"cloudInstances"`
+			StaticInstances struct {
+				Count int32 `json:"count"`
+			} `json:"staticInstances"`
+		} `json:"spec"`
+	}
+
+	err := sdk.FromUnstructured(obj, &ng)
+	if err != nil {
+		return nil, fmt.Errorf("from unstructured: %w", err)
+	}
+
+	replicas := masterNodeGroupReplicas{DesiredReplicas: 0}
+
+	// For cloud clusters, calculate: minPerZone * number of zones
+	if ng.Spec.CloudInstances.MinPerZone != nil {
+		zonesCount := len(ng.Spec.CloudInstances.Zones)
+		if zonesCount == 0 {
+			// If zones are not specified in NodeGroup, they will be filled with default zones
+			// by node-manager. For our purposes, we assume at least 1 zone exists.
+			// This is a conservative approach - if zones are not specified, we can't determine
+			// the exact count, so we use minPerZone as-is (which represents 1 zone minimum).
+			zonesCount = 1
+		}
+		replicas.DesiredReplicas = *ng.Spec.CloudInstances.MinPerZone * int32(zonesCount)
+	} else if ng.Spec.StaticInstances.Count >= 0 {
+		// For static clusters, use count
+		// Count = 0 is invalid for master nodes but we return it and let caller handle it
+		replicas.DesiredReplicas = ng.Spec.StaticInstances.Count
+	}
+
+	return replicas, nil
+}
+
+func isHighAvailabilityCluster(ctx context.Context, input *go_hook.HookInput, dc dependency.Container) error {
+	masterNodesSnap := input.Snapshots.Get("master_node_names")
 	mastersCount := len(masterNodesSnap)
 
 	input.Values.Set("global.discovery.clusterMasterCount", mastersCount)
-	input.Values.Set("global.discovery.clusterControlPlaneIsHighlyAvailable", mastersCount > 1)
+
+	desiredMasterReplicas := getDesiredMasterReplicasFromNodeGroup(ctx, input, dc)
+
+	if desiredMasterReplicas == 0 {
+		desiredMasterReplicas = getDesiredMasterReplicasFromClusterConfig(input)
+	}
+
+	// Determine HA mode based on desired replicas
+	// If desired replicas = 1, but current masters > 1, don't enable HA
+	// because we must avoid false HA mode during temporary scaling to multi-master
+	// Example case: destructive change in single-master cluster
+	isHA := desiredMasterReplicas > 1
+	if desiredMasterReplicas == 0 {
+		// if we couldn't determine desired master replicas, fallback to current masters count
+		isHA = mastersCount > 1
+	}
+
+	input.Values.Set("global.discovery.clusterControlPlaneIsHighlyAvailable", isHA)
+
+	// Log for debugging (Logger may be nil in tests)
+	input.Logger.Info(fmt.Sprintf("HA mode determination: desiredReplicas=%d, currentMasters=%d, isHA=%v",
+		desiredMasterReplicas, mastersCount, isHA))
 
 	return nil
+}
+
+func getDesiredMasterReplicasFromNodeGroup(ctx context.Context, input *go_hook.HookInput, dc dependency.Container) int32 {
+	kubeCl, err := dc.GetK8sClient()
+	if err != nil {
+		input.Logger.Warn(fmt.Sprintf("failed to init Kubernetes client for NodeGroup: %v", err))
+		return 0
+	}
+
+	nodeGroupGVR := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}
+	nodeGroup, err := kubeCl.Dynamic().Resource(nodeGroupGVR).Get(ctx, masterNodeGroupName, v1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			// NodeGroup CRD is not installed yet or master NodeGroup doesn't exist.
+			return 0
+		}
+		input.Logger.Warn(fmt.Sprintf("failed to get master NodeGroup: %v", err))
+		return 0
+	}
+
+	filtered, err := applyMasterNodeGroupFilter(nodeGroup)
+	if err != nil {
+		input.Logger.Warn(fmt.Sprintf("failed to parse master NodeGroup: %v", err))
+		return 0
+	}
+
+	replicas, ok := filtered.(masterNodeGroupReplicas)
+	if !ok {
+		input.Logger.Warn("unexpected master NodeGroup filter result type")
+		return 0
+	}
+
+	return replicas.DesiredReplicas
+}
+
+func getDesiredMasterReplicasFromClusterConfig(input *go_hook.HookInput) int32 {
+	clusterConfig := input.Values.Get("global.clusterConfiguration")
+	if !clusterConfig.Exists() {
+		return 0
+	}
+
+	masterNG := clusterConfig.Get("masterNodeGroup")
+	if !masterNG.Exists() {
+		return 0
+	}
+
+	replicas := masterNG.Get("replicas")
+	if !replicas.Exists() {
+		return 0
+	}
+
+	return int32(replicas.Int())
 }

--- a/global-hooks/discovery/cluster_ha_test.go
+++ b/global-hooks/discovery/cluster_ha_test.go
@@ -15,18 +15,27 @@
 /*
 
 User-stories:
-1. Hook must discover number of addresses in Endpoint default/kubernetes and save to global.discovery.clusterMasterCount,
-2. If number of addresses in Endpoint default/kubernetes is more than one — hook must set global.discovery.clusterControlPlaneIsHighlyAvailable to true, else — to false.
+1. Hook must discover number of control-plane Nodes and save to global.discovery.clusterMasterCount.
+2. Hook must determine HA mode based on desired master replicas from the master NodeGroup.
+3. If NodeGroup desired replicas are unknown, use clusterConfiguration.masterNodeGroup.replicas.
+4. If desired replicas are unknown, fallback to current master count.
 
 */
 
 package hooks
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/yaml"
+
 	. "github.com/deckhouse/deckhouse/testing/hooks"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Global hooks :: discovery :: cluster_ha ::", func() {
@@ -52,12 +61,87 @@ metadata:
   name: master-1
   labels:
     node-role.kubernetes.io/control-plane: ""`
+
+		stateMasterNodeGroupCloud = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  cloudInstances:
+    minPerZone: 1
+    zones:
+    - zone-a
+    - zone-b
+`
+
+		stateMasterNodeGroupCloudNoZones = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  cloudInstances:
+    minPerZone: 2
+`
+
+		stateMasterNodeGroupStatic = `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: master
+spec:
+  staticInstances:
+    count: 1
+`
+
+		clusterConfigurationStatic = `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+kubernetesVersion: "1.30"
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+clusterDomain: cluster.local
+`
 	)
 
 	f := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+	f.RegisterCRD("deckhouse.io", "v1", "NodeGroup", false)
+	nodeGroupGVR := schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}
+
+	applyNodeGroup := func(cfg *HookExecutionConfig, state string) {
+		obj := &unstructured.Unstructured{}
+		payload, err := yaml.YAMLToJSON([]byte(state))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj.UnmarshalJSON(payload)).To(Succeed())
+
+		_, err = cfg.KubeClient().Dynamic().Resource(nodeGroupGVR).Create(context.TODO(), obj, v1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	Context("NodeGroup CRD is missing", func() {
+		fNoNodeGroupCRD := HookExecutionConfigInit(initValuesString, initConfigValuesString)
+
+		BeforeEach(func() {
+			fNoNodeGroupCRD.ValuesDelete("global.clusterConfiguration")
+			fNoNodeGroupCRD.BindingContexts.Set(fNoNodeGroupCRD.KubeStateSet(stateFirstMasterNode))
+			fNoNodeGroupCRD.RunHook()
+		})
+
+		It("Must be executed successfully without NodeGroup CRD", func() {
+			Expect(fNoNodeGroupCRD).To(ExecuteSuccessfully())
+			Expect(fNoNodeGroupCRD.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("1"))
+			Expect(fNoNodeGroupCRD.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeFalse())
+		})
+	})
 
 	Context("Empty cluster", func() {
 		BeforeEach(func() {
+			f.ValuesDelete("global.clusterConfiguration")
 			f.BindingContexts.Set(f.KubeStateSet(``))
 			f.RunHook()
 		})
@@ -78,6 +162,7 @@ metadata:
 
 	Context("One master node in cluster", func() {
 		BeforeEach(func() {
+			f.ValuesDelete("global.clusterConfiguration")
 			f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode))
 			f.RunHook()
 		})
@@ -93,6 +178,7 @@ metadata:
 
 		Context("Two master nodes in cluster", func() {
 			BeforeEach(func() {
+				f.ValuesDelete("global.clusterConfiguration")
 				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode + stateSecondMasterNode))
 				f.RunHook()
 			})
@@ -101,6 +187,117 @@ metadata:
 				Expect(f).To(ExecuteSuccessfully())
 				Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
 
+				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("2"))
+				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeTrue())
+			})
+		})
+	})
+
+	Context("Master NodeGroup defines desired replicas", func() {
+		Context("Cloud node group with zones", func() {
+			BeforeEach(func() {
+				f.ValuesDelete("global.clusterConfiguration")
+				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode))
+				applyNodeGroup(f, stateMasterNodeGroupCloud)
+				f.RunHook()
+			})
+
+			It("must set HA based on minPerZone * zones", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("1"))
+				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeTrue())
+			})
+		})
+
+		Context("Cloud node group without zones", func() {
+			BeforeEach(func() {
+				f.ValuesDelete("global.clusterConfiguration")
+				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode))
+				applyNodeGroup(f, stateMasterNodeGroupCloudNoZones)
+				f.RunHook()
+			})
+
+			It("must treat minPerZone as desired replicas", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("1"))
+				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeTrue())
+			})
+		})
+
+		Context("Static node group with count 1 and two masters", func() {
+			BeforeEach(func() {
+				f.ValuesDelete("global.clusterConfiguration")
+				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode + stateSecondMasterNode))
+				applyNodeGroup(f, stateMasterNodeGroupStatic)
+				f.RunHook()
+			})
+
+			It("must not enable HA when desired replicas is 1", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("2"))
+				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeFalse())
+			})
+		})
+
+		Context("NodeGroup takes precedence over clusterConfiguration", func() {
+			BeforeEach(func() {
+				f.ValuesDelete("global.clusterConfiguration")
+				f.ValuesSetFromYaml("global.clusterConfiguration", []byte(clusterConfigurationStatic))
+				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode + stateSecondMasterNode))
+				applyNodeGroup(f, stateMasterNodeGroupStatic)
+				f.RunHook()
+			})
+
+			It("must follow NodeGroup desired replicas even when clusterConfiguration conflicts", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("2"))
+				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeFalse())
+			})
+		})
+	})
+
+	Context("ClusterConfiguration defines desired replicas", func() {
+		BeforeEach(func() {
+			f.ValuesDelete("global.clusterConfiguration")
+		})
+
+		Context("clusterConfiguration present with two masters", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.clusterConfiguration", []byte(clusterConfigurationStatic))
+				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode + stateSecondMasterNode))
+				f.RunHook()
+			})
+
+			It("must fallback to current masters count", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("2"))
+				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeTrue())
+			})
+		})
+
+		Context("clusterConfiguration present with one master", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.clusterConfiguration", []byte(clusterConfigurationStatic))
+				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode))
+				f.RunHook()
+			})
+
+			It("must fallback to current masters count", func() {
+				Expect(f).To(ExecuteSuccessfully())
+				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("1"))
+				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeFalse())
+			})
+		})
+
+		Context("clusterConfiguration exists without masterNodeGroup.replicas", func() {
+			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.clusterConfiguration", []byte(clusterConfigurationStatic))
+				f.BindingContexts.Set(f.KubeStateSet(stateFirstMasterNode + stateSecondMasterNode))
+				f.RunHook()
+			})
+
+			It("must fallback to current masters count", func() {
+				Expect(f).To(ExecuteSuccessfully())
 				Expect(f.ValuesGet("global.discovery.clusterMasterCount").String()).To(Equal("2"))
 				Expect(f.ValuesGet("global.discovery.clusterControlPlaneIsHighlyAvailable").Bool()).To(BeTrue())
 			})


### PR DESCRIPTION
## Description
Prevent HA mode when converging single-master cluster
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Prevent HA mode when converging single-master cluster
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
No need

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: global-hooks
type: fix
summary: prevent HA mode when destructively converging single-master cluster
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
