### PR TITLE
[istio] Replace proxy and ztunnel images containers with distroless

### DIFF
--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -40,12 +40,16 @@ import:
   group: 1337
   after: setup
 - image: libs/glibc-v2.41
-  add: /lib64
-  to: /lib64
-  includePaths:
-  - libc.so.6
-  - libm.so.6
-  - ld-linux-x86-64.so.2
+  add: /lib64/libc.so.6
+  to: /lib64/libc.so.6
+  before: install
+- image: libs/glibc-v2.41
+  add: /lib64/libm.so.6
+  to: /lib64/libm.so.6
+  before: install
+- image: libs/glibc-v2.41
+  add: /lib64/ld-linux-x86-64.so.2
+  to: /lib64/ld-linux-x86-64.so.2
   before: install
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate

--- a/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -6,16 +6,24 @@ import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/ztunnel/bin/ztunnel
     to: /usr/local/bin/ztunnel
+    owner: 1337
+    group: 1337
     before: install
   - image: libs/glibc-v2.41
-    add: /lib64/libc.musl-x86_64.so.1
-    to: /lib64/libc.musl-x86_64.so.1
+    add: /lib64/libc.so.6
+    to: /lib64/libc.so.6
+    before: install
+  - image: libs/glibc-v2.41
+    add: /lib64/libm.so.6
+    to: /lib64/libm.so.6
+    before: install
+  - image: libs/glibc-v2.41
+    add: /lib64/ld-linux-x86-64.so.2
+    to: /lib64/ld-linux-x86-64.so.2
     before: install
   - image: libs/xz-v5.8.1
-    add: /usr/lib
-    to: /lib64
-    includePaths:
-    - libc.so
+    add: /usr/lib/libc.so
+    to: /lib64/libc.so
     before: install
   - image: tools/gcc-gnu-releases/gcc-14.2.0
     add: /usr/lib/libgcc_s.so.1


### PR DESCRIPTION
## Description
Replaced containers base images `ztunnel-v1x25x2` and `proxyv2-v1x25x2` with distroless images, containing only  binaries and runtime dependencies, without shell.

## Why do we need it, and what problem does it solve?
Distroless eliminates unnecessary OS components, drastically reducing attack surface and image size. No shell means no shell-based exploits. Smaller images mean faster deployments and lower storage costs.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: replaced proxyv2-v1x25x2 and ztunnel-v1x25x2 images with distroless
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
