### PR TITLE
[cloud-provder-dvp] Refactor Dechkousemachine controller

### DIFF
--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -258,10 +258,11 @@ func (r *DeckhouseMachineReconciler) reconcileUpdates(
 	}
 	dvpMachine.Spec.ProviderID = ProviderIDPrefix + vm.Name
 
-	return r.reconcileVMPhase(logger, machine, dvpMachine, vm)
+	return r.reconcileVMPhase(ctx, logger, machine, dvpMachine, vm)
 }
 
 func (r *DeckhouseMachineReconciler) reconcileVMPhase(
+	ctx context.Context,
 	logger logr.Logger,
 	machine *clusterv1b2.Machine,
 	dvpMachine *infrastructurev1a1.DeckhouseMachine,
@@ -271,11 +272,11 @@ func (r *DeckhouseMachineReconciler) reconcileVMPhase(
 	case v1alpha2.MachineRunning:
 		return r.handleVMRunning(logger, dvpMachine, vm)
 	case v1alpha2.MachineStopped:
-		return r.handleVMStopped(logger, dvpMachine, vm)
+		return r.handleVMStopped(ctx, logger, dvpMachine, vm)
 	case v1alpha2.MachineDegraded:
 		return r.handleVMDegraded(logger, machine, dvpMachine, vm)
 	default:
-		return r.handleVMNotReady(logger, dvpMachine, vm)
+		return r.handleVMNotReady(ctx, logger, dvpMachine, vm)
 	}
 }
 
@@ -315,6 +316,7 @@ func (r *DeckhouseMachineReconciler) handleVMRunning(
 }
 
 func (r *DeckhouseMachineReconciler) handleVMStopped(
+	ctx context.Context,
 	logger logr.Logger,
 	dvpMachine *infrastructurev1a1.DeckhouseMachine,
 	vm *v1alpha2.VirtualMachine,
@@ -324,11 +326,16 @@ func (r *DeckhouseMachineReconciler) handleVMStopped(
 	logger.Info("VM is in Stopped state, waiting for DVP to bring it back up", "state", vm.Status.Phase)
 	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
 
+	message := "VM is in Stopped state, waiting for DVP to bring it back up"
+	if resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine); resourceStatus != "" {
+		message = fmt.Sprintf("%s. Resources: %s", message, resourceStatus)
+	}
+
 	conditions.Set(dvpMachine, metav1.Condition{
 		Type:               string(infrastructurev1a1.VMReadyCondition),
 		Status:             metav1.ConditionFalse,
 		Reason:             infrastructurev1a1.VMInStoppedStateReason,
-		Message:            "VM is in Stopped state, waiting for DVP to bring it back up",
+		Message:            message,
 		LastTransitionTime: metav1.Now(),
 	})
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -387,6 +394,7 @@ func (r *DeckhouseMachineReconciler) handleVMDegraded(
 }
 
 func (r *DeckhouseMachineReconciler) handleVMNotReady(
+	ctx context.Context,
 	logger logr.Logger,
 	dvpMachine *infrastructurev1a1.DeckhouseMachine,
 	vm *v1alpha2.VirtualMachine,
@@ -395,14 +403,76 @@ func (r *DeckhouseMachineReconciler) handleVMNotReady(
 	// due to potential conflict or unexpected actions
 	logger.Info("Waiting for VM state to become Running", "state", vm.Status.Phase)
 	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
+
+	message := fmt.Sprintf("VM is not ready, state is %s", vm.Status.Phase)
+	if resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine); resourceStatus != "" {
+		message = fmt.Sprintf("%s. Resources: %s", message, resourceStatus)
+	}
+
 	conditions.Set(dvpMachine, metav1.Condition{
 		Type:               string(infrastructurev1a1.VMReadyCondition),
 		Status:             metav1.ConditionUnknown,
 		Reason:             infrastructurev1a1.VMNotReadyReason,
-		Message:            fmt.Sprintf("VM is not ready, state is %s", vm.Status.Phase),
+		Message:            message,
 		LastTransitionTime: metav1.Now(),
 	})
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+func (r *DeckhouseMachineReconciler) collectOwnedResourcesStatus(
+	ctx context.Context,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+) string {
+	logger := log.FromContext(ctx)
+	var parts []string
+
+	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
+	secret := &corev1.Secret{}
+	err := r.DVP.Service.GetClient().Get(ctx, client.ObjectKey{
+		Namespace: r.DVP.ProjectNamespace(),
+		Name:      cloudInitSecretName,
+	}, secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			parts = append(parts, fmt.Sprintf("secret %s: not found", cloudInitSecretName))
+		} else {
+			logger.V(1).Info("Cannot get cloud-init secret status", "secretName", cloudInitSecretName, "error", err)
+			parts = append(parts, fmt.Sprintf("secret %s: unknown", cloudInitSecretName))
+		}
+	} else {
+		parts = append(parts, fmt.Sprintf("secret %s: exists", cloudInitSecretName))
+	}
+
+	bootDiskName := dvpMachine.Name + "-boot"
+	diskNames := []string{bootDiskName}
+	for i := range dvpMachine.Spec.AdditionalDisks {
+		diskNames = append(diskNames, fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, i))
+	}
+
+	for _, diskName := range diskNames {
+		disk, err := r.DVP.DiskService.GetDiskByName(ctx, diskName)
+		if err != nil {
+			if errors.Is(err, cloudprovider.InstanceNotFound) {
+				parts = append(parts, fmt.Sprintf("disk %s: not found", diskName))
+			} else {
+				logger.V(1).Info("Cannot get VirtualDisk status", "diskName", diskName, "error", err)
+				parts = append(parts, fmt.Sprintf("disk %s: unknown", diskName))
+			}
+			continue
+		}
+		status := fmt.Sprintf("disk %s: phase=%s", diskName, disk.Status.Phase)
+		if disk.Status.Progress != "" {
+			status += fmt.Sprintf(" progress=%s", disk.Status.Progress)
+		}
+		for _, c := range disk.Status.Conditions {
+			if c.Status != metav1.ConditionTrue {
+				status += fmt.Sprintf(" (%s: %s)", c.Type, c.Message)
+			}
+		}
+		parts = append(parts, status)
+	}
+
+	return strings.Join(parts, "; ")
 }
 
 func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -323,13 +323,15 @@ func (r *DeckhouseMachineReconciler) handleVMStopped(
 ) (ctrl.Result, error) {
 	// VM is stopped, this is unexpected as we use "AlwaysOn" run policy for VM's here.
 	// Let's wait and see what happens as this may be a part of migration process or this is a bug in the DVP VM controller.
-	logger.Info("VM is in Stopped state, waiting for DVP to bring it back up", "state", vm.Status.Phase)
 	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
 
+	resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine)
 	message := "VM is in Stopped state, waiting for DVP to bring it back up"
-	if resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine); resourceStatus != "" {
+	if resourceStatus != "" {
 		message = fmt.Sprintf("%s. Resources: %s", message, resourceStatus)
 	}
+
+	logger.Info("VM is in Stopped state, waiting for DVP to bring it back up", "state", vm.Status.Phase, "resources", resourceStatus)
 
 	conditions.Set(dvpMachine, metav1.Condition{
 		Type:               string(infrastructurev1a1.VMReadyCondition),
@@ -401,13 +403,15 @@ func (r *DeckhouseMachineReconciler) handleVMNotReady(
 ) (ctrl.Result, error) {
 	// The other states are normal (for example, migration or shutdown) but we don't want to proceed until it's up
 	// due to potential conflict or unexpected actions
-	logger.Info("Waiting for VM state to become Running", "state", vm.Status.Phase)
 	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
 
+	resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine)
 	message := fmt.Sprintf("VM is not ready, state is %s", vm.Status.Phase)
-	if resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine); resourceStatus != "" {
+	if resourceStatus != "" {
 		message = fmt.Sprintf("%s. Resources: %s", message, resourceStatus)
 	}
+
+	logger.Info("Waiting for VM state to become Running", "state", vm.Status.Phase, "resources", resourceStatus)
 
 	conditions.Set(dvpMachine, metav1.Condition{
 		Type:               string(infrastructurev1a1.VMReadyCondition),
@@ -444,7 +448,8 @@ func (r *DeckhouseMachineReconciler) collectOwnedResourcesStatus(
 	}
 
 	bootDiskName := dvpMachine.Name + "-boot"
-	diskNames := []string{bootDiskName}
+	diskNames := make([]string, 0, 1+len(dvpMachine.Spec.AdditionalDisks))
+	diskNames = append(diskNames, bootDiskName)
 	for i := range dvpMachine.Spec.AdditionalDisks {
 		diskNames = append(diskNames, fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, i))
 	}
@@ -645,14 +650,6 @@ func (r *DeckhouseMachineReconciler) ensureVM(
 	machine *clusterv1b2.Machine,
 	dvpMachine *infrastructurev1a1.DeckhouseMachine,
 ) (*v1alpha2.VirtualMachine, error) {
-	existing, err := r.DVP.ComputeService.GetVMByName(ctx, dvpMachine.Name)
-	if err == nil {
-		return existing, nil
-	}
-	if !errors.Is(err, cloudprovider.InstanceNotFound) {
-		return nil, fmt.Errorf("cannot get VirtualMachine: %w", err)
-	}
-
 	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
 	blockDeviceRefs := r.buildBlockDeviceRefs(dvpMachine)
 	runPolicy := r.resolveRunPolicy(dvpMachine)
@@ -694,6 +691,9 @@ func (r *DeckhouseMachineReconciler) ensureVM(
 		},
 	})
 	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return r.DVP.ComputeService.GetVMByName(ctx, dvpMachine.Name)
+		}
 		return nil, r.wrapVMCreationError(ctx, dvpMachine, err)
 	}
 

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -36,6 +36,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/utils/ptr"
 	clusterv1b2 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	capierrors "sigs.k8s.io/cluster-api/errors" //nolint:staticcheck
 	capiutil "sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -60,6 +61,11 @@ const (
 	// OrphanedVMTimestampAnnotation records when VM became orphaned
 	OrphanedVMTimestampAnnotation = "dvp.deckhouse.io/orphaned-vm-timestamp"
 )
+
+type ownedResourceCreator struct {
+	name   string
+	create func(ctx context.Context, vm *v1alpha2.VirtualMachine) error
+}
 
 // DeckhouseMachineReconciler reconciles a DeckhouseMachine object
 type DeckhouseMachineReconciler struct {
@@ -129,17 +135,10 @@ func (r *DeckhouseMachineReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	// Migrate old CR's to v1beta2 conditions
+	// Migrate old CR's to v1beta2 conditions and always patch the dvpMachine when exiting this function,
+	// so we can persist any DeckhouseMachine changes.
 	defer func() {
 		normalizeLegacyConditions(dvpMachine)
-		if err := patchDeckhouseMachine(ctx, patchHelper, dvpMachine); err != nil {
-			result = ctrl.Result{}
-			reterr = err
-		}
-	}()
-
-	// Always patch the dvpMachine when exiting this function, so we can persist any DeckhouseMachine changes.
-	defer func() {
 		if err := patchDeckhouseMachine(ctx, patchHelper, dvpMachine); err != nil {
 			result = ctrl.Result{}
 			reterr = err
@@ -224,7 +223,7 @@ func (r *DeckhouseMachineReconciler) reconcileUpdates(
 
 		conditions.Set(dvpMachine, metav1.Condition{
 			Type:               string(infrastructurev1a1.VMReadyCondition),
-			Status:             metav1.ConditionFalse, // False instead of MarkFalse
+			Status:             metav1.ConditionFalse,
 			Reason:             infrastructurev1a1.WaitingForBootstrapScriptReason,
 			Message:            "Bootstrap cloud-init secret is missing",
 			LastTransitionTime: metav1.Now(),
@@ -241,7 +240,7 @@ func (r *DeckhouseMachineReconciler) reconcileUpdates(
 
 		conditions.Set(dvpMachine, metav1.Condition{
 			Type:               string(infrastructurev1a1.VMReadyCondition),
-			Status:             metav1.ConditionFalse, // VMReady = False
+			Status:             metav1.ConditionFalse,
 			Reason:             infrastructurev1a1.VMErrorReason,
 			Message:            fmt.Sprintf("No VM can be found or created for Machine: %v", err),
 			LastTransitionTime: metav1.Now(),
@@ -259,115 +258,151 @@ func (r *DeckhouseMachineReconciler) reconcileUpdates(
 	}
 	dvpMachine.Spec.ProviderID = ProviderIDPrefix + vm.Name
 
+	return r.reconcileVMPhase(logger, machine, dvpMachine, vm)
+}
+
+func (r *DeckhouseMachineReconciler) reconcileVMPhase(
+	logger logr.Logger,
+	machine *clusterv1b2.Machine,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+	vm *v1alpha2.VirtualMachine,
+) (ctrl.Result, error) {
 	switch vm.Status.Phase {
 	case v1alpha2.MachineRunning:
-		// If VM is running, fetch its IP addr and add it to dvpMachine.Status.Addresses
-		logger.Info("VM is Running")
-		conditions.Set(dvpMachine, metav1.Condition{
-			Type:               string(infrastructurev1a1.VMReadyCondition),
-			Status:             metav1.ConditionTrue,
-			Reason:             "VMRunning",
-			Message:            "VM is running and ready",
-			LastTransitionTime: metav1.Now(),
-		})
-		infraReady := true
-		dvpMachine.Status.Initialization.Provisioned = &infraReady
-		dvpMachine.Status.Addresses = append(dvpMachine.Status.Addresses, []infrastructurev1a1.VMAddress{
-			{Type: clusterv1b2.MachineInternalIP, Address: vm.Status.IPAddress},
-			{Type: clusterv1b2.MachineExternalIP, Address: vm.Status.IPAddress},
-		}...)
-
-		// TODO(mvasl) DVP does not support detaching of provisioning secrets yet, but one day it will.
-		// We should detach and remove cloud-init secret we created after vm is bootstrapped and joined the cluster
-		// if machine.Status.NodeRef != nil && vm.Spec.Provisioning != nil {
-		// 	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
-		// 	logger.Info("Removing Cloud-Init secret from VirtualMachine", "secret", cloudInitSecretName)
-		// 	vm.Spec.Provisioning = nil
-		// 	if err = r.DVP.ComputeService.DeleteCloudInitProvisioningSecret(ctx, cloudInitSecretName); err != nil {
-		// 		return ctrl.Result{}, fmt.Errorf("delete cloud-init secret %q: %w", cloudInitSecretName, err)
-		// 	}
-		// }
+		return r.handleVMRunning(logger, dvpMachine, vm)
 	case v1alpha2.MachineStopped:
-		// VM is stopped, this is unexpected as we use "AlwaysOn" run policy for VM's here.
-		// Let's wait and see what happens as this may be a part of migration process or this is a bug in the DVP VM controller.
-		logger.Info("VM is in Stopped state, waiting for DVP to bring it back up", "state", vm.Status.Phase)
-		// dvpMachine.Status.Ready = false
-		infraReady := false
-		dvpMachine.Status.Initialization.Provisioned = &infraReady
-
-		conditions.Set(dvpMachine, metav1.Condition{
-			Type:               string(infrastructurev1a1.VMReadyCondition),
-			Status:             metav1.ConditionFalse, // False instead of MarkFalse
-			Reason:             infrastructurev1a1.VMInStoppedStateReason,
-			Message:            "VM is in Stopped state, waiting for DVP to bring it back up",
-			LastTransitionTime: metav1.Now(),
-		})
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		return r.handleVMStopped(logger, dvpMachine, vm)
 	case v1alpha2.MachineDegraded:
-		// If VM is in some bad state and cannot be booted up, check if it has NodeRef.
-		// The machine having a NodeRef means it was working at some point, so this could be temporary.
-		// If not, it is more likely a configuration/resource error, so we record failure and never retry.
-
-		logger.Error(fmt.Errorf("VM in degraded state"), "VM failed",
-			"vm_phase", vm.Status.Phase,
-			"vm_name", vm.Name,
-			"has_node_ref", machine.Status.NodeRef.Name != "",
-			"requested_memory", dvpMachine.Spec.Memory.String(),
-			"requested_cpu_cores", dvpMachine.Spec.CPU.Cores,
-			"vm_class", dvpMachine.Spec.VMClassName,
-		)
-
-		infraReady := false
-		dvpMachine.Status.Initialization.Provisioned = &infraReady
-
-		if machine.Status.NodeRef.Name == "" {
-			// VM never successfully started - likely a resource or configuration error
-			err = fmt.Errorf("VM state %q indicates failure, likely due to resource constraints or configuration error", vm.Status.Phase)
-
-			// choose one; UpdateMachineError is ok, CreateMachineError might be even more accurate if available in your capierrors version
-			dvpMachine.Status.FailureReason = ptr.To("UpdateError")
-			dvpMachine.Status.FailureMessage = ptr.To(fmt.Sprintf(
-				"VM failed to start (vmClass: %s, memory: %s, CPU: %d cores). Check parent DVP cluster for detailed error: %s",
-				dvpMachine.Spec.VMClassName,
-				dvpMachine.Spec.Memory.String(),
-				dvpMachine.Spec.CPU.Cores,
-				err.Error(),
-			))
-		} else {
-			// VM was working before, this might be temporary
-			logger.Info("VM had NodeRef before entering degraded state, may be temporary issue",
-				"node_name", machine.Status.NodeRef.Name,
-			)
-		}
-
-		conditions.Set(dvpMachine, metav1.Condition{
-			Type:               string(infrastructurev1a1.VMReadyCondition),
-			Status:             metav1.ConditionFalse,
-			Reason:             infrastructurev1a1.VMInFailedStateReason,
-			Message:            fmt.Sprintf("VM in degraded state: %s", vm.Status.Phase),
-			LastTransitionTime: metav1.Now(),
-		})
-
-		return ctrl.Result{}, nil
+		return r.handleVMDegraded(logger, machine, dvpMachine, vm)
 	default:
-		// The other states are normal (for example, migration or shutdown) but we don't want to proceed until it's up
-		// due to potential conflict or unexpected actions
-		logger.Info("Waiting for VM state to become Running", "state", vm.Status.Phase)
-		// dvpMachine.Status.Ready = false
-		infraReady := false
-		dvpMachine.Status.Initialization.Provisioned = &infraReady
-		conditions.Set(dvpMachine, metav1.Condition{
-			Type:               string(infrastructurev1a1.VMReadyCondition),
-			Status:             metav1.ConditionUnknown,
-			Reason:             infrastructurev1a1.VMNotReadyReason,
-			Message:            fmt.Sprintf("VM is not ready, state is %s", vm.Status.Phase),
-			LastTransitionTime: metav1.Now(),
-		})
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		return r.handleVMNotReady(logger, dvpMachine, vm)
 	}
+}
+
+func (r *DeckhouseMachineReconciler) handleVMRunning(
+	logger logr.Logger,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+	vm *v1alpha2.VirtualMachine,
+) (ctrl.Result, error) {
+	// If VM is running, fetch its IP addr and add it to dvpMachine.Status.Addresses
+	logger.Info("VM is Running")
+	conditions.Set(dvpMachine, metav1.Condition{
+		Type:               string(infrastructurev1a1.VMReadyCondition),
+		Status:             metav1.ConditionTrue,
+		Reason:             "VMRunning",
+		Message:            "VM is running and ready",
+		LastTransitionTime: metav1.Now(),
+	})
+	dvpMachine.Status.Initialization.Provisioned = ptr.To(true)
+	dvpMachine.Status.Addresses = append(dvpMachine.Status.Addresses, []infrastructurev1a1.VMAddress{
+		{Type: clusterv1b2.MachineInternalIP, Address: vm.Status.IPAddress},
+		{Type: clusterv1b2.MachineExternalIP, Address: vm.Status.IPAddress},
+	}...)
+
+	// TODO(mvasl) DVP does not support detaching of provisioning secrets yet, but one day it will.
+	// We should detach and remove cloud-init secret we created after vm is bootstrapped and joined the cluster
+	// if machine.Status.NodeRef != nil && vm.Spec.Provisioning != nil {
+	// 	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
+	// 	logger.Info("Removing Cloud-Init secret from VirtualMachine", "secret", cloudInitSecretName)
+	// 	vm.Spec.Provisioning = nil
+	// 	if err = r.DVP.ComputeService.DeleteCloudInitProvisioningSecret(ctx, cloudInitSecretName); err != nil {
+	// 		return ctrl.Result{}, fmt.Errorf("delete cloud-init secret %q: %w", cloudInitSecretName, err)
+	// 	}
+	// }
 
 	logger.Info("Reconciled DeckhouseMachine successfully")
 	return ctrl.Result{}, nil
+}
+
+func (r *DeckhouseMachineReconciler) handleVMStopped(
+	logger logr.Logger,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+	vm *v1alpha2.VirtualMachine,
+) (ctrl.Result, error) {
+	// VM is stopped, this is unexpected as we use "AlwaysOn" run policy for VM's here.
+	// Let's wait and see what happens as this may be a part of migration process or this is a bug in the DVP VM controller.
+	logger.Info("VM is in Stopped state, waiting for DVP to bring it back up", "state", vm.Status.Phase)
+	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
+
+	conditions.Set(dvpMachine, metav1.Condition{
+		Type:               string(infrastructurev1a1.VMReadyCondition),
+		Status:             metav1.ConditionFalse,
+		Reason:             infrastructurev1a1.VMInStoppedStateReason,
+		Message:            "VM is in Stopped state, waiting for DVP to bring it back up",
+		LastTransitionTime: metav1.Now(),
+	})
+	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+func (r *DeckhouseMachineReconciler) handleVMDegraded(
+	logger logr.Logger,
+	machine *clusterv1b2.Machine,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+	vm *v1alpha2.VirtualMachine,
+) (ctrl.Result, error) {
+	// If VM is in some bad state and cannot be booted up, check if it has NodeRef.
+	// The machine having a NodeRef means it was working at some point, so this could be temporary.
+	// If not, it is more likely a configuration/resource error, so we record failure and never retry.
+
+	logger.Error(fmt.Errorf("VM in degraded state"), "VM failed",
+		"vm_phase", vm.Status.Phase,
+		"vm_name", vm.Name,
+		"has_node_ref", machine.Status.NodeRef.Name != "",
+		"requested_memory", dvpMachine.Spec.Memory.String(),
+		"requested_cpu_cores", dvpMachine.Spec.CPU.Cores,
+		"vm_class", dvpMachine.Spec.VMClassName,
+	)
+
+	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
+
+	if machine.Status.NodeRef.Name == "" {
+		// VM never successfully started - likely a resource or configuration error
+		err := fmt.Errorf("VM state %q indicates failure, likely due to resource constraints or configuration error", vm.Status.Phase)
+
+		// choose one; UpdateMachineError is ok, CreateMachineError might be even more accurate if available in your capierrors version
+		dvpMachine.Status.FailureReason = ptr.To(string(capierrors.UpdateMachineError))
+		dvpMachine.Status.FailureMessage = ptr.To(fmt.Sprintf(
+			"VM failed to start (vmClass: %s, memory: %s, CPU: %d cores). Check parent DVP cluster for detailed error: %s",
+			dvpMachine.Spec.VMClassName,
+			dvpMachine.Spec.Memory.String(),
+			dvpMachine.Spec.CPU.Cores,
+			err.Error(),
+		))
+	} else {
+		// VM was working before, this might be temporary
+		logger.Info("VM had NodeRef before entering degraded state, may be temporary issue",
+			"node_name", machine.Status.NodeRef.Name,
+		)
+	}
+
+	conditions.Set(dvpMachine, metav1.Condition{
+		Type:               string(infrastructurev1a1.VMReadyCondition),
+		Status:             metav1.ConditionFalse,
+		Reason:             infrastructurev1a1.VMInFailedStateReason,
+		Message:            fmt.Sprintf("VM in degraded state: %s", vm.Status.Phase),
+		LastTransitionTime: metav1.Now(),
+	})
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DeckhouseMachineReconciler) handleVMNotReady(
+	logger logr.Logger,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+	vm *v1alpha2.VirtualMachine,
+) (ctrl.Result, error) {
+	// The other states are normal (for example, migration or shutdown) but we don't want to proceed until it's up
+	// due to potential conflict or unexpected actions
+	logger.Info("Waiting for VM state to become Running", "state", vm.Status.Phase)
+	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
+	conditions.Set(dvpMachine, metav1.Condition{
+		Type:               string(infrastructurev1a1.VMReadyCondition),
+		Status:             metav1.ConditionUnknown,
+		Reason:             infrastructurev1a1.VMNotReadyReason,
+		Message:            fmt.Sprintf("VM is not ready, state is %s", vm.Status.Phase),
+		LastTransitionTime: metav1.Now(),
+	})
+	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 }
 
 func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
@@ -471,38 +506,6 @@ func (r *DeckhouseMachineReconciler) getOrCreateVM(
 	return vm, nil
 }
 
-// cleanupVMResources removes resources created during VM provisioning
-func (r *DeckhouseMachineReconciler) cleanupVMResources(
-	ctx context.Context,
-	dvpMachine *infrastructurev1a1.DeckhouseMachine, // nolint:unparam
-	cloudInitSecretName string,
-	createdDiskNames []string,
-) {
-	logger := log.FromContext(ctx)
-
-	// Delete cloud-init secret
-	if cloudInitSecretName != "" {
-		if err := r.DVP.ComputeService.DeleteCloudInitProvisioningSecret(ctx, cloudInitSecretName); err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("Cleanup skipped: cloud-init secret not found (already deleted or never created)", "secretName", cloudInitSecretName)
-			} else {
-				logger.Error(err, "Failed to cleanup cloud-init secret", "secretName", cloudInitSecretName)
-			}
-		}
-	}
-
-	// Delete disks (boot and additional)
-	for _, diskName := range createdDiskNames {
-		if err := r.DVP.DiskService.RemoveDiskByName(ctx, diskName); err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info("Cleanup skipped: disk not found (already deleted or never created)", "diskName", diskName)
-			} else {
-				logger.Error(err, "Failed to cleanup disk", "diskName", diskName)
-			}
-		}
-	}
-}
-
 func (r *DeckhouseMachineReconciler) createVM(
 	ctx context.Context,
 	machine *clusterv1b2.Machine,
@@ -519,56 +522,73 @@ func (r *DeckhouseMachineReconciler) createVM(
 		return nil, fmt.Errorf("resource validation failed: %w", err)
 	}
 
-	var createdDiskNames []string
-	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
+	cloudInitScript, err := r.getBootstrapScript(ctx, machine)
+	if err != nil {
+		return nil, err
+	}
 
+	vm, err := r.ensureVM(ctx, machine, dvpMachine)
+	if err != nil {
+		return nil, err
+	}
+
+	vmOwnerRef := metav1.OwnerReference{
+		APIVersion: "virtualization.deckhouse.io/v1alpha2",
+		Kind:       "VirtualMachine",
+		Name:       vm.Name,
+		UID:        vm.UID,
+	}
+
+	for _, creator := range r.buildOwnedResourceCreators(dvpMachine, vmOwnerRef, cloudInitScript) {
+		if err := creator.create(ctx, vm); err != nil {
+			logger.Error(err, "Failed to ensure owned resource", "resource", creator.name)
+			return nil, fmt.Errorf("ensure %s: %w", creator.name, err)
+		}
+	}
+
+	return vm, nil
+}
+
+func (r *DeckhouseMachineReconciler) getBootstrapScript(
+	ctx context.Context,
+	machine *clusterv1b2.Machine,
+) ([]byte, error) {
 	bootstrapDataSecret := &corev1.Secret{}
 	if err := r.Client.Get(
 		ctx,
 		client.ObjectKey{Namespace: machine.GetNamespace(), Name: *machine.Spec.Bootstrap.DataSecretName},
 		bootstrapDataSecret,
 	); err != nil {
-		logger.Info("Failed to get bootstrap data secret, cleaning up created resources", "error", err.Error())
-		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 		return nil, fmt.Errorf("Cannot get cloud-init data secret: %w", err)
 	}
 
 	cloudInitScript, hasBootstrapScript := bootstrapDataSecret.Data["value"]
 	if !hasBootstrapScript {
-		logger.Info("Bootstrap script not found in secret, cleaning up created resources")
-		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
 		return nil, fmt.Errorf("Expected to find a cloud-init script in secret %s/%s", bootstrapDataSecret.Namespace, bootstrapDataSecret.Name)
 	}
 
-	bootDiskName := dvpMachine.Name + "-boot"
-	blockDeviceRefs := []v1alpha2.BlockDeviceSpecRef{
-		{Kind: v1alpha2.DiskDevice, Name: bootDiskName},
+	return cloudInitScript, nil
+}
+
+func (r *DeckhouseMachineReconciler) ensureVM(
+	ctx context.Context,
+	machine *clusterv1b2.Machine,
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+) (*v1alpha2.VirtualMachine, error) {
+	existing, err := r.DVP.ComputeService.GetVMByName(ctx, dvpMachine.Name)
+	if err == nil {
+		return existing, nil
+	}
+	if !errors.Is(err, cloudprovider.InstanceNotFound) {
+		return nil, fmt.Errorf("cannot get VirtualMachine: %w", err)
 	}
 
-	for i := range dvpMachine.Spec.AdditionalDisks {
-		addDiskName := fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, i)
-		blockDeviceRefs = append(blockDeviceRefs, v1alpha2.BlockDeviceSpecRef{
-			Kind: v1alpha2.DiskDevice,
-			Name: addDiskName,
-		})
-	}
-
-	runPolicy := dvpMachine.Spec.RunPolicy
-	if runPolicy == "" {
-		runPolicy = string(v1alpha2.AlwaysOnUnlessStoppedManually)
-	}
+	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
+	blockDeviceRefs := r.buildBlockDeviceRefs(dvpMachine)
+	runPolicy := r.resolveRunPolicy(dvpMachine)
 
 	// LiveMigrationPolicy: apply from spec or use default for masters
-	liveMigrationPolicy := dvpMachine.Spec.LiveMigrationPolicy
-	if liveMigrationPolicy == "" {
-		// For control plane nodes (masters), default to PreferForced due to high memory activity
-		if machine != nil && capiutil.IsControlPlaneMachine(machine) {
-			liveMigrationPolicy = string(v1alpha2.PreferForcedMigrationPolicy)
-		} else {
-			// For worker nodes, default to PreferSafe for safer live migrations
-			liveMigrationPolicy = string(v1alpha2.PreferSafeMigrationPolicy)
-		}
-	}
+	liveMigrationPolicy := r.resolveLiveMigrationPolicy(dvpMachine, machine)
 
 	vm, err := r.DVP.ComputeService.CreateVM(ctx, &v1alpha2.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -604,117 +624,159 @@ func (r *DeckhouseMachineReconciler) createVM(
 		},
 	})
 	if err != nil {
-		// Cleanup resources on VM creation failure
-		logger.Info("VM creation failed, cleaning up created resources", "error", err.Error())
-		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
+		return nil, r.wrapVMCreationError(ctx, dvpMachine, err)
+	}
 
-		// Log the request details for debugging
-		logger.Error(err, "Failed to create VM in parent DVP cluster",
-			"vm_name", dvpMachine.Name,
-			"vm_class", dvpMachine.Spec.VMClassName,
-			"requested_memory", dvpMachine.Spec.Memory.String(),
-			"requested_cpu_cores", dvpMachine.Spec.CPU.Cores,
-			"requested_cpu_fraction", dvpMachine.Spec.CPU.Fraction,
-		)
+	return vm, nil
+}
 
-		errMsg := err.Error()
+func (r *DeckhouseMachineReconciler) buildBlockDeviceRefs(dvpMachine *infrastructurev1a1.DeckhouseMachine) []v1alpha2.BlockDeviceSpecRef {
+	bootDiskName := dvpMachine.Name + "-boot"
+	refs := make([]v1alpha2.BlockDeviceSpecRef, 0, 1+len(dvpMachine.Spec.AdditionalDisks))
+	refs = append(refs, v1alpha2.BlockDeviceSpecRef{Kind: v1alpha2.DiskDevice, Name: bootDiskName})
 
-		// Check for permission/forbidden errors (e.g., vmClass mismatch or quota)
-		if strings.Contains(errMsg, "forbidden") || strings.Contains(errMsg, "Forbidden") {
-			return nil, fmt.Errorf("VM creation blocked in parent DVP cluster - possible vmClass resource limits exceeded or permission issue (vmClass: %s, memory: %s, CPU: %d cores @ %s): %w",
-				dvpMachine.Spec.VMClassName,
-				dvpMachine.Spec.Memory.String(),
-				dvpMachine.Spec.CPU.Cores,
-				dvpMachine.Spec.CPU.Fraction,
-				err)
-		}
+	for i := range dvpMachine.Spec.AdditionalDisks {
+		addDiskName := fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, i)
+		refs = append(refs, v1alpha2.BlockDeviceSpecRef{
+			Kind: v1alpha2.DiskDevice,
+			Name: addDiskName,
+		})
+	}
+	return refs
+}
 
-		// Check for resource constraint errors
-		if strings.Contains(errMsg, "insufficient") ||
-			strings.Contains(errMsg, "exceeded") ||
-			strings.Contains(errMsg, "quota") ||
-			strings.Contains(errMsg, "limit") {
-			return nil, fmt.Errorf("VM creation failed due to resource constraints - requested resources may exceed available capacity or vmClass limits (vmClass: %s, memory: %s, CPU: %d cores): %w",
-				dvpMachine.Spec.VMClassName,
-				dvpMachine.Spec.Memory.String(),
-				dvpMachine.Spec.CPU.Cores,
-				err)
-		}
+func (r *DeckhouseMachineReconciler) resolveRunPolicy(dvpMachine *infrastructurev1a1.DeckhouseMachine) string {
+	if dvpMachine.Spec.RunPolicy != "" {
+		return dvpMachine.Spec.RunPolicy
+	}
+	return string(v1alpha2.AlwaysOnUnlessStoppedManually)
+}
 
-		// Generic error with context
-		return nil, fmt.Errorf("create VM failed (vmClass: %s, memory: %s, CPU: %d cores): %w",
+func (r *DeckhouseMachineReconciler) resolveLiveMigrationPolicy(dvpMachine *infrastructurev1a1.DeckhouseMachine, machine *clusterv1b2.Machine) string {
+	if dvpMachine.Spec.LiveMigrationPolicy != "" {
+		return dvpMachine.Spec.LiveMigrationPolicy
+	}
+	// For control plane nodes (masters), default to PreferForced due to high memory activity
+	if machine != nil && capiutil.IsControlPlaneMachine(machine) {
+		return string(v1alpha2.PreferForcedMigrationPolicy)
+	}
+	// For worker nodes, default to PreferSafe for safer live migrations
+	return string(v1alpha2.PreferSafeMigrationPolicy)
+}
+
+func (r *DeckhouseMachineReconciler) wrapVMCreationError(ctx context.Context, dvpMachine *infrastructurev1a1.DeckhouseMachine, err error) error {
+	logger := log.FromContext(ctx)
+
+	// Log the request details for debugging
+	logger.Error(err, "Failed to create VM in parent DVP cluster",
+		"vm_name", dvpMachine.Name,
+		"vm_class", dvpMachine.Spec.VMClassName,
+		"requested_memory", dvpMachine.Spec.Memory.String(),
+		"requested_cpu_cores", dvpMachine.Spec.CPU.Cores,
+		"requested_cpu_fraction", dvpMachine.Spec.CPU.Fraction,
+	)
+
+	errMsg := err.Error()
+
+	// Check for permission/forbidden errors (e.g., vmClass mismatch or quota)
+	if strings.Contains(errMsg, "forbidden") || strings.Contains(errMsg, "Forbidden") {
+		return fmt.Errorf("VM creation blocked in parent DVP cluster - possible vmClass resource limits exceeded or permission issue (vmClass: %s, memory: %s, CPU: %d cores @ %s): %w",
+			dvpMachine.Spec.VMClassName,
+			dvpMachine.Spec.Memory.String(),
+			dvpMachine.Spec.CPU.Cores,
+			dvpMachine.Spec.CPU.Fraction,
+			err)
+	}
+
+	// Check for resource constraint errors
+	if strings.Contains(errMsg, "insufficient") ||
+		strings.Contains(errMsg, "exceeded") ||
+		strings.Contains(errMsg, "quota") ||
+		strings.Contains(errMsg, "limit") {
+		return fmt.Errorf("VM creation failed due to resource constraints - requested resources may exceed available capacity or vmClass limits (vmClass: %s, memory: %s, CPU: %d cores): %w",
 			dvpMachine.Spec.VMClassName,
 			dvpMachine.Spec.Memory.String(),
 			dvpMachine.Spec.CPU.Cores,
 			err)
 	}
 
-	if err = r.DVP.ComputeService.CreateCloudInitProvisioningSecret(
-		ctx,
-		r.ClusterUUID,
-		dvpMachine.Name,
-		cloudInitSecretName,
-		cloudInitScript,
-		vm.Name,
-		vm.UID,
-	); err != nil {
-		logger.Info("Cloud-init secret creation failed, cleaning up created resources", "error", err.Error())
-		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
-		return nil, fmt.Errorf("Cannot create cloud-init provisioning secret: %w", err)
-	}
+	// Generic error with context
+	return fmt.Errorf("create VM failed (vmClass: %s, memory: %s, CPU: %d cores): %w",
+		dvpMachine.Spec.VMClassName,
+		dvpMachine.Spec.Memory.String(),
+		dvpMachine.Spec.CPU.Cores,
+		err)
+}
 
-	if _, err = r.DVP.DiskService.CreateDiskFromDataSource(
-		ctx,
-		r.ClusterUUID,
-		dvpMachine.Name,
-		bootDiskName,
-		dvpMachine.Spec.RootDiskSize,
-		dvpMachine.Spec.RootDiskStorageClass,
-		&v1alpha2.VirtualDiskDataSource{
-			Type: v1alpha2.DataSourceTypeObjectRef,
-			ObjectRef: &v1alpha2.VirtualDiskObjectRef{
-				Kind: v1alpha2.VirtualDiskObjectRefKind(dvpMachine.Spec.BootDiskImageRef.Kind),
-				Name: dvpMachine.Spec.BootDiskImageRef.Name,
-			},
+func (r *DeckhouseMachineReconciler) buildOwnedResourceCreators(
+	dvpMachine *infrastructurev1a1.DeckhouseMachine,
+	vmOwnerRef metav1.OwnerReference,
+	cloudInitScript []byte,
+) []ownedResourceCreator {
+	cloudInitSecretName := "cloud-init-" + dvpMachine.Name
+	bootDiskName := dvpMachine.Name + "-boot"
+
+	creators := make([]ownedResourceCreator, 0, 2+len(dvpMachine.Spec.AdditionalDisks))
+	creators = append(creators, ownedResourceCreator{
+		name: "cloud-init-secret",
+		create: func(ctx context.Context, vm *v1alpha2.VirtualMachine) error {
+			return r.DVP.ComputeService.CreateCloudInitProvisioningSecret(
+				ctx,
+				r.ClusterUUID,
+				dvpMachine.Name,
+				cloudInitSecretName,
+				cloudInitScript,
+				vm.Name,
+				vm.UID,
+			)
 		},
-		[]metav1.OwnerReference{
-			{
-				APIVersion: "virtualization.deckhouse.io/v1alpha2",
-				Kind:       "VirtualMachine",
-				Name:       vm.Name,
-				UID:        vm.UID,
-			},
+	})
+	creators = append(creators, ownedResourceCreator{
+		name: "boot-disk",
+		create: func(ctx context.Context, vm *v1alpha2.VirtualMachine) error {
+			_, err := r.DVP.DiskService.CreateDiskFromDataSource(
+				ctx,
+				r.ClusterUUID,
+				dvpMachine.Name,
+				bootDiskName,
+				dvpMachine.Spec.RootDiskSize,
+				dvpMachine.Spec.RootDiskStorageClass,
+				&v1alpha2.VirtualDiskDataSource{
+					Type: v1alpha2.DataSourceTypeObjectRef,
+					ObjectRef: &v1alpha2.VirtualDiskObjectRef{
+						Kind: v1alpha2.VirtualDiskObjectRefKind(dvpMachine.Spec.BootDiskImageRef.Kind),
+						Name: dvpMachine.Spec.BootDiskImageRef.Name,
+					},
+				},
+				[]metav1.OwnerReference{vmOwnerRef},
+			)
+			return err
 		},
-	); err != nil {
-		logger.Info("Boot disk creation failed, cleaning up created resources", "error", err.Error())
-		r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
-		return nil, fmt.Errorf("Cannot create boot disk: %w", err)
-	}
-	createdDiskNames = append(createdDiskNames, bootDiskName)
+	})
 
 	for i, d := range dvpMachine.Spec.AdditionalDisks {
-		addDiskName := fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, i)
-		if _, err = r.DVP.DiskService.CreateDisk(
-			ctx,
-			r.ClusterUUID,
-			dvpMachine.Name,
-			addDiskName,
-			d.Size.Value(),
-			d.StorageClass,
-			[]metav1.OwnerReference{{
-				APIVersion: "virtualization.deckhouse.io/v1alpha2",
-				Kind:       "VirtualMachine",
-				Name:       vm.Name,
-				UID:        vm.UID,
-			}}); err != nil {
-			logger.Info("Additional disk creation failed, cleaning up created resources", "error", err.Error(), "diskName", addDiskName)
-			r.cleanupVMResources(ctx, dvpMachine, cloudInitSecretName, createdDiskNames)
-			return nil, fmt.Errorf("Cannot create additional disk %s: %w", addDiskName, err)
-		}
-		createdDiskNames = append(createdDiskNames, addDiskName)
+		diskIndex := i
+		disk := d
+		addDiskName := fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, diskIndex)
+
+		creators = append(creators, ownedResourceCreator{
+			name: fmt.Sprintf("additional-disk-%d", diskIndex),
+			create: func(ctx context.Context, vm *v1alpha2.VirtualMachine) error {
+				_, err := r.DVP.DiskService.CreateDisk(
+					ctx,
+					r.ClusterUUID,
+					dvpMachine.Name,
+					addDiskName,
+					disk.Size.Value(),
+					disk.StorageClass,
+					[]metav1.OwnerReference{vmOwnerRef},
+				)
+				return err
+			},
+		})
 	}
 
-	return vm, nil
+	return creators
 }
 
 // validateVMResources validates that VirtualMachineClass and boot image exist in parent DVP cluster


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR delete invalid and unpredictable logic in DeckhouseMachine controller
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This PR delete invalid and unpredictable logic in DeckhouseMachine controller. which could cause the deletion of owned by VM objects not in the way we want them to be deleted. And also make reconcile methods more readable. 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Fixed invalid and unpredictable logic in the DeckhouseMachine controller.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
