### PR TITLE
[upmeter] Fix probe securityContext

### DIFF
--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/k8s_pod.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/k8s_pod.go
@@ -22,6 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"d8.io/upmeter/pkg/check"
 	"d8.io/upmeter/pkg/kubernetes"
@@ -124,6 +125,16 @@ func createPodObject(podName, nodeName, agentID string, image *kubernetes.ProbeI
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Command: []string{
 						"true",
+					},
+					SecurityContext: &v1.SecurityContext{
+						ReadOnlyRootFilesystem:   ptr.To(true),
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &v1.Capabilities{
+							Drop: []v1.Capability{"ALL"},
+						},
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
## Description
Upmeter spawn pods to check all the K8s machinery. With the restricted security profile it's mandatory to have a specific security context on every pod otherwise won't pass validation and won't be created
## Why do we need it, and what problem does it solve?
This PR adds missing security context to the Pod upmeter probe

## Why do we need it in the patch release (if we do)?
We have to backport this into the 1.73 certified edition

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: upmeter
type: fix
summary: Add proper securityContext to the upmeter probe to meet the restricted security profile constraints.
impact_level: default
```