### PR TITLE
Fix access to dns in multitenancy default project template

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -61,6 +61,12 @@ spec:
   - ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
     to:
     - namespaceSelector:
         matchLabels:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
@@ -215,6 +215,12 @@ spec:
           ports:
             - protocol: UDP
               port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
     {{- end }}
 
     {{- with .parameters.clusterLogDestinationName }}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
@@ -31,6 +31,12 @@ spec:
   - ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
     to:
     - namespaceSelector:
         matchLabels:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
@@ -253,6 +253,12 @@ spec:
           ports:
             - protocol: UDP
               port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
     {{- end }}
 
     {{- with .parameters.clusterLogDestinationName }}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -64,6 +64,12 @@ spec:
   - ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
     to:
     - namespaceSelector:
         matchLabels:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
@@ -303,6 +303,12 @@ spec:
           ports:
             - protocol: UDP
               port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
     {{- end }}
 
     {{- with .parameters.clusterLogDestinationName }}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
@@ -62,6 +62,12 @@ spec:
   - ports:
     - port: 53
       protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
     to:
     - namespaceSelector:
         matchLabels:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
@@ -206,6 +206,12 @@ spec:
           ports:
             - protocol: UDP
               port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
     {{- end }}
 
     {{- with .parameters.clusterLogDestinationName }}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
@@ -216,6 +216,12 @@ spec:
           ports:
             - protocol: UDP
               port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
     {{- end }}
 
     {{- with .parameters.clusterLogDestinationName }}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
@@ -304,6 +304,12 @@ spec:
           ports:
             - protocol: UDP
               port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
     {{- end }}
 
     {{- with .parameters.clusterLogDestinationName }}

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
@@ -253,6 +253,12 @@ spec:
           ports:
             - protocol: UDP
               port: 53
+            - protocol: TCP
+              port: 53
+            - protocol: UDP
+              port: 5353
+            - protocol: TCP
+              port: 5353
     {{- end }}
 
     {{- with .parameters.clusterLogDestinationName }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix default ProjectTemplate in multitenancy-manager module.
Allow connection to 5353/UDP and 5353/TCP ports for DNS queries.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Default ProjectTemplate creates NetworkPolicy that give access only to 53/UDP port inside _kube-system_ namespace, but _d8-kube-dns-_ pods inside _kube-system_ namespace listens 5353/UDP and 5353/TCP ports only.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: multitenancy-manager
type: fix
summary: allow DNS queries for default ProjectTemplate
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
