### PR TITLE
[deckhouse] app subscriptions can only monitor resources in their namespace

### DIFF
--- a/modules/460-log-shipper/hooks/internal/composer/composer.go
+++ b/modules/460-log-shipper/hooks/internal/composer/composer.go
@@ -141,7 +141,7 @@ func (c *Composer) getDestinationSpecByName(name string) *v1alpha1.ClusterLogDes
 
 // composeDestinations resolves destination references, creates destination instances, and applies transforms.
 func (c *Composer) composeDestinations(destinationRefs []string, sourceType string) ([]PipelineDestination, error) {
-	destinations := make([]PipelineDestination, 0, len(destinationRefs))
+	var destinations []PipelineDestination
 
 	for _, ref := range destinationRefs {
 		// Create destination for this specific source to ensure correct labels


### PR DESCRIPTION
## Description

It is related with [it](https://github.com/deckhouse/module-sdk/pull/89)

In the deckhouse-controller, when initializing application hooks for each OnKubernetesEvents subscription, the following is forcibly set:
sub.Monitor.NamespaceSelector = matchNames: [ app.GetNamespace() ]
and bindings to kube-events are initialized with this “rewritten” kubeSubs list, rather than the original one.

## Why do we need it, and what problem does it solve?
Applications should not be aware of what is happening in applications in other namespaces, as this could break their logic.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: App subscriptions can only monitor resources in their namespace.
impact_level: low
```
