### PR TITLE
[helm-lib] Bump helm-lib to 1.71.1

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.70.1
-digest: sha256:1acd6b99fd12a8e5f7cc3a5821d0dd28a26db2e851f53bf2853493272b045126
-generated: "2026-01-23T12:02:28.941196351+03:00"
+  version: 1.71.1
+digest: sha256:5682a96d4c6f23060ebdd8365e201daf4f1c41f0d25a5de4aae1f7a3f12045ae
+generated: "2026-03-03T17:25:27.954468+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.70.1"
+    version: "1.71.1"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.70.1
+version: 1.71.1

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -34,6 +34,8 @@
 | [helm_lib_application_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted](#helm_lib_application_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted) |
 | **Csi Controller** |
 | [helm_lib_csi_image_with_common_fallback](#helm_lib_csi_image_with_common_fallback) |
+| **Default Gateway** |
+| [helm_lib_default_gateway](#helm_lib_default_gateway) |
 | **Dns Policy** |
 | [helm_lib_dns_policy_bootstraping_state](#helm_lib_dns_policy_bootstraping_state) |
 | **Enable Ds Eviction** |
@@ -488,6 +490,22 @@ list:
 -  Template context with .Values, .Chart, etc 
 -  Container raw name 
 -  Kubernetes semantic version 
+
+## Default Gateway
+
+### helm_lib_default_gateway
+
+ accepts a dict that is updated with current default gateway name and namespace 
+
+#### Usage
+
+`{{- include "helm_lib_default_gateway" (list . $gateway) `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  An empty dict to update with current default gateway name and namespace 
 
 ## Dns Policy
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_application_image.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_application_image.tpl
@@ -4,17 +4,17 @@
   {{- $context := index . 0 }}
 
   {{- $image := index . 1 | trimAll "\"" }}
-  {{- $imageDigest := index $context.Runtime.Package.Digests $image }}
+  {{- $imageDigest := index $context.Application.Package.Digests $image }}
   {{- if not $imageDigest }}
   {{- fail (printf "Image %s has no digest" $image) }}
   {{- end }}
 
-  {{- $registryBase := $context.Runtime.Package.Registry.repository }}
+  {{- $registryBase := $context.Application.Package.Registry.repository }}
   {{- if not $registryBase }}
   {{- fail "Registry base is not set" }}
   {{- end }}
 
-  {{- $packageName := $context.Runtime.Package.Name }}
+  {{- $packageName := $context.Application.Package.Name }}
   {{- if not $packageName }}
   {{- fail "Package name is not set" }}
   {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -84,6 +84,7 @@ memory: 50Mi
   {{- $resizerEnabled := dig "resizerEnabled" true $config }}
   {{- $syncerEnabled := dig "syncerEnabled" false $config }}
   {{- $topologyEnabled := dig "topologyEnabled" true $config }}
+  {{- $capacityEnabled := dig "capacityEnabled" true $config }}
   {{- $runAsRootUser := dig "runAsRootUser" false $config }}
   {{- $extraCreateMetadataEnabled := dig "extraCreateMetadataEnabled" false $config }}
   {{- $controllerImage := $config.controllerImage | required "$config.controllerImage is required" }}
@@ -301,8 +302,10 @@ spec:
         - "--leader-election-lease-duration=30s"
         - "--leader-election-renew-deadline=20s"
         - "--leader-election-retry-period=5s"
+  {{- if $capacityEnabled }}
         - "--enable-capacity"
         - "--capacity-ownerref-level=2"
+  {{- end }}
   {{- if $extraCreateMetadataEnabled }}
         - "--extra-create-metadata=true"
   {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_default_gateway.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_default_gateway.tpl
@@ -1,0 +1,18 @@
+{{- /* Usage: {{- include "helm_lib_default_gateway" (list . $gateway) */ -}}
+{{- /* accepts a dict that is updated with current default gateway name and namespace */ -}}
+{{- define "helm_lib_default_gateway" -}}
+  {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $result := index . 1 -}}  {{- /* An empty dict to update with current default gateway name and namespace */ -}}
+  {{- $g := dict -}}
+
+  {{- if hasKey $context.Values.global.modules "gatewayAPIDefaultGateway" -}}
+    {{- $g = $context.Values.global.modules.gatewayAPIDefaultGateway -}}
+  {{- else if and (hasKey $context.Values.global "discovery") (hasKey $context.Values.global.discovery "gatewayAPIDefaultGateway") -}}
+    {{- $g = $context.Values.global.discovery.gatewayAPIDefaultGateway -}}
+  {{- end -}}
+
+  {{- if and $g.name $g.namespace -}}
+    {{- $_ := set $result "name" $g.name -}}
+    {{- $_ := set $result "namespace" $g.namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_image.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_image.tpl
@@ -3,29 +3,54 @@
 {{- define "helm_lib_module_image" }}
   {{- $context := index . 0 }} {{- /* Template context with .Values, .Chart, etc */ -}}
   {{- $containerName := index . 1 | trimAll "\"" }} {{- /* Container name */ -}}
-  {{- $rawModuleName := $context.Chart.Name }}
-  {{- if ge (len .) 3 }}
-    {{- $rawModuleName = (index . 2) }} {{- /* Optional module name */ -}}
-  {{- end }}
-  {{- $moduleName := (include "helm_lib_module_camelcase_name" $rawModuleName) }}
-  {{- $imageDigest := index $context.Values.global.modulesImages.digests $moduleName $containerName }}
-  {{- if not $imageDigest }}
-    {{- $error := (printf "Image %s.%s has no digest" $moduleName $containerName ) }}
-    {{- fail $error }}
-  {{- end }}
-  {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
+
+  {{- /* New approach: use module package values */}} 
+  {{- if and $context.Module $context.Module.Package }}
+    {{- $registryBase := $context.Module.Package.Registry.repository }}
+    {{- if not $registryBase }}
+      {{- fail "Registry base is not set" }}
+    {{- end }}
+
+    {{- $packageName := $context.Module.Package.Name }}
+    {{- if not $packageName }}
+      {{- fail "Package name is not set" }}
+    {{- end }}
+
+    {{- $imageDigest := index $context.Module.Package.Digests $containerName }}
+    {{- if not $imageDigest }}
+      {{- fail (printf "Image %s has no digest" $containerName) }}
+    {{- end }}
+
+    {{- printf "%s/%s@%s" $registryBase $packageName $imageDigest }}
+
+  {{- /* Legacy fallback: use global modulesImages values */}}
+  {{- else }}
+    {{- $rawModuleName := $context.Chart.Name }}
+    {{- if ge (len .) 3 }}
+      {{- $rawModuleName = (index . 2) }} {{- /* Optional module name */ -}}
+    {{- end }}
+    {{- $moduleName := (include "helm_lib_module_camelcase_name" $rawModuleName) }}
+
+    {{- $imageDigest := index $context.Values.global.modulesImages.digests $moduleName $containerName }}
+    {{- if not $imageDigest }}
+      {{- $error := (printf "Image %s.%s has no digest" $moduleName $containerName ) }}
+      {{- fail $error }}
+    {{- end }}
+
+    {{- $registryBase := $context.Values.global.modulesImages.registry.base }}
   {{- /*  handle external modules registry */}}
-  {{- if index $context.Values $moduleName }}
-    {{- if index $context.Values $moduleName "registry" }}
-      {{- if index $context.Values $moduleName "registry" "base" }}
-        {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
-        {{- $path := trimAll "/" (include "helm_lib_module_kebabcase_name" $rawModuleName) }}
-        {{- $registryBase = join "/" (list $host $path) }}
+    {{- if index $context.Values $moduleName }}
+      {{- if index $context.Values $moduleName "registry" }}
+        {{- if index $context.Values $moduleName "registry" "base" }}
+          {{- $host := trimAll "/" (index $context.Values $moduleName "registry" "base") }}
+          {{- $path := trimAll "/" (include "helm_lib_module_kebabcase_name" $rawModuleName) }}
+          {{- $registryBase = join "/" (list $host $path) }}
+        {{- end }}
       {{- end }}
     {{- end }}
-  {{- end }}
   {{- /* end of external module handling block */}}
-  {{- printf "%s@%s" $registryBase $imageDigest }}
+    {{- printf "%s@%s" $registryBase $imageDigest }}
+  {{- end }}
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_image_no_fail" (list . "<container-name>") }} */ -}}


### PR DESCRIPTION
## Description
These changes are update helm-lib to latest version v1.71.1

Changes are autogenerated by `make update-lib-helm version=1.71.1` command

[lib_helm PR](https://github.com/deckhouse/lib-helm/pull/179)

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: Bump helm-lib to v1.71.1
impact_level: low
```
