### PR TITLE
[cloud-provider-aws] added ccm for k8s-1.35

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -135,7 +135,7 @@ k8s:
     crictlPatch: 0
     ccm:
       openstack: v1.34.1
-      aws: v1.34.1
+      aws: v1.35.0
       vsphere: v1.34.0
       azure: v1.34.3
       gcp: ccm/v34.0.0

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/001-identify-instances-by-name.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/001-identify-instances-by-name.patch
@@ -1,0 +1,37 @@
+diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
+index e1070ee..79e2efd 100644
+--- a/pkg/providers/v1/aws.go
++++ b/pkg/providers/v1/aws.go
+@@ -3278,6 +3278,11 @@ func mapNodeNameToPrivateDNSName(nodeName types.NodeName) string {
+ // Deprecated: use instanceIDToNodeName instead. See
+ // mapNodeNameToPrivateDNSName for details.
+ func mapInstanceToNodeName(i *ec2types.Instance) types.NodeName {
++	for _, tag := range i.Tags {
++		if aws.ToString(tag.Key) == "Name" {
++			return types.NodeName(aws.ToString(tag.Value))
++		}
++	}
+ 	return types.NodeName(aws.ToString(i.PrivateDnsName))
+ }
+ 
+@@ -3305,7 +3310,19 @@ func (c *Cloud) findInstanceByNodeName(ctx context.Context, nodeName types.NodeN
+ 	}
+ 
+ 	if len(instances) == 0 {
+-		return nil, nil
++		filters := []ec2types.Filter{
++			newEc2Filter("tag:Name", privateDNSName),
++			newEc2Filter("instance-state-name", aliveFilter...),
++		}
++
++		instances, err = c.describeInstances(ctx, filters)
++		if err != nil {
++			return nil, err
++		}
++
++		if len(instances) == 0 {
++			return nil, nil
++		}
+ 	}
+ 	if len(instances) > 1 {
+ 		return nil, fmt.Errorf("multiple instances found for name: %s", nodeName)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/002-non-type-lb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/002-non-type-lb.patch
@@ -1,0 +1,281 @@
+diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
+index 89b1d742..a2a9e3d9 100644
+--- a/pkg/providers/v1/aws.go
++++ b/pkg/providers/v1/aws.go
+@@ -305,6 +305,13 @@ var backendProtocolMapping = map[string]string{
+ 	"tcp":   "ssl",
+ }
+ 
++var backendProtocolToAwsEnumMapping = map[string]string{
++	"tcp":   string(elbv2types.ProtocolEnumTcp),
++	"tls":   string(elbv2types.ProtocolEnumTls),
++	"http":  string(elbv2types.ProtocolEnumHttp),
++	"https": string(elbv2types.ProtocolEnumHttps),
++}
++
+ // invalidSecurityGroupNameNLBPattern is a regular expression that matches any non-alphanumeric character.
+ var invalidSecurityGroupNameNLBPattern, _ = regexp.Compile("[[:^alnum:]]")
+ 
+@@ -2364,7 +2371,7 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
+ 			continue
+ 		}
+ 
+-		if isNLB(annotations) {
++		if isNLB(annotations) || isNone(annotations) {
+ 			portMapping := nlbPortMapping{
+ 				FrontendPort:     int32(port.Port),
+ 				FrontendProtocol: elbv2types.ProtocolEnum(port.Protocol),
+@@ -2376,6 +2383,12 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
+ 				return nil, err
+ 			}
+ 
++			if isNone(annotations) {
++				portMapping.HealthCheckConfig.Protocol = elbv2types.ProtocolEnumHttp
++				portMapping.HealthCheckConfig.Port = "10256" // ProxyHealthzPort
++				portMapping.HealthCheckConfig.Path = "/healthz"
++			}
++
+ 			certificateARN := annotations[ServiceAnnotationLoadBalancerCertificate]
+ 			if port.Protocol != v1.ProtocolUDP && certificateARN != "" && (sslPorts == nil || sslPorts.numbers.Has(port.Port) || sslPorts.names.Has(port.Name)) {
+ 				portMapping.FrontendProtocol = elbv2types.ProtocolEnumTls
+@@ -2387,6 +2400,19 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
+ 				}
+ 			}
+ 
++			if isNone(annotations) {
++				instanceProtocol := annotations[ServiceAnnotationLoadBalancerBEProtocol]
++				if instanceProtocol == "" {
++					portMapping.TrafficProtocol = elbv2types.ProtocolEnumTcp
++				} else {
++					protocol := backendProtocolToAwsEnumMapping[instanceProtocol]
++					if protocol == "" {
++						return nil, fmt.Errorf("invalid backend protocol %s", ServiceAnnotationLoadBalancerBEProtocol)
++					}
++					portMapping.TrafficProtocol = elbv2types.ProtocolEnum(protocol)
++				}
++			}
++
+ 			v2Mappings = append(v2Mappings, portMapping)
+ 		} else {
+ 			listener, err := buildListener(port, annotations, sslPorts)
+@@ -2415,6 +2441,58 @@ func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiS
+ 		internalELB = true
+ 	}
+ 
++	if isNone(annotations) {
++		if path, healthCheckNodePort := servicehelpers.GetServiceHealthCheckPathPort(apiService); path != "" {
++			for i := range v2Mappings {
++				v2Mappings[i].HealthCheckConfig.Port = strconv.Itoa(int(healthCheckNodePort))
++				v2Mappings[i].HealthCheckConfig.Path = path
++				v2Mappings[i].HealthCheckConfig.Protocol = elbv2types.ProtocolEnumHttp
++			}
++		}
++		loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, apiService)
++		serviceName := types.NamespacedName{Namespace: apiService.Namespace, Name: apiService.Name}
++
++		instanceIDs := []string{}
++		for id := range instances {
++			instanceIDs = append(instanceIDs, string(id))
++		}
++		// Get additional tags set by the user
++		tags := getKeyValuePropertiesFromAnnotation(annotations, ServiceAnnotationLoadBalancerAdditionalTags)
++		// Add default tags
++		tags[TagNameKubernetesService] = serviceName.String()
++		tags = c.tagging.buildTags(ResourceLifecycleOwned, tags)
++
++		for i, mapping := range v2Mappings {
++			tgNameWithSuffix := generateTgName(loadBalancerName, strconv.Itoa(i))
++			existingTg, err := c.describeTargetGroup(ctx, tgNameWithSuffix)
++			if err != nil {
++				return nil, err
++			}
++
++			_, err = c.ensureTargetGroup(
++				ctx,
++				existingTg,
++				serviceName,
++				mapping,
++				instanceIDs,
++				c.vpcID,
++				tags,
++				tgNameWithSuffix,
++			)
++			if err != nil {
++				return nil, err
++			}
++		}
++
++		return &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{
++			{
++				IP:       "0.0.0.0",
++				Hostname: "none",
++			},
++		},
++		}, nil
++	}
++
+ 	if isNLB(annotations) {
+ 		// Find the subnets that the ELB will live in
+ 		discoveredSubnetIDs, err := c.getLoadBalancerSubnets(ctx, apiService, internalELB)
+@@ -2755,6 +2833,34 @@ func (c *Cloud) GetLoadBalancer(ctx context.Context, clusterName string, service
+ 		return nil, false, nil
+ 	}
+ 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
++	if isNone(service.Annotations) {
++		tgCount := 0
++		portCount := len(service.Spec.Ports)
++		for i := range service.Spec.Ports {
++			tgNameWithSuffix := generateTgName(loadBalancerName, strconv.Itoa(i))
++			tg, err := c.describeTargetGroup(ctx, tgNameWithSuffix)
++			if err != nil {
++				return nil, false, err
++			}
++
++			if tg != nil {
++				tgCount++
++			}
++		}
++		if tgCount == 0 {
++			return nil, false, nil
++		} else if tgCount < portCount {
++			return nil, true, nil
++		} else {
++			return &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{
++				{
++					IP:       "0.0.0.0",
++					Hostname: "none",
++				},
++			},
++			}, true, nil
++		}
++	}
+ 
+ 	if isNLB(service.Annotations) {
+ 		lb, err := c.describeLoadBalancerv2(ctx, loadBalancerName)
+@@ -3228,6 +3334,27 @@ func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName strin
+ 	securityGroupIDs := map[string]struct{}{}
+ 	taggedLBSecurityGroups := map[string]struct{}{}
+ 
++	if isNone(service.Annotations) {
++		for i := range service.Spec.Ports {
++			tgNameWithSuffix := generateTgName(loadBalancerName, strconv.Itoa(i))
++			tg, err := c.describeTargetGroup(ctx, tgNameWithSuffix)
++			if err != nil {
++				return err
++			}
++			if tg == nil {
++				klog.Info("Target group already deleted: ", loadBalancerName)
++				continue
++			}
++
++			_, err = c.elbv2.DeleteTargetGroup(ctx, &elbv2.DeleteTargetGroupInput{TargetGroupArn: tg.TargetGroupArn})
++			if err != nil {
++				return err
++			}
++		}
++
++		return nil
++	}
++
+ 	if isNLB(service.Annotations) {
+ 		lb, err := c.describeLoadBalancerv2(ctx, loadBalancerName)
+ 		if err != nil {
+@@ -3350,6 +3477,10 @@ func (c *Cloud) UpdateLoadBalancer(ctx context.Context, clusterName string, serv
+ 		return err
+ 	}
+ 	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
++	if isNone(service.Annotations) {
++		_, err = c.EnsureLoadBalancer(ctx, clusterName, service, nodes)
++		return err
++	}
+ 	if isNLB(service.Annotations) {
+ 		lb, err := c.describeLoadBalancerv2(ctx, loadBalancerName)
+ 		if err != nil {
+@@ -3696,3 +3827,7 @@ func getRegionFromMetadata(ctx context.Context, cfg config.CloudConfig, metadata
+ 
+ 	return cfg.GetRegion(ctx, metadata)
+ }
++
++func generateTgName(prefix, suffix string) string {
++	return prefix[0:32-1-len(suffix)] + "-" + suffix
++}
+diff --git a/pkg/providers/v1/aws_loadbalancer.go b/pkg/providers/v1/aws_loadbalancer.go
+index f9dd5984..ef90e555 100644
+--- a/pkg/providers/v1/aws_loadbalancer.go
++++ b/pkg/providers/v1/aws_loadbalancer.go
+@@ -94,6 +94,13 @@ func isLBExternal(annotations map[string]string) bool {
+ 	return false
+ }
+ 
++func isNone(annotations map[string]string) bool {
++	if annotations[ServiceAnnotationLoadBalancerType] == "none" {
++		return true
++	}
++	return false
++}
++
+ type healthCheckConfig struct {
+ 	Port               string
+ 	Path               string
+@@ -144,6 +151,21 @@ func getKeyValuePropertiesFromAnnotation(annotations map[string]string, annotati
+ 	return additionalTags
+ }
+ 
++func (c *Cloud) describeTargetGroup(ctx context.Context, tgName string) (*elbv2types.TargetGroup, error) {
++	response, err := c.elbv2.DescribeTargetGroups(ctx, &elbv2.DescribeTargetGroupsInput{})
++	if err != nil {
++		return nil, fmt.Errorf("error describing target groups: %q", err)
++	}
++
++	for _, tg := range response.TargetGroups {
++		if aws.ToString(tg.TargetGroupName) == tgName {
++			return &tg, nil
++		}
++	}
++
++	return nil, nil
++}
++
+ // ensureLoadBalancerv2 ensures a v2 load balancer is created
+ func (c *Cloud) ensureLoadBalancerv2(ctx context.Context, namespacedName types.NamespacedName, loadBalancerName string, mappings []nlbPortMapping, instanceIDs, discoveredSubnetIDs []string, internalELB bool, annotations map[string]string, securityGroups []string) (*elbv2types.LoadBalancer, error) {
+ 	loadBalancer, err := c.describeLoadBalancerv2(ctx, loadBalancerName)
+@@ -749,12 +771,15 @@ func (c *Cloud) deleteListenerV2(ctx context.Context, listener *elbv2types.Liste
+ }
+ 
+ // ensureTargetGroup creates a target group with a set of instances.
+-func (c *Cloud) ensureTargetGroup(ctx context.Context, targetGroup *elbv2types.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string) (*elbv2types.TargetGroup, error) {
++func (c *Cloud) ensureTargetGroup(ctx context.Context, targetGroup *elbv2types.TargetGroup, serviceName types.NamespacedName, mapping nlbPortMapping, instances []string, vpcID string, tags map[string]string, tgName ...string) (*elbv2types.TargetGroup, error) {
+ 	dirty := false
+ 	expectedTargets := c.computeTargetGroupExpectedTargets(instances, mapping.TrafficPort)
+ 	if targetGroup == nil {
+ 		targetType := elbv2types.TargetTypeEnumInstance
+ 		name := c.buildTargetGroupName(serviceName, mapping.FrontendPort, mapping.TrafficPort, mapping.TrafficProtocol, targetType, mapping)
++		if len(tgName) > 0 {
++			name = tgName[0]
++		}
+ 		klog.Infof("Creating load balancer target group for %v with name: %s", serviceName, name)
+ 		input := &elbv2.CreateTargetGroupInput{
+ 			VpcId:                      aws.String(vpcID),
+@@ -799,6 +824,22 @@ func (c *Cloud) ensureTargetGroup(ctx context.Context, targetGroup *elbv2types.T
+ 		return &tg, nil
+ 	}
+ 
++	// handle protocol change
++	{
++		if targetGroup.Protocol != mapping.TrafficProtocol {
++			_, err := c.elbv2.DeleteTargetGroup(ctx, &elbv2.DeleteTargetGroupInput{TargetGroupArn: targetGroup.TargetGroupArn})
++			if err != nil {
++				return nil, err
++			}
++
++			var targetGroupName string
++			if len(tgName) > 0 {
++				targetGroupName = tgName[0]
++			}
++			return c.ensureTargetGroup(ctx, nil, serviceName, mapping, instances, vpcID, tags, targetGroupName)
++		}
++	}
++
+ 	// handle instances in service
+ 	{
+ 		tgARN := aws.ToString(targetGroup.TargetGroupArn)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/003-dont-delete-ingress-sg-rules-elb.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/003-dont-delete-ingress-sg-rules-elb.patch
@@ -1,0 +1,27 @@
+diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
+index e1070ee..feff012 100644
+--- a/pkg/providers/v1/aws.go
++++ b/pkg/providers/v1/aws.go
+@@ -2733,6 +2733,13 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(ctx context.Context,
+ 	c.sortELBSecurityGroupList(lbSecurityGroupIDs, annotations, taggedLBSecurityGroups)
+ 	loadBalancerSecurityGroupID := lbSecurityGroupIDs[0]
+ 
++	var deleteSecurityGroupID bool
++	// we shouldn't delete Ingress SG rule, if it allows access
++	// from configured "ElbSecurityGroup", so that we won't disrupt access to Nodes from other ELBs
++	if loadBalancerSecurityGroupID != c.cfg.Global.ElbSecurityGroup {
++		deleteSecurityGroupID = true
++	}
++
+ 	// Get the actual list of groups that allow ingress from the load-balancer
+ 	actualGroups := make(map[*ec2types.SecurityGroup]bool)
+ 	{
+@@ -2824,7 +2831,7 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(ctx context.Context,
+ 			if !changed {
+ 				klog.Warning("Allowing ingress was not needed; concurrent change? groupId=", instanceSecurityGroupID)
+ 			}
+-		} else {
++		} else if deleteSecurityGroupID {
+ 			changed, err := c.removeSecurityGroupIngress(ctx, instanceSecurityGroupID, permissions)
+ 			if err != nil {
+ 				return err

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/005-fix-list-routes-method.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/005-fix-list-routes-method.patch
@@ -1,0 +1,14 @@
+diff --git a/pkg/providers/v1/aws_routes.go b/pkg/providers/v1/aws_routes.go
+index 2fea345..7f2247e 100644
+--- a/pkg/providers/v1/aws_routes.go
++++ b/pkg/providers/v1/aws_routes.go
+@@ -117,7 +117,8 @@ func (c *Cloud) ListRoutes(ctx context.Context, clusterName string) ([]*cloudpro
+ 			if found {
+ 				node, err := c.instanceIDToNodeName(InstanceID(instanceID))
+ 				if err != nil {
+-					return nil, err
++					klog.Errorf("error converting instance ID '%s' to node name: %w", instanceID, err)
++					continue
+ 				}
+ 				route.TargetNode = node
+ 				routes = append(routes, route)

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/006-publicNetworkAllowList-for-NLB.patch
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/006-publicNetworkAllowList-for-NLB.patch
@@ -1,0 +1,68 @@
+diff --git a/pkg/providers/v1/aws.go b/pkg/providers/v1/aws.go
+index e1070eec..7cf02e99 100644
+--- a/pkg/providers/v1/aws.go
++++ b/pkg/providers/v1/aws.go
+@@ -373,7 +373,8 @@ type Cloud struct {
+ 	region   string
+ 	vpcID    string
+ 
+-	tagging awsTagging
++	defaultNLBClientCIDRs []string
++	tagging               awsTagging
+ 
+ 	// The AWS instance that we are running on
+ 	// Note that we cache some state in awsInstance (mountpoints), so we must preserve the instance
+@@ -584,6 +585,23 @@ func newAWSCloud2(cfg config.CloudConfig, awsServices Services, provider config.
+ 		deleteTagsBatcher:       newDeleteTagsBatcher(ctx, ec2),
+ 		describeInstanceBatcher: newdescribeInstanceBatcher(ctx, ec2),
+ 	}
++
++	s := cfg.Global.PublicNetworkAllowList
++	if s != "" {
++		parts := strings.Split(s, ",")
++		cidrs := make([]string, 0, len(parts))
++		for _, p := range parts {
++			p = strings.TrimSpace(p)
++			if p != "" {
++				cidrs = append(cidrs, p)
++			}
++		}
++		if len(cidrs) > 0 {
++			awsCloud.defaultNLBClientCIDRs = cidrs
++			klog.Infof("Using publicNetworkAllowList for NLB client CIDRs: %v", cidrs)
++		}
++	}
++
+ 	awsCloud.instanceCache.cloud = awsCloud
+ 	awsCloud.zoneCache.cloud = awsCloud
+ 	awsCloud.instanceTopologyManager = NewInstanceTopologyManager(ec2, &cfg)
+diff --git a/pkg/providers/v1/aws_loadbalancer.go b/pkg/providers/v1/aws_loadbalancer.go
+index ca95a3ab..62194a2e 100644
+--- a/pkg/providers/v1/aws_loadbalancer.go
++++ b/pkg/providers/v1/aws_loadbalancer.go
+@@ -793,6 +793,11 @@ func (c *Cloud) updateInstanceSecurityGroupsForNLB(ctx context.Context, lbName s
+ 		return nil
+ 	}
+ 
++	if (len(clientCIDRs) == 0 || (len(clientCIDRs) == 1 && clientCIDRs[0] == "0.0.0.0/0")) && len(c.defaultNLBClientCIDRs) > 0 {
++		clientCIDRs = c.defaultNLBClientCIDRs
++		klog.Infof("updateInstanceSecurityGroupsForNLB: overriding clientCIDRs with defaultNLBClientCIDRs=%v", clientCIDRs)
++	}
++
+ 	clusterSGs, err := c.getTaggedSecurityGroups(ctx)
+ 	if err != nil {
+ 		return fmt.Errorf("error querying for tagged security groups: %q", err)
+diff --git a/pkg/providers/v1/config/config.go b/pkg/providers/v1/config/config.go
+index 6dd65a20..4a08ab83 100644
+--- a/pkg/providers/v1/config/config.go
++++ b/pkg/providers/v1/config/config.go
+@@ -75,7 +75,8 @@ type CloudConfig struct {
+ 		//AWS has a hard limit of 500 security groups. For large clusters creating a security group for each ELB
+ 		//can cause the max number of security groups to be reached. If this is set instead of creating a new
+ 		//Security group for each ELB this security group will be used instead.
+-		ElbSecurityGroup string
++		ElbSecurityGroup       string
++		PublicNetworkAllowList string `json:"publicNetworkAllowList,omitempty" yaml:"publicNetworkAllowList,omitempty"`
+ 
+ 		// NodeIPFamilies determines which IP addresses are added to node objects and their ordering.
+ 		NodeIPFamilies []string

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/README.md
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/patches/1.35/README.md
@@ -1,0 +1,23 @@
+## Patches
+
+## 001-identify-instances-by-name.patch
+
+Find nodes in the cloud by the `Name` tag containing Node privateDNSName.
+
+## 002-non-type-lb.patch
+
+Ability to create LoadBalancer with type `none`. LoadBalancer with this type will have managed target groups,
+ which allows you to create ApplicationLoadBalancer with automatically managed targets.
+
+## 003-dont-delete-ingress-sg-rules-elb.patch
+
+We shouldn't delete Ingress SG rule, if it allows access from configured "ElbSecurityGroup", so that we won't disrupt access to Nodes from other ELBs.
+
+
+## 005-fix-list-routes-method.patch
+
+Modify `ListRoutes` method to handle errors gracefully without blocking reconcile loop.
+
+## 006-publicNetworkAllowList-for-NLB.patch
+
+Adds support for PublicNetworkAllowList to restrict incoming traffic to NLBs


### PR DESCRIPTION
## Description
Add cloud-controller-manager patches for Kubernetes 1.35 support for AWS provider.

This PR includes:
- Copied patches from 1.34 to 1.35 directory
- Adapted patch 002-non-type-lb.patch for v1.35.0 code changes
- Updated AWS CCM version from v1.34.1 to v1.35.0 in version_map.yml


## Why do we need it, and what problem does it solve?
This is required to support Kubernetes 1.35. Without these patches, the AWS cloud-controller-manager will not have the necessary customizations for Deckhouse-specific functionality including:
- Instance identification by Name tag
- None-type load balancers for ApplicationLoadBalancer integration
- Security group rule management
- List routes method fixes
- Public network allowlist for NLBs

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: feature
summary: add cloud-controller-manager support for Kubernetes 1.35
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
