### PR TITLE
[istio] Add validating webhooks for IstioFederation and IstioMulticluster

### DIFF
--- a/ee/modules/110-istio/webhooks/validating/istiofederations
+++ b/ee/modules/110-istio/webhooks/validating/istiofederations
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+source /shell_lib.sh
+
+function __config__() {
+  cat <<EOF
+configVersion: v1
+kubernetes:
+- name: istioMC
+  group: main
+  executeHookOnEvent: []
+  executeHookOnSynchronization: false
+  keepFullObjectsInMemory: false
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ModuleConfig
+  nameSelector:
+    matchNames:
+    - istio
+  jqFilter: |
+    {
+      "federation_enabled": .spec.settings.federation.enabled,
+    }
+kubernetesValidating:
+- name: istiofederations.deckhouse.io
+  group: main
+  includeSnapshotsFrom: ["istioMC"]
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["v1alpha1"]
+    operations:  ["CREATE"]
+    resources:   ["istiofederations"]
+    scope:       "Cluster"
+EOF
+}
+
+function __main__() {
+  federation_enabled=$(context::jq -r '.snapshots.istioMC[]?.filterResult.federation_enabled')
+  if [ "$federation_enabled" != "true" ]; then
+    jq -nc '
+    {
+      "allowed": false,
+      "message": "IstioFederations can only be created when federation is enabled. Enable spec.settings.federation.enabled in the istio ModuleConfig."
+    }
+    ' > $VALIDATING_RESPONSE_PATH
+    exit 0
+  fi
+
+  jq -nc '{"allowed": true}' >"$VALIDATING_RESPONSE_PATH"
+}
+
+hook::run "$@"

--- a/ee/modules/110-istio/webhooks/validating/istiofederations
+++ b/ee/modules/110-istio/webhooks/validating/istiofederations
@@ -9,7 +9,7 @@ function __config__() {
   cat <<EOF
 configVersion: v1
 kubernetes:
-- name: istioMC
+- name: istio_mc
   group: main
   executeHookOnEvent: []
   executeHookOnSynchronization: false
@@ -21,12 +21,12 @@ kubernetes:
     - istio
   jqFilter: |
     {
-      "federation_enabled": .spec.settings.federation.enabled,
+      "federationEnabled": .spec.settings.federation.enabled,
     }
 kubernetesValidating:
 - name: istiofederations.deckhouse.io
   group: main
-  includeSnapshotsFrom: ["istioMC"]
+  includeSnapshotsFrom: ["istio_mc"]
   rules:
   - apiGroups:   ["deckhouse.io"]
     apiVersions: ["v1alpha1"]
@@ -37,7 +37,7 @@ EOF
 }
 
 function __main__() {
-  federation_enabled=$(context::jq -r '.snapshots.istioMC[]?.filterResult.federation_enabled')
+  federation_enabled=$(context::jq -r '.snapshots.istio_mc[]?.filterResult.federationEnabled')
   if [ "$federation_enabled" != "true" ]; then
     jq -nc '
     {

--- a/ee/modules/110-istio/webhooks/validating/istiomulticluster
+++ b/ee/modules/110-istio/webhooks/validating/istiomulticluster
@@ -9,7 +9,7 @@ function __config__() {
   cat <<EOF
 configVersion: v1
 kubernetes:
-- name: istioMC
+- name: istio_mc
   group: main
   executeHookOnEvent: []
   executeHookOnSynchronization: false
@@ -21,12 +21,12 @@ kubernetes:
     - istio
   jqFilter: |
     {
-      "multicluster_enabled": .spec.settings.multicluster.enabled,
+      "multiclusterEnabled": .spec.settings.multicluster.enabled,
     }
 kubernetesValidating:
 - name: istiomulticlusters.deckhouse.io
   group: main
-  includeSnapshotsFrom: ["istioMC"]
+  includeSnapshotsFrom: ["istio_mc"]
   rules:
   - apiGroups:   ["deckhouse.io"]
     apiVersions: ["v1alpha1"]
@@ -37,7 +37,7 @@ EOF
 }
 
 function __main__() {
-  multicluster_enabled=$(context::jq -r '.snapshots.istioMC[]?.filterResult.multicluster_enabled')
+  multicluster_enabled=$(context::jq -r '.snapshots.istio_mc[]?.filterResult.multiclusterEnabled')
   if [ "$multicluster_enabled" != "true" ]; then
     jq -nc '
     {

--- a/ee/modules/110-istio/webhooks/validating/istiomulticluster
+++ b/ee/modules/110-istio/webhooks/validating/istiomulticluster
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
+# Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+
+source /shell_lib.sh
+
+function __config__() {
+  cat <<EOF
+configVersion: v1
+kubernetes:
+- name: istioMC
+  group: main
+  executeHookOnEvent: []
+  executeHookOnSynchronization: false
+  keepFullObjectsInMemory: false
+  apiVersion: deckhouse.io/v1alpha1
+  kind: ModuleConfig
+  nameSelector:
+    matchNames:
+    - istio
+  jqFilter: |
+    {
+      "multicluster_enabled": .spec.settings.multicluster.enabled,
+    }
+kubernetesValidating:
+- name: istiomulticlusters.deckhouse.io
+  group: main
+  includeSnapshotsFrom: ["istioMC"]
+  rules:
+  - apiGroups:   ["deckhouse.io"]
+    apiVersions: ["v1alpha1"]
+    operations:  ["CREATE"]
+    resources:   ["istiomulticlusters"]
+    scope:       "Cluster"
+EOF
+}
+
+function __main__() {
+  multicluster_enabled=$(context::jq -r '.snapshots.istioMC[]?.filterResult.multicluster_enabled')
+  if [ "$multicluster_enabled" != "true" ]; then
+    jq -nc '
+    {
+      "allowed": false,
+      "message": "IstioMulticlusters can only be created when multicluster is enabled. Enable spec.settings.multicluster.enabled in the istio ModuleConfig."
+    }
+    ' > $VALIDATING_RESPONSE_PATH
+    exit 0
+  fi
+
+  jq -nc '{"allowed": true}' >"$VALIDATING_RESPONSE_PATH"
+}
+
+hook::run "$@"


### PR DESCRIPTION
## Description

This PR adds two validating webhooks for the Istio EE module:
1. istiofederations — Validates creation of IstioFederation resources. Creation is allowed only when the Istio module has federation enabled (spec.settings.federation.enabled: true in the istio ModuleConfig).
2. istiomulticluster — Validates creation of IstioMulticluster resources. Creation is allowed only when the Istio module has multicluster enabled (spec.settings.multicluster.enabled: true in the istio ModuleConfig).

## Why do we need it, and what problem does it solve?

Without these webhooks, users can create IstioFederation or IstioMulticluster resources even when the corresponding feature (federation or multicluster) is disabled in the Istio module. That leads to misconfiguration and confusing behaviour. The webhooks enforce that these resources are only created when the relevant feature is enabled in the module configuration, giving immediate, clear feedback at admission time.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Added validating webhooks for IstioFederation and IstioMulticluster resources.
impact: Creation of IstioFederation is only allowed when Istio federation is enabled in the module configuration. Creation of IstioMulticluster is only allowed when Istio multicluster is enabled in the module configuration.
impact_level: default
```