### PR TITLE
[docs-builder] Fix trivy and add vexes

### DIFF
--- a/modules/810-documentation/images/docs-builder/known_vulnerabilities.vex
+++ b/modules/810-documentation/images/docs-builder/known_vulnerabilities.vex
@@ -1,0 +1,54 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "urn:deckhouse:vex:3a4f910385960098934503700078170889218760057250688085605068848460",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 2,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-61726",
+        "description": "Issues related to archive/zip processing"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Archive/zip processing - Функционал обработки и сжатия ZIP-архивов в стандартной библиотеке Go (stdlib) версии 1.25.5 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Приложение docs-builder не обращается к пакету archive/zip в процессе своего выполнения, что исключает возможность эксплуатации уязвимости.",
+      "timestamp": "2026-02-03T10:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-61728",
+        "description": "Potential memory overflow via malformed GET requests"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "Memory overflow via GET requests - Риск исчерпания памяти при обработке некорректных GET-запросов в библиотеке Go stdlib версии 1.25.5 нивелируется архитектурой среды исполнения. Сервис функционирует в контейнеризированной среде с жесткими лимитами ресурсов и автоматическим восстановлением (health recovery), что исключает возможность персистентного отказа в обслуживании, повреждения данных или эскалации привилегий.",
+      "timestamp": "2026-02-03T10:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2025-61730",
+        "description": "TLS information disclosure"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/stdlib@v1.25.5"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "TLS information disclosure - Эксплуатация уязвимости раскрытия информации в TLS-стеке библиотеки Go stdlib версии 1.25.5 требует специфических условий и высокой сложности атаки, которые отсутствуют в рамках текущей конфигурации развертывания. Вектор атаки признан непрактичным, так как уязвимый код эффективно изолирован от контроля со стороны злоумышленника.",
+      "timestamp": "2026-02-03T10:00:00Z"
+    }
+  ],
+  "timestamp": "2026-02-03T10:00:00Z"
+}

--- a/modules/810-documentation/images/docs-builder/werf.inc.yaml
+++ b/modules/810-documentation/images/docs-builder/werf.inc.yaml
@@ -1,2 +1,3 @@
 {{- $context := . }}
 {{ tpl (.Files.Get (printf "%sdocs/site/werf-docs-builder.inc.yaml" .ModulePath)) $context }}
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -281,8 +281,9 @@ var DefaultImagesDigests = map[string]interface{}{
 		"deschedulerVexArtifact": "imageHash-descheduler-deschedulerVexArtifact",
 	},
 	"documentation": map[string]interface{}{
-		"docsBuilder": "imageHash-documentation-docsBuilder",
-		"web":         "imageHash-documentation-web",
+		"docsBuilder":            "imageHash-documentation-docsBuilder",
+		"docsBuilderVexArtifact": "imageHash-documentation-docsBuilderVexArtifact",
+		"web":                    "imageHash-documentation-web",
 	},
 	"extendedMonitoring": map[string]interface{}{
 		"eventsExporter":             "imageHash-extendedMonitoring-eventsExporter",


### PR DESCRIPTION
## Description
Add vexes to docs-builder
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Users should be warned that we are aware of the bugs and they do not pose a threat.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs-builder
type: chore
summary: Fix trivy toolchain error
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
