### PR TITLE
[candi] Add new feature-gates with 1.35

### DIFF
--- a/candi/feature_gates_map.yml
+++ b/candi/feature_gates_map.yml
@@ -233,7 +233,6 @@
     - ResourceHealthStatus
     - RestartAllContainersOnContainerExits
     - SELinuxMount
-    - UserNamespacesHostNetworkSupport
   apiserver:
     - AllowUnsafeMalformedObjectDeletion
     - ComponentFlagz
@@ -241,6 +240,7 @@
     - ConcurrentWatchObjectDecode
     - ConstrainedImpersonation
     - ContainerStopSignals
+    - CRDObservedGenerationTracking
     - CrossNamespaceVolumeDataSource
     - HPAScaleToZero
     - MutablePodResourcesForSuspendedJobs
@@ -254,12 +254,10 @@
     - SELinuxMount
     - StrictIPCIDRValidation
     - TaintTolerationComparisonOperators
-    - UserNamespacesHostNetworkSupport
   kubeControllerManager:
     - ComponentFlagz
     - ComponentStatusz
     - ConcurrentWatchObjectDecode
-    - CRDObservedGenerationTracking
     - CrossNamespaceVolumeDataSource
     - SELinuxMount
   kubeScheduler:
@@ -268,4 +266,3 @@
     - ConcurrentWatchObjectDecode
     - NodeDeclaredFeatures
     - TaintTolerationComparisonOperators
-    - UserNamespacesHostNetworkSupport

--- a/modules/040-control-plane-manager/hooks/feature_gates_generated.go
+++ b/modules/040-control-plane-manager/hooks/feature_gates_generated.go
@@ -337,7 +337,6 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"ResourceHealthStatus",
 			"RestartAllContainersOnContainerExits",
 			"SELinuxMount",
-			"UserNamespacesHostNetworkSupport",
 		},
 		APIServer: []string{
 			"AllowUnsafeMalformedObjectDeletion",
@@ -346,6 +345,7 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"ConcurrentWatchObjectDecode",
 			"ConstrainedImpersonation",
 			"ContainerStopSignals",
+			"CRDObservedGenerationTracking",
 			"CrossNamespaceVolumeDataSource",
 			"HPAScaleToZero",
 			"MutablePodResourcesForSuspendedJobs",
@@ -359,13 +359,11 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"SELinuxMount",
 			"StrictIPCIDRValidation",
 			"TaintTolerationComparisonOperators",
-			"UserNamespacesHostNetworkSupport",
 		},
 		KubeControllerManager: []string{
 			"ComponentFlagz",
 			"ComponentStatusz",
 			"ConcurrentWatchObjectDecode",
-			"CRDObservedGenerationTracking",
 			"CrossNamespaceVolumeDataSource",
 			"SELinuxMount",
 		},
@@ -375,7 +373,6 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"ConcurrentWatchObjectDecode",
 			"NodeDeclaredFeatures",
 			"TaintTolerationComparisonOperators",
-			"UserNamespacesHostNetworkSupport",
 		},
 	},
 }

--- a/modules/040-control-plane-manager/webhooks/validating/feature_gates_generated.py
+++ b/modules/040-control-plane-manager/webhooks/validating/feature_gates_generated.py
@@ -255,7 +255,6 @@ versions = {
             "ResourceHealthStatus",
             "RestartAllContainersOnContainerExits",
             "SELinuxMount",
-            "UserNamespacesHostNetworkSupport",
         ],
         "apiserver": [
             "AllowUnsafeMalformedObjectDeletion",
@@ -264,6 +263,7 @@ versions = {
             "ConcurrentWatchObjectDecode",
             "ConstrainedImpersonation",
             "ContainerStopSignals",
+            "CRDObservedGenerationTracking",
             "CrossNamespaceVolumeDataSource",
             "HPAScaleToZero",
             "MutablePodResourcesForSuspendedJobs",
@@ -277,13 +277,11 @@ versions = {
             "SELinuxMount",
             "StrictIPCIDRValidation",
             "TaintTolerationComparisonOperators",
-            "UserNamespacesHostNetworkSupport",
         ],
         "kubeControllerManager": [
             "ComponentFlagz",
             "ComponentStatusz",
             "ConcurrentWatchObjectDecode",
-            "CRDObservedGenerationTracking",
             "CrossNamespaceVolumeDataSource",
             "SELinuxMount",
         ],
@@ -293,7 +291,6 @@ versions = {
             "ConcurrentWatchObjectDecode",
             "NodeDeclaredFeatures",
             "TaintTolerationComparisonOperators",
-            "UserNamespacesHostNetworkSupport",
         ],
     },
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR adds support for the following `Kubernetes v1.35` feature gates:
 - RestartAllContainersOnContainerExits
 - ConstrainedImpersonation
 - CRDObservedGenerationTracking
 - MutablePodResourcesForSuspendedJobs
 - MutableSchedulingDirectivesForSuspendedJobs
 - MutablePVNodeAffinity
 - NodeDeclaredFeatures
 - TaintTolerationComparisonOperators

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR enables support for several Kubernetes v1.35 feature gates to allow users to experiment with and adopt new upstream functionality.

Brief description and example for each:

* **RestartAllContainersOnContainerExits**
  Allows restarting all containers in a Pod (including init containers) when one container exits with specific conditions.
  *Example:* Restart entire Pod (in-place, preserving IP) if main container exits with code 42.

* **ConstrainedImpersonation**
  Adds fine-grained RBAC control over impersonation actions, limiting what operations are allowed when impersonating another user or service account.
  *Example:* Allow impersonating a ServiceAccount only for `get`/`list` Pods, but not for `create` or `delete`.

* **CRDObservedGenerationTracking**
  Adds `observedGeneration` tracking to CRD status conditions, enabling better reconciliation state awareness.
  *Example:* Controller can verify whether `.status.conditions[].observedGeneration` matches `.metadata.generation` to detect stale status.

* **MutablePodResourcesForSuspendedJobs**
  Allows updating container resource requests/limits for suspended Jobs.
  *Example:* Increase memory limits of a suspended Job before resuming it.

* **MutableSchedulingDirectivesForSuspendedJobs**
  Allows modifying scheduling-related fields (nodeSelector, tolerations, affinity) for suspended Jobs.
  *Example:* Change `nodeSelector` while Job is suspended to move it to a different node pool.

* **MutablePVNodeAffinity**
  Allows updating `spec.nodeAffinity` for PersistentVolumes.
  *Example:* Adjust zone/region constraints without recreating the PV.

* **NodeDeclaredFeatures**
  Enables nodes to declare supported Kubernetes features via status, improving scheduling and admission decisions.
  *Example:* Scheduler avoids placing Pods requiring specific capabilities on nodes that do not declare support.

* **TaintTolerationComparisonOperators**
  Introduces `Gt` and `Lt` operators for numeric taint comparison in tolerations.
  *Example:* Schedule Pods only on nodes where `failure-probability < 5`.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Added support for multiple Kubernetes v1.35 feature gates.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
