### PR TITLE
[docs] Simplify resource allocation descriptions

### DIFF
--- a/global-hooks/openapi/config-values.yaml
+++ b/global-hooks/openapi/config-values.yaml
@@ -148,7 +148,7 @@ properties:
                 default: "false"
       resourcesRequests:
         description: |
-          The amount of resources (CPU and memory) allocated to Deckhouse components running on each node of the cluster (usually these are DaemonSets, for example, `cni-flannel`, `monitoring-ping`).
+          The amount of resources (CPU and memory) allocated to some components.
 
           [More](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) about resource units in Kubernetes.
         type: object
@@ -160,7 +160,9 @@ properties:
             default: {}
             additionalProperties: false
             description: |
-              Amount of resources (CPU and memory) allocated to control plane components on each master node. These settings do not apply if the cluster control plane is managed by a cloud provider (for example, Google Kubernetes Engine or Azure Kubernetes Service).
+              Amount of resources (CPU and memory) allocated to control plane components on each master node.
+
+              These settings do not apply if the cluster control plane is managed by a cloud provider (for example, Google Kubernetes Engine or Azure Kubernetes Service).
             x-examples:
               - cpu: 1000m
                 memory: 500M

--- a/global-hooks/openapi/doc-ru-config-values.yaml
+++ b/global-hooks/openapi/doc-ru-config-values.yaml
@@ -84,13 +84,15 @@ properties:
                   Указанный Secret должен быть в формате [kubernetes.io/tls](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#tls-secrets).
       resourcesRequests:
         description: |
-          Количество ресурсов (CPU и памяти), выделяемых для работы компонентов Deckhouse, работающих на каждом узле кластера (обычно это DaemonSet'ы, например `cni-flannel`, `monitoring-ping`).
+          Количество ресурсов (CPU и памяти), выделяемых для работы некоторых компонентов.
 
           [Подробнее](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) про единицы измерения ресурсов.
         properties:
           controlPlane:
             description: |
-              Объём ресурсов (CPU и памяти), выделяемых для компонентов control plane на каждом master-узле кластера. Настройки не применяются, если control plane кластера управляется облачным провайдером (например, Google Kubernetes Engine или Azure Kubernetes Service).
+              Объём ресурсов (CPU и памяти), выделяемых для компонентов control plane на каждом master-узле кластера.
+
+              Настройки не применяются, если control plane кластера управляется облачным провайдером (например, Google Kubernetes Engine или Azure Kubernetes Service).
             properties:
               cpu:
                 description: |


### PR DESCRIPTION
## Description
Simplify resource allocation descriptions:
- Refine resource allocation descriptions for specific components to enhance clarity and reduce ambiguity.
- Maintain focus on control plane component allocations, clarifying exceptions for cloud-managed control planes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Simplify resource allocation descriptions.
impact_level: low
```
