### PR TITLE
Fix error handling in module deployment by renaming error variable

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
@@ -369,8 +369,8 @@ func (r *reconciler) deployModule(ctx context.Context, source *v1alpha1.ModuleSo
 	}
 	if err = def.Validate(values, r.log); err != nil {
 		mpo.Status.Message = fmt.Sprintf("Validation error: %v", err)
-		if err = r.updateModulePullOverrideStatus(ctx, mpo); err != nil {
-			return fmt.Errorf("update mpo status: %w", err)
+		if err2 := r.updateModulePullOverrideStatus(ctx, mpo); err2 != nil {
+			return fmt.Errorf("update mpo status: %w", err2)
 		}
 
 		return fmt.Errorf("validation error: %w", err)

--- a/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
@@ -367,10 +367,10 @@ func (r *reconciler) deployModule(ctx context.Context, source *v1alpha1.ModuleSo
 			values = addonutils.Values(settings)
 		}
 	}
-	if err = def.Validate(values, r.log); err != nil {
+	if err := def.Validate(values, r.log); err != nil {
 		mpo.Status.Message = fmt.Sprintf("Validation error: %v", err)
-		if err2 := r.updateModulePullOverrideStatus(ctx, mpo); err2 != nil {
-			return fmt.Errorf("update mpo status: %w", err2)
+		if err := r.updateModulePullOverrideStatus(ctx, mpo); err != nil {
+			return fmt.Errorf("update mpo status: %w", err)
 		}
 
 		return fmt.Errorf("validation error: %w", err)


### PR DESCRIPTION
## Description
Fixed returned variable for MPO validation error

Before:
```json
{
	"level": "error",
	"logger": "deckhouse-controller.module-pull-override-controller",
	"msg": "failed to deploy module",
	"error": "validation error: %!w(<nil>)",
	"module": "test",
	"stacktrace": 
...
```

After:
```json
{
	"level": "error",
	"logger": "deckhouse-controller.module-pull-override-controller",
	"msg": "failed to deploy module",
	"error": "validation error: validate module: test.releaseChannel in body is a forbidden property test.kubeall.host in body is required",
	"module": "test",
	"stacktrace": 
...
```
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
This changes improve error handling
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed error logging for MPO validation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
