### PR TITLE
[cloud-provider-vsphere] Filter discovered zones and datastores by zones from provider configurations

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
@@ -134,7 +134,7 @@ func NewDiscoverer(logger *log.Logger) *Discoverer {
 
 	config := &vsphere.ProviderClusterConfiguration{
 		Region:            region,
-		Zones: 			   zones,
+		Zones:             zones,
 		RegionTagCategory: regionTagCategory,
 		ZoneTagCategory:   zoneTagCategory,
 		Provider: vsphere.Provider{

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/src/discoverer.go
@@ -114,6 +114,9 @@ func NewDiscoverer(logger *log.Logger) *Discoverer {
 		logger.Fatal("Cannot get REGION env")
 	}
 
+	zonesRaw := os.Getenv("ZONES")
+	zones := strings.Split(zonesRaw, ",")
+
 	regionTagCategory := os.Getenv("REGION_TAG_CATEGORY")
 	if regionTagCategory == "" {
 		logger.Fatal("Cannot get REGION_TAG_CATEGORY env")
@@ -131,6 +134,7 @@ func NewDiscoverer(logger *log.Logger) *Discoverer {
 
 	config := &vsphere.ProviderClusterConfiguration{
 		Region:            region,
+		Zones: 			   zones,
 		RegionTagCategory: regionTagCategory,
 		ZoneTagCategory:   zoneTagCategory,
 		Provider: vsphere.Provider{

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/deployment.yaml
@@ -106,6 +106,11 @@ spec:
             secretKeyRef:
               name: cloud-data-discoverer
               key: region
+        - name: ZONES
+          valueFrom:
+            secretKeyRef:
+              name: cloud-data-discoverer
+              key: zones
         - name: REGION_TAG_CATEGORY
           valueFrom:
             secretKeyRef:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/secret.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/cloud-data-discoverer/secret.yaml
@@ -13,6 +13,7 @@ data:
   password: {{ .provider.password | b64enc | quote }}
   insecure: {{ .provider.insecure | toString | b64enc | quote }}
   region: {{ .region | b64enc | quote }}
+  zones: {{ .zones | join "," | b64enc | quote }}
   regionTagCategory: {{ .regionTagCategory | b64enc | quote }}
   zoneTagCategory: {{ .zoneTagCategory | b64enc | quote }}
   vmFolderPath: {{ .vmFolderPath | b64enc | quote }}

--- a/go_lib/dependency/vsphere/vsphere.go
+++ b/go_lib/dependency/vsphere/vsphere.go
@@ -62,6 +62,7 @@ const (
 type ProviderClusterConfiguration struct {
 	Provider          Provider `json:"provider"`
 	Region            string   `json:"region"`
+	Zones             []string `json:"zones"`
 	RegionTagCategory string   `json:"regionTagCategory"`
 	ZoneTagCategory   string   `json:"zoneTagCategory"`
 }
@@ -113,10 +114,6 @@ func NewClient(config *ProviderClusterConfiguration) (Client, error) {
 }
 
 func (v *client) GetZonesDatastores() (*Output, error) {
-	var (
-		zoneTagCategoryName = v.config.ZoneTagCategory
-	)
-
 	dc, err := v.getDCByRegion(context.TODO())
 	if err != nil {
 		return nil, err
@@ -130,7 +127,7 @@ func (v *client) GetZonesDatastores() (*Output, error) {
 		panic("no zonedDataStores returned")
 	}
 
-	zones, err := v.getZonesInDC(context.TODO(), dc, zoneTagCategoryName)
+	zones, err := v.getZonesInDC(context.TODO(), dc)
 	if err != nil {
 		return nil, err
 	}
@@ -264,7 +261,7 @@ func (v *client) getDCByRegion(ctx context.Context) (*object.Datacenter, error) 
 	return datacenter, nil
 }
 
-func (v *client) getZonesInDC(ctx context.Context, datacenter *object.Datacenter, zoneTagCategoryName string) ([]string, error) {
+func (v *client) getZonesInDC(ctx context.Context, datacenter *object.Datacenter) ([]string, error) {
 	finder := find.NewFinder(v.client.Client, true)
 
 	clusters, err := finder.ClusterComputeResourceList(ctx, path.Join(datacenter.InventoryPath, "..."))
@@ -278,7 +275,7 @@ func (v *client) getZonesInDC(ctx context.Context, datacenter *object.Datacenter
 
 	tagsClient := tags.NewManager(v.restClient)
 
-	zoneTagCategory, err := tagsClient.GetCategory(ctx, zoneTagCategoryName)
+	zoneTagCategory, err := tagsClient.GetCategory(ctx, v.config.ZoneTagCategory)
 	if err != nil {
 		return nil, err
 	}
@@ -299,10 +296,20 @@ func (v *client) getZonesInDC(ctx context.Context, datacenter *object.Datacenter
 		return nil, err
 	}
 
+	allowedZones := make(map[string]any, len(v.config.Zones))
+	for _, z := range v.config.Zones {
+		allowedZones[z] = struct{}{}
+	}
+
 	var matchingZonesMap = make(map[string]struct{})
 	for _, clusterTags := range clustersWithTags {
 		for _, clusterTag := range clusterTags.Tags {
 			if _, ok := tagsInCategoryMap[clusterTag.Name]; ok {
+				if len(allowedZones) > 0 {
+					if _, allowed := allowedZones[clusterTag.Name]; !allowed {
+						continue
+					}
+				}
 				matchingZonesMap[clusterTag.Name] = struct{}{}
 			}
 		}
@@ -371,11 +378,21 @@ func (v *client) getDataStoresInDC(ctx context.Context, datacenter *object.Datac
 		return nil, err
 	}
 
+	allowedZones := make(map[string]any, len(v.config.Zones))
+	for _, z := range v.config.Zones {
+		allowedZones[z] = struct{}{}
+	}
+
 	zds := make([]ZonedDataStore, 0)
 	for _, attachedTags := range datastoresWithTags {
 		var dsZones []string
 		for _, tag := range attachedTags.Tags {
 			if tag.CategoryID == zoneTagCategory.ID {
+				if len(allowedZones) > 0 {
+					if _, allowed := allowedZones[tag.Name]; !allowed {
+						continue
+					}
+				}
 				dsZones = append(dsZones, tag.Name)
 			}
 		}

--- a/go_lib/dependency/vsphere/vsphere.go
+++ b/go_lib/dependency/vsphere/vsphere.go
@@ -304,12 +304,11 @@ func (v *client) getZonesInDC(ctx context.Context, datacenter *object.Datacenter
 	var matchingZonesMap = make(map[string]struct{})
 	for _, clusterTags := range clustersWithTags {
 		for _, clusterTag := range clusterTags.Tags {
-			if _, ok := tagsInCategoryMap[clusterTag.Name]; ok {
-				if len(allowedZones) > 0 {
-					if _, allowed := allowedZones[clusterTag.Name]; !allowed {
-						continue
-					}
-				}
+			if _, ok := tagsInCategoryMap[clusterTag.Name]; !ok {
+				continue
+			}
+
+			if isZoneAllowed(allowedZones, clusterTag.Name) {
 				matchingZonesMap[clusterTag.Name] = struct{}{}
 			}
 		}
@@ -387,15 +386,15 @@ func (v *client) getDataStoresInDC(ctx context.Context, datacenter *object.Datac
 	for _, attachedTags := range datastoresWithTags {
 		var dsZones []string
 		for _, tag := range attachedTags.Tags {
-			if tag.CategoryID == zoneTagCategory.ID {
-				if len(allowedZones) > 0 {
-					if _, allowed := allowedZones[tag.Name]; !allowed {
-						continue
-					}
-				}
+			if tag.CategoryID != zoneTagCategory.ID {
+				continue
+			}
+
+			if isZoneAllowed(allowedZones, tag.Name) {
 				dsZones = append(dsZones, tag.Name)
 			}
 		}
+
 		if len(dsZones) == 0 {
 			continue
 		}
@@ -534,4 +533,14 @@ func murmurHash(args ...string) string {
 
 func prepareHashArgs(args ...string) string {
 	return strings.Join(args, ":::")
+}
+
+func isZoneAllowed(allowedZones map[string]any, zone string) bool {
+	// If no allowed zones are specified, then we assume that all zones are allowed
+	if len(allowedZones) == 0 {
+		return true
+	}
+
+	_, allowed := allowedZones[zone]
+	return allowed
 }


### PR DESCRIPTION
## Description

The `cloud-provider-vsphere` discovery process now respects the `zones` parameter from the provider configuration. Previously, discovery fetched all objects (datastores, clusters) tagged with any tag from `zoneTagCategory`, ignoring the configured `zones` list.

## Why do we need it, and what problem does it solve?

When a vSphere environment contains more zones (tags in `zoneTagCategory`) than are listed in the cluster's `zones` configuration, the discovery process incorrectly includes datastores from unconfigured zones. This leads to:

* Extraneous StorageClasses being created for zones not present in the cluster configuration.
* Incorrect topology on those StorageClasses — `region` is taken from the config, but `zone` comes from a tag on the datastore that shouldn't be in scope.
* CSI errors such as `duplicate values detected for category k8s-zone`, causing storage provisioning failures.

## Why do we need it in the patch release (if we do)?

This fix resolves CSI failures (`duplicate values detected for category k8s-zone`) that break storage provisioning in vSphere environments where the infrastructure has more zones tagged than the cluster is configured to use. This is a data-path affecting issue that can prevent PVC creation and pod scheduling.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-vsphere
type: fix
summary: Added filtering discovered zones and datastores by `zones` from provider configurations.
impact_level: default
```