### PR TITLE
[monitoring-kubernetes] Fix query ambiguity in kube_persistentvolume_is_local

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/propagated-kube-state-metrics.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/generic/propagated-kube-state-metrics.yaml
@@ -19,6 +19,6 @@
         or
           (kube_persistentvolume_info - 1)
       ) * on(persistentvolume) group_left(namespace) max by (namespace, persistentvolume) (
-        label_replace(kube_persistentvolumeclaim_info{volumename!=""}, "persistentvolume", "$1", "volumename", "(.+)")
+        label_replace(kube_persistentvolumeclaim_info{job="kube-state-metrics", volumename!=""}, "persistentvolume", "$1", "volumename", "(.+)")
       )
     record: kube_persistentvolume_is_local


### PR DESCRIPTION
## Description
`kube_persistentvolume_is_local` is a recording rule that uses metrics from kube-state-metrics. If a user deploys his own kube-state-metrics the rule evaluation fails due to multiple series in `kube_persistentvolumeclaim_info`. This PR eliminates ambiguity by using an extra label selector `job="kube-state-metrics"`.

## Why do we need it, and what problem does it solve?
This PR fixes some edge cases when multiple kube-state-metrics exporters coexist in a single cluster.

## Why do we need it in the patch release (if we do)?
It would be nice to have.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: monitoring-kubernetes
type: fix
summary: fix kube_persistentvolume_is_local recording rule when there are more than one kube-state-metrics exporter in cluster
impact_level: default
```