### PR TITLE
[candi] Add mutliversion parsing from oss.yaml file in werf, add tests

### DIFF
--- a/.werf/defines/oss-yaml.tmpl
+++ b/.werf/defines/oss-yaml.tmpl
@@ -430,7 +430,7 @@ Run: `go test ./testing/werf_defines/oss-yaml`.
 
   {{- $sParts := splitList "." $start -}}
   {{- $eParts := splitList "." $end -}}
-  {{- if or (lt (len $sParts) 2) (lt (len $eParts) 2) -}}
+  {{- if or (ne (len $sParts) 2) (ne (len $eParts) 2) -}}
     {{- fail (printf "\n[ERROR] start/end must look like '<major>.<minor>' (e.g. 1.32). Got start=%s end=%s" $start $end) -}}
   {{- end -}}
 

--- a/.werf/defines/oss-yaml.tmpl
+++ b/.werf/defines/oss-yaml.tmpl
@@ -1,3 +1,7 @@
+{{/*
+This file is covered by tests in `testing/werf_defines/oss-yaml`.
+Run: `go test ./testing/werf_defines/oss-yaml`.
+*/}}
 {{- define "get_oss_version_by_id" -}}
   {{- $id := index . 0 -}}
   {{- $ctx := index . 1 -}}
@@ -8,11 +12,32 @@
   {{- end -}}
 
   {{- $raw := printf "data:\n%s" ($ctx.Files.Get $ctx.OssYamlPath) | fromYaml -}}
+
+  {{- $item := dict -}}
   {{- range $raw.data -}}
     {{- if eq .id $id -}}
-      {{- $version = .version | default "" -}}
+      {{- $item = . -}}
       {{- break -}}
     {{- end -}}
+  {{- end -}}
+
+  {{- if eq (len $item) 0 -}}
+    {{- fail (printf "\n[ERROR] ID '%s' not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $versions := index $item "versions" -}}
+  {{- if not $versions -}}
+    {{- $versions = list -}}
+  {{- end -}}
+
+  {{- if gt (len $versions) 0 -}}
+    {{- if eq (len $versions) 1 -}}
+      {{- $version = (index (index $versions 0) "version") | default "" -}}
+    {{- else -}}
+      {{- fail (printf "\n[ERROR] Multiple versions are defined for ID '%s' in file: %s. Use helper 'get_oss_version_by_id_and_condition'." $id $ctx.OssYamlPath) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $version = (index $item "version") | default "" -}}
   {{- end -}}
 
   {{- if eq $version "" -}}
@@ -20,4 +45,494 @@
   {{- end -}}
 
   {{- $version -}}
+{{- end -}}
+
+{{/*
+  Returns YAML of a single version structure for a given id.
+
+  Input: (list <id:string> <ctx:werf_context>)
+
+  Behaviour:
+    - if `versions` exists and has exactly 1 item: returns that item
+    - if `versions` has >1 items: fails (ambiguous), use get_oss_version_by_id_and_condition or get_oss_versions_by_id
+    - if scalar `version` exists: returns pseudo-structure: {version: "<value>"}
+
+  Typical usage:
+    {{- $v := include "get_oss_version_struct_by_id" (list "example-service" $) | fromYaml -}}
+*/}}
+{{- define "get_oss_version_struct_by_id" -}}
+  {{- $id := index . 0 -}}
+  {{- $ctx := index . 1 -}}
+
+  {{- if not ($ctx.Files.Exists $ctx.OssYamlPath) -}}
+    {{- fail (printf "\n[ERROR] OSS file not found at path: %s" $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $raw := printf "data:\n%s" ($ctx.Files.Get $ctx.OssYamlPath) | fromYaml -}}
+
+  {{- $item := dict -}}
+  {{- range $raw.data -}}
+    {{- if eq .id $id -}}
+      {{- $item = . -}}
+      {{- break -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if eq (len $item) 0 -}}
+    {{- fail (printf "\n[ERROR] ID '%s' not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $versions := index $item "versions" -}}
+  {{- if not $versions -}}
+    {{- $versions = list -}}
+  {{- end -}}
+
+  {{- if gt (len $versions) 0 -}}
+    {{- if eq (len $versions) 1 -}}
+      {{- toYaml (index $versions 0) | trim -}}
+    {{- else -}}
+      {{- fail (printf "\n[ERROR] Multiple versions are defined for ID '%s' in file: %s. Use helper 'get_oss_version_by_id_and_condition' or 'get_oss_versions_by_id'." $id $ctx.OssYamlPath) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $version := (index $item "version") | default "" -}}
+    {{- if eq $version "" -}}
+      {{- fail (printf "\n[ERROR] Version for ID '%s' is empty or not found in file: %s" $id $ctx.OssYamlPath) -}}
+    {{- end -}}
+    {{- toYaml (dict "version" $version) | trim -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Returns concrete version string for a given id and condition.
+
+  Input: (list <id:string> <condition:map> <ctx:werf_context>)
+
+  Behaviour:
+    - if `versions` is present: finds first item where `.condition` matches provided map and returns `.version`
+      Matching rules per key:
+        - scalar in oss.yaml matches scalar in query by equality
+        - array in oss.yaml matches scalar in query by membership
+        - if query value is an array: all query values must be contained in oss.yaml value(s)
+    - if only scalar `version` is present: returns it (condition is ignored)
+
+  Typical usage:
+    {{- $ver := include "get_oss_version_by_id_and_condition" (list "example-service" (dict "k8s" "1.31") $) -}}
+*/}}
+{{- define "get_oss_version_by_id_and_condition" -}}
+  {{- $id := index . 0 -}}
+  {{- $condition := index . 1 -}}
+  {{- $ctx := index . 2 -}}
+  {{- $version := "" -}}
+
+  {{- if not ($ctx.Files.Exists $ctx.OssYamlPath) -}}
+    {{- fail (printf "\n[ERROR] OSS file not found at path: %s" $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $raw := printf "data:\n%s" ($ctx.Files.Get $ctx.OssYamlPath) | fromYaml -}}
+
+  {{- $item := dict -}}
+  {{- range $raw.data -}}
+    {{- if eq .id $id -}}
+      {{- $item = . -}}
+      {{- break -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if eq (len $item) 0 -}}
+    {{- fail (printf "\n[ERROR] ID '%s' not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $versions := index $item "versions" -}}
+  {{- if not $versions -}}
+    {{- $versions = list -}}
+  {{- end -}}
+
+  {{- if gt (len $versions) 0 -}}
+    {{- range $versions -}}
+      {{- $vCond := index . "condition" -}}
+      {{- if not $vCond -}}
+        {{- $vCond = dict -}}
+      {{- end -}}
+
+      {{- $match := true -}}
+
+      {{- range $k, $qVal := $condition -}}
+        {{- $cVal := index $vCond $k -}}
+        {{- if eq $cVal nil -}}
+          {{- $match = false -}}
+          {{- break -}}
+        {{- end -}}
+
+        {{- $cand := list -}}
+        {{- if kindIs "slice" $cVal -}}
+          {{- range $cVal -}}
+            {{- $cand = append $cand (printf "%v" .) -}}
+          {{- end -}}
+        {{- else -}}
+          {{- $cand = append $cand (printf "%v" $cVal) -}}
+        {{- end -}}
+
+        {{- $query := list -}}
+        {{- if kindIs "slice" $qVal -}}
+          {{- range $qVal -}}
+            {{- $query = append $query (printf "%v" .) -}}
+          {{- end -}}
+        {{- else -}}
+          {{- $query = append $query (printf "%v" $qVal) -}}
+        {{- end -}}
+
+        {{- range $query -}}
+          {{- $q := . -}}
+          {{- $found := false -}}
+          {{- range $cand -}}
+            {{- if eq . $q -}}
+              {{- $found = true -}}
+              {{- break -}}
+            {{- end -}}
+          {{- end -}}
+          {{- if not $found -}}
+            {{- $match = false -}}
+            {{- break -}}
+          {{- end -}}
+        {{- end -}}
+
+        {{- if not $match -}}
+          {{- break -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- if $match -}}
+        {{- $version = (index . "version") | default "" -}}
+        {{- break -}}
+      {{- end -}}
+    {{- end -}}
+
+    {{- if eq $version "" -}}
+      {{- $available := list -}}
+      {{- range $versions -}}
+        {{- $c := index . "condition" -}}
+        {{- if not $c -}}
+          {{- $c = dict -}}
+        {{- end -}}
+        {{- $available = append $available ((toYaml $c | trim) | default "{}") -}}
+      {{- end -}}
+      {{- fail (printf "\n[ERROR] Version for ID '%s' not found for condition %s in file: %s. Available conditions: %s" $id (toJson $condition) $ctx.OssYamlPath (join "; " $available)) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $version = (index $item "version") | default "" -}}
+  {{- end -}}
+
+  {{- if eq $version "" -}}
+    {{- fail (printf "\n[ERROR] Version for ID '%s' is empty or not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $version -}}
+{{- end -}}
+
+{{/*
+  Returns YAML array of version structures for a given id.
+
+  Input: (list <id:string> <ctx:werf_context>)
+
+  Behaviour:
+    - if `versions` exists: returns it as YAML
+    - else if scalar `version` exists: returns a single-item list: [{version: "<value>"}]
+
+  Typical usage:
+    {{- $versions := include "get_oss_versions_by_id" (list "example-service" $) | fromYaml -}}
+    {{- range $versions }}...{{- end -}}
+*/}}
+{{- define "get_oss_versions_by_id" -}}
+  {{- $id := index . 0 -}}
+  {{- $ctx := index . 1 -}}
+
+  {{- if not ($ctx.Files.Exists $ctx.OssYamlPath) -}}
+    {{- fail (printf "\n[ERROR] OSS file not found at path: %s" $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $raw := printf "data:\n%s" ($ctx.Files.Get $ctx.OssYamlPath) | fromYaml -}}
+
+  {{- $item := dict -}}
+  {{- range $raw.data -}}
+    {{- if eq .id $id -}}
+      {{- $item = . -}}
+      {{- break -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if eq (len $item) 0 -}}
+    {{- fail (printf "\n[ERROR] ID '%s' not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $versions := index $item "versions" -}}
+  {{- if not $versions -}}
+    {{- $versions = list -}}
+  {{- end -}}
+
+  {{- if gt (len $versions) 0 -}}
+    {{- toYaml $versions | trim -}}
+  {{- else -}}
+    {{- $version := (index $item "version") | default "" -}}
+    {{- if eq $version "" -}}
+      {{- fail (printf "\n[ERROR] Version for ID '%s' is empty or not found in file: %s" $id $ctx.OssYamlPath) -}}
+    {{- end -}}
+    {{- toYaml (list (dict "version" $version)) | trim -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Returns mapping <condition[key] value> -> <version> for a given id.
+
+  Input: (list <id:string> <conditionKey:string> <ctx:werf_context>)
+
+  Notes:
+    - supports scalar and array values in `condition.<key>`.
+    - if any condition values intersect between different versions (duplicate mapping key) -> fails.
+
+  Example oss.yaml:
+    - id: example-service
+      versions:
+        - condition: {k8s: ["1.31", "1.32"]}
+          version: 1.2.1
+        - condition: {k8s: ["1.33"]}
+          version: 1.2.2
+
+  Typical usage:
+    {{- $m := include "get_oss_version_map_by_id_and_condition_key" (list "example-service" "k8s" $) -}}
+*/}}
+{{- define "get_oss_version_map_by_id_and_condition_key" -}}
+  {{- $id := index . 0 -}}
+  {{- $key := index . 1 -}}
+  {{- $ctx := index . 2 -}}
+
+  {{- if not ($ctx.Files.Exists $ctx.OssYamlPath) -}}
+    {{- fail (printf "\n[ERROR] OSS file not found at path: %s" $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $raw := printf "data:\n%s" ($ctx.Files.Get $ctx.OssYamlPath) | fromYaml -}}
+
+  {{- $item := dict -}}
+  {{- range $raw.data -}}
+    {{- if eq .id $id -}}
+      {{- $item = . -}}
+      {{- break -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if eq (len $item) 0 -}}
+    {{- fail (printf "\n[ERROR] ID '%s' not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $versions := index $item "versions" -}}
+  {{- if not $versions -}}
+    {{- $versions = list -}}
+  {{- end -}}
+
+  {{- if eq (len $versions) 0 -}}
+    {{- fail (printf "\n[ERROR] No 'versions' array is defined for ID '%s' in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $out := dict -}}
+
+  {{- range $versions -}}
+    {{- $cond := index . "condition" -}}
+    {{- if not $cond -}}
+      {{- $cond = dict -}}
+    {{- end -}}
+
+    {{- $val := index $cond $key -}}
+    {{- if eq $val nil -}}
+      {{- fail (printf "\n[ERROR] Condition key '%s' is not defined for ID '%s' in file: %s. Condition: %s" $key $id $ctx.OssYamlPath (toYaml $cond | trim)) -}}
+    {{- end -}}
+
+    {{- $ver := (index . "version") | default "" -}}
+    {{- if eq $ver "" -}}
+      {{- fail (printf "\n[ERROR] Empty version in versions[] for ID '%s' in file: %s" $id $ctx.OssYamlPath) -}}
+    {{- end -}}
+
+    {{- $vals := list -}}
+    {{- if kindIs "slice" $val -}}
+      {{- range $val -}}
+        {{- $vals = append $vals (printf "%v" .) -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $vals = append $vals (printf "%v" $val) -}}
+    {{- end -}}
+
+    {{- range $vals -}}
+      {{- $k := . -}}
+      {{- if ne (index $out $k) nil -}}
+        {{- fail (printf "\n[ERROR] Overlapping conditions for ID '%s' and key '%s': value '%s' is defined more than once in file: %s" $id $key $k $ctx.OssYamlPath) -}}
+      {{- end -}}
+      {{- $_ := set $out $k $ver -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $keys := keys $out | sortAlpha -}}
+  {{- range $i, $k := $keys -}}
+    {{- printf "%s: %s\n" ($k | quote) ((index $out $k) | quote) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Returns mapping <k8s_version_in_range> -> <version> by evaluating semver constraints in `condition.<key>`.
+
+  Input: (list <id:string> <conditionKey:string> <rangeSpec:list> <ctx:werf_context>)
+
+  rangeSpec is a list of alternating key/value, e.g.:
+    (list "start" "1.32" "end" "1.35")
+
+  Notes:
+    - This helper expands the minor-version range [start..end] into discrete values: 1.32, 1.33, ...
+      (major must match in start/end).
+    - `condition.<key>` items may be:
+        - exact version: "1.35"
+        - semver constraint: "<=1.34", ">=1.32 <1.35", etc.
+      Constraints are evaluated via `semverCompare`.
+    - If multiple version entries match the same expanded version -> fails (overlap).
+    - If no version entry matches some expanded version -> fails (gap).
+
+  Typical usage:
+    {{- $m := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32" "end" "1.35") $) -}}
+*/}}
+{{- define "get_oss_version_map_by_id_and_condition_key_semver" -}}
+  {{- $id := index . 0 -}}
+  {{- $key := index . 1 -}}
+  {{- $rangeSpec := index . 2 -}}
+  {{- $ctx := index . 3 -}}
+
+  {{- if not ($ctx.Files.Exists $ctx.OssYamlPath) -}}
+    {{- fail (printf "\n[ERROR] OSS file not found at path: %s" $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- if not (kindIs "slice" $rangeSpec) -}}
+    {{- fail (printf "\n[ERROR] rangeSpec must be a list, got: %s" (kindOf $rangeSpec)) -}}
+  {{- end -}}
+
+  {{- if ne (mod (len $rangeSpec) 2) 0 -}}
+    {{- fail (printf "\n[ERROR] rangeSpec must contain even number of elements (key/value pairs), got len=%d" (len $rangeSpec)) -}}
+  {{- end -}}
+
+  {{- $range := dict -}}
+  {{- range $i, $_ := $rangeSpec -}}
+    {{- if eq (mod $i 2) 0 -}}
+      {{- $k := printf "%v" (index $rangeSpec $i) -}}
+      {{- $v := printf "%v" (index $rangeSpec (add $i 1)) -}}
+      {{- $_ := set $range $k $v -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $start := (index $range "start") | default "" -}}
+  {{- $end := (index $range "end") | default "" -}}
+  {{- if or (eq $start "") (eq $end "") -}}
+    {{- fail (printf "\n[ERROR] rangeSpec must include 'start' and 'end'. Got: %s" (toJson $range)) -}}
+  {{- end -}}
+
+  {{- $sParts := splitList "." $start -}}
+  {{- $eParts := splitList "." $end -}}
+  {{- if or (lt (len $sParts) 2) (lt (len $eParts) 2) -}}
+    {{- fail (printf "\n[ERROR] start/end must look like '<major>.<minor>' (e.g. 1.32). Got start=%s end=%s" $start $end) -}}
+  {{- end -}}
+
+  {{- $major := (atoi (index $sParts 0)) | int -}}
+  {{- $sMinor := (atoi (index $sParts 1)) | int -}}
+  {{- $eMajor := (atoi (index $eParts 0)) | int -}}
+  {{- $eMinor := (atoi (index $eParts 1)) | int -}}
+  {{- if ne $major $eMajor -}}
+    {{- fail (printf "\n[ERROR] start/end major version mismatch: start=%s end=%s" $start $end) -}}
+  {{- end -}}
+  {{- if gt $sMinor $eMinor -}}
+    {{- fail (printf "\n[ERROR] start minor must be <= end minor: start=%s end=%s" $start $end) -}}
+  {{- end -}}
+
+  {{- $raw := printf "data:\n%s" ($ctx.Files.Get $ctx.OssYamlPath) | fromYaml -}}
+
+  {{- $item := dict -}}
+  {{- range $raw.data -}}
+    {{- if eq .id $id -}}
+      {{- $item = . -}}
+      {{- break -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if eq (len $item) 0 -}}
+    {{- fail (printf "\n[ERROR] ID '%s' not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $versions := index $item "versions" -}}
+  {{- if not $versions -}}
+    {{- $versions = list -}}
+  {{- end -}}
+
+  {{- if eq (len $versions) 0 -}}
+    {{- fail (printf "\n[ERROR] No 'versions' array is defined for ID '%s' in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- range $minor := untilStep $sMinor (add $eMinor 1 | int) 1 -}}
+    {{- $target := printf "%d.%d" $major $minor -}}
+
+    {{- $matchedVersion := "" -}}
+    {{- $matchedCount := 0 -}}
+
+    {{- range $versions -}}
+      {{- $cond := index . "condition" -}}
+      {{- if not $cond -}}
+        {{- $cond = dict -}}
+      {{- end -}}
+
+      {{- $val := index $cond $key -}}
+      {{- if eq $val nil -}}
+        {{- fail (printf "\n[ERROR] Condition key '%s' is not defined for ID '%s' in file: %s. Condition: %s" $key $id $ctx.OssYamlPath (toYaml $cond | trim)) -}}
+      {{- end -}}
+
+      {{- $ver := (index . "version") | default "" -}}
+      {{- if eq $ver "" -}}
+        {{- fail (printf "\n[ERROR] Empty version in versions[] for ID '%s' in file: %s" $id $ctx.OssYamlPath) -}}
+      {{- end -}}
+
+      {{- $constraints := list -}}
+      {{- if kindIs "slice" $val -}}
+        {{- range $val -}}
+          {{- $constraints = append $constraints (printf "%v" .) -}}
+        {{- end -}}
+      {{- else -}}
+        {{- $constraints = append $constraints (printf "%v" $val) -}}
+      {{- end -}}
+
+      {{- $entryMatches := false -}}
+      {{- range $constraints -}}
+        {{- $c := . -}}
+        {{- $cNorm := $c -}}
+
+        {{- /* exact version '1.35' -> '= 1.35' */ -}}
+        {{- if regexMatch "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$" $cNorm -}}
+          {{- $cNorm = printf "= %s" $cNorm -}}
+        {{- else -}}
+          {{- /* normalize operator without whitespace: '<=1.34' -> '<= 1.34' */ -}}
+          {{- $cNorm = regexReplaceAll "^(<=|>=|<|>|=|!=)\\s*" $cNorm "${1} " -}}
+        {{- end -}}
+
+        {{- if semverCompare $cNorm $target -}}
+          {{- $entryMatches = true -}}
+          {{- break -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- if $entryMatches -}}
+        {{- $matchedCount = add $matchedCount 1 -}}
+        {{- if eq $matchedCount 1 -}}
+          {{- $matchedVersion = $ver -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+
+    {{- if eq $matchedCount 0 -}}
+      {{- fail (printf "\n[ERROR] No version matched for ID '%s' key '%s' at %s in file: %s" $id $key $target $ctx.OssYamlPath) -}}
+    {{- end -}}
+    {{- if gt $matchedCount 1 -}}
+      {{- fail (printf "\n[ERROR] Overlapping semver conditions for ID '%s' key '%s' at %s in file: %s" $id $key $target $ctx.OssYamlPath) -}}
+    {{- end -}}
+
+    {{- printf "%s: %s\n" ($target | quote) ($matchedVersion | quote) -}}
+  {{- end -}}
 {{- end -}}

--- a/.werf/defines/oss-yaml.tmpl
+++ b/.werf/defines/oss-yaml.tmpl
@@ -2,6 +2,66 @@
 This file is covered by tests in `testing/werf_defines/oss-yaml`.
 Run: `go test ./testing/werf_defines/oss-yaml`.
 */}}
+
+{{/*
+Internal helpers.
+
+werf template function set differs between versions/contexts (e.g. `werf config render` in CI).
+Avoid using Helm-only helpers like `toYaml` here.
+*/}}
+{{- define "oss_yaml_render_condition" -}}
+  {{- $cond := index . 0 -}}
+  {{- $indent := (index . 1) | default "" -}}
+
+  {{- if not $cond -}}
+    {{- /* nothing */ -}}
+  {{- else -}}
+    {{- /* fromYaml returns map[interface{}]interface{}; normalize to map[string]interface{} for deterministic key sorting */ -}}
+    {{- $condStr := dict -}}
+    {{- range $k, $v := $cond -}}
+      {{- $_ := set $condStr (printf "%v" $k) $v -}}
+    {{- end -}}
+
+    {{- $keys := keys $condStr | sortAlpha -}}
+    {{- range $keys -}}
+      {{- $k := . -}}
+      {{- $val := index $condStr $k -}}
+
+      {{- if kindIs "slice" $val -}}
+        {{- printf "%s%s:\n" $indent ($k | quote) -}}
+        {{- range $val -}}
+          {{- printf "%s  - %s\n" $indent ((printf "%v" .) | quote) -}}
+        {{- end -}}
+      {{- else -}}
+        {{- printf "%s%s: %s\n" $indent ($k | quote) ((printf "%v" $val) | quote) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "oss_yaml_render_version_struct" -}}
+  {{- $v := index . 0 -}}
+  {{- $indent := (index . 1) | default "" -}}
+
+  {{- $ver := (index $v "version") | default "" -}}
+  {{- if eq $ver "" -}}
+    {{- fail "\n[ERROR] Version struct has empty .version" -}}
+  {{- end -}}
+
+  {{- printf "%sversion: %s\n" $indent ($ver | quote) -}}
+
+  {{- $name := (index $v "name") | default "" -}}
+  {{- if ne $name "" -}}
+    {{- printf "%sname: %s\n" $indent ($name | quote) -}}
+  {{- end -}}
+
+  {{- $cond := index $v "condition" -}}
+  {{- if $cond -}}
+    {{- printf "%scondition:\n" $indent -}}
+    {{- include "oss_yaml_render_condition" (list $cond (printf "%s  " $indent)) -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "get_oss_version_by_id" -}}
   {{- $id := index . 0 -}}
   {{- $ctx := index . 1 -}}
@@ -89,7 +149,7 @@ Run: `go test ./testing/werf_defines/oss-yaml`.
 
   {{- if gt (len $versions) 0 -}}
     {{- if eq (len $versions) 1 -}}
-      {{- toYaml (index $versions 0) | trim -}}
+      {{- include "oss_yaml_render_version_struct" (list (index $versions 0) "") | trim -}}
     {{- else -}}
       {{- fail (printf "\n[ERROR] Multiple versions are defined for ID '%s' in file: %s. Use helper 'get_oss_version_by_id_and_condition' or 'get_oss_versions_by_id'." $id $ctx.OssYamlPath) -}}
     {{- end -}}
@@ -98,7 +158,7 @@ Run: `go test ./testing/werf_defines/oss-yaml`.
     {{- if eq $version "" -}}
       {{- fail (printf "\n[ERROR] Version for ID '%s' is empty or not found in file: %s" $id $ctx.OssYamlPath) -}}
     {{- end -}}
-    {{- toYaml (dict "version" $version) | trim -}}
+    {{- include "oss_yaml_render_version_struct" (list (dict "version" $version) "") | trim -}}
   {{- end -}}
 {{- end -}}
 
@@ -214,7 +274,7 @@ Run: `go test ./testing/werf_defines/oss-yaml`.
         {{- if not $c -}}
           {{- $c = dict -}}
         {{- end -}}
-        {{- $available = append $available ((toYaml $c | trim) | default "{}") -}}
+        {{- $available = append $available ((toJson $c) | default "{}") -}}
       {{- end -}}
       {{- fail (printf "\n[ERROR] Version for ID '%s' not found for condition %s in file: %s. Available conditions: %s" $id (toJson $condition) $ctx.OssYamlPath (join "; " $available)) -}}
     {{- end -}}
@@ -270,13 +330,32 @@ Run: `go test ./testing/werf_defines/oss-yaml`.
   {{- end -}}
 
   {{- if gt (len $versions) 0 -}}
-    {{- toYaml $versions | trim -}}
+    {{- range $versions -}}
+      {{- $v := . -}}
+      {{- $ver := (index $v "version") | default "" -}}
+      {{- if eq $ver "" -}}
+        {{- fail (printf "\n[ERROR] Empty version in versions[] for ID '%s' in file: %s" $id $ctx.OssYamlPath) -}}
+      {{- end -}}
+
+      {{- printf "- version: %s\n" ($ver | quote) -}}
+
+      {{- $name := (index $v "name") | default "" -}}
+      {{- if ne $name "" -}}
+        {{- printf "  name: %s\n" ($name | quote) -}}
+      {{- end -}}
+
+      {{- $cond := index $v "condition" -}}
+      {{- if $cond -}}
+        {{- printf "  condition:\n" -}}
+        {{- include "oss_yaml_render_condition" (list $cond "    ") -}}
+      {{- end -}}
+    {{- end -}}
   {{- else -}}
     {{- $version := (index $item "version") | default "" -}}
     {{- if eq $version "" -}}
       {{- fail (printf "\n[ERROR] Version for ID '%s' is empty or not found in file: %s" $id $ctx.OssYamlPath) -}}
     {{- end -}}
-    {{- toYaml (list (dict "version" $version)) | trim -}}
+    {{- printf "- version: %s\n" ($version | quote) -}}
   {{- end -}}
 {{- end -}}
 
@@ -342,7 +421,7 @@ Run: `go test ./testing/werf_defines/oss-yaml`.
 
     {{- $val := index $cond $key -}}
     {{- if eq $val nil -}}
-      {{- fail (printf "\n[ERROR] Condition key '%s' is not defined for ID '%s' in file: %s. Condition: %s" $key $id $ctx.OssYamlPath (toYaml $cond | trim)) -}}
+      {{- fail (printf "\n[ERROR] Condition key '%s' is not defined for ID '%s' in file: %s. Condition: %s" $key $id $ctx.OssYamlPath (toJson $cond)) -}}
     {{- end -}}
 
     {{- $ver := (index . "version") | default "" -}}
@@ -482,7 +561,7 @@ Run: `go test ./testing/werf_defines/oss-yaml`.
 
       {{- $val := index $cond $key -}}
       {{- if eq $val nil -}}
-        {{- fail (printf "\n[ERROR] Condition key '%s' is not defined for ID '%s' in file: %s. Condition: %s" $key $id $ctx.OssYamlPath (toYaml $cond | trim)) -}}
+        {{- fail (printf "\n[ERROR] Condition key '%s' is not defined for ID '%s' in file: %s. Condition: %s" $key $id $ctx.OssYamlPath (toJson $cond)) -}}
       {{- end -}}
 
       {{- $ver := (index . "version") | default "" -}}

--- a/.werf/defines/oss-yaml.tmpl
+++ b/.werf/defines/oss-yaml.tmpl
@@ -298,6 +298,9 @@ Avoid using Helm-only helpers like `toYaml` here.
     - if `versions` exists: returns it as YAML
     - else if scalar `version` exists: returns a single-item list: [{version: "<value>"}]
 
+  Note:
+    - `versions[].condition` is optional.
+
   Typical usage:
     {{- $versions := include "get_oss_versions_by_id" (list "example-service" $) | fromYaml -}}
     {{- range $versions }}...{{- end -}}
@@ -356,6 +359,65 @@ Avoid using Helm-only helpers like `toYaml` here.
       {{- fail (printf "\n[ERROR] Version for ID '%s' is empty or not found in file: %s" $id $ctx.OssYamlPath) -}}
     {{- end -}}
     {{- printf "- version: %s\n" ($version | quote) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+  Returns YAML array of version strings for a given id.
+
+  Input: (list <id:string> <ctx:werf_context>)
+
+  Behaviour:
+    - if `versions` exists: returns list of `.version` values
+    - else if scalar `version` exists: returns single-item list
+
+  Intended for cases where `versions[]` items have no `condition` and you need all versions.
+
+  Typical usage:
+    {{- $raw := printf "data:\n%s" (include "get_oss_version_strings_by_id" (list "example-service" $)) | fromYaml -}}
+    {{- $versions := index $raw "data" -}}
+*/}}
+{{- define "get_oss_version_strings_by_id" -}}
+  {{- $id := index . 0 -}}
+  {{- $ctx := index . 1 -}}
+
+  {{- if not ($ctx.Files.Exists $ctx.OssYamlPath) -}}
+    {{- fail (printf "\n[ERROR] OSS file not found at path: %s" $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $raw := printf "data:\n%s" ($ctx.Files.Get $ctx.OssYamlPath) | fromYaml -}}
+
+  {{- $item := dict -}}
+  {{- range $raw.data -}}
+    {{- if eq .id $id -}}
+      {{- $item = . -}}
+      {{- break -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if eq (len $item) 0 -}}
+    {{- fail (printf "\n[ERROR] ID '%s' not found in file: %s" $id $ctx.OssYamlPath) -}}
+  {{- end -}}
+
+  {{- $versions := index $item "versions" -}}
+  {{- if not $versions -}}
+    {{- $versions = list -}}
+  {{- end -}}
+
+  {{- if gt (len $versions) 0 -}}
+    {{- range $versions -}}
+      {{- $ver := (index . "version") | default "" -}}
+      {{- if eq $ver "" -}}
+        {{- fail (printf "\n[ERROR] Empty version in versions[] for ID '%s' in file: %s" $id $ctx.OssYamlPath) -}}
+      {{- end -}}
+      {{- printf "- %s\n" ($ver | quote) -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $version := (index $item "version") | default "" -}}
+    {{- if eq $version "" -}}
+      {{- fail (printf "\n[ERROR] Version for ID '%s' is empty or not found in file: %s" $id $ctx.OssYamlPath) -}}
+    {{- end -}}
+    {{- printf "- %s\n" ($version | quote) -}}
   {{- end -}}
 {{- end -}}
 

--- a/testing/werf_defines/oss-yaml/README.md
+++ b/testing/werf_defines/oss-yaml/README.md
@@ -1,0 +1,82 @@
+# oss.yaml werf helpers tests
+
+This directory contains small integration-style tests for werf go-template helpers implemented in [` .werf/defines/oss-yaml.tmpl`](../../.werf/defines/oss-yaml.tmpl:1).
+
+The tests render minimal werf configs using `werf config render --dev` and assert that:
+- **render-ok** cases render successfully
+- **render-fail** cases fail to render
+
+## How to run
+
+From the repository root:
+
+```bash
+go test ./testing/werf_defines/oss-yaml
+```
+
+The test runner expects a `werf` binary at `./bin/werf`. If it is missing, the test tries to build it via `make bin/werf`. If build fails, tests will be skipped.
+
+## Structure
+
+- `render-ok/<case-name>/`
+  - `werf.yaml` — a minimal werf config that uses one or more helpers and fails explicitly if the helper result is not as expected
+  - `oss.yaml` — per-case fixture file
+
+- `render-fail/<case-name>/`
+  - `werf.yaml` — a minimal werf config that is expected to fail rendering (e.g. ambiguous version selection, overlap, missing id)
+  - `oss.yaml` — per-case fixture file
+
+## How helpers are wired into fixtures
+
+Each fixture directory is treated as an independent werf project.
+
+Before rendering a case, the Go test creates `.<caseDir>/.werf/defines/oss-yaml.tmpl` as a **symlink** to the repository helper template [` .werf/defines/oss-yaml.tmpl`](../../.werf/defines/oss-yaml.tmpl:1). This guarantees that tests always run against the current helper implementation.
+
+On Windows, the test falls back to copying the file (symlinks may require elevated privileges).
+
+## Adding a new test case
+
+1. Pick whether it should render:
+   - success: add a directory under `render-ok/`
+   - failure: add a directory under `render-fail/`
+
+2. Create two files in the case directory:
+   - `oss.yaml`
+   - `werf.yaml`
+
+3. In `werf.yaml` ensure the helper reads the local fixture:
+
+```yaml
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+```
+
+4. Add assertions in `werf.yaml`:
+   - For *render-ok* cases: compute the helper output and call `fail` if it is not equal to the expected result.
+   - For *render-fail* cases: it is enough to call the helper in a way that should fail.
+
+Notes:
+- Werf `fromYaml` expects a map (document) at top-level. If you need to parse an array returned by a helper, wrap it first:
+
+```yaml
+{{- $raw := printf "data:\n%s" (include "get_oss_versions_by_id" (list "example-service" $)) | fromYaml -}}
+{{- $versions := index $raw "data" -}}
+```
+
+## Debugging
+
+If rendering fails unexpectedly, run the same render command manually in a case directory:
+
+```bash
+cd testing/werf_defines/oss-yaml/render-ok/<case>
+../../../../bin/werf config render --dev --debug-templates
+```
+
+The test runner also sets `WERF_GITERMINISM_CONFIG` to [`werf-giterminism.yaml`](../../werf-giterminism.yaml:1) to make rendering possible from nested fixture directories.

--- a/testing/werf_defines/oss-yaml/oss_yaml_helpers_test.go
+++ b/testing/werf_defines/oss-yaml/oss_yaml_helpers_test.go
@@ -1,0 +1,153 @@
+package oss_yaml_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	cur := wd
+	for {
+		if _, err := os.Stat(filepath.Join(cur, "go.mod")); err == nil {
+			return cur
+		}
+		next := filepath.Dir(cur)
+		if next == cur {
+			t.Fatalf("repo root not found from %s", wd)
+		}
+		cur = next
+	}
+}
+
+func ensureWerfBinary(t *testing.T, repoRoot string) string {
+	t.Helper()
+	werf := filepath.Join(repoRoot, "bin", "werf")
+	if runtime.GOOS == "windows" {
+		werf += ".exe"
+	}
+	if _, err := os.Stat(werf); err == nil {
+		return werf
+	}
+
+	cmd := exec.Command("make", "bin/werf")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("werf binary not found and failed to build via `make bin/werf`: %v\n%s", err, strings.TrimSpace(string(out)))
+	}
+
+	if _, err := os.Stat(werf); err != nil {
+		t.Skipf("werf binary still not found after build at %s", werf)
+	}
+	return werf
+}
+
+func syncHelperIntoCaseDir(t *testing.T, repoRoot, caseDir string) {
+	t.Helper()
+
+	src := filepath.Join(repoRoot, ".werf", "defines", "oss-yaml.tmpl")
+	dstDir := filepath.Join(caseDir, ".werf", "defines")
+	dst := filepath.Join(dstDir, "oss-yaml.tmpl")
+
+	// Ensure clean state (remove possible symlink leftover).
+	_ = os.RemoveAll(dstDir)
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dstDir, err)
+	}
+
+	// Prefer symlink to always test the current helper implementation.
+	// On Windows symlinks might require special privileges, so we fallback to copying.
+	if runtime.GOOS != "windows" {
+		rel, err := filepath.Rel(dstDir, src)
+		if err != nil {
+			t.Fatalf("rel symlink path from %s to %s: %v", dstDir, src, err)
+		}
+		if err := os.Symlink(rel, dst); err != nil {
+			t.Fatalf("symlink %s -> %s: %v", dst, rel, err)
+		}
+		return
+	}
+
+	b, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read helper template %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, b, 0o644); err != nil {
+		t.Fatalf("write helper template %s: %v", dst, err)
+	}
+}
+
+func runWerfRender(t *testing.T, repoRoot, werf, dir string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(werf, "config", "render", "--dev")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"WERF_LOG_COLOR_MODE=off",
+		"WERF_LOG_VERBOSE=false",
+		"WERF_GITERMINISM_CONFIG="+filepath.Join(repoRoot, "werf-giterminism.yaml"),
+	)
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func listCaseDirs(t *testing.T, base string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(base)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", base, err)
+	}
+	var dirs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dirs = append(dirs, filepath.Join(base, e.Name()))
+	}
+	if len(dirs) == 0 {
+		t.Fatalf("no testcases found in %s", base)
+	}
+	return dirs
+}
+
+func TestWerfDefinesOssYamlHelpers_RenderOK(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	werf := ensureWerfBinary(t, repoRoot)
+	base := filepath.Join(repoRoot, "testing", "werf_defines", "oss-yaml", "render-ok")
+
+	for _, d := range listCaseDirs(t, base) {
+		name := filepath.Base(d)
+		t.Run(name, func(t *testing.T) {
+			syncHelperIntoCaseDir(t, repoRoot, d)
+			out, err := runWerfRender(t, repoRoot, werf, d)
+			if err != nil {
+				t.Fatalf("expected render OK, got error: %v\n--- output ---\n%s", err, out)
+			}
+		})
+	}
+}
+
+func TestWerfDefinesOssYamlHelpers_RenderFail(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	werf := ensureWerfBinary(t, repoRoot)
+	base := filepath.Join(repoRoot, "testing", "werf_defines", "oss-yaml", "render-fail")
+
+	for _, d := range listCaseDirs(t, base) {
+		name := filepath.Base(d)
+		t.Run(name, func(t *testing.T) {
+			syncHelperIntoCaseDir(t, repoRoot, d)
+			out, err := runWerfRender(t, repoRoot, werf, d)
+			if err == nil {
+				t.Fatalf("expected render to fail, but it succeeded\n--- output ---\n%s", out)
+			}
+		})
+	}
+}

--- a/testing/werf_defines/oss-yaml/oss_yaml_helpers_test.go
+++ b/testing/werf_defines/oss-yaml/oss_yaml_helpers_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package oss_yaml_test
 
 import (

--- a/testing/werf_defines/oss-yaml/render-fail/01-get_oss_version_by_id_ambiguous/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/01-get_oss_version_by_id_ambiguous/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/01-get_oss_version_by_id_ambiguous/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/01-get_oss_version_by_id_ambiguous/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [1.31]
+      version: 1.2.1
+    - condition:
+        k8s: [1.32]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-fail/01-get_oss_version_by_id_ambiguous/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/01-get_oss_version_by_id_ambiguous/werf.yaml
@@ -1,0 +1,11 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $_ := include "get_oss_version_by_id" (list "example-service" $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/02-get_oss_version_struct_by_id_ambiguous/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/02-get_oss_version_struct_by_id_ambiguous/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/02-get_oss_version_struct_by_id_ambiguous/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/02-get_oss_version_struct_by_id_ambiguous/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [1.31]
+      version: 1.2.1
+    - condition:
+        k8s: [1.32]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-fail/02-get_oss_version_struct_by_id_ambiguous/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/02-get_oss_version_struct_by_id_ambiguous/werf.yaml
@@ -1,0 +1,11 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $_ := include "get_oss_version_struct_by_id" (list "example-service" $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/03-get_oss_version_by_id_and_condition_not_found/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/03-get_oss_version_by_id_and_condition_not_found/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/03-get_oss_version_by_id_and_condition_not_found/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/03-get_oss_version_by_id_and_condition_not_found/oss.yaml
@@ -1,0 +1,6 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [1.31]
+      version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-fail/03-get_oss_version_by_id_and_condition_not_found/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/03-get_oss_version_by_id_and_condition_not_found/werf.yaml
@@ -1,0 +1,11 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $_ := include "get_oss_version_by_id_and_condition" (list "example-service" (dict "k8s" "1.32") $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/04-get_oss_versions_by_id_id_not_found/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/04-get_oss_versions_by_id_id_not_found/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/04-get_oss_versions_by_id_id_not_found/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/04-get_oss_versions_by_id_id_not_found/oss.yaml
@@ -1,0 +1,3 @@
+- name: Example service
+  id: example-service
+  version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-fail/04-get_oss_versions_by_id_id_not_found/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/04-get_oss_versions_by_id_id_not_found/werf.yaml
@@ -1,0 +1,11 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $_ := include "get_oss_versions_by_id" (list "missing-id" $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/05-get_oss_version_map_overlap/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/05-get_oss_version_map_overlap/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/05-get_oss_version_map_overlap/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/05-get_oss_version_map_overlap/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [1.31, 1.32]
+      version: 1.2.1
+    - condition:
+        k8s: [1.32]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-fail/05-get_oss_version_map_overlap/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/05-get_oss_version_map_overlap/werf.yaml
@@ -1,0 +1,11 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key" (list "example-service" "k8s" $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/06-get_oss_version_map_semver_overlap/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/06-get_oss_version_map_semver_overlap/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/06-get_oss_version_map_semver_overlap/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/06-get_oss_version_map_semver_overlap/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [">=1.32"]
+      version: 1.2.1
+    - condition:
+        k8s: ["<=1.34"]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-fail/06-get_oss_version_map_semver_overlap/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/06-get_oss_version_map_semver_overlap/werf.yaml
@@ -1,0 +1,11 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32" "end" "1.35") $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/07-get_oss_version_map_semver_overlap_exact_and_range/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/07-get_oss_version_map_semver_overlap_exact_and_range/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/07-get_oss_version_map_semver_overlap_exact_and_range/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/07-get_oss_version_map_semver_overlap_exact_and_range/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [">=1.34"]
+      version: 1.2.1
+    - condition:
+        k8s: ["1.34"]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-fail/07-get_oss_version_map_semver_overlap_exact_and_range/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/07-get_oss_version_map_semver_overlap_exact_and_range/werf.yaml
@@ -1,0 +1,12 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- /* exact + range overlap for 1.34 -> should fail */ -}}
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.34" "end" "1.34") $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/08-get_oss_version_map_semver_gap/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/08-get_oss_version_map_semver_gap/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/08-get_oss_version_map_semver_gap/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/08-get_oss_version_map_semver_gap/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: ["<=1.33"]
+      version: 1.2.1
+    - condition:
+        k8s: ["1.35"]
+      version: 1.3.1

--- a/testing/werf_defines/oss-yaml/render-fail/08-get_oss_version_map_semver_gap/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/08-get_oss_version_map_semver_gap/werf.yaml
@@ -1,0 +1,11 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32" "end" "1.35") $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/09-get_oss_version_map_semver_invalid_rangespec_missing_end/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/09-get_oss_version_map_semver_invalid_rangespec_missing_end/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/09-get_oss_version_map_semver_invalid_rangespec_missing_end/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/09-get_oss_version_map_semver_invalid_rangespec_missing_end/oss.yaml
@@ -1,0 +1,6 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: ["<=1.35"]
+      version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-fail/09-get_oss_version_map_semver_invalid_rangespec_missing_end/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/09-get_oss_version_map_semver_invalid_rangespec_missing_end/werf.yaml
@@ -1,0 +1,12 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- /* missing `end` in rangeSpec -> should fail */ -}}
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32" "finish" "1.35") $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/10-get_oss_version_map_semver_invalid_rangespec_odd_len/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/10-get_oss_version_map_semver_invalid_rangespec_odd_len/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/10-get_oss_version_map_semver_invalid_rangespec_odd_len/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/10-get_oss_version_map_semver_invalid_rangespec_odd_len/oss.yaml
@@ -1,0 +1,6 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: ["<=1.35"]
+      version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-fail/10-get_oss_version_map_semver_invalid_rangespec_odd_len/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/10-get_oss_version_map_semver_invalid_rangespec_odd_len/werf.yaml
@@ -1,0 +1,12 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- /* odd number of elements in rangeSpec -> should fail */ -}}
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32" "end") $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/11-get_oss_version_map_semver_invalid_range_patch_in_start/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/11-get_oss_version_map_semver_invalid_range_patch_in_start/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/11-get_oss_version_map_semver_invalid_range_patch_in_start/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/11-get_oss_version_map_semver_invalid_range_patch_in_start/oss.yaml
@@ -1,0 +1,6 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: ["<=1.35"]
+      version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-fail/11-get_oss_version_map_semver_invalid_range_patch_in_start/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/11-get_oss_version_map_semver_invalid_range_patch_in_start/werf.yaml
@@ -1,0 +1,12 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- /* start has patch version -> should fail (expects <major>.<minor>) */ -}}
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32.1" "end" "1.35") $) -}}

--- a/testing/werf_defines/oss-yaml/render-fail/12-get_oss_version_map_semver_wrong_condition_key/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-fail/12-get_oss_version_map_semver_wrong_condition_key/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-fail/12-get_oss_version_map_semver_wrong_condition_key/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/12-get_oss_version_map_semver_wrong_condition_key/oss.yaml
@@ -1,0 +1,6 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        platform: ["<=1.33"]
+      version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-fail/12-get_oss_version_map_semver_wrong_condition_key/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-fail/12-get_oss_version_map_semver_wrong_condition_key/werf.yaml
@@ -1,0 +1,12 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- /* oss.yaml uses different condition key -> should fail */ -}}
+{{- $_ := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32" "end" "1.33") $) -}}

--- a/testing/werf_defines/oss-yaml/render-ok/01-get_oss_version_by_id_simple/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-ok/01-get_oss_version_by_id_simple/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-ok/01-get_oss_version_by_id_simple/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/01-get_oss_version_by_id_simple/oss.yaml
@@ -1,0 +1,3 @@
+- name: Example service
+  id: example-service
+  version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-ok/01-get_oss_version_by_id_simple/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/01-get_oss_version_by_id_simple/werf.yaml
@@ -1,0 +1,14 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $ver := include "get_oss_version_by_id" (list "example-service" $) -}}
+{{- if ne $ver "1.2.1" -}}
+  {{- fail (printf "expected version 1.2.1, got %s" $ver) -}}
+{{- end -}}

--- a/testing/werf_defines/oss-yaml/render-ok/02-get_oss_version_struct_by_id_from_scalar/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-ok/02-get_oss_version_struct_by_id_from_scalar/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-ok/02-get_oss_version_struct_by_id_from_scalar/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/02-get_oss_version_struct_by_id_from_scalar/oss.yaml
@@ -1,0 +1,3 @@
+- name: Example service
+  id: example-service
+  version: 1.2.1

--- a/testing/werf_defines/oss-yaml/render-ok/02-get_oss_version_struct_by_id_from_scalar/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/02-get_oss_version_struct_by_id_from_scalar/werf.yaml
@@ -1,0 +1,14 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $v := include "get_oss_version_struct_by_id" (list "example-service" $) | fromYaml -}}
+{{- if ne (get $v "version") "1.2.1" -}}
+  {{- fail (printf "expected v.version=1.2.1, got %v" $v) -}}
+{{- end -}}

--- a/testing/werf_defines/oss-yaml/render-ok/03-get_oss_version_by_id_and_condition_membership/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-ok/03-get_oss_version_by_id_and_condition_membership/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-ok/03-get_oss_version_by_id_and_condition_membership/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/03-get_oss_version_by_id_and_condition_membership/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [1.31, 1.32]
+      version: 1.2.1
+    - condition:
+        k8s: [1.33]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-ok/03-get_oss_version_by_id_and_condition_membership/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/03-get_oss_version_by_id_and_condition_membership/werf.yaml
@@ -1,0 +1,14 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $ver := include "get_oss_version_by_id_and_condition" (list "example-service" (dict "k8s" "1.32") $) -}}
+{{- if ne $ver "1.2.1" -}}
+  {{- fail (printf "expected 1.2.1 for k8s=1.32, got %s" $ver) -}}
+{{- end -}}

--- a/testing/werf_defines/oss-yaml/render-ok/04-get_oss_versions_by_id_list/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-ok/04-get_oss_versions_by_id_list/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-ok/04-get_oss_versions_by_id_list/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/04-get_oss_versions_by_id_list/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [1.31]
+      version: 1.2.1
+    - condition:
+        k8s: [1.32]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-ok/04-get_oss_versions_by_id_list/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/04-get_oss_versions_by_id_list/werf.yaml
@@ -1,0 +1,21 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $raw := printf "data:\n%s" (include "get_oss_versions_by_id" (list "example-service" $)) | fromYaml -}}
+{{- $versions := index $raw "data" -}}
+{{- if ne (len $versions) 2 -}}
+  {{- fail (printf "expected 2 versions, got %d" (len $versions)) -}}
+{{- end -}}
+{{- if ne (index (index $versions 0) "version") "1.2.1" -}}
+  {{- fail (printf "expected first version=1.2.1, got %v" (index $versions 0)) -}}
+{{- end -}}
+{{- if ne (index (index $versions 1) "version") "1.2.2" -}}
+  {{- fail (printf "expected second version=1.2.2, got %v" (index $versions 1)) -}}
+{{- end -}}

--- a/testing/werf_defines/oss-yaml/render-ok/05-get_oss_version_map_by_id_and_condition_key/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-ok/05-get_oss_version_map_by_id_and_condition_key/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-ok/05-get_oss_version_map_by_id_and_condition_key/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/05-get_oss_version_map_by_id_and_condition_key/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: [1.31, 1.32]
+      version: 1.2.1
+    - condition:
+        k8s: [1.33]
+      version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-ok/05-get_oss_version_map_by_id_and_condition_key/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/05-get_oss_version_map_by_id_and_condition_key/werf.yaml
@@ -1,0 +1,20 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $m := include "get_oss_version_map_by_id_and_condition_key" (list "example-service" "k8s" $) | fromYaml -}}
+{{- if ne (get $m "1.31") "1.2.1" -}}
+  {{- fail (printf "expected map[1.31]=1.2.1, got %v" $m) -}}
+{{- end -}}
+{{- if ne (get $m "1.32") "1.2.1" -}}
+  {{- fail (printf "expected map[1.32]=1.2.1, got %v" $m) -}}
+{{- end -}}
+{{- if ne (get $m "1.33") "1.2.2" -}}
+  {{- fail (printf "expected map[1.33]=1.2.2, got %v" $m) -}}
+{{- end -}}

--- a/testing/werf_defines/oss-yaml/render-ok/06-get_oss_version_map_by_id_and_condition_key_semver/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-ok/06-get_oss_version_map_by_id_and_condition_key_semver/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-ok/06-get_oss_version_map_by_id_and_condition_key_semver/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/06-get_oss_version_map_by_id_and_condition_key_semver/oss.yaml
@@ -1,0 +1,9 @@
+- name: Example service
+  id: example-service
+  versions:
+    - condition:
+        k8s: ["<=1.34"]
+      version: 1.2.1
+    - condition:
+        k8s: ["1.35"]
+      version: 1.3.1

--- a/testing/werf_defines/oss-yaml/render-ok/06-get_oss_version_map_by_id_and_condition_key_semver/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/06-get_oss_version_map_by_id_and_condition_key_semver/werf.yaml
@@ -1,0 +1,23 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $m := include "get_oss_version_map_by_id_and_condition_key_semver" (list "example-service" "k8s" (list "start" "1.32" "end" "1.35") $) | fromYaml -}}
+{{- if ne (get $m "1.32") "1.2.1" -}}
+  {{- fail (printf "expected map[1.32]=1.2.1, got %v" $m) -}}
+{{- end -}}
+{{- if ne (get $m "1.33") "1.2.1" -}}
+  {{- fail (printf "expected map[1.33]=1.2.1, got %v" $m) -}}
+{{- end -}}
+{{- if ne (get $m "1.34") "1.2.1" -}}
+  {{- fail (printf "expected map[1.34]=1.2.1, got %v" $m) -}}
+{{- end -}}
+{{- if ne (get $m "1.35") "1.3.1" -}}
+  {{- fail (printf "expected map[1.35]=1.3.1, got %v" $m) -}}
+{{- end -}}

--- a/testing/werf_defines/oss-yaml/render-ok/07-get_oss_version_strings_by_id_list/.werf/defines/oss-yaml.tmpl
+++ b/testing/werf_defines/oss-yaml/render-ok/07-get_oss_version_strings_by_id_list/.werf/defines/oss-yaml.tmpl
@@ -1,0 +1,1 @@
+../../../../../../../.werf/defines/oss-yaml.tmpl

--- a/testing/werf_defines/oss-yaml/render-ok/07-get_oss_version_strings_by_id_list/oss.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/07-get_oss_version_strings_by_id_list/oss.yaml
@@ -1,0 +1,5 @@
+- name: Example service
+  id: example-service
+  versions:
+    - version: 1.2.1
+    - version: 1.2.2

--- a/testing/werf_defines/oss-yaml/render-ok/07-get_oss_version_strings_by_id_list/werf.yaml
+++ b/testing/werf_defines/oss-yaml/render-ok/07-get_oss_version_strings_by_id_list/werf.yaml
@@ -1,0 +1,22 @@
+{{- $_ := set . "OssYamlPath" "oss.yaml" -}}
+project: test-oss-yaml-helper
+configVersion: 1
+---
+image: test
+from: alpine:3.20
+shell:
+  install:
+  - echo ok
+
+{{- $raw := printf "data:\n%s" (include "get_oss_version_strings_by_id" (list "example-service" $)) | fromYaml -}}
+{{- $versions := index $raw "data" -}}
+
+{{- if ne (len $versions) 2 -}}
+  {{- fail (printf "expected 2 versions, got %d" (len $versions)) -}}
+{{- end -}}
+{{- if ne (index $versions 0) "1.2.1" -}}
+  {{- fail (printf "expected first version=1.2.1, got %v" (index $versions 0)) -}}
+{{- end -}}
+{{- if ne (index $versions 1) "1.2.2" -}}
+  {{- fail (printf "expected second version=1.2.2, got %v" (index $versions 1)) -}}
+{{- end -}}


### PR DESCRIPTION
## Description
Updated werf oss.yaml parsing to support the extended format where a single id can have multiple versions selected by condition (including array-valued conditions and semver-range mapping).

## Why do we need it, and what problem does it solve?

Werf previously handled only the simple oss.yaml case (single version per id).
Some modules require selecting different upstream component versions depending on conditions (e.g. Kubernetes minor version). This change adds a supported way to declare multiple versions per id and retrieve the correct one via dedicated helpers (including conflict detection and semver-based range mapping). It makes the format expressive enough for real-world cases and reduces template duplication/errors.




## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: candi
type: feature
summary: Added multiversion parsing from `oss.yaml` in werf and tests.
impact_level: default
```
