### PR TITLE
[node-manager] Add test case for DVPSpecWorker and fix parsing logic for DVPInstanceClass

### DIFF
--- a/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
+++ b/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity.go
@@ -283,43 +283,6 @@ func (c *huaweiCloudInstanceClass) ExtractCapacity(catalog *InstanceTypesCatalog
 	return catalog.Get(c)
 }
 
-//type dvpInstanceClass struct {
-//	CPU struct {
-//		Cores int `json:"cores"`
-//	} `json:"cpu"`
-//
-//	Memory int `json:"memory"`
-//}
-
-/*
-apiVersion: deckhouse.io/v1alpha1
-kind: DVPInstanceClass
-metadata:
-  creationTimestamp: "2025-12-30T06:47:54Z"
-  generation: 1
-  name: worker
-  resourceVersion: "9580100"
-  uid: 878e51e6-a6e6-4f00-a408-d78a17ff0763
-spec:
-  rootDisk:
-    image:
-      kind: ClusterVirtualImage
-      name: ubuntu-24-04-lts
-    size: 30Gi
-    storageClass: replicated
-  virtualMachine:
-    bootloader: EFI
-    cpu:
-      coreFraction: 20%
-      cores: 4
-    liveMigrationPolicy: PreferForced
-    memory:
-      size: 8Gi
-    runPolicy: AlwaysOnUnlessStoppedManually
-    virtualMachineClassName: amd-epyc-gen-3
-`
-*/
-
 type dvpInstanceClass struct {
 	VirtualMachine struct {
 		CPU struct {
@@ -333,20 +296,12 @@ type dvpInstanceClass struct {
 }
 
 func (d dvpInstanceClass) ExtractCapacity(_ *InstanceTypesCatalog) (*v1alpha1.InstanceType, error) {
-	//cpuStr := strconv.FormatInt(int64(d.CPU.Cores), 10)
-	//memStr := strconv.FormatInt(int64(d.Memory), 10)
-
 	cpuStr := strconv.FormatInt(int64(d.VirtualMachine.CPU.Cores), 10)
-	//memStr := strconv.FormatInt(int64(d.VirtualMachine.Memory), 10)
 
 	cpuRes, err := resource.ParseQuantity(cpuStr)
 	if err != nil {
 		return nil, err
 	}
-	//memRes, err := resource.ParseQuantity(memStr + "Mi")
-	//if err != nil {
-	//	return nil, err
-	//}
 
 	memRes, err := resource.ParseQuantity(d.VirtualMachine.Memory.Size)
 	if err != nil {

--- a/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity_test.go
+++ b/modules/040-node-manager/hooks/internal/autoscaler/capacity/capacity_test.go
@@ -193,18 +193,11 @@ func TestCapacityExtractor(t *testing.T) {
 		assert.Equal(t, "8", capac.CPU.String())
 	})
 
-	t.Run("DVPSpecWorker", func(t *testing.T) {
+	t.Run("DVPSpec", func(t *testing.T) {
 		t.Parallel()
 		var instanceClass map[string]interface{}
-		err := yaml.Unmarshal([]byte(dvpSpecWorker), &instanceClass)
+		err := yaml.Unmarshal([]byte(dvpSpec), &instanceClass)
 		require.NoError(t, err)
-		//catalog := NewInstanceTypesCatalog([]v1alpha1.InstanceType{
-		//	{
-		//		Name:   "amd-epyc-gen-3",
-		//		CPU:    resource.MustParse("8"),
-		//		Memory: resource.MustParse(strconv.FormatInt(16384, 10) + "Mi"),
-		//	},
-		//})
 		catalog := NewInstanceTypesCatalog(make([]v1alpha1.InstanceType, 0))
 		capac, err := CalculateNodeTemplateCapacity(instanceClass["kind"].(string), instanceClass["spec"], catalog)
 		require.NoError(t, err)
@@ -339,7 +332,7 @@ spec:
   mainNetwork: ndev
 `
 
-	dvpSpecWorker = `
+	dvpSpec = `
 apiVersion: deckhouse.io/v1alpha1
 kind: DVPInstanceClass
 metadata:


### PR DESCRIPTION
## Description
This PR fixes capacity parsing for `DVPInstanceClass` by matching the actual spec shape: CPU cores and memory are now read from the nested `virtualMachine` section instead of top-level fields. Memory parsing is corrected to use the quantity string provided by the spec (e.g., `8Gi`) rather than treating memory as an integer in MiB. It also includes additional in-code documentation (a commented example manifest) to clarify the expected structure. Test changes are excluded from this explanation.

## Why do we need it, and what problem does it solve?
Fix ExtractCapacity for DVPInstanceClass so that the module correctly interprets CPU and memory values as defined in the CRD. Previously the top-level fields were used incorrectly and memory was parsed as an integer in MiB which led to wrong capacity reporting and potential scheduling issues.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager 
type: fix
summary: Fix capacity parsing logic for DVPInstanceClass and add test case for DVPSpecWorker
impact: Capacity values (CPU/memory) for DVPInstanceClass are now correctly extracted according to spec shape. Nested `virtualMachine` fields are used and memory quantities like `Gi` are properly parsed.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
