### PR TITLE
[candi] Enable DRA alpha feature gates for multi allocations

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -330,6 +330,11 @@ featureGates:
 {{- if semverCompare ">=1.32 <1.34" .kubernetesVersion }}
   DynamicResourceAllocation: true
 {{- end }}
+{{- if semverCompare ">=1.34" .kubernetesVersion }}
+  DRADeviceBindingConditions: true
+  DRAResourceClaimDeviceStatus: true
+  DRAConsumableCapacity: true
+{{- end }}
 {{- range .allowedKubeletFeatureGates }}
   {{ . }}: true
 {{- end }}

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -7,6 +7,16 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 {{- if semverCompare ">=1.32 <1.34" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "DynamicResourceAllocation=true" -}}
 {{- end }}
+{{- if semverCompare ">=1.34" .clusterConfiguration.kubernetesVersion -}}
+  {{- /*
+  Enable DRA multi-allocations by activating required feature gates:
+  DRADeviceBindingConditions and DRAResourceClaimDeviceStatus (for BindsToNode)
+  DRAConsumableCapacity (for AllowMultipleAllocations)
+  */ -}}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceBindingConditions=true" -}}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRAResourceClaimDeviceStatus=true" -}}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
+{{- end }}
 {{- if semverCompare "<=1.32" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "InPlacePodVerticalScaling=true" -}}
 {{- end }}


### PR DESCRIPTION
## Description
This PR enables alpha feature gates required for DRA multi-allocations and device binding:

- DRAConsumableCapacity (for AllowMultipleAllocations)
- DRADeviceBindingConditions and DRAResourceClaimDeviceStatus (for BindsToNode)

These feature gates allow devices to be allocated multiple times with consumable capacity,
and enable binding allocations to specific nodes. This is an alpha functionality available
for Kubernetes 1.34+.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Enable DRA alpha feature gates for multi allocations
impact_level: default
impact: Kubelet, api-server, controller-manager and scheduler will be restarted.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
