### PR TITLE
[admission-policy-engine] Additional fix ValidatingAdmissionPolicy for label gatekeeper.sh/operation=webhook 

### DIFF
--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -63,13 +63,13 @@ spec:
   validations:
     - expression: >-
         !(
-          has(object.metadata)
-          && has(object.metadata.labels)
-          && "gatekeeper.sh/operation" in object.metadata.labels
-          && object.metadata.labels["gatekeeper.sh/operation"] == "webhook"
+          has(object.metadata) &&
+          has(object.metadata.labels) &&
+          ('gatekeeper.sh/operation' in object.metadata.labels) &&
+          object.metadata.labels['gatekeeper.sh/operation'] == 'webhook'
         )
-        || request.userInfo.username.startsWith("system:serviceaccount:d8-")
-        || request.userInfo.username.startsWith("system:serviceaccount:kube-")
+        || request.userInfo.username.startsWith('system:serviceaccount:d8-')
+        || request.userInfo.username.startsWith('system:serviceaccount:kube-')
       reason: Forbidden
       message: "Pods with label 'gatekeeper.sh/operation=webhook' are not allowed" 
 ---
@@ -103,8 +103,11 @@ spec:
         scope: "*"
   validations:
     - expression: |-
-        !(has(object.spec.template.metadata.labels) &&
-          object.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook')
+        !(
+          has(object.spec.template.metadata.labels) &&
+          ('gatekeeper.sh/operation' in object.spec.template.metadata.labels) &&
+          object.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook'
+        )
         || request.userInfo.username.startsWith("system:serviceaccount:d8-")
         || request.userInfo.username.startsWith("system:serviceaccount:kube-")
       message: Setting gatekeeper.sh/operation=webhook in pod template is forbidden
@@ -134,8 +137,11 @@ spec:
         scope: "*"
   validations:
     - expression: |-
-        !(has(object.spec.jobTemplate.spec.template.metadata.labels) &&
-          object.spec.jobTemplate.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook')
+        !(
+          has(object.spec.jobTemplate.spec.template.metadata.labels) &&
+          ('gatekeeper.sh/operation' in object.spec.jobTemplate.spec.template.metadata.labels) &&
+          object.spec.jobTemplate.spec.template.metadata.labels['gatekeeper.sh/operation'] == 'webhook'
+        )
         || request.userInfo.username.startsWith("system:serviceaccount:d8-")
         || request.userInfo.username.startsWith("system:serviceaccount:kube-")
       message: Setting gatekeeper.sh/operation=webhook in CronJob pod template is forbidden


### PR DESCRIPTION
## Description
Updated Gatekeeper-related ValidatingAdmissionPolicies to correctly block using the `gatekeeper.sh/operation=webhook` label on Pods and workload pod templates, while allowing internal Deckhouse and Kubernetes serviceaccounts.

## Why do we need it, and what problem does it solve?
The existing ValidatingAdmissionPolicy only covered direct Pod creates/updates and could be bypassed by setting `gatekeeper.sh/operation=webhook` inside controller templates (e.g., Deployments/Jobs). This change closes that gap by validating workload resources that generate Pods from templates.

Additionally, the policy now explicitly allows `system:serviceaccount:kube-*` alongside `system:serviceaccount:d8-*` to avoid blocking system components that may legitimately operate in Kubernetes system namespaces.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Additional fix ValidatingAdmissionPolicy for label gatekeeper.sh/operation=webhook
impact_level: low
```
