### PR TITLE
[cloud-provider-huaweicloud] updated CRD for new capi

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudclusters.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudclusters.yaml
@@ -7,8 +7,9 @@ metadata:
     module: cloud-provider-huaweicloud
     cluster.x-k8s.io/provider: huaweicloud
     cluster.x-k8s.io/v1beta1: v1alpha1
+    cluster.x-k8s.io/v1beta2: v1alpha1
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: huaweicloudclusters.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -19,59 +20,70 @@ spec:
     singular: huaweicloudcluster
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: HuaweiCloudCluster is the schema for the huaweicloudclusters.
-            API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HuaweiCloudClusterSpec defines the desired state of HuaweiCloudCluster.
-              properties:
-                controlPlaneEndpoint:
-                  description: APIEndpoint represents a reachable Kubernetes API endpoint.
-                  properties:
-                    host:
-                      description: The hostname on which the API server is serving.
-                      type: string
-                    port:
-                      description: The port on which the API server is serving.
-                      format: int32
-                      type: integer
-                  required:
-                    - host
-                    - port
-                  type: object
-              type: object
-            status:
-              description: HuaweiCloudClusterStatus defines the observed state of HuaweiCloudCluster
-              properties:
-                failureMessage:
-                  type: string
-                failureReason:
-                  type: string
-                ready:
-                  type: boolean
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HuaweiCloudCluster is the Schema for the huaweicloudclusters
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HuaweiCloudClusterSpec defines the desired state of HuaweiCloudCluster
+            properties:
+              controlPlaneEndpoint:
+                description: APIEndpoint represents a reachable Kubernetes API endpoint.
+                minProperties: 1
+                properties:
+                  host:
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                  port:
+                    description: port is the port on which the API server is serving.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: HuaweiCloudClusterStatus defines the observed state of HuaweiCloudCluster
+            properties:
+              failureMessage:
+                type: string
+              failureReason:
+                type: string
+              initialization:
+                description: Initialization provides observations of the HuaweiCloudCluster
+                  initialization process.
+                properties:
+                  provisioned:
+                    description: Provisioned is true when the infrastructure provider
+                      reports that the cluster's infrastructure is fully provisioned.
+                    type: boolean
+                type: object
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudclusters.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudclusters.yaml
@@ -6,7 +6,6 @@ metadata:
     heritage: deckhouse
     module: cloud-provider-huaweicloud
     cluster.x-k8s.io/provider: huaweicloud
-    cluster.x-k8s.io/v1beta1: v1alpha1
     cluster.x-k8s.io/v1beta2: v1alpha1
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3

--- a/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachines.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachines.yaml
@@ -6,7 +6,6 @@ metadata:
     heritage: deckhouse
     module: cloud-provider-huaweicloud
     cluster.x-k8s.io/provider: huaweicloud
-    cluster.x-k8s.io/v1beta1: v1alpha1
     cluster.x-k8s.io/v1beta2: v1alpha1
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
@@ -140,51 +139,56 @@ spec:
               conditions:
                 description: Conditions defines current service state of the HuaweiCloudMachine.
                 items:
-                  description: Condition defines an observation of a Cluster API resource
-                    operational state.
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
                         lastTransitionTime is the last time the condition transitioned from one status to another.
-                        This should be when the underlying condition changed. If that is not known, then using the time when
-                        the API field changed is acceptable.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
                         message is a human readable message indicating details about the transition.
-                        This field may be empty.
-                      maxLength: 10240
-                      minLength: 1
+                        This may be an empty string.
+                      maxLength: 32768
                       type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
                       description: |-
-                        reason is the reason for the condition's last transition in CamelCase.
-                        The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may be empty.
-                      maxLength: 256
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
                       minLength: 1
-                      type: string
-                    severity:
-                      description: |-
-                        severity provides an explicit classification of Reason code, so the users or machines can immediately
-                        understand the current situation and act accordingly.
-                        The Severity field MUST be set only when Status=False.
-                      maxLength: 32
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
-                        can be useful (see .node.status.conditions), the ability to deconflict is important.
-                      maxLength: 256
-                      minLength: 1
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
                   - lastTransitionTime
+                  - message
+                  - reason
                   - status
                   - type
                   type: object

--- a/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachines.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachines.yaml
@@ -7,8 +7,9 @@ metadata:
     module: cloud-provider-huaweicloud
     cluster.x-k8s.io/provider: huaweicloud
     cluster.x-k8s.io/v1beta1: v1alpha1
+    cluster.x-k8s.io/v1beta2: v1alpha1
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: huaweicloudmachines.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -19,175 +20,198 @@ spec:
     singular: huaweicloudmachine
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: HuaweiCloudMachine is the schema for the huaweicloudmachines.
-            API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HuaweiCloudMachineSpec defines the desired state of HuaweiCloudMachine.
-              properties:
-                availabilityZone:
-                  description: Specifies the availability zone in which to create the
-                    instance.
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HuaweiCloudMachine is the Schema for the huaweicloudmachines
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HuaweiCloudMachineSpec defines the desired state of HuaweiCloudMachine
+            properties:
+              availabilityZone:
+                description: Specifies the availability zone in which to create the
+                  instance.
+                type: string
+              flavorName:
+                description: The flavor reference for the flavor for your server instance.
+                type: string
+              id:
+                description: ID is the UUID of the VM
+                type: string
+              imageName:
+                description: The name of the image to use for your server instance.
+                type: string
+              providerID:
+                description: ProviderID is the UUID of the VM.
+                type: string
+              rootDiskSize:
+                default: 30
+                description: RootDiskSize size of the bootable disk in GiB.
+                format: int32
+                type: integer
+              rootDiskType:
+                default: GPSSD
+                description: RootDiskType is the type of the bootable disk.
+                enum:
+                - SAS
+                - SSD
+                - GPSSD
+                - ESSD
+                - GPSSD2
+                - ESSD2
+                type: string
+              securityGroups:
+                description: The UUID's of the security groups to assign to the instance
+                items:
                   type: string
-                flavorName:
-                  description: The flavor reference for the flavor of your server instance.
+                type: array
+              serverGroupID:
+                description: The server group to assign the machine to
+                type: string
+              subnets:
+                description: Specifies an array of one or more subnets to attach to
+                  the instance.
+                items:
                   type: string
-                id:
-                  description: ID is the UUID of the virtual machine.
-                  type: string
-                imageName:
-                  description: The name of the image to use for your server instance.
-                  type: string
-                providerID:
-                  description: ProviderID is the UUID of the virtual machine, prefixed with 'huaweicloud://'.
-                    proto.
-                  type: string
-                rootDiskSize:
-                  default: 30
-                  description: RootDiskSize size of the bootable disk in GiB.
-                  format: int32
-                  type: integer
-                rootDiskType:
-                  default: GPSSD
-                  description: RootDiskType is the type of the bootable disk.
-                  enum:
-                    - SAS
-                    - SSD
-                    - GPSSD
-                    - ESSD
-                    - GPSSD2
-                    - ESSD2
-                  type: string
-                securityGroups:
-                  description: The UUIDs of the security groups to assign to the instance.
-                  items:
-                    type: string
-                  type: array
-                serverGroupID:
-                  description: The server group to assign the machine to.
-                  type: string
-                subnets:
-                  description: Specifies an array of one or more subnets to attach to
-                    the instance.
-                  items:
-                    type: string
-                  minItems: 1
-                  type: array
-                vipAddress:
-                  description: Virtual IP address
-                  type: string
-                vipPortID:
-                  description: vipPortID contains ID for VIP port, if VIP is enabled
-                  type: string
-              required:
-                - flavorName
-                - imageName
-                - rootDiskSize
-                - rootDiskType
-                - subnets
-              type: object
-            status:
-              description: HuaweiCloudMachineStatus defines the observed state of HuaweiCloudMachine.
-              properties:
-                addresses:
-                  description: Addresses holds a list of the host names, external IP
-                    addresses, internal IP addresses, external DNS names, and/or internal
-                    DNS names for the VM.
-                  items:
-                    description: MachineAddress contains information for the node's
-                      address.
-                    properties:
-                      address:
-                        description: The machine address.
-                        type: string
-                      type:
-                        description: Machine address type, one of Hostname, ExternalIP,
-                          InternalIP, ExternalDNS, or InternalDNS.
-                        type: string
-                    required:
-                      - address
-                      - type
-                    type: object
-                  type: array
-                conditions:
-                  description: Conditions defines the current service state of the HuaweiCloudMachine.
-                  items:
-                    description: Conditions defines an observation of a Cluster API resource
-                      operational state.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          The last time when the condition transitioned from one status to another.
-                          This should be when the underlying condition changed. If it's unknown, then it's acceptable to use the time when
-                          the API field was changed.
-                        format: date-time
-                        type: string
-                      message:
-                        description: |-
-                          A human-readable message indicating details about the transition.
-                          This field may be empty.
-                        type: string
-                      reason:
-                        description: |-
-                          The reason for the condition's last transition in CamelCase.
-                          The specific API may choose whether or not this field is considered a guaranteed API.
-                          This field may not be empty.
-                        type: string
-                      severity:
-                        description: |-
-                          Severity provides an explicit classification of Reason code, so the users or machines can immediately
-                          understand the current situation and act accordingly.
-                          The Severity field MUST be set only when Status=False.
-                        type: string
-                      status:
-                        description: The status of the condition, one of True, False, or Unknown.
-                        type: string
-                      type:
-                        description: |-
-                          The type of a condition in CamelCase or in foo.example.com/CamelCase.
-                          Many .condition.type values are consistent across resources like Available, but since arbitrary conditions
-                          can be useful (see .node.status.conditions), the ability to deconflict is important.
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - status
-                      - type
-                    type: object
-                  type: array
-                failureMessage:
-                  description: FailureMessage will describe an error if something goes
-                    wrong during a Machine lifecycle.
-                  type: string
-                failureReason:
-                  description: FailureReason will contain an error type if something
-                    goes wrong during a Machine lifecycle.
-                  type: string
-                ready:
-                  description: Ready indicates the VM has been provisioned and is ready.
-                  type: boolean
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                minItems: 1
+                type: array
+              vipAddress:
+                description: Virtual IP address
+                type: string
+              vipPortID:
+                description: VipPortID contains ID for VIP port, if VIP is enabled
+                type: string
+            required:
+            - flavorName
+            - imageName
+            - rootDiskSize
+            - rootDiskType
+            - subnets
+            type: object
+          status:
+            description: HuaweiCloudMachineStatus defines the observed state of HuaweiCloudMachine
+            properties:
+              addresses:
+                description: Addresses holds a list of the host names, external IP
+                  addresses, internal IP addresses, external DNS names, and/or internal
+                  DNS names for the VM.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the HuaweiCloudMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: FailureMessage will describe an error if something goes
+                  wrong during Machine lifecycle.
+                type: string
+              failureReason:
+                description: FailureReason will contain an error type if something
+                  goes wrong during Machine lifecycle.
+                type: string
+              initialization:
+                description: Initialization provides observations of the HuaweiCloudMachine
+                  initialization process.
+                properties:
+                  provisioned:
+                    description: Provisioned is true when the infrastructure provider
+                      reports that the machine's infrastructure is fully provisioned.
+                    type: boolean
+                type: object
+              ready:
+                description: Ready indicates the VM has been provisioned and is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachinetemplates.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachinetemplates.yaml
@@ -6,7 +6,6 @@ metadata:
     heritage: deckhouse
     module: cloud-provider-huaweicloud
     cluster.x-k8s.io/provider: huaweicloud
-    cluster.x-k8s.io/v1beta1: v1alpha1
     cluster.x-k8s.io/v1beta2: v1alpha1
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3

--- a/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachinetemplates.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/crds/external/huaweicloudmachinetemplates.yaml
@@ -7,8 +7,9 @@ metadata:
     module: cloud-provider-huaweicloud
     cluster.x-k8s.io/provider: huaweicloud
     cluster.x-k8s.io/v1beta1: v1alpha1
+    cluster.x-k8s.io/v1beta2: v1alpha1
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.3
   name: huaweicloudmachinetemplates.infrastructure.cluster.x-k8s.io
 spec:
   group: infrastructure.cluster.x-k8s.io
@@ -19,142 +20,143 @@ spec:
     singular: huaweicloudmachinetemplate
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: HuaweiCloudMachineTemplate is the schema for the huaweicloudmachinetemplates
-            API.
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: HuaweiCloudMachineTemplateSpec defines the desired state
-                of HuaweiCloudMachineTemplate.
-              properties:
-                template:
-                  properties:
-                    metadata:
-                      description: |-
-                        ObjectMeta is metadata that all persisted resources must have, which includes all objects
-                        users must create. This is a copy of customizable fields from metav1.ObjectMeta.
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: HuaweiCloudMachineTemplate is the Schema for the huaweicloudmachinetemplates
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: HuaweiCloudMachineTemplateSpec defines the desired state
+              of HuaweiCloudMachineTemplate
+            properties:
+              template:
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta is metadata that all persisted resources must have, which includes all objects
+                      users must create. This is a copy of customizable fields from metav1.ObjectMeta.
 
-                        ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template`, and `MachineSet.Template`,
-                        which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
-                        and read-only fields, which end up in the generated CRD validation, having it as a subset simplifies
-                        the API and some issues that can impact user experience.
+                      ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,
+                      which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
+                      and read-only fields which end up in the generated CRD validation, having it as a subset simplifies
+                      the API and some issues that can impact user experience.
 
-                        During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
-                        for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
-                        specifically `spec.metadata.creationTimestamp in body must be of type string: "null"`.
-                        The investigation showed that `controller-tools@v2` behaves differently than its previous version
-                        when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
+                      During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
+                      for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
+                      specifically `spec.metadata.creationTimestamp in body must be of type string: "null"`.
+                      The investigation showed that `controller-tools@v2` behaves differently than its previous version
+                      when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
 
-                        In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
-                        had validation properties, including for `creationTimestamp` (metav1.Time).
-                        The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
-                        which breaks validation because the field isn't marked as nullable.
+                      In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
+                      had validation properties, including for `creationTimestamp` (metav1.Time).
+                      The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
+                      which breaks validation because the field isn't marked as nullable.
 
-                        In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
-                        types. When that happens, this hack should be revisited.
-                      properties:
-                        annotations:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Annotations is an unstructured key value map stored with a resource that may be
-                            set by external tools to store and retrieve arbitrary metadata. They are not
-                            queryable and should be preserved when modifying objects.
-                            More info: http://kubernetes.io/docs/user-guide/annotations
-                          type: object
-                        labels:
-                          additionalProperties:
-                            type: string
-                          description: |-
-                            Map of string keys and values that can be used to organize and categorize
-                            (scope and select) objects. May match selectors of replication controllers
-                            and services.
-                            More info: http://kubernetes.io/docs/user-guide/labels
-                          type: object
-                      type: object
-                    spec:
-                      properties:
-                        availabilityZone:
-                          description: Specifies the availability zone in which to create
-                            the instance.
+                      In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
+                      types. When that happens, this hack should be revisited.
+                    minProperties: 1
+                    properties:
+                      annotations:
+                        additionalProperties:
                           type: string
-                        flavorName:
-                          description: The flavor reference for the flavor for your
-                            server instance.
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
                           type: string
-                        imageName:
-                          description: The name of the image to use for your server
-                            instance.
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      availabilityZone:
+                        description: Specifies the availability zone in which to create
+                          the instance.
+                        type: string
+                      flavorName:
+                        description: The flavor reference for the flavor for your
+                          server instance.
+                        type: string
+                      imageName:
+                        description: The name of the image to use for your server
+                          instance.
+                        type: string
+                      rootDiskSize:
+                        default: 30
+                        description: RootDiskSize size of the bootable disk in GiB.
+                        format: int32
+                        type: integer
+                      rootDiskType:
+                        default: GPSSD
+                        description: RootDiskType is the type of the bootable disk.
+                        enum:
+                        - SAS
+                        - SSD
+                        - GPSSD
+                        - ESSD
+                        - GPSSD2
+                        - ESSD2
+                        type: string
+                      securityGroups:
+                        description: The UUID's of the security groups to assign to
+                          the instance
+                        items:
                           type: string
-                        rootDiskSize:
-                          default: 30
-                          description: RootDiskSize is the size of the bootable disk in GiB.
-                          format: int32
-                          type: integer
-                        rootDiskType:
-                          default: GPSSD
-                          description: RootDiskType is the type of the bootable disk.
-                          enum:
-                            - SAS
-                            - SSD
-                            - GPSSD
-                            - ESSD
-                            - GPSSD2
-                            - ESSD2
+                        type: array
+                      serverGroupID:
+                        description: The server group to assign the machine to
+                        type: string
+                      subnets:
+                        description: Specifies an array of one or more subnets to
+                          attach to the instance.
+                        items:
                           type: string
-                        securityGroups:
-                          description: The UUIDs of the security groups to assign to
-                            the instance.
-                          items:
-                            type: string
-                          type: array
-                        serverGroupID:
-                          description: The server group to assign the machine to.
-                          type: string
-                        subnets:
-                          description: Specifies an array of one or more subnets to
-                            attach to the instance.
-                          items:
-                            type: string
-                          minItems: 1
-                          type: array
-                        vipAddress:
-                          description: Virtual IP address
-                          type: string
-                      required:
-                        - flavorName
-                        - imageName
-                        - rootDiskSize
-                        - rootDiskType
-                        - subnets
-                      type: object
-                  required:
-                    - spec
-                  type: object
-              required:
-                - template
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                        minItems: 1
+                        type: array
+                      vipAddress:
+                        description: Virtual IP address
+                        type: string
+                    required:
+                    - flavorName
+                    - imageName
+                    - rootDiskSize
+                    - rootDiskType
+                    - subnets
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -18,8 +18,8 @@ secrets:
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}
 shell:
   install:
-  - export VERSION="v0.5.1"
-  - export VERSION_COMMON="v0.7.1"
+  - export VERSION="v0.6.0"
+  - export VERSION_COMMON="v0.8.0"
   - git clone --depth 1 --branch ${VERSION} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/caphc-controller-manager.git /src
   - git clone --depth 1 --branch ${VERSION_COMMON} $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/huaweicloud/huaweicloud-common.git /src/huaweicloud-common
   - cd /src/huaweicloud-common


### PR DESCRIPTION
## Description
Migrate caphc-controller-manager from CAPI v1beta1 contract to v1beta2.

- Bump cluster-api v1.8.5 → v1.12.2 in caphc-controller-manager and huaweicloud-common
- Change import path: sigs.k8s.io/cluster-api/api/v1beta1 → api/core/v1beta2 (alias clusterv1b2)
- Use deprecated/v1beta1 conditions package for MarkFalse/MarkTrue/SetSummary to preserve existing controller logic
- Add Initialization.Provisioned field to HuaweiCloudCluster and HuaweiCloudMachine status (v1beta2 contract requirement)
- Update CRD labels: add cluster.x-k8s.io/v1beta2: v1alpha1 to all three CRDs
- Bump controller-gen v0.16.1 → v0.17.3 (Go 1.25 compatibility)

## Why do we need it, and what problem does it solve?
CAPI v1beta2 contract is required for compatibility with cluster-api v1.12+.
Without this migration the provider cannot work with newer versions of Cluster API
which use v1beta2 contract by default for discovering infrastructure providers.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: feature
summary: Migrated CAPI provider to the Cluster API v1beta2 contract.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
