### PR TITLE
[cloud-provider-openstack] Enable proxy ipMode support

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"golang.org/x/mod/semver"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
 	"github.com/deckhouse/deckhouse/testing/library/object_store"
@@ -291,10 +292,17 @@ monitor-delay = "2s"
 monitor-timeout = "1s"
 subnet-id = "my-subnet-id"
 floating-network-id = "my-floating-network-id"
-enable-ingress-hostname = true
+enable-ingress-hostname = %s
 [BlockStorage]
 ignore-volume-microversion = false
 rescan-on-resize = true`
+
+		// TODO: Remove after support for Kubernetes version 1.32 ends
+		enableIngressHostname := "true"
+		if semver.Compare(k8sVer, "1.32.0") >= 0 {
+			enableIngressHostname = "false"
+		}
+		ccmExpectedConfig = fmt.Sprintf(ccmExpectedConfig, enableIngressHostname)
 
 		ccmConfig, err := base64.StdEncoding.DecodeString(ccmSecret.Field("data.cloud-config").String())
 		Expect(err).ShouldNot(HaveOccurred())

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
@@ -46,7 +46,8 @@ subnet-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.subnetID | q
 floating-network-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.floatingNetworkID | quote }}
     {{- end }}
   {{- end }}
-enable-ingress-hostname = true
+{{- /* TODO: Replace with `false` after support for Kubernetes version 1.32 ends */}}
+enable-ingress-hostname = {{ not (semverCompare ">= 1.32" .Values.global.discovery.kubernetesVersion) }}
 [BlockStorage]
 ignore-volume-microversion = {{ .Values.cloudProviderOpenstack.ignoreVolumeMicroversion }}
 rescan-on-resize = true


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Disable the `enable-ingress-hostname` option in the OpenStack cloud controller manager for Kubernetes >= 1.32.

Starting with Kubernetes 1.32, the `LoadBalancerIPMode` feature is GA and enabled by default (https://github.com/kubernetes/kubernetes/pull/127348). This means kube-proxy respects `ipMode: Proxy` on LoadBalancer ingress status, which allows traffic to be handled entirely by the external load balancer without hairpin NAT rules on nodes.

When `enable-ingress-hostname` is active, CCM sets a hostname instead of an IP in the LoadBalancer status, which prevents `ipMode: Proxy` from working correctly with proxy protocol.

This change ensures that on clusters running Kubernetes 1.32+, the LoadBalancer status contains an IP address with `ipMode: Proxy`, enabling proper proxy protocol support and source IP preservation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When using OpenStack load balancers with proxy protocol on Kubernetes >= 1.32, the `enable-ingress-hostname` flag causes CCM to populate `status.loadBalancer.ingress` with a hostname instead of an IP. This prevents kube-proxy from applying `ipMode: Proxy`, resulting in broken proxy protocol handling and loss of client source IP.

Disabling `enable-ingress-hostname` for K8s >= 1.32 allows CCM to set the IP directly with `ipMode: Proxy`, so kube-proxy skips creating local NAT rules and traffic flows correctly through the external load balancer.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: feature
summary: Disabled `enable-ingress-hostname` for Kubernetes >=1.32 to use proxy ipMode in LoadBalancer with proxy protocol.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
