### PR TITLE
[chore][ci] Update CODEOWNERS for architecture documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,7 @@ csi/                                     @AleksZimin @duckhawk
 deckhouse-controller/                    @ldmonster
 dhctl/                                   @name212 @090809
 docs/                                    @z9r5
+docs/documentation/pages/architecture/   @voitenkov
 helm_lib/                                @name212 @090809 @sprait
 crds/                                    @z9r5
 openapi/                                 @z9r5


### PR DESCRIPTION
## Description

This pull request adds a new ownership assignment in the `.github/CODEOWNERS` file. The change designates responsibility for the `docs/documentation/pages/architecture/` directory to the `@voitenkov` user.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Update CODEOWNERS for architecture documentation.
impact_level: low
```
