### PR TITLE
[deckhouse] Fix vexes for deckhouse-controller and deckhouse-tools

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -45,7 +45,7 @@
         {"@id": "pkg:golang/golang.org/x/crypto@v0.38.0"},
         {"@id": "pkg:golang/golang.org/x/crypto@v0.43.0"}
       ],
-      "status": "affected",
+      "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Go x/crypto SSH Agent new identity requests vulnerability - Уязвимость в компоненте SSH Agent библиотеки golang.org/x/crypto, связанная с обработкой запросов добавления идентичностей (new identity requests), формально присутствует в используемой версии зависимости. Вместе с тем, в deckhouse-controller отсутствуют сценарии использования уязвимого функционала в контексте, допускающем управление параметрами и размерами обрабатываемых сообщений со стороны потенциального нарушителя. В результате условия эксплуатации уязвимости в рамках текущей архитектуры и эксплуатационной модели не выполняются.",
       "timestamp": "2026-03-04T12:00:00Z"
@@ -59,7 +59,7 @@
         {"@id": "pkg:golang/golang.org/x/crypto@v0.38.0"},
         {"@id": "pkg:golang/golang.org/x/crypto@v0.43.0"}
       ],
-      "status": "affected",
+      "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Go x/crypto GSSAPI authentication parsing vulnerability - Уязвимость, затрагивающая разбор механизмов аутентификации GSSAPI в библиотеке golang.org/x/crypto, формально присутствует в составе применяемой версии зависимости. При этом в архитектуре deckhouse-controller отсутствуют внешние входные данные и сценарии, позволяющие нарушителю контролировать количество и состав механизмов аутентификации, необходимых для воспроизведения условия уязвимости. Таким образом, эксплуатация уязвимости в рамках фактических процессов обработки и текущих функциональных спецификаций системы не представляется возможной.",
       "timestamp": "2026-03-04T12:00:00Z"

--- a/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
+++ b/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
@@ -83,7 +83,7 @@
           "@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"
         }
       ],
-      "status": "affected",
+      "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "go-git pack/index integrity verification bypass vulnerability - Уязвимость, связанная с проверкой целостности файлов .idx/.pack в go-git, формально присутствует в используемой версии зависимости. Однако реализация атаки требует подмены данных Git-репозитория на стороне источника. В типовой модели эксплуатации deckhouse-tools web источники репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности управлять входными данными в необходимом объеме и существенно снижает применимость сценария эксплуатации.",
       "timestamp": "2026-03-04T12:00:00Z"


### PR DESCRIPTION
## Description
Fix vexes for deckhouse-controller and deckhouse-tools
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Users should be warned that we are aware of the bugs and they do not pose a threat.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Fix vexes for deckhouse, deckhouse-controller and deckhouse-tools.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
