### PR TITLE
[ci] Cleanup build workdir

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -307,5 +307,9 @@ steps:
       path: |
         ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+  - name: Cleanup workdir
+    if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+    run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
 # </template: build_template>
 {!{ end }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -664,6 +664,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -965,6 +969,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 
@@ -1268,6 +1276,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -1569,6 +1581,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 
@@ -1872,6 +1888,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -2173,6 +2193,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -442,6 +442,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -441,6 +441,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -751,6 +755,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 
@@ -1063,6 +1071,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -1373,6 +1385,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 
@@ -1685,6 +1701,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -1995,6 +2015,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -625,6 +625,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -1019,6 +1023,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 
@@ -1415,6 +1423,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -1797,6 +1809,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 
@@ -2181,6 +2197,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 
@@ -2563,6 +2583,10 @@ jobs:
           name: build_report_${{ env.WERF_ENV }}
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
 
     # </template: build_template>
 

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -427,6 +427,10 @@ jobs:
           path: |
             ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
 
+      - name: Cleanup workdir
+        if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
+        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+
     # </template: build_template>
 
 


### PR DESCRIPTION
## Description
Restores build workdir cleanup lost during build reworks.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Cleanup build workdir.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
