### PR TITLE
[user-authn] Restore ContinueOnConnectorFailure flag handling in Dex configuration

### DIFF
--- a/modules/150-user-authn/images/dex/patches/004-2fa.patch
+++ b/modules/150-user-authn/images/dex/patches/004-2fa.patch
@@ -51,49 +51,18 @@ index 68abe1f7..004330ce 100644
  			Level:  slog.LevelDebug,
  			Format: "json",
 diff --git a/cmd/dex/serve.go b/cmd/dex/serve.go
-index ac715e60..a29ca72e 100644
+index ac715e60..27dbdeb8 100644
 --- a/cmd/dex/serve.go
 +++ b/cmd/dex/serve.go
-@@ -291,22 +291,23 @@ func runServe(options serveOptions) error {
- 	healthChecker := gosundheit.New()
- 
- 	serverConfig := server.Config{
--		AllowedGrantTypes:          c.OAuth2.GrantTypes,
--		SupportedResponseTypes:     c.OAuth2.ResponseTypes,
--		SkipApprovalScreen:         c.OAuth2.SkipApprovalScreen,
--		AlwaysShowLoginScreen:      c.OAuth2.AlwaysShowLoginScreen,
--		PasswordConnector:          c.OAuth2.PasswordConnector,
--		Headers:                    c.Web.Headers.ToHTTPHeader(),
--		AllowedOrigins:             c.Web.AllowedOrigins,
--		AllowedHeaders:             c.Web.AllowedHeaders,
--		Issuer:                     c.Issuer,
--		Storage:                    s,
--		Web:                        c.Frontend,
--		Logger:                     logger,
--		Now:                        now,
--		PrometheusRegistry:         prometheusRegistry,
--		HealthChecker:              healthChecker,
--		ContinueOnConnectorFailure: featureflags.ContinueOnConnectorFailure.Enabled(),
-+		AllowedGrantTypes:      c.OAuth2.GrantTypes,
-+		SupportedResponseTypes: c.OAuth2.ResponseTypes,
-+		SkipApprovalScreen:     c.OAuth2.SkipApprovalScreen,
-+		AlwaysShowLoginScreen:  c.OAuth2.AlwaysShowLoginScreen,
-+		PasswordConnector:      c.OAuth2.PasswordConnector,
-+		Headers:                c.Web.Headers.ToHTTPHeader(),
-+		AllowedOrigins:         c.Web.AllowedOrigins,
-+		AllowedHeaders:         c.Web.AllowedHeaders,
-+		Issuer:                 c.Issuer,
-+		Storage:                s,
-+		Web:                    c.Frontend,
-+		Logger:                 logger,
-+		Now:                    now,
-+		PrometheusRegistry:     prometheusRegistry,
-+		HealthChecker:          healthChecker,
-+		TOTPIssuer:             c.TOTP.Issuer,
-+		TOTPConnectors:         c.TOTP.Connectors,
+@@ -306,6 +306,8 @@ func runServe(options serveOptions) error {
+ 		Now:                        now,
+ 		PrometheusRegistry:         prometheusRegistry,
+ 		HealthChecker:              healthChecker,
++		TOTPIssuer:                 c.TOTP.Issuer,
++		TOTPConnectors:             c.TOTP.Connectors,
+ 		ContinueOnConnectorFailure: featureflags.ContinueOnConnectorFailure.Enabled(),
  	}
  	if c.Expiry.SigningKeys != "" {
- 		signingKeys, err := time.ParseDuration(c.Expiry.SigningKeys)
 diff --git a/go.mod b/go.mod
 index cf2d5d4d..b62cba5d 100644
 --- a/go.mod


### PR DESCRIPTION
## Description

Restores the `ContinueOnConnectorFailure` flag in the Dex server configuration.
The flag is passed back to `server.Config` to ensure correct handling of connector failures during authentication flow.
The change affects only the Dex container in the `user-authn` module.

## Why do we need it, and what problem does it solve?

Previously, the `ContinueOnConnectorFailure` option was unintentionally removed from the server configuration.
As a result, Dex no longer respected the feature flag controlling whether authentication should continue when a connector fails.

This fix restores the expected behavior and prevents authentication flow regressions in environments relying on this feature.

## Why do we need it in the patch release (if we do)?


## Checklist

* [ ] The code is covered by unit tests.
* [ ] e2e tests passed.
* [ ] Documentation updated according to the changes.
* [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Restore ContinueOnConnectorFailure flag handling in Dex configuration
impact_level: default
```
