### PR TITLE
[deckhouse] Race in ModuleConfig processing at the start

### DIFF
--- a/deckhouse-controller/pkg/controller/moduleloader/loader.go
+++ b/deckhouse-controller/pkg/controller/moduleloader/loader.go
@@ -338,13 +338,11 @@ func (l *Loader) LoadModulesFromFS(ctx context.Context) error {
 		}
 	}
 
-	// OPTIMIZATION: Make cleanup async to not block module loading startup!
-	// Cleanup is non-critical housekeeping that can happen in background
-	go func() {
-		if err := l.cleanupDeletedModules(ctx); err != nil {
-			l.logger.Warn("async cleanup failed", slog.String("error", err.Error()))
-		}
-	}()
+	// Run cleanup synchronously to avoid race with module-config-controller:
+	// async cleanup could set EnabledByModuleConfig to Unknown while the controller is processing a config.
+	if err := l.cleanupDeletedModules(ctx); err != nil {
+		return fmt.Errorf("cleanup deleted modules: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description
When starting deckhouse, we cleanup modules in go-routine, without waiting it due to this the module-config-controller can simultaneously process same resource, that could lead to race.

```
The config was processed at 06:11:09
EnabledByModuleConfig became Unknown at 06:11:10
```

## Why do we need it, and what problem does it solve?
We need to make a wedge without a neck.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fixed a race condition in ModuleConfig processing during startup.
impact_level: default
```
