### PR TITLE
[node-local-dns] Fix name of registry secret at safe-updater

### DIFF
--- a/ee/be/modules/350-node-local-dns/templates/safe-updater/deployment.yaml
+++ b/ee/be/modules/350-node-local-dns/templates/safe-updater/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       imagePullSecrets:
-      - name: {{ .Chart.Name }}-registry
+      - name: deckhouse-registry
       containers:
         - name: safe-updater
           image: {{ include "helm_lib_module_image" (list . "safeUpdater") }}


### PR DESCRIPTION
## Description
Fix name of registry secret at safe-updater

## Why do we need it, and what problem does it solve?
Fix errors in kubelet
```
Mar 23 20:43:02 archdev-master-0 d8-kubelet-forker[1265]: I0323 20:43:02.117916    1265 kubelet_pods.go:1014] "Unable to retrieve pull secret, the image pull may not succeed." pod="kube-system/node-local-dns-safe-updater-796478cc44-v76db" secret="" err="secret \"node-local-dns-registry\" not found"
```

## Why do we need it in the patch release (if we do)?
Correct configuration

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-local-dns
type: fix
summary: Fix name of registry secret in safe-updater deployment
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
