### PR TITLE
[control-plane-manager] Use etcd version from oss.yaml

### DIFF
--- a/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/etcd/werf.inc.yaml
@@ -1,3 +1,5 @@
+{{- $version := include "get_oss_version_by_id" (list "etcd" $ ) }}
+{{- $version = printf "v%s" $version }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 final: false
@@ -13,7 +15,7 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
-  - git clone -b v3.6.7 --depth 1 $(cat /run/secrets/SOURCE_REPO)/etcd-io/etcd.git /src
+  - git clone -b {{ $version }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/etcd-io/etcd.git /src
   - cd /src
   - git apply /patches/*.patch --verbose
   - rm -rf tools

--- a/modules/040-control-plane-manager/oss.yaml
+++ b/modules/040-control-plane-manager/oss.yaml
@@ -9,4 +9,5 @@
   description: A distributed reliable key-value store for the most critical data of a distributed system.
   logo: /images/logos/etcd-icon-color.svg
   license: Apache License 2.0
-
+  id: etcd
+  version: 3.6.7


### PR DESCRIPTION
## Description
Declare open-source software (in this case `etcd`) versions in oss.yaml and use info from that file during builds.

## Why do we need it, and what problem does it solve?
As part of the process of making managing OSS versions more transparent and automated.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Use etcd version from oss.yaml
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
