### PR TITLE
[ci] Disable constant rebuilds for vex and trivyignore artifacts

### DIFF
--- a/.werf/defines/trivyignore.tmpl
+++ b/.werf/defines/trivyignore.tmpl
@@ -15,7 +15,6 @@
   {{- if $trivyIgnoreFile }}
 ---
 image: {{ $imageName }}-trivy-ignore-artifact
-fromCacheVersion: {{ div $context.Commit.Date.Unix (mul 60 60) }}v1
 fromImage: base/vex
 final: true
 secrets:

--- a/.werf/defines/vex.tmpl
+++ b/.werf/defines/vex.tmpl
@@ -21,7 +21,6 @@
   {{- if $vexFile }}
 ---
 image: {{ $imageName }}-vex-artifact
-fromCacheVersion: {{ div $context.Commit.Date.Unix (mul 60 60) }}v1
 fromImage: base/vex
 final: true
 secrets:


### PR DESCRIPTION
## Description
Disable constant rebuilds for vex and trivyignore artifacts by removing `fromCacheVersion` directive.

## Why do we need it, and what problem does it solve?
Constants reattestations take a significant amount of time, slowing down development and testing.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Disable constant rebuilds for vex and trivyignore artifacts.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
