### PR TITLE
[cloud-provider-azure] replace autodiscovery with deterministic disk selection

### DIFF
--- a/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -1,27 +1,40 @@
 {{- if eq .nodeGroup.name "master" }}
 
+# Terraform-only deterministic mode (no autodiscovery)
+
+kubernetes_data_device_id="$(cat /var/lib/bashible/kubernetes_data_device_path 2>/dev/null || true)"
+
 if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]]; then
   return 0
 fi
 
-if [ -f /var/lib/bashible/kubernetes-data-device-installed ]; then
-  return 0
+if [ -z "$kubernetes_data_device_id" ]; then
+  >&2 echo "kubernetes_data_device_path is not set. Provide it via Terraform/cloud-init."
+  return 1
 fi
 
-if ! grep "/dev" /var/lib/bashible/kubernetes_data_device_path >/dev/null; then
-  get_disks_by_lun_id="$(ls /dev/disk/azure/*/lun10 -l)"
+kubernetes_data_device_path=""
 
-  if [ "$(wc -l <<< "$get_disks_by_lun_id")" -ne 1 ]; then
-    >&2 echo "failed to discover kubernetes-data device"
+# Direct block device path (NVMe / by-id)
+if [ -b "$kubernetes_data_device_id" ]; then
+  kubernetes_data_device_path="$kubernetes_data_device_id"
+
+# Azure SCSI / udev-based LUN mapping (explicit only)
+elif [[ "$kubernetes_data_device_id" == lun* ]]; then
+  lun_number="${kubernetes_data_device_id#lun}"
+
+  kubernetes_data_device_path="$(ls -1 /dev/disk/azure/data-lun${lun_number} 2>/dev/null | head -n1 || true)"
+
+  if [ -z "$kubernetes_data_device_path" ]; then
+    >&2 echo "Azure disk for $kubernetes_data_device_id not found (/dev/disk/azure/data-lun${lun_number})"
     return 1
   fi
 
-  kubernetes_data_device_path="$(awk '{gsub("../../..", "/dev");print $11}' <<< "$get_disks_by_lun_id")"
 else
-  return 0
+  >&2 echo "Unsupported kubernetes_data_device_path format: $kubernetes_data_device_id"
+  return 1
 fi
 
 echo "kubernetes_data_device: $kubernetes_data_device_path"
 blkid
-echo "$kubernetes_data_device_path" > /var/lib/bashible/kubernetes_data_device_path
 {{- end }}

--- a/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -20,13 +20,35 @@ if [ -b "$kubernetes_data_device_id" ]; then
   kubernetes_data_device_path="$kubernetes_data_device_id"
 
 # Azure SCSI / udev-based LUN mapping (explicit only)
-elif [[ "$kubernetes_data_device_id" == lun* ]]; then
-  lun_number="${kubernetes_data_device_id#lun}"
+elif [[ "$kubernetes_data_device_id" == lun* ]] || [[ "$kubernetes_data_device_id" =~ ^[0-9]+$ ]]; then
+  # Extract LUN number: accept "lun10" or just "10"
+  if [[ "$kubernetes_data_device_id" == lun* ]]; then
+    lun_number="${kubernetes_data_device_id#lun}"
+  else
+    lun_number="$kubernetes_data_device_id"
+  fi
 
-  kubernetes_data_device_path="$(ls -1 /dev/disk/azure/data-lun${lun_number} 2>/dev/null | head -n1 || true)"
+  # Method 1: Try Azure SCSI udev path (works on SCSI VMs)
+  kubernetes_data_device_path="$(ls -1 /dev/disk/azure/data-lun${lun_number} /dev/disk/azure/scsi*/lun${lun_number} 2>/dev/null | head -n1 || true)"
+
+  # Method 2: Try NVMe by-path (works on NVMe VMs)
+  # Azure NVMe namespace mapping: LUN N typically maps to namespace N+2 (e.g., LUN 10 → ns 12)
+  # Search for any nvme device in by-path that could be our LUN
+  if [ -z "$kubernetes_data_device_path" ]; then
+    # Try common namespace patterns: LUN+2, LUN+1, LUN itself
+    for ns_offset in 2 1 0; do
+      ns_id=$((lun_number + ns_offset))
+      path_candidate="$(ls -1 /dev/disk/by-path/*nvme-${ns_id} 2>/dev/null | head -n1 || true)"
+      if [ -n "$path_candidate" ] && [ -b "$path_candidate" ]; then
+        kubernetes_data_device_path="$path_candidate"
+        break
+      fi
+    done
+  fi
 
   if [ -z "$kubernetes_data_device_path" ]; then
-    >&2 echo "Azure disk for $kubernetes_data_device_id not found (/dev/disk/azure/data-lun${lun_number})"
+    >&2 echo "Azure disk for $kubernetes_data_device_id (LUN ${lun_number}) not found"
+    >&2 echo "Tried: /dev/disk/azure/*lun${lun_number}, /dev/disk/by-path/*nvme-*"
     return 1
   fi
 

--- a/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -9,54 +9,14 @@ if [ -f /var/lib/bashible/kubernetes-data-device-installed ]; then
 fi
 
 if ! grep "/dev" /var/lib/bashible/kubernetes_data_device_path >/dev/null; then
- kubernetes_data_device_path=""
+  get_disks_by_lun_id="$(ls /dev/disk/azure/*/lun10 -l)"
 
-  # Method 1: Try standard Azure udev paths (SCSI and NVMe)
-  for path in /dev/disk/azure/scsi1/lun10 /dev/disk/azure/data/by-lun/lun10; do
-    if [ -L "$path" ]; then
-      kubernetes_data_device_path="$(readlink -f "$path")"
-      break
-    fi
-  done
-
-  # Method 2: Fallback - search for unmounted empty disk with expected size
-  # This handles cases where udev rules don't create /dev/disk/azure/ (e.g., NVMe without proper rules)
-  if [ -z "$kubernetes_data_device_path" ]; then
-    for disk in /dev/nvme*n[0-9] /dev/sd[b-z]; do
-      [ -b "$disk" ] || continue
-
-      # Skip if disk is mounted
-      if mount | grep -q "^$disk"; then
-        continue
-      fi
-
-      # Skip if disk has partitions
-      if ls ${disk}p* ${disk}[0-9] 2>/dev/null | grep -q .; then
-        continue
-      fi
-
-      # Skip if disk has filesystem
-      if blkid "$disk" 2>/dev/null | grep -q TYPE; then
-        continue
-      fi
-
-      # Check size: expect etcd data disk around 20GB (allow 15-50GB range)
-      size_bytes=$(lsblk -b -n -o SIZE "$disk" 2>/dev/null || echo "0")
-      size_gb=$((size_bytes / 1024 / 1024 / 1024))
-
-      if [ "$size_gb" -ge 15 ] && [ "$size_gb" -le 50 ]; then
-        kubernetes_data_device_path="$disk"
-        >&2 echo "Found kubernetes-data device using fallback method: $disk (${size_gb}GB)"
-        break
-      fi
-    done
-  fi
-
-  if [ -z "$kubernetes_data_device_path" ]; then
+  if [ "$(wc -l <<< "$get_disks_by_lun_id")" -ne 1 ]; then
     >&2 echo "failed to discover kubernetes-data device"
     return 1
   fi
-  
+
+  kubernetes_data_device_path="$(awk '{gsub("../../..", "/dev");print $11}' <<< "$get_disks_by_lun_id")"
 else
   return 0
 fi

--- a/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -9,14 +9,54 @@ if [ -f /var/lib/bashible/kubernetes-data-device-installed ]; then
 fi
 
 if ! grep "/dev" /var/lib/bashible/kubernetes_data_device_path >/dev/null; then
-  get_disks_by_lun_id="$(ls /dev/disk/azure/*/lun10 -l)"
+ kubernetes_data_device_path=""
 
-  if [ "$(wc -l <<< "$get_disks_by_lun_id")" -ne 1 ]; then
+  # Method 1: Try standard Azure udev paths (SCSI and NVMe)
+  for path in /dev/disk/azure/scsi1/lun10 /dev/disk/azure/data/by-lun/lun10; do
+    if [ -L "$path" ]; then
+      kubernetes_data_device_path="$(readlink -f "$path")"
+      break
+    fi
+  done
+
+  # Method 2: Fallback - search for unmounted empty disk with expected size
+  # This handles cases where udev rules don't create /dev/disk/azure/ (e.g., NVMe without proper rules)
+  if [ -z "$kubernetes_data_device_path" ]; then
+    for disk in /dev/nvme*n[0-9] /dev/sd[b-z]; do
+      [ -b "$disk" ] || continue
+
+      # Skip if disk is mounted
+      if mount | grep -q "^$disk"; then
+        continue
+      fi
+
+      # Skip if disk has partitions
+      if ls ${disk}p* ${disk}[0-9] 2>/dev/null | grep -q .; then
+        continue
+      fi
+
+      # Skip if disk has filesystem
+      if blkid "$disk" 2>/dev/null | grep -q TYPE; then
+        continue
+      fi
+
+      # Check size: expect etcd data disk around 20GB (allow 15-50GB range)
+      size_bytes=$(lsblk -b -n -o SIZE "$disk" 2>/dev/null || echo "0")
+      size_gb=$((size_bytes / 1024 / 1024 / 1024))
+
+      if [ "$size_gb" -ge 15 ] && [ "$size_gb" -le 50 ]; then
+        kubernetes_data_device_path="$disk"
+        >&2 echo "Found kubernetes-data device using fallback method: $disk (${size_gb}GB)"
+        break
+      fi
+    done
+  fi
+
+  if [ -z "$kubernetes_data_device_path" ]; then
     >&2 echo "failed to discover kubernetes-data device"
     return 1
   fi
-
-  kubernetes_data_device_path="$(awk '{gsub("../../..", "/dev");print $11}' <<< "$get_disks_by_lun_id")"
+  
 else
   return 0
 fi

--- a/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_install_azure_nvme_udev_rules.sh.tpl
+++ b/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/000_install_azure_nvme_udev_rules.sh.tpl
@@ -1,0 +1,106 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install Azure udev rules for NVMe disk support (Gen2 VMs)
+# This fixes disk discovery for Ubuntu 22.04 and other NVMe-based instances
+# See: https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/2777
+
+if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]]; then
+  exit 0
+fi
+
+# Check if running on Azure with NVMe controller
+if ! lsblk -o NAME,MODEL | grep -q "MSFT NVMe"; then
+  # Not an NVMe VM, skip
+  exit 0
+fi
+
+UDEV_RULES_FILE="/etc/udev/rules.d/80-azure-disk.rules"
+
+# Download official Azure udev rules for NVMe disk mapping
+# These rules create /dev/disk/azure/data/by-lun/* symlinks for CSI driver
+bb-log-info "Installing Azure NVMe udev rules for disk discovery"
+
+cat > "$UDEV_RULES_FILE" << 'EOF'
+ACTION!="add|change", GOTO="azure_disk_end"
+SUBSYSTEM!="block", GOTO="azure_disk_end"
+
+KERNEL=="nvme*", ATTRS{nsid}=="?*", ENV{ID_MODEL}=="Microsoft NVMe Direct Disk", GOTO="azure_disk_nvme_direct_v1"
+KERNEL=="nvme*", ATTRS{nsid}=="?*", ENV{ID_MODEL}=="Microsoft NVMe Direct Disk v2", GOTO="azure_disk_nvme_direct_v2"
+KERNEL=="nvme*", ATTRS{nsid}=="?*", ENV{ID_MODEL}=="MSFT NVMe Accelerator v1.0", GOTO="azure_disk_nvme_remote_v1"
+ENV{ID_VENDOR}=="Msft", ENV{ID_MODEL}=="Virtual_Disk", GOTO="azure_disk_scsi"
+GOTO="azure_disk_end"
+
+LABEL="azure_disk_scsi"
+ATTRS{device_id}=="?00000000-0000-*", ENV{AZURE_DISK_TYPE}="os", GOTO="azure_disk_symlink"
+ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{AZURE_DISK_LUN}="$result"
+ENV{DEVTYPE}=="disk", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{AZURE_DISK_LUN}="$result"
+ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{AZURE_DISK_LUN}=="0", ENV{AZURE_DISK_TYPE}="os", ENV{AZURE_DISK_LUN}="", GOTO="azure_disk_symlink"
+ATTRS{device_id}=="{f8b3781b-1e82-4818-a1c3-63d806ec15bb}", ENV{AZURE_DISK_TYPE}="data", GOTO="azure_disk_symlink"
+ATTRS{device_id}=="{f8b3781c-1e82-4818-a1c3-63d806ec15bb}", ENV{AZURE_DISK_TYPE}="data", GOTO="azure_disk_symlink"
+ATTRS{device_id}=="{f8b3781d-1e82-4818-a1c3-63d806ec15bb}", ENV{AZURE_DISK_TYPE}="data", GOTO="azure_disk_symlink"
+
+# Use "resource" type for local SCSI because some VM skus offer NVMe local disks in addition to a SCSI resource disk, e.g. LSv3 family.
+# This logic is already in walinuxagent rules but we duplicate it here to avoid an unnecessary dependency for anyone requiring it.
+ATTRS{device_id}=="?00000000-0001-*", ENV{AZURE_DISK_TYPE}="resource", ENV{AZURE_DISK_LUN}="", GOTO="azure_disk_symlink"
+ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{AZURE_DISK_LUN}=="1", ENV{AZURE_DISK_TYPE}="resource", ENV{AZURE_DISK_LUN}="", GOTO="azure_disk_symlink"
+GOTO="azure_disk_end"
+
+LABEL="azure_disk_nvme_direct_v1"
+LABEL="azure_disk_nvme_direct_v2"
+ATTRS{nsid}=="?*", ENV{AZURE_DISK_TYPE}="local", ENV{AZURE_DISK_SERIAL}="$env{ID_SERIAL_SHORT}"
+GOTO="azure_disk_nvme_id"
+
+LABEL="azure_disk_nvme_remote_v1"
+# Azure hosts will retry remote I/O requests for up to 120 seconds.  If I/O times out for longer than that, host will reboot OS.
+# Set timeout for remote disks to 240 seconds, giving host time to handle the retry or reboot the VM.
+ENV{DEVTYPE}=="disk", ATTRS{nsid}=="?*", ATTR{queue/io_timeout}="240000"
+
+# For remote disks, namespace ID=1 is OS disk, ID=2+ are data disks with customer-configured lun=ID-2 (e.g. lun=0 will have nsid=2).
+ATTRS{nsid}=="1", ENV{AZURE_DISK_TYPE}="os", GOTO="azure_disk_nvme_id"
+ATTRS{nsid}=="?*", ENV{AZURE_DISK_TYPE}="data", PROGRAM="/bin/sh -ec 'echo $$((%s{nsid}-2))'", ENV{AZURE_DISK_LUN}="$result"
+
+LABEL="azure_disk_nvme_id"
+# Skip azure-nvme-id if not available (it's optional for basic functionality)
+TEST=="/usr/sbin/azure-nvme-id", IMPORT{program}="/usr/sbin/azure-nvme-id --udev"
+
+LABEL="azure_disk_symlink"
+# systemd v254 ships an updated 60-persistent-storage.rules that would allow
+# these to be deduplicated using $env{.PART_SUFFIX}
+ENV{DEVTYPE}=="disk", ENV{AZURE_DISK_TYPE}=="os|resource|root", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}"
+ENV{DEVTYPE}=="disk", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_INDEX}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-index/$env{AZURE_DISK_INDEX}"
+ENV{DEVTYPE}=="disk", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_LUN}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-lun/$env{AZURE_DISK_LUN}"
+ENV{DEVTYPE}=="disk", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_NAME}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-name/$env{AZURE_DISK_NAME}"
+ENV{DEVTYPE}=="disk", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_SERIAL}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-serial/$env{AZURE_DISK_SERIAL}"
+ENV{DEVTYPE}=="partition", ENV{AZURE_DISK_TYPE}=="os|resource|root", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}-part%n"
+ENV{DEVTYPE}=="partition", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_INDEX}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-index/$env{AZURE_DISK_INDEX}-part%n"
+ENV{DEVTYPE}=="partition", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_LUN}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-lun/$env{AZURE_DISK_LUN}-part%n"
+ENV{DEVTYPE}=="partition", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_NAME}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-name/$env{AZURE_DISK_NAME}-part%n"
+ENV{DEVTYPE}=="partition", ENV{AZURE_DISK_TYPE}=="?*", ENV{AZURE_DISK_SERIAL}=="?*", SYMLINK+="disk/azure/$env{AZURE_DISK_TYPE}/by-serial/$env{AZURE_DISK_SERIAL}-part%n"
+LABEL="azure_disk_end"
+EOF
+
+# Reload udev rules and trigger re-evaluation
+udevadm control --reload-rules
+udevadm trigger
+
+bb-log-info "Azure NVMe udev rules installed and activated"
+
+# Verify symlinks were created
+if [ -d /dev/disk/azure/data ]; then
+  bb-log-info "Azure disk symlinks created successfully:"
+  ls -la /dev/disk/azure/data/by-lun/ 2>/dev/null || bb-log-warning "No data disks found yet"
+else
+  bb-log-warning "Azure disk symlinks directory not created - disks may appear after reboot or disk attachment"
+fi

--- a/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/001_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-azure/candi/bashible/common-steps/all/001_discover_kubernetes_data_device_path.sh.tpl
@@ -28,12 +28,16 @@ elif [[ "$kubernetes_data_device_id" == lun* ]] || [[ "$kubernetes_data_device_i
     lun_number="$kubernetes_data_device_id"
   fi
 
-  # Method 1: Try Azure SCSI udev path (works on SCSI VMs)
-  kubernetes_data_device_path="$(ls -1 /dev/disk/azure/data-lun${lun_number} /dev/disk/azure/scsi*/lun${lun_number} 2>/dev/null | head -n1 || true)"
+  # Method 1: Try new Azure udev rules (works on both SCSI and NVMe VMs with 80-azure-disk.rules)
+  kubernetes_data_device_path="$(ls -1 /dev/disk/azure/data/by-lun/${lun_number} 2>/dev/null | head -n1 || true)"
 
-  # Method 2: Try NVMe by-path (works on NVMe VMs)
+  # Method 2: Try legacy Azure SCSI udev path (works on older SCSI VMs)
+  if [ -z "$kubernetes_data_device_path" ]; then
+    kubernetes_data_device_path="$(ls -1 /dev/disk/azure/data-lun${lun_number} /dev/disk/azure/scsi*/lun${lun_number} 2>/dev/null | head -n1 || true)"
+  fi
+
+  # Method 3: Try NVMe by-path fallback (works on NVMe VMs without udev rules)
   # Azure NVMe namespace mapping: LUN N typically maps to namespace N+2 (e.g., LUN 10 → ns 12)
-  # Search for any nvme device in by-path that could be our LUN
   if [ -z "$kubernetes_data_device_path" ]; then
     # Try common namespace patterns: LUN+2, LUN+1, LUN itself
     for ns_offset in 2 1 0; do
@@ -48,7 +52,7 @@ elif [[ "$kubernetes_data_device_id" == lun* ]] || [[ "$kubernetes_data_device_i
 
   if [ -z "$kubernetes_data_device_path" ]; then
     >&2 echo "Azure disk for $kubernetes_data_device_id (LUN ${lun_number}) not found"
-    >&2 echo "Tried: /dev/disk/azure/*lun${lun_number}, /dev/disk/by-path/*nvme-*"
+    >&2 echo "Tried: /dev/disk/azure/data/by-lun/${lun_number}, /dev/disk/azure/*lun${lun_number}, /dev/disk/by-path/*nvme-*"
     return 1
   fi
 

--- a/modules/030-cloud-provider-gcp/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-gcp/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -13,13 +13,17 @@
 # limitations under the License.
 
 {{- if eq .nodeGroup.name "master" }}
+
 function get_data_device_secret() {
   secret="d8-masters-kubernetes-data-device-path"
 
   if [ -f /var/lib/bashible/bootstrap-token ]; then
     while true; do
       for server in {{ .normal.apiserverEndpoints | join " " }}; do
-        if d8-curl --connect-timeout 10 -s -f -X GET "https://$server/api/v1/namespaces/d8-system/secrets/$secret" --header "Authorization: Bearer $(</var/lib/bashible/bootstrap-token)" --cacert "$BOOTSTRAP_DIR/ca.crt"
+        if d8-curl --connect-timeout 10 -s -f -X GET \
+          "https://$server/api/v1/namespaces/d8-system/secrets/$secret" \
+          --header "Authorization: Bearer $(</var/lib/bashible/bootstrap-token)" \
+          --cacert "$BOOTSTRAP_DIR/ca.crt"
         then
           return 0
         else
@@ -36,12 +40,33 @@ function get_data_device_secret() {
 
 function discover_device_path() {
   cloud_disk_name="$1"
-  device_name="$(lsblk -lo name,serial | grep "$cloud_disk_name" | cut -d " " -f1)"
-  if [ "$device_name" == "" ]; then
-    >&2 echo "failed to discover kubernetes-data device"
-    return 1
+
+  # 1) Prefer stable by-id links (BEST PRACTICE)
+  if [ -n "$cloud_disk_name" ] && [ -d /dev/disk/by-id ]; then
+    byid_match="$(ls -1 /dev/disk/by-id/ 2>/dev/null | grep -F "$cloud_disk_name" | head -n1)"
+    if [ -n "$byid_match" ] && [ -e "/dev/disk/by-id/$byid_match" ]; then
+      echo "$(readlink -f "/dev/disk/by-id/$byid_match")"
+      return 0
+    fi
   fi
-  echo "/dev/$device_name"
+
+  # 2) Safe SERIAL fallback (strict match)
+  device_name="$(lsblk -dn -o NAME,SERIAL 2>/dev/null | awk -v id="$cloud_disk_name" '$2==id {print $1; exit}')"
+  if [ -n "$device_name" ]; then
+    echo "/dev/$device_name"
+    return 0
+  fi
+
+  # 3) Azure fallback (robust LUN scan)
+  if [ -d /dev/disk/azure ]; then
+    azure_device="$(readlink -f /dev/disk/azure/scsi*/* 2>/dev/null | head -n1)"
+    if [ -n "$azure_device" ]; then
+      echo "$azure_device"
+      return 0
+    fi
+  fi
+
+  return 1
 }
 
 if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]]; then
@@ -62,5 +87,47 @@ else
   cloud_disk_name="$(get_data_device_secret | jq -re --arg hostname "$(bb-d8-node-name)" '.data[$hostname]' | base64 -d)"
 fi
 
+>&2 echo "discover_device_path: resolving disk for: $cloud_disk_name"
+
+# Robust root disk detection (works with LVM, mapper, NVMe, cloud images)
+root_src="$(findmnt -n -o SOURCE / 2>/dev/null)"
+root_dev="$(lsblk -no PKNAME "$root_src" 2>/dev/null)"
+
+# fallback if PKNAME fails (LVM/mapper cases)
+if [ -z "$root_dev" ]; then
+  root_dev="$(lsblk -ln -o NAME,MOUNTPOINT 2>/dev/null | awk '$2=="/" {print $1; exit}')"
+fi
+
+# build candidate list safely (exclude system disks early)
+candidates="$(lsblk -dn -o NAME,TYPE 2>/dev/null | awk '$2=="disk"{print "/dev/"$1}')"
+
+for disk in $candidates; do
+  [ -e "$disk" ] || continue
+
+  # Skip root disk completely
+  base_disk="$(basename "$disk" 2>/dev/null | sed 's/p[0-9]*$//')"
+  if [ -n "$root_dev" ] && [ "$base_disk" = "$root_dev" ]; then
+    continue
+  fi
+
+  # skip disks with any mountpoints
+  if lsblk -no MOUNTPOINT "$disk" 2>/dev/null | grep -q "/"; then
+    continue
+  fi
+
+  # skip OS-like partitions
+  part_types="$(lsblk -no PARTTYPE "$disk" 2>/dev/null | tr '\n' ' ')"
+  if echo "$part_types" | grep -Eqi "efi|swap|linux_raid|linux_lvm"; then
+    continue
+  fi
+
+  echo "$disk"
+  return 0
+done
+
+>&2 echo "FAILED: no safe data disk found (system disks excluded)"
+return 1
+
 echo "$(discover_device_path "$cloud_disk_name")" > /var/lib/bashible/kubernetes_data_device_path
+
 {{- end }}

--- a/modules/030-cloud-provider-gcp/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-gcp/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -41,31 +41,40 @@ function get_data_device_secret() {
 function discover_device_path() {
   cloud_disk_name="$1"
 
-  # 1) Prefer stable by-id links (BEST PRACTICE)
-  if [ -n "$cloud_disk_name" ] && [ -d /dev/disk/by-id ]; then
+  if [ -z "$cloud_disk_name" ]; then
+    >&2 echo "ERROR: empty cloud_disk_name"
+    return 1
+  fi
+
+  # 1. by-id resolution
+  if [ -d /dev/disk/by-id ]; then
     byid_match="$(ls -1 /dev/disk/by-id/ 2>/dev/null | grep -F "$cloud_disk_name" | head -n1)"
-    if [ -n "$byid_match" ] && [ -e "/dev/disk/by-id/$byid_match" ]; then
-      echo "$(readlink -f "/dev/disk/by-id/$byid_match")"
-      return 0
+    if [ -n "$byid_match" ]; then
+      dev="$(readlink -f "/dev/disk/by-id/$byid_match")"
+      if [ -b "$dev" ]; then
+        echo "$dev"
+        return 0
+      fi
     fi
   fi
 
-  # 2) Safe SERIAL fallback (strict match)
+  # 2. serial match (no fuzzy matching)
   device_name="$(lsblk -dn -o NAME,SERIAL 2>/dev/null | awk -v id="$cloud_disk_name" '$2==id {print $1; exit}')"
   if [ -n "$device_name" ]; then
     echo "/dev/$device_name"
     return 0
   fi
 
-  # 3) Azure fallback (robust LUN scan)
+  # 3. azure fallback (safe, last resort)
   if [ -d /dev/disk/azure ]; then
-    azure_device="$(readlink -f /dev/disk/azure/scsi*/* 2>/dev/null | head -n1)"
+    azure_device="$(readlink -f /dev/disk/azure/scsi*/lun* 2>/dev/null | head -n1)"
     if [ -n "$azure_device" ]; then
       echo "$azure_device"
       return 0
     fi
   fi
 
+  >&2 echo "ERROR: failed to resolve kubernetes data disk: $cloud_disk_name"
   return 1
 }
 
@@ -87,47 +96,13 @@ else
   cloud_disk_name="$(get_data_device_secret | jq -re --arg hostname "$(bb-d8-node-name)" '.data[$hostname]' | base64 -d)"
 fi
 
->&2 echo "discover_device_path: resolving disk for: $cloud_disk_name"
+resolved_device="$(discover_device_path "$cloud_disk_name")"
 
-# Robust root disk detection (works with LVM, mapper, NVMe, cloud images)
-root_src="$(findmnt -n -o SOURCE / 2>/dev/null)"
-root_dev="$(lsblk -no PKNAME "$root_src" 2>/dev/null)"
-
-# fallback if PKNAME fails (LVM/mapper cases)
-if [ -z "$root_dev" ]; then
-  root_dev="$(lsblk -ln -o NAME,MOUNTPOINT 2>/dev/null | awk '$2=="/" {print $1; exit}')"
+if [ -z "$resolved_device" ]; then
+  >&2 echo "FATAL: no data disk resolved"
+  return 1
 fi
 
-# build candidate list safely (exclude system disks early)
-candidates="$(lsblk -dn -o NAME,TYPE 2>/dev/null | awk '$2=="disk"{print "/dev/"$1}')"
-
-for disk in $candidates; do
-  [ -e "$disk" ] || continue
-
-  # Skip root disk completely
-  base_disk="$(basename "$disk" 2>/dev/null | sed 's/p[0-9]*$//')"
-  if [ -n "$root_dev" ] && [ "$base_disk" = "$root_dev" ]; then
-    continue
-  fi
-
-  # skip disks with any mountpoints
-  if lsblk -no MOUNTPOINT "$disk" 2>/dev/null | grep -q "/"; then
-    continue
-  fi
-
-  # skip OS-like partitions
-  part_types="$(lsblk -no PARTTYPE "$disk" 2>/dev/null | tr '\n' ' ')"
-  if echo "$part_types" | grep -Eqi "efi|swap|linux_raid|linux_lvm"; then
-    continue
-  fi
-
-  echo "$disk"
-  return 0
-done
-
->&2 echo "FAILED: no safe data disk found (system disks excluded)"
-return 1
-
-echo "$(discover_device_path "$cloud_disk_name")" > /var/lib/bashible/kubernetes_data_device_path
+echo "$resolved_device" > /var/lib/bashible/kubernetes_data_device_path
 
 {{- end }}

--- a/modules/030-cloud-provider-gcp/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
+++ b/modules/030-cloud-provider-gcp/candi/bashible/common-steps/all/000_discover_kubernetes_data_device_path.sh.tpl
@@ -13,17 +13,13 @@
 # limitations under the License.
 
 {{- if eq .nodeGroup.name "master" }}
-
 function get_data_device_secret() {
   secret="d8-masters-kubernetes-data-device-path"
 
   if [ -f /var/lib/bashible/bootstrap-token ]; then
     while true; do
       for server in {{ .normal.apiserverEndpoints | join " " }}; do
-        if d8-curl --connect-timeout 10 -s -f -X GET \
-          "https://$server/api/v1/namespaces/d8-system/secrets/$secret" \
-          --header "Authorization: Bearer $(</var/lib/bashible/bootstrap-token)" \
-          --cacert "$BOOTSTRAP_DIR/ca.crt"
+        if d8-curl --connect-timeout 10 -s -f -X GET "https://$server/api/v1/namespaces/d8-system/secrets/$secret" --header "Authorization: Bearer $(</var/lib/bashible/bootstrap-token)" --cacert "$BOOTSTRAP_DIR/ca.crt"
         then
           return 0
         else
@@ -40,42 +36,12 @@ function get_data_device_secret() {
 
 function discover_device_path() {
   cloud_disk_name="$1"
-
-  if [ -z "$cloud_disk_name" ]; then
-    >&2 echo "ERROR: empty cloud_disk_name"
+  device_name="$(lsblk -lo name,serial | grep "$cloud_disk_name" | cut -d " " -f1)"
+  if [ "$device_name" == "" ]; then
+    >&2 echo "failed to discover kubernetes-data device"
     return 1
   fi
-
-  # 1. by-id resolution
-  if [ -d /dev/disk/by-id ]; then
-    byid_match="$(ls -1 /dev/disk/by-id/ 2>/dev/null | grep -F "$cloud_disk_name" | head -n1)"
-    if [ -n "$byid_match" ]; then
-      dev="$(readlink -f "/dev/disk/by-id/$byid_match")"
-      if [ -b "$dev" ]; then
-        echo "$dev"
-        return 0
-      fi
-    fi
-  fi
-
-  # 2. serial match (no fuzzy matching)
-  device_name="$(lsblk -dn -o NAME,SERIAL 2>/dev/null | awk -v id="$cloud_disk_name" '$2==id {print $1; exit}')"
-  if [ -n "$device_name" ]; then
-    echo "/dev/$device_name"
-    return 0
-  fi
-
-  # 3. azure fallback (safe, last resort)
-  if [ -d /dev/disk/azure ]; then
-    azure_device="$(readlink -f /dev/disk/azure/scsi*/lun* 2>/dev/null | head -n1)"
-    if [ -n "$azure_device" ]; then
-      echo "$azure_device"
-      return 0
-    fi
-  fi
-
-  >&2 echo "ERROR: failed to resolve kubernetes data disk: $cloud_disk_name"
-  return 1
+  echo "/dev/$device_name"
 }
 
 if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]]; then
@@ -96,13 +62,5 @@ else
   cloud_disk_name="$(get_data_device_secret | jq -re --arg hostname "$(bb-d8-node-name)" '.data[$hostname]' | base64 -d)"
 fi
 
-resolved_device="$(discover_device_path "$cloud_disk_name")"
-
-if [ -z "$resolved_device" ]; then
-  >&2 echo "FATAL: no data disk resolved"
-  return 1
-fi
-
-echo "$resolved_device" > /var/lib/bashible/kubernetes_data_device_path
-
+echo "$(discover_device_path "$cloud_disk_name")" > /var/lib/bashible/kubernetes_data_device_path
 {{- end }}


### PR DESCRIPTION
## Description
Fixed Azure disk discovery for NVMe-based Gen2 VMs (Ubuntu 22.04) by installing official Azure udev rules and implementing multi-tier fallback mechanism. Root cause: Azure Gen2 VMs use NVMe controllers where disks are identified by namespace ID (e.g., nvme0n12), but Kubernetes components expect LUN-based paths. Without proper udev rules, the system cannot create the necessary symlinks, causing both etcd disk mounting and CSI driver volume attachment to fail. Solution:

1. Install Azure udev rules (000_install_azure_nvme_udev_rules.sh.tpl):
- Creates /dev/disk/azure/data/by-lun/X symlinks for all attached disks
- Maps NVMe namespace to LUN (formula: namespace_id - 2 = LUN)
- Supports both SCSI (Gen1) and NVMe (Gen2) VMs
- Based on official Azure rules from [azuredisk-csi-driver#2777](https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/2777)
2. Implement 3-tier disk discovery (001_discover_kubernetes_data_device_path.sh.tpl):
- Method 1: /dev/disk/azure/data/by-lun/X (new udev rules, works everywhere)
- Method 2: /dev/disk/azure/scsi*/lunX (legacy SCSI VMs)
- Method 3: /dev/disk/by-path/*nvme-X (direct NVMe namespace lookup as last resort)

## Why do we need it, and what problem does it solve?
**Problem 1:** Azure E2E tests failing - etcd couldn't start on master nodes because the data disk wasn't found
**Problem 2:** Stateful workloads (Prometheus, etc.) couldn't mount PVC volumes on worker nodes - CSI driver reported findDiskByLun(0) failed Both issues stem from the same root cause: Ubuntu 22.04 Gen2 VMs use NVMe controllers, and without proper udev rules, there's no mapping between LUN numbers (used by Terraform/CSI) and NVMe namespaces (actual device paths).## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-azure
type: feature
summary: Added NVMe disk discovery support for Ubuntu 22.04 Gen2 VMs.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
