### PR TITLE
[node-manager] fix: update monitoring template

### DIFF
--- a/ee/modules/040-node-manager/templates/monitoring.yaml
+++ b/ee/modules/040-node-manager/templates/monitoring.yaml
@@ -1,4 +1,3 @@
-{{- if not (.Values.global.enabledModules | has "gpu") }}
 {{- $prometheusRules := list
   "monitoring/prometheus-rules/caps-nodes.tpl"
   "monitoring/prometheus-rules/cloud-data-discovery.tpl"
@@ -24,6 +23,7 @@
 
 {{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager" $prometheusRules) }}
 
+{{- if not (.Values.global.enabledModules | has "gpu") }}
 {{- if include "nvidia_gpu_enabled" . }}
   {{- include "helm_lib_grafana_dashboard_definitions" . }}
 {{- end }}


### PR DESCRIPTION
## Description
Fix incorrect condition in the monitoring template

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: node-manager
type: fix
summary: "Monitoring resource rendering does not depend on the availability of the *gpu* module"
impact_level: low
```