### PR TITLE
[ingress-nginx] Fix annotation validation in 1.12

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-12/patches/011-restore-validation.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/011-restore-validation.patch
@@ -1,37 +1,11 @@
-From 415e46a014fa323c0414a88e8e776e5621ce28ff Mon Sep 17 00:00:00 2001
-From: Roman Orudzhov <raorudzhov@gmail.com>
-Date: Mon, 9 Jun 2025 01:50:02 +0300
-Subject: [PATCH] restore validation
-
----
- internal/ingress/annotations/annotations.go    | 3 ---
- internal/ingress/controller/controller.go      | 3 ---
- internal/ingress/controller/controller_test.go | 3 ---
- test/e2e/admission/admission.go                | 4 +---
- 5 files changed, 2 insertions(+), 13 deletions(-)
-
-diff --git a/internal/ingress/annotations/annotations.go b/internal/ingress/annotations/annotations.go
-index e10cc9be1..bfd466ab1 100644
---- a/internal/ingress/annotations/annotations.go
-+++ b/internal/ingress/annotations/annotations.go
-@@ -183,9 +183,6 @@ func (e Extractor) Extract(ing *networking.Ingress) (*Ingress, error) {
-
- 	data := make(map[string]interface{})
- 	for name, annotationParser := range e.annotations {
--		if err := annotationParser.Validate(ing.GetAnnotations()); err != nil {
--			return nil, errors.NewRiskyAnnotations(name)
--		}
- 		val, err := annotationParser.Parse(ing)
- 		klog.V(5).InfoS("Parsing Ingress annotation", "name", name, "ingress", klog.KObj(ing), "value", val)
- 		if err != nil {
 diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
-index ae8c79bd9..aa0707224 100644
+index 54c8e281e..c5c2049d5 100644
 --- a/internal/ingress/controller/controller.go
 +++ b/internal/ingress/controller/controller.go
-@@ -420,14 +420,11 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
+@@ -442,14 +442,11 @@ func (n *NGINXController) CheckIngress(ing *networking.Ingress) error {
  		return err
  	}
-
+ 
 -	/* Deactivated to mitigate CVE-2025-1974
 -	// TODO: Implement sandboxing so this test can be done safely
  	err = n.testTemplate(content)
@@ -40,59 +14,6 @@ index ae8c79bd9..aa0707224 100644
  		return err
  	}
 -	*/
-
+ 
  	n.metricCollector.IncCheckCount(ing.ObjectMeta.Namespace, ing.Name)
  	endCheck := time.Now().UnixNano() / 1000000
-diff --git a/internal/ingress/controller/controller_test.go b/internal/ingress/controller/controller_test.go
-index 3b7a3c4eb..9d3fea470 100644
---- a/internal/ingress/controller/controller_test.go
-+++ b/internal/ingress/controller/controller_test.go
-@@ -250,8 +250,6 @@ func TestCheckIngress(t *testing.T) {
- 			}
- 		})
-
--		/* Deactivated to mitigate CVE-2025-1974
--		// TODO: Implement sandboxing so this test can be done safely
- 		t.Run("When nginx test returns an error", func(t *testing.T) {
- 			nginx.command = testNginxTestCommand{
- 				t:        t,
-@@ -263,7 +261,6 @@ func TestCheckIngress(t *testing.T) {
- 				t.Errorf("with a new ingress with an error, an error should be returned")
- 			}
- 		})
--		*/
-
- 		t.Run("When the default annotation prefix is used despite an override", func(t *testing.T) {
- 			defer func() {
-diff --git a/test/e2e/admission/admission.go b/test/e2e/admission/admission.go
-index 2c94a5893..a86541213 100644
---- a/test/e2e/admission/admission.go
-+++ b/test/e2e/admission/admission.go
-@@ -20,6 +20,7 @@ import (
- 	"bytes"
- 	"context"
- 	"fmt"
-+	"github.com/onsi/ginkgo"
- 	"net/http"
- 	"os/exec"
- 	"strings"
-@@ -209,8 +210,6 @@ var _ = framework.IngressNginxDescribeSerial("[Admission] admission controller",
- 			Status(http.StatusOK)
- 	})
-
--	/* Deactivated to mitigate CVE-2025-1974
--	// TODO: Implement sandboxing so this test can be done safely
- 	ginkgo.It("should return an error if the Ingress V1 definition contains invalid annotations", func() {
- 		disableSnippet := f.AllowSnippetConfiguration()
- 		defer disableSnippet()
-@@ -224,7 +223,6 @@ var _ = framework.IngressNginxDescribeSerial("[Admission] admission controller",
- 			assert.NotNil(ginkgo.GinkgoT(), err, "creating an ingress with invalid configuration should return an error")
- 		}
- 	})
--	*/
-
- 	ginkgo.It("should not return an error for an invalid Ingress when it has unknown class", func() {
- 		disableSnippet := f.AllowSnippetConfiguration()
---
-2.39.5 (Apple Git-154)
-


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Aligned controller-1-12 `011-restore-validation.patch` with the validation behavior used in 1.14.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Controller version 1.12 contains a patch containing an extra change that disables `Risky` annotation validation in Ingress resources. Regardless of the value of the `annotations-risk-level` parameter, Ingress resources with High/Critical annotations will begin to flow further.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Manual testing

<details>
<summary>Test validation Risky After patch fix </summary>

<img width="1890" height="106" alt="image" src="https://github.com/user-attachments/assets/01705964-4b3e-4fb6-81c3-fbd366e67d2a" />

</details>

<details>
<summary>Test validation Risky Before patch fix </summary>

<img width="764" height="121" alt="image" src="https://github.com/user-attachments/assets/a8d023da-8275-4956-83d2-59933521479d" />

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: The annotation validation is fixed in 1.12.
impact: All ingress-nginx controller pods of the 1.12 version will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
