### PR TITLE
[docs][modules] Escape HTML in OpenAPI descriptions

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-attributes.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-attributes.html
@@ -13,7 +13,7 @@
   {{- $description =  $attributes.description }}
 {{- end }}
 
-<div class="resources__prop_description">{{ $description | markdownify }}</div>
+<div class="resources__prop_description">{{ $description | htmlEscape | markdownify }}</div>
 
 {{- if isset $attributes "x-doc-default" }}
   {{- template "format-default" (index $attributes "x-doc-default") }}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
@@ -48,7 +48,7 @@
       {{- if $langVersionData.schema.openAPIV3Schema.description }}{{ $description = $langVersionData.schema.openAPIV3Schema.description }}{{ end }}
     {{- end }}
 
-    <div class="resources__prop_description">{{ $description | markdownify }}</div>
+    <div class="resources__prop_description">{{ $description | htmlEscape | markdownify }}</div>
     <ul class="resources">
       {{- range $property, $propertyData := $versionSchema.properties }}
         {{- if eq $property "status" }}{{ continue }}{{ end }} {{/* skip .status for now*/}}

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-schema.html
@@ -24,9 +24,9 @@
 
 {{- if reflect.IsMap $data }}
   {{- if and (reflect.IsMap $langData) $langData.description }}
-    {{- $description = $langData.description | markdownify }}
+    {{- $description = $langData.description | htmlEscape | markdownify }}
   {{- else }}
-    {{- $description =  $data.description | markdownify }}
+    {{- $description =  $data.description | htmlEscape | markdownify }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Description

Fixed rendering of HTML characters in CRD.

This pull request introduces a security improvement to the documentation templates by ensuring that descriptions rendered from OpenAPI schemas are properly HTML-escaped before being processed as Markdown. This helps prevent potential injection vulnerabilities and ensures safer rendering of user-supplied content.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Escape HTML in OpenAPI descriptions
impact_level: low
```
