### PR TITLE
[node-manager] Refactor deprecated code in hook

### DIFF
--- a/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
+++ b/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
@@ -60,7 +60,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		},
 		{
 			Name:       "apiserver_endpointSlice",
-			ApiVersion: "discovery/v1",
+			ApiVersion: "discovery.k8s.io/v1",
 			Kind:       "EndpointSlice",
 			NamespaceSelector: &types.NamespaceSelector{
 				NameSelector: &types.NameSelector{
@@ -126,9 +126,9 @@ func apiEndpointsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, e
 func handleAPIEndpoints(_ context.Context, input *go_hook.HookInput) error {
 	endpointsSet := set.NewFromSnapshot(input.Snapshots.Get("kube_apiserver"))
 
-	for ep, err := range sdkobjectpatch.SnapshotIter[[]string](input.Snapshots.Get("apiserver_endpoints")) {
+	for ep, err := range sdkobjectpatch.SnapshotIter[[]string](input.Snapshots.Get("apiserver_endpointSlice")) {
 		if err != nil {
-			return fmt.Errorf("cannot iterate over 'apiserver_endpoints' snapshot: %w", err)
+			return fmt.Errorf("cannot iterate over 'apiserver_endpointSlice' snapshot: %w", err)
 		}
 		endpointsSet.Add(ep...)
 	}

--- a/modules/040-node-manager/hooks/discover_apiserver_endpoints_test.go
+++ b/modules/040-node-manager/hooks/discover_apiserver_endpoints_test.go
@@ -27,59 +27,95 @@ var _ = Describe("Modules :: node-manager :: hooks :: discover_apiserver_endpoin
 	const (
 		stateSingleAddress = `
 ---
-apiVersion: v1
-kind: Endpoints
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 10.0.3.192
+  conditions:
+    ready: true
+kind: EndpointSlice
 metadata:
+  labels:
+    kubernetes.io/service-name: kubernetes
   name: kubernetes
   namespace: default
-subsets:
-- addresses:
-  - ip: 10.0.3.192
-  ports:
-  - name: https
-    port: 6443
-    protocol: TCP
+ports:
+- name: https
+  port: 6443
+  protocol: TCP
 `
 
 		stateMultipleAddresses = `
 ---
-apiVersion: v1
-kind: Endpoints
+addressType: IPv4
+apiVersion: discovery.k8s.io/v1
+endpoints:
+- addresses:
+  - 10.0.3.192
+  conditions:
+    ready: true
+- addresses:
+  - 10.0.3.193
+  conditions:
+    ready: true
+- addresses:
+  - 10.0.3.194
+  conditions:
+    ready: true
+kind: EndpointSlice
 metadata:
+  labels:
+    kubernetes.io/service-name: kubernetes
   name: kubernetes
   namespace: default
-subsets:
-- addresses:
-  - ip: 10.0.3.192
-  - ip: 10.0.3.193
-  - ip: 10.0.3.194
-  ports:
-  - name: https
-    port: 6443
-    protocol: TCP
+ports:
+- name: https
+  port: 6443
+  protocol: TCP
 `
 
 		stateMultupleAddressesWithDifferentPorts = `
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
-  name: kubernetes
+  name: kubernetes-ipv4-1
   namespace: default
-subsets:
-- addresses:
-  - ip: 10.0.3.192
-  - ip: 10.0.3.193
-  ports:
+  labels:
+    kubernetes.io/service-name: kubernetes
+addressType: IPv4
+ports:
   - name: https
     port: 6443
     protocol: TCP
-- addresses:
-  - ip: 10.0.3.194
-  ports:
+endpoints:
+  - addresses:
+      - 10.0.3.192
+    conditions:
+      ready: true
+  - addresses:
+      - 10.0.3.193
+    conditions:
+      ready: true
+---
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: kubernetes-ipv4-2
+  namespace: default
+  labels:
+    kubernetes.io/service-name: kubernetes
+addressType: IPv4
+ports:
   - name: https
     port: 6444
     protocol: TCP
+endpoints:
+  - addresses:
+      - 10.0.3.194
+    conditions:
+      ready: true
 `
 
 		stateDeckhouseAPIServerPod = `


### PR DESCRIPTION
## Description

Use EndpointSlice instead of deprecated Endpoints in discover_apiserver_endpoints hook

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Use EndpointSlice instead of deprecated Endpoints in discover_apiserver_endpoints hook.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
