### PR TITLE
[docs] Moving the platform update section to the top in the sidebar

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -390,26 +390,6 @@ entries:
                     ru: Гибридный кластер
                   url: /admin/integrations/hybrid/overview.html
             - title:
-                en: Platform update
-                ru: Обновление платформы
-              folders:
-                - title:
-                    en: Overview
-                    ru: Обзор
-                  url: /admin/configuration/update/
-                - title:
-                    en: Configuring updates
-                    ru: Настройка обновлений
-                  url: /admin/configuration/update/configuration.html
-                - title:
-                    en: Configuring notifications
-                    ru: Настройка уведомлений
-                  url: /admin/configuration/update/notifications.html
-                - title:
-                    en: FAQ
-                    ru: FAQ
-                  url: /admin/configuration/update/faq.html
-            - title:
                 en: High reliability and availability
                 ru: Высокая надежность и доступность
               folders:
@@ -453,10 +433,6 @@ entries:
                         en: Scaling and changing master nodes
                         ru: Масштабирование и изменение master-узлов
                       url: /admin/configuration/platform-scaling/control-plane/scaling-and-changing-master-nodes.html
-                    - title:
-                        en: Updating Kubernetes and versioning
-                        ru: Обновление Kubernetes и управление версиями
-                      url: /admin/configuration/platform-scaling/control-plane/updating-and-versioning.html
                 - title:
                     en: Node management
                     ru: Управление узлами
@@ -877,6 +853,30 @@ entries:
                 en: Assigning namespace labels
                 ru: Назначение лейблов пространствам имён
               url: /admin/configuration/label-assignment.html
+        - title:
+            en: Platform update
+            ru: Обновление платформы
+          folders:
+            - title:
+                en: Overview
+                ru: Обзор
+              url: /admin/configuration/update/
+            - title:
+                en: Configuring updates
+                ru: Настройка обновлений
+              url: /admin/configuration/update/configuration.html
+            - title:
+                en: Configuring notifications
+                ru: Настройка уведомлений
+              url: /admin/configuration/update/notifications.html
+            - title:
+                en: Updating Kubernetes and versioning
+                ru: Обновление Kubernetes и управление версиями
+              url: /admin/configuration/platform-scaling/control-plane/updating-and-versioning.html
+            - title:
+                en: FAQ
+                ru: FAQ
+              url: /admin/configuration/update/faq.html
         - title:
             en: Platform uninstalling
             ru: Удаление платформы


### PR DESCRIPTION
## Description

Moving the platform update to a separate section.

This pull request reorganizes the sidebar navigation in `main.yml` to improve the structure and accessibility of documentation related to platform updates and Kubernetes versioning. The main changes involve moving and consolidating the "Platform update" section and its related topics to a more appropriate location in the sidebar.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix 
summary: Moving the platform update section to the top in the sidebar.
impact_level: low
```