### PR TITLE
[docs][tools] Fix external module documentation local generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,7 @@ MODULE_VERSION ?= v0.1.0
 docs: bin/werf ## Run containers with the documentation.
 	@echo "Building documentation containers..."
 	@echo -n "werf: "; bin/werf version
+	@$(MAKE) -C docs/site free-port-80
 	@cd docs/site/; ../../bin/werf compose up --docker-compose-command-options='-d' --env local --repo ":local" --skip-image-spec-stage=true
 	echo "Open http://localhost/products/kubernetes-platform/documentation/v1/ to access DKP documentation..."
 
@@ -293,6 +294,7 @@ docs-external-module: yq bin/werf ## Build an external module docs and run the l
 	MODULE_PATH="$(MODULE_PATH)" CHANNEL="$(CHANNEL)" MODULE_VERSION="$(MODULE_VERSION)" ./tools/docs/external-module-docs.sh
 	@echo "Building documentation containers..."
 	@echo -n "werf: "; bin/werf version
+	@$(MAKE) -C docs/site free-port-80
 	@cd docs/site/; ../../bin/werf compose up --docker-compose-command-options='-d' --env local --repo ":local" --skip-image-spec-stage=true
 	echo "Open http://localhost/products/kubernetes-platform/documentation/v1/ to access DKP documentation..."
 
@@ -305,6 +307,7 @@ docs-external-module-clean: ## Remove generated external module documentation ou
 docs-dev: bin/werf ## Run containers with the documentation in the dev mode (allow uncommited files).
 	@echo "Building documentation containers (dev mode)..."
 	@echo -n "werf: "; bin/werf version;
+	@$(MAKE) -C docs/site free-port-80
 	@cd docs/site/; ../../bin/werf compose up --docker-compose-command-options='-d' --dev --env development --repo ":local" --skip-image-spec-stage=true
 	echo "Open http://localhost/products/kubernetes-platform/documentation/v1/ to access DKP documentation..."
 

--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -26,6 +26,7 @@ up: werf-bin ## Start documentation containers in a werf watch mode (rebuilding 
 		else \
 			echo "\nStarting documentation in a watch mode using local docker images store..."; \
 		fi
+		@$(MAKE) free-port-80
 		@echo -n "\nwerf: "; $(WERF_BIN) version
 		@$(WERF_BIN) compose up --follow --docker-compose-command-options='-d --force-recreate' --env local --repo $(WERF_REPO) --skip-image-spec-stage=true
 
@@ -37,6 +38,7 @@ dev: werf-bin ## Start documentation containers in a werf watch mode (rebuilding
 		else \
 			echo "\nStarting documentation in a DEV watch mode using local docker images store..."; \
 		fi
+		@$(MAKE) free-port-80
 		@echo -n "\nwerf: "; $(WERF_BIN) version
 		@$(WERF_BIN) compose up --follow --docker-compose-command-options='-d --force-recreate' --dev --env development --repo $(WERF_REPO) --skip-image-spec-stage=true
 
@@ -55,6 +57,7 @@ external-module: werf-bin ## Watch external module docs and run the local portal
 		trap cleanup EXIT INT TERM; \
 		sleep 2; \
 		kill -0 $$HUGO_PID; \
+		$(MAKE) free-port-80; \
 		echo -n "\nwerf: "; $(WERF_BIN) version; \
 		$(WERF_BIN) compose up --follow --docker-compose-command-options='-d --force-recreate' --dev --env development --repo $(WERF_REPO) --skip-image-spec-stage=true
 
@@ -75,6 +78,27 @@ registry: ## Start local Docker registry on localhost:4999
 .PHONY:
 registry-down: ## Stop and remove local Docker registry
 		docker rm -f registry; docker volume prune -fa
+
+free-port-80: ## Stop Docker containers that publish host port 80
+		@containers="$$(docker ps --filter publish=80 --format '{{.ID}} {{.Names}}')"; \
+		if [ -n "$$containers" ]; then \
+			echo "Stopping Docker containers that use host port 80:"; \
+			printf '%s\n' "$$containers" | while IFS= read -r line; do \
+				id="$${line%% *}"; \
+				name="$${line#* }"; \
+				echo "  - $$name ($$id)"; \
+				docker stop "$$id" >/dev/null; \
+			done; \
+		else \
+			echo "No Docker containers use host port 80."; \
+		fi; \
+		if command -v python3 >/dev/null 2>&1; then \
+			if ! python3 -c 'import socket; s=socket.socket(socket.AF_INET, socket.SOCK_STREAM); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind(("0.0.0.0", 80)); s.close()' >/dev/null 2>&1; then \
+				echo "Port 80 is still busy. It is likely occupied by a non-Docker process on the host."; \
+			fi; \
+		else \
+			echo "python3 is not available, skipping host-level port 80 check."; \
+		fi
 
 clean: werf-bin ## Clean up werf artifacts in localhost repo mode
 		##~ Options: USE_LOCALHOST_REPO=1
@@ -123,4 +147,4 @@ help: ## Show this help message
 	/^.?.?##~/              { printf "  %-20s %s\n", "", substr($$1, 6) }' $(MAKEFILE_LIST)
 
 .PHONY: help up dev regenerate-menu
-.PHONY: werf-bin clean down regenerate-metadata registry registry-down external-module
+.PHONY: werf-bin clean down regenerate-metadata registry registry-down free-port-80 external-module

--- a/tools/docs/external-module-docs.sh
+++ b/tools/docs/external-module-docs.sh
@@ -157,6 +157,7 @@ if [[ "${MODE}" == "serve" ]]; then
     --entrypoint hugo
     "${HUGO_IMAGE}"
     server
+    --noBuildLock
     --source /src
     --destination /out
     --environment production
@@ -225,6 +226,7 @@ else
     --workdir /src \
     --entrypoint hugo \
     "${HUGO_IMAGE}" \
+    --noBuildLock \
     --source /src \
     --destination /out \
     --environment production

--- a/tools/docs/external-module-docs.sh
+++ b/tools/docs/external-module-docs.sh
@@ -61,7 +61,30 @@ if [[ -z "${MODULE_NAME}" || "${MODULE_NAME}" == "null" ]]; then
   exit 1
 fi
 
-TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/external-module-docs.XXXXXX")"
+create_temp_dir() {
+  local base_dir="${TMPDIR:-/tmp}"
+  local temp_dir=""
+
+  if temp_dir="$(mktemp -d "${base_dir%/}/external-module-docs.XXXXXX" 2>/dev/null)"; then
+    printf '%s\n' "${temp_dir}"
+    return 0
+  fi
+
+  if temp_dir="$(TMPDIR="${base_dir%/}" mktemp -d -t external-module-docs.XXXXXX 2>/dev/null)"; then
+    printf '%s\n' "${temp_dir}"
+    return 0
+  fi
+
+  if temp_dir="$(TMPDIR="${base_dir%/}" mktemp -d -t external-module-docs 2>/dev/null)"; then
+    printf '%s\n' "${temp_dir}"
+    return 0
+  fi
+
+  echo "Failed to create a temporary directory." >&2
+  exit 1
+}
+
+TMP_DIR="$(create_temp_dir)"
 
 cleanup() {
   rm -rf "${TMP_DIR}"
@@ -69,70 +92,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-mkdir -p \
-  "${TMP_DIR}/content/modules/${MODULE_NAME}" \
-  "${TMP_DIR}/content/search" \
-  "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}" \
-  "${OUTPUT_DIR}"
-
-cp -R "${TEMPLATE_DIR}/config" "${TMP_DIR}/config"
-cp -R "${TEMPLATE_DIR}/i18n" "${TMP_DIR}/i18n"
-cp -R "${TEMPLATE_DIR}/layouts" "${TMP_DIR}/layouts"
-cp "${TEMPLATE_DIR}/data/channels.yaml" "${TMP_DIR}/data/channels.yaml"
-cp "${TEMPLATE_DIR}/data/helpers.yaml" "${TMP_DIR}/data/helpers.yaml"
-cp "${TEMPLATE_DIR}/data/modules_all.json" "${TMP_DIR}/data/modules_all.json"
-cp -R "${TEMPLATE_DIR}/data/dkp" "${TMP_DIR}/data/dkp"
-cp "${TEMPLATE_DIR}/content/modules/_index.md" "${TMP_DIR}/content/modules/_index.md"
-cp "${TEMPLATE_DIR}/content/modules/_index.ru.md" "${TMP_DIR}/content/modules/_index.ru.md"
-cp "${TEMPLATE_DIR}/content/search/search.md" "${TMP_DIR}/content/search/search.md"
-cp "${TEMPLATE_DIR}/content/search/search.ru.md" "${TMP_DIR}/content/search/search.ru.md"
-
-MODULE_CHANNEL_CONTENT_DIR="${TMP_DIR}/content/modules/${MODULE_NAME}/${CHANNEL}"
-MODULE_CHANNEL_DATA_DIR="${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}"
-MODULE_CHANNEL_OPENAPI_DIR="${MODULE_CHANNEL_DATA_DIR}/openapi"
-MODULE_CHANNEL_CRDS_DIR="${MODULE_CHANNEL_DATA_DIR}/crds"
-
-sync_module_sources() {
-  rm -rf "${MODULE_CHANNEL_CONTENT_DIR}" "${MODULE_CHANNEL_DATA_DIR}"
-
-  mkdir -p "${MODULE_CHANNEL_CONTENT_DIR}"
-  mkdir -p "${MODULE_CHANNEL_DATA_DIR}"
-  cp -R "${MODULE_PATH}/docs/." "${TMP_DIR}/content/modules/${MODULE_NAME}/${CHANNEL}/"
-  cp "${MODULE_PATH}/module.yaml" "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/module.yaml"
-
-  if [[ -f "${MODULE_PATH}/oss.yaml" ]]; then
-    cp "${MODULE_PATH}/oss.yaml" "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/oss.yaml"
-  fi
-
-  if [[ -f "${MODULE_PATH}/openapi/config-values.yaml" || -f "${MODULE_PATH}/openapi/doc-ru-config-values.yaml" ]]; then
-    mkdir -p "${MODULE_CHANNEL_OPENAPI_DIR}"
-  fi
-
-  if [[ -f "${MODULE_PATH}/openapi/config-values.yaml" ]]; then
-    cp "${MODULE_PATH}/openapi/config-values.yaml" "${MODULE_CHANNEL_OPENAPI_DIR}/config-values.yaml"
-  fi
-
-  if [[ -f "${MODULE_PATH}/openapi/doc-ru-config-values.yaml" ]]; then
-    cp "${MODULE_PATH}/openapi/doc-ru-config-values.yaml" "${MODULE_CHANNEL_OPENAPI_DIR}/doc-ru-config-values.yaml"
-  fi
-
-  if [[ -d "${MODULE_PATH}/crds" ]]; then
-    shopt -s nullglob
-    root_crds=("${MODULE_PATH}"/crds/*.yaml "${MODULE_PATH}"/crds/*.yml)
-    shopt -u nullglob
-
-    if (( ${#root_crds[@]} > 0 )); then
-      mkdir -p "${MODULE_CHANNEL_CRDS_DIR}"
-      cp "${root_crds[@]}" "${MODULE_CHANNEL_CRDS_DIR}/"
-    fi
-  fi
-}
-
-prepare_serve_mountpoints() {
-  mkdir -p "${MODULE_CHANNEL_CONTENT_DIR}"
-  mkdir -p "${MODULE_CHANNEL_OPENAPI_DIR}"
-  mkdir -p "${MODULE_CHANNEL_CRDS_DIR}"
-}
+mkdir -p "${TMP_DIR}/data/modules" "${OUTPUT_DIR}"
 
 cat > "${TMP_DIR}/data/modules/channels.yaml" <<EOF
 ${MODULE_NAME}:
@@ -151,14 +111,22 @@ echo "  image:   ${HUGO_IMAGE}"
 echo "  mode:    ${MODE}"
 
 if [[ "${MODE}" == "serve" ]]; then
-  prepare_serve_mountpoints
-
   docker_args=(
     run --rm
-    --user "$(id -u):$(id -g)" \
-    --volume "${TMP_DIR}:/src" \
-    --volume "${OUTPUT_DIR}:/out" \
-    --volume "${MODULE_PATH}/docs:/src/content/modules/${MODULE_NAME}/${CHANNEL}:ro" \
+    --user "$(id -u):$(id -g)"
+    --volume "${OUTPUT_DIR}:/out"
+    --volume "${TEMPLATE_DIR}/config:/src/config:ro"
+    --volume "${TEMPLATE_DIR}/i18n:/src/i18n:ro"
+    --volume "${TEMPLATE_DIR}/layouts:/src/layouts:ro"
+    --volume "${TEMPLATE_DIR}/data/dkp:/src/data/dkp:ro"
+    --volume "${TEMPLATE_DIR}/data/channels.yaml:/src/data/channels.yaml:ro"
+    --volume "${TEMPLATE_DIR}/data/helpers.yaml:/src/data/helpers.yaml:ro"
+    --volume "${TEMPLATE_DIR}/data/modules_all.json:/src/data/modules_all.json:ro"
+    --volume "${TMP_DIR}/data/modules/channels.yaml:/src/data/modules/channels.yaml:ro"
+    --volume "${TEMPLATE_DIR}/content/modules/_index.md:/src/content/modules/_index.md:ro"
+    --volume "${TEMPLATE_DIR}/content/modules/_index.ru.md:/src/content/modules/_index.ru.md:ro"
+    --volume "${TEMPLATE_DIR}/content/search:/src/content/search:ro"
+    --volume "${MODULE_PATH}/docs:/src/content/modules/${MODULE_NAME}/${CHANNEL}:ro"
     --volume "${MODULE_PATH}/module.yaml:/src/data/modules/${MODULE_NAME}/${CHANNEL}/module.yaml:ro"
   )
 
@@ -203,7 +171,52 @@ if [[ "${MODE}" == "serve" ]]; then
 
   docker "${docker_args[@]}"
 else
-  sync_module_sources
+  mkdir -p \
+    "${TMP_DIR}/content/modules/${MODULE_NAME}/${CHANNEL}" \
+    "${TMP_DIR}/content/search" \
+    "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}"
+
+  cp -R "${TEMPLATE_DIR}/config" "${TMP_DIR}/config"
+  cp -R "${TEMPLATE_DIR}/i18n" "${TMP_DIR}/i18n"
+  cp -R "${TEMPLATE_DIR}/layouts" "${TMP_DIR}/layouts"
+  cp "${TEMPLATE_DIR}/data/channels.yaml" "${TMP_DIR}/data/channels.yaml"
+  cp "${TEMPLATE_DIR}/data/helpers.yaml" "${TMP_DIR}/data/helpers.yaml"
+  cp "${TEMPLATE_DIR}/data/modules_all.json" "${TMP_DIR}/data/modules_all.json"
+  cp -R "${TEMPLATE_DIR}/data/dkp" "${TMP_DIR}/data/dkp"
+  cp "${TEMPLATE_DIR}/content/modules/_index.md" "${TMP_DIR}/content/modules/_index.md"
+  cp "${TEMPLATE_DIR}/content/modules/_index.ru.md" "${TMP_DIR}/content/modules/_index.ru.md"
+  cp "${TEMPLATE_DIR}/content/search/search.md" "${TMP_DIR}/content/search/search.md"
+  cp "${TEMPLATE_DIR}/content/search/search.ru.md" "${TMP_DIR}/content/search/search.ru.md"
+
+  cp -R "${MODULE_PATH}/docs/." "${TMP_DIR}/content/modules/${MODULE_NAME}/${CHANNEL}/"
+  cp "${MODULE_PATH}/module.yaml" "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/module.yaml"
+
+  if [[ -f "${MODULE_PATH}/oss.yaml" ]]; then
+    cp "${MODULE_PATH}/oss.yaml" "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/oss.yaml"
+  fi
+
+  if [[ -f "${MODULE_PATH}/openapi/config-values.yaml" || -f "${MODULE_PATH}/openapi/doc-ru-config-values.yaml" ]]; then
+    mkdir -p "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/openapi"
+  fi
+
+  if [[ -f "${MODULE_PATH}/openapi/config-values.yaml" ]]; then
+    cp "${MODULE_PATH}/openapi/config-values.yaml" "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/openapi/config-values.yaml"
+  fi
+
+  if [[ -f "${MODULE_PATH}/openapi/doc-ru-config-values.yaml" ]]; then
+    cp "${MODULE_PATH}/openapi/doc-ru-config-values.yaml" "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/openapi/doc-ru-config-values.yaml"
+  fi
+
+  if [[ -d "${MODULE_PATH}/crds" ]]; then
+    shopt -s nullglob
+    root_crds=("${MODULE_PATH}"/crds/*.yaml "${MODULE_PATH}"/crds/*.yml)
+    shopt -u nullglob
+
+    if (( ${#root_crds[@]} > 0 )); then
+      mkdir -p "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/crds"
+      cp "${root_crds[@]}" "${TMP_DIR}/data/modules/${MODULE_NAME}/${CHANNEL}/crds/"
+    fi
+  fi
 
   docker run --rm \
     --user "$(id -u):$(id -g)" \


### PR DESCRIPTION
## Description

This pull request introduces improvements to the documentation build process, focusing on reliably freeing up host port 80 before starting documentation containers and refactoring the external module documentation script for better platform independency.

Ref: https://github.com/deckhouse/deckhouse/pull/18670

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix external module documentation local generation.
impact_level: low
```
