### PR TITLE
[dhctl] system requirements based on bundle

### DIFF
--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	DefaultBundle   = "Default"
+	MinimalBundle   = "Minimal"
 	DefaultLogLevel = "Info"
 )
 

--- a/dhctl/pkg/preflight/specs_cloud.go
+++ b/dhctl/pkg/preflight/specs_cloud.go
@@ -26,19 +26,12 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
-const (
-	minimumRequiredCPUCores       = 4
-	minimumRequiredMemoryMB       = 8192 - reservedMemoryThresholdMB
-	minimumRequiredRootDiskSizeGB = 50
-
-	reservedMemoryThresholdMB = 512
-)
-
 func (pc *Checker) CheckCloudMasterNodeSystemRequirements(_ context.Context) error {
 	if app.PreflightSkipSystemRequirementsCheck {
 		log.DebugLn("System requirements check is skipped")
 		return nil
 	}
+	requirements := pc.getSystemRequirements()
 
 	configObject := make(map[string]any)
 	configKind, err := unmarshalProviderClusterConfiguration(pc.installConfig.ProviderClusterConfig, configObject)
@@ -94,13 +87,13 @@ func (pc *Checker) CheckCloudMasterNodeSystemRequirements(_ context.Context) err
 		return fmt.Errorf("unknown provider cluster configuration kind: %s", configKind)
 	}
 
-	if err = validateIntegerPropertyAtPath(configObject, rootDiskPropertyPath, minimumRequiredRootDiskSizeGB, true); err != nil {
+	if err = validateIntegerPropertyAtPath(configObject, rootDiskPropertyPath, requirements.rootDiskSizeGB, true); err != nil {
 		return fmt.Errorf("Root disk capacity: %v", err)
 	}
-	if err = validateIntegerPropertyAtPath(configObject, ramAmountPropertyPath, minimumRequiredMemoryMB, false); err != nil {
+	if err = validateIntegerPropertyAtPath(configObject, ramAmountPropertyPath, requirements.memoryMB, false); err != nil {
 		return fmt.Errorf("RAM amount: %v", err)
 	}
-	if err = validateIntegerPropertyAtPath(configObject, coreCountPropertyPath, minimumRequiredCPUCores, false); err != nil {
+	if err = validateIntegerPropertyAtPath(configObject, coreCountPropertyPath, requirements.cpuCores, false); err != nil {
 		return fmt.Errorf("CPU cores count: %v", err)
 	}
 

--- a/dhctl/pkg/preflight/specs_cloud_test.go
+++ b/dhctl/pkg/preflight/specs_cloud_test.go
@@ -34,6 +34,9 @@ var invalidPCC []byte
 //go:embed testdata/specs_test_malformed_pcc.yml
 var malformedPCC []byte
 
+//go:embed testdata/specs_test_minimal_pcc.yml
+var minimalPCC []byte
+
 func TestCloudMasterNodeSystemRequirementsCheck(t *testing.T) {
 	type fields struct {
 		installConfig *config.DeckhouseInstaller
@@ -47,13 +50,63 @@ func TestCloudMasterNodeSystemRequirementsCheck(t *testing.T) {
 			name: "happy path",
 			fields: fields{installConfig: &config.DeckhouseInstaller{
 				ProviderClusterConfig: validPCC,
+				Bundle:                config.DefaultBundle,
 			}},
 			wantErr: assert.NoError,
+		},
+		{
+			name: "minimal bundle happy path",
+			fields: fields{installConfig: &config.DeckhouseInstaller{
+				ProviderClusterConfig: minimalPCC,
+				Bundle:                config.MinimalBundle,
+			}},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "minimal node sizing fails for default bundle",
+			fields: fields{installConfig: &config.DeckhouseInstaller{
+				ProviderClusterConfig: minimalPCC,
+				Bundle:                config.DefaultBundle,
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "expected at least")
+			},
+		},
+		{
+			name: "minimal bundle fails with less than 2 CPU",
+			fields: fields{installConfig: &config.DeckhouseInstaller{
+				ProviderClusterConfig: minimalZvirtPCC(1, 4096, 30),
+				Bundle:                config.MinimalBundle,
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "CPU cores count")
+			},
+		},
+		{
+			name: "minimal bundle fails with less than 4GiB RAM",
+			fields: fields{installConfig: &config.DeckhouseInstaller{
+				ProviderClusterConfig: minimalZvirtPCC(2, 3072, 30),
+				Bundle:                config.MinimalBundle,
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "RAM amount")
+			},
+		},
+		{
+			name: "minimal bundle fails with less than 30GiB root disk",
+			fields: fields{installConfig: &config.DeckhouseInstaller{
+				ProviderClusterConfig: minimalZvirtPCC(2, 4096, 20),
+				Bundle:                config.MinimalBundle,
+			}},
+			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.ErrorContains(t, err, "Root disk capacity")
+			},
 		},
 		{
 			name: "invalid ProviderClusterConfiguration",
 			fields: fields{installConfig: &config.DeckhouseInstaller{
 				ProviderClusterConfig: invalidPCC,
+				Bundle:                config.DefaultBundle,
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorContains(t, err, "expected at least")
@@ -63,6 +116,7 @@ func TestCloudMasterNodeSystemRequirementsCheck(t *testing.T) {
 			name: "malformed ProviderClusterConfiguration",
 			fields: fields{installConfig: &config.DeckhouseInstaller{
 				ProviderClusterConfig: malformedPCC,
+				Bundle:                config.DefaultBundle,
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.ErrorContains(t, err, "malformed provider cluster configuration")
@@ -76,8 +130,39 @@ func TestCloudMasterNodeSystemRequirementsCheck(t *testing.T) {
 			}
 			tt.wantErr(t,
 				pc.CheckCloudMasterNodeSystemRequirements(context.Background()),
-				fmt.Sprintf("CheckCloudMasterNodeSystemRequirements()"),
+				"CheckCloudMasterNodeSystemRequirements()",
 			)
 		})
 	}
+}
+
+func minimalZvirtPCC(cpuCores, memoryMB, rootDiskSizeGB int) []byte {
+	return []byte(fmt.Sprintf(`
+apiVersion: deckhouse.io/v1
+kind: ZvirtClusterConfiguration
+layout: Standard
+clusterID: b46372e7-0d52-40c7-9bbf-fda31e187088
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    numCPUs: %d
+    memory: %d
+    rootDiskSizeGb: %d
+    template: debian-bookworm
+    vnicProfileID: 49bb4594-0cd4-4eb7-8288-8594eafd5a86
+    storageDomainID: c4bf82a5-b803-40c3-9f6c-b9398378f424
+nodeGroups:
+  - name: worker
+    replicas: 1
+    instanceClass:
+      numCPUs: 2
+      memory: 4096
+      template: debian-bookworm
+      vnicProfileID: 49bb4594-0cd4-4eb7-8288-8594eafd5a86
+provider:
+  server: "<SERVER>"
+  username: "<USERNAME>"
+  password: "<PASSWORD>"
+  insecure: true
+`, cpuCores, memoryMB, rootDiskSizeGB))
 }

--- a/dhctl/pkg/preflight/specs_static_test.go
+++ b/dhctl/pkg/preflight/specs_static_test.go
@@ -15,10 +15,15 @@
 package preflight
 
 import (
+	"context"
 	_ "embed"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 )
 
 //go:embed testdata/specs_test_cpuinfo_6_cores_1_socket.txt
@@ -56,4 +61,99 @@ func TestCPUCoresCountDetection(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestCheckStaticNodeSystemRequirementsByBundle(t *testing.T) {
+	tests := []struct {
+		name          string
+		bundle        string
+		ramKB         int
+		cpuInfo       string
+		expectedError string
+	}{
+		{
+			name:    "minimal bundle accepts 2 CPU and 4GiB RAM",
+			bundle:  config.MinimalBundle,
+			ramKB:   4096 * 1024,
+			cpuInfo: testCPUInfoWithProcessors(2),
+		},
+		{
+			name:          "default bundle rejects 2 CPU and 4GiB RAM",
+			bundle:        config.DefaultBundle,
+			ramKB:         4096 * 1024,
+			cpuInfo:       testCPUInfoWithProcessors(2),
+			expectedError: "at least 4 CPU(s)",
+		},
+		{
+			name:          "minimal bundle rejects one CPU",
+			bundle:        config.MinimalBundle,
+			ramKB:         4096 * 1024,
+			cpuInfo:       testCPUInfoWithProcessors(1),
+			expectedError: "at least 2 CPU(s)",
+		},
+		{
+			name:          "minimal bundle rejects less than minimal RAM threshold",
+			bundle:        config.MinimalBundle,
+			ramKB:         3072 * 1024,
+			cpuInfo:       testCPUInfoWithProcessors(2),
+			expectedError: "at least 3584 MiB of RAM",
+		},
+		{
+			name:          "empty bundle uses default requirements",
+			bundle:        "",
+			ramKB:         4096 * 1024,
+			cpuInfo:       testCPUInfoWithProcessors(2),
+			expectedError: "at least 4 CPU(s)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeMock := &mockNodeInterface{}
+			memCmdMock := &mockCommand{}
+			cpuCmdMock := &mockCommand{}
+
+			nodeMock.
+				On("Command", "cat", []string{"/proc/meminfo"}).
+				Return(memCmdMock).
+				Once()
+			nodeMock.
+				On("Command", "cat", []string{"/proc/cpuinfo"}).
+				Return(cpuCmdMock).
+				Once()
+
+			memCmdMock.
+				On("Output", mock.Anything).
+				Return([]byte(fmt.Sprintf("MemTotal:       %d kB\n", tt.ramKB)), []byte{}, nil).
+				Once()
+			cpuCmdMock.
+				On("Output", mock.Anything).
+				Return([]byte(tt.cpuInfo), []byte{}, nil).
+				Once()
+
+			checker := &Checker{
+				nodeInterface: nodeMock,
+				installConfig: &config.DeckhouseInstaller{Bundle: tt.bundle},
+			}
+
+			err := checker.CheckStaticNodeSystemRequirements(context.Background())
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			nodeMock.AssertExpectations(t)
+			memCmdMock.AssertExpectations(t)
+			cpuCmdMock.AssertExpectations(t)
+		})
+	}
+}
+
+func testCPUInfoWithProcessors(count int) string {
+	output := ""
+	for i := 0; i < count; i++ {
+		output += fmt.Sprintf("processor\t: %d\nvendor_id\t: GenuineIntel\n\n", i)
+	}
+	return output
 }

--- a/dhctl/pkg/preflight/system_requirements.go
+++ b/dhctl/pkg/preflight/system_requirements.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import "github.com/deckhouse/deckhouse/dhctl/pkg/config"
+
+const (
+	// System requirements for Deckhouse Default bundle
+	defaultRequiredCPUCores       = 4
+	defaultRequiredMemoryMB       = 8192 - reservedMemoryThresholdMB
+	defaultRequiredRootDiskSizeGB = 50
+
+	// System requirements for Deckhouse Minimal bundle
+	minimalRequiredCPUCores       = 2
+	minimalRequiredMemoryMB       = 4096 - reservedMemoryThresholdMB
+	minimalRequiredRootDiskSizeGB = 30
+
+	reservedMemoryThresholdMB = 512
+)
+
+type systemRequirements struct {
+	cpuCores       int
+	memoryMB       int
+	rootDiskSizeGB int
+}
+
+func (pc *Checker) getSystemRequirements() systemRequirements {
+	switch pc.installConfig.Bundle {
+	case config.MinimalBundle:
+		return systemRequirements{
+			cpuCores:       minimalRequiredCPUCores,
+			memoryMB:       minimalRequiredMemoryMB,
+			rootDiskSizeGB: minimalRequiredRootDiskSizeGB,
+		}
+	default:
+		return systemRequirements{
+			cpuCores:       defaultRequiredCPUCores,
+			memoryMB:       defaultRequiredMemoryMB,
+			rootDiskSizeGB: defaultRequiredRootDiskSizeGB,
+		}
+	}
+}

--- a/dhctl/pkg/preflight/system_requirements_test.go
+++ b/dhctl/pkg/preflight/system_requirements_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package preflight
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+)
+
+func TestChecker_getSystemRequirements(t *testing.T) {
+	tests := []struct {
+		name     string
+		checker  *Checker
+		expected systemRequirements
+	}{
+		{
+			name:    "default bundle requirements",
+			checker: &Checker{installConfig: &config.DeckhouseInstaller{Bundle: config.DefaultBundle}},
+			expected: systemRequirements{
+				cpuCores:       defaultRequiredCPUCores,
+				memoryMB:       defaultRequiredMemoryMB,
+				rootDiskSizeGB: defaultRequiredRootDiskSizeGB,
+			},
+		},
+		{
+			name:    "minimal bundle requirements",
+			checker: &Checker{installConfig: &config.DeckhouseInstaller{Bundle: config.MinimalBundle}},
+			expected: systemRequirements{
+				cpuCores:       minimalRequiredCPUCores,
+				memoryMB:       minimalRequiredMemoryMB,
+				rootDiskSizeGB: minimalRequiredRootDiskSizeGB,
+			},
+		},
+		{
+			name:    "empty bundle falls back to default requirements",
+			checker: &Checker{installConfig: &config.DeckhouseInstaller{}},
+			expected: systemRequirements{
+				cpuCores:       defaultRequiredCPUCores,
+				memoryMB:       defaultRequiredMemoryMB,
+				rootDiskSizeGB: defaultRequiredRootDiskSizeGB,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.checker.getSystemRequirements())
+		})
+	}
+}

--- a/dhctl/pkg/preflight/testdata/specs_test_minimal_pcc.yml
+++ b/dhctl/pkg/preflight/testdata/specs_test_minimal_pcc.yml
@@ -1,0 +1,26 @@
+apiVersion: deckhouse.io/v1
+kind: ZvirtClusterConfiguration
+layout: Standard
+clusterID: b46372e7-0d52-40c7-9bbf-fda31e187088
+masterNodeGroup:
+  replicas: 1
+  instanceClass:
+    numCPUs: 2
+    memory: 4096
+    rootDiskSizeGb: 30
+    template: debian-bookworm
+    vnicProfileID: 49bb4594-0cd4-4eb7-8288-8594eafd5a86
+    storageDomainID: c4bf82a5-b803-40c3-9f6c-b9398378f424
+nodeGroups:
+  - name: worker
+    replicas: 1
+    instanceClass:
+      numCPUs: 2
+      memory: 4096
+      template: debian-bookworm
+      vnicProfileID: 49bb4594-0cd4-4eb7-8288-8594eafd5a86
+provider:
+  server: "<SERVER>"
+  username: "<USERNAME>"
+  password: "<PASSWORD>"
+  insecure: true


### PR DESCRIPTION
## Description
system requirements based on bundle

## Why do we need it, and what problem does it solve?
system requirements based on bundle

## Why do we need it in the patch release (if we do)?
no need

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: make system requirements based on bundle
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
