### PR TITLE
[extended-monitoring] Fix namespace monitoring toggle

### DIFF
--- a/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/watcher/watcher.go
+++ b/modules/340-extended-monitoring/images/extended-monitoring-exporter/src/watcher/watcher.go
@@ -117,7 +117,7 @@ func (w *Watcher) addNamespace(ctx context.Context, ns *v1.Namespace) {
 }
 
 func (w *Watcher) updateNamespace(ctx context.Context, ns *v1.Namespace) {
-	enabled := enabledLabel(ns.Labels)
+	enabled := enabledOnNamespace(ns.Labels)
 	w.metrics.NamespacesEnabled.WithLabelValues(ns.Name).Set(boolToFloat64(enabled))
 	log.Printf("[NAMESPACE UPDATE] %s", ns.Name)
 


### PR DESCRIPTION
## Description
There is yet another bug left after rewritting extended-monitoring exporter in Golang. An improper annotation check function was used in the namespace update handling function. This made it impossible to disable extended monitoring on a per-namespace basis.

## Why do we need it, and what problem does it solve?
This bug led to unsolicited and excessive alerting virtually from every namespace, with no option to disable it.

## Why do we need it in the patch release (if we do)?
It would be nice to have it ASAP because the bug brings a negative user experience.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: extended-monitoring
type: fix
summary: Fix namespace extended-monitoring toggle
impact: namespaces without a `extended-monitoring.deckhouse.io/enabled` label won't be monitored.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
