### PR TITLE
[registry-packages-proxy] Resolve golangci-lint issues

### DIFF
--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/cache/cache.go
@@ -126,10 +126,11 @@ func (c *Cache) Set(digest string, layerDigest string, reader io.Reader) error {
 	}
 
 	file, err := os.Create(path)
-	defer file.Close()
 	if err != nil {
 		return err
 	}
+	defer file.Close()
+
 	size, err := io.Copy(file, reader)
 	if err != nil {
 		return err
@@ -310,11 +311,11 @@ func (c *Cache) checkHashIsOK(layerDigest string) bool {
 	path := c.layerDigestToPath(layerDigest)
 	c.logger.Info("checking hash sum of file in the cache", slog.String("layer_digest", layerDigest), slog.String("path", path))
 	file, err := os.Open(path)
-	defer file.Close()
 	if err != nil {
 		c.logger.Warn("failed to open file", slog.String("path", path), log.Err(err))
 		return false
 	}
+	defer file.Close()
 
 	h := sha256.New()
 	if _, err := io.Copy(h, file); err != nil {

--- a/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
+++ b/modules/039-registry-packages-proxy/images/registry-packages-proxy/src/internal/credentials/watcher.go
@@ -161,7 +161,7 @@ func (w *Watcher) watchModuleSources(ctx context.Context) {
 
 	moduleSourcesWatcher, err := toolsWatch.NewRetryWatcher("1", &cache.ListWatch{WatchFunc: watchFunc})
 	if err != nil {
-		w.logger.Errorf("Watch module sources: %v", err)
+		w.logger.Error("Watch module sources: %v", err)
 		return
 	}
 	defer moduleSourcesWatcher.Stop()
@@ -179,7 +179,7 @@ func (w *Watcher) watchModuleSources(ctx context.Context) {
 
 			err = w.processModuleSourceEvent(event)
 			if err != nil {
-				w.logger.Errorf("Process module source event: %v", err)
+				w.logger.Error("Process module source event: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Resolve golangci-lint issues

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry-packages-proxy
type: chore
summary: Resolve golangci-lint issues.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
