### PR TITLE
[docs] Update controller-plane-manager documentation

### DIFF
--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -318,7 +318,7 @@ properties:
       List of feature gates enabled in the control plane.
 
       More information about feature gates is available in the [Kubernetes documentation](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).
-      The list of feature gates supported in DKP can be found [in the Feature Gates section](../#feature-gates).
+      The list of feature gates supported in DKP can be found on the [module overview page](./#feature-gates).
     items:
       type: string
       pattern: '^[a-zA-Z]+$'

--- a/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/doc-ru-config-values.yaml
@@ -188,7 +188,7 @@ properties:
       > **Важно!** При изменении этого параметра потребуется перезапуск подов.
   enabledFeatureGates:
     description: |
-      Список включенных в control plane feature gates.
+      Список включенных в control plane экспериментальных функций (feature gates).
 
       Описание отдельных feature gates доступно в [документации Kubernetes](https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/).
-      Список поддерживаемых в DKP feature gates см. [в разделе Feature Gates](../#feature-gates).
+      Список поддерживаемых в DKP feature gates доступен на [странице описания модуля](./#feature-gates).


### PR DESCRIPTION
## Description

This PR fixes a typo in the link on the Configuration page.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated controller-plane-manager documentation.
impact_level: low
```