### PR TITLE
[bashible] Add SELinux support for RHEL-based distributions.

### DIFF
--- a/candi/bashible/bashbooster/50_dnf.sh
+++ b/candi/bashible/bashbooster/50_dnf.sh
@@ -45,6 +45,10 @@ bb-dnf-repo?() {
 }
 
 bb-dnf-package?() {
+    if [ "$(bb-check-dnf)" = "yum" ]; then
+        bb-yum-package? "$@"
+        return
+    fi
     bb-set-proxy
     trap bb-unset-proxy RETURN
     dnf list installed "$1" &>/dev/null

--- a/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
@@ -14,14 +14,6 @@
 
 {{- if or ( eq .cri "Containerd") ( eq .cri "ContainerdV2") }}
 
-is_package_installed() {
-  if rpm -q "$1" &>/dev/null; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 bb-event-on 'bb-package-installed' 'post-install'
 
 # This handler triggered by 'bb-event-fire "bb-package-installed" "${PACKAGE}"'
@@ -62,8 +54,8 @@ cntrd_version_change_check() {
 command -v containerd &>/dev/null && cntrd_version_change_check
 
 if bb-is-distro-like? "rhel"; then
-  if is_package_installed "selinux-policy"; then
-    if ! is_package_installed "container-selinux"; then
+  if bb-dnf-package? "selinux-policy"; then
+    if ! bb-dnf-package? "container-selinux"; then
       bb-log-info "Installing container-selinux"
       bb-dnf-install "container-selinux"
     fi


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adds automatic installation of SELinux packages (`selinux-policy` and `container-selinux`) for RHEL-based distributions during node bootstrap.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Containerd requires `container-selinux` package on RHEL-based systems when SELinux is enabled. The `container-selinux` package depends on `selinux-policy`, so both packages need to be installed in the correct order.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary:  add container-selinux package for selinux policies on rhel based distributions.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
