### PR TITLE
[cloud-provider-gcp] add nestedVirtualization and additionalDisks

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
@@ -220,6 +220,41 @@ DKP also automatically creates StorageClasses that cover all available disk type
 
 You can exclude unnecessary StorageClasses by specifying them in the [`exclude`](/modules/cloud-provider-gcp/configuration.html#parameters-storageclass-exclude) parameter.
 
+### Enabling nested virtualization
+
+To run virtual machine workloads (e.g., KVM-based VMs) inside GCP instances, enable nested virtualization.
+
+> Only supported on specific machine types. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: vm-nodes
+spec:
+  machineType: n2-standard-8
+  nestedVirtualization: true
+```
+
+### Adding additional disks
+
+To attach additional disks to instances (for example, for LINSTOR, Ceph, NFS storage nodes, and similar solutions), specify them in the `additionalDisks` parameter:
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: storage-nodes
+spec:
+  machineType: n1-standard-8
+  additionalDisks:
+  - sizeGb: 200
+    type: pd-ssd
+  - sizeGb: 500
+    type: pd-standard
+    autoDelete: true
+```
+
 ### Configuring node security policies
 
 You may need to restrict or allow incoming and outgoing traffic on GCP virtual machines for various reasons:

--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT.md
@@ -224,7 +224,9 @@ You can exclude unnecessary StorageClasses by specifying them in the [`exclude`]
 
 To run virtual machine workloads (e.g., KVM-based VMs) inside GCP instances, enable nested virtualization.
 
-> Only supported on specific machine types. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+{% alert %}
+Only specific machine types support nested virtualization. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+{% endalert %}
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
@@ -214,7 +214,9 @@ provider:
 
 Для запуска виртуальных машин (например, KVM) внутри GCP-инстансов необходимо включить вложенную виртуализацию.
 
-> Поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+{% alert %}
+Вложенная виртуализация поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+{% endalert %}
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/public/gcp/CONFIGURATION_AND_LAYOUT_RU.md
@@ -210,6 +210,41 @@ provider:
 
 Можно отфильтровать ненужные StorageClass'ы, для этого укажите их в [параметре `exclude`](/modules/cloud-provider-gcp/configuration.html#parameters-storageclass-exclude).
 
+### Включение вложенной виртуализации
+
+Для запуска виртуальных машин (например, KVM) внутри GCP-инстансов необходимо включить вложенную виртуализацию.
+
+> Поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: vm-nodes
+spec:
+  machineType: n2-standard-8
+  nestedVirtualization: true
+```
+
+### Добавление дополнительных дисков
+
+Чтобы подключить к инстансам дополнительные диски (например, для узлов хранилища LINSTOR, Ceph, NFS и аналогичных решений), задайте их в параметре `additionalDisks`:
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: storage-nodes
+spec:
+  machineType: n1-standard-8
+  additionalDisks:
+  - sizeGb: 200
+    type: pd-ssd
+  - sizeGb: 500
+    type: pd-standard
+    autoDelete: true
+```
+
 ### Настройка политик безопасности на узлах
 
 На виртуальных машинах кластера в GCP может возникнуть необходимость ограничить или расширить входящий и исходящий трафик по различным причинам. Некоторые из них могут включать:

--- a/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
@@ -61,6 +61,45 @@ spec:
                     Список дополнительных лейблов.
 
                     Подробно про лейблы можно прочитать [в официальной документации](https://cloud.google.com/resource-manager/docs/creating-managing-labels).
+                nestedVirtualization:
+                  description: |
+                    Включает [вложенную виртуализацию](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview) на инстансе.
+
+                    Необходимо для запуска виртуальных машин (например, KVM) внутри GCP-инстансов.
+
+                    > **Внимание.** Поддерживается только на определённых типах машин. Список совместимых типов приведён в [документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+                additionalDisks:
+                  description: |
+                    Список дополнительных дисков, которые будут подключены к инстансу.
+
+                    Полезно для нагрузок, связанных с хранением данных: LinStor, Ceph, NFS и аналогичных.
+                  items:
+                    properties:
+                      sizeGb:
+                        description: Размер диска в гибибайтах.
+                      type:
+                        description: |
+                          Тип диска.
+
+                          - `pd-standard` — стандартный Persistent Disk (HDD).
+                          - `pd-balanced` — сбалансированный Persistent Disk (SSD).
+                          - `pd-ssd` — SSD Persistent Disk.
+                          - `pd-extreme` — экстремальный Persistent Disk; требует указания `provisionedIops`.
+                          - `hyperdisk-balanced` — Hyperdisk со сбалансированной производительностью.
+                          - `hyperdisk-throughput` — Hyperdisk, оптимизированный для пропускной способности.
+                          - `hyperdisk-extreme` — Hyperdisk с максимальной производительностью; требует указания `provisionedIops`.
+                      autoDelete:
+                        description: Автоматически удалять диск при удалении инстанса.
+                      provisionedIops:
+                        description: |
+                          Запрошенное количество IOPS для диска.
+
+                          Обязательно для типов `pd-extreme` и `hyperdisk-extreme`.
+                      provisionedThroughput:
+                        description: |
+                          Запрошенная пропускная способность диска в МиБ/с.
+
+                          Применимо для типов `hyperdisk-balanced` и `hyperdisk-throughput`.
     - name: v1
       schema: *schema
 

--- a/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
@@ -75,8 +75,8 @@ spec:
                     Полезно для нагрузок, связанных с хранением данных, таких как LINSTOR, Ceph, NFS и аналогичные решения.
                   items:
                     properties:
-                      sizeGb:
-                        description: Размер диска в ГБ.
+                      size:
+                        description: Размер диска в гигабайтах (ГБ).
                       type:
                         description: |
                           Тип диска.

--- a/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
@@ -63,20 +63,20 @@ spec:
                     Подробно про лейблы можно прочитать [в официальной документации](https://cloud.google.com/resource-manager/docs/creating-managing-labels).
                 nestedVirtualization:
                   description: |
-                    Включает [вложенную виртуализацию](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview) на инстансе.
+                    Включить [вложенную виртуализацию](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview) на инстансе.
 
                     Необходимо для запуска виртуальных машин (например, KVM) внутри GCP-инстансов.
 
-                    > **Внимание.** Поддерживается только на определённых типах машин. Список совместимых типов приведён в [документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+                    **Внимание.** Поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
                 additionalDisks:
                   description: |
                     Список дополнительных дисков, которые будут подключены к инстансу.
 
-                    Полезно для нагрузок, связанных с хранением данных: LinStor, Ceph, NFS и аналогичных.
+                    Полезно для нагрузок, связанных с хранением данных, таких как LINSTOR, Ceph, NFS и аналогичные решения.
                   items:
                     properties:
                       sizeGb:
-                        description: Размер диска в гибибайтах.
+                        description: Размер диска в ГБ.
                       type:
                         description: |
                           Тип диска.

--- a/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/doc-ru-instance_class.yaml
@@ -61,7 +61,7 @@ spec:
                     Список дополнительных лейблов.
 
                     Подробно про лейблы можно прочитать [в официальной документации](https://cloud.google.com/resource-manager/docs/creating-managing-labels).
-                nestedVirtualization:
+                enableNestedVirtualization:
                   description: |
                     Включить [вложенную виртуализацию](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview) на инстансе.
 

--- a/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
@@ -112,6 +112,74 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                   additionalProperties:
                     type: string
+                nestedVirtualization:
+                  description: |
+                    Enables [nested virtualization](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview) on the instance.
+
+                    Required for running virtual machine workloads (e.g., KVM-based VMs) inside GCP instances.
+
+                    > **Note.** Only supported on specific machine types. See the [GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+                  type: boolean
+                  x-doc-default: false
+                additionalDisks:
+                  description: |
+                    A list of additional disks to attach to the instance.
+
+                    Useful for storage workloads such as LinStor, Ceph, NFS, and similar.
+                  type: array
+                  x-doc-examples:
+                  - - sizeGb: 100
+                      type: pd-ssd
+                  items:
+                    type: object
+                    required:
+                      - sizeGb
+                      - type
+                    properties:
+                      sizeGb:
+                        description: Disk size in gibibytes.
+                        type: integer
+                        minimum: 1
+                        x-doc-examples: [100]
+                      type:
+                        description: |
+                          Disk type.
+
+                          - `pd-standard` — standard Persistent Disk (HDD).
+                          - `pd-balanced` — balanced Persistent Disk (SSD).
+                          - `pd-ssd` — SSD Persistent Disk.
+                          - `pd-extreme` — extreme Persistent Disk; requires `provisionedIops`.
+                          - `hyperdisk-balanced` — Hyperdisk with balanced performance.
+                          - `hyperdisk-throughput` — Hyperdisk optimized for throughput.
+                          - `hyperdisk-extreme` — Hyperdisk with maximum performance; requires `provisionedIops`.
+                        type: string
+                        enum:
+                          - "pd-standard"
+                          - "pd-balanced"
+                          - "pd-ssd"
+                          - "pd-extreme"
+                          - "hyperdisk-balanced"
+                          - "hyperdisk-throughput"
+                          - "hyperdisk-extreme"
+                        x-doc-examples: ["pd-ssd"]
+                      autoDelete:
+                        description: Automatically delete the disk when the instance is deleted.
+                        type: boolean
+                        x-doc-default: true
+                      provisionedIops:
+                        description: |
+                          Provisioned IOPS for the disk.
+
+                          Required for `pd-extreme` and `hyperdisk-extreme` disk types.
+                        type: integer
+                        minimum: 1
+                      provisionedThroughput:
+                        description: |
+                          Provisioned throughput in MiB/s for the disk.
+
+                          Applicable for `hyperdisk-balanced` and `hyperdisk-throughput` disk types.
+                        type: integer
+                        minimum: 1
             status:
               type: object
               properties:

--- a/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
@@ -118,14 +118,14 @@ spec:
 
                     Required for running virtual machine workloads (e.g., KVM-based VMs) inside GCP instances.
 
-                    > **Note.** Only supported on specific machine types. See the [GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+                    **Warning.** Only supported on specific machine types. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
                   type: boolean
                   x-doc-default: false
                 additionalDisks:
                   description: |
                     A list of additional disks to attach to the instance.
 
-                    Useful for storage workloads such as LinStor, Ceph, NFS, and similar.
+                    Useful for storage workloads such as LINSTOR, Ceph, NFS, and similar.
                   type: array
                   x-doc-examples:
                   - - sizeGb: 100
@@ -137,7 +137,7 @@ spec:
                       - type
                     properties:
                       sizeGb:
-                        description: Disk size in gibibytes.
+                        description: Disk size in GB.
                         type: integer
                         minimum: 1
                         x-doc-examples: [100]

--- a/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
@@ -112,7 +112,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                   additionalProperties:
                     type: string
-                nestedVirtualization:
+                enableNestedVirtualization:
                   description: |
                     Enables [nested virtualization](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview) on the instance.
 

--- a/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml
@@ -128,16 +128,16 @@ spec:
                     Useful for storage workloads such as LINSTOR, Ceph, NFS, and similar.
                   type: array
                   x-doc-examples:
-                  - - sizeGb: 100
+                  - - size: 100
                       type: pd-ssd
                   items:
                     type: object
                     required:
-                      - sizeGb
+                      - size
                       - type
                     properties:
-                      sizeGb:
-                        description: Disk size in GB.
+                      size:
+                        description: Disk size in gigabytes (GB).
                         type: integer
                         minimum: 1
                         x-doc-examples: [100]

--- a/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
@@ -64,6 +64,8 @@ spec:
   metadata:
   - key: ssh-keys
     value: 'user:{{ .Values.nodeManager.internal.cloudProvider.gcp.sshKey }}'
+  - key: debug-nestedvirt
+    value: '{{ .nodeGroup.instanceClass.nestedVirtualization }}'
   tags:
   # These tags are mandatory as the safety controller uses them to identify VMs created by this controller.
   - kubernetes-io-cluster-deckhouse-{{ .Values.global.discovery.clusterUUID | sha256sum | trunc 30 }}

--- a/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
@@ -9,12 +9,30 @@ spec:
   region: {{ .Values.nodeManager.internal.cloudProvider.gcp.region | quote }}
   zone: {{ .zoneName }}
   machineType: {{ .nodeGroup.instanceClass.machineType }}
+{{- if .nodeGroup.instanceClass.nestedVirtualization | default false }}
+  advancedMachineFeatures:
+    enableNestedVirtualization: true
+{{- end }}
   disks:
   - autoDelete: true
     boot: true
     sizeGb: {{ if hasKey .nodeGroup.instanceClass "diskSizeGb" }}{{ .nodeGroup.instanceClass.diskSizeGb }}{{ else }}{{ .Values.nodeManager.internal.cloudProvider.gcp.diskSizeGb }}{{ end }}
     type: {{ if hasKey .nodeGroup.instanceClass "diskType" }}{{ .nodeGroup.instanceClass.diskType | quote }}{{ else }}{{ .Values.nodeManager.internal.cloudProvider.gcp.diskType | quote }}{{ end }}
     image: {{ if hasKey .nodeGroup.instanceClass "image" }}{{ .nodeGroup.instanceClass.image | quote }}{{ else }}{{ .Values.nodeManager.internal.cloudProvider.gcp.image | quote }}{{ end }}
+{{- if hasKey .nodeGroup.instanceClass "additionalDisks" }}
+  {{- range .nodeGroup.instanceClass.additionalDisks }}
+  - boot: false
+    autoDelete: {{ if hasKey . "autoDelete" }}{{ .autoDelete }}{{ else }}true{{ end }}
+    sizeGb: {{ .sizeGb }}
+    type: {{ .type | quote }}
+    {{- if hasKey . "provisionedIops" }}
+    provisionedIops: {{ .provisionedIops }}
+    {{- end }}
+    {{- if hasKey . "provisionedThroughput" }}
+    provisionedThroughput: {{ .provisionedThroughput }}
+    {{- end }}
+  {{- end }}
+{{- end }}
   serviceAccounts:
   - email: {{ index (.Values.nodeManager.internal.cloudProvider.gcp.serviceAccountJSON | fromJson) "client_email" | quote }}
     scopes:

--- a/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
@@ -9,9 +9,11 @@ spec:
   region: {{ .Values.nodeManager.internal.cloudProvider.gcp.region | quote }}
   zone: {{ .zoneName }}
   machineType: {{ .nodeGroup.instanceClass.machineType }}
-{{- if .nodeGroup.instanceClass.nestedVirtualization | default false }}
+{{- if hasKey .nodeGroup.instanceClass "nestedVirtualization" }}
+  {{- if .nodeGroup.instanceClass.nestedVirtualization }}
   advancedMachineFeatures:
     enableNestedVirtualization: true
+  {{- end }}
 {{- end }}
   disks:
   - autoDelete: true
@@ -64,8 +66,6 @@ spec:
   metadata:
   - key: ssh-keys
     value: 'user:{{ .Values.nodeManager.internal.cloudProvider.gcp.sshKey }}'
-  - key: debug-nestedvirt
-    value: '{{ .nodeGroup.instanceClass.nestedVirtualization }}'
   tags:
   # These tags are mandatory as the safety controller uses them to identify VMs created by this controller.
   - kubernetes-io-cluster-deckhouse-{{ .Values.global.discovery.clusterUUID | sha256sum | trunc 30 }}

--- a/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
@@ -25,7 +25,7 @@ spec:
   {{- range .nodeGroup.instanceClass.additionalDisks }}
   - boot: false
     autoDelete: {{ if hasKey . "autoDelete" }}{{ .autoDelete }}{{ else }}true{{ end }}
-    sizeGb: {{ .sizeGb }}
+    sizeGb: {{ .size }}
     type: {{ .type | quote }}
     {{- if hasKey . "provisionedIops" }}
     provisionedIops: {{ .provisionedIops }}

--- a/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
+++ b/modules/030-cloud-provider-gcp/cloud-instance-manager/machine-class.yaml
@@ -9,8 +9,8 @@ spec:
   region: {{ .Values.nodeManager.internal.cloudProvider.gcp.region | quote }}
   zone: {{ .zoneName }}
   machineType: {{ .nodeGroup.instanceClass.machineType }}
-{{- if hasKey .nodeGroup.instanceClass "nestedVirtualization" }}
-  {{- if .nodeGroup.instanceClass.nestedVirtualization }}
+{{- if hasKey .nodeGroup.instanceClass "enableNestedVirtualization" }}
+  {{- if .nodeGroup.instanceClass.enableNestedVirtualization }}
   advancedMachineFeatures:
     enableNestedVirtualization: true
   {{- end }}

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
@@ -2,7 +2,7 @@
 title: "Cloud provider — GCP: examples"
 ---
 
-## An example of the `GCPInstanceClass`custom resource
+## An example of the `GCPInstanceClass` custom resource
 
 Below is a simple example of custom resource `GCPInstanceClass` configuration:
 
@@ -13,6 +13,41 @@ metadata:
   name: test
 spec:
   machineType: n1-standard-1
+```
+
+## Enabling nested virtualization
+
+To run virtual machine workloads (e.g., KVM-based VMs) inside GCP instances, enable nested virtualization.
+
+> **Note.** Only supported on specific machine types. See the [GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: vm-nodes
+spec:
+  machineType: n2-standard-8
+  nestedVirtualization: true
+```
+
+## Adding additional disks
+
+To attach extra disks to instances (e.g., for LinStor, Ceph, NFS storage nodes):
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: storage-nodes
+spec:
+  machineType: n1-standard-8
+  additionalDisks:
+  - sizeGb: 200
+    type: pd-ssd
+  - sizeGb: 500
+    type: pd-standard
+    autoDelete: true
 ```
 
 ## Configuring security policies on nodes

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
@@ -28,7 +28,7 @@ metadata:
   name: vm-nodes
 spec:
   machineType: n2-standard-8
-  nestedVirtualization: true
+  enableNestedVirtualization: true
 ```
 
 ## Adding additional disks

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
@@ -19,7 +19,7 @@ spec:
 
 To run virtual machine workloads (e.g., KVM-based VMs) inside GCP instances, enable nested virtualization.
 
-> **Warning.** Only supported on specific machine types. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+> Only supported on specific machine types. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
@@ -43,9 +43,9 @@ metadata:
 spec:
   machineType: n1-standard-8
   additionalDisks:
-  - sizeGb: 200
+  - size: 200
     type: pd-ssd
-  - sizeGb: 500
+  - size: 500
     type: pd-standard
     autoDelete: true
 ```

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
@@ -19,7 +19,7 @@ spec:
 
 To run virtual machine workloads (e.g., KVM-based VMs) inside GCP instances, enable nested virtualization.
 
-> **Note.** Only supported on specific machine types. See the [GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+> **Warning.** Only supported on specific machine types. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -33,7 +33,7 @@ spec:
 
 ## Adding additional disks
 
-To attach extra disks to instances (e.g., for LinStor, Ceph, NFS storage nodes):
+To attach additional disks to instances (for example, for LINSTOR, Ceph, NFS storage nodes, and similar solutions), specify them in the `additionalDisks` parameter:
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES.md
@@ -19,7 +19,9 @@ spec:
 
 To run virtual machine workloads (e.g., KVM-based VMs) inside GCP instances, enable nested virtualization.
 
-> Only supported on specific machine types. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+{% alert %}
+Only specific machine types support nested virtualization. See [the GCP documentation](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types) for the list of compatible types.
+{% endalert %}
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
@@ -15,6 +15,41 @@ spec:
   machineType: n1-standard-1
 ```
 
+## Включение вложенной виртуализации
+
+Для запуска виртуальных машин (например, KVM) внутри GCP-инстансов необходимо включить вложенную виртуализацию.
+
+> **Внимание.** Поддерживается только на определённых типах машин. Список совместимых типов приведён в [документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: vm-nodes
+spec:
+  machineType: n2-standard-8
+  nestedVirtualization: true
+```
+
+## Добавление дополнительных дисков
+
+Для подключения дополнительных дисков к инстансам (например, для узлов хранилища LinStor, Ceph, NFS):
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: GCPInstanceClass
+metadata:
+  name: storage-nodes
+spec:
+  machineType: n1-standard-8
+  additionalDisks:
+  - sizeGb: 200
+    type: pd-ssd
+  - sizeGb: 500
+    type: pd-standard
+    autoDelete: true
+```
+
 ## Настройка политик безопасности на узлах
 
 На виртуальных машинах кластера в GCP может возникнуть необходимость ограничить или расширить входящий и исходящий трафик по различным причинам. Некоторые из них могут включать:

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
@@ -43,9 +43,9 @@ metadata:
 spec:
   machineType: n1-standard-8
   additionalDisks:
-  - sizeGb: 200
+  - size: 200
     type: pd-ssd
-  - sizeGb: 500
+  - size: 500
     type: pd-standard
     autoDelete: true
 ```

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
@@ -28,7 +28,7 @@ metadata:
   name: vm-nodes
 spec:
   machineType: n2-standard-8
-  nestedVirtualization: true
+  enableNestedVirtualization: true
 ```
 
 ## Добавление дополнительных дисков

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
@@ -19,7 +19,7 @@ spec:
 
 Для запуска виртуальных машин (например, KVM) внутри GCP-инстансов необходимо включить вложенную виртуализацию.
 
-> **Внимание.** Поддерживается только на определённых типах машин. Список совместимых типов приведён в [документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+> **Внимание.** Поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
 
 ```yaml
 apiVersion: deckhouse.io/v1
@@ -33,7 +33,7 @@ spec:
 
 ## Добавление дополнительных дисков
 
-Для подключения дополнительных дисков к инстансам (например, для узлов хранилища LinStor, Ceph, NFS):
+Чтобы подключить к инстансам дополнительные диски (например, для узлов хранилища LINSTOR, Ceph, NFS и аналогичных решений), задайте их в параметре `additionalDisks`:
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
@@ -19,7 +19,7 @@ spec:
 
 Для запуска виртуальных машин (например, KVM) внутри GCP-инстансов необходимо включить вложенную виртуализацию.
 
-> **Внимание.** Поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+> Поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/EXAMPLES_RU.md
@@ -19,7 +19,9 @@ spec:
 
 Для запуска виртуальных машин (например, KVM) внутри GCP-инстансов необходимо включить вложенную виртуализацию.
 
-> Поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+{% alert %}
+Вложенная виртуализация поддерживается только на определённых типах машин. Список совместимых типов приведён [в документации GCP](https://cloud.google.com/compute/docs/instances/nested-virtualization/overview#supported_machine_types).
+{% endalert %}
 
 ```yaml
 apiVersion: deckhouse.io/v1

--- a/testing/openapi_validation/validators/enum.go
+++ b/testing/openapi_validation/validators/enum.go
@@ -61,10 +61,14 @@ var (
 		// disk types: pd-standard, pd-ssd, ...
 		"candi/cloud-providers/gcp/openapi/instance_class.yaml": {
 			"spec.versions[*].schema.openAPIV3Schema.properties.spec.properties.diskType",
+			// disk types for additionalDisks: pd-standard, pd-ssd, pd-balanced, ...
+			"spec.versions[*].schema.openAPIV3Schema.properties.spec.properties.additionalDisks.items.properties.type",
 		},
 		// disk types: pd-standard, pd-ssd, ...
 		"modules/030-cloud-provider-gcp/candi/openapi/instance_class.yaml": {
 			"spec.versions[*].schema.openAPIV3Schema.properties.spec.properties.diskType",
+			// disk types for additionalDisks: pd-standard, pd-ssd, pd-balanced, ...
+			"spec.versions[*].schema.openAPIV3Schema.properties.spec.properties.additionalDisks.items.properties.type",
 		},
 		"modules/030-cloud-provider-gcp/openapi/values.yaml": {
 			"properties.internal.properties.providerClusterConfiguration.properties.apiVersion",


### PR DESCRIPTION
## Description
Add two new optional fields to GCPInstanceClass:
- nestedVirtualization (bool) — enables nested virtualization via GCP 
- advancedMachineFeatures.enableNestedVirtualization
- additionalDisks (array) — attaches extra persistent disks to the instance (non-boot)

Both fields are optional and do not affect existing configurations.
## Why do we need it, and what problem does it solve?
GCPInstanceClass did not expose two capabilities that the underlying MCM GCP driver already supports natively:
- Nested virtualization — required for node groups that run VM workloads. Without this option, users had to configure advancedMachineFeatures.enableNestedVirtualization manually outside of Deckhouse, which breaks the declarative node provisioning model.
- Additional disks — required for storage node groups that need dedicated block devices. Without this option, users had to attach and configure disks manually after node provisioning, which is error-prone and not reproducible via GitOps.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-gcp
type: feature
summary: Added `nestedVirtualization` and `additionalDisks` options to GCPInstanceClass.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
