### PR TITLE
[istio] Disable Gateway API Deployment controller

### DIFF
--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -195,6 +195,9 @@ spec:
 
     pilot:
       autoscaleEnabled: false
+      env:
+        PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: false
+        PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER: false
       podAnnotations:
         istio-mtls-ca-bundle-checksum: {{ $.Values.istio.internal.ca | toYaml | sha256sum }}
   {{- if eq $.Values.istio.controlPlane.replicasManagement.mode "Standard" }}


### PR DESCRIPTION
## Description

Disable the Gateway API deployment controller and GatewayClass controller in Istio 1.21 operator by setting environment variables:
- `PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: false`
- `PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER: false`

## Why do we need it, and what problem does it solve?

Deckhouse does not support the Kubernetes Gateway API in the Istio module, at least not with Istio version 1.21. Additionally, these controllers don't work in our environment because the Istio Operator cannot create the necessary ClusterRoles and ClusterRoleBindings due to Deckhouse's RBAC security restrictions. Disabling these controllers prevents unsuccessful reconciliation attempts and avoids errors polluting kube-apiserver audit logs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Disable Gateway API deployment and GatewayClass controllers in Istio 1.21.
impact_level: low
```