### PR TITLE
[ingress-nginx] backport fix CVE-2026-1580 CVE-2026-24512 CVE-2026-24513 CVE-2026-24514 CVEs

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/024-cve-03022026-controller.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/024-cve-03022026-controller.patch
@@ -1,0 +1,99 @@
+diff --git a/internal/admission/controller/server.go b/internal/admission/controller/server.go
+index 7fc61bcbb..a7bf20106 100644
+--- a/internal/admission/controller/server.go
++++ b/internal/admission/controller/server.go
+@@ -28,6 +28,12 @@ import (
+ 
+ var scheme = runtime.NewScheme()
+ 
++// The Kubernetes default is 3 MB.
++// Multiply by 3 to be safe
++//
++// https://github.com/kubernetes/kubernetes/blob/3025b0a7b4b9fba6110759e905346ead5c9c0720/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/buffers.go#L47
++const maxBodySizeBytes = 9 * 1024 * 1024 //  9 MB
++
+ func init() {
+ 	if err := admissionv1.AddToScheme(scheme); err != nil {
+ 		klog.ErrorS(err, "Failed to add scheme")
+@@ -59,12 +65,20 @@ func NewAdmissionControllerServer(ac AdmissionController) *AdmissionControllerSe
+ func (acs *AdmissionControllerServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+ 	defer req.Body.Close()
+ 
+-	data, err := io.ReadAll(req.Body)
++	lr := io.LimitReader(req.Body, maxBodySizeBytes)
++	data, err := io.ReadAll(lr)
+ 	if err != nil {
+ 		klog.ErrorS(err, "Failed to read request body")
+ 		w.WriteHeader(http.StatusBadRequest)
+ 		return
+ 	}
++	if len(data) == maxBodySizeBytes {
++		// buffer full, request is too large
++		klog.Errorf("Request body too large. Max is %d bytes", maxBodySizeBytes-1)
++		w.WriteHeader(http.StatusRequestEntityTooLarge)
++		return
++	}
++	klog.ErrorS(nil, "Admission review request received", "body", len(data))
+ 
+ 	codec := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{
+ 		Pretty: true,
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index ad38c36b1..4e5c88173 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -247,7 +247,7 @@ func (e1 *Config) Equal(e2 *Config) bool {
+ }
+ 
+ var (
+-	methodsRegex    = regexp.MustCompile("(GET|HEAD|POST|PUT|PATCH|DELETE|CONNECT|OPTIONS|TRACE)")
++	methodsRegex    = regexp.MustCompile("^(GET|HEAD|POST|PUT|PATCH|DELETE|CONNECT|OPTIONS|TRACE)$")
+ 	headerRegexp    = regexp.MustCompile(`^[a-zA-Z\d\-_]+$`)
+ 	statusCodeRegex = regexp.MustCompile(`^\d{3}$`)
+ 	durationRegex   = regexp.MustCompile(`^\d+(ms|s|m|h|d|w|M|y)$`) // see http://nginx.org/en/docs/syntax.html
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index c5345e65f..e07a9ee73 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -243,6 +243,7 @@ var funcMap = text_template.FuncMap{
+ 	"buildLuaSharedDictionaries":      buildLuaSharedDictionaries,
+ 	"luaConfigurationRequestBodySize": luaConfigurationRequestBodySize,
+ 	"buildLocation":                   buildLocation,
++	"sanitizeQuotedRegex":             sanitizeQuotedRegex,
+ 	"buildAuthLocation":               buildAuthLocation,
+ 	"shouldApplyGlobalAuth":           shouldApplyGlobalAuth,
+ 	"buildAuthResponseHeaders":        buildAuthResponseHeaders,
+@@ -554,16 +555,30 @@ func buildLocation(input interface{}, enforceRegex bool) string {
+ 		return slash
+ 	}
+ 
+-	path := location.Path
++	path := sanitizeQuotedRegex(location.Path)
+ 	if enforceRegex {
+ 		return fmt.Sprintf(`~* "^%s"`, path)
+ 	}
+-
+ 	if location.PathType != nil && *location.PathType == networkingv1.PathTypeExact {
+-		return fmt.Sprintf(`= %s`, path)
++		return fmt.Sprintf(`= "%s"`, path)
+ 	}
+ 
+-	return path
++	return fmt.Sprintf(`"%s"`, path)
++}
++
++// sanitizeQuotedRegex escapes backslashes and double quotes in a location path
++// so paths cannot escape NGINX configuration.
++func sanitizeQuotedRegex(path string) string {
++	builder := strings.Builder{}
++	builder.Grow(2 * len(path))
++	// note that iterating over a string iterates over its runes, not bytes
++	for _, r := range path {
++		if r == '\\' || r == '"' {
++			builder.WriteByte('\\')
++		}
++		builder.WriteRune(r)
++	}
++	return builder.String()
+ }
+ 
+ func buildAuthLocation(input interface{}, globalExternalAuthURL string) string {

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/025-cve-03022026-rootfs.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/025-cve-03022026-rootfs.patch
@@ -1,0 +1,30 @@
+diff --git a/etc/nginx/template/nginx.tmpl b/etc/nginx/template/nginx.tmpl
+index a273a28ec..24d4367c1 100644
+--- a/etc/nginx/template/nginx.tmpl
++++ b/etc/nginx/template/nginx.tmpl
+@@ -594,7 +594,7 @@ http {
+     {{ range $redirect := .RedirectServers }}
+     ## start server {{ $redirect.From }}
+     server {
+-        server_name {{ $redirect.From }};
++        server_name {{ $redirect.From | quote }};
+ 
+         {{ buildHTTPListener  $all $redirect.From }}
+         {{ buildHTTPSListener $all $redirect.From }}
+@@ -669,7 +669,7 @@ http {
+     {{ range $server := $servers }}
+     ## start server {{ $server.Hostname }}
+     server {
+-        server_name {{ buildServerName $server.Hostname }} {{range $server.Aliases }}{{ . }} {{ end }};
++        server_name {{ buildServerName $server.Hostname | quote }} {{ range $server.Aliases }}"{{ sanitizeQuotedRegex . }}" {{ end }};
+ 
+         {{ if $cfg.UseHTTP2 }}
+             http2 on;
+@@ -1136,6 +1136,7 @@ stream {
+             # resumes it has the correct value set for this variable so that Lua can pick backend correctly
+             set $proxy_upstream_name {{ buildUpstreamName $location | quote }};
+ 
++            proxy_intercept_errors      off;
+             proxy_pass_request_body     off;
+             proxy_set_header            Content-Length          "";
+             proxy_set_header            X-Forwarded-Proto       "";

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -123,3 +123,21 @@ This patch adds a metric that reflects current GeoIP version in use (0 - no geoi
 
 ### 021-skip-tls-verification-maxmind.patch
 Adds a flag to disable TLS verification when downloading from the MaxMind mirror.
+
+### 024-cve-03022026-controller.patch
+
+Fixes the following CVEs:
+CVE-2026-1580
+CVE-2026-24512
+CVE-2026-24513
+CVE-2026-24514
+https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts
+
+### 025-cve-03022026-rootfs.patch
+
+Fixes the following CVEs (rootfs part):
+CVE-2026-1580
+CVE-2026-24512
+CVE-2026-24513
+CVE-2026-24514
+https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -60,10 +60,12 @@ shell:
   - patch -p1 < /patches/019-fix-sorting.patch
   - patch -p1 < /patches/020-geoip-ver-metric.patch
   - patch -p1 < /patches/021-skip-tls-verification-maxmind.patch
+  - patch -p1 < /patches/024-cve-03022026-controller.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch
   - patch -p1 < /patches/007-auth-cookie-always.patch
+  - patch -p1 < /patches/025-cve-03022026-rootfs.patch
   # pass env for build
   - cd /src/ingress-nginx
   - echo "export COMMIT_SHA=git-$(git rev-parse --short HEAD)" > .env_pass

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/022-cve-03022026.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/022-cve-03022026.patch
@@ -1,0 +1,129 @@
+diff --git a/internal/admission/controller/server.go b/internal/admission/controller/server.go
+index 74f55fd01..4cab8a9d0 100644
+--- a/internal/admission/controller/server.go
++++ b/internal/admission/controller/server.go
+@@ -28,6 +28,12 @@ import (
+ 
+ var scheme = runtime.NewScheme()
+ 
++// The Kubernetes default is 3 MB.
++// Multiply by 3 to be safe
++//
++// https://github.com/kubernetes/kubernetes/blob/3025b0a7b4b9fba6110759e905346ead5c9c0720/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/buffers.go#L47
++const maxBodySizeBytes = 9 * 1024 * 1024 //  9 MB
++
+ func init() {
+ 	if err := admissionv1.AddToScheme(scheme); err != nil {
+ 		klog.ErrorS(err, "Failed to add scheme")
+@@ -59,12 +65,20 @@ func NewAdmissionControllerServer(ac AdmissionController) *AdmissionControllerSe
+ func (acs *AdmissionControllerServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+ 	defer req.Body.Close()
+ 
+-	data, err := io.ReadAll(req.Body)
++	lr := io.LimitReader(req.Body, maxBodySizeBytes)
++	data, err := io.ReadAll(lr)
+ 	if err != nil {
+ 		klog.ErrorS(err, "Failed to read request body")
+ 		w.WriteHeader(http.StatusBadRequest)
+ 		return
+ 	}
++	if len(data) == maxBodySizeBytes {
++		// buffer full, request is too large
++		klog.Errorf("Request body too large. Max is %d bytes", maxBodySizeBytes-1)
++		w.WriteHeader(http.StatusRequestEntityTooLarge)
++		return
++	}
++	klog.ErrorS(nil, "Admission review request received", "body", len(data))
+ 
+ 	codec := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{
+ 		Pretty: true,
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index ad38c36b1..4e5c88173 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -247,7 +247,7 @@ func (e1 *Config) Equal(e2 *Config) bool {
+ }
+ 
+ var (
+-	methodsRegex    = regexp.MustCompile("(GET|HEAD|POST|PUT|PATCH|DELETE|CONNECT|OPTIONS|TRACE)")
++	methodsRegex    = regexp.MustCompile("^(GET|HEAD|POST|PUT|PATCH|DELETE|CONNECT|OPTIONS|TRACE)$")
+ 	headerRegexp    = regexp.MustCompile(`^[a-zA-Z\d\-_]+$`)
+ 	statusCodeRegex = regexp.MustCompile(`^\d{3}$`)
+ 	durationRegex   = regexp.MustCompile(`^\d+(ms|s|m|h|d|w|M|y)$`) // see http://nginx.org/en/docs/syntax.html
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index e2f5d035d..8cb5730ab 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -279,6 +279,7 @@ var funcMap = text_template.FuncMap{
+ 	"buildLuaSharedDictionaries":      buildLuaSharedDictionaries,
+ 	"luaConfigurationRequestBodySize": luaConfigurationRequestBodySize,
+ 	"buildLocation":                   buildLocation,
++	"sanitizeQuotedRegex":             sanitizeQuotedRegex,
+ 	"buildAuthLocation":               buildAuthLocation,
+ 	"shouldApplyGlobalAuth":           shouldApplyGlobalAuth,
+ 	"buildAuthResponseHeaders":        buildAuthResponseHeaders,
+@@ -527,16 +528,30 @@ func buildLocation(input interface{}, enforceRegex bool) string {
+ 		return slash
+ 	}
+ 
+-	path := location.Path
++	path := sanitizeQuotedRegex(location.Path)
+ 	if enforceRegex {
+ 		return fmt.Sprintf(`~* "^%s"`, path)
+ 	}
+-
+ 	if location.PathType != nil && *location.PathType == networkingv1.PathTypeExact {
+-		return fmt.Sprintf(`= %s`, path)
++		return fmt.Sprintf(`= "%s"`, path)
+ 	}
+ 
+-	return path
++	return fmt.Sprintf(`"%s"`, path)
++}
++
++// sanitizeQuotedRegex escapes backslashes and double quotes in a location path
++// so paths cannot escape NGINX configuration.
++func sanitizeQuotedRegex(path string) string {
++	builder := strings.Builder{}
++	builder.Grow(2 * len(path))
++	// note that iterating over a string iterates over its runes, not bytes
++	for _, r := range path {
++		if r == '\\' || r == '"' {
++			builder.WriteByte('\\')
++		}
++		builder.WriteRune(r)
++	}
++	return builder.String()
+ }
+ 
+ func buildAuthLocation(input interface{}, globalExternalAuthURL string) string {
+diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
+index b60715185..f2124720e 100644
+--- a/rootfs/etc/nginx/template/nginx.tmpl
++++ b/rootfs/etc/nginx/template/nginx.tmpl
+@@ -562,7 +562,7 @@ http {
+     {{ range $redirect := .RedirectServers }}
+     ## start server {{ $redirect.From }}
+     server {
+-        server_name {{ $redirect.From }};
++        server_name {{ $redirect.From | quote }};
+ 
+         {{ buildHTTPListener  $all $redirect.From }}
+         {{ buildHTTPSListener $all $redirect.From }}
+@@ -612,7 +612,7 @@ http {
+     {{ range $server := $servers }}
+     ## start server {{ $server.Hostname }}
+     server {
+-        server_name {{ buildServerName $server.Hostname }} {{range $server.Aliases }}{{ . }} {{ end }};
++        server_name {{ buildServerName $server.Hostname | quote }} {{ range $server.Aliases }}"{{ sanitizeQuotedRegex . }}" {{ end }};
+ 
+         {{ if $cfg.UseHTTP2 }}
+             http2 on;
+@@ -1024,6 +1024,7 @@ stream {
+             # resumes it has the correct value set for this variable so that Lua can pick backend correctly
+             set $proxy_upstream_name {{ buildUpstreamName $location | quote }};
+ 
++            proxy_intercept_errors      off;
+             proxy_pass_request_body     off;
+             proxy_set_header            Content-Length          "";
+             proxy_set_header            X-Forwarded-Proto       "";

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -110,3 +110,12 @@ This patch adds a metric that reflects current GeoIP version in use (0 - no geoi
 
 ### 019-skip-tls-verification-maxmind.patch
 Adds a flag to disable TLS verification when downloading from the MaxMind mirror.
+
+### 022-cve-03022026.patch
+
+Fixes the following CVEs:
+CVE-2026-1580
+CVE-2026-24512
+CVE-2026-24513
+CVE-2026-24514
+https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/021-cve-03022026.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/021-cve-03022026.patch
@@ -1,0 +1,99 @@
+diff --git a/internal/admission/controller/server.go b/internal/admission/controller/server.go
+index 7fc61bcbb..a7bf20106 100644
+--- a/internal/admission/controller/server.go
++++ b/internal/admission/controller/server.go
+@@ -28,6 +28,12 @@ import (
+ 
+ var scheme = runtime.NewScheme()
+ 
++// The Kubernetes default is 3 MB.
++// Multiply by 3 to be safe
++//
++// https://github.com/kubernetes/kubernetes/blob/3025b0a7b4b9fba6110759e905346ead5c9c0720/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes/buffers.go#L47
++const maxBodySizeBytes = 9 * 1024 * 1024 //  9 MB
++
+ func init() {
+ 	if err := admissionv1.AddToScheme(scheme); err != nil {
+ 		klog.ErrorS(err, "Failed to add scheme")
+@@ -59,12 +65,20 @@ func NewAdmissionControllerServer(ac AdmissionController) *AdmissionControllerSe
+ func (acs *AdmissionControllerServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+ 	defer req.Body.Close()
+ 
+-	data, err := io.ReadAll(req.Body)
++	lr := io.LimitReader(req.Body, maxBodySizeBytes)
++	data, err := io.ReadAll(lr)
+ 	if err != nil {
+ 		klog.ErrorS(err, "Failed to read request body")
+ 		w.WriteHeader(http.StatusBadRequest)
+ 		return
+ 	}
++	if len(data) == maxBodySizeBytes {
++		// buffer full, request is too large
++		klog.Errorf("Request body too large. Max is %d bytes", maxBodySizeBytes-1)
++		w.WriteHeader(http.StatusRequestEntityTooLarge)
++		return
++	}
++	klog.ErrorS(nil, "Admission review request received", "body", len(data))
+ 
+ 	codec := json.NewSerializerWithOptions(json.DefaultMetaFactory, scheme, scheme, json.SerializerOptions{
+ 		Pretty: true,
+diff --git a/internal/ingress/annotations/authreq/main.go b/internal/ingress/annotations/authreq/main.go
+index c66b0ed47..e931d4f4c 100644
+--- a/internal/ingress/annotations/authreq/main.go
++++ b/internal/ingress/annotations/authreq/main.go
+@@ -247,7 +247,7 @@ func (e1 *Config) Equal(e2 *Config) bool {
+ }
+ 
+ var (
+-	methodsRegex    = regexp.MustCompile("(GET|HEAD|POST|PUT|PATCH|DELETE|CONNECT|OPTIONS|TRACE)")
++	methodsRegex    = regexp.MustCompile("^(GET|HEAD|POST|PUT|PATCH|DELETE|CONNECT|OPTIONS|TRACE)$")
+ 	headerRegexp    = regexp.MustCompile(`^[a-zA-Z\d\-_]+$`)
+ 	statusCodeRegex = regexp.MustCompile(`^\d{3}$`)
+ 	durationRegex   = regexp.MustCompile(`^\d+(ms|s|m|h|d|w|M|y)$`) // see http://nginx.org/en/docs/syntax.html
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index b03c85a83..c80cda4c8 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -229,6 +229,7 @@ var funcMap = text_template.FuncMap{
+ 	"buildLuaSharedDictionaries":      buildLuaSharedDictionaries,
+ 	"luaConfigurationRequestBodySize": luaConfigurationRequestBodySize,
+ 	"buildLocation":                   buildLocation,
++	"sanitizeQuotedRegex":             sanitizeQuotedRegex,
+ 	"buildAuthLocation":               buildAuthLocation,
+ 	"shouldApplyGlobalAuth":           shouldApplyGlobalAuth,
+ 	"buildAuthResponseHeaders":        buildAuthResponseHeaders,
+@@ -539,16 +540,30 @@ func buildLocation(input interface{}, enforceRegex bool) string {
+ 		return slash
+ 	}
+ 
+-	path := location.Path
++	path := sanitizeQuotedRegex(location.Path)
+ 	if enforceRegex {
+ 		return fmt.Sprintf(`~* "^%s"`, path)
+ 	}
+-
+ 	if location.PathType != nil && *location.PathType == networkingv1.PathTypeExact {
+-		return fmt.Sprintf(`= %s`, path)
++		return fmt.Sprintf(`= "%s"`, path)
+ 	}
+ 
+-	return path
++	return fmt.Sprintf(`"%s"`, path)
++}
++
++// sanitizeQuotedRegex escapes backslashes and double quotes in a location path
++// so paths cannot escape NGINX configuration.
++func sanitizeQuotedRegex(path string) string {
++	builder := strings.Builder{}
++	builder.Grow(2 * len(path))
++	// note that iterating over a string iterates over its runes, not bytes
++	for _, r := range path {
++		if r == '\\' || r == '"' {
++			builder.WriteByte('\\')
++		}
++		builder.WriteRune(r)
++	}
++	return builder.String()
+ }
+ 
+ func buildAuthLocation(input interface{}, globalExternalAuthURL string) string {

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
@@ -91,3 +91,12 @@ This patch adds a metric that reflects current GeoIP version in use (0 - no geoi
 
 ### 018-skip-tls-verification-maxmind.patch
 Adds a flag to disable TLS verification when downloading from the MaxMind mirror.
+
+### 021-cve-03022026.patch
+
+Fixes the following CVEs:
+CVE-2026-1580
+CVE-2026-24512
+CVE-2026-24513
+CVE-2026-24514
+https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/004-cve-03022026.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/004-cve-03022026.patch
@@ -1,0 +1,30 @@
+diff --git a/etc/nginx/template/nginx.tmpl b/etc/nginx/template/nginx.tmpl
+index 2e11d39e1..b237283bb 100644
+--- a/etc/nginx/template/nginx.tmpl
++++ b/etc/nginx/template/nginx.tmpl
+@@ -604,7 +604,7 @@ http {
+     {{ range $redirect := .RedirectServers }}
+     ## start server {{ $redirect.From }}
+     server {
+-        server_name {{ $redirect.From }};
++        server_name {{ $redirect.From | quote }};
+ 
+         {{ buildHTTPListener  $all $redirect.From }}
+         {{ buildHTTPSListener $all $redirect.From }}
+@@ -676,7 +676,7 @@ http {
+     {{ range $server := $servers }}
+     ## start server {{ $server.Hostname }}
+     server {
+-        server_name {{ buildServerName $server.Hostname }} {{range $server.Aliases }}{{ . }} {{ end }};
++        server_name {{ buildServerName $server.Hostname | quote }} {{ range $server.Aliases }}"{{ sanitizeQuotedRegex . }}" {{ end }};
+ 
+         {{ if gt (len $cfg.BlockUserAgents) 0 }}
+         if ($block_ua) {
+@@ -1136,6 +1136,7 @@ stream {
+             # resumes it has the correct value set for this variable so that Lua can pick backend correctly
+             set $proxy_upstream_name {{ buildUpstreamName $location | quote }};
+ 
++            proxy_intercept_errors      off;
+             proxy_pass_request_body     off;
+             proxy_set_header            Content-Length          "";
+             proxy_set_header            X-Forwarded-Proto       "";

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/README.md
@@ -21,3 +21,12 @@ Without always option toggled, ingress-nginx does not set the cookie in case if 
 Annotation `nginx.ingress.kubernetes.io/auth-always-set-cookie` does not work. Anyway, we can't use it, because we need this behavior for all ingresses.
 
 https://github.com/kubernetes/ingress-nginx/pull/8213
+
+### 004-cve-03022026.patch
+
+Fixes the following CVEs:
+CVE-2026-1580
+CVE-2026-24512
+CVE-2026-24513
+CVE-2026-24514
+https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -75,10 +75,12 @@ shell:
   - patch -p1 < /patches/ingress-nginx/016-fix-sorting.patch
   - patch -p1 < /patches/ingress-nginx/017-geoip-ver-metric.patch
   - patch -p1 < /patches/ingress-nginx/018-skip-tls-verification-maxmind.patch
+  - patch -p1 < /patches/ingress-nginx/021-cve-03022026.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/rootfs/001-balancer-lua.patch
   - patch -p1 < /patches/rootfs/002-nginx-tmpl.patch
   - patch -p1 < /patches/rootfs/003-auth-cookie-always.patch
+  - patch -p1 < /patches/rootfs/004-cve-03022026.patch
   - rm -r /src/dumb-init/.git
   - rm -r /src/lua-protobuf/.git
   - rm -r /src/lua-iconv/.git


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr backports the fix for the following CVEs:
CVE-2026-1580
CVE-2026-24512
CVE-2026-24513
CVE-2026-24514

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
To fix the mentioned CVEs.

## Why do we need it in the patch release (if we do)?
No doubt it's a critical security fix.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: The CVE-2026-1580, CVE-2026-24512, CVE-2026-24513, CVE-2026-24514 CVEs fixes are backported.
impact: The ingress nginx controllers' pods will be restated.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->