### PR TITLE
[admission-policy-engine] Add system:sudouser in ValidatingAdmissionPolicyBinding excludes

### DIFF
--- a/modules/015-admission-policy-engine/templates/admission.yaml
+++ b/modules/015-admission-policy-engine/templates/admission.yaml
@@ -70,6 +70,7 @@ spec:
         )
         || request.userInfo.username.startsWith('system:serviceaccount:d8-')
         || request.userInfo.username.startsWith('system:serviceaccount:kube-')
+        || request.userInfo.username.startsWith('system:sudouser')
       reason: Forbidden
       message: "Pods with label 'gatekeeper.sh/operation=webhook' are not allowed" 
 ---
@@ -110,6 +111,7 @@ spec:
         )
         || request.userInfo.username.startsWith("system:serviceaccount:d8-")
         || request.userInfo.username.startsWith("system:serviceaccount:kube-")
+        || request.userInfo.username.startsWith("system:sudouser")
       message: Setting gatekeeper.sh/operation=webhook in pod template is forbidden
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}
@@ -144,6 +146,7 @@ spec:
         )
         || request.userInfo.username.startsWith("system:serviceaccount:d8-")
         || request.userInfo.username.startsWith("system:serviceaccount:kube-")
+        || request.userInfo.username.startsWith("system:sudouser")
       message: Setting gatekeeper.sh/operation=webhook in CronJob pod template is forbidden
 ---
 apiVersion: {{ include "helm_lib_get_api_version_by_kind" (list . "ValidatingAdmissionPolicyBinding") }}


### PR DESCRIPTION
## Description

Added exclusion for system:sudouser in ValidatingAdmissionPolicy CEL expressions so this user can bypass the gatekeeper.sh/operation=webhook label restriction.

## Why do we need it, and what problem does it solve?

In some operational scenarios actions are performed under system:sudouser; without this change such actions are denied by the policy

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: admission-policy-engine
type: fix 
summary: Add system:sudouser in ValidatingAdmissionPolicyBinding excludes
impact_level: low
```
