### PR TITLE
[loki] Add a valid TLS certificate for STS Loki

### DIFF
--- a/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
+++ b/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/go_lib/certificate"
+)
+
+type kubeRbacProxyTLSSnapshot struct {
+	Cert string
+	Key  string
+}
+
+const (
+	lokiKubeRbacProxyTLSQueue        = "/modules/loki/kube_rbac_proxy_tls"
+	lokiKubeRbacProxyTLSSecretName   = "loki-kube-rbac-proxy-tls"
+	lokiKubeRbacProxyTLSSecretNS     = "d8-monitoring"
+	lokiKubeRbacProxyTLSSecretSnap   = "kube_rbac_proxy_tls_secret"
+	lokiKubeRbacProxyCertCN          = "loki.d8-monitoring"
+	lokiKubeRbacProxyRotationCron    = "19 4 * * *"
+	lokiKubeRbacProxyRotateIfExpires = 15 * 24 * time.Hour
+)
+
+func kubeRbacProxyTLSSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	secret := &corev1.Secret{}
+	if err := sdk.FromUnstructured(obj, secret); err != nil {
+		return nil, fmt.Errorf("cannot convert loki kube-rbac-proxy tls secret to Secret: %w", err)
+	}
+
+	crt, ok := secret.Data["tls.crt"]
+	if !ok {
+		return nil, fmt.Errorf("'tls.crt' field not found")
+	}
+	key, ok := secret.Data["tls.key"]
+	if !ok {
+		return nil, fmt.Errorf("'tls.key' field not found")
+	}
+
+	return kubeRbacProxyTLSSnapshot{Cert: string(crt), Key: string(key)}, nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 15},
+	Schedule: []go_hook.ScheduleConfig{
+		{Name: "lokiKubeRbacProxyTLSRotation", Crontab: lokiKubeRbacProxyRotationCron},
+	},
+	Queue: lokiKubeRbacProxyTLSQueue,
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       lokiKubeRbacProxyTLSSecretSnap,
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NameSelector: &types.NameSelector{MatchNames: []string{
+				lokiKubeRbacProxyTLSSecretName,
+			}},
+			NamespaceSelector: &types.NamespaceSelector{NameSelector: &types.NameSelector{MatchNames: []string{
+				lokiKubeRbacProxyTLSSecretNS,
+			}}},
+			ExecuteHookOnSynchronization: go_hook.Bool(false),
+			FilterFunc:                   kubeRbacProxyTLSSecretFilter,
+		},
+	},
+}, generateOrRotateLokiKubeRbacProxyServerCert)
+
+func generateOrRotateLokiKubeRbacProxyServerCert(_ context.Context, input *go_hook.HookInput) error {
+	clusterDomain := input.Values.Get("global.discovery.clusterDomain").String()
+	if clusterDomain == "" {
+		return fmt.Errorf("global.discovery.clusterDomain is empty")
+	}
+
+	requiredSANs := []string{
+		"loki",
+		"loki.d8-monitoring",
+		"loki.d8-monitoring.svc",
+		fmt.Sprintf("loki.d8-monitoring.svc.%s", clusterDomain),
+	}
+
+	caAuthority := certificate.Authority{
+		Key:  input.Values.Get("global.internal.modules.kubeRBACProxyCA.key").String(),
+		Cert: input.Values.Get("global.internal.modules.kubeRBACProxyCA.cert").String(),
+	}
+	if caAuthority.Key == "" || caAuthority.Cert == "" {
+		return fmt.Errorf("global.internal.modules.kubeRBACProxyCA.{key,cert} must be set")
+	}
+
+	// If existing Secret already contains a valid, not-expiring certificate with the required SANs, reuse it.
+	snapshots := input.Snapshots.Get(lokiKubeRbacProxyTLSSecretSnap)
+	for existing, err := range sdkobjectpatch.SnapshotIter[kubeRbacProxyTLSSnapshot](snapshots) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over '%s' snapshots: %w", lokiKubeRbacProxyTLSSecretSnap, err)
+		}
+
+		if existing.Cert == "" || existing.Key == "" {
+			break
+		}
+
+		parsed, err := helpers.ParseCertificatePEM([]byte(existing.Cert))
+		if err != nil {
+			break
+		}
+
+		if !stringSlicesSetEqual(parsed.DNSNames, requiredSANs) {
+			break
+		}
+
+		expiringSoon, err := certificate.IsCertificateExpiringSoon([]byte(existing.Cert), lokiKubeRbacProxyRotateIfExpires)
+		if err != nil {
+			return fmt.Errorf("check loki kube-rbac-proxy certificate expiration: %w", err)
+		}
+		if expiringSoon {
+			break
+		}
+
+		input.Values.Set("loki.internal.kubeRbacProxyTLS", map[string]string{"cert": existing.Cert, "key": existing.Key})
+		return nil
+	}
+
+	issued, err := certificate.GenerateSelfSignedCert(
+		input.Logger,
+		lokiKubeRbacProxyCertCN,
+		caAuthority,
+		certificate.WithSANs(requiredSANs...),
+		certificate.WithSigningDefaultExpiry(10*365*24*time.Hour),
+		certificate.WithSigningDefaultUsage([]string{"signing", "key encipherment", "server auth"}),
+	)
+	if err != nil {
+		return fmt.Errorf("generate loki kube-rbac-proxy server certificate: %w", err)
+	}
+
+	input.Values.Set("loki.internal.kubeRbacProxyTLS", map[string]string{"cert": issued.Cert, "key": issued.Key})
+
+	return nil
+}
+
+func stringSlicesSetEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aCopy := append([]string(nil), a...)
+	bCopy := append([]string(nil), b...)
+
+	sort.Strings(aCopy)
+	sort.Strings(bCopy)
+
+	for i := range aCopy {
+		if aCopy[i] != bCopy[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
+++ b/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
@@ -155,7 +155,7 @@ func generateOrRotateLokiKubeRbacProxyServerCert(_ context.Context, input *go_ho
 		return fmt.Errorf("generate loki kube-rbac-proxy server certificate: %w", err)
 	}
 
-	input.Values.Set("loki.internal.kubeRbacProxyTLS", map[string]string{"cert": issued.Cert, "key": issued.Key})
+	input.Values.Set("loki.internal.kubeRbacProxyTLS", map[string]string{"cert": issued.Cert, "key": issued.Key, "ca": caAuthority.Cert})
 
 	return nil
 }

--- a/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
+++ b/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
@@ -45,7 +45,7 @@ const (
 	lokiKubeRbacProxyTLSSecretNS     = "d8-monitoring"
 	lokiKubeRbacProxyTLSSecretSnap   = "kube_rbac_proxy_tls_secret"
 	lokiKubeRbacProxyCertCN          = "loki.d8-monitoring"
-	lokiKubeRbacProxyRotationCron    = "19 4 * * *"
+	lokiKubeRbacProxyRotationCron    = "0 5 * * 1"
 	lokiKubeRbacProxyRotateIfExpires = 15 * 24 * time.Hour
 )
 

--- a/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
+++ b/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
@@ -139,7 +139,7 @@ func generateOrRotateLokiKubeRbacProxyServerCert(_ context.Context, input *go_ho
 			break
 		}
 
-		input.Values.Set("loki.internal.kubeRbacProxyTLS", map[string]string{"cert": existing.Cert, "key": existing.Key})
+		input.Values.Set("loki.internal.kubeRbacProxyTLS", map[string]string{"cert": existing.Cert, "key": existing.Key, "ca": caAuthority.Cert})
 		return nil
 	}
 

--- a/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
+++ b/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert.go
@@ -45,8 +45,8 @@ const (
 	lokiKubeRbacProxyTLSSecretNS     = "d8-monitoring"
 	lokiKubeRbacProxyTLSSecretSnap   = "kube_rbac_proxy_tls_secret"
 	lokiKubeRbacProxyCertCN          = "loki.d8-monitoring"
-	lokiKubeRbacProxyRotationCron    = "0 5 * * 1"
-	lokiKubeRbacProxyRotateIfExpires = 15 * 24 * time.Hour
+	lokiKubeRbacProxyRotationCron    = "0 5 1 * *"
+	lokiKubeRbacProxyRotateIfExpires = 60 * 24 * time.Hour // 2 months
 )
 
 func kubeRbacProxyTLSSecretFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert_test.go
+++ b/modules/462-loki/hooks/generate_kube_rbac_proxy_server_cert_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/deckhouse/deckhouse/go_lib/certificate"
+	"github.com/deckhouse/deckhouse/pkg/log"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: loki :: hooks :: generate_kube_rbac_proxy_server_cert ::", func() {
+	f := HookExecutionConfigInit(`{"loki": {"internal":{"kubeRbacProxyTLS":{}}}, "global": {"discovery": {"clusterDomain": "cluster.local"}, "internal": {"modules": {}}}}`, `{}`)
+
+	logger := log.NewNop()
+
+	It("must generate kube-rbac-proxy server certificate with required DNS SANs", func() {
+		selfSignedCA, err := certificate.GenerateCA(logger, "kube-rbac-proxy-ca-key-pair")
+		Expect(err).ToNot(HaveOccurred())
+
+		// Put CA into global values as the real global hook does.
+		// Keep YAML indentation stable for heredoc.
+		kubeRBACProxyCA := fmt.Sprintf(`
+kubeRBACProxyCA:
+  cert: |
+%s
+  key: |
+%s
+`, indentMultiline(selfSignedCA.Cert, 4), indentMultiline(selfSignedCA.Key, 4))
+		f.ValuesSetFromYaml("global.internal.modules", []byte(kubeRBACProxyCA))
+
+		f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+		f.RunHook()
+
+		Expect(f).To(ExecuteSuccessfully())
+
+		crt := f.ValuesGet("loki.internal.kubeRbacProxyTLS.cert").String()
+		Expect(crt).ToNot(BeEmpty())
+
+		block, _ := pem.Decode([]byte(crt))
+		Expect(block).ToNot(BeNil())
+
+		x509cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).ToNot(HaveOccurred())
+
+		expectedSANs := []string{
+			"loki",
+			"loki.d8-monitoring",
+			"loki.d8-monitoring.svc",
+			"loki.d8-monitoring.svc.cluster.local",
+		}
+
+		Expect(stringSlicesSetEqual(x509cert.DNSNames, expectedSANs)).To(BeTrue(), "unexpected DNS SANs: %v", x509cert.DNSNames)
+	})
+})
+
+func indentMultiline(s string, spaces int) string {
+	indent := strings.Repeat(" ", spaces)
+	lines := strings.Split(strings.TrimSuffix(s, "\n"), "\n")
+	for i := range lines {
+		lines[i] = indent + lines[i]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/modules/462-loki/openapi/values.yaml
+++ b/modules/462-loki/openapi/values.yaml
@@ -20,14 +20,16 @@ properties:
         default: ""
       kubeRbacProxyTLS:
         type: object
-        default: {}
         properties:
           cert:
             type: string
+            default: ""
           key:
             type: string
+            default: ""
           ca: 
             type: string
+            default: "ß"
       pvcSize:
         type: integer
         format: int64

--- a/modules/462-loki/openapi/values.yaml
+++ b/modules/462-loki/openapi/values.yaml
@@ -18,6 +18,16 @@ properties:
       logShipperToken:
         type: string
         default: ""
+      kubeRbacProxyTLS:
+        type: object
+        default: {}
+        properties:
+          cert:
+            type: string
+            default: ""
+          key:
+            type: string
+            default: ""
       pvcSize:
         type: integer
         format: int64

--- a/modules/462-loki/openapi/values.yaml
+++ b/modules/462-loki/openapi/values.yaml
@@ -29,7 +29,7 @@ properties:
             default: ""
           ca: 
             type: string
-            default: "ß"
+            default: ""
       pvcSize:
         type: integer
         format: int64

--- a/modules/462-loki/openapi/values.yaml
+++ b/modules/462-loki/openapi/values.yaml
@@ -24,10 +24,10 @@ properties:
         properties:
           cert:
             type: string
-            default: ""
           key:
             type: string
-            default: ""
+          ca: 
+            type: string
       pvcSize:
         type: integer
         format: int64

--- a/modules/462-loki/templates/kube-rbac-proxy-tls-secret.yaml
+++ b/modules/462-loki/templates/kube-rbac-proxy-tls-secret.yaml
@@ -9,4 +9,4 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ required ".Values.loki.internal.kubeRbacProxyTLS.cert is required" .Values.loki.internal.kubeRbacProxyTLS.cert | b64enc }}
   tls.key: {{ required ".Values.loki.internal.kubeRbacProxyTLS.key is required" .Values.loki.internal.kubeRbacProxyTLS.key | b64enc }}
-  ca.crt: {{ required ".Values.global.internal.modules.kubeRBACProxyCA.cert is required" .Values.global.internal.modules.kubeRBACProxyCA.cert | b64enc }}
+  ca.crt: {{ required ".Values.loki.internal.kubeRbacProxyTLS.ca  is required" .Values.loki.internal.kubeRbacProxyTLS.ca | b64enc }}

--- a/modules/462-loki/templates/kube-rbac-proxy-tls-secret.yaml
+++ b/modules/462-loki/templates/kube-rbac-proxy-tls-secret.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-kube-rbac-proxy-tls
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" .Chart.Name)) | nindent 2 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ required ".Values.loki.internal.kubeRbacProxyTLS.cert is required" .Values.loki.internal.kubeRbacProxyTLS.cert | b64enc }}
+  tls.key: {{ required ".Values.loki.internal.kubeRbacProxyTLS.key is required" .Values.loki.internal.kubeRbacProxyTLS.key | b64enc }}
+  ca.crt: {{ required ".Values.global.internal.modules.kubeRBACProxyCA.cert is required" .Values.global.internal.modules.kubeRBACProxyCA.cert | b64enc }}

--- a/modules/462-loki/templates/logshipper-log-destination.yaml
+++ b/modules/462-loki/templates/logshipper-log-destination.yaml
@@ -12,8 +12,9 @@ spec:
       strategy: "Bearer"
       token: {{ .Values.loki.internal.logShipperToken | quote }}
     tls:
-      verifyHostname: false
-      verifyCertificate: false
+      caFile: {{ .Values.loki.internal.kubeRbacProxyTLS.ca | b64enc }}
+      verifyHostname: true
+      verifyCertificate: true
 {{- if .Values.loki.storeSystemLogs }}
 ---
 apiVersion: deckhouse.io/v1alpha1

--- a/modules/462-loki/templates/statefulset.yaml
+++ b/modules/462-loki/templates/statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         threshold.extended-monitoring.deckhouse.io/disk-bytes-warning: "96"
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/kube-rbac-proxy-tls: {{ include (print $.Template.BasePath "/kube-rbac-proxy-tls-secret.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
       - name: deckhouse-registry
@@ -86,7 +87,9 @@ spec:
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
           - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):3100"
-          - "--client-ca-file=/etc/kube-rbac-proxy/ca.crt"
+          - "--client-ca-file=/etc/kube-rbac-proxy/ca/ca.crt"
+          - "--tls-cert-file=/etc/kube-rbac-proxy/tls/tls.crt"
+          - "--tls-private-key-file=/etc/kube-rbac-proxy/tls/tls.key"
           - "--v=2"
           - "--logtostderr=true"
           - "--stale-cache-interval=1h30m"
@@ -156,7 +159,9 @@ spec:
   {{- end }}
         volumeMounts:
           - name: kube-rbac-proxy-ca
-            mountPath: /etc/kube-rbac-proxy
+            mountPath: /etc/kube-rbac-proxy/ca
+          - name: kube-rbac-proxy-tls
+            mountPath: /etc/kube-rbac-proxy/tls
       volumes:
       - name: config
         configMap:
@@ -168,6 +173,10 @@ spec:
         configMap:
           defaultMode: 420
           name: kube-rbac-proxy-ca.crt
+      - name: kube-rbac-proxy-tls
+        secret:
+          secretName: loki-kube-rbac-proxy-tls
+          defaultMode: 420
 {{- $storageClass := .Values.loki.internal.effectiveStorageClass }}
 {{- if $storageClass }}
   volumeClaimTemplates:


### PR DESCRIPTION
## Description
Added generation and usage of a dedicated TLS server certificate for Loki kube-rbac-proxy.

A new hook issues/rotates the cert signed by the global kubeRBACProxyCA, publishes it as a Secret in d8-monitoring, and wires the Secret into the Loki StatefulSet (adds --tls-cert-file/--tls-private-key-file and rollout checksum). This leads to a Loki pod restart on certificate rotation.

## Why do we need it, and what problem does it solve?
Loki endpoint is exposed via `kube-rbac-proxy` over HTTPS. Previously there was no module-managed server certificate with the expected DNS SANs, which makes TLS identity inconsistent and complicates clients that rely on proper server name validation.

This change ensures the issued server certificate always contains the required DNS SANs:

- `loki`
- `loki.d8-monitoring`
- `loki.d8-monitoring.svc`
- `loki.d8-monitoring.svc.<clusterDomain>`


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: loki
type: feature
summary: Added generation and usage of a dedicated TLS server certificate for Loki kube-rbac-proxy
impact_level: default
```