### PR TITLE
[dhctl] dhctl check dep fix

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -652,7 +652,7 @@ func CheckDHCTLDependencies(ctx context.Context, nodeInterface node.Interface) e
 					}
 
 					log.InfoF("Checking '%s' dependency\n", dep)
-					if statusCode > 0 {
+					if statusCode == 1 {
 						log.Success(fmt.Sprintf("Dependency '%s' is available\n", dep))
 					} else {
 						log.WarnLn(fmt.Sprintf("Dependency '%s' is missing!\n", dep))
@@ -744,7 +744,6 @@ func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, conf
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -645,9 +645,14 @@ func CheckDHCTLDependencies(ctx context.Context, nodeInterface node.Interface) e
 						continue
 					}
 					status, dep := fields[0], fields[1]
+					statusCode, err := strconv.Atoi(status)
+					if err != nil {
+						// Skipping non-numeric output line, hack to bypass problems with the sshd banner
+						continue
+					}
 
 					log.InfoF("Checking '%s' dependency\n", dep)
-					if status == "1" {
+					if statusCode > 0 {
 						log.Success(fmt.Sprintf("Dependency '%s' is available\n", dep))
 					} else {
 						log.WarnLn(fmt.Sprintf("Dependency '%s' is missing!\n", dep))

--- a/dhctl/pkg/system/node/clissh/cmd/ssh.go
+++ b/dhctl/pkg/system/node/clissh/cmd/ssh.go
@@ -84,6 +84,7 @@ func (s *SSH) Cmd(ctx context.Context) *exec.Cmd {
 		"-o", "ServerAliveInterval=1",
 		"-o", "ServerAliveCountMax=3600",
 		"-o", "ConnectTimeout=15",
+		"-o", "LogLevel=ERROR",
 		"-o", "PasswordAuthentication=no",
 	}
 


### PR DESCRIPTION
## Description

Added validation of the command execution status code, status code must have a numeric value
follow https://github.com/deckhouse/deckhouse/pull/16120

## Why do we need it, and what problem does it solve?

Previously, without validation, issues could occur in cases where the user used an SSH banner.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Added validation of the command execution status code
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
