### PR TITLE
[cloud-provider-dvp] validate resources before VM creation (#17755)

### DIFF
--- a/candi/cloud-providers/dvp/layouts/standard/base-infrastructure/main.tf
+++ b/candi/cloud-providers/dvp/layouts/standard/base-infrastructure/main.tf
@@ -12,3 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Validate that required DVP resources exist before proceeding with cluster bootstrap.
+# This module will fail fast with clear error messages if VirtualMachineClass or boot images
+# are not found in the parent DVP cluster, preventing VM creation from getting stuck in Pending state.
+module "validation" {
+  source = "../../../terraform-modules/validation"
+
+  namespace                  = local.namespace
+  virtual_machine_class_name = local.virtual_machine_class_name
+  image_kind                 = local.root_disk_image.kind
+  image_name                 = local.root_disk_image.name
+}

--- a/candi/cloud-providers/dvp/layouts/standard/base-infrastructure/variables.tf
+++ b/candi/cloud-providers/dvp/layouts/standard/base-infrastructure/variables.tf
@@ -21,3 +21,16 @@ variable "providerClusterConfiguration" {
   type = any
 }
 
+# Extract locals needed for validation module
+locals {
+  namespace         = var.providerClusterConfiguration.provider.namespace
+  master_node_group = var.providerClusterConfiguration.masterNodeGroup
+  instance_class    = local.master_node_group.instanceClass
+
+  root_disk_image = {
+    kind = local.instance_class.rootDisk.image.kind
+    name = local.instance_class.rootDisk.image.name
+  }
+
+  virtual_machine_class_name = local.instance_class.virtualMachine.virtualMachineClassName
+}

--- a/candi/cloud-providers/dvp/terraform-modules/validation/main.tf
+++ b/candi/cloud-providers/dvp/terraform-modules/validation/main.tf
@@ -1,0 +1,80 @@
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This module validates that required DVP resources exist before attempting to create VMs.
+# Uses kubernetes_resources (plural) data source to list and validate resources.
+# Will fail with clear error messages if VirtualMachineClass or images are not found.
+
+# List all VirtualMachineClasses to validate the specified one exists
+data "kubernetes_resources" "virtual_machine_classes" {
+  api_version = var.api_version
+  kind        = "VirtualMachineClass"
+}
+
+# List images based on kind
+data "kubernetes_resources" "images" {
+  api_version = var.api_version
+  kind        = var.image_kind
+  namespace   = var.image_kind == "VirtualImage" ? var.namespace : null
+}
+
+# Dummy resource to validate and fail with clear error messages
+resource "terraform_data" "validation" {
+  lifecycle {
+    precondition {
+      condition = contains(
+        [for vmc in data.kubernetes_resources.virtual_machine_classes.objects : vmc.metadata.name],
+        var.virtual_machine_class_name
+      )
+      error_message = <<-EOT
+        ERROR: VirtualMachineClass '${var.virtual_machine_class_name}' not found in parent DVP cluster.
+
+        Please ensure the VirtualMachineClass exists before creating VMs.
+
+        Available VirtualMachineClasses:
+        ${join("\n", [for vmc in data.kubernetes_resources.virtual_machine_classes.objects : "  - ${vmc.metadata.name}"])}
+      EOT
+    }
+
+    precondition {
+      condition = contains(
+        [for img in data.kubernetes_resources.images.objects : img.metadata.name],
+        var.image_name
+      )
+      error_message = <<-EOT
+        ERROR: ${var.image_kind} '${var.image_name}' not found${var.image_kind == "VirtualImage" ? " in namespace '${var.namespace}'" : ""} in parent DVP cluster.
+
+        Please ensure the image exists before creating VMs.
+
+        Available ${var.image_kind}s:
+        ${join("\n", [for img in data.kubernetes_resources.images.objects : "  - ${img.metadata.name}"])}
+      EOT
+    }
+  }
+}
+
+# Output validation results for logging
+output "validation_status" {
+  value = {
+    virtual_machine_class_name = var.virtual_machine_class_name
+    image_kind                 = var.image_kind
+    image_name                 = var.image_name
+    namespace                  = var.namespace
+    validation_completed       = "true"
+    available_vm_classes       = [for vmc in data.kubernetes_resources.virtual_machine_classes.objects : vmc.metadata.name]
+    available_images           = [for img in data.kubernetes_resources.images.objects : img.metadata.name]
+  }
+  description = "Validation status of DVP resources"
+  depends_on  = [terraform_data.validation]
+}

--- a/candi/cloud-providers/dvp/terraform-modules/validation/variables.tf
+++ b/candi/cloud-providers/dvp/terraform-modules/validation/variables.tf
@@ -1,0 +1,44 @@
+# Copyright 2025 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "api_version" {
+  type        = string
+  default     = "virtualization.deckhouse.io/v1alpha2"
+  description = "API version for DVP virtualization resources"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Namespace in parent DVP cluster where VirtualImage resources should be validated"
+}
+
+variable "virtual_machine_class_name" {
+  type        = string
+  description = "Name of the VirtualMachineClass to validate in parent DVP cluster"
+}
+
+variable "image_kind" {
+  type        = string
+  description = "Kind of the boot disk image (ClusterVirtualImage or VirtualImage)"
+
+  validation {
+    condition     = contains(["ClusterVirtualImage", "VirtualImage"], var.image_kind)
+    error_message = "image_kind must be either 'ClusterVirtualImage' or 'VirtualImage'"
+  }
+}
+
+variable "image_name" {
+  type        = string
+  description = "Name of the boot disk image to validate in parent DVP cluster"
+}

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -29,7 +29,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/utils/ptr"
@@ -464,6 +466,11 @@ func (r *DeckhouseMachineReconciler) createVM(
 		return nil, fmt.Errorf("clusterv1b1.Machine does not contain bootstrap script")
 	}
 
+	// Validate VirtualMachineClass and image exist before creating VM
+	if err := r.validateVMResources(ctx, dvpMachine); err != nil {
+		return nil, fmt.Errorf("resource validation failed: %w", err)
+	}
+
 	var cloudInitSecretName string
 	var createdDiskNames []string
 
@@ -627,6 +634,97 @@ func (r *DeckhouseMachineReconciler) createVM(
 	}
 
 	return vm, nil
+}
+
+// validateVMResources validates that VirtualMachineClass and boot image exist in parent DVP cluster
+func (r *DeckhouseMachineReconciler) validateVMResources(
+	ctx context.Context,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+) error {
+	logger := log.FromContext(ctx)
+	dvpNamespace := r.DVP.ProjectNamespace()
+
+	// Validate VirtualMachineClass exists
+	vmClassName := dvpMachine.Spec.VMClassName
+	vmClassGVK := schema.GroupVersionKind{
+		Group:   "virtualization.deckhouse.io",
+		Version: "v1alpha2",
+		Kind:    "VirtualMachineClass",
+	}
+
+	vmClass := &unstructured.Unstructured{}
+	vmClass.SetGroupVersionKind(vmClassGVK)
+	err := r.DVP.Service.GetClient().Get(ctx, client.ObjectKey{Name: vmClassName}, vmClass)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Error(err, "VirtualMachineClass not found in parent DVP cluster",
+				"vmClassName", vmClassName)
+			return fmt.Errorf("VirtualMachineClass '%s' not found in parent DVP cluster. "+
+				"Please ensure the VirtualMachineClass exists before creating VMs. "+
+				"Available VirtualMachineClasses can be listed with: kubectl get virtualmachineclasses",
+				vmClassName)
+		}
+		return fmt.Errorf("failed to validate VirtualMachineClass '%s': %w", vmClassName, err)
+	}
+	logger.V(1).Info("VirtualMachineClass validated successfully", "vmClassName", vmClassName)
+
+	// Validate boot image exists
+	imageKind := dvpMachine.Spec.BootDiskImageRef.Kind
+	imageName := dvpMachine.Spec.BootDiskImageRef.Name
+
+	// Validate image kind
+	if imageKind != "ClusterVirtualImage" && imageKind != "VirtualImage" {
+		return fmt.Errorf("unsupported boot disk image kind '%s', must be either 'ClusterVirtualImage' or 'VirtualImage'",
+			imageKind)
+	}
+
+	// Build image GVK and ObjectKey
+	imageGVK := schema.GroupVersionKind{
+		Group:   "virtualization.deckhouse.io",
+		Version: "v1alpha2",
+		Kind:    imageKind,
+	}
+
+	imageKey := client.ObjectKey{Name: imageName}
+	if imageKind == "VirtualImage" {
+		imageKey.Namespace = dvpNamespace
+	}
+
+	// Validate image exists
+	image := &unstructured.Unstructured{}
+	image.SetGroupVersionKind(imageGVK)
+	err = r.DVP.Service.GetClient().Get(ctx, imageKey, image)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			namespaceInfo := ""
+			if imageKind == "VirtualImage" {
+				namespaceInfo = fmt.Sprintf(" in namespace '%s'", dvpNamespace)
+			}
+
+			logger.Error(err, fmt.Sprintf("%s not found in parent DVP cluster", imageKind),
+				"imageName", imageName, "namespace", dvpNamespace)
+
+			resourceName := strings.ToLower(imageKind) + "s"
+			kubectlCmd := fmt.Sprintf("kubectl get %s", resourceName)
+			if imageKind == "VirtualImage" {
+				kubectlCmd += fmt.Sprintf(" -n %s", dvpNamespace)
+			}
+
+			return fmt.Errorf("%s '%s' not found%s in parent DVP cluster. "+
+				"Please ensure the image exists before creating VMs. "+
+				"Available %ss can be listed with: %s",
+				imageKind, imageName, namespaceInfo, imageKind, kubectlCmd)
+		}
+
+		namespaceInfo := ""
+		if imageKind == "VirtualImage" {
+			namespaceInfo = fmt.Sprintf(" in namespace '%s'", dvpNamespace)
+		}
+		return fmt.Errorf("failed to validate %s '%s'%s: %w", imageKind, imageName, namespaceInfo, err)
+	}
+
+	logger.V(1).Info("Boot disk image validated successfully", "imageKind", imageKind, "imageName", imageName)
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/service.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/service.go
@@ -32,6 +32,11 @@ type Service struct {
 	namespace string
 }
 
+// GetClient returns the controller-runtime client for making requests to parent DVP cluster
+func (s *Service) GetClient() client.Client {
+	return s.client
+}
+
 const defaultWaitCheckInterval = time.Second
 
 type WaitFn func(obj client.Object) (bool, error)


### PR DESCRIPTION
(cherry picked from commit [9f1b010](https://github.com/deckhouse/deckhouse/commit/9f1b010abea8f6c2f2871e6d86bdbc27aabcb207))

## Description

Backport of #17755 to release-1.74 for v1.74.5

Added validation for VirtualMachineClass and boot images (ClusterVirtualImage/VirtualImage) in DVP cloud provider to prevent VMs from getting stuck in Pending state.

The validation runs at two stages:
1. **Bootstrap phase** - Terraform data sources validate resources before any infrastructure is created
2. **Runtime phase** - CAPI controller validates resources before VM creation during cluster operations


## Why do we need it, and what problem does it solve?
**Problem:**
When incorrect `virtualMachineClassName` or `image name` is specified in cluster configuration, VMs are created but remain in Pending state indefinitely with no clear error messages. This happens because:
- The validation only occurs during VM provisioning in the parent DVP cluster
- Resources (boot disks, secrets) are already created before the error is discovered
- Users have to investigate parent cluster logs to understand what went wrong

**Solution:**
- **Terraform validation module** checks that VirtualMachineClass and images exist in the parent DVP cluster during `dhctl bootstrap` before creating any resources
- **CAPI controller validation** checks resources before VM creation during runtime operations (e.g., NodeGroup scale-up)
- Clear, actionable error messages with `kubectl` commands to list available resources

Original PR: https://github.com/deckhouse/deckhouse/pull/17755

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Validate VirtualMachineClass and boot images before VM creation to prevent Pending state
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
