### PR TITLE
[bashible] Get RPP addresses from cluster

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -318,7 +318,7 @@ function get_rpp_address() {
 
 function get_rpp_token() {
   local rpp_token="$(get_secret "registry-packages-proxy-token" | jq -r '.data.token' |base64 -d)"
-  echo "{rpp_token}"
+  echo "${rpp_token}"
 }
 
 function main() {
@@ -349,9 +349,9 @@ function main() {
   if [[ -n $rpp_addr ]]; then
     export PACKAGES_PROXY_ADDRESSES="${rpp_addr}"
   fi
-  rpp_token=="$(get_rpp_token)"
-  if [[ -n $rpp_addr ]]; then
-    export PACKAGES_PROXY_TOKEN="${get_rpp_token}"
+  rpp_token="$(get_rpp_token)"
+  if [[ -n $rpp_token ]]; then
+    export PACKAGES_PROXY_TOKEN="${rpp_token}"
   fi
   {{- end }}
 {{- end }}

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -310,10 +310,15 @@ function get_rpp_address() {
     local labelSelector="app%3Dregistry-packages-proxy"
 
     rpp_ips=$(get_pods $namespace $labelSelector $token | jq -r '.items[] | select(.status.phase == "Running") | .status.podIP')
-    port=4129
+    port=4219
     ips_csv=$(echo "$rpp_ips" | grep -v '^[[:space:]]*$' | sed "s/$/:$port/" | tr '\n' ',' | sed 's/,$//')
     echo "$ips_csv"
   fi
+}
+
+function get_rpp_token() {
+  local rpp_token="$(get_secret "registry-packages-proxy-token" | jq -r '.data.token' |base64 -d)"
+  echo "{rpp_token}"
 }
 
 function main() {
@@ -343,6 +348,11 @@ function main() {
   rpp_addr="$(get_rpp_address)"
   if [[ -n $rpp_addr ]]; then
     export PACKAGES_PROXY_ADDRESSES="${rpp_addr}"
+  fi
+  rpp_token=="$(get_rpp_token)"
+  if [[ -n $rpp_addr ]]; then
+    export PACKAGES_PROXY_TOKEN="${get_rpp_token}"
+  fi
   {{- end }}
 {{- end }}
 

--- a/modules/040-node-manager/.dmtlint.yaml
+++ b/modules/040-node-manager/.dmtlint.yaml
@@ -125,6 +125,10 @@ linters-settings:
           name: node-manager:nvidia-gpu:node-feature-discovery-worker
         - kind: RoleBinding
           name: node-manager:nvidia-gpu:node-feature-discovery-worker
+        - kind: Role
+          name: d8:node-manager:bashible:rpp
+        - kind: RoleBinding
+          name: d8:node-manager:bashible:rpp
   module:
     conversions:
       disable: true

--- a/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
@@ -10,6 +10,7 @@ rules:
   resourceNames:
   - bashible-bashbooster
   - node-users
+  - registry-packages-proxy-token
 {{- range $bundle := $.Values.nodeManager.internal.allowedBundles }}
   {{- range $.Values.nodeManager.internal.nodeGroups }}
   - bashible-{{ .name }}-{{ $bundle }}
@@ -19,6 +20,21 @@ rules:
   - secrets
   verbs:
   - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: d8:node-manager:bashible:rpp
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
 
 ---
 # todo remove after 1.47
@@ -150,6 +166,25 @@ roleRef:
 subjects:
 - kind: Group
   name: system:bootstrappers:d8-node-manager
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: d8:node-manager:bashible:rpp
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . ) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: d8:node-manager:bashible:rpp
+subjects:
+- kind: Group
+  name: system:bootstrappers:d8-node-manager
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: system:nodes
   apiGroup: rbac.authorization.k8s.io
 
 ---


### PR DESCRIPTION
## Description

On node bootstrap, get registry packages proxy addresses from cluster instead of rendered template

## Why do we need it, and what problem does it solve?

It allows us to use only up and running pods of registry packages proxy instead of list of all pods, what lead to reduce node bootstrap time, because we don't need to iterate over non-available instances.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Change the way to determinate registry packages proxy addresses during node bootstrap.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
