### PR TITLE
[node-manager] PSS: SecurityPolicyException

### DIFF
--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -21,7 +21,12 @@ metadata:
   name: d8-cloud-instance-manager
   annotations:
     helm.sh/resource-policy: keep
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "extended-monitoring.deckhouse.io/enabled" ""
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+    "security.deckhouse.io/enable-security-policy-check" "true"
+  )) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-system") }}
 ---

--- a/modules/039-registry-packages-proxy/templates/deployment.yaml
+++ b/modules/039-registry-packages-proxy/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
     metadata:
       labels:
         app: registry-packages-proxy
+        security.deckhouse.io/security-policy-exception: registry-packages-proxy
       annotations:
         kubectl.kubernetes.io/default-exec-container: registry-packages-proxy
         kubectl.kubernetes.io/default-logs-container: registry-packages-proxy
@@ -78,7 +79,7 @@ spec:
       serviceAccountName: registry-packages-proxy
       containers:
       - name: registry-packages-proxy
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" . | nindent 8 }}
         image: {{ include "helm_lib_module_image" (list . "registryPackagesProxy") }}
         imagePullPolicy: IfNotPresent
         args:

--- a/modules/039-registry-packages-proxy/templates/security-policy-exception.yaml
+++ b/modules/039-registry-packages-proxy/templates/security-policy-exception.yaml
@@ -18,4 +18,8 @@ spec:
         protocol: TCP
         metadata:
           description: HTTPS endpoint of registry-packages-proxy exposed through kube-rbac-proxy
+      - port: 4282
+        protocol: TCP
+        metadata:
+          description: HTTP endpoint of the package registry proxy server is required to download the rpp-get client during node bootstrap
 {{- end }}

--- a/modules/039-registry-packages-proxy/templates/security-policy-exception.yaml
+++ b/modules/039-registry-packages-proxy/templates/security-policy-exception.yaml
@@ -1,0 +1,21 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: registry-packages-proxy
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "registry-packages-proxy")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow registry-packages-proxy to run on the host network
+    hostPorts:
+      - port: 4219
+        protocol: TCP
+        metadata:
+          description: HTTPS endpoint of registry-packages-proxy exposed through kube-rbac-proxy
+{{- end }}

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -56,6 +56,7 @@ spec:
     metadata:
       labels:
         app: "bashible-apiserver"
+        security.deckhouse.io/security-policy-exception: bashible-apiserver
     spec:
       {{- include "helm_lib_node_selector"  (tuple . "master")  | nindent 6 }}
       {{- include "helm_lib_tolerations"    (tuple . "any-node" "uninitialized")  | nindent 6 }}
@@ -86,6 +87,7 @@ spec:
           - name: https
             hostPort: 4221
             containerPort: 4221
+            protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz

--- a/modules/040-node-manager/templates/bashible-apiserver/security-policy-exception.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/security-policy-exception.yaml
@@ -1,0 +1,21 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: bashible-apiserver
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "bashible-apiserver")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: false
+      metadata:
+        description: |
+          Allow the Bashible API server to expose a node-local hostPort without joining the host network namespace.
+    hostPorts:
+      - port: 4221
+        protocol: TCP
+        metadata:
+          description: HTTPS listener for the Bashible API server
+{{- end }}

--- a/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
@@ -66,6 +66,7 @@ spec:
         app: capi-controller-manager
         cluster.x-k8s.io/provider: cluster-api
         control-plane: controller-manager
+        security.deckhouse.io/security-policy-exception: capi-controller-manager
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "capi-controller-manager")) | nindent 6 }}
@@ -82,7 +83,7 @@ spec:
       containers:
       - image: {{ include "helm_lib_module_image" (list . "capiControllerManager") }}
         name: capi-controller-manager
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         command:
         - /capi-controller-manager
         args:
@@ -182,6 +183,7 @@ spec:
         ports:
         - containerPort: 4211
           name: https-metrics
+          protocol: TCP
         livenessProbe:
           httpGet:
             path: /livez

--- a/modules/040-node-manager/templates/capi-controller-manager/security-policy-exception.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/security-policy-exception.yaml
@@ -1,0 +1,25 @@
+{{- if and (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) (include "capi_controller_manager_enabled" .) }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: capi-controller-manager
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow the CAPI controller manager to run on the host network, CAPI should not depend on the operation of CNI
+    hostPorts:
+      - port: 4200
+        protocol: TCP
+        metadata:
+          description: CAPI controller manager webhook listener.
+      - port: 4211
+        protocol: TCP
+        metadata:
+          description: CAPI controller manager metrics endpoint exposed through kube-rbac-proxy
+{{- end }}

--- a/modules/040-node-manager/templates/early-oom/daemonset.yaml
+++ b/modules/040-node-manager/templates/early-oom/daemonset.yaml
@@ -48,6 +48,7 @@ spec:
     metadata:
       labels:
         app: early-oom
+        security.deckhouse.io/security-policy-exception: early-oom
       name: early-oom
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}

--- a/modules/040-node-manager/templates/early-oom/security-policy-exception.yaml
+++ b/modules/040-node-manager/templates/early-oom/security-policy-exception.yaml
@@ -1,0 +1,23 @@
+{{- if and (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) .Values.nodeManager.earlyOomEnabled }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: early-oom
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "early-oom")) | nindent 2 }}
+spec:
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          Allow the early-oom daemon to use hostPath volumes for access to host PSI metrics and process information.
+    hostPath:
+      allowedValues:
+        - path: /proc
+          readOnly: false
+          metadata:
+            description: Access to the host /proc filesystem is required to collect PSI metrics for OOM prevention
+{{- end }}

--- a/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/daemonset.yaml
@@ -48,6 +48,7 @@ spec:
       labels:
         app: fencing-agent
         node-group-name: {{ $ng.name }}
+        security.deckhouse.io/security-policy-exception: fencing-agent-{{ $ng.name }}
       annotations:
         container.apparmor.security.beta.kubernetes.io/fencing-agent: "unconfined"
     spec:

--- a/modules/040-node-manager/templates/fencing-agent/security-policy-exception.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/security-policy-exception.yaml
@@ -29,6 +29,11 @@ spec:
       metadata:
         description: |
           Privileged mode required for watchdog device access
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Required because the container runs in privileged mode with SYS_ADMIN capability    
     capabilities:
       allowedValues:
         add:

--- a/modules/040-node-manager/templates/fencing-agent/security-policy-exception.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/security-policy-exception.yaml
@@ -24,6 +24,20 @@ spec:
       metadata:
         description: |
           Allow the SELinux label used by the privileged fencing agent container
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          Privileged mode required for watchdog device access
+    capabilities:
+      allowedValues:
+        add:
+          - SYS_ADMIN
+        drop:
+          - ALL
+      metadata:
+        description: |
+          SYS_ADMIN needed for host watchdog; all other caps dropped
   network:
     hostNetwork:
       allowedValue: false
@@ -40,6 +54,11 @@ spec:
         metadata:
           description: Memberlist UDP listener used by the fencing agent
   volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: hostPath volumes needed for watchdog and socket access
     hostPath:
       allowedValues:
         - path: /dev/watchdog

--- a/modules/040-node-manager/templates/fencing-agent/security-policy-exception.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/security-policy-exception.yaml
@@ -1,0 +1,55 @@
+{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+{{- range $ng := .Values.nodeManager.internal.nodeGroups }}
+  {{- $mode := dig "fencing" "mode" "" $ng }}
+  {{- if or (eq $mode "Watchdog") (eq $mode "Notify") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: fencing-agent-{{ $ng.name }}
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "fencing-agent")) | nindent 2 }}
+spec:
+  securityContext:
+    appArmorProfile:
+      allowedValues:
+        - unconfined
+      metadata:
+        description: |
+          The fencing agent needs the unconfined AppArmor profile to interact with host watchdog and socket resources
+    seLinuxOptions:
+      allowedValues:
+        - level: s0
+          type: spc_t
+      metadata:
+        description: |
+          Allow the SELinux label used by the privileged fencing agent container
+  network:
+    hostNetwork:
+      allowedValue: false
+      metadata:
+        description: |
+          Allow the fencing agent to reserve node-local memberlist ports
+    hostPorts:
+      - port: 8500
+        protocol: TCP
+        metadata:
+          description: Memberlist TCP listener used by the fencing agent
+      - port: 8500
+        protocol: UDP
+        metadata:
+          description: Memberlist UDP listener used by the fencing agent
+  volumes:
+    hostPath:
+      allowedValues:
+        - path: /dev/watchdog
+          readOnly: false
+          metadata:
+            description: Access to the hardware watchdog device for node fencing.
+        - path: /tmp
+          readOnly: false
+          metadata:
+            description: Shared host socket directory used by the fencing agent.
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/deployment.yaml
@@ -47,6 +47,7 @@ spec:
     metadata:
       labels:
         app: machine-controller-manager
+        security.deckhouse.io/security-policy-exception: machine-controller-manager
     spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "machine-controller-manager")) | nindent 6 }}
@@ -133,6 +134,7 @@ spec:
           ports:
           - containerPort: 4203
             name: https-metrics
+            protocol: TCP
           livenessProbe:
             httpGet:
               path: /livez

--- a/modules/040-node-manager/templates/machine-controller-manager/security-policy-exception.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/security-policy-exception.yaml
@@ -1,0 +1,21 @@
+{{- if and (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) (include "machine_controller_manager_enabled" .) (hasKey $.Values.nodeManager.internal "cloudProvider") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: machine-controller-manager
+  namespace: d8-cloud-instance-manager
+  {{- include "helm_lib_module_labels" (list . (dict "app" "machine-controller-manager")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow the machine-controller-manager to run on the host network so it stays independent from CNI availability
+    hostPorts:
+      - port: 4203
+        protocol: TCP
+        metadata:
+          description: Metrics endpoint exposed through kube-rbac-proxy
+{{- end }}

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -70,7 +70,7 @@ spec:
       containers:
       - image: {{ include "helm_lib_module_image" (list . "nodeController") }}
         name: node-controller
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         command:
         - /node-controller
         args:


### PR DESCRIPTION
## Description
follow https://github.com/deckhouse/deckhouse/pull/16738
Added SecurityPolicyException for node-manager and registry-packages-proxy

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: SecurityPolicyException for node-manager and registry-packages-proxy
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
