### PR TITLE
[cni-cilium] RBAC v2 metadata.labels render via helm_lib_module_labels

### DIFF
--- a/modules/021-cni-cilium/templates/rbacv2/manage/edit.yaml
+++ b/modules/021-cni-cilium/templates/rbacv2/manage/edit.yaml
@@ -1,14 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: cni-cilium
-    rbac.deckhouse.io/aggregate-to-networking-as: manager
-    rbac.deckhouse.io/kind: manage
-    rbac.deckhouse.io/level: module
-    rbac.deckhouse.io/namespace: d8-cni-cilium
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-networking-as" "manager" "rbac.deckhouse.io/kind" "manage" "rbac.deckhouse.io/level" "module" "rbac.deckhouse.io/namespace" "d8-cni-cilium")) | nindent 2 }}
   name: d8:manage:permission:module:cni-cilium:edit
 rules:
 - apiGroups:

--- a/modules/021-cni-cilium/templates/rbacv2/manage/view.yaml
+++ b/modules/021-cni-cilium/templates/rbacv2/manage/view.yaml
@@ -1,14 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: cni-cilium
-    rbac.deckhouse.io/aggregate-to-networking-as: viewer
-    rbac.deckhouse.io/kind: manage
-    rbac.deckhouse.io/level: module
-    rbac.deckhouse.io/namespace: d8-cni-cilium
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-networking-as" "viewer" "rbac.deckhouse.io/kind" "manage" "rbac.deckhouse.io/level" "module" "rbac.deckhouse.io/namespace" "d8-cni-cilium")) | nindent 2 }}
   name: d8:manage:permission:module:cni-cilium:view
 rules:
 - apiGroups:

--- a/modules/021-cni-cilium/templates/rbacv2/use/edit.yaml
+++ b/modules/021-cni-cilium/templates/rbacv2/use/edit.yaml
@@ -1,13 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: cni-cilium
-    rbac.deckhouse.io/aggregate-to-kubernetes-as: manager
-    rbac.deckhouse.io/aggregate-to-networking-as: manager
-    rbac.deckhouse.io/kind: use
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-kubernetes-as" "manager" "rbac.deckhouse.io/aggregate-to-networking-as" "manager" "rbac.deckhouse.io/kind" "use")) | nindent 2 }}
   name: d8:use:capability:module:cni-cilium:edit
 rules:
 - apiGroups:

--- a/modules/021-cni-cilium/templates/rbacv2/use/view.yaml
+++ b/modules/021-cni-cilium/templates/rbacv2/use/view.yaml
@@ -1,13 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
-  labels:
-    heritage: deckhouse
-    module: cni-cilium
-    rbac.deckhouse.io/aggregate-to-kubernetes-as: viewer
-    rbac.deckhouse.io/aggregate-to-networking-as: viewer
-    rbac.deckhouse.io/kind: use
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-kubernetes-as" "viewer" "rbac.deckhouse.io/aggregate-to-networking-as" "viewer" "rbac.deckhouse.io/kind" "use")) | nindent 2 }}
   name: d8:use:capability:module:cni-cilium:view
 rules:
 - apiGroups:


### PR DESCRIPTION
## Description
Replaced plain labels in ClusterRole resource with `{{- include "helm_lib_module_labels" }}`

## Why do we need it, and what problem does it solve?
Unifying render of metadata.labels in ClusterRole resource.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: chore
summary: metadata.labels render changed to use "helm_lib_module_labels"
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
