### PR TITLE
[docs] Update d8 cni-migration commands in the CNI migration guide

### DIFF
--- a/docs/site/pages/guides/CNI_MIGRATION.md
+++ b/docs/site/pages/guides/CNI_MIGRATION.md
@@ -35,7 +35,7 @@ Supported CNI switching modes:
 
 There are several methods to switch CNI in a DKP cluster.
 
-## Method 1: Using the d8 cni-migration command group of the d8 utility (automated switching)
+## Method 1: Using the d8 network cni-migration command group of the d8 utility (automated switching)
 
 The [d8](/products/kubernetes-platform/documentation/v1/cli/d8/reference/) utility provides a command group for managing the migration process.
 
@@ -44,7 +44,7 @@ The [d8](/products/kubernetes-platform/documentation/v1/cli/d8/reference/) utili
 To start the process, execute the `switch` command, specifying the target CNI (e.g., `cilium`, `flannel`, or `simple-bridge`):
 
 ```bash
-d8 cni-migration switch --to-cni cilium
+d8 network cni-migration switch --to-cni cilium
 ```
 
 This command will create the necessary resource in the cluster and start the migration controller. DKP will automatically deploy the necessary components: Manager and Agents in the `d8-system` namespace.
@@ -54,7 +54,7 @@ This command will create the necessary resource in the cluster and start the mig
 To monitor the progress in real-time, use the command:
 
 ```bash
-d8 cni-migration watch
+d8 network cni-migration watch
 ```
 
 You will see a dynamic interface with the following information:
@@ -79,7 +79,7 @@ Main phases of the process:
 After the migration status changes to `Succeeded`, you must remove the migration resources (controllers and agents) so that they do not consume cluster resources. To do this, use the command:
 
 ```bash
-d8 cni-migration cleanup
+d8 network cni-migration cleanup
 ```
 
 ## Method 2: Using the d8 k commands (manual switching)

--- a/docs/site/pages/guides/CNI_MIGRATION_RU.md
+++ b/docs/site/pages/guides/CNI_MIGRATION_RU.md
@@ -35,16 +35,16 @@ layout: sidebar-guides
 
 Переключение CNI в кластере DKP можно выполнить несколькими способами.
 
-## Способ 1: Использование группы команд d8 cni-migration утилиты d8 (автоматизированное переключение)
+## Способ 1: Использование группы команд d8 network cni-migration утилиты d8 (автоматизированное переключение)
 
-Утилита [d8](/products/kubernetes-platform/documentation/v1/cli/d8/reference/) предоставляет группу команд `d8 cni-migration` для управления процессом миграции.
+Утилита [d8](/products/kubernetes-platform/documentation/v1/cli/d8/reference/) предоставляет группу команд `d8 network cni-migration` для управления процессом миграции.
 
 ### Запуск миграции
 
 Для начала процесса выполните команду `switch`, указав целевой CNI (например, `cilium`, `flannel` или `simple-bridge`):
 
 ```bash
-d8 cni-migration switch --to-cni cilium
+d8 network cni-migration switch --to-cni cilium
 ```
 
 Эта команда создаст необходимый ресурс в кластере и запустит контроллер миграции. DKP автоматически развернет необходимые компоненты: Менеджер (Manager) и Агенты (Agents) в неймспейсе `d8-system`.
@@ -54,7 +54,7 @@ d8 cni-migration switch --to-cni cilium
 Чтобы следить за ходом выполнения в реальном времени, используйте команду:
 
 ```bash
-d8 cni-migration watch
+d8 network cni-migration watch
 ```
 
 Вы увидите динамический интерфейс со следующей информацией:
@@ -79,7 +79,7 @@ d8 cni-migration watch
 После того как статус миграции перейдет в `Succeeded`, удалите ресурсы миграции (контроллеры и агенты), чтобы они не потребляли ресурсы кластера. Для этого используйте команду:
 
 ```bash
-d8 cni-migration cleanup
+d8 network cni-migration cleanup
 ```
 
 ## Способ 2: Использование команд d8 k (ручное переключение)


### PR DESCRIPTION
## Description

The CLI command for CNI migration has been changed from `d8 cni-migration` to `d8 network cni-migration` in a recent release. This PR updates the corresponding commands in the English and Russian versions of the CNI migration guide to reflect the actual state of the `d8` CLI tool.

## Why do we need it, and what problem does it solve?

This change provides users with the correct and up-to-date instructions for the CNI migration process using the `d8` utility. Previously documented commands like `d8 cni-migration switch` are no longer valid because the tool was moved under the `network` subcommand.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Updated the `d8 cni-migration` commands in the CNI migration guide to `d8 network cni-migration`.
```