### PR TITLE
[admission-policy-engine] Change default PSS policy for unrecognized deckhouse versions

### DIFF
--- a/modules/015-admission-policy-engine/hooks/detect_pss_default_policy.go
+++ b/modules/015-admission-policy-engine/hooks/detect_pss_default_policy.go
@@ -106,7 +106,7 @@ func getDefaultPolicy(_ context.Context, input *go_hook.HookInput) string {
 
 	// if deckhouse bootstrap release < v1.55
 	if semver.Compare(semver.MajorMinor(deckhouseVersion), milestone) < 0 {
-		input.Logger.Info("PSS default policy is set to baseline", slog.String("version", deckhouseVersion))
+		input.Logger.Info("PSS default policy is set to privileged", slog.String("version", deckhouseVersion))
 		return "Privileged"
 	}
 

--- a/modules/015-admission-policy-engine/hooks/detect_pss_default_policy.go
+++ b/modules/015-admission-policy-engine/hooks/detect_pss_default_policy.go
@@ -88,12 +88,12 @@ func getDefaultPolicy(_ context.Context, input *go_hook.HookInput) string {
 	installDataSlice, err := sdkobjectpatch.UnmarshalToStruct[string](input.Snapshots, "install_data")
 	if err != nil {
 		input.Logger.Error("failed to unmarshal install_data snapshot", log.Err(err))
-		return "Privileged"
+		return "Baseline"
 	}
 
 	// no map found - an old cluster
 	if len(installDataSlice) == 0 {
-		return "Privileged"
+		return "Baseline"
 	}
 
 	deckhouseVersion := installDataSlice[0]
@@ -101,16 +101,16 @@ func getDefaultPolicy(_ context.Context, input *go_hook.HookInput) string {
 	// no version field found or invalid semver - something went wrong
 	if len(deckhouseVersion) == 0 || !semver.IsValid(deckhouseVersion) {
 		input.Logger.Warn("deckhouseVersion isn't found or invalid", slog.String("version", deckhouseVersion))
-		return "Privileged"
-	}
-
-	// if deckhouse bootstrap release >= v1.55
-	if semver.Compare(semver.MajorMinor(deckhouseVersion), milestone) >= 0 {
-		input.Logger.Info("PSS default policy is set to baseline", slog.String("version", deckhouseVersion))
 		return "Baseline"
 	}
 
-	return "Privileged"
+	// if deckhouse bootstrap release < v1.55
+	if semver.Compare(semver.MajorMinor(deckhouseVersion), milestone) < 0 {
+		input.Logger.Info("PSS default policy is set to baseline", slog.String("version", deckhouseVersion))
+		return "Privileged"
+	}
+
+	return "Baseline"
 }
 
 func getVersion(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/modules/015-admission-policy-engine/hooks/detect_pss_default_policy_test.go
+++ b/modules/015-admission-policy-engine/hooks/detect_pss_default_policy_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 				Name:   "d8_admission_policy_engine_pss_default_policy",
 				Group:  "d8_admission_policy_engine_pss_default_policy",
 				Action: operation.ActionGaugeSet,
-				Value:  ptr.To(3.0),
+				Value:  ptr.To(policyCode("Restricted")),
 				Labels: map[string]string{},
 			}))
 		})
@@ -67,9 +67,9 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
-		It("should have the default policy set to Privileged", func() {
+		It("should have the default policy set to Baseline", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("admissionPolicyEngine.podSecurityStandards.defaultPolicy").String()).To(Equal(pssPrivilegedPolicy))
+			Expect(f.ValuesGet("admissionPolicyEngine.podSecurityStandards.defaultPolicy").String()).To(Equal(pssBaselinePolicy))
 			m := f.MetricsCollector.CollectedMetrics()
 			Expect(m).To(HaveLen(2))
 			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
@@ -80,7 +80,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 				Name:   "d8_admission_policy_engine_pss_default_policy",
 				Group:  "d8_admission_policy_engine_pss_default_policy",
 				Action: operation.ActionGaugeSet,
-				Value:  ptr.To(1.0),
+				Value:  ptr.To(policyCode("Baseline")),
 				Labels: map[string]string{},
 			}))
 		})
@@ -92,9 +92,9 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
-		It("should have the default policy set to Privileged", func() {
+		It("should have the default policy set to Baseline", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("admissionPolicyEngine.podSecurityStandards.defaultPolicy").String()).To(Equal(pssPrivilegedPolicy))
+			Expect(f.ValuesGet("admissionPolicyEngine.podSecurityStandards.defaultPolicy").String()).To(Equal(pssBaselinePolicy))
 			m := f.MetricsCollector.CollectedMetrics()
 			Expect(m).To(HaveLen(2))
 			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
@@ -105,7 +105,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 				Name:   "d8_admission_policy_engine_pss_default_policy",
 				Group:  "d8_admission_policy_engine_pss_default_policy",
 				Action: operation.ActionGaugeSet,
-				Value:  ptr.To(1.0),
+				Value:  ptr.To(policyCode("Baseline")),
 				Labels: map[string]string{},
 			}))
 		})
@@ -117,9 +117,9 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
 			f.RunHook()
 		})
-		It("should have the default policy set to Privileged", func() {
+		It("should have the default policy set to Baseline", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("admissionPolicyEngine.podSecurityStandards.defaultPolicy").String()).To(Equal(pssPrivilegedPolicy))
+			Expect(f.ValuesGet("admissionPolicyEngine.podSecurityStandards.defaultPolicy").String()).To(Equal(pssBaselinePolicy))
 			m := f.MetricsCollector.CollectedMetrics()
 			Expect(m).To(HaveLen(2))
 			Expect(m[0]).To(BeEquivalentTo(operation.MetricOperation{
@@ -130,7 +130,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 				Name:   "d8_admission_policy_engine_pss_default_policy",
 				Group:  "d8_admission_policy_engine_pss_default_policy",
 				Action: operation.ActionGaugeSet,
-				Value:  ptr.To(1.0),
+				Value:  ptr.To(policyCode("Baseline")),
 				Labels: map[string]string{},
 			}))
 		})
@@ -155,7 +155,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 				Name:   "d8_admission_policy_engine_pss_default_policy",
 				Group:  "d8_admission_policy_engine_pss_default_policy",
 				Action: operation.ActionGaugeSet,
-				Value:  ptr.To(1.0),
+				Value:  ptr.To(policyCode("Privileged")),
 				Labels: map[string]string{},
 			}))
 		})
@@ -180,7 +180,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 				Name:   "d8_admission_policy_engine_pss_default_policy",
 				Group:  "d8_admission_policy_engine_pss_default_policy",
 				Action: operation.ActionGaugeSet,
-				Value:  ptr.To(2.0),
+				Value:  ptr.To(policyCode("Baseline")),
 				Labels: map[string]string{},
 			}))
 		})
@@ -205,7 +205,7 @@ var _ = Describe("Modules :: admission-policy-engine :: hooks :: detect pss defa
 				Name:   "d8_admission_policy_engine_pss_default_policy",
 				Group:  "d8_admission_policy_engine_pss_default_policy",
 				Action: operation.ActionGaugeSet,
-				Value:  ptr.To(2.0),
+				Value:  ptr.To(policyCode("Baseline")),
 				Labels: map[string]string{},
 			}))
 		})


### PR DESCRIPTION
## Description

Previously, unrecognized versions were set to `Privileged` mode, which contradicted the documentation. 
Now, `Baseline` mode is specified.

## Why do we need it, and what problem does it solve?

Users expect behavior as documented—for deckhouse versions higher than 1.54, the default policy is `Privileged`.
However, in some cases (for example, during a dev build), the hook fails to recognize the actual version and sets the default policy to `Privileged`. Now, in such cases, `Baseline` is set.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: admission-policy-engine
type: fix 
summary: Changed default PSS policy to Baseline for unrecognized deckhouse versions
impact_level: default 
```