### PR TITLE
Support custom image ID for Azure nodes

### DIFF
--- a/modules/030-cloud-provider-azure/candi/terraform-modules/master-node/main.tf
+++ b/modules/030-cloud-provider-azure/candi/terraform-modules/master-node/main.tf
@@ -83,12 +83,17 @@ resource "azurerm_linux_virtual_machine" "master" {
     disk_size_gb         = local.disk_size_gb
   }
 
-  source_image_reference {
-    publisher = local.image_publisher
-    offer     = local.image_offer
-    sku       = local.image_sku
-    version   = local.image_version
+  dynamic "source_image_reference" {
+    for_each = local.image_id == null ? [1] : []
+    content {
+      publisher = local.image_publisher
+      offer     = local.image_offer
+      sku       = local.image_sku
+      version   = local.image_version
+    }
   }
+
+  source_image_id = local.image_id
 
   custom_data = var.cloudConfig != "" ? var.cloudConfig : base64encode(local.default_cloud_config)
 

--- a/modules/030-cloud-provider-azure/candi/terraform-modules/master-node/variables.tf
+++ b/modules/030-cloud-provider-azure/candi/terraform-modules/master-node/variables.tf
@@ -53,11 +53,13 @@ locals {
   disk_size_gb           = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "diskSizeGb", 50)
   etcd_disk_size_gb      = var.providerClusterConfiguration.masterNodeGroup.instanceClass.etcdDiskSizeGb
   enable_external_ip     = lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "enableExternalIP", false)
-  urn                    = split(":", var.providerClusterConfiguration.masterNodeGroup.instanceClass.urn)
-  image_publisher        = local.urn[0]
-  image_offer            = local.urn[1]
-  image_sku              = local.urn[2]
-  image_version          = local.urn[3]
+  is_custom_id           = substr(var.providerClusterConfiguration.masterNodeGroup.instanceClass.urn, 0, 1) == "/"
+  urn                    = local.is_custom_id ? [] : split(":", var.providerClusterConfiguration.masterNodeGroup.instanceClass.urn)
+  image_publisher        = local.is_custom_id ? null : local.urn[0]
+  image_offer            = local.is_custom_id ? null : local.urn[1]
+  image_sku              = local.is_custom_id ? null : local.urn[2]
+  image_version          = local.is_custom_id ? null : local.urn[3]
+  image_id               = local.is_custom_id ? var.providerClusterConfiguration.masterNodeGroup.instanceClass.urn : null
   actual_zones           = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
   zones                  = lookup(var.providerClusterConfiguration.masterNodeGroup, "zones", null) != null ? tolist(setintersection(local.actual_zones, var.providerClusterConfiguration.masterNodeGroup["zones"])) : local.actual_zones
   additional_tags        = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(var.providerClusterConfiguration.masterNodeGroup.instanceClass, "additionalTags", {}))

--- a/modules/030-cloud-provider-azure/candi/terraform-modules/static-node/main.tf
+++ b/modules/030-cloud-provider-azure/candi/terraform-modules/static-node/main.tf
@@ -83,12 +83,17 @@ resource "azurerm_linux_virtual_machine" "node" {
     disk_size_gb         = local.disk_size_gb
   }
 
-  source_image_reference {
-    publisher = local.image_publisher
-    offer     = local.image_offer
-    sku       = local.image_sku
-    version   = local.image_version
+  dynamic "source_image_reference" {
+    for_each = local.image_id == null ? [1] : []
+    content {
+      publisher = local.image_publisher
+      offer     = local.image_offer
+      sku       = local.image_sku
+      version   = local.image_version
+    }
   }
+
+  source_image_id = local.image_id
 
   custom_data = var.cloudConfig != "" ? var.cloudConfig : base64encode(local.default_cloud_config)
 

--- a/modules/030-cloud-provider-azure/candi/terraform-modules/static-node/variables.tf
+++ b/modules/030-cloud-provider-azure/candi/terraform-modules/static-node/variables.tf
@@ -54,11 +54,13 @@ locals {
   disk_type              = lookup(local.node_group.instanceClass, "diskType", "StandardSSD_LRS")
   disk_size_gb           = lookup(local.node_group.instanceClass, "diskSizeGb", 50)
   enable_external_ip     = lookup(local.node_group.instanceClass, "enableExternalIP", false)
-  urn                    = split(":", local.node_group.instanceClass.urn)
-  image_publisher        = local.urn[0]
-  image_offer            = local.urn[1]
-  image_sku              = local.urn[2]
-  image_version          = local.urn[3]
+  is_custom_id           = substr(local.node_group.instanceClass.urn, 0, 1) == "/"
+  urn                    = local.is_custom_id ? [] : split(":", local.node_group.instanceClass.urn)
+  image_publisher        = local.is_custom_id ? null : local.urn[0]
+  image_offer            = local.is_custom_id ? null : local.urn[1]
+  image_sku              = local.is_custom_id ? null : local.urn[2]
+  image_version          = local.is_custom_id ? null : local.urn[3]
+  image_id               = local.is_custom_id ? local.node_group.instanceClass.urn : null
   actual_zones           = lookup(var.providerClusterConfiguration, "zones", null) != null ? tolist(setintersection(["1", "2", "3"], var.providerClusterConfiguration.zones)) : ["1", "2", "3"]
   zones                  = lookup(local.node_group, "zones", null) != null ? tolist(setintersection(local.actual_zones, local.node_group["zones"])) : local.actual_zones
   additional_tags        = merge(lookup(var.providerClusterConfiguration, "tags", {}), lookup(local.node_group.instanceClass, "additionalTags", {}))


### PR DESCRIPTION
## Description
Allow urn to be a custom image ID (path starting with "/") in addition to marketplace URN. Use source_image_id when URN is an ID and source_image_reference when it is publisher:offer:sku:version so Azure API requirement is met.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-azure
type: feature
summary: nodes support custom image by ID (URN starting with "/") in addition to marketplace URN.
impact: users can set masterNodeGroup.instanceClass.urn to a custom image resource ID (e.g. /subscriptions/.../images/...) instead of only marketplace URN (publisher:offer:sku:version). Existing URN-based configs are unchanged.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
