### PR TITLE
[dhctl] fix(dhctl-for-commander): send second sigint to opentofu in server mode

### DIFF
--- a/dhctl/pkg/infrastructure/exec/exec.go
+++ b/dhctl/pkg/infrastructure/exec/exec.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -35,6 +36,8 @@ const HasChangesExitCode = 2
 // based on https://stackoverflow.com/a/43931246
 // https://regex101.com/r/qtIrSj/1
 var infrastructureLogsMatcher = regexp.MustCompile(`(\s+\[(TRACE|DEBUG|INFO|WARN|ERROR)\]\s+|Use TF_LOG=TRACE|there is no package|\-\-\-\-)`)
+
+type forceStopKey struct{}
 
 func Exec(ctx context.Context, cmd *exec.Cmd, logger log.Logger) (int, error) {
 	// Start infrastructure utility as a leader of the new process group to prevent
@@ -109,9 +112,13 @@ func Exec(ctx context.Context, cmd *exec.Cmd, logger log.Logger) (int, error) {
 		return cmd.ProcessState.ExitCode(), err
 	}
 
+	processDone := make(chan struct{})
+	go forceStopOnTimeout(ctx, processDone, cmd.Process.Pid, logger)
+
 	wg.Wait()
 
 	err = cmd.Wait()
+	close(processDone)
 
 	exitCode := cmd.ProcessState.ExitCode() // 2 = exit code, if infrastructure plan has diff
 	if err != nil && exitCode != HasChangesExitCode {
@@ -139,4 +146,45 @@ func ReplaceHomeDirEnv(env []string, homeDir string) []string {
 	}
 
 	return res
+}
+
+// ContextWithForceStop returns a new context that enables force stop behavior.
+// Intended for server mode where hanging processes must be terminated within a bounded time.
+func ContextWithForceStop(ctx context.Context) context.Context {
+	return context.WithValue(ctx, forceStopKey{}, true)
+}
+
+// forceStopOnTimeout waits for the context to be cancelled, then gives the process
+// gracefulStopDelay to exit on its own after the first SIGINT.
+// If the process does not exit in time, a second SIGINT is sent to force immediate exit.
+func forceStopOnTimeout(ctx context.Context, processDone <-chan struct{}, pid int, logger log.Logger) {
+	const gracefulStopDelay = time.Minute
+
+	if !hasForceStop(ctx) {
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-processDone:
+		return
+	}
+
+	t := time.NewTimer(gracefulStopDelay)
+	defer t.Stop()
+
+	select {
+	case <-t.C:
+		logger.LogInfoF(
+			"infrastructure utility process did not exit after graceful stop timeout (%s), sending second SIGINT\n",
+			gracefulStopDelay.String(),
+		)
+		_ = syscall.Kill(-pid, syscall.SIGINT)
+	case <-processDone:
+	}
+}
+
+func hasForceStop(ctx context.Context) bool {
+	v, _ := ctx.Value(forceStopKey{}).(bool)
+	return v
 }

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	infraexec "github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/exec"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/check"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
@@ -90,6 +91,7 @@ func operationCtx(server grpc.ServerStream) (context.Context, context.CancelFunc
 	}()
 
 	opCtx, cancel := context.WithCancel(ctx)
+	opCtx = infraexec.ContextWithForceStop(opCtx)
 
 	return logger.ToContext(
 		opCtx,


### PR DESCRIPTION
Send second sigint to opentofu in server mode if process did not exit after graceful stop timeout

## Description
When a user clicks "Cancel" in Commander, dhctl server receives a cancellation event and sends SIGINT to the running OpenTofu process. However, OpenTofu's graceful shutdown on the first SIGINT does not cancel provider gRPC contexts — it only stops scheduling new operations and waits for the currently running one to finish naturally. 

For DVP, the current operation is a readiness polling loop inside kubernetes_resource_ready_v1 that can run up to 30 minutes. As a result, the user clicks "Cancel" and nothing visibly happens for up to 30 minutes, after which the operation times out on its own.

This fix adds forced stop behavior for server mode: if OpenTofu does not exit within 1 minute after the first SIGINT, a second SIGINT is sent. OpenTofu treats the second SIGINT as an immediate exit signal ("Two interrupts received. Exiting immediately.") and terminates promptly.
The behavior is opt-in via a context key (WithForceStop) that is set only in operationCtx — the entry point for all gRPC server operations. 

CLI mode behavior is unchanged.

**Before**: user clicks Cancel → dhctl sends SIGINT → OpenTofu hangs for up to 30 minutes → times out with error.
<details>
<summary>Before</summary>
<img width="1209" height="671" alt="Screenshot 2026-03-30 at 15 41 21" src="https://github.com/user-attachments/assets/70e52918-8359-49e6-b3a0-42f090bac04c" />
</details>

**After**: user clicks Cancel → dhctl sends SIGINT → 1 minute grace period for state saving → second SIGINT → OpenTofu exits immediately.

<details>
<summary>After</summary>
<img width="1209" height="595" alt="Screenshot 2026-03-30 at 15 41 56" src="https://github.com/user-attachments/assets/bc124a7a-0fbf-4c50-8c9f-288a66407d69" />

</details>

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Send second sigint to opentofu in server mode if process did not exit after graceful stop timeout
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
