### PR TITLE
[global-hooks] add HA preservation mechanism

### DIFF
--- a/dhctl/pkg/operations/converge/context/converge_state.go
+++ b/dhctl/pkg/operations/converge/context/converge_state.go
@@ -36,8 +36,9 @@ const (
 )
 
 type State struct {
-	Phase               phases.OperationPhase   `json:"phase"`
-	NodeUserCredentials *v1.NodeUserCredentials `json:"nodeUserCredentials"`
+	Phase                  phases.OperationPhase   `json:"phase"`
+	NodeUserCredentials    *v1.NodeUserCredentials `json:"nodeUserCredentials"`
+	PreserveExistingHAMode bool                    `json:"preserveExistingHAMode"`
 }
 
 type stateStore interface {

--- a/dhctl/pkg/operations/converge/controller/master_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/master_node_group.go
@@ -140,6 +140,14 @@ func (c *MasterNodeGroupController) run(ctx *context.Context) error {
 
 		replicas := 3
 
+		if !c.convergeState.PreserveExistingHAMode {
+			c.convergeState.PreserveExistingHAMode = true
+			err := ctx.SetConvergeState(c.convergeState)
+			if err != nil {
+				return fmt.Errorf("failed to set converge state: %w", err)
+			}
+		}
+
 		err = c.runWithReplicas(ctx, replicas)
 		if err != nil {
 			return fmt.Errorf("failed to converge with 3 replicas: %w", err)
@@ -170,6 +178,7 @@ func (c *MasterNodeGroupController) run(ctx *context.Context) error {
 		}
 
 		c.convergeState.Phase = ""
+		c.convergeState.PreserveExistingHAMode = false
 
 		dhlog.FromContext(ctx.Ctx()).DebugContext(ctx.Ctx(), "scaled to single-master, saving state...")
 
@@ -410,6 +419,7 @@ func (c *MasterNodeGroupController) updateNode(ctx *context.Context, nodeName st
 			dhlog.FromContext(ctx.Ctx()).DebugContext(ctx.Ctx(), "Destructive change single master. Scale to multimaster and converge")
 
 			c.convergeState.Phase = phases.ScaleToMultiMasterPhase
+			c.convergeState.PreserveExistingHAMode = true
 
 			err := ctx.SetConvergeState(c.convergeState)
 			if err != nil {

--- a/modules/039-registry-packages-proxy/template_tests/module_test.go
+++ b/modules/039-registry-packages-proxy/template_tests/module_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}
+
+const globalValues = `
+enabledModules: ["vertical-pod-autoscaler"]
+modules:
+  placement: {}
+discovery:
+  kubernetesVersion: 1.31.8
+  d8SpecificNodeCountByRole:
+    master: 3
+`
+
+var _ = Describe("Module :: registry-packages-proxy :: helm template ::", func() {
+	f := SetupHelmConfig(``)
+
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", globalValues)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+	})
+
+	Context("HA disabled", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.highAvailability", false)
+			f.HelmRender()
+		})
+
+		It("PDB does not exist", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			pdb := f.KubernetesResource("PodDisruptionBudget", "d8-cloud-instance-manager", "registry-packages-proxy")
+			Expect(pdb.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("HA enabled", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.highAvailability", true)
+			f.HelmRender()
+		})
+
+		It("PDB exists", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			pdb := f.KubernetesResource("PodDisruptionBudget", "d8-cloud-instance-manager", "registry-packages-proxy")
+			Expect(pdb.Exists()).To(BeTrue())
+		})
+	})
+})

--- a/modules/039-registry-packages-proxy/templates/deployment.yaml
+++ b/modules/039-registry-packages-proxy/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         memory: 30Mi
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
 {{- end }}
+{{- if (include "helm_lib_ha_enabled" .) }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -42,6 +43,7 @@ spec:
   selector:
     matchLabels:
       app: "registry-packages-proxy"
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -747,6 +747,41 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 		f.ValuesSet("global.modulesImages", GetModulesImages())
 	})
 
+	Context("Bashible apiserver PDB", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("nodeManager", nodeManagerConfigValues+nodeManagerValues)
+			setBashibleAPIServerTLSValues(f)
+		})
+
+		Context("HA disabled", func() {
+			BeforeEach(func() {
+				f.ValuesSet("global.highAvailability", false)
+				f.HelmRender()
+			})
+
+			It("PDB does not exist", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				pdb := f.KubernetesResource("PodDisruptionBudget", "d8-cloud-instance-manager", "bashible-apiserver")
+				Expect(pdb.Exists()).To(BeFalse())
+			})
+		})
+
+		Context("HA enabled", func() {
+			BeforeEach(func() {
+				f.ValuesSet("global.highAvailability", true)
+				f.HelmRender()
+			})
+
+			It("PDB exists", func() {
+				Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+				pdb := f.KubernetesResource("PodDisruptionBudget", "d8-cloud-instance-manager", "bashible-apiserver")
+				Expect(pdb.Exists()).To(BeTrue())
+			})
+		})
+	})
+
 	Context("Prometheus rules", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("nodeManager", nodeManagerConfigValues+nodeManagerValues)

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         cpu: 50m
         memory: 200Mi
 {{- end }}
+{{- if (include "helm_lib_ha_enabled" .) }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -39,6 +40,7 @@ spec:
   selector:
     matchLabels:
       app: "bashible-apiserver"
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Description
add HA preservation mechanism
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
add HA preservation mechanism
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?
no
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: prevent HA mode when destructively converging single-master cluster
impact_level: default
```
```changes
section: global-hooks
type: fix
summary: prevent HA mode when destructively converging single-master cluster
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
