### PR TITLE
[docs] Update 404 pages with new DKP documentation links

### DIFF
--- a/docs/documentation/pages/404.md
+++ b/docs/documentation/pages/404.md
@@ -15,8 +15,8 @@ We have changed the structure of the documentation, and some old links may not w
 {% endalert %}
 
 If you need documentation for previous versions, the following links might be helpful:
+- [DKP v1.73 Documentation](/products/kubernetes-platform/documentation/v1.73/)
+- [DKP v1.72 Documentation](/products/kubernetes-platform/documentation/v1.72/)
 - [DKP v1.71 Documentation](/products/kubernetes-platform/documentation/v1.71/deckhouse-overview.html)
 - [DKP v1.70 Documentation](/products/kubernetes-platform/documentation/v1.70/deckhouse-overview.html)
 - [DKP v1.69 Documentation](/products/kubernetes-platform/documentation/v1.69/deckhouse-overview.html)
-- [DKP v1.68 Documentation](/products/kubernetes-platform/documentation/v1.68/deckhouse-overview.html)
-- [DKP v1.67 Documentation](/products/kubernetes-platform/documentation/v1.67/deckhouse-overview.html)

--- a/docs/documentation/pages/404_RU.md
+++ b/docs/documentation/pages/404_RU.md
@@ -16,8 +16,8 @@ feedback: false
 {% endalert %}
 
 Если вам нужна документация предыдущих версий, возможно следующие ссылки будут полезны:
+- [Документация DKP v1.73](/products/kubernetes-platform/documentation/v1.73/)
+- [Документация DKP v1.72](/products/kubernetes-platform/documentation/v1.72/)
 - [Документация DKP v1.71](/products/kubernetes-platform/documentation/v1.71/deckhouse-overview.html)
 - [Документация DKP v1.70](/products/kubernetes-platform/documentation/v1.70/deckhouse-overview.html)
 - [Документация DKP v1.69](/products/kubernetes-platform/documentation/v1.69/deckhouse-overview.html)
-- [Документация DKP v1.68](/products/kubernetes-platform/documentation/v1.68/deckhouse-overview.html)
-- [Документация DKP v1.67](/products/kubernetes-platform/documentation/v1.67/deckhouse-overview.html)

--- a/docs/site/pages/404.md
+++ b/docs/site/pages/404.md
@@ -17,8 +17,8 @@ We have changed the structure of the documentation, and some old links may not w
 {% endalert %}
 
 If you need documentation for previous versions, the following links might be helpful:
+- [DKP v1.73 Documentation](/products/kubernetes-platform/documentation/v1.73/)
+- [DKP v1.72 Documentation](/products/kubernetes-platform/documentation/v1.72/)
 - [DKP v1.71 Documentation](/products/kubernetes-platform/documentation/v1.71/deckhouse-overview.html)
 - [DKP v1.70 Documentation](/products/kubernetes-platform/documentation/v1.70/deckhouse-overview.html)
 - [DKP v1.69 Documentation](/products/kubernetes-platform/documentation/v1.69/deckhouse-overview.html)
-- [DKP v1.68 Documentation](/products/kubernetes-platform/documentation/v1.68/deckhouse-overview.html)
-- [DKP v1.67 Documentation](/products/kubernetes-platform/documentation/v1.67/deckhouse-overview.html)

--- a/docs/site/pages/404_RU.md
+++ b/docs/site/pages/404_RU.md
@@ -18,8 +18,8 @@ feedback: false
 {% endalert %}
 
 Если вам нужна документация предыдущих версий, возможно следующие ссылки будут полезны:
+- [Документация DKP v1.73](/products/kubernetes-platform/documentation/v1.73/)
+- [Документация DKP v1.72](/products/kubernetes-platform/documentation/v1.72/)
 - [Документация DKP v1.71](/products/kubernetes-platform/documentation/v1.71/deckhouse-overview.html)
 - [Документация DKP v1.70](/products/kubernetes-platform/documentation/v1.70/deckhouse-overview.html)
 - [Документация DKP v1.69](/products/kubernetes-platform/documentation/v1.69/deckhouse-overview.html)
-- [Документация DKP v1.68](/products/kubernetes-platform/documentation/v1.68/deckhouse-overview.html)
-- [Документация DKP v1.67](/products/kubernetes-platform/documentation/v1.67/deckhouse-overview.html)


### PR DESCRIPTION
## Description

Update 404 pages with new DKP documentation links:
- Add links for DKP v1.73 and v1.72 to ensure users can access the latest documentation versions.
- Replace outdated links for better navigation and user guidance across both English and Russian documentation sites.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Updated 404 pages with new DKP documentation links.
impact_level: low
```
