### PR TITLE
[docs] Delete examples page from deckhouse-tools module documentation

### DIFF
--- a/modules/800-deckhouse-tools/docs/EXAMPLES.md
+++ b/modules/800-deckhouse-tools/docs/EXAMPLES.md
@@ -1,3 +1,0 @@
----
-title: "The deckhouse-tools module: examples"
----

--- a/modules/800-deckhouse-tools/docs/EXAMPLES_RU.md
+++ b/modules/800-deckhouse-tools/docs/EXAMPLES_RU.md
@@ -1,3 +1,0 @@
----
-title: "Модуль deckhouse-tools: примеры"
----


### PR DESCRIPTION
## Description
Removed examples page from deckhouse-tools module documentation.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Removed examples page from deckhouse-tools module documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
