### PR TITLE
[network-policy-engine] Fix a bug that led to CrashLoopBackOff kube-router's pods

### DIFF
--- a/modules/050-network-policy-engine/templates/podmonitor.yaml
+++ b/modules/050-network-policy-engine/templates/podmonitor.yaml
@@ -21,7 +21,7 @@ spec:
   selector:
     matchLabels:
       app: kube-router
-    namespaceSelector:
+  namespaceSelector:
       matchNames:
       - d8-system
 {{- end }}


### PR DESCRIPTION
## Description

Fixed an error in the `podmonitor.yaml` manifest, which was causing the Helm release to not fully apply. As a result, the `ClusterRole/d8:network-policy-engine` resource was not created in the cluster. This caused the `kube-router` pod to lack access rights to the Kubernetes API, leading to `CrashLoopBackOff`.


## Why do we need it, and what problem does it solve?

if the kube-router pods are in the `CrashLoopBackOff` status, then network policies do not work, and pod traffic may be droped.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: network-policy-engine
type: fix
summary: Fixed a bug that led to CrashLoopBackOff kube-router's pods.
```
