### PR TITLE
[control-plane-manager] add k8s version to cm update-observer

### DIFF
--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/const.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/const.go
@@ -17,9 +17,11 @@ limitations under the License.
 package cluster
 
 const (
-	componentLabelKey           = "component"
-	kubeVersionAnnotation       = "control-plane-manager.deckhouse.io/kubernetes-version"
-	clusterConfigurationYAML    = "cluster-configuration.yaml"
-	defaultKubernetesVersion    = "deckhouseDefaultKubernetesVersion"
-	ControlPlaneComponentsCount = 3
+	componentLabelKey              = "component"
+	kubeVersionAnnotation          = "control-plane-manager.deckhouse.io/kubernetes-version"
+	clusterConfigurationYAML       = "cluster-configuration.yaml"
+	defaultKubernetesVersion       = "deckhouseDefaultKubernetesVersion"
+	ControlPlaneComponentsCount    = 3
+	automaticKubernetesVersionEnv  = "AUTOMATIC_KUBERNETES_VERSION"
+	supportedKubernetesVersionsEnv = "ALLOWED_KUBERNETES_VERSIONS"
 )

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/env.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/env.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"update-observer/pkg/version"
+)
+
+type VersionSettings struct {
+	Supported []string
+	Automatic string
+}
+
+func LoadVersionSettingsFromEnv() (VersionSettings, error) {
+	supportedVersionsEnv := os.Getenv(supportedKubernetesVersionsEnv)
+	automaticVersion := os.Getenv(automaticKubernetesVersionEnv)
+	if supportedVersionsEnv == "" || automaticVersion == "" {
+		return VersionSettings{}, fmt.Errorf("%s or %s not found", supportedKubernetesVersionsEnv, automaticKubernetesVersionEnv)
+	}
+
+	var err error
+	var nAutomaticVersion string
+
+	if nAutomaticVersion, err = version.Normalize(automaticVersion); err != nil {
+		return VersionSettings{}, err
+	}
+
+	supportedVersions := strings.Split(supportedVersionsEnv, ",")
+	nSupportedVersions := make([]string, 0, len(supportedVersions))
+	for _, v := range supportedVersions {
+		if nV, err := version.Normalize(v); err != nil {
+			return VersionSettings{}, err
+		} else {
+			nSupportedVersions = append(nSupportedVersions, nV)
+		}
+	}
+
+	return VersionSettings{
+		Supported: nSupportedVersions,
+		Automatic: nAutomaticVersion,
+	}, nil
+
+}
+func (s VersionSettings) Available(maxUsedVersion string) []string {
+	for i, v := range s.Supported {
+		if v == maxUsedVersion {
+			// available versions from (maxUsed - 1) to newest
+			return s.Supported[max(i-1, 0):]
+		}
+	}
+
+	// maxVersion not found in supported list (shouldn't happen)
+	return s.Supported
+}

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/env.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/env.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
 	"update-observer/pkg/version"
 )
 
@@ -56,8 +57,8 @@ func LoadVersionSettingsFromEnv() (VersionSettings, error) {
 		Supported: nSupportedVersions,
 		Automatic: nAutomaticVersion,
 	}, nil
-
 }
+
 func (s VersionSettings) Available(maxUsedVersion string) []string {
 	for i, v := range s.Supported {
 		if v == maxUsedVersion {

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
@@ -26,14 +26,19 @@ type State struct {
 	Status
 }
 
-func GetState(cfg *Configuration, nodes *NodesState, controlPlane *ControlPlaneState, downgradeInProgress bool) *State {
+func GetState(cfg *Configuration, nodes *NodesState, controlPlane *ControlPlaneState, versionSettings VersionSettings, maxUsedVersion string, downgradeInProgress bool) *State {
+	currentVersion := determineCurrentVersion(nodes.versions, controlPlane.versions, downgradeInProgress)
+
 	state := &State{
 		Spec: Spec{
 			DesiredVersion: cfg.DesiredVersion,
 			UpdateMode:     cfg.UpdateMode,
 		},
 		Status: Status{
-			CurrentVersion:    determineCurrentVersion(nodes.versions, controlPlane.versions, downgradeInProgress),
+			CurrentVersion:    currentVersion,
+			SupportedVersions: versionSettings.Supported,
+			AvailableVersions: versionSettings.Available(version.GetMax(maxUsedVersion, currentVersion)), // prevent stale list when maxUsedVersion updates post-calculation
+			AutomaticVersion:  versionSettings.Automatic,
 			ControlPlaneState: *controlPlane,
 			NodesState:        *nodes,
 		},
@@ -55,7 +60,7 @@ func (s *State) determineStatePhase() {
 	case ControlPlaneInconsistent:
 		phase = ClusterControlPlaneInconsistent
 	case ControlPlaneUpToDate:
-		if s.Spec.UpdateMode == UpdateModeAutomatic && s.CurrentVersion > s.Spec.DesiredVersion {
+		if s.Spec.UpdateMode == UpdateModeAutomatic && version.Compare(s.CurrentVersion, s.Spec.DesiredVersion) > 0 {
 			phase = ClusterVersionDrift
 			break
 		}
@@ -96,6 +101,9 @@ type Spec struct {
 
 type Status struct {
 	CurrentVersion    string
+	SupportedVersions []string
+	AvailableVersions []string
+	AutomaticVersion  string
 	ControlPlaneState ControlPlaneState
 	NodesState        NodesState
 	Phase             Phase

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/cluster.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/cluster.go
@@ -31,7 +31,7 @@ import (
 	podstatus "update-observer/pkg/pod-status"
 )
 
-func (r *reconciler) getClusterState(ctx context.Context, cfg *cluster.Configuration, downgradeInProgress bool) (*cluster.State, error) {
+func (r *reconciler) getClusterState(ctx context.Context, cfg *cluster.Configuration, configmapLabels map[string]string, downgradeInProgress bool) (*cluster.State, error) {
 	nodesState, err := r.getNodesState(ctx, cfg.DesiredVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get nodes state: %w", err)
@@ -42,7 +42,13 @@ func (r *reconciler) getClusterState(ctx context.Context, cfg *cluster.Configura
 		return nil, fmt.Errorf("failed to get control plane state: %w", err)
 	}
 
-	return cluster.GetState(cfg, nodesState, controlPlaneState, downgradeInProgress), nil
+	maxUsedVersion := configmapLabels[common.MaxK8sVersionLabelKey]
+	versionSettings, err := cluster.LoadVersionSettingsFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse versions from env: %w", err)
+	}
+
+	return cluster.GetState(cfg, nodesState, controlPlaneState, versionSettings, maxUsedVersion, downgradeInProgress), nil
 }
 
 func (r *reconciler) getClusterConfiguration(ctx context.Context) (*cluster.Configuration, error) {

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/configmap.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/configmap.go
@@ -44,11 +44,14 @@ type Spec struct {
 }
 
 type Status struct {
-	CurrentVersion string             `yaml:"currentVersion"`
-	Phase          string             `yaml:"phase"`
-	Progress       string             `yaml:"progress,omitempty"`
-	ControlPlane   []ControlPlaneNode `yaml:"controlPlane"`
-	Nodes          Nodes              `yaml:"nodes"`
+	CurrentVersion    string             `yaml:"currentVersion"`
+	SupportedVersions []string           `yaml:"supportedVersions"`
+	AvailableVersions []string           `yaml:"availableVersions"`
+	AutomaticVersion  string             `yaml:"automaticVersion"`
+	Phase             string             `yaml:"phase"`
+	Progress          string             `yaml:"progress,omitempty"`
+	ControlPlane      []ControlPlaneNode `yaml:"controlPlane"`
+	Nodes             Nodes              `yaml:"nodes"`
 }
 
 type ControlPlaneNode struct {
@@ -176,10 +179,13 @@ func renderConfigMapData(clusterState *cluster.State) ConfigMapData {
 			UpdateMode:     string(clusterState.Spec.UpdateMode),
 		},
 		Status: &Status{
-			CurrentVersion: clusterState.CurrentVersion,
-			Phase:          string(clusterState.Status.Phase),
-			Progress:       renderProgress(clusterState.Progress),
-			ControlPlane:   renderControlPlanes(clusterState.ControlPlaneState.MasterNodes),
+			CurrentVersion:    clusterState.CurrentVersion,
+			SupportedVersions: clusterState.SupportedVersions,
+			AvailableVersions: clusterState.AvailableVersions,
+			AutomaticVersion:  clusterState.AutomaticVersion,
+			Phase:             string(clusterState.Status.Phase),
+			Progress:          renderProgress(clusterState.Progress),
+			ControlPlane:      renderControlPlanes(clusterState.ControlPlaneState.MasterNodes),
 			Nodes: Nodes{
 				DesiredCount:  clusterState.NodesState.DesiredCount,
 				UpToDateCount: clusterState.NodesState.UpToDateCount,

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/controller.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/controller.go
@@ -174,7 +174,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	reconcileTrigger := determineReconcileTrigger(configMap, clusterCfg)
 
-	clusterState, err := r.getClusterState(ctx, clusterCfg, reconcileTrigger == ReconcileTriggerDowngradeK8s)
+	clusterState, err := r.getClusterState(ctx, clusterCfg, configMap.Labels, reconcileTrigger == ReconcileTriggerDowngradeK8s)
 	if err != nil {
 		klog.Error("Error encountered while getting cluster state", err)
 		return reconcile.Result{RequeueAfter: requeueInterval}, nil

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/controller_test.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/controller_test.go
@@ -74,6 +74,9 @@ type ControllerTestSuite struct {
 
 func (suite *ControllerTestSuite) TestConfigMapIsValid() {
 	synctest.Test(suite.T(), func(*testing.T) {
+		suite.T().Setenv("ALLOWED_KUBERNETES_VERSIONS", "1.31,1.32,1.33,1.34,1.35")
+		suite.T().Setenv("AUTOMATIC_KUBERNETES_VERSION", "1.33")
+
 		suite.Run("When cluster is up to date", func() {
 			suite.setupController(suite.fetchTestFileData("init-up-to-date.yaml"))
 
@@ -86,6 +89,17 @@ func (suite *ControllerTestSuite) TestConfigMapIsValid() {
 		})
 		suite.Run("When control plane component was failed", func() {
 			suite.setupController(suite.fetchTestFileData("pods-failed.yaml"))
+
+			_, err := suite.controller.Reconcile(
+				suite.ctx,
+				reconcile.Request{},
+			)
+
+			require.NoError(suite.T(), err)
+		})
+		suite.Run("When supported and automatic versions are set via env", func() {
+
+			suite.setupController(suite.fetchTestFileData("versions-with-env.yaml"))
 
 			_, err := suite.controller.Reconcile(
 				suite.ctx,

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/cases/pods-failed.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/cases/pods-failed.yaml
@@ -7,7 +7,22 @@ metadata:
 data:
   cluster-configuration.yaml: |
     YXBpVmVyc2lvbjogZGVja2hvdXNlLmlvL3YxCmtpbmQ6IENsdXN0ZXJDb25maWd1cmF0aW9uCmt1YmVybmV0ZXNWZXJzaW9uOiBBdXRvbWF0aWM=
+  # v1.35
   deckhouseDefaultKubernetesVersion: djEuMzU=
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    cause: idle
+    lastReconciliationTime: '2026-01-01T00:00:00Z'
+    lastUpToDateTime: '2026-01-01T00:00:00Z'
+  labels:
+    heritage: deckhouse
+    k8s-version: v1.35
+    max-k8s-version: v1.35
+  name: d8-cluster-kubernetes
+  namespace: kube-system
 ---
 apiVersion: v1
 kind: Node

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/cases/versions-with-env.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/cases/versions-with-env.yaml
@@ -1,0 +1,94 @@
+---
+apiVersion: v1
+data:
+  # kubernetesVersion: Automatic
+  cluster-configuration.yaml: |
+    YXBpVmVyc2lvbjogZGVja2hvdXNlLmlvL3YxCmtpbmQ6IENsdXN0ZXJDb25maWd1cmF0aW9uCmt1YmVybmV0ZXNWZXJzaW9uOiBBdXRvbWF0aWM=
+  # v1.33
+  deckhouseDefaultKubernetesVersion: djEuMzM=
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    cause: idle
+    lastReconciliationTime: '2026-01-01T00:00:00Z'
+    lastUpToDateTime: '2026-01-01T00:00:00Z'
+  labels:
+    heritage: deckhouse
+    k8s-version: v1.34
+    max-k8s-version: v1.34
+  name: d8-cluster-kubernetes
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-1
+status:
+  nodeInfo:
+    kubeletVersion: v1.34.5
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    control-plane-manager.deckhouse.io/kubernetes-version: v1.34.5
+  labels:
+    component: kube-apiserver
+  name: kube-apiserver-master-1
+  namespace: kube-system
+spec:
+  nodeName: master-1
+status:
+  containerStatuses:
+    - containerID: containerd://ca4b72fae2d83e56cca8add30a09f815f3c595e5e93c614f0094f0a41d823b72
+      ready: true
+      state:
+        running:
+          startedAt: '2026-01-28T06:34:19Z'
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    control-plane-manager.deckhouse.io/kubernetes-version: v1.34.5
+  labels:
+    component: kube-scheduler
+  name: kube-scheduler-master-1
+  namespace: kube-system
+spec:
+  nodeName: master-1
+status:
+  containerStatuses:
+    - containerID: containerd://ca4b72fae2d83e56cca8add30a09f815f3c595e5e93c614f0094f0a41d823b72
+      ready: true
+      state:
+        running:
+          startedAt: '2026-01-28T06:34:19Z'
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    control-plane-manager.deckhouse.io/kubernetes-version: v1.34.5
+  labels:
+    component: kube-controller-manager
+  name: kube-controller-manager-master-1
+  namespace: kube-system
+spec:
+  nodeName: master-1
+status:
+  containerStatuses:
+    - containerID: containerd://ca4b72fae2d83e56cca8add30a09f815f3c595e5e93c614f0094f0a41d823b72
+      ready: true
+      state:
+        running:
+          startedAt: '2026-01-28T06:34:19Z'
+  phase: Running

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/init-up-to-date.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/init-up-to-date.yaml
@@ -5,6 +5,16 @@ data:
     updateMode: Automatic
   status: |
     currentVersion: v1.35
+    supportedVersions:
+    - v1.31
+    - v1.32
+    - v1.33
+    - v1.34
+    - v1.35
+    availableVersions:
+    - v1.34
+    - v1.35
+    automaticVersion: v1.33
     phase: UpToDate
     controlPlane:
     - name: master-1
@@ -25,7 +35,7 @@ data:
 metadata:
   annotations:
     cause: init
-    lastReconciliationTime: "2000-01-01T03:00:00+03:00"
+    lastReconciliationTime: "2000-01-01T04:00:00+04:00"
   labels:
     heritage: deckhouse
     k8s-version: v1.35

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/pods-failed.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/pods-failed.yaml
@@ -5,6 +5,16 @@ data:
     updateMode: Automatic
   status: |
     currentVersion: v1.35
+    supportedVersions:
+    - v1.31
+    - v1.32
+    - v1.33
+    - v1.34
+    - v1.35
+    availableVersions:
+    - v1.34
+    - v1.35
+    automaticVersion: v1.33
     phase: ControlPlaneUpdating
     progress: 77%
     controlPlane:
@@ -27,8 +37,9 @@ data:
       upToDateCount: 3
 metadata:
   annotations:
-    cause: init
-    lastReconciliationTime: "2000-01-01T03:00:30+03:00"
+    cause: idle
+    lastReconciliationTime: "2000-01-01T04:00:30+04:00"
+    lastUpToDateTime: "2026-01-01T00:00:00Z"
   labels:
     heritage: deckhouse
     k8s-version: v1.35

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/versions-with-env.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/versions-with-env.yaml
@@ -1,0 +1,41 @@
+---
+data:
+  spec: |
+    desiredVersion: v1.33
+    updateMode: Automatic
+  status: |
+    currentVersion: v1.34
+    supportedVersions:
+    - v1.31
+    - v1.32
+    - v1.33
+    - v1.34
+    - v1.35
+    availableVersions:
+    - v1.33
+    - v1.34
+    - v1.35
+    automaticVersion: v1.33
+    phase: ControlPlaneUpdating
+    progress: 0%
+    controlPlane:
+    - name: master-1
+      phase: Updating
+      components:
+        kube-apiserver: v1.34
+        kube-controller-manager: v1.34
+        kube-scheduler: v1.34
+    nodes:
+      desiredCount: 1
+      upToDateCount: 0
+metadata:
+  annotations:
+    cause: downgradeK8s
+    lastReconciliationTime: "2000-01-01T04:00:30+04:00"
+    lastUpToDateTime: "2026-01-01T00:00:00Z"
+  labels:
+    heritage: deckhouse
+    k8s-version: v1.34
+    max-k8s-version: v1.34
+  name: d8-cluster-kubernetes
+  namespace: kube-system

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -20,6 +20,18 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+// Compare compares two versions semantically by normalizing them first.
+// Returns -1, 0, or 1 analogous to semver.Compare - 0 if v == w, -1 if v < w, or +1 if v > w.
+// If normalization of either version fails, returns 0 (versions are considered equal).
+func Compare(v, w string) int {
+	vNorm, errV := Normalize(v)
+	wNorm, errW := Normalize(w)
+	if errV != nil || errW != nil {
+		return 0
+	}
+	return semver.Compare(vNorm, wNorm)
+}
+
 func GetMax(v, w string) string {
 	switch semver.Compare(v, w) {
 	case -1:

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/normalize.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/normalize.go
@@ -28,6 +28,20 @@ const (
 )
 
 func NormalizeAndTrimPatch(version string) (string, error) {
+	normalized, err := Normalize(version)
+	if err != nil {
+		return "", err
+	}
+
+	parts := strings.Split(normalized, ".")
+	if len(parts) < SemverMajorMinorAccuracy {
+		return "", fmt.Errorf("version must have at least MAJOR.MINOR: %s", version)
+	}
+
+	return fmt.Sprintf("%s.%s", parts[0], parts[1]), nil
+}
+
+func Normalize(version string) (string, error) {
 	if version == "" {
 		return "", nil
 	}
@@ -41,10 +55,13 @@ func NormalizeAndTrimPatch(version string) (string, error) {
 		return "", fmt.Errorf("invalid semver: %s", version)
 	}
 
-	parts := strings.Split(normalized, ".")
-	if len(parts) < SemverMajorMinorAccuracy {
-		return "", fmt.Errorf("version must have at least MAJOR.MINOR: %s", version)
+	return normalized, nil
+}
+
+func Denormalize(version string) string {
+	if version == "" {
+		return ""
 	}
 
-	return fmt.Sprintf("%s.%s", parts[0], parts[1]), nil
+	return strings.TrimPrefix(version, "v")
 }

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -52,7 +52,11 @@ memory: 10Mi
 {{- $_ := set $tpl_context "resourcesRequestsMemoryControlPlane" .Values.global.internal.modules.resourcesRequests.memoryControlPlane }}
 
 {{- $allowedKubernetesVersions := list }}
-{{- range $key, $_ := $tpl_context.k8s }}
+{{- $automaticVersion := ""}}
+{{- range $key, $value := $tpl_context.k8s }}
+  {{- if $value.default}}
+    {{- $automaticVersion = (toString $key)}}
+  {{- end }}
   {{- $allowedKubernetesVersions = append $allowedKubernetesVersions (toString $key) }}
 {{- end }}
 
@@ -352,6 +356,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: ALLOWED_KUBERNETES_VERSIONS
+          value: {{ $allowedKubernetesVersions | sortAlpha | join  "," | quote }}
+        - name: AUTOMATIC_KUBERNETES_VERSION
+          value: {{ $automaticVersion | quote }}
         {{- include "helm_lib_envs_for_proxy" $ | nindent 8 }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add information to `d8-cluster-kubernetes` about supported versions, available versions, and the current "automatic" version.

<details>
  <summary>Before:</summary>

```yaml
  apiVersion: v1
  data:
    spec: |
      desiredVersion: v1.34
      updateMode: Manual
    status: |
      currentVersion: v1.34
      phase: UpToDate
      controlPlane:
      - name: dev-master-0
        phase: UpToDate
        components:
          kube-apiserver: v1.34
          kube-controller-manager: v1.34
          kube-scheduler: v1.34
      - name: dev-master-1
        phase: UpToDate
        components:
          kube-apiserver: v1.34
          kube-controller-manager: v1.34
          kube-scheduler: v1.34
      nodes:
        desiredCount: 5
        upToDateCount: 5
  kind: ConfigMap
  metadata:
    annotations:
      cause: idle
      lastReconciliationTime: "2026-03-26T09:30:28Z"
      lastUpToDateTime: "2026-03-24T06:49:47Z"
    creationTimestamp: "2026-02-04T06:37:32Z"
    labels:
      heritage: deckhouse
      k8s-version: v1.34
      max-k8s-version: v1.34
    name: d8-cluster-kubernetes
    namespace: kube-system
    resourceVersion: "77143239"
    uid: c75b4c67-d4a6-405d-81ef-9c6fb1b9d553
```
</details>

<details>
  <summary>After:</summary>

```yaml
  apiVersion: v1
  data:
    spec: |
      desiredVersion: v1.34
      updateMode: Manual
    status: |
      currentVersion: v1.34
      supportedVersions:
      - v1.31
      - v1.32
      - v1.33
      - v1.34
      - v1.35
      availableVersions:
      - v1.33
      - v1.34
      - v1.35
      automaticVersion: v1.33
      phase: UpToDate
      controlPlane:
      - name: ngorbatov-dev-master-0
        phase: UpToDate
        components:
          kube-apiserver: v1.34
          kube-controller-manager: v1.34
          kube-scheduler: v1.34
      - name: ngorbatov-dev-master-1
        phase: UpToDate
        components:
          kube-apiserver: v1.34
          kube-controller-manager: v1.34
          kube-scheduler: v1.34
      nodes:
        desiredCount: 5
        upToDateCount: 5
  kind: ConfigMap
  metadata:
    annotations:
      cause: idle
      lastReconciliationTime: "2026-03-27T11:39:34Z"
      lastUpToDateTime: "2026-03-24T06:49:47Z"
    creationTimestamp: "2026-02-04T06:37:32Z"
    labels:
      heritage: deckhouse
      k8s-version: v1.34
      max-k8s-version: v1.34
    name: d8-cluster-kubernetes
    namespace: kube-system
    resourceVersion: "78416109"
    uid: c75b4c67-d4a6-405d-81ef-9c6fb1b9d553
```
</details>

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Adding information about k8s versions.

- **supportedVersions** -  supported in the current release 
- **availableVersions** - list of Kubernetes versions available for upgrade or downgrade in this specific cluster. This list is constrained by the maximum version ever installed on the cluster. Since a downgrade is only possible by one minor version at a time, versions beyond that limit are excluded.
- **automaticVersion** - version that will be used when "Automatic" is selected

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Added information to `d8-cluster-kubernetes` about the supported, available, and current `Automatic` versions of Kubernetes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
