### PR TITLE
[istio] Rewrite werf.inc.yaml files to werf git cloning

### DIFF
--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -11,24 +11,36 @@ git:
   stageDependencies:
     install:
     - '**/*'
-secrets:
-- id: SOURCE_REPO
-  value: {{ .SOURCE_REPO }}
+- url: {{ .SOURCE_REPO }}/istio/istio.git
+  tag: {{ $istioVersion }}
+  add: /
+  to: /src/istio
+  excludePaths:
+  - samples
+  - security/samples
+  - security/tools/jwt/samples
+  stageDependencies:
+    install:
+    - '**/*'
+- url: {{ .SOURCE_REPO }}/istio/kiali.git
+  tag: {{ $kialiVersion }}
+  add: /
+  to: /src/kiali
+  excludePaths:
+  - frontend
+  stageDependencies:
+    install:
+    - '**/*'
+- url: {{ .SOURCE_REPO }}/istio/kiali-frontend-assets.git
+  tag: {{ $kialiVersion }}
+  add: /
+  to: /src/kial-frontend-assets
+  stageDependencies:
+    install:
+    - '**/*'
 shell:
   install:
-  - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/istio.git /src/istio/
-  - cd /src/istio/
-  - git apply --verbose /patches/001-istio-apply_go.patch /patches/002-istio-gomod_gosum.patch /patches/003-istio-server_fmtText.patch
-  - rm -rf /src/istio/.git
-  - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali.git /src/kiali/
-  - cd /src/kiali/
-  - git apply --verbose /patches/001-kiali-go-mod.patch
-  - rm -rf /src/kiali/.git
-  - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali-frontend-assets.git /src/kial-frontend-assets/
-  - rm -rf /src/kiali-frontend-assets/.git
-
-  # getting rid of unused vulnerable code
-  - rm -rf /src/istio/samples
-  - rm -rf /src/istio/security/samples
-  - rm -rf /src/istio/security/tools/jwt/samples
-  - rm -rf /src/kiali/frontend
+  - cd /src/istio/ && git apply --verbose /patches/001-istio-apply_go.patch
+  - cd /src/istio/ && git apply --verbose /patches/002-istio-gomod_gosum.patch
+  - cd /src/istio/ && git apply --verbose /patches/003-istio-server_fmtText.patch
+  - cd /src/kiali/ && git apply --verbose /patches/001-kiali-go-mod.patch

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -5,27 +5,36 @@
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
-secrets:
-- id: SOURCE_REPO
-  value: {{ .SOURCE_REPO }}
 git:
-  - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
-    to: /patches
-    stageDependencies:
-      install:
-        - '**/*'
+- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
+- url: {{ .SOURCE_REPO }}/istio/istio.git
+  tag: {{ $istioVersion }}
+  add: /
+  to: /src/istio
+  excludePaths:
+  - samples
+  stageDependencies:
+    install:
+    - '**/*'
+- url: {{ .SOURCE_REPO }}/istio/kiali.git
+  tag: {{ $kialiVersion }}
+  add: /
+  to: /src/kiali
+  stageDependencies:
+    install:
+    - '**/*'
+- url: {{ .SOURCE_REPO }}/istio/kiali-frontend-assets.git
+  tag: {{ $kialiVersion }}
+  add: /
+  to: /src/kial-frontend-assets
+  stageDependencies:
+    install:
+    - '**/*'
 shell:
   install:
-  - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/istio.git /src/istio/
-  - cd /src/istio/
-  - git apply --verbose /patches/001-istio-gomod_gosum.patch
-  - rm -rf /src/istio/.git
-  - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali.git /src/kiali/
-  - cd /src/kiali/
-  - git apply --verbose /patches/001-kiali-go-mod.patch
-  - rm -rf /src/kiali/.git
-  - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali-frontend-assets.git /src/kial-frontend-assets/
-  - rm -rf /src/kiali-frontend-assets/.git
-
-  # getting rid of unused vulnerable code
-  - rm -rf /src/istio/samples
+  - cd /src/istio/ && git apply --verbose /patches/001-istio-gomod_gosum.patch
+  - cd /src/kiali/ && git apply --verbose /patches/001-kiali-go-mod.patch

--- a/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/operator-v1x25x2/werf.inc.yaml
@@ -59,19 +59,21 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
-secrets:
-- id: DECKHOUSE_PRIVATE_REPO
-  value: {{ .DECKHOUSE_PRIVATE_REPO }}
 git:
-  - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
-    to: /patches
-    stageDependencies:
-      install:
-        - '**/*'
+- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+    - '**/*'
+- url: git@{{ .DECKHOUSE_PRIVATE_REPO }}:deckhouse/network/sail-operator.git
+  tag: tag-{{ $istioVersion }}
+  add: /
+  to: /src/operator
+  stageDependencies:
+    install:
+    - '**/*'
 shell:
   install:
-  - git clone --depth 1 --branch {{ $istioVersion }} git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/network/sail-operator.git /src/operator
-  - cd /src/operator
-  - git apply --verbose /patches/001-istio-go-mod.patch /patches/002-istio-operato-cni_status_restrict.patch
-  - rm -rf /src/operator/.git
+  - cd /src/operator && git apply --verbose /patches/001-istio-go-mod.patch
+  - cd /src/operator && git apply --verbose /patches/002-istio-operato-cni_status_restrict.patch
 ---

--- a/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x21x6/werf.inc.yaml
@@ -351,6 +351,17 @@ git:
   stageDependencies:
     install:
     - '**/*'
+- url: {{ .SOURCE_REPO }}/llvm/llvm-project.git
+  tag: {{ $llvmRev }}
+  add: /
+  to: /src/llvm
+  excludePaths:
+  - llvm/utils/git
+  - mlir/utils/vscode
+  - third-party/benchmark
+  stageDependencies:
+    install:
+    - '**/*'
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -359,12 +370,5 @@ shell:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/proxy.git /src/proxy
   - cd /src/proxy/
   - git apply --verbose /patches/*.patch
-  - git clone --branch "{{ $llvmRev }}" $(cat /run/secrets/SOURCE_REPO)/llvm/llvm-project.git /src/llvm
-  - rm -rf /src/llvm/.git
-
-  # getting rid of unused vulnerable code
-  - rm -rf /src/llvm/llvm/utils/git
-  - rm -rf /src/llvm/mlir/utils/vscode
-  - rm -rf /src/llvm/third-party/benchmark && mkdir /src/llvm/third-party/benchmark
-  - touch /src/llvm/third-party/benchmark/placeholder.txt
+  - mkdir /src/llvm/third-party/benchmark && touch /src/llvm/third-party/benchmark/placeholder.txt
 ---


### PR DESCRIPTION
## Description
Git clone calls moved from the shell werf section to the git werf section for all repositories where this is possible, removed unnecessary shell calls to remove directories - instead of this they excluded when cloning via werf git section.

## Why do we need it, and what problem does it solve?
Werf files became cleaner, more readable and unified, following werf patterns for cloning repos (via git section).

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Git clone for images common-v1x21x6, common-v1x25x2, operator-v1x25x2 and proxyv2-v1x21x6 moved to git section of werf.inc.yaml 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
