### PR TITLE
[deckhouse] Migrate to endpointslices in validate_cluster_configuration

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration.go
@@ -29,6 +29,7 @@ import (
 	"github.com/slok/kubewebhook/v2/pkg/model"
 	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -132,18 +133,18 @@ func validateDefaultCRI(defaultCRI string, cli client.Client) (*kwhvalidating.Va
 }
 
 func getKubernetesEndpointsCount(ctx context.Context, cli client.Client) (int, error) {
-	endpoints := &v1.Endpoints{}
+	endpointslice := &discoveryv1.EndpointSlice{}
 	err := cli.Get(ctx, client.ObjectKey{
 		Namespace: "default",
 		Name:      "kubernetes",
-	}, endpoints)
+	}, endpointslice)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get kubernetes endpoints: %w", err)
+		return 0, fmt.Errorf("failed to get kubernetes endpointslice: %w", err)
 	}
 
 	count := 0
-	for _, subset := range endpoints.Subsets {
-		count += len(subset.Addresses)
+	for _, endpoints := range endpointslice.Endpoints {
+		count += len(endpoints.Addresses)
 	}
 	return count, nil
 }


### PR DESCRIPTION
## Description
Migrate to using `EndpointsSlices` from `Endpoints` in `getKubernetesEndpointsCount` function in `validate_cluster_configuration.go`

## Why do we need it, and what problem does it solve?
`Endpoints` resource is long deprecated https://kubernetes.io/blog/2025/04/24/endpoints-deprecation/

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: chore
summary: Migrate to EndpointSlices in cluster configuration validation package.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
