### PR TITLE
[common] Fixed golangci-lint issue in check-kernel-version image

### DIFF
--- a/modules/000-common/images/check-kernel-version/src/check-kernel-version.go
+++ b/modules/000-common/images/check-kernel-version/src/check-kernel-version.go
@@ -36,7 +36,9 @@ func main() {
 	}
 
 	utsname := unix.Utsname{}
-	unix.Uname(&utsname)
+	if err := unix.Uname(&utsname); err != nil {
+		log.Fatalf("failed to get kernel version: %v", err)
+	}
 	kernelVersion := string(utsname.Release[:])
 	/* Kernel version should be splitted to parts because versions `5.15.0-52-generic`
 	parses by semver as prerelease version. Prerelease versions by default come before stable versions

--- a/modules/000-common/images/check-kernel-version/src/go.mod
+++ b/modules/000-common/images/check-kernel-version/src/go.mod
@@ -1,6 +1,6 @@
 module check-kernel-version
 
-go 1.18
+go 1.25
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1


### PR DESCRIPTION
## Description
Fixed golangci-lint issues in ./modules/000-common/images/check-kernel-version/src/check-kernel-version.go

## Why do we need it, and what problem does it solve?
We need it to meet the requirements of "zero issues" golangci-lint.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: chore
summary: fixed golangci-lint issues in ./modules/000-common/images/check-kernel-version/src/check-kernel-version.go
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
