### PR TITLE
Change `PackageRepositoryOperationStatusFailedPackageError`

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
@@ -173,8 +173,8 @@ type PackageRepositoryOperationStatusFailedPackage struct {
 }
 
 type PackageRepositoryOperationStatusFailedPackageError struct {
-	// Name of the error.
-	Name string `json:"name"`
+	// Version of the package that failed.
+	Version string `json:"version"`
 
 	// Error message.
 	Error string `json:"error"`

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
@@ -507,8 +507,8 @@ func (r *reconciler) processNextPackage(ctx context.Context, operation *v1alpha1
 	failedList := make([]v1alpha1.PackageRepositoryOperationStatusFailedPackageError, 0, len(processResult.Failed))
 	for _, failedVersion := range processResult.Failed {
 		failedList = append(failedList, v1alpha1.PackageRepositoryOperationStatusFailedPackageError{
-			Name:  failedVersion.Name,
-			Error: failedVersion.Error,
+			Version: failedVersion.Name,
+			Error:   failedVersion.Error,
 		})
 	}
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-versions.yaml
@@ -33,10 +33,10 @@ status:
     - errors:
       - error: 'ensure application package version: create application package version:
           simulated create error for v1.1.0'
-        name: v1.1.0
+        version: v1.1.0
       - error: 'ensure application package version: create application package version:
           simulated create error for v1.2.0'
-        name: v1.2.0
+        version: v1.2.0
       name: test-package
     processed:
     - name: test-package


### PR DESCRIPTION
## Description

Rename `Name` → `Version` field in `PackageRepositoryOperationStatusFailedPackageError` struct and the corresponding internal `failedVersion` type to accurately reflect that the field stores a semver version string (e.g. `v1.1.0`), not a name.

## Why do we need it, and what problem does it solve?

In `PackageRepositoryOperation` status, each failed package version error had a `name` field that actually contained a semver tag (e.g. `v1.1.0`):

```yaml
status:
  packages:
    failed:
    - name: test-package        # this is a package name — correct
      errors:
      - name: v1.1.0            # this is a version, not a name — misleading
        error: '...'
```

Renaming `name` → `version` in the `errors` items fixes the mismatch between field name and its actual content.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: chore
summary: Rename `name` to `version` in PackageRepositoryOperation failed package error status field
impact_level: low
```


<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
