### PR TITLE
[node-manager] Fix to CAPS for use StaticMachine CreationTimestamp for adopt timeout instead of StaticInstance LastUpdateTime.

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
@@ -39,13 +39,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 	infrav1 "caps-controller-manager/api/infrastructure/v1alpha1"
 	"caps-controller-manager/internal/client"
 	"caps-controller-manager/internal/controller"
 	"caps-controller-manager/internal/event"
 	"caps-controller-manager/internal/pool"
 	"caps-controller-manager/internal/scope"
+
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 )
 
 const (
@@ -403,7 +404,7 @@ func (r *StaticMachineReconciler) reconcileStaticInstancePhase(
 		instanceScope.Logger.V(1).Info("StaticInstance is adopting")
 
 		estimated := DefaultStaticInstanceAdoptTimeout -
-			time.Since(instanceScope.Instance.Status.CurrentStatus.LastUpdateTime.Time)
+			time.Since(instanceScope.MachineScope.StaticMachine.CreationTimestamp.Time)
 
 		if estimated < (10 * time.Second) {
 			instanceScope.MachineScope.Fail("UpdateError",

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
@@ -39,14 +39,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 	infrav1 "caps-controller-manager/api/infrastructure/v1alpha1"
 	"caps-controller-manager/internal/client"
 	"caps-controller-manager/internal/controller"
 	"caps-controller-manager/internal/event"
 	"caps-controller-manager/internal/pool"
 	"caps-controller-manager/internal/scope"
-
-	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 )
 
 const (

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,8 +46,6 @@ import (
 	"caps-controller-manager/internal/event"
 	"caps-controller-manager/internal/pool"
 	"caps-controller-manager/internal/scope"
-
-	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 )
 
 const (

--- a/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/internal/controller/infrastructure/staticmachine_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +45,8 @@ import (
 	"caps-controller-manager/internal/event"
 	"caps-controller-manager/internal/pool"
 	"caps-controller-manager/internal/scope"
+
+	deckhousev1 "caps-controller-manager/api/deckhouse.io/v1alpha2"
 )
 
 const (


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
During cluster bootstrap with static nodes, the CAPS controller fails to adopt the master node because the adopt timeout is calculated from a timestamp set long before the controller can start. This fix changes the timeout reference point to StaticMachine's CreationTimestamp, which reflects when the controller is actually ready to begin adoption.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The adopt timeout (5 minutes) is currently measured from StaticInstance's LastUpdateTime, but in some cases during bootstrap the CAPS controller needs more than 5 minutes just to start (waiting for API server, leader lease, etc.). 

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: Fixed CAPS to use StaticMachine CreationTimestamp for the adopt timeout instead of StaticInstance.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
