### PR TITLE
[ingress-nginx] allow empty dir

### DIFF
--- a/modules/402-ingress-nginx/hooks/storage/storage_class_change.go
+++ b/modules/402-ingress-nginx/hooks/storage/storage_class_change.go
@@ -27,4 +27,5 @@ var _ = storage_class_change.RegisterHook(storage_class_change.Args{
 	LabelSelectorValue: "geoproxy",
 	ObjectKind:         "StatefulSet",
 	ObjectName:         "geoproxy",
+	AllowEmptyDir:      true,
 })


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The storage_class_change hook of the module is updated to allow usage of emptyDir volumes.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In some cases like missing default storage class in the cluster, the storage_class_change hook may trigger the DeckhouseModuleUseEmptyDir alert even if there is no need to create a storage for the module in the cluster. By adding the AllowEmptyDir: true setting to the hook, we prevent such alerts from firing, leaving the decision of using a valid storage class vs using an emptyDir up to the cluster administrators.

## Why do we need it in the patch release (if we do)?

The storage_class_change hook was introduced in the 1.74 release so it makes sense to readjust it to stop firing misleading alerts.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Fixed useless geoip alerts.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
