### PR TITLE
[deckhouse] remove duplicating cache entries from packages feature flag

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -208,8 +208,6 @@ func NewDeckhouseController(
 		opts.Cache.ByObject[&v1alpha1.ApplicationPackageVersion{}] = cache.ByObject{}
 		opts.Cache.ByObject[&v1alpha1.ApplicationPackage{}] = cache.ByObject{}
 		opts.Cache.ByObject[&v1alpha1.Application{}] = cache.ByObject{}
-		opts.Cache.ByObject[&v1alpha1.ModulePackageVersion{}] = cache.ByObject{}
-		opts.Cache.ByObject[&v1alpha1.ModulePackage{}] = cache.ByObject{}
 	}
 
 	// Module package controllers (feature flag)


### PR DESCRIPTION
## Description
It removes duplicating entries from packages feature flag.

## Why do we need it, and what problem does it solve?

It fixes the missing crds problem when packages feature flag is enabled.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Remove duplicating cache entries from packages feature flag.
impact_level: low
```
