### PR TITLE
[node-manager] Fix error handling in CAPS gossh

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/gossh/gossh.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/ssh/gossh/gossh.go
@@ -71,7 +71,7 @@ func CreateSSHClient(instanceScope *scope.InstanceScope) (*SSH, error) {
 
 	sshClient, err := ssh.Dial("tcp", addr, config)
 	if err != nil {
-		return nil, fmt.Errorf("cannot connect to SSH host %s", addr)
+		return nil, fmt.Errorf("cannot connect to SSH host %s : %w", addr, err)
 	}
 
 	return &SSH{sshClient: sshClient}, nil
@@ -96,7 +96,7 @@ func (s *SSH) ExecSSHCommand(instanceScope *scope.InstanceScope, command string,
 
 	session, err := s.sshClient.NewSession()
 	if err != nil {
-		return fmt.Errorf("cannot create session")
+		return fmt.Errorf("cannot create session: %w", err)
 	}
 	defer session.Close()
 


### PR DESCRIPTION
## Description

Fix error handling in CAPS gossh: log error while connecting to host

## Why do we need it, and what problem does it solve?

To determinate, what exactly is wrong about ssh connection, we must log an error during connection try


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fixed logging errors during ssh connections in caps.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
