### PR TITLE
backport [cloud-provider-dvp] cleanup resources on VM creation failure (#17533)

### DIFF
--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -421,18 +421,56 @@ func (r *DeckhouseMachineReconciler) getOrCreateVM(
 	return vm, nil
 }
 
+// cleanupVMResources removes resources created during VM provisioning
+func (r *DeckhouseMachineReconciler) cleanupVMResources(
+	ctx context.Context,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+	cloudInitSecretName string,
+	createdDiskNames []string,
+) {
+	logger := log.FromContext(ctx)
+
+	// Delete cloud-init secret
+	if cloudInitSecretName != "" {
+		if err := r.DVP.ComputeService.DeleteCloudInitProvisioningSecret(ctx, cloudInitSecretName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Info("Cleanup skipped: cloud-init secret not found (already deleted or never created)", "secretName", cloudInitSecretName)
+			} else {
+				logger.Error(err, "Failed to cleanup cloud-init secret", "secretName", cloudInitSecretName)
+			}
+		}
+	}
+
+	// Delete disks (boot and additional)
+	for _, diskName := range createdDiskNames {
+		if err := r.DVP.DiskService.RemoveDiskByName(ctx, diskName); err != nil {
+			if apierrors.IsNotFound(err) {
+				logger.Info("Cleanup skipped: disk not found (already deleted or never created)", "diskName", diskName)
+			} else {
+				logger.Error(err, "Failed to cleanup disk", "diskName", diskName)
+			}
+		}
+	}
+}
+
 func (r *DeckhouseMachineReconciler) createVM(
 	ctx context.Context,
 	machine *clusterv1b1.Machine,
 	dvpMachine *infrastructurev1a1.DeckhouseMachine,
 ) (*v1alpha2.VirtualMachine, error) {
+	logger := log.FromContext(ctx)
+
 	if machine.Spec.Bootstrap.DataSecretName == nil {
 		return nil, fmt.Errorf("clusterv1b1.Machine does not contain bootstrap script")
 	}
 
+	var cloudInitSecretName string
+	var createdDiskNames []string
+
+	bootDiskName := dvpMachine.Name + "-boot"
 	bootDisk, err := r.DVP.DiskService.CreateDiskFromDataSource(
 		ctx,
-		dvpMachine.Name+"-boot",
+		bootDiskName,
 		dvpMachine.Spec.RootDiskSize,
 		dvpMachine.Spec.RootDiskStorageClass,
 		&v1alpha2.VirtualDiskDataSource{
@@ -444,8 +482,11 @@ func (r *DeckhouseMachineReconciler) createVM(
 		},
 	)
 	if err != nil {
+		logger.Info("Boot disk creation failed, cleaning up created resources", "error", err.Error())
+		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 		return nil, fmt.Errorf("Cannot create boot disk: %w", err)
 	}
+	createdDiskNames = append(createdDiskNames, bootDiskName)
 
 	bootstrapDataSecret := &corev1.Secret{}
 	if err := r.Client.Get(
@@ -453,17 +494,23 @@ func (r *DeckhouseMachineReconciler) createVM(
 		client.ObjectKey{Namespace: machine.GetNamespace(), Name: *machine.Spec.Bootstrap.DataSecretName},
 		bootstrapDataSecret,
 	); err != nil {
+		logger.Info("Failed to get bootstrap data secret, cleaning up created resources", "error", err.Error())
+		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 		return nil, fmt.Errorf("Cannot get cloud-init data secret: %w", err)
 	}
 
 	cloudInitScript, hasBootstrapScript := bootstrapDataSecret.Data["value"]
 	if !hasBootstrapScript {
+		logger.Info("Bootstrap script not found in secret, cleaning up created resources")
+		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 		return nil, fmt.Errorf("Expected to find a cloud-init script in secret %s/%s", bootstrapDataSecret.Namespace, bootstrapDataSecret.Name)
 	}
 
-	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
+	cloudInitSecretName = "cloud-init-" + dvpMachine.Name
 	// CreateCloudInitProvisioningSecret is idempotent - it will update existing secret if it already exists
 	if err := r.DVP.ComputeService.CreateCloudInitProvisioningSecret(ctx, cloudInitSecretName, cloudInitScript); err != nil {
+		logger.Info("Cloud-init secret creation failed, cleaning up created resources", "error", err.Error())
+		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 		return nil, fmt.Errorf("Cannot create cloud-init provisioning secret: %w", err)
 	}
 	blockDeviceRefs := []v1alpha2.BlockDeviceSpecRef{
@@ -474,8 +521,11 @@ func (r *DeckhouseMachineReconciler) createVM(
 		addDiskName := fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, i)
 		addDisk, err := r.DVP.DiskService.CreateDisk(ctx, addDiskName, d.Size.Value(), d.StorageClass)
 		if err != nil {
+			logger.Info("Additional disk creation failed, cleaning up created resources", "error", err.Error(), "diskName", addDiskName)
+			r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 			return nil, fmt.Errorf("Cannot create additional disk %s: %w", addDiskName, err)
 		}
+		createdDiskNames = append(createdDiskNames, addDiskName)
 		blockDeviceRefs = append(blockDeviceRefs, v1alpha2.BlockDeviceSpecRef{
 			Kind: v1alpha2.DiskDevice,
 			Name: addDisk.Name,
@@ -531,8 +581,9 @@ func (r *DeckhouseMachineReconciler) createVM(
 		},
 	})
 	if err != nil {
-		// Get logger for detailed error logging
-		logger := log.FromContext(ctx)
+		// Cleanup resources on VM creation failure
+		logger.Info("VM creation failed, cleaning up created resources", "error", err.Error())
+		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 
 		// Log the request details for debugging
 		logger.Error(err, "Failed to create VM in parent DVP cluster",


### PR DESCRIPTION
(cherry picked from commit [d5a0fa7](https://github.com/deckhouse/deckhouse/commit/d5a0fa7ea33b5ac1da4651470f1dce05d46112a1))

## Description
Backport of [17533](https://github.com/deckhouse/deckhouse/pull/17533) to release-1.74.

## Why do we need it, and what problem does it solve?
Prevents resource leaks and improves error visibility when VM creation fails due to vmClass mismatch or permission issues in the parent DVP cluster. See changes in [17533](https://github.com/deckhouse/deckhouse/pull/17533) 
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Cleanup orphaned resources when VM creation fails
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
