### PR TITLE
[cloud-provider-yandex] fix external IP removal from nodes

### DIFF
--- a/modules/030-cloud-provider-yandex/candi/terraform-modules/master-node/main.tf
+++ b/modules/030-cloud-provider-yandex/candi/terraform-modules/master-node/main.tf
@@ -57,29 +57,29 @@ data "yandex_vpc_subnet" "kube_d" {
 resource "yandex_vpc_address" "addr" {
   count = (var.nodeIndex < length(local.external_ip_addresses)
     ? (local.external_ip_addresses[var.nodeIndex] == "Auto" ? 1 : 0)
-    : (length(local.external_ip_addresses) > 0 ? 1 : 0))
-  name  = join("-", [local.prefix, "master", var.nodeIndex])
+  : (length(local.external_ip_addresses) > 0 ? 1 : 0))
+  name = join("-", [local.prefix, "master", var.nodeIndex])
 
   external_ipv4_address {
     zone_id = local.internal_subnet.zone
   }
 
-#   If we specify this flag and change the zone_id, terraform will exit with an error.
-#   lifecycle {
-#     create_before_destroy = true
-#   }
+  #   If we specify this flag and change the zone_id, terraform will exit with an error.
+  #   lifecycle {
+  #     create_before_destroy = true
+  #   }
 }
 
 locals {
   external_ip_address = (var.nodeIndex < length(local.external_ip_addresses)
     ? (local.external_ip_addresses[var.nodeIndex] == "Auto"
-      ? yandex_vpc_address.addr[0].external_ipv4_address[0].address
-      : local.external_ip_addresses[var.nodeIndex])
+      ? try(yandex_vpc_address.addr[0].external_ipv4_address[0].address, null)
+    : local.external_ip_addresses[var.nodeIndex])
     : (length(local.external_ip_addresses) > 0
-      ? yandex_vpc_address.addr[0].external_ipv4_address[0].address
+      ? try(yandex_vpc_address.addr[0].external_ipv4_address[0].address, null)
       : null
-      )
     )
+  )
 }
 
 resource "yandex_compute_disk" "kubernetes_data" {
@@ -150,6 +150,7 @@ resource "yandex_compute_instance" "master" {
       metadata,
       secondary_disk,
     ]
+    create_before_destroy = true
   }
 
   timeouts {

--- a/modules/030-cloud-provider-yandex/candi/terraform-modules/master-node/outputs.tf
+++ b/modules/030-cloud-provider-yandex/candi/terraform-modules/master-node/outputs.tf
@@ -17,7 +17,13 @@ locals {
 }
 
 output "master_ip_address_for_ssh" {
-  value = lookup(yandex_compute_instance.master.network_interface.0, "nat_ip_address", "") != "" ? yandex_compute_instance.master.network_interface.0.nat_ip_address : yandex_compute_instance.master.network_interface.0.ip_address
+  value = ( 
+    lookup(yandex_compute_instance.master.network_interface.0, "nat_ip_address", "") != "" ? 
+      (yandex_compute_instance.master.network_interface.0.nat == true ? 
+         yandex_compute_instance.master.network_interface.0.nat_ip_address : 
+         yandex_compute_instance.master.network_interface.0.ip_address) : 
+      yandex_compute_instance.master.network_interface.0.ip_address
+  )
 }
 
 output "node_internal_ip_address" {

--- a/modules/030-cloud-provider-yandex/candi/terraform-modules/static-node/main.tf
+++ b/modules/030-cloud-provider-yandex/candi/terraform-modules/static-node/main.tf
@@ -34,23 +34,23 @@ locals {
 }
 
 data "yandex_vpc_subnet" "existing" {
-  for_each = local.mapping
+  for_each  = local.mapping
   subnet_id = each.value
 }
 
 data "yandex_vpc_subnet" "kube_a" {
   count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-a"
+  name  = "${local.prefix}-a"
 }
 
 data "yandex_vpc_subnet" "kube_b" {
   count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-b"
+  name  = "${local.prefix}-b"
 }
 
 data "yandex_vpc_subnet" "kube_d" {
   count = length(local.mapping) == 0 ? 1 : 0
-  name = "${local.prefix}-d"
+  name  = "${local.prefix}-d"
 }
 
 resource "yandex_vpc_address" "addr" {
@@ -63,10 +63,11 @@ resource "yandex_vpc_address" "addr" {
 }
 
 locals {
-  # null if var.nodeIndex < length(local.external_ip_addresses)
-  # yandex_vpc_address.addr[0].external_ipv4_address[0].address if local.external_ip_addresses == Auto
-  # local.external_ip_addresses[var.nodeIndex] if local.external_ip_addresses contain IP-addresses
-  external_ip = var.nodeIndex < length(local.external_ip_addresses) ? local.external_ip_addresses[var.nodeIndex] == "Auto" ? yandex_vpc_address.addr[0].external_ipv4_address[0].address : local.external_ip_addresses[var.nodeIndex] : null
+  external_ip = var.nodeIndex < length(local.external_ip_addresses) ? (
+    local.external_ip_addresses[var.nodeIndex] == "Auto" ? (
+      try(yandex_vpc_address.addr[0].external_ipv4_address[0].address, null)
+    ) : local.external_ip_addresses[var.nodeIndex]
+  ) : null
 }
 
 resource "yandex_compute_instance" "static" {
@@ -115,6 +116,7 @@ resource "yandex_compute_instance" "static" {
       metadata,
       secondary_disk,
     ]
+    create_before_destroy = true
   }
 
   timeouts {


### PR DESCRIPTION
## Description
Fixed the issue where removing externalIPAddresses parameter from CloudPermanent or master nodes caused Terraform to fail with error: rpc error: code = FailedPrecondition desc = Address in use. Changes:
- Added try() function when accessing yandex_vpc_address resource to gracefully handle cases when the address is being removed
- Added create_before_destroy = true to compute instance lifecycle to ensure proper resource deletion order

## Why do we need it, and what problem does it solve?
Fixes #15751 Currently, users cannot remove public IP addresses from nodes after they've been assigned. Any attempt to remove the externalIPAddresses parameter from CloudPermanent node configuration results in Terraform convergence failure with "Address in use" error. This blocks users from:
- Migrating nodes from public to private network configuration
- Reducing infrastructure costs by removing unused public IPs
- Implementing security improvements by removing public network access

The fix enables smooth removal of external IP addresses without manual intervention or node recreation.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Fixed removing public IP addresses from nodes by deleting `externalIPAddresses`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
