### PR TITLE
[deckhouse] Change deployment update mode to InPlaceOrRecreate

### DIFF
--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     kind: Deployment
     name: deckhouse
   updatePolicy:
-    updateMode: "Initial"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     - containerName: deckhouse


### PR DESCRIPTION
## Description
This PR change update mode in VPA for deckhouse to InPlaceOrRecreate.
VPA will monitor pod resource consumption metrics and update pod CPU and memory usage requests directly in-place so they also display normal pod resource consumption.

### Current behavior:
When creating a deckhouse pod in VPA "Initial" mode, VPA applies the recommended CPU and memory usage requests only once during pod creation.
```bash
kubect get vpa deckhouse
NAME        MODE      CPU   MEM     PROVIDED   AGE
deckhouse   Initial   1     500Mi   True       21d

kgp -l app=deckhouse -o yaml|yq '.items[].spec.containers[0].resources' 
limits:
  memory: 6Gi
requests:
  cpu: "1"
  ephemeral-storage: 150Mi
  memory: 500Mi

# and no changes over time even if we change VPA minimal memory requests to 700Mi
kubect get vpa deckhouse
NAME        MODE      CPU   MEM     PROVIDED   AGE
deckhouse   Initial   1     700Mi   True       21d

kgp -l app=deckhouse -o yaml|yq '.items[].spec.containers[0].resources' 
limits:
  memory: 6Gi
requests:
  cpu: "1"
  ephemeral-storage: 150Mi
  memory: 500Mi
```

### With InPlaceOrRecreate mode:
In InPlaceOrRecreate mode, VPA attempts to update Pod resource requests and limits without restarting the Pod when possible. However, if in-place updates cannot be performed for a particular resource change, VPA falls back to evicting the Pod (similar to Recreate mode) and allowing the workload controller to create a replacement Pod with updated resources.

In this mode, the updater applies recommendations in-place using the [Resize Container Resources In-Place](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/) feature.
```bash
kubect get vpa deckhouse
NAME        MODE      CPU   MEM     PROVIDED   AGE
deckhouse   Initial   1     500Mi   True       21d

kgp -l app=deckhouse -o yaml|yq '.items[].spec.containers[0].resources' 
limits:
  memory: 6Gi
requests:
  cpu: "1"
  ephemeral-storage: 150Mi
  memory: 500Mi

# and it will changes over time 
# for example, we can change VPA minimal memory requests to 700Mi to trigger requests update
kubect get vpa deckhouse
NAME        MODE      CPU   MEM     PROVIDED   AGE
deckhouse   Initial   1     700Mi   True       21d

kgp -l app=deckhouse -o yaml|yq '.items[].spec.containers[0].resources' 
limits:
  memory: 6Gi
requests:
  cpu: "1"
  ephemeral-storage: 150Mi
  memory: 700Mi
```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
This is necessary to prevent a Deckhouse module from being scheduled to run on a node that does not have enough resources to run it, or to prevent it from being evicted from that node.

<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Changed Deckhouse VPA update mode to `InPlaceOrRecreate`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
