### PR TITLE
[kubelet]Add container log paths functionality to Kubelet

### DIFF
--- a/modules/000-common/images/kubernetes/patches/1.31/011-kubelet-container-log-paths.patch
+++ b/modules/000-common/images/kubernetes/patches/1.31/011-kubelet-container-log-paths.patch
@@ -1,0 +1,359 @@
+diff --git a/pkg/kubelet/kubelet_container_log_paths.go b/pkg/kubelet/kubelet_container_log_paths.go
+new file mode 100644
+index 00000000000..2f9478000ee
+--- /dev/null
++++ b/pkg/kubelet/kubelet_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package kubelet
++
++import (
++	"context"
++	"fmt"
++
++	"k8s.io/apimachinery/pkg/types"
++	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
++)
++
++// GetContainerLogPaths returns a map of container names to their log directory
++// paths for all containers (init, regular, and ephemeral) in the given pod.
++func (kl *Kubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := kl.GetPodByName(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q in namespace %q not found", podName, podNamespace)
++	}
++
++	var podUID types.UID
++	pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
++	if wasMirror {
++		if pod == nil {
++			return nil, fmt.Errorf("mirror pod %q does not have a corresponding pod", podName)
++		}
++		podUID = mirrorPod.UID
++	} else {
++		podUID = pod.UID
++	}
++
++	result := make(map[string]string)
++	podLogsDir := kl.getPodLogsDir()
++
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++
++	return result, nil
++}
+diff --git a/pkg/kubelet/server/auth_test.go b/pkg/kubelet/server/auth_test.go
+index a03c0047f92..693e5254a19 100644
+--- a/pkg/kubelet/server/auth_test.go
++++ b/pkg/kubelet/server/auth_test.go
+@@ -112,6 +112,7 @@ func AuthzTestCases() []AuthzTestCase {
+ 		"/attach/{podNamespace}/{podID}/{uid}/{containerName}": "proxy",
+ 		"/checkpoint/{podNamespace}/{podID}/{containerName}":   "checkpoint",
+ 		"/configz": "proxy",
++		"/containerLogPaths/{podNamespace}/{podID}":              "proxy",
+ 		"/containerLogs/{podNamespace}/{podID}/{containerName}": "proxy",
+ 		"/debug/flags/v":                                     "proxy",
+ 		"/debug/pprof/{subpath:*}":                           "proxy",
+diff --git a/pkg/kubelet/server/server.go b/pkg/kubelet/server/server.go
+index 998169be724..adeca934eeb 100644
+--- a/pkg/kubelet/server/server.go
++++ b/pkg/kubelet/server/server.go
+@@ -257,6 +257,7 @@ type HostInterface interface {
+ 	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string) ([]byte, error)
+ 	CheckpointContainer(ctx context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error
+ 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
++	GetContainerLogPaths(ctx context.Context, podNamespace, podName string) (map[string]string, error)
+ 	ServeLogs(w http.ResponseWriter, req *http.Request)
+ 	ResyncInterval() time.Duration
+ 	GetHostname() string
+@@ -523,6 +524,16 @@ func (s *Server) InstallDebuggingHandlers() {
+ 		Operation("getContainerLogs"))
+ 	s.restfulCont.Add(ws)
+ 
++	s.addMetricsBucketMatcher("containerLogPaths")
++	ws = new(restful.WebService)
++	ws.
++		Path("/containerLogPaths").
++		Produces(restful.MIME_JSON)
++	ws.Route(ws.GET("/{podNamespace}/{podID}").
++		To(s.getContainerLogPaths).
++		Operation("getContainerLogPaths"))
++	s.restfulCont.Add(ws)
++
+ 	s.addMetricsBucketMatcher("configz")
+ 	configz.InstallHandler(s.restfulCont)
+ 
+@@ -560,11 +571,12 @@ func (s *Server) InstallDebuggingDisabledHandlers() {
+ 	s.addMetricsBucketMatcher("attach")
+ 	s.addMetricsBucketMatcher("portForward")
+ 	s.addMetricsBucketMatcher("containerLogs")
++	s.addMetricsBucketMatcher("containerLogPaths")
+ 	s.addMetricsBucketMatcher("runningpods")
+ 	s.addMetricsBucketMatcher("pprof")
+ 	s.addMetricsBucketMatcher("logs")
+ 	paths := []string{
+-		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/",
++		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/", "/containerLogPaths/",
+ 		"/runningpods/", pprofBasePath, logsPath}
+ 	for _, p := range paths {
+ 		s.restfulCont.Handle(p, h)
+diff --git a/pkg/kubelet/server/server_container_log_paths.go b/pkg/kubelet/server/server_container_log_paths.go
+new file mode 100644
+index 00000000000..bc2e493bbd6
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"net/http"
++
++	"github.com/emicklei/go-restful/v3"
++)
++
++// getContainerLogPaths returns the log directory paths for all containers in the specified pod.
++func (s *Server) getContainerLogPaths(request *restful.Request, response *restful.Response) {
++	podNamespace := request.PathParameter("podNamespace")
++	podID := request.PathParameter("podID")
++	ctx := request.Request.Context()
++
++	if len(podID) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podID."}`))
++		return
++	}
++	if len(podNamespace) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podNamespace."}`))
++		return
++	}
++
++	pod, ok := s.host.GetPodByName(podNamespace, podID)
++	if !ok {
++		response.WriteError(http.StatusNotFound, fmt.Errorf("pod %q does not exist", podID))
++		return
++	}
++
++	logPaths, err := s.host.GetContainerLogPaths(ctx, pod.Namespace, pod.Name)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++
++	data, err := json.Marshal(logPaths)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++	writeJSONResponse(response, data)
++}
+diff --git a/pkg/kubelet/server/server_container_log_paths_test.go b/pkg/kubelet/server/server_container_log_paths_test.go
+new file mode 100644
+index 00000000000..bea7d48c9a8
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths_test.go
+@@ -0,0 +1,137 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"io"
++	"net/http"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++
++	v1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/types"
++)
++
++func TestContainerLogPaths(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "other"
++	podName := "foo"
++	podUID := types.UID("test-uid-123")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		if namespace == podNamespace && name == podName {
++			return &v1.Pod{
++				ObjectMeta: metav1.ObjectMeta{
++					Namespace: podNamespace,
++					Name:      podName,
++					UID:       podUID,
++				},
++				Spec: v1.PodSpec{
++					InitContainers: []v1.Container{
++						{Name: "init-container"},
++					},
++					Containers: []v1.Container{
++						{Name: "main-app"},
++						{Name: "sidecar"},
++					},
++					EphemeralContainers: []v1.EphemeralContainer{
++						{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "debug"}},
++					},
++				},
++			}, true
++		}
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	expected := map[string]string{
++		"init-container": fmt.Sprintf("/var/log/pods/%s_%s_%s/init-container", podNamespace, podName, podUID),
++		"main-app":       fmt.Sprintf("/var/log/pods/%s_%s_%s/main-app", podNamespace, podName, podUID),
++		"sidecar":        fmt.Sprintf("/var/log/pods/%s_%s_%s/sidecar", podNamespace, podName, podUID),
++		"debug":          fmt.Sprintf("/var/log/pods/%s_%s_%s/debug", podNamespace, podName, podUID),
++	}
++	assert.Equal(t, expected, result)
++}
++
++func TestContainerLogPathsPodNotFound(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/default/nonexistent")
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
++}
++
++func TestContainerLogPathsNoContainers(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "default"
++	podName := "empty-pod"
++	podUID := types.UID("empty-uid")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return &v1.Pod{
++			ObjectMeta: metav1.ObjectMeta{
++				Namespace: podNamespace,
++				Name:      podName,
++				UID:       podUID,
++			},
++			Spec: v1.PodSpec{},
++		}, true
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	assert.Empty(t, result)
++}
+diff --git a/pkg/kubelet/server/server_test.go b/pkg/kubelet/server/server_test.go
+index a8ba75464ad..81fdab1e951 100644
+--- a/pkg/kubelet/server/server_test.go
++++ b/pkg/kubelet/server/server_test.go
+@@ -131,6 +131,24 @@ func (fk *fakeKubelet) GetKubeletContainerLogs(ctx context.Context, podFullName,
+ 	return fk.containerLogsFunc(ctx, podFullName, containerName, logOptions, stdout, stderr)
+ }
+ 
++func (fk *fakeKubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := fk.podByNameFunc(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q not found", podName)
++	}
++	result := make(map[string]string)
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	return result, nil
++}
++
+ func (fk *fakeKubelet) GetHostname() string {
+ 	return fk.hostnameFunc()
+ }

--- a/modules/000-common/images/kubernetes/patches/1.32/010-kubelet-container-log-paths.patch
+++ b/modules/000-common/images/kubernetes/patches/1.32/010-kubelet-container-log-paths.patch
@@ -1,0 +1,359 @@
+diff --git a/pkg/kubelet/kubelet_container_log_paths.go b/pkg/kubelet/kubelet_container_log_paths.go
+new file mode 100644
+index 00000000000..2f9478000ee
+--- /dev/null
++++ b/pkg/kubelet/kubelet_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package kubelet
++
++import (
++	"context"
++	"fmt"
++
++	"k8s.io/apimachinery/pkg/types"
++	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
++)
++
++// GetContainerLogPaths returns a map of container names to their log directory
++// paths for all containers (init, regular, and ephemeral) in the given pod.
++func (kl *Kubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := kl.GetPodByName(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q in namespace %q not found", podName, podNamespace)
++	}
++
++	var podUID types.UID
++	pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
++	if wasMirror {
++		if pod == nil {
++			return nil, fmt.Errorf("mirror pod %q does not have a corresponding pod", podName)
++		}
++		podUID = mirrorPod.UID
++	} else {
++		podUID = pod.UID
++	}
++
++	result := make(map[string]string)
++	podLogsDir := kl.getPodLogsDir()
++
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++
++	return result, nil
++}
+diff --git a/pkg/kubelet/server/auth_test.go b/pkg/kubelet/server/auth_test.go
+index fd0256059d2..d06c3d7745a 100644
+--- a/pkg/kubelet/server/auth_test.go
++++ b/pkg/kubelet/server/auth_test.go
+@@ -125,6 +125,7 @@ func AuthzTestCases(fineGrained bool) []AuthzTestCase {
+ 		"/attach/{podNamespace}/{podID}/{uid}/{containerName}": {"proxy"},
+ 		"/checkpoint/{podNamespace}/{podID}/{containerName}":   {"checkpoint"},
+ 		"/configz": {"proxy"},
++		"/containerLogPaths/{podNamespace}/{podID}":              {"proxy"},
+ 		"/containerLogs/{podNamespace}/{podID}/{containerName}": {"proxy"},
+ 		"/debug/flags/v":                                     {"proxy"},
+ 		"/debug/pprof/{subpath:*}":                           {"proxy"},
+diff --git a/pkg/kubelet/server/server.go b/pkg/kubelet/server/server.go
+index 9121d42f8e3..b54c035ce12 100644
+--- a/pkg/kubelet/server/server.go
++++ b/pkg/kubelet/server/server.go
+@@ -268,6 +268,7 @@ type HostInterface interface {
+ 	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string) ([]byte, error)
+ 	CheckpointContainer(ctx context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error
+ 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
++	GetContainerLogPaths(ctx context.Context, podNamespace, podName string) (map[string]string, error)
+ 	ServeLogs(w http.ResponseWriter, req *http.Request)
+ 	GetHostname() string
+ 	SyncLoopHealthCheck(req *http.Request) error
+@@ -553,6 +554,16 @@ func (s *Server) InstallDebuggingHandlers() {
+ 		Operation("getContainerLogs"))
+ 	s.restfulCont.Add(ws)
+ 
++	s.addMetricsBucketMatcher("containerLogPaths")
++	ws = new(restful.WebService)
++	ws.
++		Path("/containerLogPaths").
++		Produces(restful.MIME_JSON)
++	ws.Route(ws.GET("/{podNamespace}/{podID}").
++		To(s.getContainerLogPaths).
++		Operation("getContainerLogPaths"))
++	s.restfulCont.Add(ws)
++
+ 	s.addMetricsBucketMatcher("configz")
+ 	configz.InstallHandler(s.restfulCont)
+ 
+@@ -590,11 +601,12 @@ func (s *Server) InstallDebuggingDisabledHandlers() {
+ 	s.addMetricsBucketMatcher("attach")
+ 	s.addMetricsBucketMatcher("portForward")
+ 	s.addMetricsBucketMatcher("containerLogs")
++	s.addMetricsBucketMatcher("containerLogPaths")
+ 	s.addMetricsBucketMatcher("runningpods")
+ 	s.addMetricsBucketMatcher("pprof")
+ 	s.addMetricsBucketMatcher("logs")
+ 	paths := []string{
+-		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/",
++		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/", "/containerLogPaths/",
+ 		runningPodsPath, pprofBasePath, logsPath}
+ 	for _, p := range paths {
+ 		s.restfulCont.Handle(p, h)
+diff --git a/pkg/kubelet/server/server_container_log_paths.go b/pkg/kubelet/server/server_container_log_paths.go
+new file mode 100644
+index 00000000000..bc2e493bbd6
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"net/http"
++
++	"github.com/emicklei/go-restful/v3"
++)
++
++// getContainerLogPaths returns the log directory paths for all containers in the specified pod.
++func (s *Server) getContainerLogPaths(request *restful.Request, response *restful.Response) {
++	podNamespace := request.PathParameter("podNamespace")
++	podID := request.PathParameter("podID")
++	ctx := request.Request.Context()
++
++	if len(podID) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podID."}`))
++		return
++	}
++	if len(podNamespace) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podNamespace."}`))
++		return
++	}
++
++	pod, ok := s.host.GetPodByName(podNamespace, podID)
++	if !ok {
++		response.WriteError(http.StatusNotFound, fmt.Errorf("pod %q does not exist", podID))
++		return
++	}
++
++	logPaths, err := s.host.GetContainerLogPaths(ctx, pod.Namespace, pod.Name)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++
++	data, err := json.Marshal(logPaths)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++	writeJSONResponse(response, data)
++}
+diff --git a/pkg/kubelet/server/server_container_log_paths_test.go b/pkg/kubelet/server/server_container_log_paths_test.go
+new file mode 100644
+index 00000000000..bea7d48c9a8
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths_test.go
+@@ -0,0 +1,137 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"io"
++	"net/http"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++
++	v1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/types"
++)
++
++func TestContainerLogPaths(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "other"
++	podName := "foo"
++	podUID := types.UID("test-uid-123")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		if namespace == podNamespace && name == podName {
++			return &v1.Pod{
++				ObjectMeta: metav1.ObjectMeta{
++					Namespace: podNamespace,
++					Name:      podName,
++					UID:       podUID,
++				},
++				Spec: v1.PodSpec{
++					InitContainers: []v1.Container{
++						{Name: "init-container"},
++					},
++					Containers: []v1.Container{
++						{Name: "main-app"},
++						{Name: "sidecar"},
++					},
++					EphemeralContainers: []v1.EphemeralContainer{
++						{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "debug"}},
++					},
++				},
++			}, true
++		}
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	expected := map[string]string{
++		"init-container": fmt.Sprintf("/var/log/pods/%s_%s_%s/init-container", podNamespace, podName, podUID),
++		"main-app":       fmt.Sprintf("/var/log/pods/%s_%s_%s/main-app", podNamespace, podName, podUID),
++		"sidecar":        fmt.Sprintf("/var/log/pods/%s_%s_%s/sidecar", podNamespace, podName, podUID),
++		"debug":          fmt.Sprintf("/var/log/pods/%s_%s_%s/debug", podNamespace, podName, podUID),
++	}
++	assert.Equal(t, expected, result)
++}
++
++func TestContainerLogPathsPodNotFound(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/default/nonexistent")
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
++}
++
++func TestContainerLogPathsNoContainers(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "default"
++	podName := "empty-pod"
++	podUID := types.UID("empty-uid")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return &v1.Pod{
++			ObjectMeta: metav1.ObjectMeta{
++				Namespace: podNamespace,
++				Name:      podName,
++				UID:       podUID,
++			},
++			Spec: v1.PodSpec{},
++		}, true
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	assert.Empty(t, result)
++}
+diff --git a/pkg/kubelet/server/server_test.go b/pkg/kubelet/server/server_test.go
+index a79e71742bf..73f04e722b5 100644
+--- a/pkg/kubelet/server/server_test.go
++++ b/pkg/kubelet/server/server_test.go
+@@ -129,6 +129,24 @@ func (fk *fakeKubelet) GetKubeletContainerLogs(ctx context.Context, podFullName,
+ 	return fk.containerLogsFunc(ctx, podFullName, containerName, logOptions, stdout, stderr)
+ }
+ 
++func (fk *fakeKubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := fk.podByNameFunc(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q not found", podName)
++	}
++	result := make(map[string]string)
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	return result, nil
++}
++
+ func (fk *fakeKubelet) GetHostname() string {
+ 	return fk.hostnameFunc()
+ }

--- a/modules/000-common/images/kubernetes/patches/1.33/010-kubelet-container-log-paths.patch
+++ b/modules/000-common/images/kubernetes/patches/1.33/010-kubelet-container-log-paths.patch
@@ -1,0 +1,367 @@
+diff --git a/pkg/kubelet/kubelet_container_log_paths.go b/pkg/kubelet/kubelet_container_log_paths.go
+new file mode 100644
+index 00000000000..2f9478000ee
+--- /dev/null
++++ b/pkg/kubelet/kubelet_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package kubelet
++
++import (
++	"context"
++	"fmt"
++
++	"k8s.io/apimachinery/pkg/types"
++	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
++)
++
++// GetContainerLogPaths returns a map of container names to their log directory
++// paths for all containers (init, regular, and ephemeral) in the given pod.
++func (kl *Kubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := kl.GetPodByName(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q in namespace %q not found", podName, podNamespace)
++	}
++
++	var podUID types.UID
++	pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
++	if wasMirror {
++		if pod == nil {
++			return nil, fmt.Errorf("mirror pod %q does not have a corresponding pod", podName)
++		}
++		podUID = mirrorPod.UID
++	} else {
++		podUID = pod.UID
++	}
++
++	result := make(map[string]string)
++	podLogsDir := kl.getPodLogsDir()
++
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++
++	return result, nil
++}
+diff --git a/pkg/kubelet/server/auth_test.go b/pkg/kubelet/server/auth_test.go
+index 05874015bc9..10bb217c43b 100644
+--- a/pkg/kubelet/server/auth_test.go
++++ b/pkg/kubelet/server/auth_test.go
+@@ -127,6 +127,7 @@ func AuthzTestCases(fineGrained bool) []AuthzTestCase {
+ 		"/configz": {"proxy"},
+ 		"/flagz":   {"configz"},
+ 		"/statusz": {"statusz"},
++		"/containerLogPaths/{podNamespace}/{podID}":              {"proxy"},
+ 		"/containerLogs/{podNamespace}/{podID}/{containerName}": {"proxy"},
+ 		"/debug/flags/v":                                     {"proxy"},
+ 		"/debug/pprof/{subpath:*}":                           {"proxy"},
+diff --git a/pkg/kubelet/server/server.go b/pkg/kubelet/server/server.go
+index 83d344d17b5..0583421049d 100644
+--- a/pkg/kubelet/server/server.go
++++ b/pkg/kubelet/server/server.go
+@@ -280,6 +280,7 @@ type HostInterface interface {
+ 	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string) ([]byte, error)
+ 	CheckpointContainer(ctx context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error
+ 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
++	GetContainerLogPaths(ctx context.Context, podNamespace, podName string) (map[string]string, error)
+ 	ServeLogs(w http.ResponseWriter, req *http.Request)
+ 	GetHostname() string
+ 	SyncLoopHealthCheck(req *http.Request) error
+@@ -578,6 +579,16 @@ func (s *Server) InstallAuthRequiredHandlers() {
+ 		Operation("getContainerLogs"))
+ 	s.restfulCont.Add(ws)
+ 
++	s.addMetricsBucketMatcher("containerLogPaths")
++	ws = new(restful.WebService)
++	ws.
++		Path("/containerLogPaths").
++		Produces(restful.MIME_JSON)
++	ws.Route(ws.GET("/{podNamespace}/{podID}").
++		To(s.getContainerLogPaths).
++		Operation("getContainerLogPaths"))
++	s.restfulCont.Add(ws)
++
+ 	s.addMetricsBucketMatcher("configz")
+ 	configz.InstallHandler(s.restfulCont)
+ 
+@@ -627,11 +638,12 @@ func (s *Server) InstallDebuggingDisabledHandlers() {
+ 	s.addMetricsBucketMatcher("attach")
+ 	s.addMetricsBucketMatcher("portForward")
+ 	s.addMetricsBucketMatcher("containerLogs")
++	s.addMetricsBucketMatcher("containerLogPaths")
+ 	s.addMetricsBucketMatcher("runningpods")
+ 	s.addMetricsBucketMatcher("pprof")
+ 	s.addMetricsBucketMatcher("logs")
+ 	paths := []string{
+-		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/",
++		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/", "/containerLogPaths/",
+ 		runningPodsPath, pprofBasePath, logsPath}
+ 	for _, p := range paths {
+ 		s.restfulCont.Handle(p, h)
+diff --git a/pkg/kubelet/server/server_container_log_paths.go b/pkg/kubelet/server/server_container_log_paths.go
+new file mode 100644
+index 00000000000..bc2e493bbd6
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"net/http"
++
++	"github.com/emicklei/go-restful/v3"
++)
++
++// getContainerLogPaths returns the log directory paths for all containers in the specified pod.
++func (s *Server) getContainerLogPaths(request *restful.Request, response *restful.Response) {
++	podNamespace := request.PathParameter("podNamespace")
++	podID := request.PathParameter("podID")
++	ctx := request.Request.Context()
++
++	if len(podID) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podID."}`))
++		return
++	}
++	if len(podNamespace) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podNamespace."}`))
++		return
++	}
++
++	pod, ok := s.host.GetPodByName(podNamespace, podID)
++	if !ok {
++		response.WriteError(http.StatusNotFound, fmt.Errorf("pod %q does not exist", podID))
++		return
++	}
++
++	logPaths, err := s.host.GetContainerLogPaths(ctx, pod.Namespace, pod.Name)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++
++	data, err := json.Marshal(logPaths)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++	writeJSONResponse(response, data)
++}
+diff --git a/pkg/kubelet/server/server_container_log_paths_test.go b/pkg/kubelet/server/server_container_log_paths_test.go
+new file mode 100644
+index 00000000000..bea7d48c9a8
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths_test.go
+@@ -0,0 +1,137 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"io"
++	"net/http"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++
++	v1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/types"
++)
++
++func TestContainerLogPaths(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "other"
++	podName := "foo"
++	podUID := types.UID("test-uid-123")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		if namespace == podNamespace && name == podName {
++			return &v1.Pod{
++				ObjectMeta: metav1.ObjectMeta{
++					Namespace: podNamespace,
++					Name:      podName,
++					UID:       podUID,
++				},
++				Spec: v1.PodSpec{
++					InitContainers: []v1.Container{
++						{Name: "init-container"},
++					},
++					Containers: []v1.Container{
++						{Name: "main-app"},
++						{Name: "sidecar"},
++					},
++					EphemeralContainers: []v1.EphemeralContainer{
++						{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "debug"}},
++					},
++				},
++			}, true
++		}
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	expected := map[string]string{
++		"init-container": fmt.Sprintf("/var/log/pods/%s_%s_%s/init-container", podNamespace, podName, podUID),
++		"main-app":       fmt.Sprintf("/var/log/pods/%s_%s_%s/main-app", podNamespace, podName, podUID),
++		"sidecar":        fmt.Sprintf("/var/log/pods/%s_%s_%s/sidecar", podNamespace, podName, podUID),
++		"debug":          fmt.Sprintf("/var/log/pods/%s_%s_%s/debug", podNamespace, podName, podUID),
++	}
++	assert.Equal(t, expected, result)
++}
++
++func TestContainerLogPathsPodNotFound(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/default/nonexistent")
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
++}
++
++func TestContainerLogPathsNoContainers(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "default"
++	podName := "empty-pod"
++	podUID := types.UID("empty-uid")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return &v1.Pod{
++			ObjectMeta: metav1.ObjectMeta{
++				Namespace: podNamespace,
++				Name:      podName,
++				UID:       podUID,
++			},
++			Spec: v1.PodSpec{},
++		}, true
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	assert.Empty(t, result)
++}
+diff --git a/pkg/kubelet/server/server_test.go b/pkg/kubelet/server/server_test.go
+index 8a9c2f5d1c9..f4890a143fc 100644
+--- a/pkg/kubelet/server/server_test.go
++++ b/pkg/kubelet/server/server_test.go
+@@ -132,6 +132,24 @@ func (fk *fakeKubelet) GetKubeletContainerLogs(ctx context.Context, podFullName,
+ 	return fk.containerLogsFunc(ctx, podFullName, containerName, logOptions, stdout, stderr)
+ }
+ 
++func (fk *fakeKubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := fk.podByNameFunc(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q not found", podName)
++	}
++	result := make(map[string]string)
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	return result, nil
++}
++
+ func (fk *fakeKubelet) GetHostname() string {
+ 	return fk.hostnameFunc()
+ }
+@@ -605,6 +623,7 @@ func TestInstallAuthNotRequiredHandlers(t *testing.T) {
+ 		"/attach/",
+ 		"/portForward/",
+ 		"/containerLogs/",
++		"/containerLogPaths/",
+ 		"/runningpods/",
+ 		"/debug/pprof/",
+ 		"/logs/",

--- a/modules/000-common/images/kubernetes/patches/1.34/010-kubelet-container-log-paths.patch
+++ b/modules/000-common/images/kubernetes/patches/1.34/010-kubelet-container-log-paths.patch
@@ -1,0 +1,367 @@
+diff --git a/pkg/kubelet/kubelet_container_log_paths.go b/pkg/kubelet/kubelet_container_log_paths.go
+new file mode 100644
+index 00000000000..2f9478000ee
+--- /dev/null
++++ b/pkg/kubelet/kubelet_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package kubelet
++
++import (
++	"context"
++	"fmt"
++
++	"k8s.io/apimachinery/pkg/types"
++	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
++)
++
++// GetContainerLogPaths returns a map of container names to their log directory
++// paths for all containers (init, regular, and ephemeral) in the given pod.
++func (kl *Kubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := kl.GetPodByName(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q in namespace %q not found", podName, podNamespace)
++	}
++
++	var podUID types.UID
++	pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
++	if wasMirror {
++		if pod == nil {
++			return nil, fmt.Errorf("mirror pod %q does not have a corresponding pod", podName)
++		}
++		podUID = mirrorPod.UID
++	} else {
++		podUID = pod.UID
++	}
++
++	result := make(map[string]string)
++	podLogsDir := kl.getPodLogsDir()
++
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++
++	return result, nil
++}
+diff --git a/pkg/kubelet/server/auth_test.go b/pkg/kubelet/server/auth_test.go
+index 05874015bc9..10bb217c43b 100644
+--- a/pkg/kubelet/server/auth_test.go
++++ b/pkg/kubelet/server/auth_test.go
+@@ -127,6 +127,7 @@ func AuthzTestCases(fineGrained bool) []AuthzTestCase {
+ 		"/configz": {"proxy"},
+ 		"/flagz":   {"configz"},
+ 		"/statusz": {"statusz"},
++		"/containerLogPaths/{podNamespace}/{podID}":              {"proxy"},
+ 		"/containerLogs/{podNamespace}/{podID}/{containerName}": {"proxy"},
+ 		"/debug/flags/v":                                     {"proxy"},
+ 		"/debug/pprof/{subpath:*}":                           {"proxy"},
+diff --git a/pkg/kubelet/server/server.go b/pkg/kubelet/server/server.go
+index 4496a5a937d..8cc197663fa 100644
+--- a/pkg/kubelet/server/server.go
++++ b/pkg/kubelet/server/server.go
+@@ -274,6 +274,7 @@ type HostInterface interface {
+ 	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string) ([]byte, error)
+ 	CheckpointContainer(ctx context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error
+ 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
++	GetContainerLogPaths(ctx context.Context, podNamespace, podName string) (map[string]string, error)
+ 	ServeLogs(w http.ResponseWriter, req *http.Request)
+ 	SyncLoopHealthCheck(req *http.Request) error
+ 	GetExec(ctx context.Context, podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommandserver.Options) (*url.URL, error)
+@@ -571,6 +572,16 @@ func (s *Server) InstallAuthRequiredHandlers() {
+ 		Operation("getContainerLogs"))
+ 	s.restfulCont.Add(ws)
+ 
++	s.addMetricsBucketMatcher("containerLogPaths")
++	ws = new(restful.WebService)
++	ws.
++		Path("/containerLogPaths").
++		Produces(restful.MIME_JSON)
++	ws.Route(ws.GET("/{podNamespace}/{podID}").
++		To(s.getContainerLogPaths).
++		Operation("getContainerLogPaths"))
++	s.restfulCont.Add(ws)
++
+ 	s.addMetricsBucketMatcher("configz")
+ 	configz.InstallHandler(s.restfulCont)
+ 
+@@ -620,11 +631,12 @@ func (s *Server) InstallDebuggingDisabledHandlers() {
+ 	s.addMetricsBucketMatcher("attach")
+ 	s.addMetricsBucketMatcher("portForward")
+ 	s.addMetricsBucketMatcher("containerLogs")
++	s.addMetricsBucketMatcher("containerLogPaths")
+ 	s.addMetricsBucketMatcher("runningpods")
+ 	s.addMetricsBucketMatcher("pprof")
+ 	s.addMetricsBucketMatcher("logs")
+ 	paths := []string{
+-		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/",
++		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/", "/containerLogPaths/",
+ 		runningPodsPath, pprofBasePath, logsPath}
+ 	for _, p := range paths {
+ 		s.restfulCont.Handle(p, h)
+diff --git a/pkg/kubelet/server/server_container_log_paths.go b/pkg/kubelet/server/server_container_log_paths.go
+new file mode 100644
+index 00000000000..bc2e493bbd6
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"net/http"
++
++	"github.com/emicklei/go-restful/v3"
++)
++
++// getContainerLogPaths returns the log directory paths for all containers in the specified pod.
++func (s *Server) getContainerLogPaths(request *restful.Request, response *restful.Response) {
++	podNamespace := request.PathParameter("podNamespace")
++	podID := request.PathParameter("podID")
++	ctx := request.Request.Context()
++
++	if len(podID) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podID."}`))
++		return
++	}
++	if len(podNamespace) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podNamespace."}`))
++		return
++	}
++
++	pod, ok := s.host.GetPodByName(podNamespace, podID)
++	if !ok {
++		response.WriteError(http.StatusNotFound, fmt.Errorf("pod %q does not exist", podID))
++		return
++	}
++
++	logPaths, err := s.host.GetContainerLogPaths(ctx, pod.Namespace, pod.Name)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++
++	data, err := json.Marshal(logPaths)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++	writeJSONResponse(response, data)
++}
+diff --git a/pkg/kubelet/server/server_container_log_paths_test.go b/pkg/kubelet/server/server_container_log_paths_test.go
+new file mode 100644
+index 00000000000..bea7d48c9a8
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths_test.go
+@@ -0,0 +1,137 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"io"
++	"net/http"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++
++	v1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/types"
++)
++
++func TestContainerLogPaths(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "other"
++	podName := "foo"
++	podUID := types.UID("test-uid-123")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		if namespace == podNamespace && name == podName {
++			return &v1.Pod{
++				ObjectMeta: metav1.ObjectMeta{
++					Namespace: podNamespace,
++					Name:      podName,
++					UID:       podUID,
++				},
++				Spec: v1.PodSpec{
++					InitContainers: []v1.Container{
++						{Name: "init-container"},
++					},
++					Containers: []v1.Container{
++						{Name: "main-app"},
++						{Name: "sidecar"},
++					},
++					EphemeralContainers: []v1.EphemeralContainer{
++						{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "debug"}},
++					},
++				},
++			}, true
++		}
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	expected := map[string]string{
++		"init-container": fmt.Sprintf("/var/log/pods/%s_%s_%s/init-container", podNamespace, podName, podUID),
++		"main-app":       fmt.Sprintf("/var/log/pods/%s_%s_%s/main-app", podNamespace, podName, podUID),
++		"sidecar":        fmt.Sprintf("/var/log/pods/%s_%s_%s/sidecar", podNamespace, podName, podUID),
++		"debug":          fmt.Sprintf("/var/log/pods/%s_%s_%s/debug", podNamespace, podName, podUID),
++	}
++	assert.Equal(t, expected, result)
++}
++
++func TestContainerLogPathsPodNotFound(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/default/nonexistent")
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
++}
++
++func TestContainerLogPathsNoContainers(t *testing.T) {
++	fw := newServerTest()
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "default"
++	podName := "empty-pod"
++	podUID := types.UID("empty-uid")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return &v1.Pod{
++			ObjectMeta: metav1.ObjectMeta{
++				Namespace: podNamespace,
++				Name:      podName,
++				UID:       podUID,
++			},
++			Spec: v1.PodSpec{},
++		}, true
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	assert.Empty(t, result)
++}
+diff --git a/pkg/kubelet/server/server_test.go b/pkg/kubelet/server/server_test.go
+index 89c55f0e97b..4abbf61f035 100644
+--- a/pkg/kubelet/server/server_test.go
++++ b/pkg/kubelet/server/server_test.go
+@@ -131,6 +131,24 @@ func (fk *fakeKubelet) GetKubeletContainerLogs(ctx context.Context, podFullName,
+ 	return fk.containerLogsFunc(ctx, podFullName, containerName, logOptions, stdout, stderr)
+ }
+ 
++func (fk *fakeKubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := fk.podByNameFunc(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q not found", podName)
++	}
++	result := make(map[string]string)
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	return result, nil
++}
++
+ func (fk *fakeKubelet) RunInContainer(_ context.Context, podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error) {
+ 	return fk.runFunc(podFullName, uid, containerName, cmd)
+ }
+@@ -587,6 +605,7 @@ func TestInstallAuthNotRequiredHandlers(t *testing.T) {
+ 		"/attach/",
+ 		"/portForward/",
+ 		"/containerLogs/",
++		"/containerLogPaths/",
+ 		"/runningpods/",
+ 		"/debug/pprof/",
+ 		"/logs/",

--- a/modules/000-common/images/kubernetes/patches/1.35/008-kubelet-container-log-paths.patch
+++ b/modules/000-common/images/kubernetes/patches/1.35/008-kubelet-container-log-paths.patch
@@ -1,0 +1,374 @@
+diff --git a/pkg/kubelet/kubelet_container_log_paths.go b/pkg/kubelet/kubelet_container_log_paths.go
+new file mode 100644
+index 00000000000..2f9478000ee
+--- /dev/null
++++ b/pkg/kubelet/kubelet_container_log_paths.go
+@@ -0,0 +1,60 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package kubelet
++
++import (
++	"context"
++	"fmt"
++
++	"k8s.io/apimachinery/pkg/types"
++	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
++)
++
++// GetContainerLogPaths returns a map of container names to their log directory
++// paths for all containers (init, regular, and ephemeral) in the given pod.
++func (kl *Kubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := kl.GetPodByName(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q in namespace %q not found", podName, podNamespace)
++	}
++
++	var podUID types.UID
++	pod, mirrorPod, wasMirror := kl.podManager.GetPodAndMirrorPod(pod)
++	if wasMirror {
++		if pod == nil {
++			return nil, fmt.Errorf("mirror pod %q does not have a corresponding pod", podName)
++		}
++		podUID = mirrorPod.UID
++	} else {
++		podUID = pod.UID
++	}
++
++	result := make(map[string]string)
++	podLogsDir := kl.getPodLogsDir()
++
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = kuberuntime.BuildContainerLogsDirectory(podLogsDir, podNamespace, podName, podUID, c.Name)
++	}
++
++	return result, nil
++}
+diff --git a/pkg/kubelet/server/auth_test.go b/pkg/kubelet/server/auth_test.go
+index 27f001f99fa..ad353db76b3 100644
+--- a/pkg/kubelet/server/auth_test.go
++++ b/pkg/kubelet/server/auth_test.go
+@@ -129,6 +129,7 @@ func AuthzTestCases(fineGrained bool) []AuthzTestCase {
+ 		"/configz": {"proxy"},
+ 		"/flagz":   {"configz"},
+ 		"/statusz": {"statusz"},
++		"/containerLogPaths/{podNamespace}/{podID}":              {"proxy"},
+ 		"/containerLogs/{podNamespace}/{podID}/{containerName}": {"proxy"},
+ 		"/debug/flags/v":                                     {"proxy"},
+ 		"/debug/pprof/{subpath:*}":                           {"proxy"},
+diff --git a/pkg/kubelet/server/server.go b/pkg/kubelet/server/server.go
+index 31ecfe65672..2cbdad602a4 100644
+--- a/pkg/kubelet/server/server.go
++++ b/pkg/kubelet/server/server.go
+@@ -279,6 +279,7 @@ type HostInterface interface {
+ 	RunInContainer(ctx context.Context, name string, uid types.UID, container string, cmd []string) ([]byte, error)
+ 	CheckpointContainer(ctx context.Context, podUID types.UID, podFullName, containerName string, options *runtimeapi.CheckpointContainerRequest) error
+ 	GetKubeletContainerLogs(ctx context.Context, podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
++	GetContainerLogPaths(ctx context.Context, podNamespace, podName string) (map[string]string, error)
+ 	ServeLogs(w http.ResponseWriter, req *http.Request)
+ 	SyncLoopHealthCheck(req *http.Request) error
+ 	GetExec(ctx context.Context, podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommandserver.Options) (*url.URL, error)
+@@ -596,6 +597,18 @@ func (s *Server) InstallAuthRequiredHandlers(ctx context.Context) {
+ 		Operation("getContainerLogs"))
+ 	s.restfulCont.Add(ws)
+ 
++	s.addMetricsBucketMatcher("containerLogPaths")
++	ws = new(restful.WebService)
++	ws.
++		Path("/containerLogPaths").
++		Produces(restful.MIME_JSON)
++	ws.Route(ws.GET("/{podNamespace}/{podID}").
++		To(func(request *restful.Request, response *restful.Response) {
++			s.getContainerLogPaths(logger, request, response)
++		}).
++		Operation("getContainerLogPaths"))
++	s.restfulCont.Add(ws)
++
+ 	s.addMetricsBucketMatcher("configz")
+ 	configz.InstallHandler(s.restfulCont)
+ 
+@@ -640,11 +653,12 @@ func (s *Server) InstallDebuggingDisabledHandlers() {
+ 	s.addMetricsBucketMatcher("attach")
+ 	s.addMetricsBucketMatcher("portForward")
+ 	s.addMetricsBucketMatcher("containerLogs")
++	s.addMetricsBucketMatcher("containerLogPaths")
+ 	s.addMetricsBucketMatcher("runningpods")
+ 	s.addMetricsBucketMatcher("pprof")
+ 	s.addMetricsBucketMatcher("logs")
+ 	paths := []string{
+-		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/",
++		"/run/", "/exec/", "/attach/", "/portForward/", "/containerLogs/", "/containerLogPaths/",
+ 		runningPodsPath, pprofBasePath, logsPath}
+ 	for _, p := range paths {
+ 		s.restfulCont.Handle(p, h)
+diff --git a/pkg/kubelet/server/server_container_log_paths.go b/pkg/kubelet/server/server_container_log_paths.go
+new file mode 100644
+index 00000000000..9a49db44064
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths.go
+@@ -0,0 +1,61 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"net/http"
++
++	"github.com/emicklei/go-restful/v3"
++	"k8s.io/klog/v2"
++)
++
++// getContainerLogPaths returns the log directory paths for all containers in the specified pod.
++func (s *Server) getContainerLogPaths(logger klog.Logger, request *restful.Request, response *restful.Response) {
++	podNamespace := request.PathParameter("podNamespace")
++	podID := request.PathParameter("podID")
++	ctx := request.Request.Context()
++
++	if len(podID) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podID."}`))
++		return
++	}
++	if len(podNamespace) == 0 {
++		response.WriteError(http.StatusBadRequest, fmt.Errorf(`{"message": "Missing podNamespace."}`))
++		return
++	}
++
++	pod, ok := s.host.GetPodByName(podNamespace, podID)
++	if !ok {
++		response.WriteError(http.StatusNotFound, fmt.Errorf("pod %q does not exist", podID))
++		return
++	}
++
++	logPaths, err := s.host.GetContainerLogPaths(ctx, pod.Namespace, pod.Name)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++
++	data, err := json.Marshal(logPaths)
++	if err != nil {
++		response.WriteError(http.StatusInternalServerError, err)
++		return
++	}
++	writeJSONResponse(logger, response, data)
++}
+diff --git a/pkg/kubelet/server/server_container_log_paths_test.go b/pkg/kubelet/server/server_container_log_paths_test.go
+new file mode 100644
+index 00000000000..00a79acea32
+--- /dev/null
++++ b/pkg/kubelet/server/server_container_log_paths_test.go
+@@ -0,0 +1,141 @@
++/*
++Copyright 2024 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package server
++
++import (
++	"encoding/json"
++	"fmt"
++	"io"
++	"net/http"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++
++	v1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/types"
++	"k8s.io/kubernetes/test/utils/ktesting"
++)
++
++func TestContainerLogPaths(t *testing.T) {
++	tCtx := ktesting.Init(t)
++	fw := newServerTest(tCtx)
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "other"
++	podName := "foo"
++	podUID := types.UID("test-uid-123")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		if namespace == podNamespace && name == podName {
++			return &v1.Pod{
++				ObjectMeta: metav1.ObjectMeta{
++					Namespace: podNamespace,
++					Name:      podName,
++					UID:       podUID,
++				},
++				Spec: v1.PodSpec{
++					InitContainers: []v1.Container{
++						{Name: "init-container"},
++					},
++					Containers: []v1.Container{
++						{Name: "main-app"},
++						{Name: "sidecar"},
++					},
++					EphemeralContainers: []v1.EphemeralContainer{
++						{EphemeralContainerCommon: v1.EphemeralContainerCommon{Name: "debug"}},
++					},
++				},
++			}, true
++		}
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	expected := map[string]string{
++		"init-container": fmt.Sprintf("/var/log/pods/%s_%s_%s/init-container", podNamespace, podName, podUID),
++		"main-app":       fmt.Sprintf("/var/log/pods/%s_%s_%s/main-app", podNamespace, podName, podUID),
++		"sidecar":        fmt.Sprintf("/var/log/pods/%s_%s_%s/sidecar", podNamespace, podName, podUID),
++		"debug":          fmt.Sprintf("/var/log/pods/%s_%s_%s/debug", podNamespace, podName, podUID),
++	}
++	assert.Equal(t, expected, result)
++}
++
++func TestContainerLogPathsPodNotFound(t *testing.T) {
++	tCtx := ktesting.Init(t)
++	fw := newServerTest(tCtx)
++	defer fw.testHTTPServer.Close()
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return nil, false
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/default/nonexistent")
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
++}
++
++func TestContainerLogPathsNoContainers(t *testing.T) {
++	tCtx := ktesting.Init(t)
++	fw := newServerTest(tCtx)
++	defer fw.testHTTPServer.Close()
++
++	podNamespace := "default"
++	podName := "empty-pod"
++	podUID := types.UID("empty-uid")
++
++	fw.fakeKubelet.podByNameFunc = func(namespace, name string) (*v1.Pod, bool) {
++		return &v1.Pod{
++			ObjectMeta: metav1.ObjectMeta{
++				Namespace: podNamespace,
++				Name:      podName,
++				UID:       podUID,
++			},
++			Spec: v1.PodSpec{},
++		}, true
++	}
++
++	resp, err := http.Get(fw.testHTTPServer.URL + "/containerLogPaths/" + podNamespace + "/" + podName)
++	require.NoError(t, err)
++	defer resp.Body.Close()
++
++	assert.Equal(t, http.StatusOK, resp.StatusCode)
++
++	body, err := io.ReadAll(resp.Body)
++	require.NoError(t, err)
++
++	var result map[string]string
++	err = json.Unmarshal(body, &result)
++	require.NoError(t, err)
++
++	assert.Empty(t, result)
++}
+diff --git a/pkg/kubelet/server/server_test.go b/pkg/kubelet/server/server_test.go
+index 97091722ef5..6b17f18fac3 100644
+--- a/pkg/kubelet/server/server_test.go
++++ b/pkg/kubelet/server/server_test.go
+@@ -133,6 +133,24 @@ func (fk *fakeKubelet) GetKubeletContainerLogs(ctx context.Context, podFullName,
+ 	return fk.containerLogsFunc(ctx, podFullName, containerName, logOptions, stdout, stderr)
+ }
+ 
++func (fk *fakeKubelet) GetContainerLogPaths(_ context.Context, podNamespace, podName string) (map[string]string, error) {
++	pod, ok := fk.podByNameFunc(podNamespace, podName)
++	if !ok {
++		return nil, fmt.Errorf("pod %q not found", podName)
++	}
++	result := make(map[string]string)
++	for _, c := range pod.Spec.InitContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.Containers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	for _, c := range pod.Spec.EphemeralContainers {
++		result[c.Name] = fmt.Sprintf("/var/log/pods/%s_%s_%s/%s", podNamespace, podName, pod.UID, c.Name)
++	}
++	return result, nil
++}
++
+ func (fk *fakeKubelet) RunInContainer(_ context.Context, podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error) {
+ 	return fk.runFunc(podFullName, uid, containerName, cmd)
+ }
+@@ -632,6 +650,7 @@ func TestInstallAuthNotRequiredHandlers(t *testing.T) {
+ 		"/attach/",
+ 		"/portForward/",
+ 		"/containerLogs/",
++		"/containerLogPaths/",
+ 		"/runningpods/",
+ 		"/debug/pprof/",
+ 		"/logs/",


### PR DESCRIPTION
This commit introduces a new feature to retrieve the log directory paths for all containers (init, regular, and ephemeral) in a specified pod. The implementation includes a new API endpoint `/containerLogPaths/{podNamespace}/{podID}` that allows users to access these paths. Additionally, necessary updates were made to the server and authentication tests to support this new functionality.

- Added `GetContainerLogPaths` method in the Kubelet.
- Implemented `getContainerLogPaths` handler in the server.
- Updated routing to include the new endpoint.
- Enhanced authentication tests to cover the new log paths endpoint.