### PR TITLE
[werf] Set user ID on d8 binary for elevated permissions

### DIFF
--- a/modules/007-registrypackages/images/d8/scripts/install
+++ b/modules/007-registrypackages/images/d8/scripts/install
@@ -16,4 +16,4 @@
 set -Eeo pipefail
 mkdir -p /opt/deckhouse/bin
 cp -f d8 /opt/deckhouse/bin
-chmod u+s /opt/deckhouse/bin/d8
+chmod u+s /opt/deckhouse/bin/d8 # this is needed to get access to plugins directory

--- a/modules/007-registrypackages/images/d8/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8/werf.inc.yaml
@@ -81,7 +81,6 @@ shell:
   - mv ./dist/{{ .CandiVersionMap.d8.d8CliVersion }}/linux-amd64/bin/d8 /d8
   - mv /src/scripts/* /
   - chmod +x /d8 /install /uninstall
-  - chmod u+s /d8
   - rm ~/.gitconfig # Prevent PRIVATE_REPO_TOKEN from leaking into the image layer
 ---
 {{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}


### PR DESCRIPTION
## Description
Fixed a permission error that occurred when trying to access the default d8 plugin working directory in d8-cli.

Before:
```bash
d8 plugins install package
Installing plugin: package
Tag: v0.0.12
Plugin: package v0.0.12
Description: Operate packages
Installing to: /home/ubuntu/.deckhouse-cli/plugins/package/v0/package
Downloading and extracting plugin...
✓ Plugin 'package' successfully installed!

```

After:
```
d8 plugins install package
Installing plugin: package
Tag: v0.0.12
Plugin: package v0.0.12
Description: Operate packages
Installing to: /opt/deckhouse/lib/deckhouse-cli/plugins/package/v0/package
Downloading and extracting plugin...
✓ Plugin 'package' successfully installed!

```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: chore
summary: Fix d8 permissions error for plugins directory.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
