### PR TITLE
[node-manager] nil pointer panic in cluster-autoscaler fix

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/002-kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.30/002-kruise-ads.patch
@@ -2,12 +2,16 @@ diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simula
 index d568becef..d8b3ff8c0 100644
 --- a/cluster-autoscaler/simulator/cluster.go
 +++ b/cluster-autoscaler/simulator/cluster.go
-@@ -230,6 +230,10 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
+@@ -230,6 +230,14 @@ func (r *RemovalSimulator) findPlaceFor(removedNode string, pods []*apiv1.Pod, n
  
  	newpods := make([]*apiv1.Pod, 0, len(pods))
  	for _, podptr := range pods {
++		if podptr == nil {
++			klog.Warningf("findPlaceFor: skipping nil pod in list for node %s", removedNode)
++			continue
++		}
 +		controllerRef := drain.ControllerRef(podptr)
-+		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++		if controllerRef != nil && controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
 +			continue
 +		}
  		newpod := *podptr
@@ -23,7 +27,7 @@ index 9c9e89cf8..9efbb30d3 100644
  func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod) drainability.Status {
 +	kruiseAds := false
 +	controllerRef := drain.ControllerRef(pod)
-+	if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
++	if controllerRef != nil && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
 +		kruiseAds = true
 +	}
  	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/002-kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.31/002-kruise-ads.patch
@@ -8,12 +8,16 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
 --- a/cluster-autoscaler/simulator/cluster.go	(revision 2818e0cffbc180b42fc486630ab36d43ecf56649)
 +++ b/cluster-autoscaler/simulator/cluster.go	(date 1745485212497)
-@@ -230,6 +230,10 @@
+@@ -230,6 +230,14 @@
 
  	newpods := make([]*apiv1.Pod, 0, len(pods))
  	for _, podptr := range pods {
++		if podptr == nil {
++			klog.Warningf("findPlaceFor: skipping nil pod in list for node %s", removedNode)
++			continue
++		}
 +		controllerRef := drain.ControllerRef(podptr)
-+		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++		if controllerRef != nil && controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
 +			continue
 +		}
  		newpod := *podptr
@@ -50,7 +54,7 @@ diff --git a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go b/clust
  func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod, _ *framework.NodeInfo) drainability.Status {
 +	kruiseAds := false
 +	controllerRef := drain.ControllerRef(pod)
-+	if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
++	if controllerRef != nil && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
 +		kruiseAds = true
 +	}
  	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {

--- a/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/002-kruise-ads.patch
+++ b/modules/040-node-manager/images/cluster-autoscaler/patches/1.32/002-kruise-ads.patch
@@ -8,12 +8,16 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 diff --git a/cluster-autoscaler/simulator/cluster.go b/cluster-autoscaler/simulator/cluster.go
 --- a/cluster-autoscaler/simulator/cluster.go	(revision 669115a6814d33b9d5757aa801402710029cb5b5)
 +++ b/cluster-autoscaler/simulator/cluster.go	(date 1745485672011)
-@@ -229,6 +229,10 @@
+@@ -229,6 +229,14 @@
 
  	newpods := make([]*apiv1.Pod, 0, len(pods))
  	for _, podptr := range pods {
++		if podptr == nil {
++			klog.Warningf("findPlaceFor: skipping nil pod in list for node %s", removedNode)
++			continue
++		}
 +		controllerRef := drain.ControllerRef(podptr)
-+		if controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
++		if controllerRef != nil && controllerRef.Kind == "DaemonSet" && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" {
 +			continue
 +		}
  		newpod := *podptr
@@ -50,7 +54,7 @@ diff --git a/cluster-autoscaler/simulator/drainability/rules/pdb/rule.go b/clust
  func (Rule) Drainable(drainCtx *drainability.DrainContext, pod *apiv1.Pod, _ *framework.NodeInfo) drainability.Status {
 +	kruiseAds := false
 +	controllerRef := drain.ControllerRef(pod)
-+	if controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
++	if controllerRef != nil && controllerRef.APIVersion == "apps.kruise.io/v1alpha1" && controllerRef.Kind == "DaemonSet" {
 +		kruiseAds = true
 +	}
  	for _, pdb := range drainCtx.RemainingPdbTracker.MatchingPdbs(pod) {


### PR DESCRIPTION
## Description

Fix panic in cluster-autoscaler caused by nil pointer dereference in `findPlaceFor` function.

In rare cases, cluster-autoscaler crashes with panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1d86e05]
goroutine 205 [running]:
k8s.io/autoscaler/cluster-autoscaler/simulator.(*RemovalSimulator).findPlaceFor(...)
    /src/simulator/cluster.go:234 +0x365
k8s.io/autoscaler/cluster-autoscaler/simulator.(*RemovalSimulator).SimulateNodeRemoval.func1()
    /src/simulator/cluster.go:168 +0x49
...
```

The issue occurs when a nil pod appears in the pods list during node removal simulation. This is likely caused by race conditions in the snapshot or issues in MCM (Machine Controller Manager) cloud provider.

Changes made:
1. Added nil pod check with warning log in `findPlaceFor` function (`cluster.go`)
2. Added nil check for `controllerRef` before accessing its fields in `cluster.go`
3. Added nil check for `controllerRef` in `pdb/rule.go`

All fixes applied to patches for cluster-autoscaler versions 1.30, 1.31, and 1.32.

## Why do we need it, and what problem does it solve?

Fix panic in cluster-autoscaler during scale-down simulation. The panic causes cluster-autoscaler to crash and restart, disrupting autoscaling functionality.

## Why do we need it in the patch release (if we do)?

Critical fix for production stability. The panic can occur in any cluster using cluster-autoscaler with Kruise Advanced DaemonSets, causing autoscaler restarts and potential scaling issues.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: fix
summary: Fix panic in cluster-autoscaler caused by nil pointer dereference during node removal simulation.
impact_level: default
```
