### PR TITLE
[global-hooks] Return endpoints if master is down

### DIFF
--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -287,7 +287,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	}
 
 	controlPlaneEnabled := module.IsEnabled("control-plane-manager", input)
-	input.Logger.Info(fmt.Sprintf("podsCnt %d, endpointsCnt %d", podsCnt, endpointsCnt))
+	input.Logger.Info(fmt.Sprintf("podsCnt %d, endpointsCnt %d, controlPlaneEnabled: %v", podsCnt, endpointsCnt, controlPlaneEnabled))
 	if controlPlaneEnabled && podsCnt != endpointsCnt {
 		msg := fmt.Sprintf("Not found k8s versions. Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
 

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -298,8 +298,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 		}
 
 		msg := fmt.Sprintf("Kube-apiserver Pods(%v) count less than kubernetes Endpoints(%v) count", podsCnt, endpointsCnt)
-		input.Logger.Warn(msg)
-		return nil, nil
+		return nil, errors.New(msg)
 	}
 
 	return endpoints, nil

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -253,7 +253,8 @@ func getKubeVersionForServerFallback(input *go_hook.HookInput, err error) (*semv
 func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, error) {
 	serverK8sLabeledSnap := input.Snapshots.Get(kubeAPIServK8sLabeledSnap)
 	serverCPLabeledSnap := input.Snapshots.Get(kubeAPIServCPLabeledSnap)
-
+	input.Logger.Info(fmt.Sprintf("serverK8sLabeledSnap, length %d: %s", len(serverK8sLabeledSnap), serverK8sLabeledSnap))
+	input.Logger.Info(fmt.Sprintf("serverCPLabeledSnap, length %d: %s", len(serverCPLabeledSnap), serverCPLabeledSnap))
 	podsCnt := 0
 	if c := len(serverK8sLabeledSnap); c > 0 {
 		podsCnt = c
@@ -300,7 +301,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 
 		input.Logger.Warn(msg)
 
-		return endpoints, nil
+		return nil, nil
 	}
 
 	return endpoints, nil

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -284,7 +284,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 
 	controlPlaneEnabled := module.IsEnabled("control-plane-manager", input)
 
-	if controlPlaneEnabled && podsCnt != endpointsCnt {
+	if controlPlaneEnabled && podsCnt < endpointsCnt {
 		versions := input.Values.Get("global.discovery.kubernetesVersions")
 		minVer := input.Values.Get("global.discovery.kubernetesVersion")
 		// need return err for retry if k8s versions not found
@@ -293,12 +293,13 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 		// in bash hook we don't subscribe for deleting pods
 		// it is emulating this behaviour
 		if !versions.Exists() || !minVer.Exists() {
-			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
+			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) < Endpoints (%v) count", podsCnt, endpointsCnt)
 			return nil, errors.New(msg)
 		}
 
-		msg := fmt.Sprintf("Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
+		msg := fmt.Sprintf("Pods(%v) < Endpoints (%v) count", podsCnt, endpointsCnt)
 		input.Logger.Warn(msg)
+		return nil, nil
 	}
 
 	return endpoints, nil

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -253,8 +253,10 @@ func getKubeVersionForServerFallback(input *go_hook.HookInput, err error) (*semv
 func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, error) {
 	serverK8sLabeledSnap := input.Snapshots.Get(kubeAPIServK8sLabeledSnap)
 	serverCPLabeledSnap := input.Snapshots.Get(kubeAPIServCPLabeledSnap)
+
 	input.Logger.Info(fmt.Sprintf("serverK8sLabeledSnap, length %d: %s", len(serverK8sLabeledSnap), serverK8sLabeledSnap))
 	input.Logger.Info(fmt.Sprintf("serverCPLabeledSnap, length %d: %s", len(serverCPLabeledSnap), serverCPLabeledSnap))
+
 	podsCnt := 0
 	if c := len(serverK8sLabeledSnap); c > 0 {
 		podsCnt = c
@@ -268,6 +270,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal %s snapshot: %w", kubeEndpointsSliceSnap, err)
 	}
+	input.Logger.Info(fmt.Sprintf("endpointsSnap, length %d: %s", len(endpointsSnap), endpointsSnap))
 
 	var endpoints []string
 	if len(endpointsSnap) > 0 {

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -285,8 +285,6 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	controlPlaneEnabled := module.IsEnabled("control-plane-manager", input)
 
 	if controlPlaneEnabled && podsCnt != endpointsCnt {
-		msg := fmt.Sprintf("Not found k8s versions. Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
-
 		versions := input.Values.Get("global.discovery.kubernetesVersions")
 		minVer := input.Values.Get("global.discovery.kubernetesVersion")
 		// need return err for retry if k8s versions not found
@@ -295,11 +293,12 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 		// in bash hook we don't subscribe for deleting pods
 		// it is emulating this behaviour
 		if !versions.Exists() || !minVer.Exists() {
+			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
 			return nil, errors.New(msg)
 		}
 
+		msg := fmt.Sprintf("Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
 		input.Logger.Warn(msg)
-
 	}
 
 	return endpoints, nil

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -293,11 +293,11 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 		// in bash hook we don't subscribe for deleting pods
 		// it is emulating this behaviour
 		if !versions.Exists() || !minVer.Exists() {
-			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) count less than Endpoints (%v) count", podsCnt, endpointsCnt)
+			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) count less than Endpoints(%v) count", podsCnt, endpointsCnt)
 			return nil, errors.New(msg)
 		}
 
-		msg := fmt.Sprintf("Pods(%v) count less than Endpoints (%v) count", podsCnt, endpointsCnt)
+		msg := fmt.Sprintf("Pods(%v) count less than Endpoints(%v) count", podsCnt, endpointsCnt)
 		input.Logger.Warn(msg)
 		return nil, nil
 	}

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -293,11 +293,11 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 		// in bash hook we don't subscribe for deleting pods
 		// it is emulating this behaviour
 		if !versions.Exists() || !minVer.Exists() {
-			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) < Endpoints (%v) count", podsCnt, endpointsCnt)
+			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) count less than Endpoints (%v) count", podsCnt, endpointsCnt)
 			return nil, errors.New(msg)
 		}
 
-		msg := fmt.Sprintf("Pods(%v) < Endpoints (%v) count", podsCnt, endpointsCnt)
+		msg := fmt.Sprintf("Pods(%v) count less than Endpoints (%v) count", podsCnt, endpointsCnt)
 		input.Logger.Warn(msg)
 		return nil, nil
 	}

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -287,7 +287,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	}
 
 	controlPlaneEnabled := module.IsEnabled("control-plane-manager", input)
-
+	input.Logger.Info(fmt.Sprintf("podsCnt %d, endpointsCnt %d", podsCnt, endpointsCnt))
 	if controlPlaneEnabled && podsCnt != endpointsCnt {
 		msg := fmt.Sprintf("Not found k8s versions. Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
 

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -300,7 +300,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 
 		input.Logger.Warn(msg)
 
-		return nil, nil
+		return endpoints, nil
 	}
 
 	return endpoints, nil

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -293,11 +293,11 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 		// in bash hook we don't subscribe for deleting pods
 		// it is emulating this behaviour
 		if !versions.Exists() || !minVer.Exists() {
-			msg := fmt.Sprintf("Not found k8s versions. Pods(%v) count less than Endpoints(%v) count", podsCnt, endpointsCnt)
+			msg := fmt.Sprintf("Not found k8s versions. Kube-apiserver Pods(%v) count less than kubernetes Endpoints(%v) count", podsCnt, endpointsCnt)
 			return nil, errors.New(msg)
 		}
 
-		msg := fmt.Sprintf("Pods(%v) count less than Endpoints(%v) count", podsCnt, endpointsCnt)
+		msg := fmt.Sprintf("Kube-apiserver Pods(%v) count less than kubernetes Endpoints(%v) count", podsCnt, endpointsCnt)
 		input.Logger.Warn(msg)
 		return nil, nil
 	}

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -283,6 +283,7 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	}
 
 	controlPlaneEnabled := module.IsEnabled("control-plane-manager", input)
+
 	if controlPlaneEnabled && podsCnt != endpointsCnt {
 		msg := fmt.Sprintf("Not found k8s versions. Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
 

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -304,7 +304,6 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 
 		input.Logger.Warn(msg)
 
-		return nil, nil
 	}
 
 	return endpoints, nil

--- a/global-hooks/discovery/kubernetes_version.go
+++ b/global-hooks/discovery/kubernetes_version.go
@@ -254,9 +254,6 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	serverK8sLabeledSnap := input.Snapshots.Get(kubeAPIServK8sLabeledSnap)
 	serverCPLabeledSnap := input.Snapshots.Get(kubeAPIServCPLabeledSnap)
 
-	input.Logger.Info(fmt.Sprintf("serverK8sLabeledSnap, length %d: %s", len(serverK8sLabeledSnap), serverK8sLabeledSnap))
-	input.Logger.Info(fmt.Sprintf("serverCPLabeledSnap, length %d: %s", len(serverCPLabeledSnap), serverCPLabeledSnap))
-
 	podsCnt := 0
 	if c := len(serverK8sLabeledSnap); c > 0 {
 		podsCnt = c
@@ -270,7 +267,6 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal %s snapshot: %w", kubeEndpointsSliceSnap, err)
 	}
-	input.Logger.Info(fmt.Sprintf("endpointsSnap, length %d: %s", len(endpointsSnap), endpointsSnap))
 
 	var endpoints []string
 	if len(endpointsSnap) > 0 {
@@ -287,7 +283,6 @@ func apiServerEndpoints(_ context.Context, input *go_hook.HookInput) ([]string, 
 	}
 
 	controlPlaneEnabled := module.IsEnabled("control-plane-manager", input)
-	input.Logger.Info(fmt.Sprintf("podsCnt %d, endpointsCnt %d, controlPlaneEnabled: %v", podsCnt, endpointsCnt, controlPlaneEnabled))
 	if controlPlaneEnabled && podsCnt != endpointsCnt {
 		msg := fmt.Sprintf("Not found k8s versions. Pods(%v) != Endpoints (%v) count", podsCnt, endpointsCnt)
 

--- a/global-hooks/discovery/kubernetes_version_test.go
+++ b/global-hooks/discovery/kubernetes_version_test.go
@@ -180,6 +180,10 @@ ports:
 		Expect(f.GoHookError.Error()).Should(ContainSubstring(`k8s versions not found`))
 	}
 
+	assertErrorPodsLTEndpoints := func() {
+		Expect(f.GoHookError.Error()).Should(MatchRegexp(`^Kube-apiserver Pods(.*) count less than kubernetes Endpoints(.*) count$`))
+	}
+
 	assertNoFile := func() {
 		_, err := os.ReadFile(kubeVersionFileName)
 		Expect(os.IsNotExist(err)).To(BeTrue())
@@ -712,12 +716,12 @@ status:
 
 				It("does not change k8s version with versions array with one version into values", func() {
 					assertValues(k8sVer, initVers)
-					assertErrorVersionNotFound()
+					assertErrorPodsLTEndpoints()
 				})
 
 				It("does not change k8s version into file", func() {
 					assertVersionInFile(k8sVer)
-					assertErrorVersionNotFound()
+					assertErrorPodsLTEndpoints()
 				})
 			})
 		}

--- a/global-hooks/discovery/kubernetes_version_test.go
+++ b/global-hooks/discovery/kubernetes_version_test.go
@@ -693,6 +693,7 @@ status:
 
 				It("change k8s version into file", func() {
 					Expect(f).To(ExecuteSuccessfully())
+					assertVersionInFile(k8sVerToChange)
 				})
 			})
 		})

--- a/global-hooks/discovery/kubernetes_version_test.go
+++ b/global-hooks/discovery/kubernetes_version_test.go
@@ -641,6 +641,7 @@ status:
 	Context("Remove objects", func() {
 		initVers := []string{"1.21.20", "1.20.2", "1.19.4"}
 		k8sVer := initVers[2]
+		k8sVerToChange := initVers[0]
 
 		endpointsState := stateEndpoints(endpointsMul)
 
@@ -685,14 +686,13 @@ status:
 					f.RunHook()
 				})
 
-				It("without endpoints hook should return error and does not change k8s version into values", func() {
-					assertValues(k8sVer, initVers)
-					assertErrorVersionNotFound()
+				It("with single endpoint hook should request version and change k8s version in values", func() {
+					Expect(f).To(ExecuteSuccessfully())
+					assertValues(k8sVerToChange, []string{k8sVerToChange})
 				})
 
-				It("does not change k8s version into file", func() {
-					assertVersionInFile(k8sVer)
-					assertErrorVersionNotFound()
+				It("change k8s version into file", func() {
+					Expect(f).To(ExecuteSuccessfully())
 				})
 			})
 		})


### PR DESCRIPTION
## Description
Kubernetes_version hook function `apiServerEndpoints` returns error only if `Pods count < Endpoints count`. Error is now returned into deckhouse queue to be more descriptive.

Manually tested:
- Shutdown 1 of 3 master nodes, master node is `NotReady` - hook succesfull;
- `kubectl delete node master-2`, in this case we have only 2 kube-apiserver pods but 3 kubernetes endpoints because 3rd apiserver actually keeps working - expected error;
- K8s upgrade and downgrade - hook succesfull

## Why do we need it, and what problem does it solve?
Function `apiServerEndpoints` returned no endpoints to iterate `/version` over if pods was not equal endpoints count, caused failure if one master node was shut down: `global hook 'discovery/kubernetes_version.go' failed: k8s versions not found`

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fixed kubernetes_version.go hook logic when master node is unavailable.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
