### PR TITLE
[ingress-nginx] exclude node-specific parameters when calculating config hash

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/028-stable-config-hash-metric-02.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/028-stable-config-hash-metric-02.patch
@@ -1,5 +1,5 @@
 diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
-index 94d212e68..103c0563d 100644
+index 489f1f3d4..f530421a2 100644
 --- a/internal/ingress/controller/controller.go
 +++ b/internal/ingress/controller/controller.go
 @@ -17,13 +17,14 @@ limitations under the License.
@@ -26,7 +26,7 @@ index 94d212e68..103c0563d 100644
  	"k8s.io/ingress-nginx/internal/nginx"
  	"k8s.io/ingress-nginx/pkg/apis/ingress"
  	utilingress "k8s.io/ingress-nginx/pkg/util/ingress"
-@@ -170,6 +172,245 @@ func (n *NGINXController) GetPublishService() *apiv1.Service {
+@@ -164,6 +166,245 @@ func (n *NGINXController) GetPublishService() *apiv1.Service {
  	return s
  }
  
@@ -272,7 +272,7 @@ index 94d212e68..103c0563d 100644
  // syncIngress collects all the pieces required to assemble the NGINX
  // configuration file and passes the resulting data structures to the backend
  // (OnUpdate) when a reload is deemed necessary.
-@@ -186,9 +427,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
+@@ -180,9 +421,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
  	n.metricCollector.SetSSLExpireTime(servers)
  	n.metricCollector.SetSSLInfo(servers)
  
@@ -283,3 +283,75 @@ index 94d212e68..103c0563d 100644
  	if err != nil {
  		klog.Errorf("unexpected error hashing configuration: %v", err)
  	}
+diff --git a/internal/ingress/controller/template/configmap.go b/internal/ingress/controller/template/configmap.go
+index 9dc019bcc..a9e1d7fe4 100644
+--- a/internal/ingress/controller/template/configmap.go
++++ b/internal/ingress/controller/template/configmap.go
+@@ -17,6 +17,7 @@ limitations under the License.
+ package template
+ 
+ import (
++	"encoding/json"
+ 	"fmt"
+ 	"net"
+ 	"regexp"
+@@ -24,6 +25,7 @@ import (
+ 	"strings"
+ 	"time"
+ 
++	"github.com/cespare/xxhash/v2"
+ 	"k8s.io/klog/v2"
+ 
+ 	"github.com/mitchellh/hashstructure/v2"
+@@ -376,13 +378,18 @@ func ReadConfig(src map[string]string) config.Configuration {
+ 		delete(conf, nginxStatusIpv6Whitelist)
+ 	}
+ 
++	var workerProcessesChecksum string
+ 	if val, ok := conf[workerProcesses]; ok {
+-		to.WorkerProcesses = val
+ 		if val == "auto" {
++			workerProcessesChecksum = "auto"
+ 			to.WorkerProcesses = strconv.Itoa(runtime.NumCPU())
++		} else {
++			workerProcessesChecksum = val
++			to.WorkerProcesses = val
+ 		}
+-
+ 		delete(conf, workerProcesses)
++	} else {
++		workerProcessesChecksum = "auto"
+ 	}
+ 
+ 	if val, ok := conf[plugins]; ok {
+@@ -439,15 +446,23 @@ func ReadConfig(src map[string]string) config.Configuration {
+ 		klog.Warningf("unexpected error merging defaults: %v", err)
+ 	}
+ 
+-	hash, err := hashstructure.Hash(to, hashstructure.FormatV1, &hashstructure.HashOptions{
+-		TagName: "json",
+-	})
+-	if err != nil {
+-		klog.Warningf("unexpected error obtaining hash: %v", err)
++	savedDisableIPv6DNS := to.DisableIpv6DNS
++	savedWorkerProcesses := to.WorkerProcesses
++	to.DisableIpv6DNS = false
++	to.WorkerProcesses = workerProcessesChecksum
++	to.Checksum = ""
++	data, jerr := json.Marshal(to)
++	to.DisableIpv6DNS = savedDisableIPv6DNS
++	to.WorkerProcesses = savedWorkerProcesses
++	if jerr != nil {
++		klog.Warningf("unexpected error obtaining checksum: %v", jerr)
++		if h, herr := hashstructure.Hash(to, hashstructure.FormatV1, &hashstructure.HashOptions{TagName: "json"}); herr == nil {
++			to.Checksum = fmt.Sprintf("%v", h)
++		}
++	} else {
++		to.Checksum = fmt.Sprintf("%v", xxhash.Sum64(data))
+ 	}
+ 
+-	to.Checksum = fmt.Sprintf("%v", hash)
+-
+ 	return to
+ }
+ 

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -161,6 +161,6 @@ This patch fixes rewrite-target CVE-2026-3288 in Ingress-NGINX
 
 https://github.com/kubernetes/kubernetes/issues/137560
 
-### 028-stable-config-hash-metric-01.patch
+### 028-stable-config-hash-metric-02.patch
 
 This patch updates the way config_hash controller metric is calculated so that all pods of a controller report the same value

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -66,7 +66,7 @@ shell:
   - patch -p1 < /patches/024-cve-03022026-controller.patch
   - patch -p1 < /patches/026-lua_ingress-use-request-host-for-https-redirect.patch
   - patch -p1 < /patches/027-fix-rewrite-target-cve.patch
-  - patch -p1 < /patches/028-stable-config-hash-metric-01.patch
+  - patch -p1 < /patches/028-stable-config-hash-metric-02.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/025-stable-config-hash-metric-02.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/025-stable-config-hash-metric-02.patch
@@ -1,5 +1,5 @@
 diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
-index 489f1f3d4..f530421a2 100644
+index 94d212e68..103c0563d 100644
 --- a/internal/ingress/controller/controller.go
 +++ b/internal/ingress/controller/controller.go
 @@ -17,13 +17,14 @@ limitations under the License.
@@ -26,7 +26,7 @@ index 489f1f3d4..f530421a2 100644
  	"k8s.io/ingress-nginx/internal/nginx"
  	"k8s.io/ingress-nginx/pkg/apis/ingress"
  	utilingress "k8s.io/ingress-nginx/pkg/util/ingress"
-@@ -164,6 +166,245 @@ func (n *NGINXController) GetPublishService() *apiv1.Service {
+@@ -170,6 +172,245 @@ func (n *NGINXController) GetPublishService() *apiv1.Service {
  	return s
  }
  
@@ -272,7 +272,7 @@ index 489f1f3d4..f530421a2 100644
  // syncIngress collects all the pieces required to assemble the NGINX
  // configuration file and passes the resulting data structures to the backend
  // (OnUpdate) when a reload is deemed necessary.
-@@ -180,9 +421,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
+@@ -186,9 +427,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
  	n.metricCollector.SetSSLExpireTime(servers)
  	n.metricCollector.SetSSLInfo(servers)
  
@@ -283,3 +283,79 @@ index 489f1f3d4..f530421a2 100644
  	if err != nil {
  		klog.Errorf("unexpected error hashing configuration: %v", err)
  	}
+diff --git a/internal/ingress/controller/template/configmap.go b/internal/ingress/controller/template/configmap.go
+index febf20be0..3b0cb5e14 100644
+--- a/internal/ingress/controller/template/configmap.go
++++ b/internal/ingress/controller/template/configmap.go
+@@ -17,6 +17,7 @@ limitations under the License.
+ package template
+ 
+ import (
++	"encoding/json"
+ 	"fmt"
+ 	"net"
+ 	"regexp"
+@@ -24,6 +25,7 @@ import (
+ 	"strings"
+ 	"time"
+ 
++	"github.com/cespare/xxhash/v2"
+ 	"k8s.io/klog/v2"
+ 
+ 	"github.com/mitchellh/hashstructure/v2"
+@@ -397,13 +399,19 @@ func ReadConfig(src map[string]string) config.Configuration {
+ 		delete(conf, nginxStatusIpv6Whitelist)
+ 	}
+ 
++	// workerProcessesChecksum: checksum input omits per-node CPU (auto / NewDefault).
++	var workerProcessesChecksum string
+ 	if val, ok := conf[workerProcesses]; ok {
+-		to.WorkerProcesses = val
+ 		if val == "auto" {
++			workerProcessesChecksum = "auto"
+ 			to.WorkerProcesses = strconv.Itoa(runtime.NumCPU())
++		} else {
++			workerProcessesChecksum = val
++			to.WorkerProcesses = val
+ 		}
+-
+ 		delete(conf, workerProcesses)
++	} else {
++		workerProcessesChecksum = "auto"
+ 	}
+ 
+ 	if val, ok := conf[workerSerialReloads]; ok {
+@@ -467,15 +475,26 @@ func ReadConfig(src map[string]string) config.Configuration {
+ 		klog.Warningf("unexpected error merging defaults: %v", err)
+ 	}
+ 
+-	hash, err := hashstructure.Hash(to, hashstructure.FormatV1, &hashstructure.HashOptions{
+-		TagName: "json",
+-	})
+-	if err != nil {
+-		klog.Warningf("unexpected error obtaining hash: %v", err)
++	// Checksum: JSON+xxhash (stable across pods); omit IPv6-DNS and worker count from hash input.
++	savedDisableIPv6DNS := to.DisableIpv6DNS
++	savedWorkerProcesses := to.WorkerProcesses
++	to.DisableIpv6DNS = false
++	to.WorkerProcesses = workerProcessesChecksum
++	to.Checksum = ""
++	var data []byte
++	var jerr error
++	data, jerr = json.Marshal(to)
++	to.DisableIpv6DNS = savedDisableIPv6DNS
++	to.WorkerProcesses = savedWorkerProcesses
++	if jerr != nil {
++		klog.Warningf("unexpected error obtaining checksum: %v", jerr)
++		if h, herr := hashstructure.Hash(to, hashstructure.FormatV1, &hashstructure.HashOptions{TagName: "json"}); herr == nil {
++			to.Checksum = fmt.Sprintf("%v", h)
++		}
++	} else {
++		to.Checksum = fmt.Sprintf("%v", xxhash.Sum64(data))
+ 	}
+ 
+-	to.Checksum = fmt.Sprintf("%v", hash)
+-
+ 	return to
+ }
+ 

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -138,6 +138,6 @@ This patch fixes rewrite-target CVE-2026-3288 in Ingress-NGINX
 
 https://github.com/kubernetes/kubernetes/issues/137560
 
-### 025-stable-config-hash-metric-01.patch
+### 025-stable-config-hash-metric-02.patch
 
 This patch updates the way config_hash controller metric is calculated so that all pods of a controller report the same value

--- a/modules/402-ingress-nginx/images/controller-1-14/patches/022-stable-config-hash-metric-04.patch
+++ b/modules/402-ingress-nginx/images/controller-1-14/patches/022-stable-config-hash-metric-04.patch
@@ -1,14 +1,13 @@
 diff --git a/internal/ingress/controller/controller.go b/internal/ingress/controller/controller.go
-index 8a4278ea8..dbaba8873 100644
+index 8a4278ea8..f7b0c865c 100644
 --- a/internal/ingress/controller/controller.go
 +++ b/internal/ingress/controller/controller.go
-@@ -18,13 +18,15 @@ package controller
+@@ -18,13 +18,14 @@ package controller
  
  import (
  	"context"
 +	"encoding/json"
  	"fmt"
-+	"os"
  	"sort"
  	"strconv"
  	"strings"
@@ -19,7 +18,7 @@ index 8a4278ea8..dbaba8873 100644
  	apiv1 "k8s.io/api/core/v1"
  	networking "k8s.io/api/networking/v1"
  	apiequality "k8s.io/apimachinery/pkg/api/equality"
-@@ -47,6 +49,7 @@ import (
+@@ -47,6 +48,7 @@ import (
  	"k8s.io/ingress-nginx/internal/ingress/inspector"
  	"k8s.io/ingress-nginx/internal/ingress/metric/collectors"
  	"k8s.io/ingress-nginx/internal/k8s"
@@ -27,17 +26,7 @@ index 8a4278ea8..dbaba8873 100644
  	"k8s.io/ingress-nginx/internal/nginx"
  	"k8s.io/ingress-nginx/pkg/apis/ingress"
  	utilingress "k8s.io/ingress-nginx/pkg/util/ingress"
-@@ -54,6 +57,9 @@ import (
- )
- 
- const (
-+	// ingressControllerConfigJSONPath is written on each sync for cross-pod diff (kubectl exec … cat).
-+	ingressControllerConfigJSONPath = "/tmp/ingress_controller_config.json"
-+
- 	defUpstreamName             = "upstream-default-backend"
- 	defServerName               = "_"
- 	rootLocation                = "/"
-@@ -62,6 +68,246 @@ const (
+@@ -62,6 +64,246 @@ const (
  	orphanMetricLabelNoEndpoint = "no-endpoint"
  )
  
@@ -284,20 +273,7 @@ index 8a4278ea8..dbaba8873 100644
  // Configuration contains all the settings required by an Ingress controller
  type Configuration struct {
  	APIServerHost string
-@@ -192,12 +438,20 @@ func (n *NGINXController) syncIngress(interface{}) error {
- 	ings := n.store.ListIngresses()
- 	hosts, servers, pcfg := n.getConfiguration(ings)
- 
-+	// JSON snapshot of the same normalized structure used for config_hash (sorted, endpoints cleared, etc.).
-+	if cfgForJSON := deepCopyConfigurationForHash(pcfg); cfgForJSON != nil {
-+		if data, jerr := json.MarshalIndent(cfgForJSON, "", "  "); jerr == nil {
-+			_ = os.WriteFile(ingressControllerConfigJSONPath, data, 0o600)
-+		} else {
-+			fallback, _ := json.MarshalIndent(map[string]string{"marshalError": jerr.Error()}, "", "  ")
-+			_ = os.WriteFile(ingressControllerConfigJSONPath, fallback, 0o600)
-+		}
-+	}
-+
+@@ -195,9 +437,7 @@ func (n *NGINXController) syncIngress(interface{}) error {
  	n.metricCollector.SetSSLExpireTime(servers)
  	n.metricCollector.SetSSLInfo(servers)
  
@@ -386,88 +362,3 @@ index febf20be0..5ce2a02ba 100644
  
  	return to
  }
-diff --git a/internal/ingress/controller/template/configmap_test.go b/internal/ingress/controller/template/configmap_test.go
-index 6c7468303..09d2d2c94 100644
---- a/internal/ingress/controller/template/configmap_test.go
-+++ b/internal/ingress/controller/template/configmap_test.go
-@@ -17,18 +17,34 @@ limitations under the License.
- package template
- 
- import (
-+	"encoding/json"
- 	"fmt"
- 	"reflect"
- 	"testing"
- 	"time"
- 
-+	"github.com/cespare/xxhash/v2"
- 	"github.com/kylelemons/godebug/pretty"
--	"github.com/mitchellh/hashstructure/v2"
- 
- 	"k8s.io/ingress-nginx/internal/ingress/annotations/authreq"
- 	"k8s.io/ingress-nginx/internal/ingress/controller/config"
- )
- 
-+// backendConfigChecksum matches ReadConfig: IPv6 DNS and worker CPU count omitted from hash input.
-+func backendConfigChecksum(c *config.Configuration) string {
-+	savedDNS := c.DisableIpv6DNS
-+	savedWP := c.WorkerProcesses
-+	c.DisableIpv6DNS = false
-+	c.WorkerProcesses = "auto"
-+	b, err := json.Marshal(c)
-+	c.DisableIpv6DNS = savedDNS
-+	c.WorkerProcesses = savedWP
-+	if err != nil {
-+		return ""
-+	}
-+	return fmt.Sprintf("%v", xxhash.Sum64(b))
-+}
-+
- func TestFilterErrors(t *testing.T) {
- 	e := filterErrors([]int{200, 300, 345, 500, 555, 999})
- 	if len(e) != 4 {
-@@ -104,13 +120,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
- 	def.DefaultType = "text/plain"
- 	def.DebugConnections = []string{"127.0.0.1", "1.1.1.1/24", "::1"}
- 
--	hash, err := hashstructure.Hash(def, hashstructure.FormatV1, &hashstructure.HashOptions{
--		TagName: "json",
--	})
--	if err != nil {
--		t.Fatalf("unexpected error obtaining hash: %v", err)
--	}
--	def.Checksum = fmt.Sprintf("%v", hash)
-+	def.Checksum = backendConfigChecksum(&def)
- 
- 	to := ReadConfig(conf)
- 	if diff := pretty.Compare(to, def); diff != "" {
-@@ -134,13 +144,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
- 	def.LuaSharedDicts = defaultLuaSharedDicts
- 	def.DisableIpv6DNS = true
- 
--	hash, err = hashstructure.Hash(def, hashstructure.FormatV1, &hashstructure.HashOptions{
--		TagName: "json",
--	})
--	if err != nil {
--		t.Fatalf("unexpected error obtaining hash: %v", err)
--	}
--	def.Checksum = fmt.Sprintf("%v", hash)
-+	def.Checksum = backendConfigChecksum(&def)
- 
- 	to = ReadConfig(map[string]string{
- 		"disable-ipv6-dns": "true",
-@@ -155,13 +159,7 @@ func TestMergeConfigMapToStruct(t *testing.T) {
- 	def.WhitelistSourceRange = []string{"1.1.1.1/32"}
- 	def.DisableIpv6DNS = true
- 
--	hash, err = hashstructure.Hash(def, hashstructure.FormatV1, &hashstructure.HashOptions{
--		TagName: "json",
--	})
--	if err != nil {
--		t.Fatalf("unexpected error obtaining hash: %v", err)
--	}
--	def.Checksum = fmt.Sprintf("%v", hash)
-+	def.Checksum = backendConfigChecksum(&def)
- 
- 	to = ReadConfig(map[string]string{
- 		"denylist-source-range":  "2.2.2.2/32",

--- a/modules/402-ingress-nginx/images/controller-1-14/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-14/patches/README.md
@@ -139,6 +139,6 @@ https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts
 
 This patch sets go version to 1.25.7 to comply with current Deckhouse build image.
 
-### 022-stable-config-hash-metric-03.patch
+### 022-stable-config-hash-metric-04.patch
 
 This patch updates the way config_hash controller metric is calculated so that all pods of a controller report the same value


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The way configuration hash calculated is updated excluding two node-specific parameters (ipv6_enabled and worker_process count when set to "auto").

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Without these changes config hashes may still be different across different pods of a controller if they run on nodes with different numbers of CPU or/and different network stack settings.

## Why do we need it in the patch release (if we do)?

To prevent false positives from config hash alerts.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Node-specific parameters are excluded from config hash.
impact: All pods of Ingress-NGINX controller will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
