### PR TITLE
[extended-monitoring] Fix image-availability-exporter template typo

### DIFF
--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         # https://github.com/deckhouse/k8s-image-availability-exporter/blob/b1589b40c18290b9d105f0ac39ddc3fc554884d9/pkg/registry_checker/checker.go#L212
         # Among known inexisting images, there is the one from Upmeter probe where we don't want a container to start.
         - --check-interval={{ .Values.extendedMonitoring.imageAvailability.imageCheckInterval }}
-        - --default-registry= {{ .Values.extendedMonitoring.imageAvailability.defaultRegistry }}
+        - --default-registry={{ .Values.extendedMonitoring.imageAvailability.defaultRegistry }}
         {{- $ignoredImages := list ".*upmeter-nonexistent.*" }}
         {{- if .Values.extendedMonitoring.imageAvailability.ignoredImages }}
           {{- $ignoredImages = concat $ignoredImages .Values.extendedMonitoring.imageAvailability.ignoredImages }}


### PR DESCRIPTION
## Description
Fix template typo

## Why do we need it, and what problem does it solve?
There is a typo in the command argument

## Why do we need it in the patch release (if we do)?
To fix the bug.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: extended-monitoring
type: fix
summary: fix typo in image-availability-exporter template
impact_level: default
```