### PR TITLE
[ingress-nginx] Fix MaxMind download alerting

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4239,12 +4239,11 @@ alerts:
       module: ingress-nginx
       edition: ce
       description: |-
-        The component `{{ $labels.job }}` (pod `{{ $labels.pod }}`) failed to download the GeoIP database from MaxMind.
-        **Reason:** `{{ $labels.reason }}`
-        **Type:** `{{ $labels.type }}`
+        The component `{{ $labels.job }}` (pod `{{ $labels.pod }}`) failed to download the GeoIP database
+        from MaxMind for edition `{{ $labels.edition }}`.
         If this issue persists, investigate network connectivity or database availability.
       summary: |
-        GeoIP DB download error in {{ $labels.job }} (pod {{ $labels.pod }}).
+        GeoIP DB download error in {{ $labels.job }} (pod {{ $labels.pod }}), edition {{ $labels.edition }}.
       severity: "4"
       markupFormat: markdown
     - name: GrafanaDashboardAlertRulesDeprecated

--- a/modules/402-ingress-nginx/images/geoproxy/src/metrics.go
+++ b/modules/402-ingress-nginx/images/geoproxy/src/metrics.go
@@ -18,11 +18,11 @@ package geodownloader
 
 import "github.com/prometheus/client_golang/prometheus"
 
-// GeoIPErrors number of errors when loading Geo DB
-var GeoIPErrors = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "geoip_errors_download_total",
-		Help: "Number of errors related to GeoIP from MaxMind service",
+// GeoIPDownloadError indicates whether the last download attempt for a GeoIP edition failed.
+var GeoIPDownloadError = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "geoip_download_error",
+		Help: "Whether the last GeoIP database download attempt failed (1) or succeeded (0).",
 	},
-	[]string{"reason", "type"},
+	[]string{"edition"},
 )

--- a/modules/402-ingress-nginx/images/geoproxy/src/server.go
+++ b/modules/402-ingress-nginx/images/geoproxy/src/server.go
@@ -50,7 +50,7 @@ func (s *Server) Start(ctx context.Context, server, metrics string) error {
 	mux.HandleFunc("/readyz", ok)
 
 	reg := prometheus.NewRegistry()
-	reg.MustRegister(GeoIPErrors)
+	reg.MustRegister(GeoIPDownloadError)
 	promMux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
 
 	// pprof endpoints

--- a/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/monitoring/prometheus-rules/ingress-nginx.yaml
@@ -228,7 +228,7 @@
         To disable profiling, set `nginxProfilingEnabled: false` in the `ingressnginxcontroller` resource configuration for this controller.
 
   - alert: GeoIPDownloadErrorDetectedFromMaxMind
-    expr: sum by (job, namespace, pod, reason, type) (max_over_time(geoip_errors_download_total{type="download"}[1m])) > 0
+    expr: max by (job, namespace, pod, edition) (geoip_download_error) > 0
     for: 1m
     labels:
       severity_level: "4"
@@ -236,11 +236,10 @@
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
       summary: |-
-        GeoIP DB download error in `{{ $labels.job }}` (pod `{{ $labels.pod }}`).
+        GeoIP DB download error in `{{ $labels.job }}` (pod `{{ $labels.pod }}`), edition `{{ $labels.edition }}`.
       description: |-
-        The component `{{ $labels.job }}` (pod `{{ $labels.pod }}`) failed to download the GeoIP database from MaxMind.
-        **Reason:** `{{ $labels.reason }}`
-        **Type:** `{{ $labels.type }}`
+        The component `{{ $labels.job }}` (pod `{{ $labels.pod }}`) failed to download the GeoIP database
+        from MaxMind for edition `{{ $labels.edition }}`.
         If this issue persists, investigate network connectivity or database availability.
 
   - alert: NginxIngressMaxMindAccountIDNotSet


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added geoip_download_error gauge to reflect last download status and switched the alert to it to avoid stale counter-based firing. Alert now includes the database edition and omits the error reason to reduce noise and cardinality.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

If one of the databases was not downloaded, but then we excluded it from the list, the alert continues to appear.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Currently, the alert only clears after recreating the geoproxy pod.


## Manual testing

<details>
<summary>Screenshots</summary>

1. Added GeoIP db that not exists on mirror server.

```yaml
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
  name: main
spec:
...
  geoIP2:
    maxmindEditionIDs:
    - GeoLite2-Country
    - GeoLite2-City
    maxmindMirror:
      insecureSkipVerify: true
      url: https://193.42.118.165:8443
```

2. Check alerts, alert is firing.

<img width="1065" height="216" alt="image" src="https://github.com/user-attachments/assets/bb1c7b38-2d82-4199-946f-a5ef927a131e" />

3. Removed not existing db from list.

```yaml
apiVersion: deckhouse.io/v1
kind: IngressNginxController
metadata:
  name: main
spec:
...
  geoIP2:
    maxmindEditionIDs:
    - GeoLite2-Country
    maxmindMirror:
      insecureSkipVerify: true
      url: https://193.42.118.165:8443
```

4. Alert has gone away.

<img width="1087" height="175" alt="image" src="https://github.com/user-attachments/assets/9ec81065-2629-4dce-a348-bcb274a3ba60" />


</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: A false-positive trigger of alert GeoIPDownloadErrorDetectedFromMaxMind is fixed.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
