### PR TITLE
[common] Fix for replace kubectl binary with d8 k alias.

### DIFF
--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -28,6 +28,20 @@ if [[ "${old_kubelet_hash}" != "${new_kubelet_hash}" ]]; then
   bb-flag-set kubelet-need-restart
 fi
 
+if grep -qF '# "\e[5~": history-search-backward' /etc/inputrc; then
+  sed -i 's/\# \"\\e\[5~\": history-search-backward/\"\\e\[5~\": history-search-backward/' /etc/inputrc
+fi
+if grep -qF '# "\e[6~": history-search-forward' /etc/inputrc; then
+  sed -i 's/^\# \"\\e\[6~\": history-search-forward/\"\\e\[6~\": history-search-forward/' /etc/inputrc
+fi
+
+if grep -qF '#force_color_prompt=yes' /root/.bashrc; then
+  sed -i 's/\#force_color_prompt=yes/force_color_prompt=yes/' /root/.bashrc
+fi
+if grep -qF '01;32m' /root/.bashrc; then
+  sed -i 's/01;32m/01;31m/' /root/.bashrc
+fi
+
 completion="if [ -f /etc/bash_completion ] && ! shopt -oq posix; then . /etc/bash_completion ; fi"
 if ! grep -qF -- "$completion"  /root/.bashrc; then
   echo "$completion" >> /root/.bashrc
@@ -40,6 +54,44 @@ if [ ! -f "/etc/bash_completion.d/d8" ]; then
   mkdir -p /etc/bash_completion.d
   d8 completion bash > /etc/bash_completion.d/d8
 fi
+
+# Install kubectl as alias for d8 k
+
+# This need for correct Tab-completion in kubectl alias
+# Bash does not expand aliases during completion, so we
+# rewrite "kubectl" to "d8 k" and call d8 __complete directly
+cat <<'EOF' > /etc/bash_completion.d/d8_kubectl_completion
+_kubectl_complete() {
+    local orig_line="$COMP_LINE"
+    local orig_point="$COMP_POINT"
+    local orig_words=("${COMP_WORDS[@]}")
+    local orig_cword="$COMP_CWORD"
+
+    COMP_LINE="d8 k${COMP_LINE#kubectl}"
+    COMP_POINT=$((COMP_POINT + 1))
+    COMP_WORDS=("d8" "k" "${COMP_WORDS[@]:1}")
+    COMP_CWORD=$((COMP_CWORD + 1))
+
+    local requestComp="/opt/deckhouse/bin/d8 __complete ${COMP_WORDS[*]:1}"
+    local out directive
+    out=$(eval "${requestComp}" 2>/dev/null)
+
+    local lastLine="${out##*$'\n'}"
+    directive="${lastLine#*:}"
+    out="${out%$'\n'*}"
+
+    COMPREPLY=()
+    while IFS='' read -r line; do
+        COMPREPLY+=("${line}")
+    done < <(compgen -W "${out}" -- "${orig_words[$orig_cword]}")
+
+    COMP_LINE="$orig_line"
+    COMP_POINT="$orig_point"
+    COMP_WORDS=("${orig_words[@]}")
+    COMP_CWORD="$orig_cword"
+}
+complete -o default -F _kubectl_complete kubectl
+EOF
 
 if ! type kubectl >/dev/null 2>&1; then
   cat <<'EOF' > /opt/deckhouse/bin/kubectl

--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -62,33 +62,37 @@ fi
 # rewrite "kubectl" to "d8 k" and call d8 __complete directly
 cat <<'EOF' > /etc/bash_completion.d/d8_kubectl_completion
 _kubectl_complete() {
-    local orig_line="$COMP_LINE"
-    local orig_point="$COMP_POINT"
     local orig_words=("${COMP_WORDS[@]}")
     local orig_cword="$COMP_CWORD"
+    local cur="${COMP_WORDS[$COMP_CWORD]}"
 
-    COMP_LINE="d8 k${COMP_LINE#kubectl}"
-    COMP_POINT=$((COMP_POINT + 1))
-    COMP_WORDS=("d8" "k" "${COMP_WORDS[@]:1}")
-    COMP_CWORD=$((COMP_CWORD + 1))
+    # Build d8 __complete command: replace "kubectl" with "k"
+    local args=("k" "${COMP_WORDS[@]:1}")
+    local requestComp="/opt/deckhouse/bin/d8 __complete ${args[*]}"
 
-    local requestComp="/opt/deckhouse/bin/d8 __complete ${COMP_WORDS[*]:1}"
-    local out directive
+    # If current word is incomplete, don't add empty arg
+    # If current word is empty (user pressed space+tab), add empty arg
+    if [[ "$cur" == "" ]]; then
+        requestComp="${requestComp} \"\""
+    fi
+
+    local out
     out=$(eval "${requestComp}" 2>/dev/null)
 
-    local lastLine="${out##*$'\n'}"
-    directive="${lastLine#*:}"
-    out="${out%$'\n'*}"
+    # Parse results: remove directive line (:N) and debug lines
+    local completions=()
+    while IFS='' read -r line; do
+        [[ "$line" =~ ^:[0-9]+$ ]] && continue
+        [[ "$line" =~ ^Completion ]] && continue
+        [[ -z "$line" ]] && continue
+        completions+=("$line")
+    done <<< "$out"
 
     COMPREPLY=()
-    while IFS='' read -r line; do
-        COMPREPLY+=("${line}")
-    done < <(compgen -W "${out}" -- "${orig_words[$orig_cword]}")
-
-    COMP_LINE="$orig_line"
-    COMP_POINT="$orig_point"
-    COMP_WORDS=("${orig_words[@]}")
-    COMP_CWORD="$orig_cword"
+    if [[ ${#completions[@]} -gt 0 ]]; then
+        local IFS=$'\n'
+        COMPREPLY=($(compgen -W "${completions[*]}" -- "$cur"))
+    fi
 }
 complete -o default -F _kubectl_complete kubectl
 EOF

--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -62,30 +62,29 @@ fi
 # rewrite "kubectl" to "d8 k" and call d8 __complete directly
 cat <<'EOF' > /etc/bash_completion.d/d8_kubectl_completion
 _kubectl_complete() {
-    local orig_words=("${COMP_WORDS[@]}")
-    local orig_cword="$COMP_CWORD"
-    local cur="${COMP_WORDS[$COMP_CWORD]}"
+    local cur prev words cword
+    _init_completion -n =: || return
 
-    # Build d8 __complete command: replace "kubectl" with "k"
-    local args=("k" "${COMP_WORDS[@]:1}")
+    local args=("k" "${words[@]:1}")
     local requestComp="/opt/deckhouse/bin/d8 __complete ${args[*]}"
 
-    # If current word is incomplete, don't add empty arg
-    # If current word is empty (user pressed space+tab), add empty arg
-    if [[ "$cur" == "" ]]; then
+    local lastParam="${words[$((${#words[@]}-1))]}"
+    local lastChar="${lastParam:$((${#lastParam}-1)):1}"
+
+    if [[ -z "$cur" && "$lastChar" != "=" ]]; then
         requestComp="${requestComp} \"\""
     fi
 
     local out
     out=$(eval "${requestComp}" 2>/dev/null)
 
-    # Parse results: remove directive line (:N) and debug lines
     local completions=()
     while IFS='' read -r line; do
         [[ "$line" =~ ^:[0-9]+$ ]] && continue
         [[ "$line" =~ ^Completion ]] && continue
         [[ -z "$line" ]] && continue
-        completions+=("$line")
+        # Remove description after tab character
+        completions+=("${line%%$'\t'*}")
     done <<< "$out"
 
     COMPREPLY=()


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Deckhouse uses `d8 k` as a kubectl replacement. The built-in `d8 k completion bash`
generates a completion script that internally calls `d8 k __complete`, but `d8 k`
does not support the `__complete` subcommand — it returns help text instead of
completion results.
This causes bash to fail with:
```
bash: ((: d8 k [flags] [options]...: syntax error: invalid arithmetic operator
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This adds a thin wrapper and a custom completion script that routes everything through d8 k
while calling d8 __complete directly for tab-completion, since d8 k __complete is not supported and causes bash syntax errors.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix 
summary: Fixed replacing the `kubectl` binary with the `d8 k` alias.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
