### PR TITLE
[admission-policy-engine] Convert constraints multi-line output to single-line

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-host-network.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-host-network.yaml
@@ -129,12 +129,12 @@ spec:
 
               build_hostnetwork_message(pod_name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("The hostNetwork or hostPort are not allowed, pod: %v.\n%v\n%v\n%v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("The hostNetwork or hostPort are not allowed, pod: %v. | %v | %v | %v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_hostnetwork_message(pod_name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("The hostNetwork or hostPort are not allowed, pod: %v.\n%v\n%v", [pod_name, actual_value, allowed_by_policy])
+                msg := sprintf("The hostNetwork or hostPort are not allowed, pod: %v. | %v | %v", [pod_name, actual_value, allowed_by_policy])
               }
               allowed_by_any(obj) if {
                 allowed_by_securitypolicyexeption(obj)

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-privilege-escalation.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-privilege-escalation.yaml
@@ -104,12 +104,12 @@ spec:
 
               build_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("Privilege escalation container is not allowed: %v.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("Privilege escalation container is not allowed: %v. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("Privilege escalation container is not allowed: %v.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("Privilege escalation container is not allowed: %v. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               allowed_by_any(c) if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-privileged.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allow-privileged.yaml
@@ -106,12 +106,12 @@ spec:
 
               build_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("Privileged container is not allowed: %v.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("Privileged container is not allowed: %v. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("Privileged container is not allowed: %v.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("Privileged container is not allowed: %v. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               has_field(object, field) if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-apparmor-profiles.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-apparmor-profiles.yaml
@@ -104,12 +104,12 @@ spec:
 
               build_apparmor_message(pod_name, container_name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("AppArmor profile is not allowed, pod: %v, container: %v.\n%v\n%v\n%v", [pod_name, container_name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("AppArmor profile is not allowed, pod: %v, container: %v. | %v | %v | %v", [pod_name, container_name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_apparmor_message(pod_name, container_name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("AppArmor profile is not allowed, pod: %v, container: %v.\n%v\n%v", [pod_name, container_name, actual_value, allowed_by_policy])
+                msg := sprintf("AppArmor profile is not allowed, pod: %v, container: %v. | %v | %v", [pod_name, container_name, actual_value, allowed_by_policy])
               }
 
               allowed_by_any(pod, container) if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-capabilities.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-capabilities.yaml
@@ -140,12 +140,12 @@ spec:
 
               build_capabilities_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("container <%v> has a disallowed capability.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("container <%v> has a disallowed capability. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_capabilities_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("container <%v> has a disallowed capability.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("container <%v> has a disallowed capability. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               has_field(object, field) if {
@@ -292,12 +292,12 @@ spec:
 
               build_drop_capabilities_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("container <%v> is not dropping all required capabilities.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("container <%v> is not dropping all required capabilities. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_drop_capabilities_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("container <%v> is not dropping all required capabilities.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("container <%v> is not dropping all required capabilities. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               drops_required_capabilities_by_any(container) if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-host-paths.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-host-paths.yaml
@@ -100,12 +100,12 @@ spec:
 
               build_hostpath_message(pod_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("HostPath volume is not allowed, pod: %v.\n%v\n%v\n%v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("HostPath volume is not allowed, pod: %v. | %v | %v | %v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_hostpath_message(pod_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("HostPath volume is not allowed, pod: %v.\n%v\n%v", [pod_name, actual_value, allowed_by_policy])
+                msg := sprintf("HostPath volume is not allowed, pod: %v. | %v | %v", [pod_name, actual_value, allowed_by_policy])
               }
 
               ### SecurityPolicy logic

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-proc-mount.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-proc-mount.yaml
@@ -120,12 +120,12 @@ spec:
 
               build_proc_mount_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("ProcMount type is not allowed, container: %v.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("ProcMount type is not allowed, container: %v. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_proc_mount_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("ProcMount type is not allowed, container: %v.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("ProcMount type is not allowed, container: %v. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               has_field(object, field) if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-seccomp.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-seccomp.yaml
@@ -199,12 +199,12 @@ spec:
 
               build_seccomp_message(name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("Seccomp profile is not allowed for container '%v'.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("Seccomp profile is not allowed for container '%v'. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_seccomp_message(name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("Seccomp profile is not allowed for container '%v'.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("Seccomp profile is not allowed for container '%v'. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               input_wildcard_allowed_profiles if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-selinux.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-selinux.yaml
@@ -128,25 +128,25 @@ spec:
               build_selinux_message(pod_name, container_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 container_name != ""
                 exception_allowed != ""
-                msg := sprintf("SELinux options are not allowed, pod: %v, container %v.\n%v\n%v\n%v", [pod_name, container_name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("SELinux options are not allowed, pod: %v, container %v. | %v | %v | %v", [pod_name, container_name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_selinux_message(pod_name, container_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 container_name != ""
                 exception_allowed == ""
-                msg := sprintf("SELinux options are not allowed, pod: %v, container %v.\n%v\n%v", [pod_name, container_name, actual_value, allowed_by_policy])
+                msg := sprintf("SELinux options are not allowed, pod: %v, container %v. | %v | %v", [pod_name, container_name, actual_value, allowed_by_policy])
               }
 
               build_selinux_message(pod_name, container_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 container_name == ""
                 exception_allowed != ""
-                msg := sprintf("SELinux options are not allowed, pod: %v.\n%v\n%v\n%v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("SELinux options are not allowed, pod: %v. | %v | %v | %v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_selinux_message(pod_name, container_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 container_name == ""
                 exception_allowed == ""
-                msg := sprintf("SELinux options are not allowed, pod: %v.\n%v\n%v", [pod_name, actual_value, allowed_by_policy])
+                msg := sprintf("SELinux options are not allowed, pod: %v. | %v | %v", [pod_name, actual_value, allowed_by_policy])
               }
 
               allowed_by_any_seLinuxOptions(options) if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-sysctls.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-sysctls.yaml
@@ -120,12 +120,12 @@ spec:
 
               build_sysctl_message(pod_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                   exception_allowed != ""
-                  msg := sprintf("The sysctl is not allowed, pod: %v.\n%v\n%v\n%v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
+                  msg := sprintf("The sysctl is not allowed, pod: %v. | %v | %v | %v", [pod_name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_sysctl_message(pod_name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                   exception_allowed == ""
-                  msg := sprintf("The sysctl is not allowed, pod: %v.\n%v\n%v", [pod_name, actual_value, allowed_by_policy])
+                  msg := sprintf("The sysctl is not allowed, pod: %v. | %v | %v", [pod_name, actual_value, allowed_by_policy])
               }
 
               # Check whether sysctl is allowed through any policy

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-users.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/allowed-users.yaml
@@ -308,12 +308,12 @@ spec:
 
               build_user_message(name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("Container %v is attempting to run as disallowed user.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("Container %v is attempting to run as disallowed user. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_user_message(name, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("Container %v is attempting to run as disallowed user.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("Container %v is attempting to run as disallowed user. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               accept_users("RunAsAny", _) := true
@@ -471,12 +471,12 @@ spec:
 
               build_group_message(name, field, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("Container %v is attempting to run as disallowed %v.\n%v\n%v\n%v", [name, field, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("Container %v is attempting to run as disallowed %v. | %v | %v | %v", [name, field, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_group_message(name, field, actual_value, allowed_by_policy, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("Container %v is attempting to run as disallowed %v.\n%v\n%v", [name, field, actual_value, allowed_by_policy])
+                msg := sprintf("Container %v is attempting to run as disallowed %v. | %v | %v", [name, field, actual_value, allowed_by_policy])
               }
 
               accept_value("RunAsAny", _, _) := true

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/read-only-root-filesystem.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/read-only-root-filesystem.yaml
@@ -109,12 +109,12 @@ spec:
 
               build_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed != ""
-                msg := sprintf("only read-only root filesystem container is allowed: %v.\n%v\n%v\n%v", [name, actual_value, allowed_by_policy, exception_allowed])
+                msg := sprintf("only read-only root filesystem container is allowed: %v. | %v | %v | %v", [name, actual_value, allowed_by_policy, exception_allowed])
               }
 
               build_message(name, allowed_by_policy, actual_value, exception_allowed) := msg if {
                 exception_allowed == ""
-                msg := sprintf("only read-only root filesystem container is allowed: %v.\n%v\n%v", [name, actual_value, allowed_by_policy])
+                msg := sprintf("only read-only root filesystem container is allowed: %v. | %v | %v", [name, actual_value, allowed_by_policy])
               }
 
               allowed_by_any(c) if {

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/ingress-class/suite.yaml
@@ -15,5 +15,4 @@ tests:
         object: disallowed.yaml
         assertions:
           - violations: yes
-            message: >-
-              Ingress <disallowed> has invalid ingress class: bar
+            message: "Ingress <disallowed> has invalid ingress class: bar"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/priority-class/suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/priority-class/suite.yaml
@@ -15,5 +15,4 @@ tests:
         object: disallowed.yaml
         assertions:
           - violations: yes
-            message: >-
-              Pod <disallowed> has invalid priority class: bar
+            message: "Pod <disallowed> has invalid priority class: bar"

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/suite.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/storage-class/suite.yaml
@@ -15,5 +15,4 @@ tests:
         object: disallowed.yaml
         assertions:
           - violations: yes
-            message: >-
-              PersistentVolumeClaim <disallowed> has invalid storage class: bar
+            message: "PersistentVolumeClaim <disallowed> has invalid storage class: bar"


### PR DESCRIPTION
## Description
Current multiline msgs in constraint gatekeeper didn't work when displaying warnings because they contained multiline output. All multiline output has been changed to single-line with a delimiter.

A regression test was added to ensure ConstraintTemplate sources do not contain `\n` `\r` escapes in Rego message strings.


## Why do we need it, and what problem does it solve?
`kubectl` truncates multi-line Gatekeeper violation messages, which makes admission denial/warn output hard to read and may hide important details.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Convert constraints multi-line output to single-line
impact_level: low
```
