### PR TITLE
[dhctl] Dhctl fix in SSH tunnel preflight check.

### DIFF
--- a/dhctl/pkg/preflight/ssh.go
+++ b/dhctl/pkg/preflight/ssh.go
@@ -212,7 +212,7 @@ func startHttpServer(ctx context.Context, port int) (shutdownServerFunc, error) 
 
 	client := &http.Client{}
 
-	err = retry.NewSilentLoop("Check HTTP server running for tunnel preflight check", 50, 100*time.Millisecond).RunContext(ctx, func() error {
+	err = retry.NewSilentLoop("Check HTTP server running for tunnel preflight check", 5, 100*time.Millisecond).RunContext(ctx, func() error {
 		cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 		defer cancel() // Ensure the context is canceled to release resources
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr fix dhctl race condition when we verifying connectivity for SSH tunnel but HTTP server cannot start for some reasons.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fixed intermittent "connection refused" errors during cluster bootstrap when running dhctl. The preflight check now reliably starts the HTTP server before verifying connectivity.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed dhctl in SSH tunnel preflight check.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
