### PR TITLE
[docs] Add info about d8-cli approve/apply-now commands

### DIFF
--- a/docs/documentation/_faq/admin/APPLY_MODULE_UPDATE.md
+++ b/docs/documentation/_faq/admin/APPLY_MODULE_UPDATE.md
@@ -13,7 +13,7 @@ Example of setting the annotation for the `console` module:
 d8 k annotate mr console-v1.43.3 modules.deckhouse.io/apply-now="true"
 ```
 
-This can also be done using the d8 CLI for convenience (module names and versions are autocompleted):
+This can also be done using the [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI for convenience (module names and versions are autocompleted):
 
 ```shell
 d8 system module apply-now console v1.43.3

--- a/docs/documentation/_faq/admin/APPLY_MODULE_UPDATE_RU.md
+++ b/docs/documentation/_faq/admin/APPLY_MODULE_UPDATE_RU.md
@@ -13,7 +13,7 @@ lang: ru
 d8 k annotate mr console-v1.43.3 modules.deckhouse.io/apply-now="true"
 ```
 
-Для удобства это можно сделать с помощью d8 CLI (имена модулей и версии автодополняются):
+Для удобства это можно сделать с помощью [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI (имена модулей и версии автодополняются):
 
 ```shell
 d8 system module apply-now console v1.43.3

--- a/docs/documentation/pages/architecture/module-development/DEVELOPMENT.md
+++ b/docs/documentation/pages/architecture/module-development/DEVELOPMENT.md
@@ -366,7 +366,7 @@ To approve the module release, apply the annotation:
 d8 k annotate mr p-o-test-v0.7.25 modules.deckhouse.io/approved="true"
 ```
 
-This can also be done using the d8 CLI for convenience (module names and versions are autocompleted):
+This can also be done using the [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI for convenience (module names and versions are autocompleted):
 
 ```shell
 d8 system module approve p-o-test v0.7.25

--- a/docs/documentation/pages/architecture/module-development/DEVELOPMENT_RU.md
+++ b/docs/documentation/pages/architecture/module-development/DEVELOPMENT_RU.md
@@ -366,7 +366,7 @@ p-o-test-v0.7.25   Pending      Release is waiting for the 'modules.deckhouse.io
 d8 k annotate mr p-o-test-v0.7.25 modules.deckhouse.io/approved="true"
 ```
 
-Для удобства это можно сделать с помощью d8 CLI (имена модулей и версии автодополняются):
+Для удобства это можно сделать с помощью [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI (имена модулей и версии автодополняются):
 
 ```shell
 d8 system module approve p-o-test v0.7.25

--- a/docs/documentation/pages/architecture/module-development/RUN.md
+++ b/docs/documentation/pages/architecture/module-development/RUN.md
@@ -296,7 +296,7 @@ If a module release is `Pending`, it means that manual confirmation is required 
 d8 k annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 ```
 
-This can also be done using the d8 CLI for convenience (module names and versions are autocompleted):
+This can also be done using the [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI for convenience (module names and versions are autocompleted):
 
 ```shell
 d8 system module approve <module-name> <version>
@@ -450,7 +450,7 @@ The example output above illustrates ModuleRelease message when the update mode 
 d8 k annotate mr module-1-v1.23.2 modules.deckhouse.io/approved="true"
 ```
 
-This can also be done using the d8 CLI for convenience (module names and versions are autocompleted):
+This can also be done using the [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI for convenience (module names and versions are autocompleted):
 
 ```shell
 d8 system module approve module-1 v1.23.2

--- a/docs/documentation/pages/architecture/module-development/RUN_RU.md
+++ b/docs/documentation/pages/architecture/module-development/RUN_RU.md
@@ -298,7 +298,7 @@ module-two-v1.2.5          Pending      deckhouse       44d              Waiting
 d8 k annotate mr <module_release_name> modules.deckhouse.io/approved="true"
 ```
 
-Для удобства это можно сделать с помощью d8 CLI (имена модулей и версии автодополняются):
+Для удобства это можно сделать с помощью [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI (имена модулей и версии автодополняются):
 
 ```shell
 d8 system module approve <module-name> <version>
@@ -454,7 +454,7 @@ module-1-v1.23.2     Pending      example-update-policy  3m               Waitin
 d8 k annotate mr module-1-v1.23.2 modules.deckhouse.io/approved="true"
 ```
 
-Для удобства это можно сделать с помощью d8 CLI (имена модулей и версии автодополняются):
+Для удобства это можно сделать с помощью [`d8`](/products/kubernetes-platform/documentation/v1/cli/d8/) CLI (имена модулей и версии автодополняются):
 
 ```shell
 d8 system module approve module-1 v1.23.2


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add references to `d8 system module apply-now` and `d8 system module approve` CLI commands in the documentation where `d8 k annotate mr` with `modules.deckhouse.io/apply-now` and `modules.deckhouse.io/approved` annotations are described.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `d8` CLI provides convenient commands (`d8 system module apply-now`, `d8 system module approve`) with shell autocompletion for module names and versions, but the documentation only mentions the lower-level `d8 k annotate` approach. Users should be aware of the more convenient alternative.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add d8 CLI commands (apply-now, approve) references to module update documentation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
