### PR TITLE
[dhctl] Add validation for SSH public key

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -229,6 +229,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		ctx,
 		app.ConfigPaths,
 		infrastructureprovider.MetaConfigPreparatorProvider(preparatorParams),
+		config.ValidateOptionValidateExtensions(true),
 	)
 	if err != nil {
 		return err

--- a/dhctl/pkg/operations/destroy/common_test.go
+++ b/dhctl/pkg/operations/destroy/common_test.go
@@ -95,7 +95,7 @@ masterNodeGroup:
     imageID: imageId
     externalIPAddresses:
       - Auto
-sshPublicKey: ssh-rsa AAAAB3NzaC
+sshPublicKey: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCsCkOVy6z7SPO+NYZyz15XTFSRGYqhaw3QVAoRuUkG6J1xCK7yCXtZoDYJM5uSdk58cQhd3/+Dto7saNa3NNEm+WW3vnZ6ArLl4U/YHmpHu0pUgDaoQsaRvNHW5jG/YsBter0G88ZqChRP4adhaMHK4x7JM+Yml+dTEecAROzcl9cIjMTPjUK/3ZJdbckpTQXiqX7re+Mzer2wdAT0YtwX2Ai++nrP/GIFzO+HMTd6lLdtP+uGWL+zNnHq2KTbP1v9BumZQXJNGLVXrI8V63TW7cKICr+8ASdF+hw9DDqyIJBeRE/LNm1tj2VIfnwPaGs9G5gdP0k5FUsvq8qwS6GDd6Ro/iGfhMhOhnLBSzlobGPO0I+kb7r250eyhwpJEGPvTR3koA/5KyFKtYctgbYkaBEJzCMhtgU9CzbFHimS7Y2/XIPLcLbuWYaknCqnny++kmvxzc4G7Qj6mf8gsr1NH273Qf/dlkkwPhGxIA+OJDK9OOjEu2ZjZyM+lJOgJQ0= root@11605a4d8b81
 nodeNetworkCIDR: 10.100.0.0/21
 provider:
   cloudID: cloudId

--- a/dhctl/pkg/operations/edit.go
+++ b/dhctl/pkg/operations/edit.go
@@ -63,7 +63,7 @@ func Edit(data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	_, err = schemaStore.Validate(&modifiedData)
+	_, err = schemaStore.Validate(&modifiedData, config.ValidateOptionValidateExtensions(true))
 	if err != nil {
 		return nil, err
 	}

--- a/ee/modules/030-cloud-provider-dynamix/candi/openapi/cluster_configuration.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/candi/openapi/cluster_configuration.yaml
@@ -63,6 +63,7 @@ apiVersions:
         enum: [DynamixClusterConfiguration]
       sshPublicKey:
         type: string
+        x-rules: [sshPublicKey]
         description: A public key for accessing nodes.
       location:
         type: string

--- a/ee/modules/030-cloud-provider-huaweicloud/candi/openapi/cluster_configuration.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/candi/openapi/cluster_configuration.yaml
@@ -60,6 +60,7 @@ apiVersions:
         enum: [HuaweiCloudClusterConfiguration]
       sshPublicKey:
         type: string
+        x-rules: [sshPublicKey]
         description: |
           A public key for accessing nodes.
       zones:

--- a/ee/modules/030-cloud-provider-openstack/candi/openapi/cluster_configuration.yaml
+++ b/ee/modules/030-cloud-provider-openstack/candi/openapi/cluster_configuration.yaml
@@ -74,6 +74,7 @@ apiVersions:
         enum: [OpenStackClusterConfiguration]
       sshPublicKey:
         type: string
+        x-rules: [sshPublicKey]
         description: |
           A public key for accessing nodes.
       sshAllowList:

--- a/ee/modules/030-cloud-provider-vcd/candi/openapi/cluster_configuration.yaml
+++ b/ee/modules/030-cloud-provider-vcd/candi/openapi/cluster_configuration.yaml
@@ -386,6 +386,7 @@ apiVersions:
                     type: string
         sshPublicKey:
           type: string
+          x-rules: [sshPublicKey]
           description: |
             A public key for accessing nodes.
         organization:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/candi/openapi/cluster_configuration.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/candi/openapi/cluster_configuration.yaml
@@ -306,6 +306,7 @@ apiVersions:
                 <<: *instanceClassProperties
       sshPublicKey:
         type: string
+        x-rules: [sshPublicKey]
         description: |
           A public key for accessing nodes.
       regionTagCategory:

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/candi/openapi/cluster_configuration.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/candi/openapi/cluster_configuration.yaml
@@ -55,6 +55,7 @@ apiVersions:
         enum: [ZvirtClusterConfiguration]
       sshPublicKey:
         type: string
+        x-rules: [sshPublicKey]
         description: a public key for accessing nodes.
       clusterID:
         type: string

--- a/modules/030-cloud-provider-aws/candi/openapi/cluster_configuration.yaml
+++ b/modules/030-cloud-provider-aws/candi/openapi/cluster_configuration.yaml
@@ -388,6 +388,7 @@ apiVersions:
           * **Caution!** If there is an Internet Gateway in the target VPC, the deployment of the basic infrastructure will fail with an error. Currently, an Internet Gateway cannot be adopted.
       sshPublicKey:
         type: string
+        x-rules: [sshPublicKey]
         description: |
           A public key for accessing nodes.
       disableDefaultSecurityGroup:

--- a/modules/030-cloud-provider-azure/candi/openapi/cluster_configuration.yaml
+++ b/modules/030-cloud-provider-azure/candi/openapi/cluster_configuration.yaml
@@ -70,6 +70,7 @@ apiVersions:
             type: integer
             x-doc-default: 0
       sshPublicKey:
+        x-rules: [sshPublicKey]
         description: |
           Public key to access nodes as `azureuser`.
         type: string

--- a/modules/030-cloud-provider-dvp/candi/openapi/cluster_configuration.yaml
+++ b/modules/030-cloud-provider-dvp/candi/openapi/cluster_configuration.yaml
@@ -110,6 +110,7 @@ apiVersions:
           enum: [DVPClusterConfiguration]
         sshPublicKey:
           type: string
+          x-rules: [sshPublicKey]
           description: |
             A public key for accessing nodes.
         masterNodeGroup:

--- a/modules/030-cloud-provider-gcp/candi/openapi/cluster_configuration.yaml
+++ b/modules/030-cloud-provider-gcp/candi/openapi/cluster_configuration.yaml
@@ -64,6 +64,7 @@ apiVersions:
         x-unsafe: true
       sshKey:
         type: string
+        x-rules: [sshPublicKey]
         description: A public key to access nodes as `user`.
       sshAllowList:
         type: array

--- a/modules/030-cloud-provider-yandex/candi/openapi/cluster_configuration.yaml
+++ b/modules/030-cloud-provider-yandex/candi/openapi/cluster_configuration.yaml
@@ -66,6 +66,7 @@ apiVersions:
         enum: [YandexClusterConfiguration]
       sshPublicKey:
         type: string
+        x-rules: [sshPublicKey]
         description: |
           A public key for accessing nodes.
       masterNodeGroup:


### PR DESCRIPTION
## Description

Add validation of SSH public key to dhctl before bootstrap. Add warning if it's SSH2 public key format instead of openssh.

## Why do we need it, and what problem does it solve?

If the user specifies an invalid public SSH key in any ClusterConfiguration manifest, the bootstrapping process will create the master node using Terraform, but will then fail due to invalid SSH credentials. Similar behavior will occur with a public key in SSH2 format. We should not start the bootstrap process, if public SSH key cannot be parsed.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Added SSH public key validation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
