### PR TITLE
[docs] Network ports for hostNetwork virtualization components actualization

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -372,6 +372,11 @@ groups:
     description:
       en: "`sds-replicated-volume` CSI controller metrics"
       ru: "Метрики CSI-контроллера модуля `sds-replicated-volume`"
+  - ports: "4280"
+    protocol: TCP
+    description:
+      en: "`virtualization` USB over IP (usb/ip) protocol for sharing USB devices between cluster nodes"
+      ru: "Протокол USB over IP (usb/ip) модуля `virtualization` для проброса USB-устройств между узлами кластера"
   - ports: "4286"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description
Network ports for hostNetwork virtualization components actualization

## Why do we need it, and what problem does it solve?
We need the actual used port list in the documentation.


## Why do we need it in the patch release (if we do)?
Our clients must get actual information for their security teams

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Network ports for hostNetwork virtualization components actualization
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
