### PR TITLE
[control-plane-manager/update-observer] Remove probes out of update-observer container

### DIFF
--- a/modules/040-control-plane-manager/images/update-observer/src/manager.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/manager.go
@@ -35,15 +35,8 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-)
-
-const (
-	healthProbeBindAddress   = ":4264"
-	pprofBindAddress         = ":4265"
-	metricsserverBindAddress = ":4266"
 )
 
 var (
@@ -63,8 +56,6 @@ func NewManager(ctx context.Context, pprof bool) (*Manager, error) {
 	cfg := controllerruntime.GetConfigOrDie()
 	controllerruntime.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
 
-	// TODO: pprof flag?
-
 	runtimeManager, err := controllerruntime.NewManager(cfg, controllerruntime.Options{
 		Scheme:           scheme,
 		LeaderElection:   true,
@@ -73,10 +64,10 @@ func NewManager(ctx context.Context, pprof bool) (*Manager, error) {
 			return ctx
 		},
 		Metrics: metricsserver.Options{
-			BindAddress: metricsserverBindAddress,
+			BindAddress: "0",
 		},
-		HealthProbeBindAddress:  healthProbeBindAddress,
-		PprofBindAddress:        "",
+		HealthProbeBindAddress:  "0",
+		PprofBindAddress:        "0",
 		GracefulShutdownTimeout: ptr.To(10 * time.Second),
 		Cache: cache.Options{
 			ReaderFailOnMissingInformer: false,
@@ -138,13 +129,13 @@ func NewManager(ctx context.Context, pprof bool) (*Manager, error) {
 		return nil, fmt.Errorf("create controller runtime manager: %w", err)
 	}
 
-	if err = runtimeManager.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return nil, fmt.Errorf("add health check: %w", err)
-	}
+	// if err = runtimeManager.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+	// 	return nil, fmt.Errorf("add health check: %w", err)
+	// }
 
-	if err = runtimeManager.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		return nil, fmt.Errorf("add ready check: %w", err)
-	}
+	// if err = runtimeManager.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	// 	return nil, fmt.Errorf("add ready check: %w", err)
+	// }
 
 	if err = controller.RegisterController(runtimeManager); err != nil {
 		return nil, fmt.Errorf("add controller: %w", err)

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -342,26 +342,6 @@ spec:
         image: {{ include "helm_lib_module_image" (list $ "updateObserver") }}
         command:
         - /update-observer
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 4264
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 4264
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          successThreshold: 1
-          failureThreshold: 3
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_only_logs" $ | nindent 12 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Removed liveness and readiness probes from the update-observer container in control-plane-manager DaemonSet. This change addresses port conflicts that occurred when update-observer attempted to bind to port 4264, which was already in use by other system components (particularly CNI agents).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The update-observer component runs with hostNetwork: true as part of the control-plane-manager DaemonSet. It attempted to bind to port 4264 for health checks, but this port was already occupied by critical system components (CNI agents). This caused the update-observer container to fail with "address already in use" errors, leading to CrashLoopBackoff states.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Removed liveness and readiness probes from update-observer container.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
