### PR TITLE
[deckhouse-controller] Prevent enabling multiple CNI modules simultaneously

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -274,21 +274,24 @@ func moduleConfigValidationHandler(
 		if err != nil {
 			return allowResult(warnings)
 		}
-		exclusiveGroup := module.GetModuleExclusiveGroup()
-		if exclusiveGroup != nil {
-			modules := moduleStorage.GetModulesByExclusiveGroup(*exclusiveGroup)
 
-			for _, moduleName := range modules {
-				// if any module with same unique key enabled, return error
-				if moduleManager.IsModuleEnabled(moduleName) && moduleName != cfg.Name {
-					return rejectResult(
-						fmt.Sprintf(
-							"can't enable module %q because different module %q with same exclusiveGroup %s enabled",
-							cfg.Name,
-							moduleName,
-							*exclusiveGroup,
-						),
-					)
+		if cfg.Spec.Enabled != nil && *cfg.Spec.Enabled {
+			exclusiveGroup := module.GetModuleExclusiveGroup()
+			if exclusiveGroup != nil {
+				modules := moduleStorage.GetModulesByExclusiveGroup(*exclusiveGroup)
+
+				for _, moduleName := range modules {
+					// if any module with same unique key enabled, return error
+					if moduleManager.IsModuleEnabled(moduleName) && moduleName != cfg.Name {
+						return rejectResult(
+							fmt.Sprintf(
+								"can't enable module %q because different module %q with same exclusiveGroup %s enabled",
+								cfg.Name,
+								moduleName,
+								*exclusiveGroup,
+							),
+						)
+					}
 				}
 			}
 		}

--- a/modules/021-cni-cilium/module.yaml
+++ b/modules/021-cni-cilium/module.yaml
@@ -8,3 +8,4 @@ namespace: d8-cni-cilium
 descriptions:
   en: Provides networking in a Kubernetes cluster using the Cilium CNI with eBPF-based networking and security.
   ru: Обеспечивает работу сети в кластере Kubernetes с помощью CNI Cilium на базе eBPF.
+exclusiveGroup: cni

--- a/modules/035-cni-flannel/module.yaml
+++ b/modules/035-cni-flannel/module.yaml
@@ -8,3 +8,4 @@ namespace: d8-cni-flannel
 descriptions:
   en: Provides a network between multiple nodes in a cluster using the flannel module.
   ru: Обеспечивает работу сети в кластере с помощью модуля flannel.
+exclusiveGroup: cni

--- a/modules/035-cni-simple-bridge/module.yaml
+++ b/modules/035-cni-simple-bridge/module.yaml
@@ -8,3 +8,4 @@ namespace: d8-cni-simple-bridge
 descriptions:
   en: Provides networking with limited functionality in Kubernetes clusters.
   ru: Обеспечивает работу сети с ограниченной функциональностью в кластерах Kubernetes.
+exclusiveGroup: cni


### PR DESCRIPTION
## Description

This PR assigns all CNI modules (`cni-cilium`, `cni-flannel`, and `cni-simple-bridge`) to a single `exclusiveGroup: cni`. This leverages the built-in ValidatingWebhookConfiguration to prevent users from accidentally enabling more than one CNI module at the same time.

Additionally, it fixes a bug in the ModuleConfig webhook validation logic. Previously, the exclusive group check was performed unconditionally, which blocked users from editing the configuration of a disabled CNI module if another CNI module was already active. The logic is now properly wrapped in an `if cfg.Spec.Enabled` check so the validation only triggers when a module is explicitly being enabled.

This PR prohibits the simultaneous activation of multiple CNIs, even for the purpose of switching CNIs within a cluster. CNI switching is implemented in DKP via the platform's built-in functionality and has been added via a separate [PR](https://github.com/deckhouse/deckhouse/pull/16499), which allows multiple CNIs to be activated simultaneously within a cluster during the switching process.

## Why do we need it, and what problem does it solve?

Enabling multiple CNI modules simultaneously can lead to severe cluster network instability and conflicts.

By assigning them to the same `exclusiveGroup`, the Deckhouse admission webhook will gracefully reject the creation or modification of a ModuleConfig if it attempts to enable a second CNI module. Users must now explicitly disable the currently running CNI module before enabling a new one. The bug fix in the webhook ensures that users can still safely update the settings (e.g., in preparation for a migration) of disabled modules without triggering false-positive rejections.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: feature
summary: Prevented enabling multiple CNI modules simultaneously.
impact_level: default
```