### PR TITLE
[control-plane-manager] Fix anonymous-auth update migration

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/controller/converge.go
@@ -116,7 +116,7 @@ func convergeComponents() error {
 		components = []string{"etcd"}
 		log.Info("ETCD_ARBITER mode: skipping control-plane components")
 	} else {
-		components = []string{"etcd", "kube-apiserver", "kube-controller-manager", "kube-scheduler"}
+		components = []string{"kube-apiserver", "etcd", "kube-controller-manager", "kube-scheduler"}
 	}
 
 	for _, v := range components {


### PR DESCRIPTION
## Description
Attempt to fix apiserver misconfiguration during upgrade by changing the order of `convergeComponents`

## Why do we need it, and what problem does it solve?
During upgrade, there is a potential misconfigured state for kube-apiserver which leads to it crashing if restarted.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix order of converge components in control-plane-manager.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
