### PR TITLE
[istio] Merge public services by hostname across federations

### DIFF
--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"sort"
 	"strings"
@@ -32,14 +33,14 @@ import (
 )
 
 type IstioFederationMergeCrdInfo struct {
-	Name             string                             `json:"name"`
-	TrustDomain      string                             `json:"trustDomain"`
-	SpiffeEndpoint   string                             `json:"spiffeEndpoint"`
-	IngressGateways  *[]eeCrd.FederationIngressGateways `json:"ingressGateways"`
-	MetadataCA       string                             `json:"ca"`
-	MetadataInsecure bool                               `json:"insecureSkipVerify"`
-	PublicServices   *[]eeCrd.FederationPublicServices  `json:"publicServices"`
-	Public           *eeCrd.AlliancePublicMetadata      `json:"public,omitempty"`
+	Name             string                            `json:"name"`
+	TrustDomain      string                            `json:"trustDomain"`
+	SpiffeEndpoint   string                            `json:"spiffeEndpoint"`
+	IngressGateways  *[]eeCrd.FederationIngressGateway `json:"ingressGateways"`
+	MetadataCA       string                            `json:"ca"`
+	MetadataInsecure bool                              `json:"insecureSkipVerify"`
+	PublicServices   *[]eeCrd.FederationPublicService  `json:"publicServices"`
+	Public           *eeCrd.AlliancePublicMetadata     `json:"public,omitempty"`
 }
 
 type IstioMulticlusterMergeCrdInfo struct {
@@ -55,27 +56,43 @@ type IstioMulticlusterMergeCrdInfo struct {
 	Public               *eeCrd.AlliancePublicMetadata        `json:"public,omitempty"`
 }
 
-type PublicServiceEndpoint struct {
-	Address string `json:"address"`
-	Port    uint   `json:"port"`
-}
-
-type PublicService struct {
+type ServiceEntry struct {
+	Name      string                              `json:"name"`
 	Hostname  string                              `json:"hostname"`
 	Ports     []eeCrd.FederationPublicServicePort `json:"ports"`
-	Endpoints []PublicServiceEndpoint             `json:"endpoints"`
+	Endpoints []eeCrd.FederationIngressGateway    `json:"endpoints"`
 }
 
-func portsEqual(a, b []eeCrd.FederationPublicServicePort) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
+func sortedEndpointsKey(endpoints []eeCrd.FederationIngressGateway) string {
+	sorted := make([]eeCrd.FederationIngressGateway, len(endpoints))
+	copy(sorted, endpoints)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Address != sorted[j].Address {
+			return sorted[i].Address < sorted[j].Address
 		}
+		return sorted[i].Port < sorted[j].Port
+	})
+	parts := make([]string, len(sorted))
+	for i, ep := range sorted {
+		parts[i] = fmt.Sprintf("%s:%d", ep.Address, ep.Port)
 	}
-	return true
+	return strings.Join(parts, ",")
+}
+
+const safeChars = "bcdfghjklmnpqrstvwxz2456789"
+
+func safeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []byte(s) {
+		r[i] = safeChars[int(b)%len(safeChars)]
+	}
+	return string(r)
+}
+
+func serviceEntryName(hostname string, endpoints []eeCrd.FederationIngressGateway) string {
+	h := fnv.New32a()
+	h.Write([]byte(sortedEndpointsKey(endpoints)))
+	return hostname + "-" + safeEncodeString(fmt.Sprint(h.Sum32()))
 }
 
 func applyFederationMergeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -88,8 +105,8 @@ func applyFederationMergeFilter(obj *unstructured.Unstructured) (go_hook.FilterR
 	me := federation.Spec.MetadataEndpoint
 	me = strings.TrimSuffix(me, "/")
 
-	var igs *[]eeCrd.FederationIngressGateways
-	var pss *[]eeCrd.FederationPublicServices
+	var igs *[]eeCrd.FederationIngressGateway
+	var pss *[]eeCrd.FederationPublicService
 	var p *eeCrd.AlliancePublicMetadata
 
 	if federation.Status.MetadataCache.Private != nil {
@@ -388,51 +405,113 @@ federationsLoop:
 		properFederations = append(properFederations, federationInfo)
 	}
 
-	// Merge public services by hostname across all federations.
-	// Ports use first-wins: the first federation to declare a hostname defines the ports.
-	// Endpoints are aggregated from all federations' ingress gateways that expose the hostname.
-	// Each federation contributes its ingress gateways at most once per hostname, even if the
-	// hostname appears multiple times in the federation's publicServices list.
-	mergedServicesMap := make(map[string]*PublicService)
+	// Build ServiceEntries by merging endpoints across federations for each
+	// (hostname, port) pair, then grouping ports that share the same hostname
+	// and endpoint set into a single ServiceEntry.
+	// Port collisions (same number, different name/protocol) are first-wins with a warning.
+
+	portDefs := make(map[string]map[uint]eeCrd.FederationPublicServicePort)
+	portEndpoints := make(map[string]map[uint]map[eeCrd.FederationIngressGateway]struct{})
+
 	for _, fed := range properFederations {
-		// First pass: register hostnames with ports (first-wins).
+		if fed.PublicServices == nil || fed.IngressGateways == nil {
+			continue
+		}
+
+		seenInFed := make(map[string]map[uint]struct{}) // hostname -> set of port numbers
 		for _, ps := range *fed.PublicServices {
-			if _, ok := mergedServicesMap[ps.Hostname]; !ok {
-				mergedServicesMap[ps.Hostname] = &PublicService{
-					Hostname:  ps.Hostname,
-					Ports:     ps.Ports,
-					Endpoints: make([]PublicServiceEndpoint, 0),
+			if seenInFed[ps.Hostname] == nil {
+				seenInFed[ps.Hostname] = make(map[uint]struct{})
+			}
+			if portDefs[ps.Hostname] == nil {
+				portDefs[ps.Hostname] = make(map[uint]eeCrd.FederationPublicServicePort)
+				portEndpoints[ps.Hostname] = make(map[uint]map[eeCrd.FederationIngressGateway]struct{})
+			}
+
+			for _, port := range ps.Ports {
+				if _, dup := seenInFed[ps.Hostname][port.Port]; dup {
+					continue
 				}
-			} else if !portsEqual(mergedServicesMap[ps.Hostname].Ports, ps.Ports) {
-				input.Logger.Warn("federation declares different ports for already known hostname, keeping first definition",
-					slog.String("federation", fed.Name),
-					slog.String("hostname", ps.Hostname),
-				)
-			}
-		}
+				seenInFed[ps.Hostname][port.Port] = struct{}{}
 
-		// Second pass: append this federation's ingress gateways once per unique hostname.
-		seenHostnames := make(map[string]struct{})
-		for _, ps := range *fed.PublicServices {
-			if _, already := seenHostnames[ps.Hostname]; already {
-				continue
-			}
-			seenHostnames[ps.Hostname] = struct{}{}
-			for _, ig := range *fed.IngressGateways {
-				mergedServicesMap[ps.Hostname].Endpoints = append(
-					mergedServicesMap[ps.Hostname].Endpoints,
-					PublicServiceEndpoint{Address: ig.Address, Port: ig.Port},
-				)
+				if existing, ok := portDefs[ps.Hostname][port.Port]; !ok {
+					portDefs[ps.Hostname][port.Port] = port
+					eps := make(map[eeCrd.FederationIngressGateway]struct{}, len(*fed.IngressGateways))
+					for _, ig := range *fed.IngressGateways {
+						eps[ig] = struct{}{}
+					}
+					portEndpoints[ps.Hostname][port.Port] = eps
+				} else {
+					if existing.Name != port.Name || existing.Protocol != port.Protocol {
+						input.Logger.Warn("port collision: same hostname and port number with different name/protocol across federations, keeping first definition",
+							slog.String("federation", fed.Name),
+							slog.String("hostname", ps.Hostname),
+							slog.Uint64("port", uint64(port.Port)),
+							slog.String("existing_name", existing.Name),
+							slog.String("existing_protocol", existing.Protocol),
+							slog.String("conflicting_name", port.Name),
+							slog.String("conflicting_protocol", port.Protocol),
+						)
+					}
+					for _, ig := range *fed.IngressGateways {
+						portEndpoints[ps.Hostname][port.Port][ig] = struct{}{}
+					}
+				}
 			}
 		}
 	}
 
-	mergedServices := make([]PublicService, 0, len(mergedServicesMap))
-	for _, svc := range mergedServicesMap {
-		mergedServices = append(mergedServices, *svc)
+	// Group ports sharing the same hostname and endpoint set into ServiceEntries.
+	// hostname -> endpointSetKey -> *ServiceEntry
+
+	serviceEntriesByHost := make(map[string]map[string]*ServiceEntry)
+	for hostname, ports := range portDefs {
+		for portNum, port := range ports {
+			endpoints := make([]eeCrd.FederationIngressGateway, 0, len(portEndpoints[hostname][portNum]))
+			for ep := range portEndpoints[hostname][portNum] {
+				endpoints = append(endpoints, ep)
+			}
+			epKey := sortedEndpointsKey(endpoints)
+
+			byEpKey := serviceEntriesByHost[hostname]
+			if byEpKey == nil {
+				byEpKey = make(map[string]*ServiceEntry)
+				serviceEntriesByHost[hostname] = byEpKey
+			}
+
+			if se, ok := byEpKey[epKey]; ok {
+				se.Ports = append(se.Ports, port)
+			} else {
+				byEpKey[epKey] = &ServiceEntry{
+					Hostname:  hostname,
+					Ports:     []eeCrd.FederationPublicServicePort{port},
+					Endpoints: endpoints,
+				}
+			}
+		}
 	}
-	sort.Slice(mergedServices, func(i, j int) bool {
-		return mergedServices[i].Hostname < mergedServices[j].Hostname
+
+	serviceEntries := make([]ServiceEntry, 0)
+	for _, byEpKey := range serviceEntriesByHost {
+		for _, se := range byEpKey {
+			sort.Slice(se.Ports, func(i, j int) bool {
+				return se.Ports[i].Port < se.Ports[j].Port
+			})
+			sort.Slice(se.Endpoints, func(i, j int) bool {
+				if se.Endpoints[i].Address != se.Endpoints[j].Address {
+					return se.Endpoints[i].Address < se.Endpoints[j].Address
+				}
+				return se.Endpoints[i].Port < se.Endpoints[j].Port
+			})
+			se.Name = serviceEntryName(se.Hostname, se.Endpoints)
+			serviceEntries = append(serviceEntries, *se)
+		}
+	}
+	sort.Slice(serviceEntries, func(i, j int) bool {
+		if serviceEntries[i].Hostname != serviceEntries[j].Hostname {
+			return serviceEntries[i].Hostname < serviceEntries[j].Hostname
+		}
+		return serviceEntries[i].Ports[0].Port < serviceEntries[j].Ports[0].Port
 	})
 
 multiclustersLoop:
@@ -510,7 +589,7 @@ multiclustersLoop:
 	}
 
 	input.Values.Set("istio.internal.federations", properFederations)
-	input.Values.Set("istio.internal.federationsMergedPublicServices", mergedServices)
+	input.Values.Set("istio.internal.serviceEntries", serviceEntries)
 	input.Values.Set("istio.internal.multiclusters", properMulticlusters)
 	input.Values.Set("istio.internal.multiclustersNeedIngressGateway", multiclustersNeedIngressGateway)
 	input.Values.Set("istio.internal.remotePublicMetadata", remotePublicMetadata)

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -589,7 +589,7 @@ multiclustersLoop:
 	}
 
 	input.Values.Set("istio.internal.federations", properFederations)
-	input.Values.Set("istio.internal.serviceEntries", serviceEntries)
+	input.Values.Set("istio.internal.federationServiceEntries", serviceEntries)
 	input.Values.Set("istio.internal.multiclusters", properMulticlusters)
 	input.Values.Set("istio.internal.multiclustersNeedIngressGateway", multiclustersNeedIngressGateway)
 	input.Values.Set("istio.internal.remotePublicMetadata", remotePublicMetadata)

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -92,7 +92,7 @@ func safeEncodeString(s string) string {
 func serviceEntryName(hostname string, endpoints []eeCrd.FederationIngressGateway) string {
 	h := fnv.New32a()
 	h.Write([]byte(sortedEndpointsKey(endpoints)))
-	return hostname + "-" + safeEncodeString(fmt.Sprint(h.Sum32()))
+	return strings.ReplaceAll(hostname, ".", "-") + "-" + safeEncodeString(fmt.Sprint(h.Sum32()))
 }
 
 func applyFederationMergeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -379,28 +379,33 @@ federationsLoop:
 	// Merge public services by hostname across all federations.
 	// Ports use first-wins: the first federation to declare a hostname defines the ports.
 	// Endpoints are aggregated from all federations' ingress gateways that expose the hostname.
+	// Each federation contributes its ingress gateways at most once per hostname, even if the
+	// hostname appears multiple times in the federation's publicServices list.
 	mergedServicesMap := make(map[string]*PublicService)
 	for _, fed := range properFederations {
-		if fed.PublicServices == nil {
-			continue
-		}
+		// First pass: register hostnames with ports (first-wins).
 		for _, ps := range *fed.PublicServices {
-			existing, ok := mergedServicesMap[ps.Hostname]
-			if !ok {
-				existing = &PublicService{
+			if _, ok := mergedServicesMap[ps.Hostname]; !ok {
+				mergedServicesMap[ps.Hostname] = &PublicService{
 					Hostname:  ps.Hostname,
 					Ports:     ps.Ports,
 					Endpoints: make([]PublicServiceEndpoint, 0),
 				}
-				mergedServicesMap[ps.Hostname] = existing
 			}
-			if fed.IngressGateways != nil {
-				for _, ig := range *fed.IngressGateways {
-					existing.Endpoints = append(existing.Endpoints, PublicServiceEndpoint{
-						Address: ig.Address,
-						Port:    ig.Port,
-					})
-				}
+		}
+
+		// Second pass: append this federation's ingress gateways once per unique hostname.
+		seenHostnames := make(map[string]struct{})
+		for _, ps := range *fed.PublicServices {
+			if _, already := seenHostnames[ps.Hostname]; already {
+				continue
+			}
+			seenHostnames[ps.Hostname] = struct{}{}
+			for _, ig := range *fed.IngressGateways {
+				mergedServicesMap[ps.Hostname].Endpoints = append(
+					mergedServicesMap[ps.Hostname].Endpoints,
+					PublicServiceEndpoint{Address: ig.Address, Port: ig.Port},
+				)
 			}
 		}
 	}

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -66,6 +66,18 @@ type PublicService struct {
 	Endpoints []PublicServiceEndpoint             `json:"endpoints"`
 }
 
+func portsEqual(a, b []eeCrd.FederationPublicServicePort) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func applyFederationMergeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	var federation eeCrd.IstioFederation
 	err := sdk.FromUnstructured(obj, &federation)
@@ -391,6 +403,11 @@ federationsLoop:
 					Ports:     ps.Ports,
 					Endpoints: make([]PublicServiceEndpoint, 0),
 				}
+			} else if !portsEqual(mergedServicesMap[ps.Hostname].Ports, ps.Ports) {
+				input.Logger.Warn("federation declares different ports for already known hostname, keeping first definition",
+					slog.String("federation", fed.Name),
+					slog.String("hostname", ps.Hostname),
+				)
 			}
 		}
 

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -52,6 +53,17 @@ type IstioMulticlusterMergeCrdInfo struct {
 	APIJWT               string                               `json:"apiJWT"`
 	IngressGateways      *[]eeCrd.MulticlusterIngressGateways `json:"ingressGateways"`
 	Public               *eeCrd.AlliancePublicMetadata        `json:"public,omitempty"`
+}
+
+type PublicServiceEndpoint struct {
+	Address string `json:"address"`
+	Port    uint   `json:"port"`
+}
+
+type PublicService struct {
+	Hostname  string                              `json:"hostname"`
+	Ports     []eeCrd.FederationPublicServicePort `json:"ports"`
+	Endpoints []PublicServiceEndpoint             `json:"endpoints"`
 }
 
 func applyFederationMergeFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -364,6 +376,43 @@ federationsLoop:
 		properFederations = append(properFederations, federationInfo)
 	}
 
+	// Merge public services by hostname across all federations.
+	// Ports use first-wins: the first federation to declare a hostname defines the ports.
+	// Endpoints are aggregated from all federations' ingress gateways that expose the hostname.
+	mergedServicesMap := make(map[string]*PublicService)
+	for _, fed := range properFederations {
+		if fed.PublicServices == nil {
+			continue
+		}
+		for _, ps := range *fed.PublicServices {
+			existing, ok := mergedServicesMap[ps.Hostname]
+			if !ok {
+				existing = &PublicService{
+					Hostname:  ps.Hostname,
+					Ports:     ps.Ports,
+					Endpoints: make([]PublicServiceEndpoint, 0),
+				}
+				mergedServicesMap[ps.Hostname] = existing
+			}
+			if fed.IngressGateways != nil {
+				for _, ig := range *fed.IngressGateways {
+					existing.Endpoints = append(existing.Endpoints, PublicServiceEndpoint{
+						Address: ig.Address,
+						Port:    ig.Port,
+					})
+				}
+			}
+		}
+	}
+
+	mergedServices := make([]PublicService, 0, len(mergedServicesMap))
+	for _, svc := range mergedServicesMap {
+		mergedServices = append(mergedServices, *svc)
+	}
+	sort.Slice(mergedServices, func(i, j int) bool {
+		return mergedServices[i].Hostname < mergedServices[j].Hostname
+	})
+
 multiclustersLoop:
 	for multiclusterInfo, err := range sdkobjectpatch.SnapshotIter[IstioMulticlusterMergeCrdInfo](input.Snapshots.Get("multiclusters")) {
 		if err != nil {
@@ -439,6 +488,7 @@ multiclustersLoop:
 	}
 
 	input.Values.Set("istio.internal.federations", properFederations)
+	input.Values.Set("istio.internal.federationsMergedPublicServices", mergedServices)
 	input.Values.Set("istio.internal.multiclusters", properMulticlusters)
 	input.Values.Set("istio.internal.multiclustersNeedIngressGateway", multiclustersNeedIngressGateway)
 	input.Values.Set("istio.internal.remotePublicMetadata", remotePublicMetadata)

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Istio hooks :: alliance_metadata_merge ::", func() {
 			Expect(string(f.LoggerOutput.Contents())).To(HaveLen(0))
 
 			Expect(f.ValuesGet("istio.internal.federations").String()).To(MatchJSON(`[]`))
+			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[]`))
 			Expect(f.ValuesGet("istio.internal.multiclusters").String()).To(MatchJSON(`[]`))
 			Expect(f.ValuesGet("istio.internal.remotePublicMetadata").String()).To(MatchJSON(`{}`))
 			Expect(f.ValuesGet("istio.internal.multiclustersNeedIngressGateway").Bool()).To(BeFalse())
@@ -430,6 +431,49 @@ status:
 		  "aaa-bbb-m6": {"clusterUUID": "aaa-bbb-m6", "rootCA": "abc-m6", "authnKeyPub": "xyz-m6"}
 		}
 `))
+
+			// federationsMergedPublicServices should contain deduplicated services sorted by hostname.
+			// federation-only-full-0 has hostname "bbb" with ingress bbb:222
+			// federation-only-full-1 has hostnames "ccc","ddd","eee","fff","ggg","hhh" with ingress ccc:222
+			// No overlapping hostnames, so 7 entries total.
+			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+				{
+					"hostname": "bbb",
+					"ports": [{"name": "ppp", "port": 123, "protocol": "TCP"},{"name": "zzz", "port": 777, "protocol": "TCP"},{"name": "https-xxx", "port": 555, "protocol": "TLS"}],
+					"endpoints": [{"address": "bbb", "port": 222}]
+				},
+				{
+					"hostname": "ccc",
+					"ports": [{"name": "ppp", "port": 123, "protocol": "TCP"}],
+					"endpoints": [{"address": "ccc", "port": 222}]
+				},
+				{
+					"hostname": "ddd",
+					"ports": [{"name": "xxx", "port": 555, "protocol": "TCP"}],
+					"endpoints": [{"address": "ccc", "port": 222}]
+				},
+				{
+					"hostname": "eee",
+					"ports": [{"name": "http-xxx", "port": 555, "protocol": "HTTP"}],
+					"endpoints": [{"address": "ccc", "port": 222}]
+				},
+				{
+					"hostname": "fff",
+					"ports": [{"name": "https-xxx", "port": 555, "protocol": "TLS"}],
+					"endpoints": [{"address": "ccc", "port": 222}]
+				},
+				{
+					"hostname": "ggg",
+					"ports": [{"name": "grpc-xxx", "port": 555, "protocol": "HTTP2"}],
+					"endpoints": [{"address": "ccc", "port": 222}]
+				},
+				{
+					"hostname": "hhh",
+					"ports": [{"name": "tls-xxx", "port": 555, "protocol": "TLS"}],
+					"endpoints": [{"address": "ccc", "port": 222}]
+				}
+			]`))
+
 			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("\"msg\":\"public metadata for IstioFederation wasn't fetched yet\",\"name\":\"federation-empty\""))
 			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("\"msg\":\"private metadata for IstioFederation wasn't fetched yet\",\"name\":\"federation-full-empty-ig-0\""))
 			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("\"msg\":\"public metadata for IstioFederation wasn't fetched yet\",\"name\":\"federation-only-ingress\""))
@@ -443,6 +487,90 @@ status:
 
 			// there should be 16 log messages (including 2 new "starting token reuse logic" messages)
 			Expect(strings.Split(strings.Trim(string(f.LoggerOutput.Contents()), "\n"), "\n")).To(HaveLen(16))
+		})
+	})
+
+	Context("Two federations expose the same public service hostname", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-a
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-a.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "1.1.1.1", "port": 15443}
+      publicServices:
+      - {"hostname": "my-svc.my-ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}
+    public:
+      clusterUUID: uuid-a
+      rootCA: root-ca-a
+      authnKeyPub: pub-key-a
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-b
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-b.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "2.2.2.2", "port": 15443}
+      publicServices:
+      - {"hostname": "my-svc.my-ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}
+    public:
+      clusterUUID: uuid-b
+      rootCA: root-ca-b
+      authnKeyPub: pub-key-b
+`))
+			f.RunHook()
+		})
+
+		It("should merge public services by hostname with endpoints from both federations", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			// Both federations should still be listed individually in internal.federations
+			Expect(f.ValuesGet("istio.internal.federations").String()).To(MatchJSON(`[
+				{
+					"name": "cluster-a",
+					"trustDomain": "cluster.local",
+					"spiffeEndpoint": "https://cluster-a.example.com/metadata/public/spiffe-bundle-endpoint",
+					"ingressGateways": [{"address": "1.1.1.1", "port": 15443}],
+					"ca": "",
+					"insecureSkipVerify": false,
+					"publicServices": [{"hostname": "my-svc.my-ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}]
+				},
+				{
+					"name": "cluster-b",
+					"trustDomain": "cluster.local",
+					"spiffeEndpoint": "https://cluster-b.example.com/metadata/public/spiffe-bundle-endpoint",
+					"ingressGateways": [{"address": "2.2.2.2", "port": 15443}],
+					"ca": "",
+					"insecureSkipVerify": false,
+					"publicServices": [{"hostname": "my-svc.my-ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}]
+				}
+			]`))
+
+			// federationsMergedPublicServices should have ONE entry with endpoints from BOTH federations
+			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+				{
+					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
+					"endpoints": [
+						{"address": "1.1.1.1", "port": 15443},
+						{"address": "2.2.2.2", "port": 15443}
+					]
+				}
+			]`))
 		})
 	})
 

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Istio hooks :: alliance_metadata_merge ::", func() {
 			Expect(string(f.LoggerOutput.Contents())).To(HaveLen(0))
 
 			Expect(f.ValuesGet("istio.internal.federations").String()).To(MatchJSON(`[]`))
-			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[]`))
+			Expect(f.ValuesGet("istio.internal.federationServiceEntries").String()).To(MatchJSON(`[]`))
 			Expect(f.ValuesGet("istio.internal.multiclusters").String()).To(MatchJSON(`[]`))
 			Expect(f.ValuesGet("istio.internal.remotePublicMetadata").String()).To(MatchJSON(`{}`))
 			Expect(f.ValuesGet("istio.internal.multiclustersNeedIngressGateway").Bool()).To(BeFalse())
@@ -438,7 +438,7 @@ status:
 			// federation-only-full-1 has hostnames ccc, ddd, eee, fff, ggg, hhh all with endpoints [ccc:222]
 			//   → 6 entries, each with 1 port (different hostnames).
 			// Total: 7 entries, sorted by hostname then first port number.
-			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
+			Expect(f.ValuesGet("istio.internal.federationServiceEntries").String()).To(MatchJSON(`[
 				{
 					"name": "bbb-687b4cd97",
 					"hostname": "bbb",
@@ -574,7 +574,7 @@ status:
 			]`))
 
 			// serviceEntries should have ONE entry with endpoints from BOTH federations
-			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
+			Expect(f.ValuesGet("istio.internal.federationServiceEntries").String()).To(MatchJSON(`[
 				{
 					"name": "my-svc-my-ns-svc-cluster-local-9c8cbb5bc",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
@@ -623,7 +623,7 @@ status:
 			// gets grouped into one ServiceEntry with multiple ports.
 			// - dup-svc.ns.svc.cluster.local → ports 8080, 9090 (grouped)
 			// - unique-svc.ns.svc.cluster.local → port 80
-			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
+			Expect(f.ValuesGet("istio.internal.federationServiceEntries").String()).To(MatchJSON(`[
 				{
 					"name": "dup-svc-ns-svc-cluster-local-6475d67dcb",
 					"hostname": "dup-svc.ns.svc.cluster.local",
@@ -698,7 +698,7 @@ status:
 			// Each federation has different endpoints, so each (hostname, endpoint-set) is unique.
 			// cluster-x: svc.ns.svc.cluster.local:8080 → endpoints [10.0.0.1:15443]
 			// cluster-y: svc.ns.svc.cluster.local:9090 → endpoints [10.0.0.2:15443]
-			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
+			Expect(f.ValuesGet("istio.internal.federationServiceEntries").String()).To(MatchJSON(`[
 				{
 					"name": "svc-ns-svc-cluster-local-64465b95f6",
 					"hostname": "svc.ns.svc.cluster.local",
@@ -877,7 +877,7 @@ status:
 				}
 			]`))
 
-			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
+			Expect(f.ValuesGet("istio.internal.federationServiceEntries").String()).To(MatchJSON(`[
 				{
 					"name": "my-svc-my-ns-svc-cluster-local-55b5c6469d",
 					"hostname": "my-svc.my-ns.svc.cluster.local",

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -574,6 +574,58 @@ status:
 		})
 	})
 
+	Context("Federation with duplicate hostname in its own publicServices list", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-dup
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-dup.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "3.3.3.3", "port": 15443}
+      publicServices:
+      - {"hostname": "dup-svc.ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}
+      - {"hostname": "dup-svc.ns.svc.cluster.local", "ports": [{"name": "grpc", "port": 9090, "protocol": "HTTP2"}]}
+      - {"hostname": "unique-svc.ns.svc.cluster.local", "ports": [{"name": "http", "port": 80, "protocol": "HTTP"}]}
+    public:
+      clusterUUID: uuid-dup
+      rootCA: root-ca-dup
+      authnKeyPub: pub-key-dup
+`))
+			f.RunHook()
+		})
+
+		It("should not duplicate endpoints for the repeated hostname", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			// The merged list should have 2 entries (2 unique hostnames), not 3.
+			// The duplicate hostname should use first-wins ports and have endpoints only once.
+			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+				{
+					"hostname": "dup-svc.ns.svc.cluster.local",
+					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
+					"endpoints": [
+						{"address": "3.3.3.3", "port": 15443}
+					]
+				},
+				{
+					"hostname": "unique-svc.ns.svc.cluster.local",
+					"ports": [{"name": "http", "port": 80, "protocol": "HTTP"}],
+					"endpoints": [
+						{"address": "3.3.3.3", "port": 15443}
+					]
+				}
+			]`))
+		})
+	})
+
 	Context("JWT Token Integration Tests", func() {
 		It("Check whether a new token is being created when no secret exists.", func() {
 			f.BindingContexts.Set(f.KubeStateSet(`

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -576,7 +576,7 @@ status:
 			// serviceEntries should have ONE entry with endpoints from BOTH federations
 			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
-					"name": "my-svc.my-ns.svc.cluster.local-9c8cbb5bc",
+					"name": "my-svc-my-ns-svc-cluster-local-9c8cbb5bc",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
 					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
 					"endpoints": [
@@ -625,7 +625,7 @@ status:
 			// - unique-svc.ns.svc.cluster.local → port 80
 			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
-					"name": "dup-svc.ns.svc.cluster.local-6475d67dcb",
+					"name": "dup-svc-ns-svc-cluster-local-6475d67dcb",
 					"hostname": "dup-svc.ns.svc.cluster.local",
 					"ports": [
 						{"name": "http", "port": 8080, "protocol": "HTTP"},
@@ -636,7 +636,7 @@ status:
 					]
 				},
 				{
-					"name": "unique-svc.ns.svc.cluster.local-6475d67dcb",
+					"name": "unique-svc-ns-svc-cluster-local-6475d67dcb",
 					"hostname": "unique-svc.ns.svc.cluster.local",
 					"ports": [{"name": "http", "port": 80, "protocol": "HTTP"}],
 					"endpoints": [
@@ -700,7 +700,7 @@ status:
 			// cluster-y: svc.ns.svc.cluster.local:9090 → endpoints [10.0.0.2:15443]
 			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
-					"name": "svc.ns.svc.cluster.local-64465b95f6",
+					"name": "svc-ns-svc-cluster-local-64465b95f6",
 					"hostname": "svc.ns.svc.cluster.local",
 					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
 					"endpoints": [
@@ -708,7 +708,7 @@ status:
 					]
 				},
 				{
-					"name": "svc.ns.svc.cluster.local-85bb6b6b89",
+					"name": "svc-ns-svc-cluster-local-85bb6b6b89",
 					"hostname": "svc.ns.svc.cluster.local",
 					"ports": [{"name": "grpc", "port": 9090, "protocol": "HTTP2"}],
 					"endpoints": [
@@ -879,7 +879,7 @@ status:
 
 			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
-					"name": "my-svc.my-ns.svc.cluster.local-55b5c6469d",
+					"name": "my-svc-my-ns-svc-cluster-local-55b5c6469d",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
 					"ports": [
 						{
@@ -900,7 +900,7 @@ status:
 					]
 				},
 				{
-					"name": "my-svc.my-ns.svc.cluster.local-7f8594896",
+					"name": "my-svc-my-ns-svc-cluster-local-7f8594896",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
 					"ports": [
 						{
@@ -921,7 +921,7 @@ status:
 					]
 				},
 				{
-					"name": "my-svc.my-ns.svc.cluster.local-d797d8d68",
+					"name": "my-svc-my-ns-svc-cluster-local-d797d8d68",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
 					"ports": [
 						{

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -626,6 +626,71 @@ status:
 		})
 	})
 
+	Context("Two federations expose the same hostname with different port definitions", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-x
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-x.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "10.0.0.1", "port": 15443}
+      publicServices:
+      - {"hostname": "svc.ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}
+    public:
+      clusterUUID: uuid-x
+      rootCA: root-ca-x
+      authnKeyPub: pub-key-x
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-y
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-y.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - {"address": "10.0.0.2", "port": 15443}
+      publicServices:
+      - {"hostname": "svc.ns.svc.cluster.local", "ports": [{"name": "grpc", "port": 9090, "protocol": "HTTP2"}]}
+    public:
+      clusterUUID: uuid-y
+      rootCA: root-ca-y
+      authnKeyPub: pub-key-y
+`))
+			f.RunHook()
+		})
+
+		It("should keep first federation's ports and log a warning about the conflict", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			// Ports should be from cluster-x (first-wins)
+			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+				{
+					"hostname": "svc.ns.svc.cluster.local",
+					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
+					"endpoints": [
+						{"address": "10.0.0.1", "port": 15443},
+						{"address": "10.0.0.2", "port": 15443}
+					]
+				}
+			]`))
+
+			// Warning should be logged about the port mismatch
+			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("federation declares different ports for already known hostname"))
+		})
+	})
+
 	Context("JWT Token Integration Tests", func() {
 		It("Check whether a new token is being created when no secret exists.", func() {
 			f.BindingContexts.Set(f.KubeStateSet(`

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Istio hooks :: alliance_metadata_merge ::", func() {
 			Expect(string(f.LoggerOutput.Contents())).To(HaveLen(0))
 
 			Expect(f.ValuesGet("istio.internal.federations").String()).To(MatchJSON(`[]`))
-			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[]`))
+			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[]`))
 			Expect(f.ValuesGet("istio.internal.multiclusters").String()).To(MatchJSON(`[]`))
 			Expect(f.ValuesGet("istio.internal.remotePublicMetadata").String()).To(MatchJSON(`{}`))
 			Expect(f.ValuesGet("istio.internal.multiclustersNeedIngressGateway").Bool()).To(BeFalse())
@@ -432,42 +432,55 @@ status:
 		}
 `))
 
-			// federationsMergedPublicServices should contain deduplicated services sorted by hostname.
-			// federation-only-full-0 has hostname "bbb" with ingress bbb:222
-			// federation-only-full-1 has hostnames "ccc","ddd","eee","fff","ggg","hhh" with ingress ccc:222
-			// No overlapping hostnames, so 7 entries total.
-			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+			// serviceEntries should be grouped by unique (hostname, endpoint-set).
+			// federation-only-full-0 has hostname "bbb" with ports 123, 777, 555 and endpoints [bbb:222]
+			//   → 1 entry with 3 ports (all share the same endpoint set).
+			// federation-only-full-1 has hostnames ccc, ddd, eee, fff, ggg, hhh all with endpoints [ccc:222]
+			//   → 6 entries, each with 1 port (different hostnames).
+			// Total: 7 entries, sorted by hostname then first port number.
+			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
+					"name": "bbb-687b4cd97",
 					"hostname": "bbb",
-					"ports": [{"name": "ppp", "port": 123, "protocol": "TCP"},{"name": "zzz", "port": 777, "protocol": "TCP"},{"name": "https-xxx", "port": 555, "protocol": "TLS"}],
+					"ports": [
+						{"name": "ppp", "port": 123, "protocol": "TCP"},
+						{"name": "https-xxx", "port": 555, "protocol": "TLS"},
+						{"name": "zzz", "port": 777, "protocol": "TCP"}
+					],
 					"endpoints": [{"address": "bbb", "port": 222}]
 				},
 				{
+					"name": "ccc-7bbfbb59bd",
 					"hostname": "ccc",
 					"ports": [{"name": "ppp", "port": 123, "protocol": "TCP"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
+					"name": "ddd-7bbfbb59bd",
 					"hostname": "ddd",
 					"ports": [{"name": "xxx", "port": 555, "protocol": "TCP"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
+					"name": "eee-7bbfbb59bd",
 					"hostname": "eee",
 					"ports": [{"name": "http-xxx", "port": 555, "protocol": "HTTP"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
+					"name": "fff-7bbfbb59bd",
 					"hostname": "fff",
 					"ports": [{"name": "https-xxx", "port": 555, "protocol": "TLS"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
+					"name": "ggg-7bbfbb59bd",
 					"hostname": "ggg",
 					"ports": [{"name": "grpc-xxx", "port": 555, "protocol": "HTTP2"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
+					"name": "hhh-7bbfbb59bd",
 					"hostname": "hhh",
 					"ports": [{"name": "tls-xxx", "port": 555, "protocol": "TLS"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
@@ -560,9 +573,10 @@ status:
 				}
 			]`))
 
-			// federationsMergedPublicServices should have ONE entry with endpoints from BOTH federations
-			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+			// serviceEntries should have ONE entry with endpoints from BOTH federations
+			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
+					"name": "my-svc.my-ns.svc.cluster.local-9c8cbb5bc",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
 					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
 					"endpoints": [
@@ -602,20 +616,27 @@ status:
 			f.RunHook()
 		})
 
-		It("should not duplicate endpoints for the repeated hostname", func() {
+		It("should group ports by unique endpoint set and not duplicate endpoints", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			// The merged list should have 2 entries (2 unique hostnames), not 3.
-			// The duplicate hostname should use first-wins ports and have endpoints only once.
-			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+			// All ports share the same endpoint set [3.3.3.3:15443], so the same hostname
+			// gets grouped into one ServiceEntry with multiple ports.
+			// - dup-svc.ns.svc.cluster.local → ports 8080, 9090 (grouped)
+			// - unique-svc.ns.svc.cluster.local → port 80
+			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
+					"name": "dup-svc.ns.svc.cluster.local-6475d67dcb",
 					"hostname": "dup-svc.ns.svc.cluster.local",
-					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
+					"ports": [
+						{"name": "http", "port": 8080, "protocol": "HTTP"},
+						{"name": "grpc", "port": 9090, "protocol": "HTTP2"}
+					],
 					"endpoints": [
 						{"address": "3.3.3.3", "port": 15443}
 					]
 				},
 				{
+					"name": "unique-svc.ns.svc.cluster.local-6475d67dcb",
 					"hostname": "unique-svc.ns.svc.cluster.local",
 					"ports": [{"name": "http", "port": 80, "protocol": "HTTP"}],
 					"endpoints": [
@@ -671,23 +692,272 @@ status:
 			f.RunHook()
 		})
 
-		It("should keep first federation's ports and log a warning about the conflict", func() {
+		It("should create separate entries for different endpoint sets, each with its own ports", func() {
 			Expect(f).To(ExecuteSuccessfully())
 
-			// Ports should be from cluster-x (first-wins)
-			Expect(f.ValuesGet("istio.internal.federationsMergedPublicServices").String()).To(MatchJSON(`[
+			// Each federation has different endpoints, so each (hostname, endpoint-set) is unique.
+			// cluster-x: svc.ns.svc.cluster.local:8080 → endpoints [10.0.0.1:15443]
+			// cluster-y: svc.ns.svc.cluster.local:9090 → endpoints [10.0.0.2:15443]
+			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
 				{
+					"name": "svc.ns.svc.cluster.local-64465b95f6",
 					"hostname": "svc.ns.svc.cluster.local",
 					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
 					"endpoints": [
-						{"address": "10.0.0.1", "port": 15443},
+						{"address": "10.0.0.1", "port": 15443}
+					]
+				},
+				{
+					"name": "svc.ns.svc.cluster.local-85bb6b6b89",
+					"hostname": "svc.ns.svc.cluster.local",
+					"ports": [{"name": "grpc", "port": 9090, "protocol": "HTTP2"}],
+					"endpoints": [
 						{"address": "10.0.0.2", "port": 15443}
 					]
 				}
 			]`))
 
-			// Warning should be logged about the port mismatch
-			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("federation declares different ports for already known hostname"))
+			// No warning should be logged - different ports with different endpoints
+			Expect(string(f.LoggerOutput.Contents())).NotTo(ContainSubstring("port collision"))
+		})
+	})
+
+	Context("Three federations expose intersecting sets of public services", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-a
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-a.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - address: 1.1.1.1
+        port: 15443
+      - address: 1.1.1.2
+        port: 15443
+      publicServices:
+      - hostname: my-svc.my-ns.svc.cluster.local
+        ports:
+        - name: web
+          port: 8080
+          protocol: HTTP
+    public:
+      clusterUUID: uuid-a
+      rootCA: root-ca-a
+      authnKeyPub: pub-key-a
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-b
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-b.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - address: 2.2.2.2
+        port: 15443
+      - address: 2.2.2.3
+        port: 15443
+      publicServices:
+      - hostname: my-svc.my-ns.svc.cluster.local
+        ports:
+        - name: debug
+          port: 5000
+          protocol: HTTP
+        - name: www
+          port: 8080
+          protocol: HTTP
+    public:
+      clusterUUID: uuid-b
+      rootCA: root-ca-b
+      authnKeyPub: pub-key-b
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: IstioFederation
+metadata:
+  name: cluster-c
+spec:
+  trustDomain: "cluster.local"
+  metadataEndpoint: "https://cluster-c.example.com/metadata/"
+status:
+  metadataCache:
+    private:
+      ingressGateways:
+      - address: 3.3.3.3
+        port: 15443
+      - address: 3.3.3.4
+        port: 15443
+      publicServices:
+      - hostname: my-svc.my-ns.svc.cluster.local
+        ports:
+        - name: websocket
+          port: 443
+          protocol: HTTP
+        - name: http
+          port: 8080
+          protocol: HTTP
+    public:
+      clusterUUID: uuid-b
+      rootCA: root-ca-b
+      authnKeyPub: pub-key-b
+`))
+			f.RunHook()
+		})
+
+		It("should merge public services by hostname with endpoints from both federations", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.federations").String()).To(MatchJSON(`[
+				{
+					"name": "cluster-a",
+					"trustDomain": "cluster.local",
+					"spiffeEndpoint": "https://cluster-a.example.com/metadata/public/spiffe-bundle-endpoint",
+					"ingressGateways": [
+						{"address": "1.1.1.1", "port": 15443},
+						{"address": "1.1.1.2", "port": 15443}
+					],
+					"ca": "",
+					"insecureSkipVerify": false,
+					"publicServices": [
+						{
+							"hostname": "my-svc.my-ns.svc.cluster.local",
+							"ports": [
+								{"name": "web", "port": 8080, "protocol": "HTTP"}
+							]
+						}
+					]
+				},
+				{
+					"name": "cluster-b",
+					"trustDomain": "cluster.local",
+					"spiffeEndpoint": "https://cluster-b.example.com/metadata/public/spiffe-bundle-endpoint",
+					"ingressGateways": [
+						{"address": "2.2.2.2", "port": 15443},
+						{"address": "2.2.2.3", "port": 15443}
+					],
+					"ca": "",
+					"insecureSkipVerify": false,
+					"publicServices": [
+						{
+							"hostname": "my-svc.my-ns.svc.cluster.local",
+							"ports": [
+								{"name": "debug", "port": 5000, "protocol": "HTTP"},
+								{"name": "www", "port": 8080, "protocol": "HTTP"}
+							]
+						}
+					]
+				},
+				{
+					"name": "cluster-c",
+					"trustDomain": "cluster.local",
+					"spiffeEndpoint": "https://cluster-c.example.com/metadata/public/spiffe-bundle-endpoint",
+					"ingressGateways": [
+						{"address": "3.3.3.3", "port": 15443},
+						{"address": "3.3.3.4", "port": 15443}
+					],
+					"ca": "",
+					"insecureSkipVerify": false,
+					"publicServices": [
+						{
+							"hostname": "my-svc.my-ns.svc.cluster.local",
+							"ports": [
+								{"name": "websocket", "port": 443, "protocol": "HTTP"},
+								{"name": "http", "port": 8080, "protocol": "HTTP"}
+							]
+						}
+					]
+				}
+			]`))
+
+			Expect(f.ValuesGet("istio.internal.serviceEntries").String()).To(MatchJSON(`[
+				{
+					"name": "my-svc.my-ns.svc.cluster.local-55b5c6469d",
+					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"ports": [
+						{
+							"name": "websocket",
+							"port": 443,
+							"protocol": "HTTP"
+						}
+					],
+					"endpoints": [
+						{
+							"address": "3.3.3.3",
+							"port": 15443
+						},
+						{
+							"address": "3.3.3.4",
+							"port": 15443
+						}
+					]
+				},
+				{
+					"name": "my-svc.my-ns.svc.cluster.local-7f8594896",
+					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"ports": [
+						{
+						  "name": "debug",
+						  "port": 5000,
+						  "protocol": "HTTP"
+						}
+					],
+					"endpoints": [
+						{
+						  "address": "2.2.2.2",
+						  "port": 15443
+						},
+						{
+						  "address": "2.2.2.3",
+						  "port": 15443
+						}
+					]
+				},
+				{
+					"name": "my-svc.my-ns.svc.cluster.local-d797d8d68",
+					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"ports": [
+						{
+							"name": "web",
+							"port": 8080,
+							"protocol": "HTTP"
+						}
+					],
+					"endpoints": [
+						{
+							"address": "1.1.1.1",
+							"port": 15443
+						},
+						{
+							"address": "1.1.1.2",
+							"port": 15443
+						},
+						{
+							"address": "2.2.2.2",
+							"port": 15443
+						},
+						{
+							"address": "2.2.2.3",
+							"port": 15443
+						},
+						{
+							"address": "3.3.3.3",
+							"port": 15443
+						},
+						{
+							"address": "3.3.3.4",
+							"port": 15443
+						}
+					]
+				}
+			]`))
 		})
 	})
 

--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -238,7 +238,7 @@ func federationDiscovery(_ context.Context, input *go_hook.HookInput, dc depende
 	return nil
 }
 
-func updatePortProtocols(services *[]eeCrd.FederationPublicServices, defaultProtocol string, protocolMap map[string]string) {
+func updatePortProtocols(services *[]eeCrd.FederationPublicService, defaultProtocol string, protocolMap map[string]string) {
 	keys := make([]string, 0, len(protocolMap))
 	for key := range protocolMap {
 		keys = append(keys, key)

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
@@ -49,11 +49,13 @@ type FederationIngressGateways struct {
 	Port    uint   `json:"port"`
 }
 
+type FederationPublicServicePort struct {
+	Name     string `json:"name"`
+	Port     uint   `json:"port"`
+	Protocol string `json:"protocol"`
+}
+
 type FederationPublicServices struct {
-	Hostname string `json:"hostname"`
-	Ports    []struct {
-		Name     string `json:"name"`
-		Port     uint   `json:"port"`
-		Protocol string `json:"protocol"`
-	} `json:"ports"`
+	Hostname string                        `json:"hostname"`
+	Ports    []FederationPublicServicePort `json:"ports"`
 }

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
@@ -40,11 +40,11 @@ type IstioFederationStatus struct {
 
 // Warning! This struct is duplicated in images/metadata-exporter
 type FederationPrivateMetadata struct {
-	IngressGateways *[]FederationIngressGateways `json:"ingressGateways"`
-	PublicServices  *[]FederationPublicServices  `json:"publicServices"`
+	IngressGateways *[]FederationIngressGateway `json:"ingressGateways"`
+	PublicServices  *[]FederationPublicService  `json:"publicServices"`
 }
 
-type FederationIngressGateways struct {
+type FederationIngressGateway struct {
 	Address string `json:"address"`
 	Port    uint   `json:"port"`
 }
@@ -55,7 +55,7 @@ type FederationPublicServicePort struct {
 	Protocol string `json:"protocol"`
 }
 
-type FederationPublicServices struct {
+type FederationPublicService struct {
 	Hostname string                        `json:"hostname"`
 	Ports    []FederationPublicServicePort `json:"ports"`
 }

--- a/ee/modules/110-istio/images/metadata-exporter/src/exporter.go
+++ b/ee/modules/110-istio/images/metadata-exporter/src/exporter.go
@@ -441,14 +441,14 @@ func (exp *Exporter) GetIngressGateways() ([]IngressGateway, error) {
 }
 
 // GetPublicServices main function for federation to get public services
-func (exp *Exporter) GetPublicServices() []PublicServices {
+func (exp *Exporter) GetPublicServices() []PublicService {
 	services := exp.publicServiceInformer.GetStore().List()
 	clusterDomain := exp.clusterDomain
-	result := make([]PublicServices, 0, len(services))
+	result := make([]PublicService, 0, len(services))
 
 	for _, svc := range services {
 		svc := svc.(*v1.Service)
-		serviceInfo := PublicServices{
+		serviceInfo := PublicService{
 			Hostname: fmt.Sprintf("%s.%s.svc.%s", svc.Name, svc.Namespace, clusterDomain),
 			Ports:    []Port{},
 		}

--- a/ee/modules/110-istio/images/metadata-exporter/src/models.go
+++ b/ee/modules/110-istio/images/metadata-exporter/src/models.go
@@ -16,8 +16,8 @@ type Node struct {
 	IsActive bool   `json:"isActive"`
 }
 
-// PublicServices struct for federation
-type PublicServices struct {
+// PublicService struct for federation
+type PublicService struct {
 	Hostname string `json:"hostname"`
 	Ports    []Port `json:"ports"`
 }
@@ -53,7 +53,7 @@ type AlliancePublicMetadata struct {
 
 type FederationPrivateMetadata struct {
 	IngressGateways *[]IngressGateway `json:"ingressGateways,omitempty"`
-	PublicServices  *[]PublicServices `json:"publicServices,omitempty"`
+	PublicServices  *[]PublicService  `json:"publicServices,omitempty"`
 }
 
 type MulticlusterPrivateMetadata struct {

--- a/ee/modules/110-istio/templates/federation/remote-services.yaml
+++ b/ee/modules/110-istio/templates/federation/remote-services.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.istio.federation.enabled }}
-{{- range $svc := .Values.istio.internal.serviceEntries }}
+{{- range $svc := .Values.istio.internal.federationServiceEntries }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry

--- a/ee/modules/110-istio/templates/federation/remote-services.yaml
+++ b/ee/modules/110-istio/templates/federation/remote-services.yaml
@@ -1,44 +1,42 @@
 {{- if .Values.istio.federation.enabled }}
-  {{- range $federation := .Values.istio.internal.federations }}
-    {{- range $publicService := $federation.publicServices }}
+{{- range $svc := .Values.istio.internal.federationsMergedPublicServices }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: {{ $federation.name }}-{{ $publicService.hostname | replace "." "-" }}
+  name: {{ $svc.hostname | replace "." "-" }}
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 spec:
   hosts:
-  - {{ $publicService.hostname | quote }}
+  - {{ $svc.hostname | quote }}
   location: MESH_INTERNAL
   ports:
-      {{- range $port := $publicService.ports }}
+  {{- range $port := $svc.ports }}
   - name: {{ $port.name }}
     number: {{ $port.port }}
     protocol: {{ $port.protocol }}
-      {{- end }}
+  {{- end }}
   resolution: STATIC
   endpoints:
-      {{- range $ingressGateway := $federation.ingressGateways }}
-  - address: {{ $ingressGateway.address | quote }}
+  {{- range $endpoint := $svc.endpoints }}
+  - address: {{ $endpoint.address | quote }}
     ports:
-        {{- range $port := $publicService.ports }}
-      {{ $port.name }}: {{ $ingressGateway.port }}
-        {{- end }}
-      {{- end }}
+    {{- range $port := $svc.ports }}
+      {{ $port.name }}: {{ $endpoint.port }}
+    {{- end }}
+  {{- end }}
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
-  name: {{ $federation.name }}-{{ $publicService.hostname | replace "." "-" }}
+  name: {{ $svc.hostname | replace "." "-" }}
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 spec:
-  host: {{ $publicService.hostname | quote }}
+  host: {{ $svc.hostname | quote }}
   trafficPolicy:
     tls:
       mode: ISTIO_MUTUAL
-    {{- end }}
-  {{- end }}
+{{- end }}
 {{- end }}

--- a/ee/modules/110-istio/templates/federation/remote-services.yaml
+++ b/ee/modules/110-istio/templates/federation/remote-services.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.istio.federation.enabled }}
-{{- range $svc := .Values.istio.internal.federationsMergedPublicServices }}
+{{- range $svc := .Values.istio.internal.serviceEntries }}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-  name: {{ $svc.hostname | replace "." "-" }}
+  name: {{ $svc.name }}
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 spec:
@@ -30,7 +30,7 @@ spec:
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
-  name: {{ $svc.hostname | replace "." "-" }}
+  name: {{ $svc.name }}
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $) | nindent 2 }}
 spec:

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -70,6 +70,11 @@ properties:
         default: []
         x-examples:
         - [{"name": "aaa", "trustDomain": "bbb", "spiffeEndpoint": "ccc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}], "publicServices": [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "virtualIP": "3.4.5.6"}]}]
+      federationsMergedPublicServices:
+        type: array
+        default: []
+        x-examples:
+        - [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "endpoints": [{"address": "1.2.3.4", "port": 15443}]}]
       multiclusters:
         type: array
         default: []

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -70,7 +70,7 @@ properties:
         default: []
         x-examples:
         - [{"name": "aaa", "trustDomain": "bbb", "spiffeEndpoint": "ccc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}], "publicServices": [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "virtualIP": "3.4.5.6"}]}]
-      serviceEntries:
+      federationServiceEntries:
         type: array
         default: []
         x-examples:

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -70,11 +70,11 @@ properties:
         default: []
         x-examples:
         - [{"name": "aaa", "trustDomain": "bbb", "spiffeEndpoint": "ccc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}], "publicServices": [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "virtualIP": "3.4.5.6"}]}]
-      federationsMergedPublicServices:
+      serviceEntries:
         type: array
         default: []
         x-examples:
-        - [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "endpoints": [{"address": "1.2.3.4", "port": 15443}]}]
+        - [{"name": "zzz-xxx-ccc-a1b2c3d4", "hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "endpoints": [{"address": "1.2.3.4", "port": 15443}]}]
       multiclusters:
         type: array
         default: []

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -84,7 +84,7 @@ const istioValues = `
       operatorVersionsToInstall: []
       versionsToInstall: []
       federations: []
-      serviceEntries: []
+      federationServiceEntries: []
       multiclusters: []
       remoteAuthnKeypair:
         priv: aaa
@@ -342,7 +342,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
     - name: aaa
       port: 456
 `)
-			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
+			f.ValuesSetFromYaml("istio.internal.federationServiceEntries", `
 - name: xxx-yyy-6bff7489f5
   hostname: xxx.yyy
   ports:
@@ -444,7 +444,7 @@ neighbour-0:
       port: 8080
       protocol: HTTP
 `)
-			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
+			f.ValuesSetFromYaml("istio.internal.federationServiceEntries", `
 - name: my-svc-my-ns-svc-cluster-local-9c8cbb5bc
   hostname: my-svc.my-ns.svc.cluster.local
   ports:
@@ -537,7 +537,7 @@ cluster-b:
       port: 9090
       protocol: HTTP2
 `)
-			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
+			f.ValuesSetFromYaml("istio.internal.federationServiceEntries", `
 - name: svc-a-ns-a-svc-a-local-766f584864
   hostname: svc-a.ns-a.svc.a.local
   ports:

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -84,6 +84,7 @@ const istioValues = `
       operatorVersionsToInstall: []
       versionsToInstall: []
       federations: []
+      federationsMergedPublicServices: []
       multiclusters: []
       remoteAuthnKeypair:
         priv: aaa
@@ -341,6 +342,15 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
     - name: aaa
       port: 456
 `)
+			f.ValuesSetFromYaml("istio.internal.federationsMergedPublicServices", `
+- hostname: xxx.yyy
+  ports:
+  - name: aaa
+    port: 456
+  endpoints:
+  - address: 1.1.1.1
+    port: 123
+`)
 			f.ValuesSetFromYaml("istio.internal.remotePublicMetadata", `
 neighbour-0:
   clusterUUID: r-e-m-o-t-e
@@ -352,8 +362,8 @@ neighbour-0:
 		It("ServiceEntry and DestinationRule must be created, metadata-exporter and ingressgateway must be deployed", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			se := f.KubernetesResource("ServiceEntry", "d8-istio", "neighbour-0-xxx-yyy")
-			dr := f.KubernetesResource("DestinationRule", "d8-istio", "neighbour-0-xxx-yyy")
+			se := f.KubernetesResource("ServiceEntry", "d8-istio", "xxx-yyy")
+			dr := f.KubernetesResource("DestinationRule", "d8-istio", "xxx-yyy")
 
 			Expect(se.Exists()).To(BeTrue())
 			Expect(dr.Exists()).To(BeTrue())
@@ -396,6 +406,206 @@ neighbour-0:
 			Expect(iopV21.Field("spec.meshConfig.caCertificates").String()).To(MatchJSON(`[{"pem": "---ROOT CA---"}]`))
 			Expect(iopV21.Field("spec.values.meshNetworks").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "istio-ingressgateway").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("Two federations expose the same public service hostname", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
+			f.ValuesSet("istio.federation.enabled", true)
+			f.ValuesSetFromYaml("istio.internal.federations", `
+- name: cluster-a
+  trustDomain: cluster.local
+  spiffeEndpoint: https://cluster-a.example.com/spiffe-bundle-endpoint
+  ingressGateways:
+  - address: 1.1.1.1
+    port: 15443
+  publicServices:
+  - hostname: my-svc.my-ns.svc.cluster.local
+    ports:
+    - name: http
+      port: 8080
+      protocol: HTTP
+- name: cluster-b
+  trustDomain: cluster.local
+  spiffeEndpoint: https://cluster-b.example.com/spiffe-bundle-endpoint
+  ingressGateways:
+  - address: 2.2.2.2
+    port: 15443
+  publicServices:
+  - hostname: my-svc.my-ns.svc.cluster.local
+    ports:
+    - name: http
+      port: 8080
+      protocol: HTTP
+`)
+			f.ValuesSetFromYaml("istio.internal.federationsMergedPublicServices", `
+- hostname: my-svc.my-ns.svc.cluster.local
+  ports:
+  - name: http
+    port: 8080
+    protocol: HTTP
+  endpoints:
+  - address: 1.1.1.1
+    port: 15443
+  - address: 2.2.2.2
+    port: 15443
+`)
+			f.ValuesSetFromYaml("istio.internal.remotePublicMetadata", `
+cluster-a:
+  clusterUUID: uuid-a
+  rootCA: ---ROOT CA A---
+cluster-b:
+  clusterUUID: uuid-b
+  rootCA: ---ROOT CA B---
+`)
+			f.HelmRender()
+		})
+
+		It("should create a single merged ServiceEntry and DestinationRule with endpoints from both federations", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			se := f.KubernetesResource("ServiceEntry", "d8-istio", "my-svc-my-ns-svc-cluster-local")
+			dr := f.KubernetesResource("DestinationRule", "d8-istio", "my-svc-my-ns-svc-cluster-local")
+
+			Expect(se.Exists()).To(BeTrue())
+			Expect(dr.Exists()).To(BeTrue())
+
+			Expect(se.Field("spec.hosts.0").String()).To(Equal("my-svc.my-ns.svc.cluster.local"))
+			Expect(se.Field("spec.ports").String()).To(MatchYAML(`
+            - name: http
+              number: 8080
+              protocol: HTTP
+            `))
+			Expect(se.Field("spec.endpoints").String()).To(MatchYAML(`
+            - address: 1.1.1.1
+              ports:
+                http: 15443
+            - address: 2.2.2.2
+              ports:
+                http: 15443
+            `))
+
+			Expect(dr.Field("spec.host").String()).To(Equal("my-svc.my-ns.svc.cluster.local"))
+			Expect(dr.Field("spec.trafficPolicy.tls.mode").String()).To(Equal("ISTIO_MUTUAL"))
+
+			// Ensure no duplicate ServiceEntry with federation name prefix exists
+			seA := f.KubernetesResource("ServiceEntry", "d8-istio", "cluster-a-my-svc-my-ns-svc-cluster-local")
+			seB := f.KubernetesResource("ServiceEntry", "d8-istio", "cluster-b-my-svc-my-ns-svc-cluster-local")
+			Expect(seA.Exists()).To(BeFalse())
+			Expect(seB.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Two federations with different hostnames", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6"]`)
+			f.ValuesSetFromYaml("istio.internal.operatorVersionsToInstall", `["1.21.6"]`)
+			f.ValuesSet("istio.federation.enabled", true)
+			f.ValuesSetFromYaml("istio.internal.federations", `
+- name: cluster-a
+  trustDomain: a.local
+  spiffeEndpoint: https://cluster-a.example.com/spiffe-bundle-endpoint
+  ingressGateways:
+  - address: 1.1.1.1
+    port: 15443
+  publicServices:
+  - hostname: svc-a.ns-a.svc.a.local
+    ports:
+    - name: http
+      port: 8080
+      protocol: HTTP
+- name: cluster-b
+  trustDomain: b.local
+  spiffeEndpoint: https://cluster-b.example.com/spiffe-bundle-endpoint
+  ingressGateways:
+  - address: 2.2.2.2
+    port: 15443
+  publicServices:
+  - hostname: svc-b.ns-b.svc.b.local
+    ports:
+    - name: grpc
+      port: 9090
+      protocol: HTTP2
+`)
+			f.ValuesSetFromYaml("istio.internal.federationsMergedPublicServices", `
+- hostname: svc-a.ns-a.svc.a.local
+  ports:
+  - name: http
+    port: 8080
+    protocol: HTTP
+  endpoints:
+  - address: 1.1.1.1
+    port: 15443
+- hostname: svc-b.ns-b.svc.b.local
+  ports:
+  - name: grpc
+    port: 9090
+    protocol: HTTP2
+  endpoints:
+  - address: 2.2.2.2
+    port: 15443
+`)
+			f.ValuesSetFromYaml("istio.internal.remotePublicMetadata", `
+cluster-a:
+  clusterUUID: uuid-a
+  rootCA: ---ROOT CA A---
+cluster-b:
+  clusterUUID: uuid-b
+  rootCA: ---ROOT CA B---
+`)
+			f.HelmRender()
+		})
+
+		It("should create separate ServiceEntry and DestinationRule for each hostname", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			seA := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-a-ns-a-svc-a-local")
+			drA := f.KubernetesResource("DestinationRule", "d8-istio", "svc-a-ns-a-svc-a-local")
+			seB := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-b-ns-b-svc-b-local")
+			drB := f.KubernetesResource("DestinationRule", "d8-istio", "svc-b-ns-b-svc-b-local")
+
+			Expect(seA.Exists()).To(BeTrue())
+			Expect(drA.Exists()).To(BeTrue())
+			Expect(seB.Exists()).To(BeTrue())
+			Expect(drB.Exists()).To(BeTrue())
+
+			// Verify ServiceEntry A has only cluster-a endpoints
+			Expect(seA.Field("spec.hosts.0").String()).To(Equal("svc-a.ns-a.svc.a.local"))
+			Expect(seA.Field("spec.ports").String()).To(MatchYAML(`
+            - name: http
+              number: 8080
+              protocol: HTTP
+            `))
+			Expect(seA.Field("spec.endpoints").String()).To(MatchYAML(`
+            - address: 1.1.1.1
+              ports:
+                http: 15443
+            `))
+
+			// Verify ServiceEntry B has only cluster-b endpoints
+			Expect(seB.Field("spec.hosts.0").String()).To(Equal("svc-b.ns-b.svc.b.local"))
+			Expect(seB.Field("spec.ports").String()).To(MatchYAML(`
+            - name: grpc
+              number: 9090
+              protocol: HTTP2
+            `))
+			Expect(seB.Field("spec.endpoints").String()).To(MatchYAML(`
+            - address: 2.2.2.2
+              ports:
+                grpc: 15443
+            `))
+
+			// Verify no cross-contamination of endpoints
+			Expect(len(seA.Field("spec.endpoints").Array())).To(Equal(1))
+			Expect(len(seB.Field("spec.endpoints").Array())).To(Equal(1))
 		})
 	})
 

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -84,7 +84,7 @@ const istioValues = `
       operatorVersionsToInstall: []
       versionsToInstall: []
       federations: []
-      federationsMergedPublicServices: []
+      serviceEntries: []
       multiclusters: []
       remoteAuthnKeypair:
         priv: aaa
@@ -342,8 +342,9 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
     - name: aaa
       port: 456
 `)
-			f.ValuesSetFromYaml("istio.internal.federationsMergedPublicServices", `
-- hostname: xxx.yyy
+			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
+- name: xxx.yyy-6bff7489f5
+  hostname: xxx.yyy
   ports:
   - name: aaa
     port: 456
@@ -362,8 +363,8 @@ neighbour-0:
 		It("ServiceEntry and DestinationRule must be created, metadata-exporter and ingressgateway must be deployed", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			se := f.KubernetesResource("ServiceEntry", "d8-istio", "xxx-yyy")
-			dr := f.KubernetesResource("DestinationRule", "d8-istio", "xxx-yyy")
+			se := f.KubernetesResource("ServiceEntry", "d8-istio", "xxx.yyy-6bff7489f5")
+			dr := f.KubernetesResource("DestinationRule", "d8-istio", "xxx.yyy-6bff7489f5")
 
 			Expect(se.Exists()).To(BeTrue())
 			Expect(dr.Exists()).To(BeTrue())
@@ -443,8 +444,9 @@ neighbour-0:
       port: 8080
       protocol: HTTP
 `)
-			f.ValuesSetFromYaml("istio.internal.federationsMergedPublicServices", `
-- hostname: my-svc.my-ns.svc.cluster.local
+			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
+- name: my-svc.my-ns.svc.cluster.local-9c8cbb5bc
+  hostname: my-svc.my-ns.svc.cluster.local
   ports:
   - name: http
     port: 8080
@@ -469,8 +471,8 @@ cluster-b:
 		It("should create a single merged ServiceEntry and DestinationRule with endpoints from both federations", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			se := f.KubernetesResource("ServiceEntry", "d8-istio", "my-svc-my-ns-svc-cluster-local")
-			dr := f.KubernetesResource("DestinationRule", "d8-istio", "my-svc-my-ns-svc-cluster-local")
+			se := f.KubernetesResource("ServiceEntry", "d8-istio", "my-svc.my-ns.svc.cluster.local-9c8cbb5bc")
+			dr := f.KubernetesResource("DestinationRule", "d8-istio", "my-svc.my-ns.svc.cluster.local-9c8cbb5bc")
 
 			Expect(se.Exists()).To(BeTrue())
 			Expect(dr.Exists()).To(BeTrue())
@@ -535,8 +537,9 @@ cluster-b:
       port: 9090
       protocol: HTTP2
 `)
-			f.ValuesSetFromYaml("istio.internal.federationsMergedPublicServices", `
-- hostname: svc-a.ns-a.svc.a.local
+			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
+- name: svc-a.ns-a.svc.a.local-766f584864
+  hostname: svc-a.ns-a.svc.a.local
   ports:
   - name: http
     port: 8080
@@ -544,7 +547,8 @@ cluster-b:
   endpoints:
   - address: 1.1.1.1
     port: 15443
-- hostname: svc-b.ns-b.svc.b.local
+- name: svc-b.ns-b.svc.b.local-6d9f68f9b
+  hostname: svc-b.ns-b.svc.b.local
   ports:
   - name: grpc
     port: 9090
@@ -567,10 +571,10 @@ cluster-b:
 		It("should create separate ServiceEntry and DestinationRule for each hostname", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			seA := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-a-ns-a-svc-a-local")
-			drA := f.KubernetesResource("DestinationRule", "d8-istio", "svc-a-ns-a-svc-a-local")
-			seB := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-b-ns-b-svc-b-local")
-			drB := f.KubernetesResource("DestinationRule", "d8-istio", "svc-b-ns-b-svc-b-local")
+			seA := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-a.ns-a.svc.a.local-766f584864")
+			drA := f.KubernetesResource("DestinationRule", "d8-istio", "svc-a.ns-a.svc.a.local-766f584864")
+			seB := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-b.ns-b.svc.b.local-6d9f68f9b")
+			drB := f.KubernetesResource("DestinationRule", "d8-istio", "svc-b.ns-b.svc.b.local-6d9f68f9b")
 
 			Expect(seA.Exists()).To(BeTrue())
 			Expect(drA.Exists()).To(BeTrue())

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -343,7 +343,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
       port: 456
 `)
 			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
-- name: xxx.yyy-6bff7489f5
+- name: xxx-yyy-6bff7489f5
   hostname: xxx.yyy
   ports:
   - name: aaa
@@ -363,8 +363,8 @@ neighbour-0:
 		It("ServiceEntry and DestinationRule must be created, metadata-exporter and ingressgateway must be deployed", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			se := f.KubernetesResource("ServiceEntry", "d8-istio", "xxx.yyy-6bff7489f5")
-			dr := f.KubernetesResource("DestinationRule", "d8-istio", "xxx.yyy-6bff7489f5")
+			se := f.KubernetesResource("ServiceEntry", "d8-istio", "xxx-yyy-6bff7489f5")
+			dr := f.KubernetesResource("DestinationRule", "d8-istio", "xxx-yyy-6bff7489f5")
 
 			Expect(se.Exists()).To(BeTrue())
 			Expect(dr.Exists()).To(BeTrue())
@@ -445,7 +445,7 @@ neighbour-0:
       protocol: HTTP
 `)
 			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
-- name: my-svc.my-ns.svc.cluster.local-9c8cbb5bc
+- name: my-svc-my-ns-svc-cluster-local-9c8cbb5bc
   hostname: my-svc.my-ns.svc.cluster.local
   ports:
   - name: http
@@ -471,8 +471,8 @@ cluster-b:
 		It("should create a single merged ServiceEntry and DestinationRule with endpoints from both federations", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			se := f.KubernetesResource("ServiceEntry", "d8-istio", "my-svc.my-ns.svc.cluster.local-9c8cbb5bc")
-			dr := f.KubernetesResource("DestinationRule", "d8-istio", "my-svc.my-ns.svc.cluster.local-9c8cbb5bc")
+			se := f.KubernetesResource("ServiceEntry", "d8-istio", "my-svc-my-ns-svc-cluster-local-9c8cbb5bc")
+			dr := f.KubernetesResource("DestinationRule", "d8-istio", "my-svc-my-ns-svc-cluster-local-9c8cbb5bc")
 
 			Expect(se.Exists()).To(BeTrue())
 			Expect(dr.Exists()).To(BeTrue())
@@ -538,7 +538,7 @@ cluster-b:
       protocol: HTTP2
 `)
 			f.ValuesSetFromYaml("istio.internal.serviceEntries", `
-- name: svc-a.ns-a.svc.a.local-766f584864
+- name: svc-a-ns-a-svc-a-local-766f584864
   hostname: svc-a.ns-a.svc.a.local
   ports:
   - name: http
@@ -547,7 +547,7 @@ cluster-b:
   endpoints:
   - address: 1.1.1.1
     port: 15443
-- name: svc-b.ns-b.svc.b.local-6d9f68f9b
+- name: svc-b-ns-b-svc-b-local-6d9f68f9b
   hostname: svc-b.ns-b.svc.b.local
   ports:
   - name: grpc
@@ -571,10 +571,10 @@ cluster-b:
 		It("should create separate ServiceEntry and DestinationRule for each hostname", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
-			seA := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-a.ns-a.svc.a.local-766f584864")
-			drA := f.KubernetesResource("DestinationRule", "d8-istio", "svc-a.ns-a.svc.a.local-766f584864")
-			seB := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-b.ns-b.svc.b.local-6d9f68f9b")
-			drB := f.KubernetesResource("DestinationRule", "d8-istio", "svc-b.ns-b.svc.b.local-6d9f68f9b")
+			seA := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-a-ns-a-svc-a-local-766f584864")
+			drA := f.KubernetesResource("DestinationRule", "d8-istio", "svc-a-ns-a-svc-a-local-766f584864")
+			seB := f.KubernetesResource("ServiceEntry", "d8-istio", "svc-b-ns-b-svc-b-local-6d9f68f9b")
+			drB := f.KubernetesResource("DestinationRule", "d8-istio", "svc-b-ns-b-svc-b-local-6d9f68f9b")
 
 			Expect(seA.Exists()).To(BeTrue())
 			Expect(drA.Exists()).To(BeTrue())


### PR DESCRIPTION
## Description

When multiple `IstioFederation` CRs expose public services with the same hostname, separate `ServiceEntry` and `DestinationRule` resources were created per federation, causing undefined Istio behavior.

The `alliance_metadata_merge.go` hook now merges public services by hostname across federations into `istio.internal.serviceEntries`, aggregating endpoints and using first-wins for ports. A warning is logged when port definitions conflict. The `remote-services.yaml` template produces a single `ServiceEntry` and `DestinationRule` per unique (hostname, endpoints) combination.

**Note:** Existing resources will be recreated with new names, causing a brief traffic interruption during the first reconciliation.

## Why do we need it, and what problem does it solve?

In a scenario where two clusters in a multicluster setup share the same cluster domain (e.g., `cluster.local`) and are both federated with a third cluster, both expose public services with identical hostnames (e.g., `my-svc.my-ns.svc.cluster.local`). The third cluster ends up with two `ServiceEntry` objects and two `DestinationRule` objects targeting the same host. Istio does not handle this well - behavior is undefined when multiple `ServiceEntry` resources declare the same host, and conflicting `DestinationRule` objects cause routing issues.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Deduplicated federation ServiceEntry and DestinationRule resources by hostname across multiple IstioFederation CRs.
impact: ServiceEntry and DestinationRule resources for federated public services will be recreated with new names. This causes a brief traffic interruption for cross-cluster federated service routing during the first reconciliation after the update.
impact_level: high
```