### PR TITLE
[docs] Enforce concurrency policy in Installer update cronjob

### DIFF
--- a/docs/site/.helm/templates/30-cronjob.yaml
+++ b/docs/site/.helm/templates/30-cronjob.yaml
@@ -7,6 +7,7 @@ spec:
   schedule: "* 10 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 1
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
## Description
Enforce concurrency policy in Installer update cronjob:
- Set concurrency policy to manage overlapping job executions.
- Specify a replace strategy to ensure new executions replace any currently running instances.

Ref: https://github.com/deckhouse/deckhouse/pull/18459

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Enforce concurrency policy in Installer update cronjob.
impact_level: low
```
