### PR TITLE
[ingress-nginx] optimize werf build

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -4,7 +4,7 @@
 {{- $controllerUID := "64535" }}
 
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-patches-artifact
 fromImage: common/src-artifact
 final: false
 git:
@@ -12,7 +12,48 @@ git:
   to: /patches
   stageDependencies:
     install:
-      - '**/*'
+      - 001-go-mod.patch
+      - 002-healthcheck.patch
+      - 004-lua-info.patch
+      - 005-makefile.patch
+      - 006-metrics-SetSSLExpireTime.patch
+      - 008-util.patch
+      - 009-fix-cleanup.patch
+      - 011-add-http3.patch
+      - 012-new-metrics.patch
+      - 013-default-backend-fix.patch
+      - 015-validation-mode.patch
+      - 016-verbose-maxmind-logs.patch
+      - 017-fix-success-reload-metric.patch
+      - 018-disable-error-logs.patch
+      - 019-fix-sorting.patch
+      - 020-geoip-ver-metric.patch
+      - 021-skip-tls-verification-maxmind.patch
+      - 022-ingress-update-status.patch
+      - 023-use-proxy-real-ip-cidr-v2.patch
+      - 024-cve-03022026-controller.patch
+      - 027-fix-rewrite-target-cve.patch
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-patches-artifact
+fromImage: common/src-artifact
+final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+      - 003-nginx-tmpl.patch
+      - 007-auth-cookie-always.patch
+      - 010-nginx-build.patch
+      - 014-balancer-lua.patch
+      - 023-use-proxy-real-ip-cidr-v2.patch
+      - 025-cve-03022026-rootfs.patch
+      - 026-lua_ingress-use-request-host-for-https-redirect.patch
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
+fromImage: common/src-artifact
+final: false
+git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/rootfs
   to: /src/rootfs
   stageDependencies:
@@ -28,6 +69,32 @@ git:
   stageDependencies:
     install:
       - '**/*'
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-aux-src-artifact
+fromImage: common/src-artifact
+final: false
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
+shell:
+  setup:
+  - mkdir -p /src
+  - cd /src
+  - git clone --branch v1.2.5 --depth 1 $(cat /run/secrets/SOURCE_REPO)/yelp/dumb-init.git
+  - git clone --branch 0.5.1 $(cat /run/secrets/SOURCE_REPO)/starwing/lua-protobuf
+  - git clone --branch 7-3 $(cat /run/secrets/SOURCE_REPO)/luarocks-sorces/lua-iconv
+  - rm -rf /src/dumb-init/.git
+  - rm -rf /src/lua-protobuf/.git
+  - rm -rf /src/lua-iconv/.git
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+fromImage: common/src-artifact
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-patches-artifact
+  add: /patches
+  to: /patches
+  before: install
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -38,9 +105,6 @@ shell:
   setup:
   - mkdir -p /src
   - cd /src
-  - git clone --branch v1.2.5 --depth 1 $(cat /run/secrets/SOURCE_REPO)/yelp/dumb-init.git
-  - git clone --branch 0.5.1 $(cat /run/secrets/SOURCE_REPO)/starwing/lua-protobuf
-  - git clone --branch 7-3 $(cat /run/secrets/SOURCE_REPO)/luarocks-sorces/lua-iconv
   - git clone --branch {{ $controllerBranch }} --depth 1 {{$.SOURCE_REPO}}/kubernetes/ingress-nginx.git
   - cd /src/ingress-nginx
   - patch -p1 < /patches/001-go-mod.patch
@@ -50,7 +114,6 @@ shell:
   - patch -p1 < /patches/006-metrics-SetSSLExpireTime.patch
   - patch -p1 < /patches/008-util.patch
   - patch -p1 < /patches/009-fix-cleanup.patch
-  - patch -p1 < /patches/010-nginx-build.patch
   - patch -p1 < /patches/011-add-http3.patch
   - patch -p1 < /patches/012-new-metrics.patch
   - patch -p1 < /patches/013-default-backend-fix.patch
@@ -64,22 +127,42 @@ shell:
   - patch -p1 < /patches/022-ingress-update-status.patch
   - patch -p1 < /patches/023-use-proxy-real-ip-cidr-v2.patch
   - patch -p1 < /patches/024-cve-03022026-controller.patch
-  - patch -p1 < /patches/026-lua_ingress-use-request-host-for-https-redirect.patch
   - patch -p1 < /patches/027-fix-rewrite-target-cve.patch
   - patch -p1 < /patches/028-stable-config-hash-metric-02.patch
+  # pass env for build
+  - echo "export COMMIT_SHA=git-$(git rev-parse --short HEAD)" > .env_pass
+  - echo "export REPO_INFO=$(git config --get remote.origin.url)" >> .env_pass
+  - echo "export TAG=$(git describe --tags --always)" >> .env_pass
+  - rm -rf /src/ingress-nginx/.git
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
+fromImage: common/src-artifact
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-patches-artifact
+  add: /patches
+  to: /patches
+  before: install
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
+shell:
+  beforeInstall:
+  {{- include "alt packages proxy" . | nindent 2 }}
+  - apt-get install patch
+  setup:
+  - mkdir -p /src
+  - cd /src
+  - git clone --branch {{ $controllerBranch }} --depth 1 {{$.SOURCE_REPO}}/kubernetes/ingress-nginx.git
+  - cd /src/ingress-nginx
+  - patch -p1 < /patches/010-nginx-build.patch
+  - patch -p1 < /patches/023-use-proxy-real-ip-cidr-v2.patch
+  - patch -p1 < /patches/026-lua_ingress-use-request-host-for-https-redirect.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch
   - patch -p1 < /patches/007-auth-cookie-always.patch
   - patch -p1 < /patches/025-cve-03022026-rootfs.patch
-  # pass env for build
-  - cd /src/ingress-nginx
-  - echo "export COMMIT_SHA=git-$(git rev-parse --short HEAD)" > .env_pass
-  - echo "export REPO_INFO=$(git config --get remote.origin.url)" >> .env_pass
-  - echo "export TAG=$(git describe --tags --always)" >> .env_pass
-  - rm -rf /src/dumb-init/.git
-  - rm -rf /src/lua-protobuf/.git
-  - rm -rf /src/lua-iconv/.git
   - rm -rf /src/ingress-nginx/.git
 
 ---
@@ -87,7 +170,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-dumb-init-artifact
 fromImage: common/alt-p11-artifact
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-aux-src-artifact
   add: /src/dumb-init
   to: /src
   before: install
@@ -103,11 +186,11 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-lua-rocks-artifact
 fromImage: common/alt-p11-artifact
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-aux-src-artifact
   add: /src/lua-protobuf
   to: /src/lua-protobuf
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-aux-src-artifact
   add: /src/lua-iconv
   to: /src/lua-iconv
   before: install
@@ -157,11 +240,11 @@ mount:
 - from: tmp_dir
   to: /tmp
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
   add: /src/ingress-nginx/images/nginx-1.25/rootfs/
   to: /
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/rootfs/etc
   to: /src/etc
   before: install
@@ -217,8 +300,8 @@ import:
   add: /usr/share/lua/5.1/protoc.lua
   to: /usr/local/share/lua/5.1/protoc.lua
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-artifact
-  add: /src/rootfs/etc
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
+  add: /src/ingress-nginx/rootfs/etc
   to: /src/rootfs/etc
   before: install
 shell:
@@ -340,11 +423,11 @@ import:
   add: /bin/pgrep
   to: /usr/bin/pgrep
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/curl-chroot-wrapper.sh
   to: /usr/bin/curl
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/nginx-chroot-wrapper.sh
   to: /usr/bin/nginx
   before: setup
@@ -352,7 +435,7 @@ import:
   add: /src/dumb-init
   to: /usr/bin/dumb-init
   before: setup
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/rootfs/etc
   to: /src/rootfs/etc
   before: setup

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -32,7 +32,7 @@
 {{ $yajlVersion := "2.1.0" }}
 {{ $gccVersion := "releases/gcc-14.2.0" }}
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-patches-artifact
 fromImage: builder/src
 final: false
 git:
@@ -40,7 +40,46 @@ git:
   to: /patches
   stageDependencies:
     install:
-      - '**/*'
+      - 001-lua-info.patch
+      - 002-makefile.patch
+      - 003-healthcheck.patch
+      - 004-util.patch
+      - 005-add-http3.patch
+      - 006-new-metrics.patch
+      - 007-default-backend-fix.patch
+      - 011-restore-validation.patch
+      - 012-validation-mode.patch
+      - 013-verbose-maxmind-logs.patch
+      - 014-go-mod.patch
+      - 015-fix-success-reload-metric.patch
+      - 016-disable-error-logs.patch
+      - 017-fix-sorting.patch
+      - 018-geoip-ver-metric.patch
+      - 019-skip-tls-verification-maxmind.patch
+      - 020-ingress-update-status.patch
+      - 021-use-proxy-real-ip-cidr-v2.patch
+      - 022-cve-03022026.patch
+      - 024-fix-rewrite-target-cve.patch
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-patches-artifact
+fromImage: builder/src
+final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+      - 008-balancer-lua.patch
+      - 009-nginx-tmpl.patch
+      - 010-auth-cookie-always.patch
+      - 021-use-proxy-real-ip-cidr-v2.patch
+      - 022-cve-03022026.patch
+      - 023-lua_ingress-use-request-host-for-https-redirect.patch
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
+fromImage: builder/src
+final: false
+git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/rootfs
   to: /src/rootfs
   stageDependencies:
@@ -56,6 +95,15 @@ git:
   stageDependencies:
     install:
       - '**/*'
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+fromImage: builder/src
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-patches-artifact
+  add: /patches
+  to: /patches
+  before: install
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -65,11 +113,72 @@ shell:
   - cd /src
   - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git
   - cd /src/ingress-nginx
-  - git apply /patches/*.patch --verbose
+  - |
+    for PATCH in \
+      001-lua-info.patch \
+      002-makefile.patch \
+      003-healthcheck.patch \
+      004-util.patch \
+      005-add-http3.patch \
+      006-new-metrics.patch \
+      007-default-backend-fix.patch \
+      011-restore-validation.patch \
+      012-validation-mode.patch \
+      013-verbose-maxmind-logs.patch \
+      014-go-mod.patch \
+      015-fix-success-reload-metric.patch \
+      016-disable-error-logs.patch \
+      017-fix-sorting.patch \
+      018-geoip-ver-metric.patch \
+      019-skip-tls-verification-maxmind.patch \
+      020-ingress-update-status.patch \
+      021-use-proxy-real-ip-cidr-v2.patch \
+      022-cve-03022026.patch \
+      024-fix-rewrite-target-cve.patch; do
+      git apply "/patches/${PATCH}" --verbose
+    done
   - echo "export COMMIT_SHA=git-$(git rev-parse --short HEAD)" > .env_pass
   - echo "export REPO_INFO=$(git config --get remote.origin.url)" >> .env_pass
   - echo "export TAG=$(git describe --tags --always)" >> .env_pass
-  #
+  - rm -rf /src/ingress-nginx/.git
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
+fromImage: builder/src
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-patches-artifact
+  add: /patches
+  to: /patches
+  before: install
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
+shell:
+  install:
+  - mkdir -p /src
+  - cd /src
+  - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git
+  - cd /src/ingress-nginx
+  - |
+    for PATCH in \
+      008-balancer-lua.patch \
+      009-nginx-tmpl.patch \
+      010-auth-cookie-always.patch \
+      021-use-proxy-real-ip-cidr-v2.patch \
+      022-cve-03022026.patch \
+      023-lua_ingress-use-request-host-for-https-redirect.patch; do
+      git apply "/patches/${PATCH}" --verbose
+    done
+  - rm -rf /src/ingress-nginx/.git
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-deps-artifact
+fromImage: builder/src
+final: false
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
+shell:
+  install:
   - mkdir -p /src/nginx-deps
   - git clone -b {{ $nginxDepsBranch }} $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx-deps.git /src/nginx-deps
     # Dependency for opentelemetry-cpp (source: opentelemetry-cpp/cmake/nlohmann-json.cmakee)
@@ -117,20 +226,19 @@ shell:
   - git clone -b {{ $coreRulesetBranch }} $(cat /run/secrets/SOURCE_REPO)/coreruleset/coreruleset
   - mv coreruleset owasp-modsecurity-crs
   #
-  - rm -rf /src/ingress-nginx/.git
   - rm -rf /src/nginx-deps/.git
   - rm -rf /src/nginx-deps/opentelemetry-cpp/third_party/nlohmann-json/.git
-  - rm -rf /src/ngx_brotli/.git
-  - rm -rf /src/ngx_brotli/deps/brotli/.git
-  - rm -rf /src/ssdeep/.git
-  - rm -rf /src/ModSecurity/.git
-  - rm -rf /src/ModSecurity/test/test-cases/secrules-language-tests/.git
-  - rm -rf /src/ModSecurity/others/libinjection/.git
-  - rm -rf /src/ModSecurity/bindings/python/.git
-  - rm -rf /src/ModSecurity/others/mbedtls/.git
-  - rm -rf /src/ModSecurity/others/mbedtls/framework/.git
+  - rm -rf /src/nginx-deps/ngx_brotli/.git
+  - rm -rf /src/nginx-deps/ngx_brotli/deps/brotli/.git
+  - rm -rf /src/nginx-deps/ssdeep/.git
+  - rm -rf /src/nginx-deps/ModSecurity/.git
+  - rm -rf /src/nginx-deps/ModSecurity/test/test-cases/secrules-language-tests/.git
+  - rm -rf /src/nginx-deps/ModSecurity/others/libinjection/.git
+  - rm -rf /src/nginx-deps/ModSecurity/bindings/python/.git
+  - rm -rf /src/nginx-deps/ModSecurity/others/mbedtls/.git
+  - rm -rf /src/nginx-deps/ModSecurity/others/mbedtls/framework/.git
   - rm -rf /src/nginx-deps/opentelemetry-cpp-contrib/.git
-  - rm -rf /src/owasp-modsecurity-crs/.git
+  - rm -rf /src/nginx-deps/owasp-modsecurity-crs/.git
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-controller-artifact
 fromImage: builder/golang-alpine
@@ -163,15 +271,15 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
 fromImage: builder/alpine-3.21
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
   add: /src/ingress-nginx/images/nginx/rootfs/
   to: /
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/rootfs/etc
   to: /src/etc
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-deps-artifact
   add: /src/nginx-deps
   to: /src/nginx-deps
   before: install
@@ -713,8 +821,8 @@ import:
   - lib/lua/5.1/pb.so
   - share/lua/5.1/protoc.lua
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-artifact
-  add: /src/rootfs/etc
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
+  add: /src/ingress-nginx/rootfs/etc
   to: /src/rootfs/etc
   before: install
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
@@ -934,13 +1042,13 @@ import:
   owner: "64535"
   group: "64535"
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/curl-chroot-wrapper.sh
   to: /usr/bin/curl
   owner: "64535"
   group: "64535"
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/nginx-chroot-wrapper.sh
   to: /usr/bin/nginx
   owner: "64535"

--- a/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
@@ -32,7 +32,7 @@
 {{ $yajlVersion := "2.1.0" }}
 {{ $gccVersion := "releases/gcc-14.2.0" }}
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-patches-artifact
 fromImage: builder/src
 final: false
 git:
@@ -40,7 +40,43 @@ git:
   to: /patches
   stageDependencies:
     install:
-      - '**/*'
+      - 001-lua-info.patch
+      - 002-makefile.patch
+      - 003-healthcheck.patch
+      - 004-util.patch
+      - 005-add-http3.patch
+      - 006-new-metrics.patch
+      - 007-default-backend-fix.patch
+      - 011-restore-validation.patch
+      - 012-validation-mode.patch
+      - 013-verbose-maxmind-logs.patch
+      - 014-disable-error-logs.patch
+      - 015-geoip-ver-metric.patch
+      - 016-skip-tls-verification-maxmind.patch
+      - 017-ingress-update-status.patch
+      - 018-use-proxy-real-ip-cidr.patch
+      - 021-go-mod.patch
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-patches-artifact
+fromImage: builder/src
+final: false
+git:
+- add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    install:
+      - 005-add-http3.patch
+      - 008-balancer-lua.patch
+      - 009-nginx-tmpl.patch
+      - 010-auth-cookie-always.patch
+      - 018-use-proxy-real-ip-cidr.patch
+      - 019-removed-deprecated-patches.patch
+      - 020-lua_ingress-use-request-host-for-https-redirect.patch
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
+fromImage: builder/src
+final: false
+git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/rootfs
   to: /src/rootfs
   stageDependencies:
@@ -56,6 +92,15 @@ git:
   stageDependencies:
     install:
       - '**/*'
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+fromImage: builder/src
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-patches-artifact
+  add: /patches
+  to: /patches
+  before: install
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -65,11 +110,69 @@ shell:
   - cd /src
   - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git
   - cd /src/ingress-nginx
-  - git apply /patches/*.patch --verbose
+  - |
+    for PATCH in \
+      001-lua-info.patch \
+      002-makefile.patch \
+      003-healthcheck.patch \
+      004-util.patch \
+      005-add-http3.patch \
+      006-new-metrics.patch \
+      007-default-backend-fix.patch \
+      011-restore-validation.patch \
+      012-validation-mode.patch \
+      013-verbose-maxmind-logs.patch \
+      014-disable-error-logs.patch \
+      015-geoip-ver-metric.patch \
+      016-skip-tls-verification-maxmind.patch \
+      017-ingress-update-status.patch \
+      018-use-proxy-real-ip-cidr.patch \
+      021-go-mod.patch; do
+      git apply "/patches/${PATCH}" --verbose
+    done
   - echo "export COMMIT_SHA=git-$(git rev-parse --short HEAD)" > .env_pass
   - echo "export REPO_INFO=$(git config --get remote.origin.url)" >> .env_pass
   - echo "export TAG=$(git describe --tags --always)" >> .env_pass
-  #
+  - rm -rf /src/ingress-nginx/.git
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
+fromImage: builder/src
+final: false
+import:
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-patches-artifact
+  add: /patches
+  to: /patches
+  before: install
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
+shell:
+  install:
+  - mkdir -p /src
+  - cd /src
+  - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git
+  - cd /src/ingress-nginx
+  - |
+    for PATCH in \
+      005-add-http3.patch \
+      008-balancer-lua.patch \
+      009-nginx-tmpl.patch \
+      010-auth-cookie-always.patch \
+      018-use-proxy-real-ip-cidr.patch \
+      019-removed-deprecated-patches.patch \
+      020-lua_ingress-use-request-host-for-https-redirect.patch; do
+      git apply "/patches/${PATCH}" --verbose
+    done
+  - rm -rf /src/ingress-nginx/.git
+---
+image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-deps-artifact
+fromImage: builder/src
+final: false
+secrets:
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
+shell:
+  install:
   - mkdir -p /src/nginx-deps
   - git clone -b {{ $nginxDepsBranch }} $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx-deps.git /src/nginx-deps
     # Dependency for opentelemetry-cpp (source: opentelemetry-cpp/cmake/nlohmann-json.cmakee)
@@ -117,20 +220,19 @@ shell:
   - git clone -b {{ $coreRulesetBranch }} $(cat /run/secrets/SOURCE_REPO)/coreruleset/coreruleset
   - mv coreruleset owasp-modsecurity-crs
   #
-  - rm -rf /src/ingress-nginx/.git
   - rm -rf /src/nginx-deps/.git
   - rm -rf /src/nginx-deps/opentelemetry-cpp/third_party/nlohmann-json/.git
-  - rm -rf /src/ngx_brotli/.git
-  - rm -rf /src/ngx_brotli/deps/brotli/.git
-  - rm -rf /src/ssdeep/.git
-  - rm -rf /src/ModSecurity/.git
-  - rm -rf /src/ModSecurity/test/test-cases/secrules-language-tests/.git
-  - rm -rf /src/ModSecurity/others/libinjection/.git
-  - rm -rf /src/ModSecurity/bindings/python/.git
-  - rm -rf /src/ModSecurity/others/mbedtls/.git
-  - rm -rf /src/ModSecurity/others/mbedtls/framework/.git
+  - rm -rf /src/nginx-deps/ngx_brotli/.git
+  - rm -rf /src/nginx-deps/ngx_brotli/deps/brotli/.git
+  - rm -rf /src/nginx-deps/ssdeep/.git
+  - rm -rf /src/nginx-deps/ModSecurity/.git
+  - rm -rf /src/nginx-deps/ModSecurity/test/test-cases/secrules-language-tests/.git
+  - rm -rf /src/nginx-deps/ModSecurity/others/libinjection/.git
+  - rm -rf /src/nginx-deps/ModSecurity/bindings/python/.git
+  - rm -rf /src/nginx-deps/ModSecurity/others/mbedtls/.git
+  - rm -rf /src/nginx-deps/ModSecurity/others/mbedtls/framework/.git
   - rm -rf /src/nginx-deps/opentelemetry-cpp-contrib/.git
-  - rm -rf /src/owasp-modsecurity-crs/.git
+  - rm -rf /src/nginx-deps/owasp-modsecurity-crs/.git
 ---
 image: {{ .ModuleName }}/{{ $.ImageName }}-controller-artifact
 fromImage: builder/golang-alpine
@@ -163,15 +265,15 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
 fromImage: builder/alpine-3.21
 final: false
 import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
   add: /src/ingress-nginx/images/nginx/rootfs/
   to: /
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/rootfs/etc
   to: /src/etc
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-deps-artifact
   add: /src/nginx-deps
   to: /src/nginx-deps
   before: install
@@ -712,8 +814,8 @@ import:
   - lib/lua/5.1/pb.so
   - share/lua/5.1/protoc.lua
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-controller-artifact
-  add: /src/rootfs/etc
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-src-artifact
+  add: /src/ingress-nginx/rootfs/etc
   to: /src/rootfs/etc
   before: install
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-nginx-artifact
@@ -933,13 +1035,13 @@ import:
   owner: "64535"
   group: "64535"
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/curl-chroot-wrapper.sh
   to: /usr/bin/curl
   owner: "64535"
   group: "64535"
   before: install
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+- image: {{ $.ModuleName }}/{{ $.ImageName }}-local-files-artifact
   add: /src/nginx-chroot-wrapper.sh
   to: /usr/bin/nginx
   owner: "64535"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Split the ingress-nginx source artifact into several smaller artifacts.

This change lets us rebuild only the controller-related artifacts without rebuilding nginx when changes affect only ingress controller patches.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

During development, patch changes in ingress-nginx often require rebuilding images. Previously, controller sources, nginx sources, local files, and auxiliary build inputs were grouped into a common source artifact. Because of that, changing a controller-only patch could still invalidate the nginx build path and trigger an unnecessary nginx rebuild.

By splitting these sources into smaller artifacts, we reduce unnecessary rebuilds and speed up development and image iteration.

## Manual test

For the test, we renamed 3 patches, one from each image (`1.10`, `1.12`, `1.14`) of the controller. During the build, this affected only the controller image and took about 6 minutes instead of 30-40 when rebuilding all the images.

https://github.com/deckhouse/deckhouse/actions/runs/23000884688/job/66784933260?pr=18442



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: chore
summary: Optimized image build.
impact: All Ingress-NGINX controller pods will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
