### PR TITLE
[node-manager] Fix StaticMachine deletion stuck on inconsistent Pending StaticInstance.

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
@@ -30,7 +30,9 @@ import (
 
 // Cleanup runs the cleanup script on StaticInstance.
 func (c *Client) Cleanup(ctx context.Context, instanceScope *scope.InstanceScope) error {
-	switch instanceScope.GetPhase() {
+	phase := instanceScope.GetPhase()
+
+	switch phase {
 	case
 		deckhousev1.StaticInstanceStatusCurrentStatusPhaseBootstrapping,
 		deckhousev1.StaticInstanceStatusCurrentStatusPhaseRunning:
@@ -43,11 +45,36 @@ func (c *Client) Cleanup(ctx context.Context, instanceScope *scope.InstanceScope
 		if err != nil {
 			return errors.Wrap(err, "failed to clean up StaticInstance from cleaning phase")
 		}
+	case
+		"",
+		deckhousev1.StaticInstanceStatusCurrentStatusPhasePending:
+		if !canSkipCleanupForPendingPhase(instanceScope) {
+			return errors.New("StaticInstance is pending outside delete flow")
+		}
+		// During machine deletion, StaticInstance can still be Pending.
+		// In this case cleanup is a no-op and deletion should proceed.
+		instanceScope.Logger.V(1).Info("Skipping cleanup for StaticInstance in pending phase during deletion", "phase", phase)
 	default:
 		return errors.New("StaticInstance is not running or cleaning")
 	}
 
 	return nil
+}
+
+func canSkipCleanupForPendingPhase(instanceScope *scope.InstanceScope) bool {
+	if instanceScope.MachineScope == nil || instanceScope.MachineScope.StaticMachine == nil || instanceScope.MachineScope.Machine == nil {
+		return false
+	}
+
+	if instanceScope.MachineScope.StaticMachine.DeletionTimestamp.IsZero() || instanceScope.MachineScope.Machine.DeletionTimestamp.IsZero() {
+		return false
+	}
+
+	if instanceScope.Instance.Status.MachineRef == nil {
+		return true
+	}
+
+	return instanceScope.Instance.Status.MachineRef.UID == instanceScope.MachineScope.StaticMachine.UID
 }
 
 func (c *Client) cleanupFromBootstrappingOrRunningPhase(ctx context.Context, instanceScope *scope.InstanceScope) error {

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/client/cleanup.go
@@ -21,11 +21,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 	"caps-controller-manager/internal/scope"
 	"caps-controller-manager/internal/ssh"
 	"caps-controller-manager/internal/ssh/clissh"
 	"caps-controller-manager/internal/ssh/gossh"
+
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 )
 
 // Cleanup runs the cleanup script on StaticInstance.
@@ -46,7 +47,6 @@ func (c *Client) Cleanup(ctx context.Context, instanceScope *scope.InstanceScope
 			return errors.Wrap(err, "failed to clean up StaticInstance from cleaning phase")
 		}
 	case
-		"",
 		deckhousev1.StaticInstanceStatusCurrentStatusPhasePending:
 		if !canSkipCleanupForPendingPhase(instanceScope) {
 			return errors.New("StaticInstance is pending outside delete flow")

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
@@ -39,13 +39,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 	infrav1 "caps-controller-manager/api/infrastructure/v1alpha1"
 	"caps-controller-manager/internal/client"
 	"caps-controller-manager/internal/controller"
 	"caps-controller-manager/internal/event"
 	"caps-controller-manager/internal/pool"
 	"caps-controller-manager/internal/scope"
+
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 )
 
 const (
@@ -308,7 +309,7 @@ func (r *StaticMachineReconciler) cleanup(
 
 	// Delete flow might observe an inconsistent state where phase is Pending (or empty),
 	// but refs are still set. Normalize it and allow StaticMachine deletion to proceed.
-	if phase == "" || phase == deckhousev1.StaticInstanceStatusCurrentStatusPhasePending {
+	if phase == deckhousev1.StaticInstanceStatusCurrentStatusPhasePending {
 		if instanceScope.Instance.Status.MachineRef != nil || instanceScope.Instance.Status.NodeRef != nil || instanceScope.Instance.Status.CurrentStatus != nil {
 			err := instanceScope.ToPending(ctx)
 			if err != nil {

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
@@ -304,8 +304,21 @@ func (r *StaticMachineReconciler) cleanup(
 	instanceScope *scope.InstanceScope,
 ) (ctrl.Result, error) {
 	instanceScope.Logger.V(1).Info("StaticInstance is cleaning")
+	phase := instanceScope.GetPhase()
 
-	if instanceScope.GetPhase() != deckhousev1.StaticInstanceStatusCurrentStatusPhaseCleaning &&
+	// Delete flow might observe an inconsistent state where phase is Pending (or empty),
+	// but refs are still set. Normalize it and allow StaticMachine deletion to proceed.
+	if phase == "" || phase == deckhousev1.StaticInstanceStatusCurrentStatusPhasePending {
+		if instanceScope.Instance.Status.MachineRef != nil || instanceScope.Instance.Status.NodeRef != nil || instanceScope.Instance.Status.CurrentStatus != nil {
+			err := instanceScope.ToPending(ctx)
+			if err != nil {
+				return ctrl.Result{}, errors.Wrap(err, "failed to normalize StaticInstance to Pending phase")
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if phase != deckhousev1.StaticInstanceStatusCurrentStatusPhaseCleaning &&
 		instanceScope.Instance.Status.NodeRef != nil {
 		instanceScope.MachineScope.SetNotReady()
 
@@ -347,7 +360,7 @@ func (r *StaticMachineReconciler) cleanup(
 
 	estimated := DefaultStaticInstanceCleanupTimeout - time.Since(instanceScope.Instance.Status.CurrentStatus.LastUpdateTime.Time)
 
-	if instanceScope.GetPhase() == deckhousev1.StaticInstanceStatusCurrentStatusPhaseCleaning && estimated < (10*time.Second) {
+	if phase == deckhousev1.StaticInstanceStatusCurrentStatusPhaseCleaning && estimated < (10*time.Second) {
 		instanceScope.MachineScope.Fail("DeleteError", errors.New("timed out waiting for StaticInstance to clean up"))
 
 		r.Recorder.SendWarningEvent(instanceScope.Instance, instanceScope.MachineScope.StaticMachine.Labels["node-group"], "StaticInstanceCleanupTimeoutReached", "Timed out waiting for StaticInstance to clean up")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR fixes a stuck deletion scenario for StaticMachine in CAPS when the linked StaticInstance is in an inconsistent state (phase=Pending with non-empty machineRef/nodeRef). During delete reconciliation, CAPS now normalizes such StaticInstance objects to a consistent Pending state and then proceeds with StaticMachine finalizer removal.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In this state, CAPI waits indefinitely at WaitingForInfrastructureDeletion because the StaticMachine finalizer is never removed. The fix unblocks the delete flow, prevents infinite cleanup/requeue loops, and allows machine remediation/recreation to continue normally.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: caps fix inconsistent pending staticinstance
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
