### PR TITLE
[registrypackages] Toml-merge go linter fixes

### DIFF
--- a/modules/007-registrypackages/images/toml-merge/src/toml-merge.go
+++ b/modules/007-registrypackages/images/toml-merge/src/toml-merge.go
@@ -36,7 +36,7 @@ Version %s.
 Copyright 2023 Flant JSC.
 Licensed under the Apache License, Version 2.0.
 http://www.apache.org/licenses/LICENSE-2.0
-`, os.Args[0])
+`, os.Args[0], version)
 }
 
 func main() {
@@ -45,13 +45,19 @@ func main() {
 		os.Exit(0)
 	}
 
+	if err := merge(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func merge() error {
 	inFiles := os.Args[1 : len(os.Args)-1]
 	outFile := os.Args[len(os.Args)-1]
 
 	out, err := toml.Merge(inFiles)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return fmt.Errorf("%w", err)
 	}
 
 	var f *os.File
@@ -60,8 +66,7 @@ func main() {
 	} else {
 		f, err = os.OpenFile(outFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			return fmt.Errorf("%w", err)
 		}
 		defer f.Close()
 	}
@@ -69,13 +74,12 @@ func main() {
 	writer := bufio.NewWriter(f)
 	_, err = writer.Write(out)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return fmt.Errorf("%w", err)
 	}
 
 	err = writer.Flush()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		return fmt.Errorf("%w", err)
 	}
+	return nil
 }


### PR DESCRIPTION
## Description
- `version` was missing from `usage()` output
- Deferred function f.Close could be skipped if an error called os.Exit. Added nested function `merge()` so deferred call is declared there, but `main()` handles the exit.

```
Running golangci-lint in in ./modules/007-registrypackages/images/toml-merge/src
============================================================

0 issues.
```

## Why do we need it, and what problem does it solve?
Fixes golang linter issues:
```
/deckhouse/modules/007-registrypackages/images/toml-merge/src   main  (⎈|N/A:N/A) golangci-lint run
modules/007-registrypackages/images/toml-merge/src/toml-merge.go:73:3: exitAfterDefer: os.Exit will exit, and `defer f.Close()` will not run (gocritic)
		os.Exit(1)
		^
modules/007-registrypackages/images/toml-merge/src/toml-merge.go:35:9: printf: fmt.Printf format %s reads arg #2, but call has 1 arg (govet)
Version %s.
        ^
modules/007-registrypackages/images/toml-merge/src/toml-merge.go:30:13: SA5009: Printf format %s reads arg #2, but call has only 1 args (staticcheck)
	fmt.Printf(`Usage: %s SOURCE ... DEST
	           ^
modules/007-registrypackages/images/toml-merge/src/toml-merge.go:27:7: const version is unused (unused)
const version = "0.1"
      ^
4 issues:
* gocritic: 1
* govet: 1
* staticcheck: 1
* unused: 1
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: chore
summary: Toml-merge go refactoring.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
