### PR TITLE
[cloud-provider-vsphere] fix maping for kubernetes data disk

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/candi/terraform-modules/master-node/outputs.tf
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/candi/terraform-modules/master-node/outputs.tf
@@ -1,7 +1,12 @@
 # Copyright 2021 Flant JSC
 # Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
 locals {
-  kubernetes_data_device_uuid = replace(vsphere_virtual_machine.master, "-", "")
+  kubernetes_data_device_uuid_list = [
+    for disk in vsphere_virtual_machine.master.disk :
+    disk.uuid if disk.label == "disk1"
+  ]
+  kubernetes_data_device_uuid = replace(length(local.kubernetes_data_device_uuid_list) > 0 ? local.kubernetes_data_device_uuid_list[0] : "", "-", "")
+  kubernetes_data_device_path = local.kubernetes_data_device_uuid != "" ? "/dev/disk/by-id/wwn-0x${local.kubernetes_data_device_uuid}" : "/dev/sdb"
 }
 
 output "master_ip_address_for_ssh" {
@@ -13,10 +18,6 @@ output "node_internal_ip_address" {
 }
 
 output "kubernetes_data_device_path" {
-  value = "/dev/sdb"
-}
-
-output "master-data2" {
-  value = "wwn-0x${local.kubernetes_data_device_uuid}"
+  value = local.kubernetes_data_device_path
 }
 


### PR DESCRIPTION
## Description
Fix maping for kubernetes data disk
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Sometimes cannot bootstrap cluster due to incorrect path definition to disk for Kubernetes data
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: Fix maping for kubernetes data disk
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
