### PR TITLE
[admission-policy-engine] Fix ValidatingAdmissionPolicy for label gatekeeper.sh/operation=webhook

### DIFF
--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -95,27 +95,19 @@ spec:
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
         resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+        scope: "*"
       - apiGroups: ["batch"]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
-        resources: ["jobs", "cronjobs"]
+        resources: ["jobs"]
+        scope: "*"
   validations:
-    # deployments/rs/sts/ds + jobs
-    - expression: >-
-        request.resource.resource == 'cronjobs'
-        || !(has(object.spec.template.metadata.labels) &&
-             object.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook')
+    - expression: |-
+        !(has(object.spec.template.metadata.labels) &&
+          object.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook')
         || request.userInfo.username.startsWith("system:serviceaccount:d8-")
         || request.userInfo.username.startsWith("system:serviceaccount:kube-")
-      message: "Setting gatekeeper.sh/operation=webhook in pod template is forbidden"
-    # cronjobs
-    - expression: >-
-        request.resource.resource != 'cronjobs'
-        || !(has(object.spec.jobTemplate.spec.template.metadata.labels) &&
-             object.spec.jobTemplate.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook')
-        || request.userInfo.username.startsWith("system:serviceaccount:d8-")
-        || request.userInfo.username.startsWith("system:serviceaccount:kube-")
-      message: "Setting gatekeeper.sh/operation=webhook in CronJob pod template is forbidden"
+      message: Setting gatekeeper.sh/operation=webhook in pod template is forbidden
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
 kind: ValidatingAdmissionPolicyBinding
@@ -124,4 +116,35 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper")) | nindent 2 }}
 spec:
   policyName: deny-gatekeeper-webhook-operation-label-controllers
+  validationActions: [Deny]
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicy") }}
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-gatekeeper-webhook-operation-label-controllers-cronjobs
+  {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper")) | nindent 2 }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["cronjobs"]
+        scope: "*"
+  validations:
+    - expression: |-
+        !(has(object.spec.jobTemplate.spec.template.metadata.labels) &&
+          object.spec.jobTemplate.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook')
+        || request.userInfo.username.startsWith("system:serviceaccount:d8-")
+        || request.userInfo.username.startsWith("system:serviceaccount:kube-")
+      message: Setting gatekeeper.sh/operation=webhook in CronJob pod template is forbidden
+---
+apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "deny-gatekeeper-webhook-operation-label-controllers-cronjobs-binding"
+  {{- include "helm_lib_module_labels" (list . (dict "app" "gatekeeper")) | nindent 2 }}
+spec:
+  policyName: deny-gatekeeper-webhook-operation-label-controllers-cronjobs
   validationActions: [Deny]


### PR DESCRIPTION
## Description
Updated Gatekeeper-related ValidatingAdmissionPolicies to correctly block using the `gatekeeper.sh/operation=webhook` label on Pods and workload pod templates, while allowing internal Deckhouse and Kubernetes serviceaccounts.

## Why do we need it, and what problem does it solve?
The existing ValidatingAdmissionPolicy only covered direct Pod creates/updates and could be bypassed by setting `gatekeeper.sh/operation=webhook` inside controller templates (e.g., Deployments/Jobs). This change closes that gap by validating workload resources that generate Pods from templates.

Additionally, the policy now explicitly allows `system:serviceaccount:kube-*` alongside `system:serviceaccount:d8-*` to avoid blocking system components that may legitimately operate in Kubernetes system namespaces.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Fix ValidatingAdmissionPolicy for label gatekeeper.sh/operation=webhook
impact_level: low
```
