### PR TITLE
Fix unparam lint warnings in webhook operator controllers

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/conversionwebhook_controller.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/conversionwebhook_controller.go
@@ -119,8 +119,7 @@ func (r *ConversionWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if !webhook.DeletionTimestamp.IsZero() {
 		r.logger.Debug("conversion webhook deletion", slog.String("deletion_timestamp", webhook.DeletionTimestamp.String()))
 
-		res, err := r.handleDeleteConversionWebhook(ctx, webhook)
-		if err != nil {
+		if err := r.handleDeleteConversionWebhook(ctx, webhook); err != nil {
 			r.logger.Warn("delete conversion webhook", log.Err(err))
 
 			return res, err
@@ -128,8 +127,7 @@ func (r *ConversionWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return res, nil
 	}
 
-	res, err = r.handleProcessConversionWebhook(ctx, webhook)
-	if err != nil {
+	if err = r.handleProcessConversionWebhook(ctx, webhook); err != nil {
 		r.logger.Warn("process conversion webhook", log.Err(err))
 
 		return res, err
@@ -138,20 +136,18 @@ func (r *ConversionWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return res, nil
 }
 
-func (r *ConversionWebhookReconciler) handleProcessConversionWebhook(ctx context.Context, cwh *deckhouseiov1alpha1.ConversionWebhook) (ctrl.Result, error) {
-	var res ctrl.Result
-
+func (r *ConversionWebhookReconciler) handleProcessConversionWebhook(ctx context.Context, cwh *deckhouseiov1alpha1.ConversionWebhook) error {
 	logger := r.logger.With(slog.String("webhook", cwh.Name))
 
 	webhookDir := r.webhookDir(cwh.Name)
 	if err := os.MkdirAll(webhookDir, directoryPermissions); err != nil {
 		logger.Error("failed to create directory", slog.String("path", webhookDir), log.Err(err))
-		return res, fmt.Errorf("create dir %s: %w", webhookDir, err)
+		return fmt.Errorf("create dir %s: %w", webhookDir, err)
 	}
 
 	buf, err := templater.RenderConversionTemplate(r.pythonTemplate, cwh)
 	if err != nil {
-		return res, fmt.Errorf("render template: %w", err)
+		return fmt.Errorf("render template: %w", err)
 	}
 
 	webhookFile := r.webhookFilePath(cwh.Name)
@@ -159,12 +155,12 @@ func (r *ConversionWebhookReconciler) handleProcessConversionWebhook(ctx context
 	isChanged := r.isWebhookFileChanged(webhookFile, buf.Bytes())
 	if !isChanged {
 		logger.Debug("webhook file not changed, skipping webhook file update")
-		return res, nil
+		return nil
 	}
 
 	if err := os.WriteFile(webhookFile, buf.Bytes(), filePermissions); err != nil {
 		logger.Error("failed to write webhook file", slog.String("path", webhookFile), log.Err(err))
-		return res, fmt.Errorf("write file %s: %w", webhookFile, err)
+		return fmt.Errorf("write file %s: %w", webhookFile, err)
 	}
 
 	r.isReloadShellNeed.Store(true)
@@ -186,37 +182,35 @@ func (r *ConversionWebhookReconciler) handleProcessConversionWebhook(ctx context
 			if removeErr := os.Remove(webhookFile); removeErr != nil {
 				logger.Warn("failed to cleanup webhook file", log.Err(removeErr))
 			}
-			return res, fmt.Errorf("add finalizers: %w", err)
+			return fmt.Errorf("add finalizers: %w", err)
 		}
 	}
 
-	return res, nil
+	return nil
 }
 
-func (r *ConversionWebhookReconciler) handleDeleteConversionWebhook(ctx context.Context, cwh *deckhouseiov1alpha1.ConversionWebhook) (ctrl.Result, error) {
-	var res ctrl.Result
-
+func (r *ConversionWebhookReconciler) handleDeleteConversionWebhook(ctx context.Context, cwh *deckhouseiov1alpha1.ConversionWebhook) error {
 	// Clean up the target CRD's conversion config before removing FS files.
 	// So it won't try to route conversion requests to a non-existent webhook.
 	if controllerutil.ContainsFinalizer(cwh, deckhouseiov1alpha1.ConversionWebhookCRDCleanupFinalizer) {
 		if err := r.cleanupCRDConversion(ctx, cwh.Name); err != nil {
-			return res, fmt.Errorf("cleanup CRD conversion for %s: %w", cwh.Name, err)
+			return fmt.Errorf("cleanup CRD conversion for %s: %w", cwh.Name, err)
 		}
 
 		r.logger.Debug("remove crd-cleanup finalizer")
 		controllerutil.RemoveFinalizer(cwh, deckhouseiov1alpha1.ConversionWebhookCRDCleanupFinalizer)
 		if err := r.client.Update(ctx, cwh); err != nil {
-			return res, fmt.Errorf("remove crd-cleanup finalizer for %s: %w", cwh.Name, err)
+			return fmt.Errorf("remove crd-cleanup finalizer for %s: %w", cwh.Name, err)
 		}
 
 		// Return so the next reconcile handles FS cleanup
-		return res, nil
+		return nil
 	}
 
 	// Clean up the filesystem.
 	webhookFile := r.webhookFilePath(cwh.Name)
 	if err := os.Remove(webhookFile); err != nil && !os.IsNotExist(err) {
-		return res, fmt.Errorf("delete webhook file %s: %w", webhookFile, err)
+		return fmt.Errorf("delete webhook file %s: %w", webhookFile, err)
 	}
 
 	r.isReloadShellNeed.Store(true)
@@ -227,11 +221,11 @@ func (r *ConversionWebhookReconciler) handleDeleteConversionWebhook(ctx context.
 		controllerutil.RemoveFinalizer(cwh, deckhouseiov1alpha1.ConversionWebhookFinalizer)
 
 		if err := r.client.Update(ctx, cwh); err != nil {
-			return res, fmt.Errorf("remove finalizer for %s: %w", cwh.Name, err)
+			return fmt.Errorf("remove finalizer for %s: %w", cwh.Name, err)
 		}
 	}
 
-	return res, nil
+	return nil
 }
 
 // cleanupCRDConversion resets the target CRD's conversion strategy to None,

--- a/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/validationwebhook_controller.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/validationwebhook_controller.go
@@ -120,8 +120,7 @@ func (r *ValidationWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		r.logger.Debug("validating webhook deletion", slog.String("deletion_timestamp", webhook.DeletionTimestamp.String()))
 
 		// TODO: retries
-		res, err := r.handleDeleteValidatingWebhook(ctx, webhook)
-		if err != nil {
+		if err := r.handleDeleteValidatingWebhook(ctx, webhook); err != nil {
 			r.logger.Warn("delete validating webhook", log.Err(err))
 
 			return res, err
@@ -129,8 +128,7 @@ func (r *ValidationWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return res, nil
 	}
 
-	res, err = r.handleProcessValidatingWebhook(ctx, webhook)
-	if err != nil {
+	if err = r.handleProcessValidatingWebhook(ctx, webhook); err != nil {
 		r.logger.Warn("process validating webhook", log.Err(err))
 
 		return res, err
@@ -139,32 +137,30 @@ func (r *ValidationWebhookReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return res, nil
 }
 
-func (r *ValidationWebhookReconciler) handleProcessValidatingWebhook(ctx context.Context, vwh *deckhouseiov1alpha1.ValidationWebhook) (ctrl.Result, error) {
-	var res ctrl.Result
-
+func (r *ValidationWebhookReconciler) handleProcessValidatingWebhook(ctx context.Context, vwh *deckhouseiov1alpha1.ValidationWebhook) error {
 	logger := r.logger.With(slog.String("webhook", vwh.Name))
 
 	webhookDir := r.webhookDir(vwh.Name)
 	if err := os.MkdirAll(webhookDir, validationWebhookDirectoryPerms); err != nil {
 		logger.Error("failed to create directory", slog.String("path", webhookDir), log.Err(err))
-		return res, fmt.Errorf("create dir %s: %w", webhookDir, err)
+		return fmt.Errorf("create dir %s: %w", webhookDir, err)
 	}
 
 	buf, err := templater.RenderValidationTemplate(r.pythonTemplate, vwh)
 	if err != nil {
-		return res, fmt.Errorf("render template: %w", err)
+		return fmt.Errorf("render template: %w", err)
 	}
 
 	webhookFile := r.webhookFilePath(vwh.Name)
 	isChanged := r.isWebhookFileChanged(webhookFile, buf.Bytes())
 	if !isChanged {
 		logger.Debug("webhook file not changed, skipping webhook file update")
-		return res, nil
+		return nil
 	}
 
 	if err := os.WriteFile(webhookFile, buf.Bytes(), validationWebhookFilePerms); err != nil {
 		logger.Error("failed to write webhook file", slog.String("path", webhookFile), log.Err(err))
-		return res, fmt.Errorf("write file %s: %w", webhookFile, err)
+		return fmt.Errorf("write file %s: %w", webhookFile, err)
 	}
 
 	r.isReloadShellNeed.Store(true)
@@ -178,19 +174,17 @@ func (r *ValidationWebhookReconciler) handleProcessValidatingWebhook(ctx context
 			if removeErr := os.Remove(webhookFile); removeErr != nil {
 				logger.Warn("failed to cleanup webhook file", log.Err(removeErr))
 			}
-			return res, fmt.Errorf("add finalizer: %w", err)
+			return fmt.Errorf("add finalizer: %w", err)
 		}
 	}
 
-	return res, nil
+	return nil
 }
 
-func (r *ValidationWebhookReconciler) handleDeleteValidatingWebhook(ctx context.Context, vh *deckhouseiov1alpha1.ValidationWebhook) (ctrl.Result, error) {
-	var res ctrl.Result
-
+func (r *ValidationWebhookReconciler) handleDeleteValidatingWebhook(ctx context.Context, vh *deckhouseiov1alpha1.ValidationWebhook) error {
 	webhookFile := r.webhookFilePath(vh.Name)
 	if err := os.Remove(webhookFile); err != nil && !os.IsNotExist(err) {
-		return res, fmt.Errorf("delete webhook file %s: %w", webhookFile, err)
+		return fmt.Errorf("delete webhook file %s: %w", webhookFile, err)
 	}
 
 	r.isReloadShellNeed.Store(true)
@@ -201,11 +195,11 @@ func (r *ValidationWebhookReconciler) handleDeleteValidatingWebhook(ctx context.
 		controllerutil.RemoveFinalizer(vh, deckhouseiov1alpha1.ValidationWebhookFinalizer)
 
 		if err := r.client.Update(ctx, vh); err != nil {
-			return res, fmt.Errorf("remove finalizer for %s: %w", vh.Name, err)
+			return fmt.Errorf("remove finalizer for %s: %w", vh.Name, err)
 		}
 	}
 
-	return res, nil
+	return nil
 }
 
 // isWebhookFileChanged returns true if the webhook file has changed.

--- a/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/validationwebhook_controller_test.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/validationwebhook_controller_test.go
@@ -146,7 +146,7 @@ func TestTemplateNoContext(t *testing.T) {
 	err = k8sClient.Create(context.Background(), vh)
 	assert.NoError(t, err)
 
-	_, err = r.handleProcessValidatingWebhook(context.TODO(), vh)
+	err = r.handleProcessValidatingWebhook(context.TODO(), vh)
 	assert.NoError(t, err)
 
 	// test equality
@@ -166,7 +166,7 @@ func TestTemplateTwoContext(t *testing.T) {
 	err = k8sClient.Create(context.Background(), vh)
 	assert.NoError(t, err)
 
-	_, err = r.handleProcessValidatingWebhook(context.TODO(), vh)
+	err = r.handleProcessValidatingWebhook(context.TODO(), vh)
 	assert.NoError(t, err)
 
 	// test equality
@@ -186,7 +186,7 @@ func TestTemplateEqual(t *testing.T) {
 	err = k8sClient.Create(context.Background(), vh)
 	assert.NoError(t, err)
 
-	_, err = r.handleProcessValidatingWebhook(context.TODO(), vh)
+	err = r.handleProcessValidatingWebhook(context.TODO(), vh)
 	assert.NoError(t, err)
 
 	ref, err := os.ReadFile("testdata/validating/golden/prometheusremotewrite.py")
@@ -207,7 +207,7 @@ func TestTemplateIncludeSnapshotsFrom(t *testing.T) {
 	err = k8sClient.Create(context.Background(), vh)
 	assert.NoError(t, err)
 
-	_, err = r.handleProcessValidatingWebhook(context.TODO(), vh)
+	err = r.handleProcessValidatingWebhook(context.TODO(), vh)
 	assert.NoError(t, err)
 
 	ref, err := os.ReadFile("testdata/validating/golden/publicdomaintemplate.py")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Remove unused `ctrl.Result` return value from internal handler methods in webhook controllers to fix `unparam` lint warnings.

No impact on runtime behavior - the returned `ctrl.Result` was always zero-valued.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

- `golangci-lint` reports 4 `unparam` violations in webhook controllers
- Internal handler methods (`handleProcess*`, `handleDelete*`) always return zero `ctrl.Result`, which the linter flags as unnecessary

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Fix unparam lint warnings in webhook operator controllers
impact_level: low
```
