### PR TITLE
[kube-proxy] Fixed tests to avoid intermittent Tests faults

### DIFF
--- a/modules/036-kube-proxy/hooks/discover_api_endpoints_test.go
+++ b/modules/036-kube-proxy/hooks/discover_api_endpoints_test.go
@@ -25,7 +25,7 @@ import (
 
 var _ = Describe("Modules :: kube-proxy :: hooks :: discover_apiserver_endpoints ::", func() {
 	const (
-		stateSingleAddress = `
+		stateSingleEndpointSliceWithOneIPAndOnePort = `
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
@@ -42,7 +42,7 @@ ports:
   protocol: TCP
 `
 
-		stateMultipleAddressesWithOnePort = `
+		stateSingleEndpointSliceWithThreeIPAndOnePort = `
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
@@ -62,7 +62,7 @@ ports:
   port: 6443
   protocol: TCP
 `
-		stateMultipleAddressesWithMultiplePorts = `
+		stateSingleEndpointSliceWithTwoIPAndTwoPorts = `
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
 metadata:
@@ -83,7 +83,7 @@ ports:
   port: 8443
   protocol: TCP
 `
-		stateMultipleSlicesWithMultipleAddressesWithMultiplePorts = `
+		stateThreeEndpointSlicesWithDublicatedAndMultipleIPPorts = `
 ---
 apiVersion: discovery.k8s.io/v1
 kind: EndpointSlice
@@ -142,9 +142,9 @@ ports:
 
 	f := HookExecutionConfigInit(`{"kubeProxy":{"internal": {}}}`, `{}`)
 
-	Context("Endpoint default/kubernetes has single address in .endpoints[]", func() {
+	Context("Single EndpointSlice resource with one IP and one port", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(stateSingleAddress))
+			f.BindingContexts.Set(f.KubeStateSet(stateSingleEndpointSliceWithOneIPAndOnePort))
 			f.RunHook()
 		})
 
@@ -152,46 +152,11 @@ ports:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443"]`))
 		})
-
-		Context("Someone added additional addresses to .endpoints[]", func() {
-			BeforeEach(func() {
-				f.BindingContexts.Set(f.KubeStateSet(stateMultipleAddressesWithOnePort))
-				f.RunHook()
-			})
-
-			It("`kubeProxy.internal.clusterMasterAddresses` must be ['10.0.1.192:6443','10.0.1.193:6443','10.0.1.194:6443']", func() {
-				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443","10.0.1.193:6443","10.0.1.194:6443"]`))
-			})
-
-			Context("Someone added another port", func() {
-				BeforeEach(func() {
-					f.BindingContexts.Set(f.KubeStateSet(stateMultipleAddressesWithMultiplePorts))
-					f.RunHook()
-				})
-
-				It("`kubeProxy.internal.clusterMasterAddresses` must be ['10.0.1.192:6443','10.0.1.193:8443','10.0.1.193:6443','10.0.1.193:8443']", func() {
-					Expect(f).To(ExecuteSuccessfully())
-					Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443","10.0.1.192:8443","10.0.1.193:6443","10.0.1.193:8443"]`))
-				})
-				Context("Someone added another addresses with different ports", func() {
-					BeforeEach(func() {
-						f.BindingContexts.Set(f.KubeStateSet(stateMultipleSlicesWithMultipleAddressesWithMultiplePorts))
-						f.RunHook()
-					})
-
-					It("`kubeProxy.internal.clusterMasterAddresses` must be ['10.0.1.192:6443','10.0.1.193:6443','10.0.1.193:8443','10.0.1.195:6443','10.0.1.195:8443']", func() {
-						Expect(f).To(ExecuteSuccessfully())
-						Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443","10.0.1.193:8443","10.0.1.194:8443","10.0.1.195:6443","10.0.1.195:8443"]`))
-					})
-				})
-			})
-		})
 	})
 
-	Context("Endpoint default/kubernetes has multiple addresses in .endpoints[]", func() {
+	Context("Single EndpointSlice resource with three IP and one port", func() {
 		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(stateMultipleAddressesWithOnePort))
+			f.BindingContexts.Set(f.KubeStateSet(stateSingleEndpointSliceWithThreeIPAndOnePort))
 			f.RunHook()
 		})
 
@@ -199,17 +164,29 @@ ports:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443","10.0.1.193:6443","10.0.1.194:6443"]`))
 		})
+	})
 
-		Context("Someone set number of addresses in .endpoints[] to one", func() {
-			BeforeEach(func() {
-				f.BindingContexts.Set(f.KubeStateSet(stateSingleAddress))
-				f.RunHook()
-			})
+	Context("Single EndpointSlice resource two IP and two ports", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(stateSingleEndpointSliceWithTwoIPAndTwoPorts))
+			f.RunHook()
+		})
 
-			It("`kubeProxy.internal.clusterMasterAddresses` must be ['10.0.1.192:6443']", func() {
-				Expect(f).To(ExecuteSuccessfully())
-				Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443"]`))
-			})
+		It("`kubeProxy.internal.clusterMasterAddresses` must be ['10.0.1.192:6443','10.0.1.192:8443','10.0.1.193:6443','10.0.1.193:8443']", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443","10.0.1.192:8443","10.0.1.193:6443","10.0.1.193:8443"]`))
+		})
+	})
+
+	Context("Three EndpointSlice resources with mixed combination and dublicated IP", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(stateThreeEndpointSlicesWithDublicatedAndMultipleIPPorts))
+			f.RunHook()
+		})
+
+		It("`kubeProxy.internal.clusterMasterAddresses` must be ['10.0.1.192:6443','10.0.1.193:6443','10.0.1.193:8443','10.0.1.195:6443','10.0.1.195:8443']", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("kubeProxy.internal.clusterMasterAddresses").String()).To(MatchJSON(`["10.0.1.192:6443","10.0.1.193:8443","10.0.1.194:8443","10.0.1.195:6443","10.0.1.195:8443"]`))
 		})
 	})
 })


### PR DESCRIPTION
## Description
Non-reproducible error in tests presumably related to context nesting, when a data set from a previous context was compared in the nested assertion.

## Why do we need it, and what problem does it solve?
It is assumed that by removing the nesting the error will disappear.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: kube-proxy
type: chore
summary: fixed tests of discover_api_endpoints.go
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
