### PR TITLE
[node-manager] add new label setting, when fencing-agent is on

### DIFF
--- a/modules/040-node-manager/images/fencing-agent/src/cmd/main.go
+++ b/modules/040-node-manager/images/fencing-agent/src/cmd/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -39,15 +40,16 @@ import (
 )
 
 const (
-	Notify   = "Notify"
-	Watchdog = "Watchdog"
+	Notify               = "Notify"
+	Watchdog             = "Watchdog"
+	fencingNodeLabel     = "node-manager.deckhouse.io/fencing-enabled"
+	fencingNodeLabelMode = "node-manager.deckhouse.io/fencing-mode"
 )
 
 func main() {
 	var cfg config.Config
 	cfg.MustLoad()
 
-	// logging
 	log := logger.NewLogger(cfg.LogLevel)
 
 	err := AppRun(cfg, log)
@@ -101,6 +103,12 @@ func AppRun(cfg config.Config, log *log.Logger) error {
 
 	mblist.BroadcastNodesNumber(totalNodes)
 
+	err = setNodeLabels(ctx, kubeClient, cfg.FencingMode)
+	if err != nil {
+		return fmt.Errorf("failed to set node labels: %w", err)
+	}
+	defer removeNodeLabels(kubeClient)
+
 	if cfg.FencingMode == Watchdog {
 		log.Info("Watchdog enabled, starting health monitor")
 
@@ -114,7 +122,6 @@ func AppRun(cfg config.Config, log *log.Logger) error {
 		fallback := usecase.NewFallback(log, kubeClient)
 
 		fencingAgent := usecase.NewHealthMonitor(
-			kubeClient,
 			kubeClient,
 			mblist,
 			softdog,
@@ -157,4 +164,33 @@ func AppRun(cfg config.Config, log *log.Logger) error {
 	})
 
 	return g.Wait()
+}
+
+func setNodeLabels(ctx context.Context, kubeClient *kubeclient.Client, fencingNodeModeValue string) error {
+	if labelErr := kubeClient.SetNodeLabel(ctx, fencingNodeLabel, ""); labelErr != nil {
+		kubeClient.Logger.Error("unable to set node label, disarming watchdog for safety", sl.Err(labelErr))
+		return labelErr
+	}
+
+	if labelErr := kubeClient.SetNodeLabel(ctx, fencingNodeLabelMode, fencingNodeModeValue); labelErr != nil {
+		kubeClient.Logger.Error("unable to set node label, disarming watchdog for safety", sl.Err(labelErr))
+		if err := kubeClient.RemoveNodeLabel(ctx, fencingNodeLabel); err != nil {
+			kubeClient.Logger.Error("unable to remove node label", sl.Err(err))
+		}
+		return labelErr
+	}
+	return nil
+}
+
+func removeNodeLabels(kubeClient *kubeclient.Client) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if labelErr := kubeClient.RemoveNodeLabel(ctx, fencingNodeLabel); labelErr != nil {
+		kubeClient.Logger.Error("unable to remove node label", sl.Err(labelErr))
+	}
+
+	if labelErr := kubeClient.RemoveNodeLabel(ctx, fencingNodeLabelMode); labelErr != nil {
+		kubeClient.Logger.Error("unable to remove node label", sl.Err(labelErr))
+	}
 }

--- a/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
@@ -62,7 +62,7 @@ var maintenanceAnnotations = [...]string{
 
 type Client struct {
 	client            kubernetes.Interface
-	logger            *log.Logger
+	Logger            *log.Logger
 	nodeName          string
 	nodeGroup         string
 	inMaintenanceMode atomic.Bool
@@ -90,7 +90,7 @@ func New(cfg Config,
 
 	client := &Client{
 		client:    kubeClient,
-		logger:    logger,
+		Logger:    logger,
 		nodeName:  nodeName,
 		nodeGroup: nodeGroup,
 	}
@@ -111,7 +111,7 @@ func (c *Client) SetNodeLabel(ctx context.Context, key, value string) error {
 		return fmt.Errorf("failed to patch node %s labels: %w", c.nodeName, err)
 	}
 
-	c.logger.Info("node label set",
+	c.Logger.Info("node label set",
 		slog.String("node", c.nodeName),
 		slog.String("label", key),
 		slog.String("value", value))
@@ -127,7 +127,7 @@ func (c *Client) RemoveNodeLabel(ctx context.Context, key string) error {
 		return fmt.Errorf("failed to patch node %s labels: %w", c.nodeName, err)
 	}
 
-	c.logger.Info("node label removed",
+	c.Logger.Info("node label removed",
 		slog.String("node", c.nodeName),
 		slog.String("label", key))
 	return nil
@@ -136,13 +136,13 @@ func (c *Client) RemoveNodeLabel(ctx context.Context, key string) error {
 func (c *Client) GetNodesIP(ctx context.Context) ([]string, error) {
 	labelSelector := fmt.Sprintf("node.deckhouse.io/group=%s", c.nodeGroup)
 
-	c.logger.Debug("get nodes", slog.String("label_selector", labelSelector))
+	c.Logger.Debug("get nodes", slog.String("label_selector", labelSelector))
 
 	nodes, err := c.client.CoreV1().Nodes().List(ctx, v1meta.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {
-		c.logger.Warn("failed to get nodes from kubeapi", sl.Err(err))
+		c.Logger.Warn("failed to get nodes from kubeapi", sl.Err(err))
 		return nil, err
 	}
 
@@ -187,7 +187,7 @@ func (c *Client) StartInformer(ctx context.Context) error {
 		AddFunc: func(obj interface{}) {
 			node, ok := obj.(*v1.Node)
 			if !ok {
-				c.logger.Warn("failed to cast object to Node in AddFunc")
+				c.Logger.Warn("failed to cast object to Node in AddFunc")
 				return
 			}
 			if node.Name == c.nodeName {
@@ -197,7 +197,7 @@ func (c *Client) StartInformer(ctx context.Context) error {
 		UpdateFunc: func(_, newObj interface{}) {
 			node, ok := newObj.(*v1.Node)
 			if !ok {
-				c.logger.Warn("failed to cast object to Node in UpdateFunc")
+				c.Logger.Warn("failed to cast object to Node in UpdateFunc")
 				return
 			}
 			if node.Name == c.nodeName {
@@ -208,11 +208,11 @@ func (c *Client) StartInformer(ctx context.Context) error {
 			// If our node is deleted, we're likely shutting down anyway
 			node, ok := obj.(*v1.Node)
 			if !ok {
-				c.logger.Warn("failed to cast object to Node in DeleteFunc")
+				c.Logger.Warn("failed to cast object to Node in DeleteFunc")
 				return
 			}
 			if node.Name == c.nodeName {
-				c.logger.Warn("current node deleted from cluster")
+				c.Logger.Warn("current node deleted from cluster")
 			}
 		},
 	})
@@ -228,7 +228,7 @@ func (c *Client) StartInformer(ctx context.Context) error {
 	if !cache.WaitForCacheSync(ctx.Done(), nodeInformer.HasSynced) {
 		return fmt.Errorf("failed to sync node informer cache")
 	}
-	c.logger.Info("node informer cache synced successfully")
+	c.Logger.Info("node informer cache synced successfully")
 	return nil
 }
 
@@ -248,11 +248,11 @@ func (c *Client) checkMaintenanceAnnotations(node *v1.Node) {
 
 	if oldValue != hasAnnotation {
 		if hasAnnotation {
-			c.logger.Info("maintenance mode detected",
+			c.Logger.Info("maintenance mode detected",
 				slog.String("node", c.nodeName),
 				slog.String("annotation", foundAnnotation))
 		} else {
-			c.logger.Info("maintenance mode cleared",
+			c.Logger.Info("maintenance mode cleared",
 				slog.String("node", c.nodeName))
 		}
 	}
@@ -261,7 +261,7 @@ func (c *Client) checkMaintenanceAnnotations(node *v1.Node) {
 func (c *Client) StopInformer() {
 	if c.informerStopCh != nil {
 		close(c.informerStopCh)
-		c.logger.Info("node informer stopped")
+		c.Logger.Info("node informer stopped")
 	}
 }
 

--- a/modules/040-node-manager/images/fencing-agent/src/internal/usecase/health_monitor.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/usecase/health_monitor.go
@@ -20,7 +20,6 @@ package usecase
 //go:generate minimock -i NodeWatcher -o ./mock/nodewatcher_mock.go -g
 //go:generate minimock -i Decider -o ./mock/decider_mock.go -g
 //go:generate minimock -i FallbackDecider -o ./mock/fallbackdecider_mock.go -g
-//go:generate minimock -i ClusterProvider -o ./mock/clusterprovider_mock.go -g
 //go:generate minimock -i MemberlistProvider -o ./mock/memberlistprovider_mock.go -g
 
 import (
@@ -32,10 +31,6 @@ import (
 
 	"fencing-agent/internal/lib/backoff"
 	"fencing-agent/internal/lib/logger/sl"
-)
-
-const (
-	fencingNodeLabel = "node-manager.deckhouse.io/fencing-enabled"
 )
 
 type WatchDog interface {
@@ -57,11 +52,6 @@ type FallbackDecider interface {
 	ShouldFeed(ctx context.Context) bool
 }
 
-type ClusterProvider interface {
-	SetNodeLabel(ctx context.Context, key string, value string) error
-	RemoveNodeLabel(ctx context.Context, key string) error
-}
-
 type MemberlistProvider interface {
 	NumMembers() int
 }
@@ -69,7 +59,6 @@ type MemberlistProvider interface {
 type HealthMonitor struct {
 	mu         *sync.Mutex
 	logger     *log.Logger
-	cluster    ClusterProvider
 	membership MemberlistProvider
 	watchdog   WatchDog
 	decider    Decider
@@ -79,13 +68,11 @@ type HealthMonitor struct {
 
 func NewHealthMonitor(
 	watcher NodeWatcher,
-	cluster ClusterProvider,
 	membership MemberlistProvider,
 	watchdog WatchDog, decider Decider,
 	fallbacker FallbackDecider,
 	logger *log.Logger) *HealthMonitor {
 	return &HealthMonitor{
-		cluster:    cluster,
 		membership: membership,
 		watchdog:   watchdog,
 		mu:         &sync.Mutex{},
@@ -118,12 +105,10 @@ func (h *HealthMonitor) Start(ctx context.Context, watchdogTimeout int) error {
 }
 
 func (h *HealthMonitor) Stop() {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	if h.watchdog.IsArmed() {
-		if err := h.stopWatchdog(ctx); err != nil {
+		if err := h.stopWatchdog(); err != nil {
 			h.logger.Error("unable to stop watchdog", sl.Err(err))
 		}
 	}
@@ -140,7 +125,7 @@ func (h *HealthMonitor) check(ctx context.Context) {
 		if h.watchdog.IsArmed() {
 			h.logger.Info("node is in maintenance mode, watchdog is armed, disarming watchdog")
 
-			err := h.stopWatchdog(ctx)
+			err := h.stopWatchdog()
 			if err == nil {
 				h.logger.Info("watchdog disarmed successfully")
 				return
@@ -192,28 +177,9 @@ func (h *HealthMonitor) startWatchdogBackoff(ctx context.Context) error {
 		return err
 	}
 
-	// Set node label to indicate fencing is enabled
-	if labelErr := h.cluster.SetNodeLabel(ctx, fencingNodeLabel, ""); labelErr != nil {
-		h.logger.Error("unable to set node label, disarming watchdog for safety", sl.Err(labelErr))
-
-		if stopErr := h.watchdog.Stop(); stopErr != nil {
-			h.logger.Error("failed to stop watchdog after label error", sl.Err(stopErr))
-		}
-
-		return labelErr
-	}
-
 	return nil
 }
 
-func (h *HealthMonitor) stopWatchdog(ctx context.Context) error {
-	if err := h.cluster.RemoveNodeLabel(ctx, fencingNodeLabel); err != nil {
-		h.logger.Error("Unable to remove node label", sl.Err(err))
-	}
-
-	if err := h.watchdog.Stop(); err != nil {
-		return err
-	}
-
-	return nil
+func (h *HealthMonitor) stopWatchdog() error {
+	return h.watchdog.Stop()
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

A new `node-manager.deckhouse.io/fencing-mode` label is added to indicate the active fencing mode (Notify/Watchdog) on the node.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: setting new label to indicate fencing mode.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
