### PR TITLE
[admission-policy-engine] gatekeeper: enable applying patches

### DIFF
--- a/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
+++ b/modules/015-admission-policy-engine/images/gatekeeper/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
   install:
   - git clone --depth 1 --branch {{ $gatekeeperVersion }} $(cat /run/secrets/SOURCE_REPO)/open-policy-agent/gatekeeper.git /src
   - cd /src
-  #- git apply /patches/*.patch --verbose
+  - git apply /patches/*.patch --verbose
   - rm -rf website
   - rm -rf .git
   # check if module crds/gatekeeper are the same as gatekeeper crds


### PR DESCRIPTION
## Description

This PR enables applying local Gatekeeper patches during the image build by uncommenting the `git apply /patches/*.patch` step in `werf.inc.yaml`.

**Impact:** the Gatekeeper image will be rebuilt with repository patches applied. During upgrade this may lead to a rollout/restart of admission-policy-engine Gatekeeper components (standard image update behavior).

---

## Why do we need it, and what problem does it solve?

Previously, the module shipped Gatekeeper patches in the repository, but they were not applied during the build because the `git apply` step was commented out.

As a result, security fixes and other patch changes could be silently ignored.

This PR ensures that all repository patches are actually applied when building the Gatekeeper image.

---

## Why do we need it in the patch release (if we do)?

Yes — this change is required for security-related patches (including CVE-related dependency updates) to take effect in the shipped module image.

---

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.


## Changelog entries
```changes
section: admission-policy-engine
type: fix
summary: uncomment git apply string to apply the gatekeeper patches
impact_level: low
```