### PR TITLE
[common] Remove Python from debug-container and add VEX for etcdctl

### DIFF
--- a/modules/000-common/images/debug-container/known_vulnerabilities.vex
+++ b/modules/000-common/images/debug-container/known_vulnerabilities.vex
@@ -1,0 +1,38 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-41a5cb02200a981d0e152bffdd0754addf47f69efe2db1b00812aff0a07fe3f3",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 2,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-24051"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-24051 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды ioreg, которая является специфичной для операционной системы macOS (Darwin) и отсутствует в ядре Linux.",
+      "timestamp": "2026-03-04T09:42:58.078449Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33186"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/google.golang.org/grpc"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в etcd в рамках Deckhouse: etcd не использует path-based авторизационные интерцепторы (grpc/authz или аналоги) с deny-правилами и fallback allow. Авторизация в etcd реализована через собственный встроенный механизм на основе mTLS и username/password, который не подвержен данной уязвимости.",
+      "timestamp": "2026-03-24T10:09:40.852754Z"
+    }
+  ],
+  "timestamp": "2026-03-04T09:42:58Z",
+  "last_updated": "2026-03-24T10:09:40Z"
+}

--- a/modules/000-common/images/debug-container/werf.inc.yaml
+++ b/modules/000-common/images/debug-container/werf.inc.yaml
@@ -2,7 +2,7 @@
 {{- $iptables_image_version := $iptables_version | replace "." "-" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
-fromImage: common/relocate-artifact
+from: {{ index $.Images "builder/alpine" }}
 final: false
 import:
 - image: registrypackages/iptables-artifact-{{ $iptables_image_version }}
@@ -27,17 +27,13 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 import:
-- image: common-base-python-artifact
+- from: {{ index $.Images "libs/musl" }}
+  add: /usr/lib/libc.so
+  to: /usr/lib/libc.so
+  before: install
+- from: {{ index $.Images "libs/musl" }}
   add: /lib/ld-musl-x86_64.so.1
   to: /lib/ld-musl-x86_64.so.1
-  before: install
-- image: common-base-python-artifact
-  add: /usr
-  to: /usr
-  includePaths:
-  - bin/python*
-  - lib/python*
-  - lib/libc.so
   before: install
 - from: {{ index $.Images "tools/curl" }}
   add: /usr/bin/curl


### PR DESCRIPTION
## Description

- Completely removed Python from the `debug-container` image as it is no longer needed for the container's functionality. This inherently resolves multiple Python-related CVEs found by security scanners (including findings for `pip:25.3`, `cryptography:44.0.1`, and `pyOpenSSL:24.3.0`).
- Added an OpenVEX file (`known_vulnerabilities.vex`) for the `debug-container` image to justify that vulnerabilities found in `etcdctl` and `etcdutl` (like `CVE-2026-33186` for `google.golang.org/grpc`, and `CVE-2026-24051` for `go.opentelemetry.io/otel/sdk`) are not exploitable in the context of Deckhouse.

## Why do we need it, and what problem does it solve?

Python is no longer needed in the `debug-container` image. By completely removing it, we simplify the container, drastically reduce its attack surface, and automatically eliminate a whole class of vulnerabilities previously flagged by security scanners (such as those in `pip`, `cryptography`, and `pyOpenSSL`).

Furthermore, scanners flag `etcdctl` and `etcdutl` binaries due to known CVEs in their Go module dependencies (`google.golang.org/grpc` and `go.opentelemetry.io/otel/sdk`). We need to provide a VEX statement to explicitly document that these specific vulnerabilities are not exploitable in the Deckhouse environment, thus clearing false-positive security reports.

## Why do we need it in the patch release (if we do)?

We need to backport this into patch releases to provide a clean security footprint and resolve critical vulnerabilities and false positives reported by user security scanners as quickly as possible.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Removed Python completely from the debug-container image as it is no longer needed, resolving corresponding CVEs, and silenced false positives for etcd binaries via VEX.
impact_level: default
```