### PR TITLE
[candi] Fix internal node IP discovery for static nodes in DVP clusters

### DIFF
--- a/candi/bashible/common-steps/all/000_discover_node_ip.sh.tpl
+++ b/candi/bashible/common-steps/all/000_discover_node_ip.sh.tpl
@@ -12,6 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+function discover_internal_network_cidrs() {
+  local physical_iface
+  local discovered_internal_network_cidrs
+
+  physical_iface="$(ls -l /sys/class/net/ | grep -vE "virtual|total" | grep "devices" | awk '{print $9}')"
+  if [[ "$(wc -l <<< "${physical_iface}")" -eq 1 ]]; then
+    discovered_internal_network_cidrs="$(ip route show scope link proto kernel dev "${physical_iface}" | awk '{print $1}')"
+    echo "$discovered_internal_network_cidrs"
+  else
+    bb-log-error "Cannot discover internal network CIDRs. Node has more than one interface, and StaticClusterConfiguration internalNetworkCIDRs is not set."
+    return 1
+  fi
+}
+
+function check_slash32_node_ip() {
+  local inet_lines
+  inet_lines="$(ip -4 -o addr show up scope global | awk '$2 != "lo" {print $4}')"
+  if [[ -z "$inet_lines" || "$(wc -l <<< "${inet_lines}")" -ne 1 ]]; then
+    return 1
+  fi
+
+  local inet_line="${inet_lines}"
+  local addr="${inet_line%/*}"
+  local prefix="${inet_line#*/}"
+
+  [[ "$prefix" == "32" ]] && echo "$addr"
+}
+
+
 # Ensure we have file
 touch /var/lib/bashible/discovered-node-ip
 
@@ -37,20 +66,11 @@ fi
   {{- if and (hasKey .nodeGroup "static") (hasKey .nodeGroup.static "internalNetworkCIDRs")}}
 internal_network_cidrs={{ .nodeGroup.static.internalNetworkCIDRs | join " " | quote }}
   {{- end }}
+
 if [[ -z "$internal_network_cidrs" ]]; then
-  # if internal network cidrs is not set, and the node has one interface, use its network as internal_network_cidr
-  physical_iface="$(ls -l /sys/class/net/ | grep -vE "virtual|total" | grep "devices" | awk '{print $9}')"
-  if [[ "$(wc -l <<< "${physical_iface}")" -eq 1 ]]; then
-    internal_network_cidrs="$(ip route show scope link proto kernel dev "${physical_iface}" | awk '{print $1}')"
-  else
-    bb-log-error "Cannot discover internal network CIDRs. Node has more than one interface, and StaticClusterConfiguration internalNetworkCIDRs is not set."
-    bb-log-error "Please deploy StaticClusterConfiguration with internalNetworkCIDRs set to one of the node networks:"
-    for network in $($ip_route_get_cmd | awk '{print $1}'); do
-      bb-log-error "  - $network"
-    done
-    exit 1
-  fi
+  internal_network_cidrs="$(discover_internal_network_cidrs || true)"
 fi
+
 
 function is_ip_in_cidr() {
   ip="$1"
@@ -73,6 +93,15 @@ else
   ip_in_system=$(ip -4 -o addr show up scope global | awk '$2 != "lo" {print $4}' | cut -d/ -f1)
 fi
 
+# DVP like case (with /32 addr)
+if [[ -z "$internal_network_cidrs" ]]; then
+  if slash32_node_ip="$(check_slash32_node_ip)"; then
+    echo "$slash32_node_ip" > /var/lib/bashible/discovered-node-ip
+    exit 0
+  fi
+fi
+
+# Other cases
 for cidr in $internal_network_cidrs; do
   for ip in $ip_in_system; do
     if is_ip_in_cidr "$ip" "$cidr"; then


### PR DESCRIPTION
## Description

This PR fixes static node internal IP discovery in DVP clusters.

Before this change, adding a static node could fail when Deckhouse could not detect `internal_network_cidrs` from routes and the node had only one global IPv4 address with `/32` mask.

## Why do we need it, and what problem does it solve?

We need this fix because static nodes in some DVP clusters could not join the cluster.

The problem was in internal node IP discovery. In `/32` address case, bashible could not correctly find internal network CIDRs and because of that it could not choose the node internal IP.

Now the logic is safer and more explicit:
- internal network CIDRs discovery is moved to a separate helper
- if CIDRs are still empty, bashible checks special `/32` case
- if the node has exactly one global IPv4 address and it is `/32`, this IP is used as discovered node IP


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed internal node IP discovery for static nodes in DVP clusters.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
