### PR TITLE
[user-authn] migrate discover_apiserver_endpoints from Endpoints to EndpointSlice

### DIFF
--- a/modules/150-user-authn/hooks/discover_apiserver_endpoints_test.go
+++ b/modules/150-user-authn/hooks/discover_apiserver_endpoints_test.go
@@ -38,14 +38,17 @@ spec:
   ports:
   - targetPort: 6443
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: kubernetes
   namespace: default
-subsets:
+  labels:
+    kubernetes.io/service-name: kubernetes
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 192.168.1.1
+  - 192.168.1.1
 `))
 			f.RunHook()
 		})
@@ -70,16 +73,21 @@ spec:
   ports:
   - targetPort: 443
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: kubernetes
   namespace: default
-subsets:
+  labels:
+    kubernetes.io/service-name: kubernetes
+addressType: IPv4
+endpoints:
 - addresses:
-  - ip: 192.168.1.1
-  - ip: 192.168.1.2
-  - ip: 192.168.1.3
+  - 192.168.1.1
+- addresses:
+  - 192.168.1.2
+- addresses:
+  - 192.168.1.3
 `))
 				f.RunHook()
 			})
@@ -118,13 +126,15 @@ spec:
   ports:
   - targetPort: 6443
 ---
-apiVersion: v1
-kind: Endpoints
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
 metadata:
   name: kubernetes
   namespace: default
-subsets:
-- addresses: []
+  labels:
+    kubernetes.io/service-name: kubernetes
+addressType: IPv4
+endpoints: []
 `))
 			f.RunHook()
 		})


### PR DESCRIPTION
## Description

Switched the `discover_apiserver_endpoints` hook from deprecated `v1.Endpoints` to `discoveryv1.EndpointSlice`. The hook still discovers Kubernetes API server addresses for `userAuthn.publishAPI`; only the API used for discovery has changed.

## Why do we need it, and what problem does it solve?

`v1.Endpoints` is deprecated in Kubernetes v1.33+ and triggers staticcheck SA1019. This change removes the deprecation warning and uses the recommended `discoveryv1.EndpointSlice` API instead.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Migrate discover_apiserver_endpoints from deprecated Endpoints to EndpointSlice API
impact_level: low
```