### PR TITLE
[admission-policy-engine] Fix SecurityPolicy constraints for omitted fields

### DIFF
--- a/modules/015-admission-policy-engine/template_tests/security_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/security_policies_test.go
@@ -106,6 +106,35 @@ admissionPolicyEngine:
             namespaceSelector:
               matchNames:
                 - default
+      - metadata:
+          name: minpolicy
+        spec:
+          policies:
+            allowPrivileged: false
+          match:
+            namespaceSelector:
+              matchNames:
+                - default
+      - metadata:
+          name: hostportspolicy
+        spec:
+          policies:
+            allowedHostPorts:
+              - min: 8080
+                max: 8080
+          match:
+            namespaceSelector:
+              matchNames:
+                - default
+      - metadata:
+          name: pidpolicy
+        spec:
+          policies:
+            allowHostPID: false
+          match:
+            namespaceSelector:
+              matchNames:
+                - default
     trackedConstraintResources:
       - apiGroups:
           - ""
@@ -161,6 +190,50 @@ admissionPolicyEngine:
 			Expect(f.KubernetesGlobalResource("D8AppArmor", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8VerifyImageSignatures", testPolicyName).Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("D8AllowRbacWildcards", testPolicyName).Exists()).To(BeTrue())
+		})
+
+		It("Minimal security policy must not render unrelated constraints", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			// allowPrivileged and allowPrivilegeEscalation have documented default "false",
+			// so their constraints must be created even when fields are omitted.
+			Expect(f.KubernetesGlobalResource("D8PrivilegedContainer", "minpolicy").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("D8AllowPrivilegeEscalation", "minpolicy").Exists()).To(BeTrue())
+
+			// All other constraints must NOT be created when their fields are not specified.
+			Expect(f.KubernetesGlobalResource("D8HostNetwork", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8HostProcesses", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AutomountServiceAccountTokenPod", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8ReadOnlyRootFilesystem", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedCapabilities", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedFlexVolumes", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedHostPaths", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedVolumeTypes", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedSysctls", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedUsers", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8SeLinux", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedProcMount", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AppArmor", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedSeccompProfiles", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowedClusterRoles", "minpolicy").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("D8AllowRbacWildcards", "minpolicy").Exists()).To(BeFalse())
+		})
+
+		It("Policy with only allowedHostPorts must create D8HostNetwork with allowHostNetwork=true", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			hostNet := f.KubernetesGlobalResource("D8HostNetwork", "hostportspolicy")
+			Expect(hostNet.Exists()).To(BeTrue())
+			Expect(hostNet.Field("spec.parameters.allowHostNetwork").Bool()).To(BeTrue())
+		})
+
+		It("Policy with only allowHostPID must create D8HostProcesses with allowHostIPC=true", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			hostProc := f.KubernetesGlobalResource("D8HostProcesses", "pidpolicy")
+			Expect(hostProc.Exists()).To(BeTrue())
+			Expect(hostProc.Field("spec.parameters.allowHostPID").Bool()).To(BeFalse())
+			Expect(hostProc.Field("spec.parameters.allowHostIPC").Bool()).To(BeTrue())
 		})
 
 		It("All security policy constraints must have valid YAML", func() {

--- a/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
@@ -9,16 +9,16 @@
   {{- if not $cr.spec.policies.allowPrivilegeEscalation }}
     {{- include "allow_privilege_escalation" (list $context $cr) }}
   {{- end }}
-  {{- if or (not $cr.spec.policies.allowHostPID) (not $cr.spec.policies.allowHostIPC) }}
+  {{- if or (and (hasKey $cr.spec.policies "allowHostPID") (not $cr.spec.policies.allowHostPID)) (and (hasKey $cr.spec.policies "allowHostIPC") (not $cr.spec.policies.allowHostIPC)) }}
     {{- include "allow_host_processes" (list $context $cr) }}
   {{- end }}
-  {{- if or (not $cr.spec.policies.allowHostNetwork) (hasKey $cr.spec.policies "allowedHostPorts") }}
+  {{- if or (and (hasKey $cr.spec.policies "allowHostNetwork") (not $cr.spec.policies.allowHostNetwork)) (hasKey $cr.spec.policies "allowedHostPorts") }}
     {{- include "allow_host_network" (list $context $cr) }}
   {{- end }}
   {{- if hasKey $cr.spec.policies "readOnlyRootFilesystem" }}
     {{- include "read_only_root_filesystem" (list $context $cr) }}
   {{- end }}
-  {{- if not $cr.spec.policies.automountServiceAccountToken }}
+  {{- if and (hasKey $cr.spec.policies "automountServiceAccountToken") (not $cr.spec.policies.automountServiceAccountToken) }}
     {{- include "automount_service_account_token" (list $context $cr) }}
   {{- end }}
   {{- if hasKey $cr.spec.policies "allowRbacWildcards" }}
@@ -135,8 +135,8 @@ spec:
     scope: Namespaced
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    allowHostPID: {{ $cr.spec.policies.allowHostPID | default false }}
-    allowHostIPC: {{ $cr.spec.policies.allowHostIPC | default false }}
+    allowHostPID: {{- if hasKey $cr.spec.policies "allowHostPID" }} {{ $cr.spec.policies.allowHostPID }} {{- else }} true {{- end }}
+    allowHostIPC: {{- if hasKey $cr.spec.policies "allowHostIPC" }} {{ $cr.spec.policies.allowHostIPC }} {{- else }} true {{- end }}
 {{- end }}
 
 {{- define "allow_host_network" }}
@@ -157,7 +157,7 @@ spec:
     scope: Namespaced
     {{- include "constraint_selector" (list $cr) }}
   parameters:
-    allowHostNetwork: {{ $cr.spec.policies.allowHostNetwork | default false }}
+    allowHostNetwork: {{- if hasKey $cr.spec.policies "allowHostNetwork" }} {{ $cr.spec.policies.allowHostNetwork }} {{- else }} true {{- end }}
     {{- if hasKey $cr.spec.policies "allowedHostPorts" }}
     ranges:
       {{- $cr.spec.policies.allowedHostPorts | toYaml | nindent 6 }}


### PR DESCRIPTION
## Description
Fixes `SecurityPolicy` constraints generation in `admission-policy-engine` so omitted boolean fields don’t unintentionally enable unrelated Gatekeeper constraints. Adds regression and edge-case template tests for this behavior.


## Why do we need it, and what problem does it solve?
When a `SecurityPolicy` had only `allowPrivileged: false` set, Helm templating logic used negation (`not`) on omitted boolean fields and incorrectly rendered additional constraints (e.g. `D8HostNetwork`), causing workload Pods to be denied with unexpected `hostNetwork` / `hostPort` violations.

This change makes constraint rendering depend on the explicit presence of corresponding fields (except documented defaults) and prevents accidental enforcement of unrelated policies.


## Why do we need it in the patch release (if we do)?
Fixes unexpected admission denials for workloads when `SecurityPolicy` omits unrelated boolean fields. This is a user-facing bug affecting cluster operations and should be safe to backport.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: admission-policy-engine
type: fix
summary: Prevent unintended Gatekeeper constraints from being rendered for SecurityPolicy when boolean fields are omitted.
impact: Workload Pods are no longer denied by unrelated SecurityPolicy checks (e.g. hostNetwork/hostPort) when corresponding policy fields are not explicitly set.
impact_level: default
```
