### PR TITLE
[ci] Switch to e2e-terraform for 1.69

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -174,7 +174,7 @@ steps:
         publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
         publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
         publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-        publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+        publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
       else
         echo "Branch unset, skipping branch publish."
       fi

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -793,7 +793,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -490,7 +490,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -658,7 +658,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi
@@ -969,7 +969,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi
@@ -1280,7 +1280,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi
@@ -1591,7 +1591,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi
@@ -1902,7 +1902,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi
@@ -2213,7 +2213,7 @@ jobs:
             publish_image 'dev' "${DEV_REGISTRY_PATH}:${IMAGE_TAG}"
             publish_image 'dev/install' "${DEV_REGISTRY_PATH}/install:${IMAGE_TAG}"
             publish_image 'dev/install-standalone' "${DEV_REGISTRY_PATH}/install-standalone:${IMAGE_TAG}"
-            publish_image 'e2e-opentofu-eks' "${DEV_REGISTRY_PATH}/e2e-opentofu-eks:${IMAGE_TAG}"
+            publish_image 'e2e-terraform' "${DEV_REGISTRY_PATH}/e2e-terraform:${IMAGE_TAG}"
           else
             echo "Branch unset, skipping branch publish."
           fi


### PR DESCRIPTION
## Description
Switch to e2e-terraform for 1.69.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Switch to e2e-terraform for 1.69.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
