### PR TITLE
[common] add support accesiblenamespaces in k8s v1.35

### DIFF
--- a/modules/000-common/images/kubernetes/patches/1.35/007-namespace-list-acl-filtering.patch
+++ b/modules/000-common/images/kubernetes/patches/1.35/007-namespace-list-acl-filtering.patch
@@ -1,0 +1,746 @@
+diff --git a/pkg/registry/core/namespace/storage/accessible_fetcher.go b/pkg/registry/core/namespace/storage/accessible_fetcher.go
+new file mode 100644
+index 00000000000..1e31f66de0f
+--- /dev/null
++++ b/pkg/registry/core/namespace/storage/accessible_fetcher.go
+@@ -0,0 +1,176 @@
++/*
++Copyright 2025 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package storage
++
++import (
++	"context"
++	"encoding/json"
++	"fmt"
++	"io"
++	"net/http"
++	"strings"
++	"time"
++
++	restclient "k8s.io/client-go/rest"
++	"k8s.io/client-go/transport"
++	"k8s.io/klog/v2"
++)
++
++const (
++	// accessibleNamespacesAPIPath is the path to the accessiblenamespaces API
++	// provided by permission-browser-apiserver (Deckhouse extension).
++	accessibleNamespacesAPIPath = "/apis/authorization.deckhouse.io/v1alpha1/accessiblenamespaces"
++
++	// DefaultHTTPTimeout is the default timeout for HTTP requests.
++	DefaultHTTPTimeout = 10 * time.Second
++)
++
++// AccessibleNamespaceResponse represents a single accessible namespace from the API response.
++type AccessibleNamespaceResponse struct {
++	Metadata struct {
++		Name string `json:"name"`
++	} `json:"metadata"`
++}
++
++// AccessibleNamespaceListResponse represents the list response from the accessible namespaces API.
++type AccessibleNamespaceListResponse struct {
++	Items []AccessibleNamespaceResponse `json:"items"`
++}
++
++// LoopbackAccessibleNamespaceFetcher implements AccessibleNamespaceFetcher by calling
++// the permission-browser-apiserver's accessiblenamespaces API through kube-apiserver's
++// loopback connection. This ensures proper authentication via loopback client credentials
++// while using impersonation to act as the target user.
++//
++// Deckhouse-specific: used for ACL-based namespace filtering.
++type LoopbackAccessibleNamespaceFetcher struct {
++	// baseURL is the base URL for API requests (typically https://127.0.0.1:6443)
++	baseURL string
++
++	// roundTripper is the authenticated transport from loopback config
++	roundTripper http.RoundTripper
++
++	// timeout for HTTP requests
++	timeout time.Duration
++}
++
++// NewLoopbackAccessibleNamespaceFetcher creates a new fetcher that uses the kube-apiserver's
++// loopback client configuration to call the accessiblenamespaces API with impersonation.
++func NewLoopbackAccessibleNamespaceFetcher(loopbackConfig *restclient.Config) (*LoopbackAccessibleNamespaceFetcher, error) {
++	if loopbackConfig == nil {
++		return nil, fmt.Errorf("loopback config is required")
++	}
++
++	cfg := restclient.CopyConfig(loopbackConfig)
++	transportConfig, err := cfg.TransportConfig()
++	if err != nil {
++		return nil, fmt.Errorf("failed to get transport config: %w", err)
++	}
++
++	rt, err := transport.New(transportConfig)
++	if err != nil {
++		return nil, fmt.Errorf("failed to create transport: %w", err)
++	}
++
++	baseURL := strings.TrimRight(cfg.Host, "/")
++
++	return &LoopbackAccessibleNamespaceFetcher{
++		baseURL:      baseURL,
++		roundTripper: rt,
++		timeout:      DefaultHTTPTimeout,
++	}, nil
++}
++
++func (f *LoopbackAccessibleNamespaceFetcher) httpClientFor(username string, groups []string, extra map[string][]string) *http.Client {
++	// IMPORTANT:
++	// User extra keys may contain characters that are invalid in HTTP header field-names (e.g. '/').
++	// Kubernetes solves this by escaping extra keys in impersonation headers.
++	// Use client-go's impersonating round-tripper to match upstream behavior.
++	impRT := transport.NewImpersonatingRoundTripper(transport.ImpersonationConfig{
++		UserName: username,
++		Groups:   groups,
++		Extra:    extra,
++	}, f.roundTripper)
++
++	return &http.Client{
++		Transport: impRT,
++		Timeout:   f.timeout,
++	}
++}
++
++// FetchAccessibleNamespaces fetches the list of accessible namespace names for the user.
++func (f *LoopbackAccessibleNamespaceFetcher) FetchAccessibleNamespaces(ctx context.Context, username string, groups []string, extra map[string][]string) ([]string, error) {
++	url := f.baseURL + accessibleNamespacesAPIPath
++
++	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
++	if err != nil {
++		return nil, fmt.Errorf("failed to create request: %w", err)
++	}
++
++	klog.V(4).Infof("Fetching accessible namespaces for user %s via loopback at %s", username, url)
++
++	client := f.httpClientFor(username, groups, extra)
++	resp, err := client.Do(req)
++	if err != nil {
++		return nil, fmt.Errorf("failed to fetch accessible namespaces: %w", err)
++	}
++	defer resp.Body.Close()
++
++	if resp.StatusCode != http.StatusOK {
++		body, _ := io.ReadAll(resp.Body)
++		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
++	}
++
++	var listResponse AccessibleNamespaceListResponse
++	if err := json.NewDecoder(resp.Body).Decode(&listResponse); err != nil {
++		return nil, fmt.Errorf("failed to decode response: %w", err)
++	}
++
++	names := make([]string, len(listResponse.Items))
++	for i, item := range listResponse.Items {
++		names[i] = item.Metadata.Name
++	}
++
++	return names, nil
++}
++
++// IsNamespaceAccessible checks if a specific namespace is accessible to the user.
++func (f *LoopbackAccessibleNamespaceFetcher) IsNamespaceAccessible(ctx context.Context, username string, groups []string, extra map[string][]string, namespace string) (bool, error) {
++	url := fmt.Sprintf("%s%s/%s", f.baseURL, accessibleNamespacesAPIPath, namespace)
++
++	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
++	if err != nil {
++		return false, fmt.Errorf("failed to create request: %w", err)
++	}
++
++	client := f.httpClientFor(username, groups, extra)
++	resp, err := client.Do(req)
++	if err != nil {
++		return false, fmt.Errorf("failed to check namespace accessibility: %w", err)
++	}
++	defer resp.Body.Close()
++
++	switch resp.StatusCode {
++	case http.StatusOK:
++		return true, nil
++	case http.StatusNotFound:
++		return false, nil
++	default:
++		body, _ := io.ReadAll(resp.Body)
++		return false, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, string(body))
++	}
++}
+diff --git a/pkg/registry/core/namespace/storage/filtering_test.go b/pkg/registry/core/namespace/storage/filtering_test.go
+new file mode 100644
+index 00000000000..c3ce9f7d232
+--- /dev/null
++++ b/pkg/registry/core/namespace/storage/filtering_test.go
+@@ -0,0 +1,256 @@
++/*
++Copyright 2025 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package storage
++
++import (
++	"context"
++	"fmt"
++	"testing"
++
++	apierrors "k8s.io/apimachinery/pkg/api/errors"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apiserver/pkg/authentication/user"
++	"k8s.io/apiserver/pkg/endpoints/filters"
++	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
++	"k8s.io/apiserver/pkg/registry/generic"
++	"k8s.io/apiserver/pkg/registry/rest"
++	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
++
++	api "k8s.io/kubernetes/pkg/apis/core"
++	"k8s.io/kubernetes/pkg/registry/registrytest"
++)
++
++// mockAccessibleFetcher implements AccessibleNamespaceFetcher for testing
++type mockAccessibleFetcher struct {
++	accessibleNamespaces []string
++	accessibleMap        map[string]bool
++	fetchError           error
++}
++
++func (m *mockAccessibleFetcher) FetchAccessibleNamespaces(ctx context.Context, username string, groups []string, extra map[string][]string) ([]string, error) {
++	if m.fetchError != nil {
++		return nil, m.fetchError
++	}
++	return m.accessibleNamespaces, nil
++}
++
++func (m *mockAccessibleFetcher) IsNamespaceAccessible(ctx context.Context, username string, groups []string, extra map[string][]string, namespace string) (bool, error) {
++	if m.fetchError != nil {
++		return false, m.fetchError
++	}
++	if m.accessibleMap != nil {
++		return m.accessibleMap[namespace], nil
++	}
++	for _, ns := range m.accessibleNamespaces {
++		if ns == namespace {
++			return true, nil
++		}
++	}
++	return false, nil
++}
++
++// newStorageWithFiltering creates a storage with filtering enabled
++func newStorageWithFiltering(t *testing.T, fetcher *mockAccessibleFetcher) (*REST, *etcd3testing.EtcdTestServer) {
++	etcdStorage, server := registrytest.NewEtcdStorage(t, "")
++	restOptions := generic.RESTOptions{StorageConfig: etcdStorage, Decorator: generic.UndecoratedStorage, DeleteCollectionWorkers: 1, ResourcePrefix: "namespaces"}
++
++	namespaceStorage, _, _, err := NewRESTWithFiltering(restOptions, fetcher)
++	if err != nil {
++		t.Fatalf("unexpected error from REST storage: %v", err)
++	}
++	return namespaceStorage, server
++}
++
++// createNamespace creates a namespace in storage
++func createNamespace(t *testing.T, storage *REST, name string) {
++	ns := &api.Namespace{
++		ObjectMeta: metav1.ObjectMeta{Name: name},
++	}
++	// namespaces are cluster-scoped, so use NamespaceNone
++	ctx := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceNone)
++	_, err := storage.Create(ctx, ns, rest.ValidateAllObjectFunc, &metav1.CreateOptions{})
++	if err != nil {
++		t.Fatalf("failed to create namespace %s: %v", name, err)
++	}
++}
++
++// ctxWithUser creates a context with user info
++func ctxWithUser(username string, groups []string) context.Context {
++	ctx := genericapirequest.NewContext()
++	ctx = genericapirequest.WithUser(ctx, &user.DefaultInfo{Name: username, Groups: groups})
++	return ctx
++}
++
++// ctxWithFilteringMode creates a context with namespace filtering mode enabled
++func ctxWithFilteringMode(ctx context.Context) context.Context {
++	return filters.WithNamespaceFilteringMode(ctx)
++}
++
++func TestListWithFiltering_NoFilteringMode_ReturnsAll(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a"}}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++	createNamespace(t, storage, "ns-b")
++	createNamespace(t, storage, "ns-c")
++
++	ctx := ctxWithUser("test-user", []string{"system:authenticated"})
++	result, err := storage.List(ctx, nil)
++	if err != nil {
++		t.Fatalf("unexpected error: %v", err)
++	}
++
++	nsList := result.(*api.NamespaceList)
++	if len(nsList.Items) != 3 {
++		t.Errorf("expected 3 namespaces, got %d", len(nsList.Items))
++	}
++}
++
++func TestListWithFiltering_FilteringMode_FilteredList(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a", "ns-c"}}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++	createNamespace(t, storage, "ns-b")
++	createNamespace(t, storage, "ns-c")
++
++	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
++	result, err := storage.List(ctx, nil)
++	if err != nil {
++		t.Fatalf("unexpected error: %v", err)
++	}
++
++	nsList := result.(*api.NamespaceList)
++	if len(nsList.Items) != 2 {
++		t.Errorf("expected 2 namespaces, got %d", len(nsList.Items))
++	}
++}
++
++func TestListWithFiltering_FilteringMode_EmptyList(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{}}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++	createNamespace(t, storage, "ns-b")
++
++	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
++	result, err := storage.List(ctx, nil)
++	if err != nil {
++		t.Fatalf("unexpected error: %v", err)
++	}
++
++	nsList := result.(*api.NamespaceList)
++	if len(nsList.Items) != 0 {
++		t.Errorf("expected 0 namespaces, got %d", len(nsList.Items))
++	}
++}
++
++func TestListWithFiltering_FetchError_ReturnsForbidden(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{fetchError: fmt.Errorf("service unavailable")}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
++	_, err := storage.List(ctx, nil)
++	if err == nil {
++		t.Fatal("expected error, got nil")
++	}
++	if !apierrors.IsForbidden(err) {
++		t.Errorf("expected Forbidden error, got %v", err)
++	}
++}
++
++func TestGetWithFiltering_NoFilteringMode_ReturnsNamespace(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a"}}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++
++	ctx := ctxWithUser("test-user", []string{"system:authenticated"})
++	result, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
++	if err != nil {
++		t.Fatalf("unexpected error: %v", err)
++	}
++	ns := result.(*api.Namespace)
++	if ns.Name != "ns-a" {
++		t.Errorf("expected ns-a, got %s", ns.Name)
++	}
++}
++
++func TestGetWithFiltering_FilteringMode_AccessibleNamespace(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{"ns-a"}, accessibleMap: map[string]bool{"ns-a": true}}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++
++	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
++	result, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
++	if err != nil {
++		t.Fatalf("unexpected error: %v", err)
++	}
++	ns := result.(*api.Namespace)
++	if ns.Name != "ns-a" {
++		t.Errorf("expected ns-a, got %s", ns.Name)
++	}
++}
++
++func TestGetWithFiltering_FilteringMode_InaccessibleNamespace_ReturnsNotFound(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{accessibleNamespaces: []string{}, accessibleMap: map[string]bool{"ns-a": false}}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++
++	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
++	_, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
++	if err == nil {
++		t.Fatal("expected error, got nil")
++	}
++	if !apierrors.IsNotFound(err) {
++		t.Errorf("expected NotFound error, got %v", err)
++	}
++}
++
++func TestGetWithFiltering_FetchError_ReturnsForbidden(t *testing.T) {
++	fetcher := &mockAccessibleFetcher{fetchError: fmt.Errorf("service unavailable")}
++	storage, server := newStorageWithFiltering(t, fetcher)
++	defer server.Terminate(t)
++	defer storage.store.DestroyFunc()
++
++	createNamespace(t, storage, "ns-a")
++
++	ctx := ctxWithFilteringMode(ctxWithUser("test-user", []string{"system:authenticated"}))
++	_, err := storage.Get(ctx, "ns-a", &metav1.GetOptions{})
++	if err == nil {
++		t.Fatal("expected error, got nil")
++	}
++	if !apierrors.IsForbidden(err) {
++		t.Errorf("expected Forbidden error, got %v", err)
++	}
++}
+diff --git a/pkg/registry/core/namespace/storage/storage.go b/pkg/registry/core/namespace/storage/storage.go
+index e67cedeb15e..8552fc47b79 100644
+--- a/pkg/registry/core/namespace/storage/storage.go
++++ b/pkg/registry/core/namespace/storage/storage.go
+@@ -26,12 +26,16 @@ import (
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+ 	"k8s.io/apimachinery/pkg/watch"
++	"k8s.io/apiserver/pkg/endpoints/filters"
++	"k8s.io/apiserver/pkg/endpoints/request"
+ 	"k8s.io/apiserver/pkg/registry/generic"
+ 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+ 	"k8s.io/apiserver/pkg/registry/rest"
+ 	"k8s.io/apiserver/pkg/storage"
+ 	storageerr "k8s.io/apiserver/pkg/storage/errors"
+ 	"k8s.io/apiserver/pkg/util/dryrun"
++	restclient "k8s.io/client-go/rest"
++	"k8s.io/klog/v2"
+ 	api "k8s.io/kubernetes/pkg/apis/core"
+ 	"k8s.io/kubernetes/pkg/printers"
+ 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
+@@ -40,10 +44,25 @@ import (
+ 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
+ )
+ 
++// AccessibleNamespaceFetcher is an interface for fetching accessible namespaces for a user.
++// This is typically implemented by calling an external service (e.g., permission-browser-apiserver).
++type AccessibleNamespaceFetcher interface {
++	// FetchAccessibleNamespaces returns a list of namespace names that the user has access to.
++	FetchAccessibleNamespaces(ctx context.Context, username string, groups []string, extra map[string][]string) ([]string, error)
++
++	// IsNamespaceAccessible checks if a specific namespace is accessible to the user.
++	IsNamespaceAccessible(ctx context.Context, username string, groups []string, extra map[string][]string, namespace string) (bool, error)
++}
++
+ // rest implements a RESTStorage for namespaces
+ type REST struct {
+ 	store  *genericregistry.Store
+ 	status *genericregistry.Store
++
++	// Deckhouse: namespace filtering support.
++	// If set, namespaces will be filtered based on user permissions
++	// when IsNamespaceFilteringMode(ctx) is true.
++	accessibleFetcher AccessibleNamespaceFetcher
+ }
+ 
+ // StatusREST implements the REST endpoint for changing the status of a namespace.
+@@ -58,6 +77,30 @@ type FinalizeREST struct {
+ 
+ // NewREST returns a RESTStorage object that will work against namespaces.
+ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *FinalizeREST, error) {
++	return NewRESTWithFiltering(optsGetter, nil)
++}
++
++// NewRESTWithDeckhouseFiltering returns a RESTStorage object with Deckhouse namespace filtering enabled.
++// It uses the loopback client config to call permission-browser-apiserver through kube-apiserver's
++// aggregated API mechanism with impersonation.
++// Filtering is triggered when IsNamespaceFilteringMode(ctx) is true (set by WithAuthorization filter).
++// If loopbackConfig is nil, filtering is disabled (vanilla Kubernetes behavior).
++func NewRESTWithDeckhouseFiltering(optsGetter generic.RESTOptionsGetter, loopbackConfig *restclient.Config) (*REST, *StatusREST, *FinalizeREST, error) {
++	var fetcher AccessibleNamespaceFetcher
++	if loopbackConfig != nil {
++		var err error
++		fetcher, err = NewLoopbackAccessibleNamespaceFetcher(loopbackConfig)
++		if err != nil {
++			klog.Warningf("Failed to create loopback accessible namespace fetcher: %v, namespace filtering disabled", err)
++			fetcher = nil
++		}
++	}
++	return NewRESTWithFiltering(optsGetter, fetcher)
++}
++
++// NewRESTWithFiltering returns a RESTStorage object with optional namespace filtering support.
++// If fetcher is nil, filtering is disabled (default Kubernetes behavior).
++func NewRESTWithFiltering(optsGetter generic.RESTOptionsGetter, fetcher AccessibleNamespaceFetcher) (*REST, *StatusREST, *FinalizeREST, error) {
+ 	store := &genericregistry.Store{
+ 		NewFunc:                   func() runtime.Object { return &api.Namespace{} },
+ 		NewListFunc:               func() runtime.Object { return &api.NamespaceList{} },
+@@ -88,7 +131,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
+ 	finalizeStore.UpdateStrategy = namespace.FinalizeStrategy
+ 	finalizeStore.ResetFieldsStrategy = namespace.FinalizeStrategy
+ 
+-	return &REST{store: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
++	r := &REST{store: store, status: &statusStore, accessibleFetcher: fetcher}
++	return r, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
+ }
+ 
+ func (r *REST) NamespaceScoped() bool {
+@@ -115,7 +159,32 @@ func (r *REST) NewList() runtime.Object {
+ }
+ 
+ func (r *REST) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+-	return r.store.List(ctx, options)
++	// Fast path: no filtering needed (either disabled or user has full access)
++	if !r.shouldFilter(ctx) {
++		return r.store.List(ctx, options)
++	}
++
++	accessibleNames, err := r.getAccessibleNamespaces(ctx)
++	if err != nil {
++		klog.Warningf("Failed to fetch accessible namespaces: %v, returning forbidden", err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), "", fmt.Errorf("cannot list namespaces"))
++	}
++
++	if len(accessibleNames) == 0 {
++		return &api.NamespaceList{
++			TypeMeta: metav1.TypeMeta{
++				Kind:       "NamespaceList",
++				APIVersion: "v1",
++			},
++		}, nil
++	}
++
++	fullList, err := r.store.List(ctx, options)
++	if err != nil {
++		return nil, apierrors.NewInternalError(err)
++	}
++
++	return r.filterNamespaceList(fullList, accessibleNames), nil
+ }
+ 
+ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+@@ -127,13 +196,101 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
+ }
+ 
+ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
++	// Fast path: no filtering needed (either disabled or user has full access)
++	if !r.shouldFilter(ctx) {
++		return r.store.Get(ctx, name, options)
++	}
++
++	accessible, err := r.isNamespaceAccessibleToUser(ctx, name)
++	if err != nil {
++		// Return Forbidden when permission-browser-apiserver is unavailable.
++		klog.Warningf("Failed to check namespace accessibility for %s: %v, returning forbidden", name, err)
++		return nil, apierrors.NewForbidden(api.Resource("namespaces"), name, fmt.Errorf("cannot get namespace"))
++	}
++
++	if !accessible {
++		// Return NotFound instead of Forbidden to avoid existence disclosure.
++		return nil, apierrors.NewNotFound(api.Resource("namespaces"), name)
++	}
++
+ 	return r.store.Get(ctx, name, options)
+ }
+ 
+ func (r *REST) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
++	// Note: Watch filtering is not implemented in MVP.
+ 	return r.store.Watch(ctx, options)
+ }
+ 
++// isFilteringEnabled returns true if namespace filtering is configured.
++func (r *REST) isFilteringEnabled() bool {
++	return r.accessibleFetcher != nil
++}
++
++// shouldFilter checks if filtering should be applied for this request.
++// Filtering is triggered when:
++// 1. accessibleFetcher is configured
++// 2. IsNamespaceFilteringMode(ctx) is true (user was denied by authorizer but bypassed)
++func (r *REST) shouldFilter(ctx context.Context) bool {
++	return r.isFilteringEnabled() && filters.IsNamespaceFilteringMode(ctx)
++}
++
++// getAccessibleNamespaces fetches accessible namespace names for the user from external service.
++func (r *REST) getAccessibleNamespaces(ctx context.Context) ([]string, error) {
++	userInfo, ok := request.UserFrom(ctx)
++	if !ok {
++		return nil, fmt.Errorf("no user info in context")
++	}
++
++	extra := make(map[string][]string)
++	for k, v := range userInfo.GetExtra() {
++		extra[k] = v
++	}
++
++	return r.accessibleFetcher.FetchAccessibleNamespaces(ctx, userInfo.GetName(), userInfo.GetGroups(), extra)
++}
++
++// isNamespaceAccessibleToUser checks if a specific namespace is accessible to the user.
++func (r *REST) isNamespaceAccessibleToUser(ctx context.Context, name string) (bool, error) {
++	userInfo, ok := request.UserFrom(ctx)
++	if !ok {
++		return false, fmt.Errorf("no user info in context")
++	}
++
++	extra := make(map[string][]string)
++	for k, v := range userInfo.GetExtra() {
++		extra[k] = v
++	}
++
++	return r.accessibleFetcher.IsNamespaceAccessible(ctx, userInfo.GetName(), userInfo.GetGroups(), extra, name)
++}
++
++// filterNamespaceList filters a NamespaceList to only include accessible namespaces.
++func (r *REST) filterNamespaceList(list runtime.Object, accessibleNames []string) runtime.Object {
++	nsList, ok := list.(*api.NamespaceList)
++	if !ok {
++		return list
++	}
++
++	accessibleSet := make(map[string]struct{}, len(accessibleNames))
++	for _, name := range accessibleNames {
++		accessibleSet[name] = struct{}{}
++	}
++
++	filtered := &api.NamespaceList{
++		TypeMeta: nsList.TypeMeta,
++		ListMeta: nsList.ListMeta,
++		Items:    make([]api.Namespace, 0, len(accessibleNames)),
++	}
++
++	for _, ns := range nsList.Items {
++		if _, ok := accessibleSet[ns.Name]; ok {
++			filtered.Items = append(filtered.Items, ns)
++		}
++	}
++
++	return filtered
++}
++
+ // Delete enforces life-cycle rules for namespace termination
+ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+ 	nsObj, err := r.Get(ctx, name, &metav1.GetOptions{})
+diff --git a/pkg/registry/core/rest/storage_core_generic.go b/pkg/registry/core/rest/storage_core_generic.go
+index 9d82ca85633..a02d7078145 100644
+--- a/pkg/registry/core/rest/storage_core_generic.go
++++ b/pkg/registry/core/rest/storage_core_generic.go
+@@ -106,7 +106,10 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
+ 		return genericapiserver.APIGroupInfo{}, err
+ 	}
+ 
+-	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage, err := namespacestore.NewREST(restOptionsGetter)
++	// Deckhouse: Always use filtering-capable namespace storage with loopback client for proper auth.
++	// Actual filtering only happens when filters.IsNamespaceFilteringMode(ctx) is true
++	// (set by WithAuthorization filter when user does not have list/get namespaces permission).
++	namespaceStorage, namespaceStatusStorage, namespaceFinalizeStorage, err := namespacestore.NewRESTWithDeckhouseFiltering(restOptionsGetter, c.LoopbackClientConfig)
+ 	if err != nil {
+ 		return genericapiserver.APIGroupInfo{}, err
+ 	}
+diff --git a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+index 6c6c94ba718..f4fa75f00b4 100644
+--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
++++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authorization.go
+@@ -47,6 +47,35 @@ const (
+ 	reasonError    = "internal error"
+ )
+ 
++// Deckhouse: Context key for namespace filtering mode.
++// When set to true, indicates that the request was denied by authorizer but bypassed
++// because it's a namespace list/get request that should be filtered by accessible namespaces.
++type namespaceFilteringModeKey struct{}
++
++// IsNamespaceFilteringMode returns true if the request context indicates that
++// namespace filtering should be applied (user doesn't have full list/get namespaces permission).
++func IsNamespaceFilteringMode(ctx context.Context) bool {
++	val, ok := ctx.Value(namespaceFilteringModeKey{}).(bool)
++	return ok && val
++}
++
++// WithNamespaceFilteringMode returns a new context with namespace filtering mode set.
++// This is primarily for testing purposes.
++func WithNamespaceFilteringMode(ctx context.Context) context.Context {
++	return context.WithValue(ctx, namespaceFilteringModeKey{}, true)
++}
++
++// isNamespaceListOrGetRequest checks if the request is for listing or getting namespaces.
++// Deckhouse-specific: these requests are bypassed from 403 to allow filtered responses.
++func isNamespaceListOrGetRequest(requestInfo *request.RequestInfo) bool {
++	return requestInfo != nil &&
++		requestInfo.IsResourceRequest &&
++		requestInfo.APIGroup == "" &&
++		requestInfo.Resource == "namespaces" &&
++		requestInfo.Subresource == "" &&
++		(requestInfo.Verb == "list" || requestInfo.Verb == "get")
++}
++
+ type recordAuthorizationMetricsFunc func(ctx context.Context, authorized authorizer.Decision, err error, authStart time.Time, authFinish time.Time)
+ 
+ // WithAuthorization passes all authorized requests on to handler, and returns a forbidden error otherwise.
+@@ -90,6 +119,20 @@ func withAuthorization(handler http.Handler, a authorizer.Authorizer, s runtime.
+ 			return
+ 		}
+ 
++		// Deckhouse: bypass 403 for namespace list/get requests to allow filtered responses.
++		// The storage layer will check IsNamespaceFilteringMode() and filter accordingly.
++		requestInfo, _ := request.RequestInfoFrom(ctx)
++		if isNamespaceListOrGetRequest(requestInfo) {
++			klog.V(4).InfoS("Bypassing authorization denial for namespace request, will filter in storage",
++				"URI", req.RequestURI, "verb", requestInfo.Verb, "reason", reason)
++			audit.AddAuditAnnotations(ctx,
++				decisionAnnotationKey, "allow-filtered",
++				reasonAnnotationKey, "namespace filtering mode")
++			filteredCtx := context.WithValue(ctx, namespaceFilteringModeKey{}, true)
++			handler.ServeHTTP(w, req.WithContext(filteredCtx))
++			return
++		}
++
+ 		klog.V(4).InfoS("Forbidden", "URI", req.RequestURI, "reason", reason)
+ 		audit.AddAuditAnnotations(ctx,
+ 			decisionAnnotationKey, decisionForbid,
+


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR add support `accesiblenamespaces` in k8s v1.35
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: feature
summary: add support accesiblenamespaces in k8s v1.35
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
