### PR TITLE
[deckhouse] Fix vexes for deckhouse-controller and deckhouse-tools

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,8 +2,26 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 12,
+  "version": 13,
   "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-15558"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/docker/cli@v25.0.6+incompatible"},
+        {"@id": "pkg:golang/github.com/docker/cli@v27.1.1+incompatible"},
+        {"@id": "pkg:golang/github.com/docker/cli@v28.0.1+incompatible"},
+        {"@id": "pkg:golang/github.com/docker/cli@v28.0.2+incompatible"},
+        {"@id": "pkg:golang/github.com/docker/cli@v28.2.2+incompatible"},
+        {"@id": "pkg:golang/github.com/docker/cli@v28.3.3+incompatible"},
+        {"@id": "pkg:golang/github.com/docker/cli@v28.5.1+incompatible"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Docker CLI Windows plugin search path vulnerability - Уязвимость CWE-427 (Uncontrolled Search Path Element) в Docker CLI затрагивает исключительно среду Microsoft Windows: поиск бинарных плагинов в каталоге C:\\ProgramData\\Docker\\cli-plugins может позволить подмену исполняемых файлов. Компонент deckhouse-controller эксплуатируется в среде Kubernetes на базе Linux; официальное описание CVE указывает, что уязвимость не затрагивает бинарные файлы под платформы, отличные от Windows (non-Windows binaries). Таким образом, в рамках текущей эксплуатационной модели уязвимый код не входит в исполняемый путь и возможность эксплуатации исключена.",
+      "timestamp": "2026-03-05T12:00:00Z"
+    },
     {
       "vulnerability": {
         "name": "CVE-2026-24051"
@@ -23,9 +41,9 @@
         "name": "CVE-2025-47914"
       },
       "products": [
-        {
-          "@id": "pkg:golang/golang.org/x/crypto@v0.36.0"
-        }
+        {"@id": "pkg:golang/golang.org/x/crypto@v0.36.0"},
+        {"@id": "pkg:golang/golang.org/x/crypto@v0.38.0"},
+        {"@id": "pkg:golang/golang.org/x/crypto@v0.43.0"}
       ],
       "status": "affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
@@ -37,9 +55,9 @@
         "name": "CVE-2025-58181"
       },
       "products": [
-        {
-          "@id": "pkg:golang/golang.org/x/crypto@v0.36.0"
-        }
+        {"@id": "pkg:golang/golang.org/x/crypto@v0.36.0"},
+        {"@id": "pkg:golang/golang.org/x/crypto@v0.38.0"},
+        {"@id": "pkg:golang/golang.org/x/crypto@v0.43.0"}
       ],
       "status": "affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
@@ -187,6 +205,6 @@
       "timestamp": "2026-02-17T12:00:00Z"
     }
   ],
-  "timestamp": "2026-03-04T12:00:00Z",
-  "last_updated": "2026-03-04T12:00:00Z"
+  "timestamp": "2026-03-05T12:00:00Z",
+  "last_updated": "2026-03-05T12:00:00Z"
 }

--- a/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
+++ b/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
@@ -2,8 +2,22 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 12,
+  "version": 13,
   "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-15558"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/cli@v25.0.6+incompatible"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Docker CLI Windows plugin search path vulnerability - Уязвимость CWE-427 (Uncontrolled Search Path Element) в Docker CLI затрагивает исключительно среду Microsoft Windows: поиск бинарных плагинов в каталоге C:\\ProgramData\\Docker\\cli-plugins может позволить подмену исполняемых файлов. Компонент deckhouse-tools web эксплуатируется в среде Kubernetes на базе Linux; официальное описание CVE указывает, что уязвимость не затрагивает бинарные файлы под платформы, отличные от Windows (non-Windows binaries). Таким образом, в рамках текущей эксплуатационной модели уязвимый код не входит в исполняемый путь и возможность эксплуатации исключена.",
+      "timestamp": "2026-03-05T12:00:00Z"
+    },
     {
       "vulnerability": {
         "name": "CVE-2026-24051"
@@ -271,6 +285,6 @@
       "timestamp": "2025-11-13T00:00:00Z"
     }
   ],
-  "timestamp": "2026-03-04T12:00:00Z",
-  "last_updated": "2026-03-04T12:00:00Z"
+  "timestamp": "2026-03-05T12:00:00Z",
+  "last_updated": "2026-03-05T12:00:00Z"
 }


### PR DESCRIPTION
## Description
Fix vexes for deckhouse-controller and deckhouse-tools
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Users should be warned that we are aware of the bugs and they do not pose a threat.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Fix vexes for deckhouse, deckhouse-controller and deckhouse-tools.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
