### PR TITLE
[istio] Fixing the list of requests from istiod to gateway API

### DIFF
--- a/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/rbac-for-us.yaml
@@ -93,6 +93,14 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
Added RBAC rules on `[get,list,watch]` for API `gateway.networking.k8s.io`.

## Why do we need it, and what problem does it solve?
If there are resources in the remote cluster `gateway.networking.k8s.io` , then there is no access to them on the list:
```
2026-02-19T11:21:10.286252Z	error	watch error in cluster kappa-cluster: failed to list *v1beta1.Gateway: gateways.gateway.networking.k8s.io is forbidden: User "system:serviceaccount:d8-istio:multicluster-api-proxy" cannot list resource "gateways" in API group "gateway.networking.k8s.io" at the cluster scope
```
Adding permissions to the list of these resources fixes this issue.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixing the list of requests from istiod to gateway API
impact_level: default
```