### PR TITLE
[docs] Remove outdated DVP disk migration limitations

### DIFF
--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/DISKS.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/DISKS.md
@@ -346,17 +346,17 @@ Limitations of disk migration between storage:
 
 - Migration is only available for virtual machines in the `Running` state.
 - Migration is only supported between disks of the same type: `Block` ↔ `Block`, `FileSystem` ↔ `FileSystem`; conversion between different types is not possible.
-- Migration is only supported for disks attached statically via the `.spec.blockDeviceRefs` parameter in the virtual machine specification.
-- If a disk was attached via the VirtualMachineBlockDeviceAttachments resource, it must be temporarily reattached directly for migration by specifying the disk name in `.spec.blockDeviceRefs`.
 {% endalert %}
 
 Example of migrating a disk to the `new-storage-class-name` StorageClass:
 
 ```bash
 d8 k patch vd disk --type=merge --patch '{"spec":{"persistentVolumeClaim":{"storageClassName":"new-storage-class-name"}}}'
+```
 
-# Alternatively, apply the changes by editing the resource.
+Alternatively, apply the changes by editing the resource:
 
+```bash
 d8 k edit vd disk
 ```
 

--- a/docs/site/pages/virtualization-platform/documentation/user/resource-managment/DISKS_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/user/resource-managment/DISKS_RU.md
@@ -347,17 +347,17 @@ linux-vm-root   Ready   11Gi       12m
 
 - Миграция доступна только для виртуальных машин в состоянии `Running`.
 - Миграция поддерживается только между дисками одного типа: `Block` ↔ `Block`, `FileSystem` ↔ `FileSystem`; перевод между разными типами невозможен.
-- Миграция поддерживается только для дисков, подключённых статически через параметр `.spec.blockDeviceRefs` в спецификации виртуальной машины.
-- Если диск был подключён посредством ресурса VirtualMachineBlockDeviceAttachments, для выполнения миграции его необходимо временно переподключить напрямую, указав имя диска в `.spec.blockDeviceRefs`.
 {% endalert %}
 
 Пример миграции диска на класс хранения `new-storage-class-name`:
 
 ```bash
 d8 k patch vd disk --type=merge --patch '{"spec":{"persistentVolumeClaim":{"storageClassName":"new-storage-class-name"}}}'
+```
 
-# Или внесите аналогичные изменения, отредактировав ресурс.
+Или внесите аналогичные изменения, отредактировав ресурс:
 
+```bash
 d8 k edit vd disk
 ```
 


### PR DESCRIPTION
## Description
Updated disk migration limitations alert.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Updated disk migration limitations alert.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
