### PR TITLE
[cloud-provider-openstack] add LB.enabled flag for Octavia compatibility

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/openapi/config-values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/config-values.yaml
@@ -115,11 +115,11 @@ properties:
     description: |
       Load Balancer parameters.
     properties:
-      enabled:
+      disabled:
         type: boolean
         description: |
-          Whether to enable LoadBalancer support. Set to `false` if the OpenStack cloud doesn't have Octavia (LBaaS) service available.
-        default: true
+          Set to `true` to disable LoadBalancer support if the OpenStack cloud doesn't have Octavia (LBaaS) service available.
+        default: false
       subnetID:
         type: string
         description: |

--- a/ee/modules/030-cloud-provider-openstack/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/doc-ru-config-values.yaml
@@ -77,9 +77,9 @@ properties:
     description: |
       Параметры Load Balancer'а.
     properties:
-      enabled:
+      disabled:
         description: |
-          Включить поддержку LoadBalancer. Установите в `false`, если в облаке OpenStack отсутствует сервис Octavia (LBaaS).
+          Отключить поддержку LoadBalancer. Установите в `true`, если в облаке OpenStack отсутствует сервис Octavia (LBaaS).
       subnetID:
         description: |
           ID подсети Neutron, в которой необходимо создать load balancer virtual IP.

--- a/ee/modules/030-cloud-provider-openstack/openapi/openapi-case-tests.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/openapi-case-tests.yaml
@@ -63,7 +63,7 @@ positive:
           tenantName: mytenantname
           region: myreg
         loadBalancer:
-          enabled: false
+          disabled: true
         podNetworkMode: VXLAN
         instances:
           sshKeyPairName: mysshkeypairname

--- a/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-openstack/openapi/values.yaml
@@ -84,7 +84,7 @@ properties:
         type: object
         default: {}
         properties:
-          enabled:
+          disabled:
             type: boolean
           subnetID:
             type: string

--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -456,13 +456,13 @@ storageclass.kubernetes.io/is-default-class: "true"
 		})
 	})
 
-	Context("LoadBalancer enabled flag", func() {
+	Context("LoadBalancer disabled flag", func() {
 		Context("LoadBalancer disabled for k8s 1.32", func() {
 			BeforeEach(func() {
 				f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
 				f.ValuesSet("global.modulesImages", GetModulesImages())
 				f.ValuesSetFromYaml("cloudProviderOpenstack", moduleValues)
-				f.ValuesSetFromYaml("cloudProviderOpenstack.internal.loadBalancer.enabled", "false")
+				f.ValuesSetFromYaml("cloudProviderOpenstack.internal.loadBalancer.disabled", "true")
 				f.HelmRender()
 			})
 
@@ -476,12 +476,12 @@ storageclass.kubernetes.io/is-default-class: "true"
 			})
 		})
 
-		Context("LoadBalancer enabled explicitly", func() {
+		Context("LoadBalancer enabled by default", func() {
 			BeforeEach(func() {
 				f.ValuesSetFromYaml("global", fmt.Sprintf(globalValues, "1.32", "1.32"))
 				f.ValuesSet("global.modulesImages", GetModulesImages())
 				f.ValuesSetFromYaml("cloudProviderOpenstack", moduleValues)
-				f.ValuesSetFromYaml("cloudProviderOpenstack.internal.loadBalancer.enabled", "true")
+				f.ValuesSetFromYaml("cloudProviderOpenstack.internal.loadBalancer.disabled", "false")
 				f.HelmRender()
 			})
 

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
@@ -28,13 +28,13 @@ internal-network-name = {{ . | quote }}
   {{- end }}
 ipv6-support-disabled = true
 [LoadBalancer]
-{{- $lbEnabled := true }}
+{{- $lbDisabled := false }}
 {{- if hasKey $internal "loadBalancer" }}
-  {{- if hasKey $internal.loadBalancer "enabled" }}
-    {{- $lbEnabled = $internal.loadBalancer.enabled }}
+  {{- if hasKey $internal.loadBalancer "disabled" }}
+    {{- $lbDisabled = $internal.loadBalancer.disabled }}
   {{- end }}
 {{- end }}
-enabled = {{ $lbEnabled }}
+enabled = {{ not $lbDisabled }}
 create-monitor = "true"
 monitor-delay = "2s"
 monitor-timeout = "1s"


### PR DESCRIPTION
## Description
Adds `loadBalancer.enabled` parameter to cloud-provider-openstack module configuration.
This parameter is passed to the `[LoadBalancer]` section in cloud-config as the `enabled` flag.

Changes:
- Add `loadBalancer.enabled` boolean parameter to module config (default: `true`)
- Pass the `enabled` flag to `[LoadBalancer]` section in CCM cloud-config secret
- Add OpenAPI schema and Russian documentation
- Add template tests and case tests for the new parameter

## Why do we need it, and what problem does it solve?
After updating to Kubernetes 1.32, CCM (cloud-controller-manager) crashes when OpenStack cloud doesn't have Octavia (LBaaS) service available.

This is caused by an upstream change in cloud-provider-openstack v1.32:
https://github.com/kubernetes/cloud-provider-openstack/commit/16c269ae7661bf70cd9a161822d9b0cceaa66c39

The upstream CCM now requires explicit `enabled = false` in the LoadBalancer configuration section when Octavia is not available.

This PR allows users to disable LoadBalancer support via ModuleConfig:
```yaml
cloudProviderOpenstack:
  loadBalancer:
    enabled: false
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix 
summary: Add loadBalancer.enabled flag to prevent CCM crashes on k8s 1.32 without Octavia service
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
