### PR TITLE
[cloud-provider-huaweicloud] Enable security policy check and add SPE for CSI and CCM

### DIFF
--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/deployment.yaml
@@ -58,6 +58,9 @@ spec:
     metadata:
       labels:
         app: cloud-controller-manager
+        {{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+        security.deckhouse.io/security-policy-exception: cloud-controller-manager
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
     spec:

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/security-policy-exception.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/cloud-controller-manager/security-policy-exception.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: cloud-controller-manager
+  namespace: d8-cloud-provider-huaweicloud
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host network access for Cloud Controller Manager.
+          The Cloud Controller Manager requires host network access to communicate with the API for managing infrastructure resources, including load balancer configuration, node lifecycle management, and routing operations.
+{{- end }}

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/csi/controller.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/csi/controller.yaml
@@ -67,6 +67,7 @@
   {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "csi_controller_volumes" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerVolumeMounts" (include "csi_controller_volume_mounts" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "dnsPolicy"  (include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet")) }}
+  {{- $_ := set $csiControllerConfig "securityPolicyExceptionEnabled" true }}
 
   {{- include "helm_lib_csi_controller_manifests" (list . $csiControllerConfig) }}
 
@@ -79,6 +80,7 @@
   {{- $_ := set $csiNodeConfig "additionalNodeVolumes" (include "csi_node_volumes" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "additionalNodeVolumeMounts" (include "csi_node_volume_mounts" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "dnsPolicy" (include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet")) }}
+  {{- $_ := set $csiNodeConfig "securityPolicyExceptionEnabled" true }}
 
   {{- include "helm_lib_csi_node_manifests" (list . $csiNodeConfig) }}
 {{- end }}

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/namespace.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/namespace.yaml
@@ -1,7 +1,15 @@
+{{- define "labels" }}
+prometheus.deckhouse.io/rules-watcher-enabled: "true"
+security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
+{{- end }}
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-huaweicloud
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-huaweicloud") }}

--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.71.2
-digest: sha256:c32b540da9793f919714fc648420a7f1c4ab94496f5e4b032e5f34024f17576d
-generated: "2026-03-11T19:25:54.754636+07:00"
+  version: 1.71.5
+digest: sha256:3824136da8b4e2bff494290d3da54836df52507b5cdceadbe9f7844acb9e251b
+generated: "2026-03-24T19:48:48.711121+07:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.71.2"
+    version: "1.71.5"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.71.2
+version: 1.71.5

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -34,8 +34,6 @@
 | [helm_lib_application_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted](#helm_lib_application_container_security_context_read_only_root_filesystem_capabilities_drop_all_pss_restricted) |
 | **Csi Controller** |
 | [helm_lib_csi_image_with_common_fallback](#helm_lib_csi_image_with_common_fallback) |
-| **Default Gateway** |
-| [helm_lib_default_gateway](#helm_lib_default_gateway) |
 | **Dns Policy** |
 | [helm_lib_dns_policy_bootstraping_state](#helm_lib_dns_policy_bootstraping_state) |
 | **Enable Ds Eviction** |
@@ -56,6 +54,8 @@
 | **Module Ephemeral Storage** |
 | [helm_lib_module_ephemeral_storage_logs_with_extra](#helm_lib_module_ephemeral_storage_logs_with_extra) |
 | [helm_lib_module_ephemeral_storage_only_logs](#helm_lib_module_ephemeral_storage_only_logs) |
+| **Module Gateway** |
+| [helm_lib_module_gateway](#helm_lib_module_gateway) |
 | **Module Generate Common Name** |
 | [helm_lib_module_generate_common_name](#helm_lib_module_generate_common_name) |
 | **Module Https** |
@@ -63,6 +63,7 @@
 | [helm_lib_module_https_mode](#helm_lib_module_https_mode) |
 | [helm_lib_module_https_cert_manager_cluster_issuer_name](#helm_lib_module_https_cert_manager_cluster_issuer_name) |
 | [helm_lib_module_https_ingress_tls_enabled](#helm_lib_module_https_ingress_tls_enabled) |
+| [helm_lib_module_https_route_tls_enabled](#helm_lib_module_https_route_tls_enabled) |
 | [helm_lib_module_https_copy_custom_certificate](#helm_lib_module_https_copy_custom_certificate) |
 | [helm_lib_module_https_secret_name](#helm_lib_module_https_secret_name) |
 | **Module Image** |
@@ -491,22 +492,6 @@ list:
 -  Container raw name 
 -  Kubernetes semantic version 
 
-## Default Gateway
-
-### helm_lib_default_gateway
-
- accepts a dict that is updated with current default gateway name and namespace 
-
-#### Usage
-
-`{{- include "helm_lib_default_gateway" (list . $gateway) `
-
-#### Arguments
-
-list:
--  Template context with .Values, .Chart, etc 
--  An empty dict to update with current default gateway name and namespace 
-
 ## Dns Policy
 
 ### helm_lib_dns_policy_bootstraping_state
@@ -662,6 +647,22 @@ list:
 
 -  Template context with .Values, .Chart, etc 
 
+## Module Gateway
+
+### helm_lib_module_gateway
+
+ accepts a dict that is updated with current gateway name and namespace 
+
+#### Usage
+
+`{{- include "helm_lib_module_gateway" (list . $gateway) `
+
+#### Arguments
+
+list:
+-  Template context with .Values, .Chart, etc 
+-  An empty dict to update with current default gateway name and namespace 
+
 ## Module Generate Common Name
 
 ### helm_lib_module_generate_common_name
@@ -721,11 +722,24 @@ list:
 
 ### helm_lib_module_https_ingress_tls_enabled
 
- returns not empty string if tls should enable for ingress  
+ returns not empty string if tls should be enabled for the ingress  
 
 #### Usage
 
 `{{ if (include "helm_lib_module_https_ingress_tls_enabled" .) }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
+
+
+### helm_lib_module_https_route_tls_enabled
+
+ returns not empty string if tls should be enabled for the route  
+
+#### Usage
+
+`{{ if (include "helm_lib_module_https_route_tls_enabled" .) }} `
 
 #### Arguments
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -116,6 +116,7 @@ memory: 50Mi
   {{- $additionalPullSecrets := $config.additionalPullSecrets }}
   {{- $forceCsiControllerPrivilegedContainer := $config.forceCsiControllerPrivilegedContainer | default false }}
   {{- $dnsPolicy := $config.dnsPolicy | default "ClusterFirstWithHostNet" }}
+  {{- $securityPolicyExceptionEnabled := $config.securityPolicyExceptionEnabled | default false }}
 
   {{- $kubernetesSemVer := semver $context.Values.global.discovery.kubernetesVersion }}
 
@@ -238,6 +239,9 @@ spec:
     metadata:
       labels:
         app: {{ $fullname }}
+        {{- if and $securityPolicyExceptionEnabled ($context.Values.global.enabledModules | has "admission-policy-engine-crd") }}
+        security.deckhouse.io/security-policy-exception: {{ $fullname }}
+        {{- end }}
       {{- if or (hasPrefix "cloud-provider-" $context.Chart.Name) ($additionalCsiControllerPodAnnotations) }}
       annotations:
       {{- if hasPrefix "cloud-provider-" $context.Chart.Name }}
@@ -556,7 +560,101 @@ spec:
         {{- $additionalControllerVolumes | toYaml | nindent 6 }}
       {{- end }}
 
+{{- if and $securityPolicyExceptionEnabled ($context.Values.global.enabledModules | has "admission-policy-engine-crd") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: {{ $fullname }}
+  namespace: d8-{{ $context.Chart.Name }}
+spec:
+{{- if or $forceCsiControllerPrivilegedContainer $runAsRootUser (eq $csiControllerHostNetwork "true") (ne $csiControllerHostPID "false") }}
+  {{- if or $forceCsiControllerPrivilegedContainer $runAsRootUser }}
+  securityContext:
+    {{- if $forceCsiControllerPrivilegedContainer }}
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow privileged mode for CSI Controller.
+          The CSI Controller requires privileged access to perform storage management operations that need direct access to host resources, including device management and volume lifecycle control.
+    capabilities:
+      allowedValues:
+        add:
+          - SYS_ADMIN
+      metadata:
+        description: |
+          Allow SYS_ADMIN capability for CSI Controller.
+          The CSI Controller requires SYS_ADMIN capability to perform privileged storage management operations such as volume provisioning, snapshotting, and direct interaction with the storage backend.
+    {{- end }}
+    {{- if $runAsRootUser }}
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          Allow running as root user (UID 0) for CSI Controller.
+          The CSI Controller requires root privileges to interact with storage backends, manage volume lifecycle operations, and access cloud provider APIs.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Allow running as root for CSI Controller.
+          The CSI Controller requires root access for storage management operations that need elevated privileges to interact with the underlying infrastructure.
+    {{- end }}
   {{- end }}
+  {{- if or (eq $csiControllerHostNetwork "true") (ne $csiControllerHostPID "false") }}
+  network:
+    {{- if eq $csiControllerHostNetwork "true" }}
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host network access for CSI Controller.
+          The CSI Controller requires host network access to communicate with cloud provider API endpoints for volume provisioning, attachment, snapshot, and lifecycle management operations.
+    {{- end }}
+    {{- if ne $csiControllerHostPID "false" }}
+    hostPID:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host PID namespace access for CSI Controller.
+          The CSI Controller requires host PID namespace access to interact with host processes for storage operations and coordinate with system-level services.
+    {{- end }}
+  {{- end }}
+  {{- $hasHostPathVolumes := false }}
+  {{- if $additionalControllerVolumes }}
+    {{- range $vol := $additionalControllerVolumes }}
+      {{- if $vol.hostPath }}
+        {{- $hasHostPathVolumes = true }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if $hasHostPathVolumes }}
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          Allow hostPath volume type for CSI Controller.
+          The CSI Controller requires hostPath volumes for accessing host-level resources needed for storage management operations specific to the cloud provider implementation.
+    hostPath:
+      allowedValues:
+      {{- range $vol := $additionalControllerVolumes }}
+        {{- if $vol.hostPath }}
+        - path: {{ $vol.hostPath.path }}
+          readOnly: false
+          metadata:
+            description: |
+              Allow access to additional hostPath volume at {{ $vol.hostPath.path }}.
+              This hostPath volume is required by the CSI Controller for storage management operations specific to the cloud provider implementation.
+        {{- end }}
+      {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
@@ -37,6 +37,7 @@ memory: 25Mi
   {{- $csiNodeHostNetwork := $config.csiNodeHostNetwork | default "true" }}
   {{- $csiNodeHostPID := $config.csiNodeHostPID | default "false" }}
   {{- $dnsPolicy := $config.dnsPolicy | default "ClusterFirstWithHostNet" }}
+  {{- $securityPolicyExceptionEnabled := $config.securityPolicyExceptionEnabled | default false }}
   {{- $kubernetesSemVer := semver $context.Values.global.discovery.kubernetesVersion }}
   {{- $driverRegistrarImage := include "helm_lib_csi_image_with_common_fallback" (list $context "csiNodeDriverRegistrar" $kubernetesSemVer) }}
   {{- if $driverRegistrarImage }}
@@ -91,6 +92,9 @@ spec:
     metadata:
       labels:
         app: {{ $fullname }}
+        {{- if and $securityPolicyExceptionEnabled ($context.Values.global.enabledModules | has "admission-policy-engine-crd") }}
+        security.deckhouse.io/security-policy-exception: {{ $fullname }}
+        {{- end }}
       {{- if or (hasPrefix "cloud-provider-" $context.Chart.Name) ($additionalCsiNodePodAnnotations) }}
       annotations:
       {{- if hasPrefix "cloud-provider-" $context.Chart.Name }}
@@ -267,6 +271,112 @@ spec:
         {{- $additionalNodeVolumes | toYaml | nindent 6 }}
       {{- end }}
 
-    {{- end }}
+{{- if and $securityPolicyExceptionEnabled ($context.Values.global.enabledModules | has "admission-policy-engine-crd") }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: {{ $fullname }}
+  namespace: d8-{{ $context.Chart.Name }}
+spec:
+  securityContext:
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow privileged mode for CSI Node Driver.
+          The CSI Node Driver requires privileged access to perform critical storage operations such as mounting/unmounting volumes, formatting block devices, and interacting directly with the host kernel for disk management.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Allow running as root for CSI Node Driver.
+          The CSI Node Driver requires root access to perform privileged storage operations on the host, including device management and filesystem mounting.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          Allow running as root user (UID 0) for CSI Node Driver.
+          The CSI Node Driver and node-driver-registrar require root privileges to perform storage operations, interact with host devices, and manage volume mounts.
+  {{- if $setSysAdminCapability }}
+    capabilities:
+      allowedValues:
+        add:
+          - SYS_ADMIN
+      metadata:
+        description: |
+          Allow SYS_ADMIN capability for CSI Node Driver.
+          The CSI Node Driver requires SYS_ADMIN capability to perform privileged filesystem operations such as mounting, unmounting, and managing block devices on the host.
   {{- end }}
+
+  {{- if or (eq $csiNodeHostNetwork "true") (ne $csiNodeHostPID "false") }}
+  network:
+  {{- if eq $csiNodeHostNetwork "true" }}
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host network access for CSI Node Driver.
+          The CSI Node Driver requires host network access to communicate with the CSI Controller, coordinate volume attachment operations, and synchronize storage metadata across the cluster.
+  {{- end }}
+  {{- if ne $csiNodeHostPID "false" }}
+    hostPID:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host PID namespace access for CSI Node Driver.
+          The CSI Node Driver requires host PID namespace access to interact with host processes for storage operations such as detecting mount points and managing device attachments.
+  {{- end }}
+  {{- end }}
+
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          Allow hostPath volume type for CSI Node.
+          The CSI Node Driver requires hostPath volumes to access host filesystem paths for proper operation, including communication with the container runtime and access to block devices.
+    hostPath:
+      allowedValues:
+        - path: /var/lib/kubelet/plugins_registry/
+          readOnly: false
+          metadata:
+            description: |
+              Allow access to the CSI plugin registry directory.
+              CSI Node Driver registers itself in this directory to enable dynamic discovery and communication with the kubelet.
+        - path: /var/lib/kubelet
+          readOnly: false
+          metadata:
+            description: |
+              Allow access to the kubelet root directory.
+              Required for CSI Node Driver to manage volume mounts and access kubelet data structures.
+        - path: /var/lib/kubelet/csi-plugins/{{ $driverFQDN }}/
+          readOnly: false
+          metadata:
+            description: |
+              Allow access to the CSI plugin directory.
+              This directory contains the CSI driver socket and persistent data required for volume attachment and mounting operations.
+        - path: /dev
+          readOnly: false
+          metadata:
+            description: |
+              Allow access to host device directory.
+              CSI Node Driver requires access to /dev to manage block devices and perform disk operations for persistent volumes.
+      {{- if $additionalNodeVolumes }}
+        {{- range $vol := $additionalNodeVolumes }}
+          {{- if $vol.hostPath }}
+        - path: {{ $vol.hostPath.path }}
+          readOnly: false
+          metadata:
+            description: |
+              Allow access to additional hostPath volume at {{ $vol.hostPath.path }}.
+              This additional hostPath volume is required by the CSI Node Driver for extended storage operations specific to the cloud provider implementation.
+          {{- end }}
+        {{- end }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_gateway.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_gateway.tpl
@@ -1,0 +1,22 @@
+{{- /* Usage: {{- include "helm_lib_module_gateway" (list . $gateway) */ -}}
+{{- /* accepts a dict that is updated with current gateway name and namespace */ -}}
+{{- define "helm_lib_module_gateway" -}}
+  {{- $context := index . 0 -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- $result := index . 1 -}}  {{- /* An empty dict to update with current default gateway name and namespace */ -}}
+  {{- $g := dict -}}
+
+  {{- $module_values := (index $context.Values (include "helm_lib_module_camelcase_name" $context)) -}}
+
+  {{- if hasKey $module_values "gatewayAPIGateway" -}}
+    {{- $g = $module_values.gatewayAPIGateway -}}
+  {{- else if hasKey $context.Values.global.modules "gatewayAPIGateway" -}}
+    {{- $g = $context.Values.global.modules.gatewayAPIGateway -}}
+  {{- else if and (hasKey $context.Values.global "discovery") (hasKey $context.Values.global.discovery "gatewayAPIDefaultGateway") -}}
+    {{- $g = $context.Values.global.discovery.gatewayAPIDefaultGateway -}}
+  {{- end -}}
+
+  {{- if and $g.name $g.namespace -}}
+    {{- $_ := set $result "name" $g.name -}}
+    {{- $_ := set $result "namespace" $g.namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_https.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_https.tpl
@@ -108,8 +108,20 @@ certManager:
 {{- end -}}
 
 {{- /* Usage: {{ if (include "helm_lib_module_https_ingress_tls_enabled" .) }} */ -}}
-{{- /* returns not empty string if tls should enable for ingress  */ -}}
+{{- /* returns not empty string if tls should be enabled for the ingress  */ -}}
 {{- define "helm_lib_module_https_ingress_tls_enabled" -}}
+  {{- $context := . -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+
+  {{- $mode := include "helm_lib_module_https_mode" $context -}}
+
+  {{- if or (eq "CertManager" $mode) (eq "CustomCertificate" $mode) -}}
+    not empty string
+  {{- end -}}
+{{- end -}}
+
+{{- /* Usage: {{ if (include "helm_lib_module_https_route_tls_enabled" .) }} */ -}}
+{{- /* returns not empty string if tls should be enabled for the route  */ -}}
+{{- define "helm_lib_module_https_route_tls_enabled" -}}
   {{- $context := . -}} {{- /* Template context with .Values, .Chart, etc */ -}}
 
   {{- $mode := include "helm_lib_module_https_mode" $context -}}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

+ Enable security policy check for namespace d8-cloud-provider-huaweicloud
+ Bump helm_lib version, as it now includes templating for the SPE resource for CSI
+ Added SecurityPolicyException rendering for Huawei Cloud CSI and CCM.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Enabling security policy checks allows you to verify pod configurations for compliance with security standards. However, some components, due to their specific features, require capabilities that the Pod Security Policy (PSS) considers too privileged. For example, CSI requires the ability to mount files on the host, and CCM requires hostNetwork to avoid relying on pod networking and utilize the node's network namespace. For such components, an SecurityPolicyException resource is added, which allows you to bypass certain policy checks.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: feature
summary: Enabled security policy checks and added SecurityPolicyException for Huawei Cloud CSI and CCM.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
