### PR TITLE
[dhctl] Fix (dhctl-for-commander): improve dhctl server startup

### DIFF
--- a/dhctl/pkg/server/server/proxy_test.go
+++ b/dhctl/pkg/server/server/proxy_test.go
@@ -37,7 +37,7 @@ func TestStreamDirectorParams_Validate(t *testing.T) {
 		{
 			name: "valid params",
 			params: StreamDirectorParams{
-				MethodsPrefix: "/dhctl.DHCTL",
+				MethodsPrefix: SinglethreadedMethodsPrefix,
 				TmpDir:        "/tmp/dhctl",
 			},
 			expectError: false,
@@ -53,7 +53,7 @@ func TestStreamDirectorParams_Validate(t *testing.T) {
 		{
 			name: "invalid tmp dir - empty",
 			params: StreamDirectorParams{
-				MethodsPrefix: "/dhctl.DHCTL",
+				MethodsPrefix: SinglethreadedMethodsPrefix,
 				TmpDir:        "",
 			},
 			expectError: true,
@@ -62,7 +62,7 @@ func TestStreamDirectorParams_Validate(t *testing.T) {
 		{
 			name: "invalid tmp dir - root",
 			params: StreamDirectorParams{
-				MethodsPrefix: "/dhctl.DHCTL",
+				MethodsPrefix: SinglethreadedMethodsPrefix,
 				TmpDir:        "/",
 			},
 			expectError: true,
@@ -94,7 +94,7 @@ func TestNewStreamDirector(t *testing.T) {
 		{
 			name: "valid params",
 			params: StreamDirectorParams{
-				MethodsPrefix: "/dhctl.DHCTL",
+				MethodsPrefix: SinglethreadedMethodsPrefix,
 				TmpDir:        "/tmp/dhctl",
 			},
 			expectError: false,
@@ -102,7 +102,7 @@ func TestNewStreamDirector(t *testing.T) {
 		{
 			name: "invalid params",
 			params: StreamDirectorParams{
-				MethodsPrefix: "/dhctl.DHCTL",
+				MethodsPrefix: SinglethreadedMethodsPrefix,
 				TmpDir:        "",
 			},
 			expectError: true,
@@ -134,10 +134,12 @@ func TestNewStreamDirector(t *testing.T) {
 func TestStreamDirector_SocketPath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dhctl-proxy-test-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	params := StreamDirectorParams{
-		MethodsPrefix: "/dhctl.DHCTL",
+		MethodsPrefix: SinglethreadedMethodsPrefix,
 		TmpDir:        tmpDir,
 	}
 
@@ -182,10 +184,12 @@ func TestStreamDirector_SocketPath(t *testing.T) {
 func TestStreamDirector_TmpDirPath(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dhctl-proxy-test-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	params := StreamDirectorParams{
-		MethodsPrefix: "/dhctl.DHCTL",
+		MethodsPrefix: SinglethreadedMethodsPrefix,
 		TmpDir:        tmpDir,
 	}
 
@@ -242,10 +246,12 @@ func TestStreamDirector_TmpDirPath(t *testing.T) {
 func TestStreamDirector_TmpDirPathConsistency(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dhctl-proxy-test-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	params := StreamDirectorParams{
-		MethodsPrefix: "/dhctl.DHCTL",
+		MethodsPrefix: SinglethreadedMethodsPrefix,
 		TmpDir:        tmpDir,
 	}
 
@@ -266,10 +272,12 @@ func TestStreamDirector_TmpDirPathConsistency(t *testing.T) {
 func TestStreamDirector_TmpDirPathUniqueness(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dhctl-proxy-test-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	params := StreamDirectorParams{
-		MethodsPrefix: "/dhctl.DHCTL",
+		MethodsPrefix: SinglethreadedMethodsPrefix,
 		TmpDir:        tmpDir,
 	}
 
@@ -298,10 +306,12 @@ func TestStreamDirector_TmpDirPathUniqueness(t *testing.T) {
 func TestStreamDirector_Wait(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dhctl-proxy-test-*")
 	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
 
 	params := StreamDirectorParams{
-		MethodsPrefix: "/dhctl.DHCTL",
+		MethodsPrefix: SinglethreadedMethodsPrefix,
 		TmpDir:        tmpDir,
 	}
 


### PR DESCRIPTION
## Description

If creating the connection to the dhctl backend fails, the proxy now sends an interrupt to the child process so it can shut down cleanly.

Adds debug logs when the server starts listening and when the backend connection is established.

Improves dhctl server startup for commander: sets gRPC health status to SERVING and registers the health service before binding the listener, so readiness/liveness probes see the server as ready only after it is fully configured.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed dhctl server startup order and interrupt child process on backend connection failure.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
