### PR TITLE
[docs] Remove Stronghold documentation locations from test environments

### DIFF
--- a/docs/site/.helm/templates/20-ingress.yaml
+++ b/docs/site/.helm/templates/20-ingress.yaml
@@ -274,6 +274,7 @@ spec:
             name: frontend
             port:
               name: http
+{{- if eq $.Values.web.env "web-production" }}
       - path: /products/stronghold/documentation/
         pathType: Prefix
         backend:
@@ -295,6 +296,7 @@ spec:
             name: frontend
             port:
               name: http
+{{- end }}
 {{- if ne $.Values.web.env "web-production" }}
 ---
 apiVersion: deckhouse.io/v1


### PR DESCRIPTION
## Description

This pull request updates the Helm ingress template to ensure that routes for Deckhouse Stronghold documentation are only exposed in the production environment. 

## Why do we need it, and what problem does it solve?
It is need for moving Deckhouse Stronghold documentation to external repository in the future and to avoid Ingress routes duplication on test environments.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Remove Stronghold documentation locations from test environments
impact_level: low
```
