### PR TITLE
[docs] Enable auto-reload for modules watcher

### DIFF
--- a/docs/site/.helm/templates/15-modules-watcher.yaml
+++ b/docs/site/.helm/templates/15-modules-watcher.yaml
@@ -5,6 +5,7 @@ metadata:
   name: registry-modules-watcher
   annotations:
     "werf.io/replicas-on-creation": "1"
+    "pod-reloader.deckhouse.io/auto": "true"
   labels:
     app: registry-modules-watcher
 spec:


### PR DESCRIPTION
## Description
Enable auto-reload for modules watcher:
- Add pod-reloader annotation to the registry modules watcher deployment to trigger automatic pod restarts on dependent resource changes

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Enable auto-reload for modules watcher.
impact_level: low
```
