### PR TITLE
[istio] Fixed indent in ztunnel daemonset template 

### DIFF
--- a/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -71,8 +71,8 @@ spec:
           name: ztunnel-stats
           protocol: TCP
         resources:
-            {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 14 }}
-            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 14 }}
+          {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
+          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
         imagePullPolicy: IfNotPresent
         securityContext:
           # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true


### PR DESCRIPTION
## Description
Incorrect indent in `spec.containers.istio-proxy.resources` section of ztunnel daemonset template.

## Why do we need it, and what problem does it solve?
Fixed deckhouse queue stuck because of wrong indent in spec.containers.istio-proxy.resources. section of ztunnel daemonset template when enabling ztunnel.

Deckhouse queue error:
```
 1. ModuleRun:main:istio:Kubernetes-Change-ModuleValues:failures 30:run helm install: install nelm release "istio": failed release "istio" (namespace: "d8-system"): execute release install plan: wait for operations completion: execute operation: create resource: server-side apply resource "DaemonSet/ztunnel-v1x25 (namespace=d8-istio)": failed to create typed patch object (d8-istio/ztunnel-v1x25; apps/v1, Kind=DaemonSet): .spec.template.spec.containers[name="istio-proxy"].resources.ephemeral-storage: field not declared in schema
```
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fixed indent in ztunnel daemonset template
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
