### PR TITLE
Fix changelog for 1.71

### DIFF
--- a/CHANGELOG/CHANGELOG-v1.71.10.yml
+++ b/CHANGELOG/CHANGELOG-v1.71.10.yml
@@ -1,0 +1,16 @@
+deckhouse-controller:
+  features:
+    - summary: ignore migrate module if disabled
+      pull_request: https://github.com/deckhouse/deckhouse/pull/16107
+  fixes:
+    - summary: fix deckhouse update accidentally minor skip
+      pull_request: https://github.com/deckhouse/deckhouse/pull/16097
+istio:
+  fixes:
+    - summary: Reduce CPU and RAM for regenerate multicluster JWT token and sort ingressGateway
+      pull_request: https://github.com/deckhouse/deckhouse/pull/18116
+local-path-provisioner:
+  fixes:
+    - summary: Fix CVE in local-path-provisioner module
+      pull_request: https://github.com/deckhouse/deckhouse/pull/16042
+

--- a/CHANGELOG/CHANGELOG-v1.71.md
+++ b/CHANGELOG/CHANGELOG-v1.71.md
@@ -1,12 +1,5 @@
 # Changelog v1.71
 
-## [MALFORMED]
-
-
- - #13874 unknown section "pod-reloader"
- - #14160 unknown section "runtime-audit-engine"
- - #14673 unknown section "runtime-audit-engine"
-
 ## Know before update
 
 
@@ -32,6 +25,7 @@
  - **[cni-cilium]** Added optional least-conn load-balancing algorithm for Services. [#13867](https://github.com/deckhouse/deckhouse/pull/13867)
  - **[cni-cilium]** Added a traffic encryption mode using WireGuard (`pod-to-pod` and `node-to-node`). [#13749](https://github.com/deckhouse/deckhouse/pull/13749)
  - **[cni-cilium]** Cni-cilium is updated to consider Virtualization Nesting Level when discovering tunnel-port value. [#9996](https://github.com/deckhouse/deckhouse/pull/9996)
+ - **[deckhouse-controller]** ignore migrate module if disabled [#16107](https://github.com/deckhouse/deckhouse/pull/16107)
  - **[deckhouse-controller]** add validation for module source changes [#14821](https://github.com/deckhouse/deckhouse/pull/14821)
  - **[deckhouse-controller]** Added user notify when module config has conflict. [#14296](https://github.com/deckhouse/deckhouse/pull/14296)
  - **[deckhouse-controller]** Optimized ModuleRelease update flow. [#14144](https://github.com/deckhouse/deckhouse/pull/14144)
@@ -86,6 +80,7 @@
  - **[cni-cilium]** fFxed bug in cilium 1.17 operator priority filter. [#13734](https://github.com/deckhouse/deckhouse/pull/13734)
  - **[control-plane-manager]** correct indentation of the 'certSANs' in v1beta4 template. [#14554](https://github.com/deckhouse/deckhouse/pull/14554)
  - **[control-plane-manager]** Used last_over_time to fetch the last available etcd DB size metric if it's missing. [#13682](https://github.com/deckhouse/deckhouse/pull/13682)
+ - **[deckhouse-controller]** fix deckhouse update accidentally minor skip [#16097](https://github.com/deckhouse/deckhouse/pull/16097)
  - **[deckhouse-controller]** Introduced a new mechanism for handling module readiness probes in Deckhouse. [#14226](https://github.com/deckhouse/deckhouse/pull/14226)
  - **[deckhouse-controller]** Added handling required module empty version for module dependency. [#14157](https://github.com/deckhouse/deckhouse/pull/14157)
  - **[deckhouse-controller]** Prevented module configuration errors from blocking the entire Deckhouse queue. [#13730](https://github.com/deckhouse/deckhouse/pull/13730)
@@ -100,6 +95,7 @@
  - **[extended-monitoring]** Fixed CVEs vulnerabilities image-availability-exporter. [#13802](https://github.com/deckhouse/deckhouse/pull/13802)
  - **[extended-monitoring]** Fixed CVEs vulnerabilities events-exporter. [#13801](https://github.com/deckhouse/deckhouse/pull/13801)
  - **[extended-monitoring]** Fixed CVEs vulnerabilities extended-monitoring-exporter. [#13798](https://github.com/deckhouse/deckhouse/pull/13798)
+ - **[istio]** Reduce CPU and RAM for regenerate multicluster JWT token and sort ingressGateway [#18116](https://github.com/deckhouse/deckhouse/pull/18116)
  - **[istio]** Added probes for `kube-rbac-proxy`. [#13877](https://github.com/deckhouse/deckhouse/pull/13877)
  - **[kube-dns]** Added probes for `kube-rbac-proxy`. [#13877](https://github.com/deckhouse/deckhouse/pull/13877)
  - **[kube-proxy]** Added probes for `kube-rbac-proxy`. [#13877](https://github.com/deckhouse/deckhouse/pull/13877)
@@ -120,6 +116,7 @@
  - **[openvpn]** Added probes for `kube-rbac-proxy`. [#13877](https://github.com/deckhouse/deckhouse/pull/13877)
  - **[operator-prometheus]** Fixed CVEs vulnerabilities operator-prometheus. [#13792](https://github.com/deckhouse/deckhouse/pull/13792)
  - **[operator-trivy]** Added startup probe to trivy-server. [#13731](https://github.com/deckhouse/deckhouse/pull/13731)
+ - **[pod-reloader]** Added probes for `kube-rbac-proxy` in pod-reloader components. [#13874](https://github.com/deckhouse/deckhouse/pull/13874)
  - **[prometheus]** fix securityContext indentation in the Prometheus main and longterm resources [#15116](https://github.com/deckhouse/deckhouse/pull/15116)
     main and longterm Prometheuses will be rollout-restarted
  - **[prometheus]** use the "deckhouse" ModuleSource as the default for the prompp ModuleConfig [#14612](https://github.com/deckhouse/deckhouse/pull/14612)
@@ -134,6 +131,8 @@
  - **[prometheus]** Fixed CVEs vulnerabilities  alerts receiver. [#13740](https://github.com/deckhouse/deckhouse/pull/13740)
  - **[prometheus]** Fixed CVEs vulnerabilities alertmanager. [#13739](https://github.com/deckhouse/deckhouse/pull/13739)
  - **[prometheus-metrics-adapter]** Fixed CVEs vulnerabilities prometheus-metrics-adapter. [#13794](https://github.com/deckhouse/deckhouse/pull/13794)
+ - **[runtime-audit-engine]** Improve memory footprint by switching to the stdlib memory allocator instead of jemalloc [#14673](https://github.com/deckhouse/deckhouse/pull/14673)
+ - **[runtime-audit-engine]** Added falco build fixes for CSE. [#14160](https://github.com/deckhouse/deckhouse/pull/14160)
  - **[service-with-healthchecks]** Added probes for `kube-rbac-proxy`. [#13877](https://github.com/deckhouse/deckhouse/pull/13877)
  - **[service-with-healthchecks]** Fixed handling of pods without IP addresses and corrected initial readiness threshold evaluation. [#12390](https://github.com/deckhouse/deckhouse/pull/12390)
  - **[user-authn]** fix dex oidc connector insecureSkipVerify and rootCAData options [#14524](https://github.com/deckhouse/deckhouse/pull/14524)


### PR DESCRIPTION
## Description
Fix changelog for 1.71.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix changelog for 1.71.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
