### PR TITLE
[bashible] Handle bashible bootstrap initialization if node has bashible-uninitialized taint in race condition.

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -405,14 +405,12 @@ function main() {
      bb-label-node-bashible-first-run-finished
      touch $BASHIBLE_INITIALIZED_FILE
   fi
-  if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]] && [[ -f "$BASHIBLE_INITIALIZED_FILE" ]]; then
-    UNINITIALIZED_TAINT="$(bb-kubectl-exec get no "$D8_NODE_HOSTNAME" -o json | jq -r '.spec.taints[]? | select(.key=="node.deckhouse.io/bashible-uninitialized") | .key' 2>/dev/null)"
-    if [[ "$UNINITIALIZED_TAINT" == "node.deckhouse.io/bashible-uninitialized" ]]; then
-      echo "Node is initialized but bashible-uninitialized taint is still present, re-labeling..."
-      bb-label-node-bashible-first-run-finished
-    fi
+  if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]] && [[ -f "$BASHIBLE_INITIALIZED_FILE" ]] && type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf; then
+     if bb-kubectl-exec get no "$D8_NODE_HOSTNAME" -o json | jq -e '.spec.taints[]? | select(.key == "node.deckhouse.io/bashible-uninitialized")' >/dev/null 2>&1; then
+        echo "WARNING: Node is initialized but bashible-uninitialized taint is still present. Re-applying first-run-finished label..."
+        bb-label-node-bashible-first-run-finished
+     fi
   fi
-
   if [[ -f $CONFIGURATION_CHECKSUM_FILE ]] && [[ "$(<$CONFIGURATION_CHECKSUM_FILE)" == "$CONFIGURATION_CHECKSUM" ]] && [[ "$REBOOT_ANNOTATION" == "null" ]] && [[ -f $UPTIME_FILE ]] && [[ "$(<$UPTIME_FILE)" < "$(current_uptime)" ]] 2>/dev/null; then
     echo "Configuration is in sync, nothing to do."
     annotate_node node.deckhouse.io/configuration-checksum=${CONFIGURATION_CHECKSUM}

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -92,10 +92,32 @@ bb-label-node-bashible-first-run-finished() {
   exit 1
 }
 
+bb-node-has-bashible-uninitialized-taint() {
+  local max_attempts=5
+  local attempt=1
+
+  while [[ $attempt -le $max_attempts ]]; do
+    if node_json="$(bb-kubectl-exec get no "$(bb-d8-node-name)" -o json 2>/dev/null)"; then
+      if echo "$node_json" | jq -e '.spec.taints[]? | select(.key == "node.deckhouse.io/bashible-uninitialized")' >/dev/null 2>&1; then
+        return 0
+      else
+        return 1
+      fi
+    fi
+    echo "[$attempt/$max_attempts] Failed to get node $(bb-d8-node-name), retrying in 5 seconds..."
+    attempt=$((attempt + 1))
+    sleep 5
+  done
+
+  echo "ERROR: Timed out after $max_attempts attempts. Could not check taint node.deckhouse.io/bashible-uninitialized on node $(bb-d8-node-name)." >&2
+  return 1
+}
+
 # make the function available in $step
 export -f bb-kubectl-exec
 export -f bb-kube-apiserver-healthy
 export -f bb-label-node-bashible-first-run-finished
+export -f bb-node-has-bashible-uninitialized-taint
 
 bb-indent-text() {
     local indent="$1"
@@ -406,10 +428,10 @@ function main() {
      touch $BASHIBLE_INITIALIZED_FILE
   fi
   if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]] && [[ -f "$BASHIBLE_INITIALIZED_FILE" ]] && type kubectl >/dev/null 2>&1 && test -f /etc/kubernetes/kubelet.conf; then
-     if bb-kubectl-exec get no "$D8_NODE_HOSTNAME" -o json | jq -e '.spec.taints[]? | select(.key == "node.deckhouse.io/bashible-uninitialized")' >/dev/null 2>&1; then
-        echo "WARNING: Node is initialized but bashible-uninitialized taint is still present. Re-applying first-run-finished label..."
-        bb-label-node-bashible-first-run-finished
-     fi
+    if bb-node-has-bashible-uninitialized-taint; then
+      echo "WARNING: Node is initialized but bashible-uninitialized taint is still present. Re-applying first-run-finished label..."
+      bb-label-node-bashible-first-run-finished
+    fi
   fi
   if [[ -f $CONFIGURATION_CHECKSUM_FILE ]] && [[ "$(<$CONFIGURATION_CHECKSUM_FILE)" == "$CONFIGURATION_CHECKSUM" ]] && [[ "$REBOOT_ANNOTATION" == "null" ]] && [[ -f $UPTIME_FILE ]] && [[ "$(<$UPTIME_FILE)" < "$(current_uptime)" ]] 2>/dev/null; then
     echo "Configuration is in sync, nothing to do."


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
A race condition can occur when kubelet re-registers a node with bashible-uninitialized taint after bashible has already completed its first run and set the bashible-first-run-finished label. The taint persists indefinitely because bashible skips re-applying the label on subsequent runs, blocking all user workloads from scheduling.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
On each bashible run, if the node is already initialized (bashible-fully-initialized file exists) but the bashible-uninitialized taint is still present, re-apply the bashible-first-run-finished label to trigger taint removal.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix 
summary: fix if node has bashible-uninitialized taint in race condition.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
