### PR TITLE
[prometheus] Use configuration-snippet annotation for redirects

### DIFF
--- a/modules/300-prometheus/templates/grafana/ingress-grafana-redirect.yaml
+++ b/modules/300-prometheus/templates/grafana/ingress-grafana-redirect.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      return 301 {{ printf "%s://%s/redirect-to/observability/dashboard/$1$is_args$args" (ternary "https" "http" (ne (include "helm_lib_module_https_ingress_tls_enabled" .) "")) (include "helm_lib_module_public_domain" (list . "console")) }}
+      return 301 {{ printf "%s://%s/redirect-to/observability/dashboard/$1$is_args$args" (ternary "https" "http" (ne (include "helm_lib_module_https_ingress_tls_enabled" .) "")) (include "helm_lib_module_public_domain" (list . "console")) }};
       {{ include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}

--- a/modules/300-prometheus/templates/prometheus/ingress-prometheus-redirect.yaml
+++ b/modules/300-prometheus/templates/prometheus/ingress-prometheus-redirect.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      return 301 {{ printf "%s://%s/redirect-to/observability/prometheus-status" (ternary "https" "http" (ne (include "helm_lib_module_https_ingress_tls_enabled" .) "")) (include "helm_lib_module_public_domain" (list . "console")) | quote }}
+      return 301 {{ printf "%s://%s/redirect-to/observability/prometheus-status" (ternary "https" "http" (ne (include "helm_lib_module_https_ingress_tls_enabled" .) "")) (include "helm_lib_module_public_domain" (list . "console")) | quote }};
       {{ include "helm_lib_module_ingress_configuration_snippet" $ | nindent 6 }}
 spec:
   ingressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}


### PR DESCRIPTION
## Description
In #16988 smart redirects to Deckhouse UI were added; the change was not tested against the Ingress Controller v1.12. It turns out that strict annotation checks were enabled by default starting with this version. It's not allowed to use any kind of nginx variables in `nginx.ingress.kubernetes.io/permanent-redirect` annotation, so the approach used in the previous PR will not work in conjunction with annotation validation.

This change switches to the good old configuration-snippet annotation to solve the issue.

## Why do we need it, and what problem does it solve?
When annotation validation is enabled, it's not possible to switch off Grafana due to the validating webhook errors.

## Why do we need it in the patch release (if we do)?
Some users who have already disabled Grafana have to re-enable it because the Deckhouse queue is hung due to this bug. So it would be nice to have this fix in the next patch release.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: prometheus
type: fix
summary: Make Grafana redirect ingress pass the annotations validation.
impact_level: default
```