### PR TITLE
[docs] Clarify how node selection logic works for module placement when `nodeSelector` and `tolerations` are not explicitly set.

### DIFF
--- a/docs/documentation/pages/admin/configuration/OVERVIEW.md
+++ b/docs/documentation/pages/admin/configuration/OVERVIEW.md
@@ -373,7 +373,7 @@ You cannot set `nodeSelector` and `tolerations` for modules:
 ### Module features that depend on its type
 
 {% alert level="info" %}
-Below is the basic (general) logic for automatically selecting nodes to place module components when no explicit `nodeSelector` and `tolerations` values are set in the module settings. Some modules may extend or override this logic (for example, by using Kubernetes mechanisms such as [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), or their own node selection rules). See the module documentation for details.
+Below is the basic (general) logic for automatically selecting nodes to place module components when no explicit `nodeSelector` and `tolerations` values are set in the module settings. Some modules may extend or override this logic (for example, by using Kubernetes mechanisms such as [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), or their own node selection rules). See the relevant module documentation for details.
 {% endalert %}
 
 {% raw %}

--- a/docs/documentation/pages/admin/configuration/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/OVERVIEW_RU.md
@@ -370,7 +370,7 @@ Deckhouse Kubernetes Platform с набором модулей `Minimal` без 
 ### Особенности автоматики, зависящие от типа модуля
 
 {% alert level="info" %}
-Ниже описана базовая (общая) логика автоматического выбора узлов для размещения компонентов модулей, когда в настройках модуля не заданы явные значения `nodeSelector` и `tolerations`. Отдельные модули могут дополнять или изменять эту логику (например, использовать механизмы Kubernetes, такие как [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), или собственные правила выбора узлов). Подробности см. в документации модуля.
+Ниже описана базовая (общая) логика автоматического выбора узлов для размещения компонентов модулей, когда в настройках модуля не заданы явные значения `nodeSelector` и `tolerations`. Некоторые модули могут дополнять или изменять эту логику (например, использовать механизмы Kubernetes, такие как [affinity/anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#topologyspreadconstraints-field), или собственные правила выбора узлов). Подробности см. в документации соответствующего модуля.
 {% endalert %}
 
 {% raw %}


### PR DESCRIPTION
## Description
This pull request updates the documentation to clarify how node selection logic works for module placement when `nodeSelector` and `tolerations` are not explicitly set.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Update the documentation to clarify how node selection logic works for module placement when `nodeSelector` and `tolerations` are not explicitly set.
impact_level: low
```
