### PR TITLE
[chore] Changelog release 1.69

### DIFF
--- a/CHANGELOG/CHANGELOG-v1.69.17.yml
+++ b/CHANGELOG/CHANGELOG-v1.69.17.yml
@@ -10,6 +10,8 @@ istio:
     - summary: Validating jwt token exp time less than 30 days
       pull_request: https://github.com/deckhouse/deckhouse/pull/18008
   fixes:
+    - summary: Fix istiod CPU leak when the order of the ingressGateways array is changed
+      pull_request: https://github.com/deckhouse/deckhouse/pull/17643
     - summary: Reduce RAM for regenerate multicluster JWT token
       pull_request: https://github.com/deckhouse/deckhouse/pull/15511
 node-manager:

--- a/CHANGELOG/CHANGELOG-v1.69.md
+++ b/CHANGELOG/CHANGELOG-v1.69.md
@@ -130,6 +130,7 @@
     Ingress-nginx controller pods of v1.9 will be restated.
  - **[ingress-nginx]** Fixed patch names in `ingress-nginx`. [#12633](https://github.com/deckhouse/deckhouse/pull/12633)
  - **[ingress-nginx]** Fixed security vulnerabilities. [#12449](https://github.com/deckhouse/deckhouse/pull/12449)
+ - **[istio]** Fix istiod CPU leak when the order of the ingressGateways array is changed [#17643](https://github.com/deckhouse/deckhouse/pull/17643)
  - **[istio]** Reduce RAM for regenerate multicluster JWT token [#15511](https://github.com/deckhouse/deckhouse/pull/15511)
  - **[istio]** The `alliance.ingressGateway.advertise` option was fixed up. [#13924](https://github.com/deckhouse/deckhouse/pull/13924)
  - **[istio]** proxy-buffer-size increased in kiali Ingress. [#13721](https://github.com/deckhouse/deckhouse/pull/13721)


### PR DESCRIPTION
## Description
Fix changelog for 1.69.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix changelog for 1.69.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
