### PR TITLE
[candi] Enable DRA alpha feature gate DRAPartitionableDevices

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -328,13 +328,21 @@ featureGates:
   InPlacePodVerticalScaling: true
 {{- end }}
 {{- if semverCompare ">=1.32 <1.34" .kubernetesVersion }}
+{{- /* DynamicResourceAllocation: GA default=true since 1.34, explicitly enable for 1.32-1.33 */}}
   DynamicResourceAllocation: true
 {{- end }}
-{{- if semverCompare ">=1.34" .kubernetesVersion }}
-  DRADeviceBindingConditions: true
+{{- if semverCompare ">=1.32 <1.33" .kubernetesVersion }}
+{{- /* DRAResourceClaimDeviceStatus: Alpha in 1.32, Beta in 1.33 (for BindsToNode) */}}
   DRAResourceClaimDeviceStatus: true
-  DRAConsumableCapacity: true
+{{- end }}
+{{- if semverCompare ">=1.33" .kubernetesVersion }}
+{{- /* DRAPartitionableDevices: Alpha in 1.33 (for NodeSelector per device) */}}
   DRAPartitionableDevices: true
+{{- end }}
+{{- if semverCompare ">=1.34" .kubernetesVersion }}
+{{- /* DRADeviceBindingConditions, DRAConsumableCapacity: Alpha in 1.34 (multi-allocations: BindsToNode, AllowMultipleAllocations) */}}
+  DRADeviceBindingConditions: true
+  DRAConsumableCapacity: true
 {{- end }}
 {{- range .allowedKubeletFeatureGates }}
   {{ . }}: true

--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -334,6 +334,7 @@ featureGates:
   DRADeviceBindingConditions: true
   DRAResourceClaimDeviceStatus: true
   DRAConsumableCapacity: true
+  DRAPartitionableDevices: true
 {{- end }}
 {{- range .allowedKubeletFeatureGates }}
   {{ . }}: true

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -3,21 +3,22 @@ RotateKubeletServerCertificate default is true, but CIS benchmark wants it to be
 https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 */ -}}
 {{- $baseFeatureGates := list "TopologyAwareHints=true" "RotateKubeletServerCertificate=true" -}}
-{{- /* DynamicResourceAllocation: GA default=true since 1.34, explicitly enable for 1.32-1.33 */ -}}
 {{- if semverCompare ">=1.32 <1.34" .clusterConfiguration.kubernetesVersion }}
+  {{- /* DynamicResourceAllocation: GA default=true since 1.34, explicitly enable for 1.32-1.33 */ -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DynamicResourceAllocation=true" -}}
 {{- end }}
 {{- if semverCompare ">=1.34" .clusterConfiguration.kubernetesVersion -}}
-  {{- /*
-  Enable DRA multi-allocations by activating required feature gates:
-  DRADeviceBindingConditions and DRAResourceClaimDeviceStatus (for BindsToNode)
-  DRAConsumableCapacity (for AllowMultipleAllocations)
-  DRAPartitionableDevices (for NodeSelector per device)
-  */ -}}
+  {{- /* DRADeviceBindingConditions, DRAConsumableCapacity: Alpha in 1.34 (multi-allocations: BindsToNode, AllowMultipleAllocations) */ -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceBindingConditions=true" -}}
-  {{- $baseFeatureGates = append $baseFeatureGates "DRAResourceClaimDeviceStatus=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
+{{- end }}
+{{- if semverCompare ">=1.33" .clusterConfiguration.kubernetesVersion }}
+  {{- /* DRAPartitionableDevices: Alpha in 1.33 (for NodeSelector per device) */ -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAPartitionableDevices=true" -}}
+{{- end }}
+{{- if semverCompare ">=1.32 <1.33" .clusterConfiguration.kubernetesVersion }}
+  {{- /* DRAResourceClaimDeviceStatus: Alpha in 1.32, Beta in 1.33 (for BindsToNode) */ -}}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRAResourceClaimDeviceStatus=true" -}}
 {{- end }}
 {{- if semverCompare "<=1.32" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "InPlacePodVerticalScaling=true" -}}

--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -12,10 +12,12 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
   Enable DRA multi-allocations by activating required feature gates:
   DRADeviceBindingConditions and DRAResourceClaimDeviceStatus (for BindsToNode)
   DRAConsumableCapacity (for AllowMultipleAllocations)
+  DRAPartitionableDevices (for NodeSelector per device)
   */ -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRADeviceBindingConditions=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAResourceClaimDeviceStatus=true" -}}
   {{- $baseFeatureGates = append $baseFeatureGates "DRAConsumableCapacity=true" -}}
+  {{- $baseFeatureGates = append $baseFeatureGates "DRAPartitionableDevices=true" -}}
 {{- end }}
 {{- if semverCompare "<=1.32" .clusterConfiguration.kubernetesVersion }}
   {{- $baseFeatureGates = append $baseFeatureGates "InPlacePodVerticalScaling=true" -}}


### PR DESCRIPTION
## Description
This PR enables the **alpha feature gate** `DRAPartitionableDevices`.

The `DRAPartitionableDevices` feature gate allows devices managed through **Dynamic Resource Allocation (DRA)** to be partitioned and exposes **per-device `NodeSelector` support**. This makes it possible to specify node selection constraints for individual devices rather than applying them only at the resource or claim level.

With this feature enabled:
- Devices can define their own `NodeSelector` constraints.
- The scheduler can take device-specific node requirements into account during allocation.

This functionality is currently **alpha** and available starting from **Kubernetes 1.33+**.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Enabled DRA alpha feature gate `DRAPartitionableDevices`.
impact_level: default
impact: Kubelet, api-server, controller-manager and scheduler will be restarted.
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
