### PR TITLE
[docs] Standardize the naming of the Ingress controller

### DIFF
--- a/docs/site/backends/docs-builder-template/data/dkp/embedded_modules.json
+++ b/docs/site/backends/docs-builder-template/data/dkp/embedded_modules.json
@@ -967,7 +967,7 @@
     },
     {
       "title": "The ingress-nginx module",
-      "description": "HTTP/HTTPS traffic balancing and termination in the Deckhouse Kubernetes Platform cluster using NGINX Ingress controller.",
+      "description": "HTTP/HTTPS traffic balancing and termination in the Deckhouse Kubernetes Platform cluster using Ingress NGINX controller.",
       "module": "ingress-nginx",
       "embedded": "true",
       "tags": [
@@ -979,7 +979,7 @@
       "url": "ingress-nginx/",
       "ru": {
         "title": "Модуль ingress-nginx",
-        "description": "Балансировка и терминация трафика HTTP/HTTPS в кластере Deckhouse Kubernetes Platform с помощью NGINX Ingress controller."
+        "description": "Балансировка и терминация трафика HTTP/HTTPS в кластере Deckhouse Kubernetes Platform с помощью Ingress NGINX controller."
       },
       "metadata": {
         "name": "ingress-nginx",
@@ -994,7 +994,7 @@
         },
         "oss": [
           {
-            "name": "NGINX Ingress Controller",
+            "name": "Ingress NGINX Controller",
             "link": "https://github.com/kubernetes/ingress-nginx",
             "description": "A ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.",
             "logo": "/images/logos/kubernetes.svg",

--- a/docs/site/backends/docs-builder-template/data/dkp/embedded_modules_metadata.json
+++ b/docs/site/backends/docs-builder-template/data/dkp/embedded_modules_metadata.json
@@ -522,7 +522,7 @@
       },
       "oss": [
         {
-          "name": "NGINX Ingress Controller",
+          "name": "Ingress NGINX Controller",
           "link": "https://github.com/kubernetes/ingress-nginx",
           "description": "A ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.",
           "logo": "/images/logos/kubernetes.svg",
@@ -1555,7 +1555,7 @@
         "prometheus"
       ]
     },
-    "NGINX Ingress Controller": {
+    "Ingress NGINX Controller": {
       "link": "https://github.com/kubernetes/ingress-nginx",
       "description": "A ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.",
       "logo": "/images/logos/kubernetes.svg",

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT.md
@@ -1384,14 +1384,14 @@ kruise-controller-manager-7dfcbdc549-b4wk7   3/3     Running   0           15m
 Create the `ingress-nginx-controller.yml` file on the master node containing the Ingress controller configuration:
 
 ```yaml
-# NGINX Ingress controller parameters.
+# Ingress NGINX controller parameters.
 # https://deckhouse.io/modules/ingress-nginx/cr.html
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
 metadata:
   name: nginx
 spec:
-  # The name of the IngressClass served by the NGINX Ingress controller.
+  # The name of the IngressClass served by the Ingress NGINX controller.
   ingressClass: nginx
   # How traffic enters from outside the cluster.
   inlet: HostPort

--- a/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
+++ b/docs/site/pages/guides/PRIVATE_ENVIRONMENT_RU.md
@@ -1402,14 +1402,14 @@ kruise-controller-manager-7dfcbdc549-b4wk7   3/3     Running   0           15m
 Создайте на master-узле файл `ingress-nginx-controller.yml`, содержащий конфигурацию Ingress-контроллера:
 
 ```yaml
-# Секция, описывающая параметры NGINX Ingress controller.
+# Секция, описывающая параметры Ingress NGINX controller.
 # https://deckhouse.ru/modules/ingress-nginx/cr.html
 apiVersion: deckhouse.io/v1
 kind: IngressNginxController
 metadata:
   name: nginx
 spec:
-  # Имя Ingress-класса для обслуживания NGINX Ingress controller.
+  # Имя Ingress-класса для обслуживания Ingress NGINX controller.
   ingressClass: nginx
   # Способ поступления трафика из внешнего мира.
   inlet: HostPort

--- a/modules/402-ingress-nginx/oss.yaml
+++ b/modules/402-ingress-nginx/oss.yaml
@@ -1,4 +1,4 @@
-- name: NGINX Ingress Controller
+- name: Ingress NGINX Controller
   link: https://github.com/kubernetes/ingress-nginx
   description: A ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.
   logo: /images/logos/kubernetes.svg


### PR DESCRIPTION
## Description

This pull request standardizes the naming of the Ingress controller throughout the documentation and metadata files, changing references from "NGINX Ingress Controller" to "Ingress NGINX Controller". 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Standardize the naming of the Ingress controller.
impact_level: low
```
