### PR TITLE
[control-plane-manager] fix linting issues for kubernetes-api-proxy/reloader

### DIFF
--- a/modules/040-control-plane-manager/images/kubernetes-api-proxy/reloader/src/watcher.go
+++ b/modules/040-control-plane-manager/images/kubernetes-api-proxy/reloader/src/watcher.go
@@ -46,6 +46,9 @@ func nginxReload() error {
 
 	// Check if nginx.conf has changed and test the new configuration
 	equal, err := fileContentsEqual(nginxConf, nginxNewConf)
+	if err != nil {
+		log.Printf("failed to calculate file contents equality, continue reloading nginx...")
+	}
 	if equal {
 		log.Printf("%s and %s are equal, skipping reload...", nginxConf, nginxNewConf)
 		return nil
@@ -121,12 +124,13 @@ func WatchNginxConf() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer watcher.Close()
 
 	err = watcher.Add(filepath.Dir(nginxNewConf))
 	if err != nil {
+		watcher.Close()
 		log.Fatal(err)
 	}
+	defer watcher.Close()
 
 	for {
 		select {


### PR DESCRIPTION
## Description
Fix several linting issues in kubernetes-api-proxy-reloader

## Why do we need it, and what problem does it solve?

<details> 
<summary>Linting requirements. </summary>

```
- `modules/040-control-plane-manager/images/kubernetes-api-proxy/reloader`
  - `src/watcher.go:128` — `exitAfterDefer`: `log.Fatal` will exit, `defer watcher.Close()` will not run *(gocritic)*
  - `src/watcher.go:48` — ineffectual assignment to `err` *(ineffassign)*
```
</details>

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: control-plane-manager kubernetes-api-proxy/reloader linter issues fixes.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
