### PR TITLE
Update base_images from v0.5.50 → v0.5.51

### DIFF
--- a/candi/base_images.yml
+++ b/candi/base_images.yml
@@ -1,4 +1,4 @@
-# version=v0.5.50
+# version=v0.5.51
 # REGISTRY_PATH is a special key which is concatenated with other base images
 REGISTRY_PATH: registry.deckhouse.io/base_images
 base/distroless: "sha256:d44b8fadcf21012913301335e3bd8e96dfd6e10bdc4317e295c3d770f1c0ac2a" # from: builder/scratch
@@ -13,8 +13,8 @@ base/ruby-bundler-v3_4_7: "sha256:e6a80bd606afb83a258b939160b2c5fe1350003822384d
 base/ruby: "sha256:11aa322ba4ef4eced1612684c53f5ee4a195afddcbc283bfa7be7173990dc985" # from: base/distroless
 base/ruby-v3_4_7: "sha256:11aa322ba4ef4eced1612684c53f5ee4a195afddcbc283bfa7be7173990dc985" # from: base/distroless
 base/scratch: "sha256:cfac1c6b53f9365ee59ffe94c90211253f2a85ece372a6a9dfad61f4e0ab0bea" # from: builder/scratch
-base/shell-operator: "sha256:08270d68b0db9008ef74b6973b83e6a4d74b9d7ff128d2f6c03642f55643822f" # from: builder/scratch
-base/shell-operator-v1.9.3: "sha256:08270d68b0db9008ef74b6973b83e6a4d74b9d7ff128d2f6c03642f55643822f" # from: builder/scratch
+base/shell-operator: "sha256:f3556750cf8bcbf42b09d52b23fb7e1ae98ebabe273dfe90ce415b1d6b3fa4db" # from: builder/scratch
+base/shell-operator-v1.9.3: "sha256:f3556750cf8bcbf42b09d52b23fb7e1ae98ebabe273dfe90ce415b1d6b3fa4db" # from: builder/scratch
 builder/alpine-3.21: "sha256:e54195b7221b3977b2abe6daaf5fabc91add7aa0a3360cd5af590c5472bb3aa7" # from: alpine:3.21.5
 builder/alpine-3.22: "sha256:2ffd38fd342a64e79ed28cf52d71216bf119b28d96b9871184acfea672a7acc8" # from: alpine:3.22.2
 builder/alpine: "sha256:2ffd38fd342a64e79ed28cf52d71216bf119b28d96b9871184acfea672a7acc8" # from: alpine:3.22.2
@@ -29,30 +29,30 @@ builder/debian-svace-12.11-slim: "sha256:20109cd79726d2e5e7418e8a75c6cf796467d86
 builder/debian-svace: "sha256:3eaf3813bbfd39c44885f2f18c3d05cdd42aa5c67c6c88a64a3db01487ee8305" # from: builder/debian-trixie-slim
 builder/debian-svace-trixie-slim: "sha256:3eaf3813bbfd39c44885f2f18c3d05cdd42aa5c67c6c88a64a3db01487ee8305" # from: builder/debian-trixie-slim
 builder/debian-trixie-slim: "sha256:261d9b2d8d2f1b5a5d1565bd88d950e14722481b1ffc92553f1e8a2326ee7363" # from: debian:trixie-slim
-builder/golang-alpine-1.24: "sha256:0efc20a74dd3b6ec6b1a00bc987613d0cb250a8b21795697af58802280e3afc0" # from: builder/alpine
-builder/golang-alpine-1.25: "sha256:c2d3b7706c8dbc65ce3e57e2adc7c8aabe4cd5b44d60d17acbab26bd5cf55c6a" # from: builder/alpine
-builder/golang-alpine: "sha256:c2d3b7706c8dbc65ce3e57e2adc7c8aabe4cd5b44d60d17acbab26bd5cf55c6a" # from: builder/alpine
-builder/golang-alpine-svace-1.24: "sha256:3cefa92076fe6b5433404df8c16d67580b6df02cd0904b0ce3e350904c7bf323" # from: builder/golang-alpine-1.24
-builder/golang-alpine-svace-1.25: "sha256:e1bce841720088a44f3f5d57c04574e72276fbe86f84205af8c61550117fc54a" # from: builder/golang-alpine-1.25
-builder/golang-alpine-svace: "sha256:e1bce841720088a44f3f5d57c04574e72276fbe86f84205af8c61550117fc54a" # from: builder/golang-alpine-1.25
-builder/golang-alt-1.24: "sha256:381c5860c04904d012a2ee757ba6eeef329bc0a5578dcc04892fc18467236c0b" # from: builder/alt
-builder/golang-alt-1.25: "sha256:6462bd6c07f767f21f5959729e5f587f921ab13cd7972f071d1435ff94c81055" # from: builder/alt
-builder/golang-alt: "sha256:6462bd6c07f767f21f5959729e5f587f921ab13cd7972f071d1435ff94c81055" # from: builder/alt
-builder/golang-alt-svace-1.24: "sha256:2a8b2b9a4d5b16b81a2a50ea91bbb75d8fd2bc7d40004b604b59cbb321a8c8d3" # from: builder/golang-alt-1.24
-builder/golang-alt-svace-1.25: "sha256:5e0f9b3b17de26d87ce73548f00972e792a74186c52eaffd18bae0c2ee93d0a9" # from: builder/golang-alt-1.25
-builder/golang-alt-svace: "sha256:5e0f9b3b17de26d87ce73548f00972e792a74186c52eaffd18bae0c2ee93d0a9" # from: builder/golang-alt-1.25
-builder/golang-bookworm-1.24: "sha256:07c85cf7ba11ade59986137dc19225647c3414d6667948b21825855a2e35bf19" # from: golang:1.24.12-bookworm
-builder/golang-bookworm-1.25: "sha256:bd481290776fdf55020b817bb4040fa40638ffafe53c0cea542ecba553e76b57" # from: golang:1.25.6-bookworm
-builder/golang-bookworm: "sha256:bd481290776fdf55020b817bb4040fa40638ffafe53c0cea542ecba553e76b57" # from: golang:1.25.6-bookworm
-builder/golang-bookworm-svace-1.24: "sha256:ffbe8de3eda7dab1cbdfa39ab4c63d758a378d10dcfb3f77da55113c93501ad9" # from: builder/golang-bookworm-1.24
-builder/golang-bookworm-svace-1.25: "sha256:bb8dd15ede6f3a2e31cea4557e48b885724bed62f64c5850f5ae994811d41084" # from: builder/golang-bookworm-1.25
-builder/golang-bookworm-svace: "sha256:bb8dd15ede6f3a2e31cea4557e48b885724bed62f64c5850f5ae994811d41084" # from: builder/golang-bookworm-1.25
+builder/golang-alpine-1.24: "sha256:5d7346ae5dfd1f5c6e78dd285d9656b49b7926272bb93942ba6470d9d1d279f8" # from: builder/alpine
+builder/golang-alpine-1.25: "sha256:425f33f84bc87800267bb5bdfb96e3a356dd9c0b6046f7fe787cdf339c7215be" # from: builder/alpine
+builder/golang-alpine: "sha256:425f33f84bc87800267bb5bdfb96e3a356dd9c0b6046f7fe787cdf339c7215be" # from: builder/alpine
+builder/golang-alpine-svace-1.24: "sha256:cd46caf412999b7f3ee4d1ed29a0ef4cead6423fe4056222e80393592155b6e2" # from: builder/golang-alpine-1.24
+builder/golang-alpine-svace-1.25: "sha256:7bce2f3691208bd5174a35918151ead0a85bd1a0f07fbf97842be6582586309a" # from: builder/golang-alpine-1.25
+builder/golang-alpine-svace: "sha256:7bce2f3691208bd5174a35918151ead0a85bd1a0f07fbf97842be6582586309a" # from: builder/golang-alpine-1.25
+builder/golang-alt-1.24: "sha256:c936cfce282d666be6392e78b0008cb10dcaf0d6e299f5261f0f6cd25badcd06" # from: builder/alt
+builder/golang-alt-1.25: "sha256:e1f79798b704ba104eb84a38d1aa1f584cba8805313285efd40ca34a0d754291" # from: builder/alt
+builder/golang-alt: "sha256:e1f79798b704ba104eb84a38d1aa1f584cba8805313285efd40ca34a0d754291" # from: builder/alt
+builder/golang-alt-svace-1.24: "sha256:05d378e91966137a676f6fcb78a6b8ae0db90ffd770695d4512b2aa6824318ae" # from: builder/golang-alt-1.24
+builder/golang-alt-svace-1.25: "sha256:d7bf46f38bfddedb41f60a9ff59d3659723396c665ffcb41648c6081021c073f" # from: builder/golang-alt-1.25
+builder/golang-alt-svace: "sha256:d7bf46f38bfddedb41f60a9ff59d3659723396c665ffcb41648c6081021c073f" # from: builder/golang-alt-1.25
+builder/golang-bookworm-1.24: "sha256:bd7cdf28c1923fa71ffd8828e684e62c8f716d2e95b962ba3219beb400a3a1d8" # from: golang:1.24.13-bookworm
+builder/golang-bookworm-1.25: "sha256:6ae07a7d16a540e1dd56d5a7afbdaaf450894c74c6f1b4a497b212d61c023838" # from: golang:1.25.7-bookworm
+builder/golang-bookworm: "sha256:6ae07a7d16a540e1dd56d5a7afbdaaf450894c74c6f1b4a497b212d61c023838" # from: golang:1.25.7-bookworm
+builder/golang-bookworm-svace-1.24: "sha256:64d5178bf902a50df988958b0cc9cf00bb43663e128ac0a9826fcbbbb99aa8f8" # from: builder/golang-bookworm-1.24
+builder/golang-bookworm-svace-1.25: "sha256:df13a2341fea0ce53b5244bb69b76862dba03472b5a71953b3e0bb51269e72b6" # from: builder/golang-bookworm-1.25
+builder/golang-bookworm-svace: "sha256:df13a2341fea0ce53b5244bb69b76862dba03472b5a71953b3e0bb51269e72b6" # from: builder/golang-bookworm-1.25
 builder/golang-bullseye-1.24: "sha256:e694827623f7a8bf932c3b9462546095ddb404c9d094ae6a3240596d7c395e53" # from: golang:1.24.6-bullseye
 builder/golang-bullseye: "sha256:e694827623f7a8bf932c3b9462546095ddb404c9d094ae6a3240596d7c395e53" # from: golang:1.24.6-bullseye
-builder/golang-gost-alpine-1.24: "sha256:45072a2bb5ec9022d36c5711cb556d4130477406d011d2e9f7bf76f6254a6e1a" # from: golang:1.24.12-alpine3.22
-builder/golang-gost-alpine: "sha256:45072a2bb5ec9022d36c5711cb556d4130477406d011d2e9f7bf76f6254a6e1a" # from: golang:1.24.12-alpine3.22
-builder/golang-gost-bookworm-1.24: "sha256:7da960481167e5d52d11a638de1685846b3fb353b11d8ad0706b47f770c8235f" # from: golang:1.24.12-bookworm
-builder/golang-gost-bookworm: "sha256:7da960481167e5d52d11a638de1685846b3fb353b11d8ad0706b47f770c8235f" # from: golang:1.24.12-bookworm
+builder/golang-gost-alpine-1.24: "sha256:9bd14d0fddc0f9950385228a1fc83ddfec7e0b1f8f69e84e944901573b2bbd7c" # from: golang:1.24.13-alpine3.22
+builder/golang-gost-alpine: "sha256:9bd14d0fddc0f9950385228a1fc83ddfec7e0b1f8f69e84e944901573b2bbd7c" # from: golang:1.24.13-alpine3.22
+builder/golang-gost-bookworm-1.24: "sha256:9a1a5a2c0e1bb6d24cca379b9a3014d27750870c8995864345f20b112e7ee384" # from: golang:1.24.13-bookworm
+builder/golang-gost-bookworm: "sha256:9a1a5a2c0e1bb6d24cca379b9a3014d27750870c8995864345f20b112e7ee384" # from: golang:1.24.13-bookworm
 builder/golang-gost-bullseye-1.24: "sha256:8bc21d5ce16de07e2655368b322e447936513257acce2b1b133a92c7813c4717" # from: golang:1.24.6-bullseye
 builder/golang-gost-bullseye: "sha256:8bc21d5ce16de07e2655368b322e447936513257acce2b1b133a92c7813c4717" # from: golang:1.24.6-bullseye
 builder/node-alpine-22.16: "sha256:6c2e7b770880f1731713010d101b238c988437c1c5e6e3f23ed27d27f39ea074" # from: node:22.16.0-alpine3.20
@@ -206,8 +206,8 @@ tools/conntrack-tools-conntrack-tools-1.4.8: "sha256:0971978df9c5a73edec4cc2b53d
 tools/conntrack-tools: "sha256:0971978df9c5a73edec4cc2b53d31a4a51494a31fb10db87d15f47b4f31f22ce" # from: builder/scratch
 tools/coreutils: "sha256:543a3a48b303cf6d2abfea7343a3ffd28744fbf593dd9686415d22b8049236ac" # from: builder/scratch
 tools/coreutils-v9.7: "sha256:543a3a48b303cf6d2abfea7343a3ffd28744fbf593dd9686415d22b8049236ac" # from: builder/scratch
-tools/cosign: "sha256:2591994c26bcc71ba6467d26ac7d1d947265e46305221b4511783a0fb0033238" # from: builder/scratch
-tools/cosign-v2.4.3: "sha256:2591994c26bcc71ba6467d26ac7d1d947265e46305221b4511783a0fb0033238" # from: builder/scratch
+tools/cosign: "sha256:120904c0e4ca7f6c57bd1c6f51493245d6167defdeaf9a34d93e28ebb42ba8b6" # from: builder/scratch
+tools/cosign-v2.4.3: "sha256:120904c0e4ca7f6c57bd1c6f51493245d6167defdeaf9a34d93e28ebb42ba8b6" # from: builder/scratch
 tools/cryptsetup: "sha256:c6148af06a6d3cce89316d6ca61e9455bdbe30abb95e99804e02fd504297931c" # from: builder/scratch
 tools/cryptsetup-v2.7.5: "sha256:c6148af06a6d3cce89316d6ca61e9455bdbe30abb95e99804e02fd504297931c" # from: builder/scratch
 tools/curl-curl-8_17_0: "sha256:a26c005481d82dfdcdf0fe782edba0fbaa064085b7b4a08808e1c4767c7d3acd" # from: builder/scratch
@@ -234,9 +234,9 @@ tools/gcc-gnu: "sha256:94dc9c9be75acf0074cadeefe0f5e34ba154150b018fa0f2015f4eddf
 tools/gcc: "sha256:43924e061e9895c005622d213690ba509372ac2aedac033081deef21c55b974f" # from: builder/scratch
 tools/git: "sha256:5f8e9cbb04c26deb0fdbac1197ec554061866435d526131db5de907cfb3a0105" # from: builder/scratch
 tools/git-v2.50.1: "sha256:5f8e9cbb04c26deb0fdbac1197ec554061866435d526131db5de907cfb3a0105" # from: builder/scratch
-tools/golang-1.24.12: "sha256:6f8be3efaf04228dc0ebf810dc1e29ec551bdb3dc8ff3f41effd06928f0d3dfa" # from: builder/scratch
-tools/golang-1.25.6: "sha256:f311c11ee90d009a762281cdd2abe8a9ca39d694469a4f310651cb3b9dd92dd8" # from: builder/scratch
-tools/golang: "sha256:f311c11ee90d009a762281cdd2abe8a9ca39d694469a4f310651cb3b9dd92dd8" # from: builder/scratch
+tools/golang-1.24.13: "sha256:4dc370fd0a45492aab8435d1628a2082c328ba63926e88e879895cad01306118" # from: builder/scratch
+tools/golang-1.25.7: "sha256:227f742764bde45608d1209ed1758c35b1b5313a2f8d99ee0cc48aecfda80dc7" # from: builder/scratch
+tools/golang: "sha256:227f742764bde45608d1209ed1758c35b1b5313a2f8d99ee0cc48aecfda80dc7" # from: builder/scratch
 tools/grep-grep-3.11: "sha256:2dbeb25b1e742a98863f70eb3b3cb3aaf9435f43f255b91093bc87a360a52a38" # from: builder/scratch
 tools/grep: "sha256:2dbeb25b1e742a98863f70eb3b3cb3aaf9435f43f255b91093bc87a360a52a38" # from: builder/scratch
 tools/iproute2: "sha256:46150bdc7959c3ff8395a427bff4d75da028f604f87139069fac951637310708" # from: builder/scratch
@@ -287,8 +287,8 @@ tools/sed: "sha256:c8593139a87d91776d4f74218913c434f18ba399ee697dbb39fedf611b5f8
 tools/sed-v4.9: "sha256:c8593139a87d91776d4f74218913c434f18ba399ee697dbb39fedf611b5f8c3e" # from: builder/scratch
 tools/semver-3.4.0: "sha256:d10c2dcee12c42900281bad834ac0ed0a085b492dcce5d1d6addd335ac1d54fd" # from: builder/scratch
 tools/semver: "sha256:d10c2dcee12c42900281bad834ac0ed0a085b492dcce5d1d6addd335ac1d54fd" # from: builder/scratch
-tools/shell-operator: "sha256:cd45e7f623af11e76218aca505855cf852c968d2ea67bd987c61183f06bd61c3" # from: builder/scratch
-tools/shell-operator-v1.9.3: "sha256:cd45e7f623af11e76218aca505855cf852c968d2ea67bd987c61183f06bd61c3" # from: builder/scratch
+tools/shell-operator: "sha256:6d2ec80f05a3610f74c0a08c36bac7204b8229bd4f53533962761de56c8cf32b" # from: builder/scratch
+tools/shell-operator-v1.9.3: "sha256:6d2ec80f05a3610f74c0a08c36bac7204b8229bd4f53533962761de56c8cf32b" # from: builder/scratch
 tools/ssh: "sha256:321d9b04ced197458a5bf1e0a3d2d5b64e4377f4ba6cafb1e1a871c2b437a96c" # from: builder/scratch
 tools/ssh-V_10_0_P2: "sha256:321d9b04ced197458a5bf1e0a3d2d5b64e4377f4ba6cafb1e1a871c2b437a96c" # from: builder/scratch
 tools/tar: "sha256:e23dfd80a2beedd81773f873f3e31c84c7b9173f3e2ef1de3fa0d6af0d03d6be" # from: builder/scratch
@@ -301,6 +301,6 @@ tools/vim: "sha256:12cfd8984130986c5522e45099b0cb22d81850dafcb256f5004bc536cf374
 tools/vim-v9.1.1236: "sha256:12cfd8984130986c5522e45099b0cb22d81850dafcb256f5004bc536cf3740f6" # from: builder/scratch
 tools/xfsprogs: "sha256:ec14d7e45fca638728c198b7eb8d675934e777dd4cfaca6f914eb543247c9444" # from: builder/scratch
 tools/xfsprogs-v6.16.0: "sha256:ec14d7e45fca638728c198b7eb8d675934e777dd4cfaca6f914eb543247c9444" # from: builder/scratch
-tools/yq: "sha256:b48155e5e0f7e02b57c18c2844aa0aab14a4cb61e8565386e56ccccb64ded848" # from: builder/scratch
-tools/yq-v4.45.1: "sha256:42fc3ce1938b90092e2c071cae21833ce43d07ce0b61e08be197417991d95ffe" # from: builder/scratch
-tools/yq-v4.47.1: "sha256:b48155e5e0f7e02b57c18c2844aa0aab14a4cb61e8565386e56ccccb64ded848" # from: builder/scratch
+tools/yq: "sha256:4f294d46559f45bbd7d20f2306e2eaa2b6ec1cb6e826f906377c10bb9eea04d5" # from: builder/scratch
+tools/yq-v4.45.1: "sha256:893d67cc466e2be16006f9053d43701cb8bd376cd6864547ca43bafa08e01127" # from: builder/scratch
+tools/yq-v4.47.1: "sha256:4f294d46559f45bbd7d20f2306e2eaa2b6ec1cb6e826f906377c10bb9eea04d5" # from: builder/scratch


### PR DESCRIPTION
## Description
Update base images to v0.5.51.

## Why do we need it, and what problem does it solve?
Update Golang to 1.25.7, fix CVE's.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Update base images to v0.5.51
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
