### PR TITLE
[ci] Remove werf tmp_dir

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -175,11 +175,6 @@ steps:
       # CE/EE/FE -> ce/ee/fe
       REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
-      # Temporary directory is moved to ensure
-      TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-      echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-      mkdir -p "$TEMP_WORKDIR"
-
     {!{- if or (eq $buildType "release") (eq $buildType "pre-release") }!}
       STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
       export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
@@ -225,10 +220,7 @@ steps:
       werf build \
         --parallel=true --parallel-tasks-limit=10 \
         --save-build-report=true \
-        --tmp-dir="$TEMP_WORKDIR" \
         --build-report-path images_tags_werf.json
-
-      cp images_tags_werf.json "$TEMP_WORKDIR"
 
       # Publish images for Git branch.
       if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -268,8 +260,8 @@ steps:
       echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
       # Filter out data from build report
-      egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-      mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+      egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+      mv images_tags_werf_filtered.json images_tags_werf.json
 
   - name: Check DKP images manifests in public registry
     if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -295,7 +287,7 @@ steps:
     run: |
       export REGISTRY_FROM="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
       export REGISTRY_TO="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${WERF_ENV,,}"
-      export IMAGES_TAGS_PATH=${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+      export IMAGES_TAGS_PATH=./images_tags_werf.json
       python .github/scripts/python/copy_attestations.py
   {!{- end }!}
 
@@ -304,12 +296,11 @@ steps:
     uses: {!{ index (ds "actions") "actions/upload-artifact" }!}
     with:
       name: build_report_${{ env.WERF_ENV }}
-      path: |
-        ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+      path: images_tags_werf.json
 
   - name: Cleanup workdir
     if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-    run: rm -r ${{ steps.build.outputs.build_report_dir }}
+    run: rm images_tags_werf.json
 
 # </template: build_template>
 {!{ end }!}

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -576,11 +576,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -597,10 +592,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -640,8 +632,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -661,12 +653,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -882,11 +873,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -903,10 +889,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -946,8 +929,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -967,12 +950,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1188,11 +1170,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -1209,10 +1186,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1252,8 +1226,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1273,12 +1247,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1494,11 +1467,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -1515,10 +1483,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1558,8 +1523,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1579,12 +1544,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1800,11 +1764,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -1821,10 +1780,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1864,8 +1820,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1885,12 +1841,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -2106,11 +2061,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -2127,10 +2077,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2170,8 +2117,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -2191,12 +2138,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -354,11 +354,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -375,10 +370,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -418,8 +410,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -439,12 +431,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -353,11 +353,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -374,10 +369,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -417,8 +409,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -438,12 +430,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -668,11 +659,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -689,10 +675,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -732,8 +715,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -753,12 +736,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -983,11 +965,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -1004,10 +981,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1047,8 +1021,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1068,12 +1042,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1298,11 +1271,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -1319,10 +1287,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1362,8 +1327,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1383,12 +1348,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1613,11 +1577,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -1634,10 +1593,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1677,8 +1633,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1698,12 +1654,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1928,11 +1883,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -1949,10 +1899,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1992,8 +1939,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -2013,12 +1960,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -517,11 +517,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -544,10 +539,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -587,8 +579,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -614,7 +606,7 @@ jobs:
         run: |
           export REGISTRY_FROM="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_TO="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${WERF_ENV,,}"
-          export IMAGES_TAGS_PATH=${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          export IMAGES_TAGS_PATH=./images_tags_werf.json
           python .github/scripts/python/copy_attestations.py
 
       - name: Save build report
@@ -622,12 +614,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -916,11 +907,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -943,10 +929,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -986,8 +969,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1013,7 +996,7 @@ jobs:
         run: |
           export REGISTRY_FROM="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_TO="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${WERF_ENV,,}"
-          export IMAGES_TAGS_PATH=${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          export IMAGES_TAGS_PATH=./images_tags_werf.json
           python .github/scripts/python/copy_attestations.py
 
       - name: Save build report
@@ -1021,12 +1004,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1315,11 +1297,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -1342,10 +1319,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1385,8 +1359,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1412,7 +1386,7 @@ jobs:
         run: |
           export REGISTRY_FROM="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_TO="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${WERF_ENV,,}"
-          export IMAGES_TAGS_PATH=${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          export IMAGES_TAGS_PATH=./images_tags_werf.json
           python .github/scripts/python/copy_attestations.py
 
       - name: Save build report
@@ -1420,12 +1394,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -1702,11 +1675,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -1729,10 +1697,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -1772,8 +1737,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -1799,7 +1764,7 @@ jobs:
         run: |
           export REGISTRY_FROM="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_TO="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${WERF_ENV,,}"
-          export IMAGES_TAGS_PATH=${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          export IMAGES_TAGS_PATH=./images_tags_werf.json
           python .github/scripts/python/copy_attestations.py
 
       - name: Save build report
@@ -1807,12 +1772,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -2089,11 +2053,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -2116,10 +2075,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2159,8 +2115,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -2186,7 +2142,7 @@ jobs:
         run: |
           export REGISTRY_FROM="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_TO="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${WERF_ENV,,}"
-          export IMAGES_TAGS_PATH=${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          export IMAGES_TAGS_PATH=./images_tags_werf.json
           python .github/scripts/python/copy_attestations.py
 
       - name: Save build report
@@ -2194,12 +2150,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 
@@ -2476,11 +2431,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
@@ -2503,10 +2453,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -2546,8 +2493,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -2573,7 +2520,7 @@ jobs:
         run: |
           export REGISTRY_FROM="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
           export REGISTRY_TO="${DECKHOUSE_REGISTRY_HOST}/deckhouse/${WERF_ENV,,}"
-          export IMAGES_TAGS_PATH=${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          export IMAGES_TAGS_PATH=./images_tags_werf.json
           python .github/scripts/python/copy_attestations.py
 
       - name: Save build report
@@ -2581,12 +2528,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -339,11 +339,6 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
-
-          # Temporary directory is moved to ensure
-          TEMP_WORKDIR="$(dirname "${{github.workspace}}")/${{github.run_id}}-$REGISTRY_SUFFIX"
-          echo "build_report_dir=$(echo ${TEMP_WORKDIR})" >> $GITHUB_OUTPUT
-          mkdir -p "$TEMP_WORKDIR"
           DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
           export REGISTRY_PATH="${DEV_REGISTRY_PATH}"
           export WERF_REPO="${DEV_REGISTRY_PATH}"
@@ -360,10 +355,7 @@ jobs:
           werf build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
-            --tmp-dir="$TEMP_WORKDIR" \
             --build-report-path images_tags_werf.json
-
-          cp images_tags_werf.json "$TEMP_WORKDIR"
 
           # Publish images for Git branch.
           if [[ -n "${CI_COMMIT_BRANCH}" ]]; then
@@ -403,8 +395,8 @@ jobs:
           echo "tests_image_name=$(echo ${TESTS_IMAGE_NAME} | gzip | base64 -w0)" >> $GITHUB_OUTPUT
 
           # Filter out data from build report
-          egrep -v '(DockerRepo|DockerImageName)' "$TEMP_WORKDIR/images_tags_werf.json" > "$TEMP_WORKDIR/images_tags_werf_filtered.json"
-          mv "$TEMP_WORKDIR/images_tags_werf_filtered.json" "$TEMP_WORKDIR/images_tags_werf.json"
+          egrep -v '(DockerRepo|DockerImageName)' images_tags_werf.json > images_tags_werf_filtered.json
+          mv images_tags_werf_filtered.json images_tags_werf.json
 
       - name: Check DKP images manifests in public registry
         if: ${{ github.repository == 'deckhouse/deckhouse' && startsWith(github.ref, 'refs/tags/v') }}
@@ -424,12 +416,11 @@ jobs:
         uses: actions/upload-artifact@v4.4.0
         with:
           name: build_report_${{ env.WERF_ENV }}
-          path: |
-            ${{ steps.build.outputs.build_report_dir }}/images_tags_werf.json
+          path: images_tags_werf.json
 
       - name: Cleanup workdir
         if: ${{ always() && (steps.build.outcome == 'success' || steps.build.outcome == 'failure') }}
-        run: rm -r ${{ steps.build.outputs.build_report_dir }}
+        run: rm images_tags_werf.json
 
     # </template: build_template>
 


### PR DESCRIPTION
## Description
Remove werf tmp_dir.

## Why do we need it, and what problem does it solve?
No longer necessary due to build runner upgrades.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Remove werf tmp_dir.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
