### PR TITLE
[common] Fix for replace kubectl binary with d8 k alias.

### DIFF
--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -60,8 +60,7 @@ fi
 # This need for correct Tab-completion in kubectl alias
 # Bash does not expand aliases during completion, so we
 # rewrite "kubectl" to "d8 k" and call d8 __complete directly
-if [ ! -f /etc/bash_completion.d/d8_kubectl_completion ]; then
-  cat <<'EOF' > /etc/bash_completion.d/d8_kubectl_completion
+cat <<'EOF' > /etc/bash_completion.d/d8_kubectl_completion
 __start_kubectl() {
     local cur prev words cword
     _init_completion -n =: || return
@@ -89,7 +88,6 @@ __start_kubectl() {
 }
 complete -o default -F __start_kubectl kubectl
 EOF
-fi
 
 if [ -f /etc/bash_completion.d/kubectl ]; then
   rm -f /etc/bash_completion.d/kubectl


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix for replace kubectl binary with d8 k alias.
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix 
summary: fix for replace kubectl binary with d8 k alias.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
