### PR TITLE
[cloud-provider-zvirt] CSI: fix token refresh patch apply

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
@@ -51,9 +51,11 @@ shell:
   install:
   - git clone --depth 1 --branch {{ $version }} $(cat /run/secrets/SOURCE_REPO)/openshift/ovirt-csi-driver.git /src
   - git clone --depth 1 --branch v0.0.1-flant $(cat /run/secrets/CLOUD_PROVIDERS_SOURCE_REPO)/ovirt/go-ovirt /src/go-ovirt
+  - git clone --depth 1 --branch v3.2.0-flant-1 $(cat /run/secrets/SOURCE_REPO)/flant/go-ovirt-client.git /src/go-ovirt-client
   - cd /src
   - git apply /patches/*.patch --verbose
   - echo "replace github.com/ovirt/go-ovirt => /src/go-ovirt" >> go.mod
+  - echo "replace github.com/ovirt/go-ovirt-client/v3 => /src/go-ovirt-client" >> go.mod
   - rm -rf vendor .git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact


### PR DESCRIPTION
## Description
This PR fixes regression bug caused by https://github.com/deckhouse/deckhouse/pull/17093

## Why do we need it, and what problem does it solve?
It fixes applying token refresh fix patch

## Why do we need it in the patch release (if we do)?
It fixes applying token refresh fix patch


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-zvirt
type: fix
summary:  fix CSI token refresh patch apply
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
