### PR TITLE
[istio] Enable trust domain validation

### DIFF
--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -51,7 +51,7 @@ type IstioMulticlusterMergeCrdInfo struct {
 	EnableIngressGateway     bool                                 `json:"enableIngressGateway"`
 	EnableInsecureConnection bool                                 `json:"insecureSkipVerify"`
 	IngressGateways          *[]eeCrd.MulticlusterIngressGateways `json:"ingressGateways"`
-	MetadataCA               string                               `json:"metadataCA"`
+	MetadataExporterCA       string                               `json:"metadataExporterCA"`
 	Name                     string                               `json:"name"`
 	NetworkName              string                               `json:"networkName"`
 	Public                   *eeCrd.AlliancePublicMetadata        `json:"public,omitempty"`
@@ -182,7 +182,7 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 		EnableIngressGateway:     multicluster.Spec.EnableIngressGateway,
 		EnableInsecureConnection: multicluster.Spec.Metadata.EnableInsecureConnection,
 		IngressGateways:          igs,
-		MetadataCA:               multicluster.Spec.Metadata.CA,
+		MetadataExporterCA:       multicluster.Spec.Metadata.CA,
 		Name:                     multicluster.GetName(),
 		NetworkName:              networkName,
 		Public:                   p,

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -33,27 +33,30 @@ import (
 )
 
 type IstioFederationMergeCrdInfo struct {
-	Name             string                            `json:"name"`
-	TrustDomain      string                            `json:"trustDomain"`
-	SpiffeEndpoint   string                            `json:"spiffeEndpoint"`
-	IngressGateways  *[]eeCrd.FederationIngressGateway `json:"ingressGateways"`
-	MetadataCA       string                            `json:"ca"`
-	MetadataInsecure bool                              `json:"insecureSkipVerify"`
-	PublicServices   *[]eeCrd.FederationPublicService  `json:"publicServices"`
-	Public           *eeCrd.AlliancePublicMetadata     `json:"public,omitempty"`
+	ClusterUUID              string                            `json:"clusterUUID"`
+	EnableInsecureConnection bool                              `json:"insecureSkipVerify"`
+	IngressGateways          *[]eeCrd.FederationIngressGateway `json:"ingressGateways"`
+	Name                     string                            `json:"name"`
+	Public                   *eeCrd.AlliancePublicMetadata     `json:"public,omitempty"`
+	PublicServices           *[]eeCrd.FederationPublicService  `json:"publicServices"`
+	RootCA                   string                            `json:"rootCA"`
+	SpiffeEndpoint           string                            `json:"spiffeEndpoint"`
+	TrustDomain              string                            `json:"trustDomain"`
 }
 
 type IstioMulticlusterMergeCrdInfo struct {
-	Name                 string                               `json:"name"`
-	SpiffeEndpoint       string                               `json:"spiffeEndpoint"`
-	EnableIngressGateway bool                                 `json:"enableIngressGateway"`
-	MetadataCA           string                               `json:"ca"`
-	MetadataInsecure     bool                                 `json:"insecureSkipVerify"`
-	APIHost              string                               `json:"apiHost"`
-	NetworkName          string                               `json:"networkName"`
-	APIJWT               string                               `json:"apiJWT"`
-	IngressGateways      *[]eeCrd.MulticlusterIngressGateways `json:"ingressGateways"`
-	Public               *eeCrd.AlliancePublicMetadata        `json:"public,omitempty"`
+	APIHost                  string                               `json:"apiHost"`
+	APIJWT                   string                               `json:"apiJWT"`
+	ClusterUUID              string                               `json:"clusterUUID"`
+	EnableIngressGateway     bool                                 `json:"enableIngressGateway"`
+	EnableInsecureConnection bool                                 `json:"insecureSkipVerify"`
+	IngressGateways          *[]eeCrd.MulticlusterIngressGateways `json:"ingressGateways"`
+	MetadataCA               string                               `json:"metadataCA"`
+	Name                     string                               `json:"name"`
+	NetworkName              string                               `json:"networkName"`
+	Public                   *eeCrd.AlliancePublicMetadata        `json:"public,omitempty"`
+	RootCA                   string                               `json:"rootCA"`
+	SpiffeEndpoint           string                               `json:"spiffeEndpoint"`
 }
 
 type ServiceEntry struct {
@@ -105,9 +108,13 @@ func applyFederationMergeFilter(obj *unstructured.Unstructured) (go_hook.FilterR
 	me := federation.Spec.MetadataEndpoint
 	me = strings.TrimSuffix(me, "/")
 
-	var igs *[]eeCrd.FederationIngressGateway
-	var pss *[]eeCrd.FederationPublicService
-	var p *eeCrd.AlliancePublicMetadata
+	var (
+		igs    *[]eeCrd.FederationIngressGateway
+		pss    *[]eeCrd.FederationPublicService
+		p      *eeCrd.AlliancePublicMetadata
+		uuid   string
+		rootCA string
+	)
 
 	if federation.Status.MetadataCache.Private != nil {
 		if federation.Status.MetadataCache.Private.IngressGateways != nil {
@@ -119,17 +126,20 @@ func applyFederationMergeFilter(obj *unstructured.Unstructured) (go_hook.FilterR
 	}
 	if federation.Status.MetadataCache.Public != nil {
 		p = federation.Status.MetadataCache.Public
+		uuid = federation.Status.MetadataCache.Public.ClusterUUID
+		rootCA = federation.Status.MetadataCache.Public.RootCA
 	}
 
 	return IstioFederationMergeCrdInfo{
-		Name:             federation.GetName(),
-		TrustDomain:      federation.Spec.TrustDomain,
-		SpiffeEndpoint:   me + "/public/spiffe-bundle-endpoint",
-		IngressGateways:  igs,
-		MetadataCA:       federation.Spec.Metadata.ClusterCA,
-		MetadataInsecure: federation.Spec.Metadata.EnableInsecureConnection,
-		PublicServices:   pss,
-		Public:           p,
+		ClusterUUID:              uuid,
+		EnableInsecureConnection: federation.Spec.Metadata.EnableInsecureConnection,
+		IngressGateways:          igs,
+		Name:                     federation.GetName(),
+		Public:                   p,
+		PublicServices:           pss,
+		RootCA:                   rootCA,
+		SpiffeEndpoint:           me + "/public/spiffe-bundle-endpoint",
+		TrustDomain:              federation.Spec.TrustDomain,
 	}, nil
 }
 
@@ -144,10 +154,14 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	me := multicluster.Spec.MetadataEndpoint
 	me = strings.TrimSuffix(me, "/")
 
-	var igs *[]eeCrd.MulticlusterIngressGateways
-	var apiHost string
-	var networkName string
-	var p *eeCrd.AlliancePublicMetadata
+	var (
+		igs         *[]eeCrd.MulticlusterIngressGateways
+		apiHost     string
+		networkName string
+		p           *eeCrd.AlliancePublicMetadata
+		uuid        string
+		rootCA      string
+	)
 
 	if multicluster.Status.MetadataCache.Private != nil {
 		if multicluster.Status.MetadataCache.Private.IngressGateways != nil {
@@ -158,18 +172,22 @@ func applyMulticlusterMergeFilter(obj *unstructured.Unstructured) (go_hook.Filte
 	}
 	if multicluster.Status.MetadataCache.Public != nil {
 		p = multicluster.Status.MetadataCache.Public
+		uuid = multicluster.Status.MetadataCache.Public.ClusterUUID
+		rootCA = multicluster.Status.MetadataCache.Public.RootCA
 	}
 
 	return IstioMulticlusterMergeCrdInfo{
-		Name:                 multicluster.GetName(),
-		SpiffeEndpoint:       me + "/public/spiffe-bundle-endpoint",
-		MetadataCA:           multicluster.Spec.Metadata.ClusterCA,
-		MetadataInsecure:     multicluster.Spec.Metadata.EnableInsecureConnection,
-		EnableIngressGateway: multicluster.Spec.EnableIngressGateway,
-		APIHost:              apiHost,
-		NetworkName:          networkName,
-		IngressGateways:      igs,
-		Public:               p,
+		APIHost:                  apiHost,
+		ClusterUUID:              uuid,
+		EnableIngressGateway:     multicluster.Spec.EnableIngressGateway,
+		EnableInsecureConnection: multicluster.Spec.Metadata.EnableInsecureConnection,
+		IngressGateways:          igs,
+		MetadataCA:               multicluster.Spec.Metadata.CA,
+		Name:                     multicluster.GetName(),
+		NetworkName:              networkName,
+		Public:                   p,
+		RootCA:                   rootCA,
+		SpiffeEndpoint:           me + "/public/spiffe-bundle-endpoint",
 	}, nil
 }
 
@@ -571,7 +589,7 @@ multiclustersLoop:
 			privKey := []byte(input.Values.Get("istio.internal.remoteAuthnKeypair.priv").String())
 			claims := map[string]string{
 				"iss":   "d8-istio",
-				"aud":   multiclusterInfo.Public.ClusterUUID,
+				"aud":   multiclusterInfo.ClusterUUID,
 				"sub":   input.Values.Get("global.discovery.clusterUUID").String(),
 				"scope": "api",
 			}

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -373,7 +373,7 @@ status:
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.spiffeEndpoint").String()).To(Equal("https://some-proper-host/public/spiffe-bundle-endpoint"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.apiHost").String()).To(Equal("istio-api-0.example.com"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.networkName").String()).To(Equal("network-qqq-123"))
-			Expect(f.ValuesGet("istio.internal.multiclusters.0.metadataCA").String()).To(Equal("custom-metadata-ca-m0"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.0.metadataExporterCA").String()).To(Equal("custom-metadata-ca-m0"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.clusterUUID").String()).To(Equal("aaa-bbb-m0"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.rootCA").String()).To(Equal("abc-m0"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.ingressGateways").String()).To(MatchJSON(`
@@ -388,7 +388,7 @@ status:
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.spiffeEndpoint").String()).To(Equal("https://some-proper-host/public/spiffe-bundle-endpoint"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.apiHost").String()).To(Equal("istio-api-1.example.com"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.networkName").String()).To(Equal("network-xxx-123"))
-			Expect(f.ValuesGet("istio.internal.multiclusters.1.metadataCA").String()).To(Equal(""))
+			Expect(f.ValuesGet("istio.internal.multiclusters.1.metadataExporterCA").String()).To(Equal(""))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.clusterUUID").String()).To(Equal("aaa-bbb-m1"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.rootCA").String()).To(Equal("abc-m1"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.ingressGateways").Exists()).To(BeTrue())

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -564,22 +564,56 @@ status:
 			// Both federations should still be listed individually in internal.federations
 			Expect(f.ValuesGet("istio.internal.federations").String()).To(MatchJSON(`[
 				{
-					"name": "cluster-a",
-					"trustDomain": "cluster.local",
-					"spiffeEndpoint": "https://cluster-a.example.com/metadata/public/spiffe-bundle-endpoint",
-					"ingressGateways": [{"address": "1.1.1.1", "port": 15443}],
-					"ca": "",
+					"clusterUUID": "uuid-a",
 					"insecureSkipVerify": false,
-					"publicServices": [{"hostname": "my-svc.my-ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}]
+					"ingressGateways": [
+						{
+							"address": "1.1.1.1",
+							"port": 15443
+						}
+					],
+					"name": "cluster-a",
+					"publicServices": [
+						{
+							"hostname": "my-svc.my-ns.svc.cluster.local",
+							"ports": [
+								{
+									"name": "http",
+									"port": 8080,
+									"protocol": "HTTP"
+								}
+							]
+						}
+					],
+					"rootCA": "root-ca-a",
+					"spiffeEndpoint": "https://cluster-a.example.com/metadata/public/spiffe-bundle-endpoint",
+					"trustDomain": "cluster.local"
 				},
 				{
-					"name": "cluster-b",
-					"trustDomain": "cluster.local",
-					"spiffeEndpoint": "https://cluster-b.example.com/metadata/public/spiffe-bundle-endpoint",
-					"ingressGateways": [{"address": "2.2.2.2", "port": 15443}],
-					"ca": "",
+					"clusterUUID": "uuid-b",
 					"insecureSkipVerify": false,
-					"publicServices": [{"hostname": "my-svc.my-ns.svc.cluster.local", "ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}]}]
+					"ingressGateways": [
+						{
+							"address": "2.2.2.2",
+							"port": 15443
+						}
+					],
+					"name": "cluster-b",
+					"publicServices": [
+						{
+							"hostname": "my-svc.my-ns.svc.cluster.local",
+							"ports": [
+								{
+									"name": "http",
+									"port": 8080,
+									"protocol": "HTTP"
+								}
+							]
+						}
+					],
+					"rootCA": "root-ca-b",
+					"spiffeEndpoint": "https://cluster-b.example.com/metadata/public/spiffe-bundle-endpoint",
+					"trustDomain": "cluster.local"
 				}
 			]`))
 
@@ -588,7 +622,13 @@ status:
 				{
 					"name": "my-svc-my-ns-svc-cluster-local-9c8cbb5bc",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
-					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
+					"ports": [
+						{
+							"name": "http",
+							"port": 8080,
+							"protocol": "HTTP"
+						}
+					],
 					"endpoints": [
 						{"address": "1.1.1.1", "port": 15443},
 						{"address": "2.2.2.2", "port": 15443}
@@ -816,9 +856,9 @@ status:
           port: 8080
           protocol: HTTP
     public:
-      clusterUUID: uuid-b
-      rootCA: root-ca-b
-      authnKeyPub: pub-key-b
+      clusterUUID: uuid-c
+      rootCA: root-ca-c
+      authnKeyPub: pub-key-c
 `))
 			f.RunHook()
 		})
@@ -827,15 +867,13 @@ status:
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("istio.internal.federations").String()).To(MatchJSON(`[
 				{
-					"name": "cluster-a",
-					"trustDomain": "cluster.local",
-					"spiffeEndpoint": "https://cluster-a.example.com/metadata/public/spiffe-bundle-endpoint",
+					"clusterUUID": "uuid-a",
+					"insecureSkipVerify": false,
 					"ingressGateways": [
 						{"address": "1.1.1.1", "port": 15443},
 						{"address": "1.1.1.2", "port": 15443}
 					],
-					"ca": "",
-					"insecureSkipVerify": false,
+					"name": "cluster-a",
 					"publicServices": [
 						{
 							"hostname": "my-svc.my-ns.svc.cluster.local",
@@ -843,17 +881,18 @@ status:
 								{"name": "web", "port": 8080, "protocol": "HTTP"}
 							]
 						}
-					]
+					],
+					"rootCA": "root-ca-a",
+					"spiffeEndpoint": "https://cluster-a.example.com/metadata/public/spiffe-bundle-endpoint",
+					"trustDomain": "cluster.local"
 				},
 				{
-					"name": "cluster-b",
-					"trustDomain": "cluster.local",
-					"spiffeEndpoint": "https://cluster-b.example.com/metadata/public/spiffe-bundle-endpoint",
+					"clusterUUID": "uuid-b",
 					"ingressGateways": [
 						{"address": "2.2.2.2", "port": 15443},
 						{"address": "2.2.2.3", "port": 15443}
 					],
-					"ca": "",
+					"name": "cluster-b",
 					"insecureSkipVerify": false,
 					"publicServices": [
 						{
@@ -863,17 +902,18 @@ status:
 								{"name": "www", "port": 8080, "protocol": "HTTP"}
 							]
 						}
-					]
+					],
+					"rootCA": "root-ca-b",
+					"spiffeEndpoint": "https://cluster-b.example.com/metadata/public/spiffe-bundle-endpoint",
+					"trustDomain": "cluster.local"
 				},
 				{
-					"name": "cluster-c",
-					"trustDomain": "cluster.local",
-					"spiffeEndpoint": "https://cluster-c.example.com/metadata/public/spiffe-bundle-endpoint",
+					"clusterUUID": "uuid-c",
 					"ingressGateways": [
 						{"address": "3.3.3.3", "port": 15443},
 						{"address": "3.3.3.4", "port": 15443}
 					],
-					"ca": "",
+					"name": "cluster-c",
 					"insecureSkipVerify": false,
 					"publicServices": [
 						{
@@ -883,7 +923,10 @@ status:
 								{"name": "http", "port": 8080, "protocol": "HTTP"}
 							]
 						}
-					]
+					],
+					"rootCA": "root-ca-c",
+					"spiffeEndpoint": "https://cluster-c.example.com/metadata/public/spiffe-bundle-endpoint",
+					"trustDomain": "cluster.local"
 				}
 			]`))
 

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -167,6 +167,8 @@ metadata:
 spec:
   enableIngressGateway: true
   metadataEndpoint: "https://some-proper-host/"
+  metadata:
+    ca: custom-metadata-ca-m0
 status:
   metadataCache:
     private:
@@ -312,7 +314,8 @@ status:
               }
             ],
             "name": "federation-only-full-0",
-            "ca": "",
+            "clusterUUID": "aaa-bbb-f3",
+            "rootCA": "abc-f3",
             "insecureSkipVerify": false,
             "publicServices": [
               {
@@ -331,7 +334,8 @@ status:
               }
             ],
             "name": "federation-only-full-1",
-            "ca": "",
+            "clusterUUID": "aaa-bbb-f4",
+            "rootCA": "abc-f4",
             "insecureSkipVerify": false,
             "publicServices": [
               {
@@ -369,6 +373,9 @@ status:
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.spiffeEndpoint").String()).To(Equal("https://some-proper-host/public/spiffe-bundle-endpoint"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.apiHost").String()).To(Equal("istio-api-0.example.com"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.networkName").String()).To(Equal("network-qqq-123"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.0.metadataCA").String()).To(Equal("custom-metadata-ca-m0"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.0.clusterUUID").String()).To(Equal("aaa-bbb-m0"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.0.rootCA").String()).To(Equal("abc-m0"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.0.ingressGateways").String()).To(MatchJSON(`
 [
   {
@@ -381,6 +388,9 @@ status:
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.spiffeEndpoint").String()).To(Equal("https://some-proper-host/public/spiffe-bundle-endpoint"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.apiHost").String()).To(Equal("istio-api-1.example.com"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.networkName").String()).To(Equal("network-xxx-123"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.1.metadataCA").String()).To(Equal(""))
+			Expect(f.ValuesGet("istio.internal.multiclusters.1.clusterUUID").String()).To(Equal("aaa-bbb-m1"))
+			Expect(f.ValuesGet("istio.internal.multiclusters.1.rootCA").String()).To(Equal("abc-m1"))
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.ingressGateways").Exists()).To(BeTrue())
 			Expect(f.ValuesGet("istio.internal.multiclusters.1.ingressGateways").Value()).To(BeNil())
 

--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -42,7 +42,7 @@ type IstioFederationDiscoveryCrdInfo struct {
 	Name                     string
 	ClusterUUID              string
 	TrustDomain              string
-	ClusterCA                string
+	MetadataCA               string
 	EnableInsecureConnection bool
 	PublicMetadataEndpoint   string
 	PrivateMetadataEndpoint  string
@@ -90,7 +90,7 @@ func applyFederationFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 	return IstioFederationDiscoveryCrdInfo{
 		Name:                     federation.GetName(),
 		TrustDomain:              federation.Spec.TrustDomain,
-		ClusterCA:                federation.Spec.Metadata.ClusterCA,
+		MetadataCA:               federation.Spec.Metadata.CA,
 		EnableInsecureConnection: federation.Spec.Metadata.EnableInsecureConnection,
 		ClusterUUID:              clusterUUID,
 		PublicMetadataEndpoint:   me + "/public/public.json",
@@ -152,8 +152,8 @@ func federationDiscovery(_ context.Context, input *go_hook.HookInput, dc depende
 
 		defaultProtocol := "TCP"
 
-		if federationInfo.ClusterCA != "" {
-			caCerts := [][]byte{[]byte(federationInfo.ClusterCA)}
+		if federationInfo.MetadataCA != "" {
+			caCerts := [][]byte{[]byte(federationInfo.MetadataCA)}
 			httpOption = append(httpOption, http.WithAdditionalCACerts(caCerts))
 		} else if federationInfo.EnableInsecureConnection {
 			httpOption = append(httpOption, http.WithInsecureSkipVerify())

--- a/ee/modules/110-istio/hooks/ee/federation_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/federation_discovery.go
@@ -42,7 +42,7 @@ type IstioFederationDiscoveryCrdInfo struct {
 	Name                     string
 	ClusterUUID              string
 	TrustDomain              string
-	MetadataCA               string
+	MetadataExporterCA       string
 	EnableInsecureConnection bool
 	PublicMetadataEndpoint   string
 	PrivateMetadataEndpoint  string
@@ -90,7 +90,7 @@ func applyFederationFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 	return IstioFederationDiscoveryCrdInfo{
 		Name:                     federation.GetName(),
 		TrustDomain:              federation.Spec.TrustDomain,
-		MetadataCA:               federation.Spec.Metadata.CA,
+		MetadataExporterCA:       federation.Spec.Metadata.CA,
 		EnableInsecureConnection: federation.Spec.Metadata.EnableInsecureConnection,
 		ClusterUUID:              clusterUUID,
 		PublicMetadataEndpoint:   me + "/public/public.json",
@@ -152,8 +152,8 @@ func federationDiscovery(_ context.Context, input *go_hook.HookInput, dc depende
 
 		defaultProtocol := "TCP"
 
-		if federationInfo.MetadataCA != "" {
-			caCerts := [][]byte{[]byte(federationInfo.MetadataCA)}
+		if federationInfo.MetadataExporterCA != "" {
+			caCerts := [][]byte{[]byte(federationInfo.MetadataExporterCA)}
 			httpOption = append(httpOption, http.WithAdditionalCACerts(caCerts))
 		} else if federationInfo.EnableInsecureConnection {
 			httpOption = append(httpOption, http.WithInsecureSkipVerify())

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiofederation.go
@@ -23,7 +23,7 @@ type IstioFederation struct {
 type IstioFederationSpec struct {
 	MetadataEndpoint string `json:"metadataEndpoint"`
 	Metadata         struct {
-		ClusterCA                string `json:"ca"`
+		CA                       string `json:"ca"`
 		EnableInsecureConnection bool   `json:"insecureSkipVerify"`
 	} `json:"metadata,omitempty"`
 	TrustDomain string `json:"trustDomain,omitempty"`

--- a/ee/modules/110-istio/hooks/ee/lib/crd/istiomulticluster.go
+++ b/ee/modules/110-istio/hooks/ee/lib/crd/istiomulticluster.go
@@ -22,7 +22,7 @@ type IstioMulticluster struct {
 type IstioMulticlusterSpec struct {
 	MetadataEndpoint string `json:"metadataEndpoint"`
 	Metadata         struct {
-		ClusterCA                string `json:"ca"`
+		CA                       string `json:"ca"`
 		EnableInsecureConnection bool   `json:"insecureSkipVerify"`
 	} `json:"metadata,omitempty"`
 	EnableIngressGateway bool `json:"enableIngressGateway"`

--- a/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
@@ -40,7 +40,7 @@ type IstioMulticlusterDiscoveryCrdInfo struct {
 	Name                     string
 	ClusterUUID              string
 	EnableIngressGateway     bool
-	ClusterCA                string
+	MetadataCA               string
 	EnableInsecureConnection bool
 	PublicMetadataEndpoint   string
 	PrivateMetadataEndpoint  string
@@ -88,7 +88,7 @@ func applyMulticlusterFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 	return IstioMulticlusterDiscoveryCrdInfo{
 		Name:                     multicluster.GetName(),
 		EnableIngressGateway:     multicluster.Spec.EnableIngressGateway,
-		ClusterCA:                multicluster.Spec.Metadata.ClusterCA,
+		MetadataCA:               multicluster.Spec.Metadata.CA,
 		EnableInsecureConnection: multicluster.Spec.Metadata.EnableInsecureConnection,
 		ClusterUUID:              clusterUUID,
 		PublicMetadataEndpoint:   me + "/public/public.json",
@@ -133,8 +133,8 @@ func multiclusterDiscovery(_ context.Context, input *go_hook.HookInput, dc depen
 		var privateMetadata eeCrd.MulticlusterPrivateMetadata
 		var httpOption []http.Option
 
-		if multiclusterInfo.ClusterCA != "" {
-			caCerts := [][]byte{[]byte(multiclusterInfo.ClusterCA)}
+		if multiclusterInfo.MetadataCA != "" {
+			caCerts := [][]byte{[]byte(multiclusterInfo.MetadataCA)}
 			httpOption = append(httpOption, http.WithAdditionalCACerts(caCerts))
 		} else if multiclusterInfo.EnableInsecureConnection {
 			httpOption = append(httpOption, http.WithInsecureSkipVerify())

--- a/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_discovery.go
@@ -40,7 +40,7 @@ type IstioMulticlusterDiscoveryCrdInfo struct {
 	Name                     string
 	ClusterUUID              string
 	EnableIngressGateway     bool
-	MetadataCA               string
+	MetadataExporterCA       string
 	EnableInsecureConnection bool
 	PublicMetadataEndpoint   string
 	PrivateMetadataEndpoint  string
@@ -88,7 +88,7 @@ func applyMulticlusterFilter(obj *unstructured.Unstructured) (go_hook.FilterResu
 	return IstioMulticlusterDiscoveryCrdInfo{
 		Name:                     multicluster.GetName(),
 		EnableIngressGateway:     multicluster.Spec.EnableIngressGateway,
-		MetadataCA:               multicluster.Spec.Metadata.CA,
+		MetadataExporterCA:       multicluster.Spec.Metadata.CA,
 		EnableInsecureConnection: multicluster.Spec.Metadata.EnableInsecureConnection,
 		ClusterUUID:              clusterUUID,
 		PublicMetadataEndpoint:   me + "/public/public.json",
@@ -133,8 +133,8 @@ func multiclusterDiscovery(_ context.Context, input *go_hook.HookInput, dc depen
 		var privateMetadata eeCrd.MulticlusterPrivateMetadata
 		var httpOption []http.Option
 
-		if multiclusterInfo.MetadataCA != "" {
-			caCerts := [][]byte{[]byte(multiclusterInfo.MetadataCA)}
+		if multiclusterInfo.MetadataExporterCA != "" {
+			caCerts := [][]byte{[]byte(multiclusterInfo.MetadataExporterCA)}
 			httpOption = append(httpOption, http.WithAdditionalCACerts(caCerts))
 		} else if multiclusterInfo.EnableInsecureConnection {
 			httpOption = append(httpOption, http.WithInsecureSkipVerify())

--- a/ee/modules/110-istio/hooks/ee/multicluster_monitoring_api_hosts.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_monitoring_api_hosts.go
@@ -61,7 +61,7 @@ func monitoringAPIHosts(_ context.Context, input *go_hook.HookInput, dc dependen
 		apiHost := m.Get("apiHost").String()
 		apiJWT := m.Get("apiJWT").String()
 		apiSkipVerify := m.Get("insecureSkipVerify").Bool()
-		apiAdditionalCA := m.Get("ca").String()
+		apiAdditionalCA := m.Get("metadataCA").String()
 
 		var options []http.Option
 		if apiSkipVerify {

--- a/ee/modules/110-istio/hooks/ee/multicluster_monitoring_api_hosts.go
+++ b/ee/modules/110-istio/hooks/ee/multicluster_monitoring_api_hosts.go
@@ -61,7 +61,7 @@ func monitoringAPIHosts(_ context.Context, input *go_hook.HookInput, dc dependen
 		apiHost := m.Get("apiHost").String()
 		apiJWT := m.Get("apiJWT").String()
 		apiSkipVerify := m.Get("insecureSkipVerify").Bool()
-		apiAdditionalCA := m.Get("metadataCA").String()
+		apiAdditionalCA := m.Get("metadataExporterCA").String()
 
 		var options []http.Option
 		if apiSkipVerify {

--- a/ee/modules/110-istio/templates/multicluster/_kubeconfig.tpl
+++ b/ee/modules/110-istio/templates/multicluster/_kubeconfig.tpl
@@ -6,7 +6,7 @@ kind: Config
 clusters:
 - cluster:
     server: https://{{ $multicluster.apiHost }}
-    certificate-authority-data: {{ $multicluster.ca | b64enc }}
+    certificate-authority-data: {{ $multicluster.metadataCA | b64enc }}
     insecure-skip-tls-verify: {{ $multicluster.insecureSkipVerify }}
   name: {{ $multicluster.name }}
 contexts:

--- a/ee/modules/110-istio/templates/multicluster/_kubeconfig.tpl
+++ b/ee/modules/110-istio/templates/multicluster/_kubeconfig.tpl
@@ -6,7 +6,7 @@ kind: Config
 clusters:
 - cluster:
     server: https://{{ $multicluster.apiHost }}
-    certificate-authority-data: {{ $multicluster.metadataCA | b64enc }}
+    certificate-authority-data: {{ $multicluster.metadataExporterCA | b64enc }}
     insecure-skip-tls-verify: {{ $multicluster.insecureSkipVerify }}
   name: {{ $multicluster.name }}
 contexts:

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -69,7 +69,7 @@ properties:
         type: array
         default: []
         x-examples:
-        - [{"name": "aaa", "trustDomain": "bbb", "spiffeEndpoint": "ccc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}], "publicServices": [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "virtualIP": "3.4.5.6"}]}]
+        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "trustDomain": "bbb", "rootCA": "---ROOT CA---", "spiffeEndpoint": "ccc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}], "publicServices": [{"hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}]}]}]
       federationServiceEntries:
         type: array
         default: []
@@ -79,7 +79,7 @@ properties:
         type: array
         default: []
         x-examples:
-        - [{"name": "aaa", "spiffeEndpoint": "ccc", "ca": "---CERT---asdasda314g---ENDCERT", "insecureSkipVerify": true, "enableIngressGateway": true, "apiHost": "aaa.sss.ddd", "networkName": "a-b-c-1-2-3", "apiJWT": "aAaA.bBbB.CcCc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}]}]
+        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "spiffeEndpoint": "ccc", "rootCA": "---ROOT CA---", "metadataCA": "---METADATA CA---", "insecureSkipVerify": true, "enableIngressGateway": true, "apiHost": "aaa.sss.ddd", "networkName": "a-b-c-1-2-3", "apiJWT": "aAaA.bBbB.CcCc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}]}]
       remotePublicMetadata:
         type: object
         default: {}

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -79,7 +79,7 @@ properties:
         type: array
         default: []
         x-examples:
-        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "spiffeEndpoint": "ccc", "rootCA": "---ROOT CA---", "metadataCA": "---METADATA CA---", "insecureSkipVerify": true, "enableIngressGateway": true, "apiHost": "aaa.sss.ddd", "networkName": "a-b-c-1-2-3", "apiJWT": "aAaA.bBbB.CcCc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}]}]
+        - [{"name": "aaa", "clusterUUID": "uuid-aaa", "spiffeEndpoint": "ccc", "rootCA": "---ROOT CA---", "metadataExporterCA": "---METADATA CA---", "insecureSkipVerify": true, "enableIngressGateway": true, "apiHost": "aaa.sss.ddd", "networkName": "a-b-c-1-2-3", "apiJWT": "aAaA.bBbB.CcCc", "ingressGateways": [{"address": "1.2.3.4", "port": 1234}]}]
       remotePublicMetadata:
         type: object
         default: {}

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -667,7 +667,7 @@ cluster-b:
   ingressGateways:
   - address: 1.1.1.1
     port: 123
-  metadataCA: |
+  metadataExporterCA: |
     -----BEGIN CERTIFICATE-----
     MIIFDTCCAvWgAwIBAgIURb+L4dH5qv53ZSD/tBRSdq37Go4wDQYJKoZIhvcNAQEL
     BQAwFjEUMBIGA1UEAwwLY3VzdG9tLXJvb3QwHhcNMjQxMTI1MTUyNzMwWhcNMzQx

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -321,7 +321,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 		})
 	})
 
-	Context("There are some federations", func() {
+	Context("There is one federation", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
@@ -331,8 +331,6 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			f.ValuesSet("istio.federation.enabled", true)
 			f.ValuesSetFromYaml("istio.internal.federations", `
 - name: neighbour-0
-  trustDomain: n.n0
-  spiffeEndpoint: https://some-proper-host/spiffe-bundle-endpoint
   ingressGateways:
   - address: 1.1.1.1
     port: 123
@@ -341,6 +339,9 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
     ports:
     - name: aaa
       port: 456
+  rootCA: ---ROOT CA---
+  spiffeEndpoint: https://some-proper-host/spiffe-bundle-endpoint
+  trustDomain: n.n0
 `)
 			f.ValuesSetFromYaml("istio.internal.federationServiceEntries", `
 - name: xxx-yyy-6bff7489f5
@@ -404,7 +405,7 @@ neighbour-0:
 			))
 
 			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
-			Expect(iopV21.Field("spec.meshConfig.caCertificates").String()).To(MatchJSON(`[{"pem": "---ROOT CA---"}]`))
+			Expect(iopV21.Field("spec.meshConfig.caCertificates").String()).To(MatchJSON(`[{"pem": "---ROOT CA---", "trustDomains": ["n.n0"]}]`))
 			Expect(iopV21.Field("spec.values.meshNetworks").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "istio-ingressgateway").Exists()).To(BeTrue())
 		})
@@ -659,11 +660,14 @@ cluster-b:
 			f.ValuesSet("istio.internal.multiclustersNeedIngressGateway", true)
 			f.ValuesSetFromYaml("istio.internal.multiclusters", `
 - name: neighbour-0
-  spiffeEndpoint: https://some-proper-host/spiffe-bundle-endpoint
-  enableIngressGateway: true
   apiHost: remote.api.example.com
+  apiJWT: aAaA.bBbB.CcCc
+  enableIngressGateway: true
   insecureSkipVerify: false
-  ca: |
+  ingressGateways:
+  - address: 1.1.1.1
+    port: 123
+  metadataCA: |
     -----BEGIN CERTIFICATE-----
     MIIFDTCCAvWgAwIBAgIURb+L4dH5qv53ZSD/tBRSdq37Go4wDQYJKoZIhvcNAQEL
     BQAwFjEUMBIGA1UEAwwLY3VzdG9tLXJvb3QwHhcNMjQxMTI1MTUyNzMwWhcNMzQx
@@ -695,10 +699,8 @@ cluster-b:
     tQ==
     -----END CERTIFICATE-----
   networkName: a-b-c-1-2-3
-  apiJWT: aAaA.bBbB.CcCc
-  ingressGateways:
-  - address: 1.1.1.1
-    port: 123
+  rootCA: ---ROOT CA---
+  spiffeEndpoint: https://some-proper-host/spiffe-bundle-endpoint
 `)
 			f.ValuesSetFromYaml("istio.internal.remotePublicMetadata", `
 neighbour-0:
@@ -772,7 +774,10 @@ users:
 			))
 
 			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
-			Expect(iopV21.Field("spec.meshConfig.caCertificates").String()).To(MatchJSON(`[{"pem": "---ROOT CA---"}]`))
+			Expect(iopV21.Field("spec.meshConfig.caCertificates").Array()).To(HaveLen(1))
+			Expect(iopV21.Field("spec.meshConfig.caCertificates.0.pem").Exists()).To(BeTrue())
+			Expect(iopV21.Field("spec.meshConfig.caCertificates.0.pem").String()).To(Equal("---ROOT CA---"))
+			Expect(iopV21.Field("spec.meshConfig.caCertificates.0.trustDomains").Exists()).To(BeFalse())
 			Expect(iopV21.Field("spec.values.global.meshNetworks").String()).To(MatchYAML(`
 a-b-c-1-2-3:
   endpoints:

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -42,8 +42,6 @@ spec:
       enabled: true
       k8s:
         env:
-        - name: PILOT_SKIP_VALIDATE_TRUST_DOMAIN
-          value: "true"
         - name: ISTIO_MULTIROOT_MESH
           value: "true"
         - name: ENABLE_ENHANCED_RESOURCE_SCOPING
@@ -118,8 +116,17 @@ spec:
 
   {{- if or $.Values.istio.federation.enabled $.Values.istio.multicluster.enabled }}
     caCertificates:
-    {{- range $metadata := $.Values.istio.internal.remotePublicMetadata }}
-    - pem: {{ $metadata.rootCA | quote }}
+    {{- range $federation := $.Values.istio.internal.federations }}
+    {{- with $federation.rootCA }}
+    - pem: {{ . | quote }}
+      trustDomains:
+        - {{ $federation.trustDomain }}
+    {{- end }}
+    {{- end }}
+    {{- range $multicluster := $.Values.istio.internal.multiclusters }}
+    {{- with $multicluster.rootCA }}
+    - pem: {{ . | quote }}
+    {{- end }}
     {{- end }}
   {{- end }}
 

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -149,8 +149,17 @@ spec:
 
     {{- if or $.Values.istio.federation.enabled $.Values.istio.multicluster.enabled }}
       caCertificates:
-      {{- range $metadata := $.Values.istio.internal.remotePublicMetadata }}
-      - pem: {{ $metadata.rootCA | quote }}
+      {{- range $federation := $.Values.istio.internal.federations }}
+      {{- with $federation.rootCA }}
+      - pem: {{ . | quote }}
+        trustDomains:
+          - {{ $federation.trustDomain }}
+      {{- end }}
+      {{- end }}
+      {{- range $multicluster := $.Values.istio.internal.multiclusters }}
+      {{- with $multicluster.rootCA }}
+      - pem: {{ . | quote }}
+      {{- end }}
       {{- end }}
     {{- end }}
 
@@ -160,7 +169,6 @@ spec:
         enabled: {{ eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
       enabled: true
       env:
-        PILOT_SKIP_VALIDATE_TRUST_DOMAIN: "true"
         ISTIO_MULTIROOT_MESH: "true"
         ENABLE_ENHANCED_RESOURCE_SCOPING: "true"
   {{- if $.Values.istio.enableHTTP10 }}


### PR DESCRIPTION
## Description

This PR makes two key changes to the Istio module:
- Enables trust domain validation by removing PILOT_SKIP_VALIDATE_TRUST_DOMAIN=true from both iop.yaml and istios.yaml, and adding trustDomains to caCertificates entries in the IstioOperator/Istio meshConfig.
- Refactors data flow so that rootCA, clusterUUID, and trustDomain are propagated directly on the federation/multicluster merge structs rather than only being available indirectly via remotePublicMetadata. This is necessary because the templates now need per-federation trustDomain alongside rootCA to build caCertificates entries properly.

Additionaly some Go struct fields and variables are renamed for clarity.

## Why do we need it, and what problem does it solve?

With `PILOT_SKIP_VALIDATE_TRUST_DOMAIN` set to `true`, Istiod accepted mTLS connections from any
trust domain without validation. This weakened the security posture of multi-cluster and federated
Istio deployments by allowing workloads from unknown or misconfigured trust domains to communicate
with the mesh.

By removing the bypass and supplying `trustDomains` per `caCertificate` entry, Istiod now enforces
that each remote root CA is only trusted for its declared trust domain. This prevents a root CA from
one federation partner being used to impersonate workloads in a different trust domain.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Enabled trust domain validation in Istio control plane for federation and multicluster.
impact: Istiod now enforces trust domain validation. Each remote root CA is now scoped to its declared trust domain in the meshConfig caCertificates. Verify that all IstioFederation resources have correct `trustDomain` values matching the remote cluster configuration.
impact_level: high
```