### PR TITLE
[istio] Monitoring reserved UID 1337 in pods

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1772,13 +1772,13 @@ alerts:
       module: istio
       edition: ce
       description: |
-        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as a UID reserved by Istio (`1337` or `64535`).
 
-        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+        These UIDs are reserved for the `istio-proxy` sidecar container. When application containers run with one of these UIDs, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
 
         To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.
       summary: |
-        Application container is running as UID 1337 (reserved by Istio).
+        Application container is running as a reserved Istio UID (1337 or 64535).
       severity: "4"
       markupFormat: markdown
     - name: D8IstioVersionIsIncompatibleWithK8sVersion

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1766,6 +1766,21 @@ alerts:
         Istio remote cluster {{$labels.cluster_id}} is not synchronized.
       severity: "4"
       markupFormat: markdown
+    - name: D8IstioReservedUIDConflict
+      sourceFile: modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
+      moduleUrl: 110-istio
+      module: istio
+      edition: ce
+      description: |
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
+
+        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+
+        To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.
+      summary: |
+        Application container is running as UID 1337 (reserved by Istio).
+      severity: "4"
+      markupFormat: markdown
     - name: D8IstioVersionIsIncompatibleWithK8sVersion
       sourceFile: modules/110-istio/monitoring/prometheus-rules/versions.tpl
       moduleUrl: 110-istio
@@ -4369,21 +4384,6 @@ alerts:
         URL {{$labels.vhost}}{{$labels.location}} on Ingress {{$labels.ingress}} has more than {{ printf &quot;extended_monitoring_ingress_threshold{threshold=&quot;5xx-warning&quot;, namespace=&quot;%s&quot;, ingress=&quot;%s&quot;}&quot; $labels.namespace $labels.ingress | query | first | value }}% of 5xx responses from the backend.
       severity: "5"
       markupFormat: default
-    - name: IstioApplicationContainerUsesReservedUID
-      sourceFile: modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
-      moduleUrl: 110-istio
-      module: istio
-      edition: ce
-      description: |
-        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
-
-        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
-
-        To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.
-      summary: |
-        Application container is running as UID 1337 (reserved by Istio).
-      severity: "4"
-      markupFormat: markdown
     - name: IstioIrrelevantExternalServiceFound
       sourceFile: modules/110-istio/monitoring/prometheus-rules/propagated-services.yaml
       moduleUrl: 110-istio

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1772,13 +1772,13 @@ alerts:
       module: istio
       edition: ce
       description: |
-        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as a UID reserved by Istio (`1337` or `64535`).
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
 
-        These UIDs are reserved for the `istio-proxy` sidecar container. When application containers run with one of these UIDs, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
 
         To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.
       summary: |
-        Application container is running as a reserved Istio UID (1337 or 64535).
+        Application container is running as UID 1337 (reserved by Istio).
       severity: "4"
       markupFormat: markdown
     - name: D8IstioVersionIsIncompatibleWithK8sVersion

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -4369,6 +4369,21 @@ alerts:
         URL {{$labels.vhost}}{{$labels.location}} on Ingress {{$labels.ingress}} has more than {{ printf &quot;extended_monitoring_ingress_threshold{threshold=&quot;5xx-warning&quot;, namespace=&quot;%s&quot;, ingress=&quot;%s&quot;}&quot; $labels.namespace $labels.ingress | query | first | value }}% of 5xx responses from the backend.
       severity: "5"
       markupFormat: default
+    - name: IstioApplicationContainerUsesReservedUID
+      sourceFile: modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
+      moduleUrl: 110-istio
+      module: istio
+      edition: ce
+      description: |
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
+
+        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+
+        To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.
+      summary: |
+        Application container is running as UID 1337 (reserved by Istio).
+      severity: "4"
+      markupFormat: markdown
     - name: IstioIrrelevantExternalServiceFound
       sourceFile: modules/110-istio/monitoring/prometheus-rules/propagated-services.yaml
       moduleUrl: 110-istio

--- a/modules/110-istio/hooks/reserved_uid_monitoring.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+)
+
+const (
+	istioReservedUID        int64 = 1337
+	istioProxyContainerName       = "istio-proxy"
+	reservedUIDMetricsGroup       = "d8_istio_reserved_uid"
+)
+
+type podReservedUIDInfo struct {
+	Namespace  string
+	Pod        string
+	Containers []string
+}
+
+func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var pod v1.Pod
+
+	err := sdk.FromUnstructured(obj, &pod)
+	if err != nil {
+		return nil, err
+	}
+
+	hasIstioProxy := false
+	for _, c := range pod.Spec.Containers {
+		if c.Name == istioProxyContainerName {
+			hasIstioProxy = true
+			break
+		}
+	}
+	if !hasIstioProxy {
+		return nil, nil
+	}
+
+	var podRunAsUser *int64
+	if pod.Spec.SecurityContext != nil {
+		podRunAsUser = pod.Spec.SecurityContext.RunAsUser
+	}
+
+	var matchingContainers []string
+	for _, container := range pod.Spec.Containers {
+		if container.Name == istioProxyContainerName {
+			continue
+		}
+
+		var effectiveRunAsUser *int64
+		if container.SecurityContext != nil && container.SecurityContext.RunAsUser != nil {
+			effectiveRunAsUser = container.SecurityContext.RunAsUser
+		} else {
+			effectiveRunAsUser = podRunAsUser
+		}
+
+		if effectiveRunAsUser != nil && *effectiveRunAsUser == istioReservedUID {
+			matchingContainers = append(matchingContainers, container.Name)
+		}
+	}
+
+	if len(matchingContainers) == 0 {
+		return nil, nil
+	}
+
+	return podReservedUIDInfo{
+		Namespace:  pod.Namespace,
+		Pod:        pod.Name,
+		Containers: matchingContainers,
+	}, nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: lib.Queue("monitoring"),
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "pods",
+			ApiVersion: "v1",
+			Kind:       "Pod",
+			FilterFunc: applyReservedUIDFilter,
+			LabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "heritage",
+						Operator: metav1.LabelSelectorOpNotIn,
+						Values:   []string{"deckhouse"},
+					},
+				},
+			},
+		},
+	},
+}, handleReservedUIDMonitoring)
+
+func handleReservedUIDMonitoring(_ context.Context, input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire(reservedUIDMetricsGroup)
+
+	for info, err := range sdkobjectpatch.SnapshotIter[podReservedUIDInfo](input.Snapshots.Get("pods")) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over pod snapshots: %w", err)
+		}
+
+		for _, containerName := range info.Containers {
+			input.MetricsCollector.Set(
+				"d8_istio_pod_container_reserved_uid",
+				1,
+				map[string]string{
+					"namespace": info.Namespace,
+					"pod":       info.Pod,
+					"container": containerName,
+				},
+				metrics.WithGroup(reservedUIDMetricsGroup),
+			)
+		}
+	}
+
+	return nil
+}

--- a/modules/110-istio/hooks/reserved_uid_monitoring.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring.go
@@ -33,10 +33,11 @@ import (
 )
 
 const (
-	istioReservedUID        int64 = 1337
 	istioProxyContainerName       = "istio-proxy"
 	reservedUIDMetricsGroup       = "d8_istio_reserved_uid"
 )
+
+var istioReservedUIDs = []int64{1337, 64535}
 
 type podReservedUIDInfo struct {
 	Namespace  string
@@ -81,7 +82,7 @@ func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 			effectiveRunAsUser = podRunAsUser
 		}
 
-		if effectiveRunAsUser != nil && *effectiveRunAsUser == istioReservedUID {
+		if effectiveRunAsUser != nil && isReservedUID(*effectiveRunAsUser) {
 			matchingContainers = append(matchingContainers, container.Name)
 		}
 	}
@@ -117,6 +118,15 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		},
 	},
 }, handleReservedUIDMonitoring)
+
+func isReservedUID(uid int64) bool {
+	for _, reserved := range istioReservedUIDs {
+		if uid == reserved {
+			return true
+		}
+	}
+	return false
+}
 
 func handleReservedUIDMonitoring(_ context.Context, input *go_hook.HookInput) error {
 	input.MetricsCollector.Expire(reservedUIDMetricsGroup)

--- a/modules/110-istio/hooks/reserved_uid_monitoring.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring.go
@@ -33,11 +33,10 @@ import (
 )
 
 const (
+	istioReservedUID        int64 = 1337
 	istioProxyContainerName       = "istio-proxy"
 	reservedUIDMetricsGroup       = "d8_istio_reserved_uid"
 )
-
-var istioReservedUIDs = []int64{1337, 64535}
 
 type podReservedUIDInfo struct {
 	Namespace  string
@@ -82,7 +81,7 @@ func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 			effectiveRunAsUser = podRunAsUser
 		}
 
-		if effectiveRunAsUser != nil && isReservedUID(*effectiveRunAsUser) {
+		if effectiveRunAsUser != nil && *effectiveRunAsUser == istioReservedUID {
 			matchingContainers = append(matchingContainers, container.Name)
 		}
 	}
@@ -118,15 +117,6 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		},
 	},
 }, handleReservedUIDMonitoring)
-
-func isReservedUID(uid int64) bool {
-	for _, reserved := range istioReservedUIDs {
-		if uid == reserved {
-			return true
-		}
-	}
-	return false
-}
 
 func handleReservedUIDMonitoring(_ context.Context, input *go_hook.HookInput) error {
 	input.MetricsCollector.Expire(reservedUIDMetricsGroup)

--- a/modules/110-istio/hooks/reserved_uid_monitoring.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring.go
@@ -33,15 +33,16 @@ import (
 )
 
 const (
-	istioReservedUID        int64 = 1337
-	istioProxyContainerName       = "istio-proxy"
-	reservedUIDMetricsGroup       = "d8_istio_reserved_uid"
+	istioReservedUID          int64 = 1337
+	istioProxyContainerName         = "istio-proxy"
+	istioCanonicalNameLabel         = "service.istio.io/canonical-name"
+	reservedUIDMetricsGroup         = "d8_istio_reserved_uid"
 )
 
 type podReservedUIDInfo struct {
 	Namespace  string
 	Pod        string
-	Containers []string
+	ImproperContainerNames []string
 }
 
 func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
@@ -50,17 +51,6 @@ func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 	err := sdk.FromUnstructured(obj, &pod)
 	if err != nil {
 		return nil, err
-	}
-
-	hasIstioProxy := false
-	for _, c := range pod.Spec.Containers {
-		if c.Name == istioProxyContainerName {
-			hasIstioProxy = true
-			break
-		}
-	}
-	if !hasIstioProxy {
-		return nil, nil
 	}
 
 	var podRunAsUser *int64
@@ -93,7 +83,7 @@ func applyReservedUIDFilter(obj *unstructured.Unstructured) (go_hook.FilterResul
 	return podReservedUIDInfo{
 		Namespace:  pod.Namespace,
 		Pod:        pod.Name,
-		Containers: matchingContainers,
+		ImproperContainerNames: matchingContainers,
 	}, nil
 }
 
@@ -107,6 +97,10 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			FilterFunc: applyReservedUIDFilter,
 			LabelSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      istioCanonicalNameLabel,
+						Operator: metav1.LabelSelectorOpExists,
+					},
 					{
 						Key:      "heritage",
 						Operator: metav1.LabelSelectorOpNotIn,
@@ -126,7 +120,7 @@ func handleReservedUIDMonitoring(_ context.Context, input *go_hook.HookInput) er
 			return fmt.Errorf("failed to iterate over pod snapshots: %w", err)
 		}
 
-		for _, containerName := range info.Containers {
+		for _, containerName := range info.ImproperContainerNames {
 			input.MetricsCollector.Set(
 				"d8_istio_pod_container_reserved_uid",
 				1,

--- a/modules/110-istio/hooks/reserved_uid_monitoring_test.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring_test.go
@@ -129,6 +129,44 @@ var _ = Describe("Istio hooks :: reserved UID monitoring ::", func() {
 			Expect(m[2].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
 		})
 	})
+
+	Context("Pod with app container running as UID 64535 and istio-proxy present", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podAppUser64535WithProxy))
+			f.RunHook()
+		})
+
+		It("Should emit metric for the app container", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
+			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
+				"namespace": "default",
+				"pod":       "app-pod-64535",
+				"container": "app",
+			}))
+		})
+	})
+
+	Context("Pod with pod-level runAsUser 64535 and istio-proxy present", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podPodLevelUser64535WithProxy))
+			f.RunHook()
+		})
+
+		It("Should emit metric for app container inheriting pod-level UID", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
+			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
+				"namespace": "default",
+				"pod":       "pod-level-uid-64535",
+				"container": "app",
+			}))
+		})
+	})
 })
 
 const (
@@ -242,5 +280,41 @@ spec:
     image: istio/proxyv2:latest
     securityContext:
       runAsUser: 1337
+`
+
+	podAppUser64535WithProxy = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-pod-64535
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: app:latest
+    securityContext:
+      runAsUser: 64535
+  - name: istio-proxy
+    image: istio/proxyv2:latest
+    securityContext:
+      runAsUser: 64535
+`
+
+	podPodLevelUser64535WithProxy = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-level-uid-64535
+  namespace: default
+spec:
+  securityContext:
+    runAsUser: 64535
+  containers:
+  - name: app
+    image: app:latest
+  - name: istio-proxy
+    image: istio/proxyv2:latest
 `
 )

--- a/modules/110-istio/hooks/reserved_uid_monitoring_test.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Istio hooks :: reserved UID monitoring ::", func() {
+	f := HookExecutionConfigInit(`{"istio":{"internal":{}}}`, "")
+
+	Context("Empty cluster", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Hook must execute successfully with no metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+		})
+	})
+
+	Context("Pod with app container running as UID 1337 and istio-proxy present", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podAppUser1337WithProxy))
+			f.RunHook()
+		})
+
+		It("Should emit metric for the app container", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
+			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
+				"namespace": "default",
+				"pod":       "app-pod",
+				"container": "app",
+			}))
+		})
+	})
+
+	Context("Pod with only istio-proxy running as UID 1337, app has normal UID", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podOnlyProxyUser1337))
+			f.RunHook()
+		})
+
+		It("Should not emit any metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+		})
+	})
+
+	Context("Pod without istio-proxy container, app running as UID 1337", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podUser1337NoProxy))
+			f.RunHook()
+		})
+
+		It("Should not emit any metrics since there is no istio-proxy to bypass", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+		})
+	})
+
+	Context("Pod with pod-level runAsUser 1337 and istio-proxy present", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podPodLevelUser1337WithProxy))
+			f.RunHook()
+		})
+
+		It("Should emit metric for app container inheriting pod-level UID", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
+			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
+				"namespace": "default",
+				"pod":       "pod-level-uid",
+				"container": "app",
+			}))
+		})
+	})
+
+	Context("Pod with pod-level runAsUser 1337, container overrides to different UID, istio-proxy present", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podOverriddenUserWithProxy))
+			f.RunHook()
+		})
+
+		It("Should not emit any metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(1))
+		})
+	})
+
+	Context("Multiple app containers with UID 1337 in one pod with istio-proxy", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(podMultipleContainers1337))
+			f.RunHook()
+		})
+
+		It("Should emit metrics for each non-istio-proxy container", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(3))
+			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
+			Expect(m[2].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
+		})
+	})
+})
+
+const (
+	podAppUser1337WithProxy = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-pod
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: app:latest
+    securityContext:
+      runAsUser: 1337
+  - name: istio-proxy
+    image: istio/proxyv2:latest
+    securityContext:
+      runAsUser: 1337
+`
+
+	podOnlyProxyUser1337 = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: proxy-only
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: app:latest
+    securityContext:
+      runAsUser: 1000
+  - name: istio-proxy
+    image: istio/proxyv2:latest
+    securityContext:
+      runAsUser: 1337
+`
+
+	podUser1337NoProxy = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: no-proxy-pod
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: app:latest
+    securityContext:
+      runAsUser: 1337
+`
+
+	podPodLevelUser1337WithProxy = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-level-uid
+  namespace: default
+spec:
+  securityContext:
+    runAsUser: 1337
+  containers:
+  - name: app
+    image: app:latest
+  - name: istio-proxy
+    image: istio/proxyv2:latest
+`
+
+	podOverriddenUserWithProxy = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: overridden-pod
+  namespace: default
+spec:
+  securityContext:
+    runAsUser: 1337
+  containers:
+  - name: app
+    image: app:latest
+    securityContext:
+      runAsUser: 1000
+  - name: istio-proxy
+    image: istio/proxyv2:latest
+`
+
+	podMultipleContainers1337 = `
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-container-pod
+  namespace: default
+spec:
+  containers:
+  - name: app
+    image: app:latest
+    securityContext:
+      runAsUser: 1337
+  - name: sidecar
+    image: sidecar:latest
+    securityContext:
+      runAsUser: 1337
+  - name: istio-proxy
+    image: istio/proxyv2:latest
+    securityContext:
+      runAsUser: 1337
+`
+)

--- a/modules/110-istio/hooks/reserved_uid_monitoring_test.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring_test.go
@@ -130,43 +130,6 @@ var _ = Describe("Istio hooks :: reserved UID monitoring ::", func() {
 		})
 	})
 
-	Context("Pod with app container running as UID 64535 and istio-proxy present", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(podAppUser64535WithProxy))
-			f.RunHook()
-		})
-
-		It("Should emit metric for the app container", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			m := f.MetricsCollector.CollectedMetrics()
-			Expect(m).To(HaveLen(2))
-			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
-			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
-				"namespace": "default",
-				"pod":       "app-pod-64535",
-				"container": "app",
-			}))
-		})
-	})
-
-	Context("Pod with pod-level runAsUser 64535 and istio-proxy present", func() {
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(podPodLevelUser64535WithProxy))
-			f.RunHook()
-		})
-
-		It("Should emit metric for app container inheriting pod-level UID", func() {
-			Expect(f).To(ExecuteSuccessfully())
-			m := f.MetricsCollector.CollectedMetrics()
-			Expect(m).To(HaveLen(2))
-			Expect(m[1].Name).To(Equal("d8_istio_pod_container_reserved_uid"))
-			Expect(m[1].Labels).To(BeEquivalentTo(map[string]string{
-				"namespace": "default",
-				"pod":       "pod-level-uid-64535",
-				"container": "app",
-			}))
-		})
-	})
 })
 
 const (
@@ -282,39 +245,4 @@ spec:
       runAsUser: 1337
 `
 
-	podAppUser64535WithProxy = `
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: app-pod-64535
-  namespace: default
-spec:
-  containers:
-  - name: app
-    image: app:latest
-    securityContext:
-      runAsUser: 64535
-  - name: istio-proxy
-    image: istio/proxyv2:latest
-    securityContext:
-      runAsUser: 64535
-`
-
-	podPodLevelUser64535WithProxy = `
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: pod-level-uid-64535
-  namespace: default
-spec:
-  securityContext:
-    runAsUser: 64535
-  containers:
-  - name: app
-    image: app:latest
-  - name: istio-proxy
-    image: istio/proxyv2:latest
-`
 )

--- a/modules/110-istio/hooks/reserved_uid_monitoring_test.go
+++ b/modules/110-istio/hooks/reserved_uid_monitoring_test.go
@@ -70,13 +70,13 @@ var _ = Describe("Istio hooks :: reserved UID monitoring ::", func() {
 		})
 	})
 
-	Context("Pod without istio-proxy container, app running as UID 1337", func() {
+	Context("Pod without istio canonical-name label, app running as UID 1337", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(podUser1337NoProxy))
 			f.RunHook()
 		})
 
-		It("Should not emit any metrics since there is no istio-proxy to bypass", func() {
+		It("Should not emit any metrics since pod is not managed by Istio", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			m := f.MetricsCollector.CollectedMetrics()
 			Expect(m).To(HaveLen(1))
@@ -140,6 +140,8 @@ kind: Pod
 metadata:
   name: app-pod
   namespace: default
+  labels:
+    service.istio.io/canonical-name: app
 spec:
   containers:
   - name: app
@@ -159,6 +161,8 @@ kind: Pod
 metadata:
   name: proxy-only
   namespace: default
+  labels:
+    service.istio.io/canonical-name: proxy-only
 spec:
   containers:
   - name: app
@@ -193,6 +197,8 @@ kind: Pod
 metadata:
   name: pod-level-uid
   namespace: default
+  labels:
+    service.istio.io/canonical-name: pod-level-uid
 spec:
   securityContext:
     runAsUser: 1337
@@ -210,6 +216,8 @@ kind: Pod
 metadata:
   name: overridden-pod
   namespace: default
+  labels:
+    service.istio.io/canonical-name: overridden-pod
 spec:
   securityContext:
     runAsUser: 1337
@@ -229,6 +237,8 @@ kind: Pod
 metadata:
   name: multi-container-pod
   namespace: default
+  labels:
+    service.istio.io/canonical-name: multi-container-pod
 spec:
   containers:
   - name: app

--- a/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
+++ b/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
@@ -1,6 +1,6 @@
 - name: d8.istio.reserved-uid
   rules:
-  - alert: IstioApplicationContainerUsesReservedUID
+  - alert: D8IstioReservedUIDConflict
     expr: max by (namespace, pod, container) (d8_istio_pod_container_reserved_uid == 1)
     for: 10m
     labels:

--- a/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
+++ b/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
@@ -1,0 +1,20 @@
+- name: d8.istio.reserved-uid
+  rules:
+  - alert: IstioApplicationContainerUsesReservedUID
+    expr: max by (namespace, pod, container) (d8_istio_pod_container_reserved_uid == 1)
+    for: 10m
+    labels:
+      severity_level: "4"
+      tier: application
+    annotations:
+      plk_markup_format: "markdown"
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      plk_grouped_by__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
+      summary: Application container is running as UID 1337 (reserved by Istio).
+      description: |
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
+
+        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+
+        To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.

--- a/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
+++ b/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
@@ -11,10 +11,10 @@
       plk_protocol_version: "1"
       plk_create_group_if_not_exists__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: Application container is running as UID 1337 (reserved by Istio).
+      summary: Application container is running as a reserved Istio UID (1337 or 64535).
       description: |
-        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as a UID reserved by Istio (`1337` or `64535`).
 
-        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+        These UIDs are reserved for the `istio-proxy` sidecar container. When application containers run with one of these UIDs, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
 
         To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.

--- a/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
+++ b/modules/110-istio/monitoring/prometheus-rules/reserved-uid.yaml
@@ -11,10 +11,10 @@
       plk_protocol_version: "1"
       plk_create_group_if_not_exists__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
       plk_grouped_by__istio_applications_using_reserved_uid: IstioApplicationsUsingReservedUID,tier=~tier,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: Application container is running as a reserved Istio UID (1337 or 64535).
+      summary: Application container is running as UID 1337 (reserved by Istio).
       description: |
-        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as a UID reserved by Istio (`1337` or `64535`).
+        Container `{{$labels.container}}` in pod `{{$labels.pod}}` in namespace `{{$labels.namespace}}` is running as UID `1337`.
 
-        These UIDs are reserved for the `istio-proxy` sidecar container. When application containers run with one of these UIDs, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
+        UID `1337` is reserved by Istio for the `istio-proxy` sidecar container. When application containers run with this UID, their traffic bypasses Istio completely — no routing rules, mTLS, or telemetry will be applied.
 
         To fix the issue, change the `runAsUser` in the container's or pod's `securityContext` to a different UID.


### PR DESCRIPTION
## Description
Added a hook and alert to monitor user usage of UID `1337` for non-system pods

## Why do we need it, and what problem does it solve?
Users can assign UID `1337` to their applications and the service mesh functions will not work together with the `istio-proxy` sidecar. To do this, an alert is added indicating which pod this UID is assigned to and in which namespace.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Added monitoring of the reserved UID `1337` in pods.
impact_level: default
```
