### PR TITLE
[istio] Fix ztunnel DaemonSet resources template

### DIFF
--- a/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -71,8 +71,7 @@ spec:
           name: ztunnel-stats
           protocol: TCP
         resources:
-          {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
-          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+          {{- include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
         imagePullPolicy: IfNotPresent
         securityContext:
           # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true


### PR DESCRIPTION
## Description

Fix ztunnel DaemonSet resource management by removing duplicate ephemeral storage configuration and simplifying the template structure.

## Why do we need it, and what problem does it solve?

The `helm_lib_resources_management_pod_resources` helper already includes ephemeral storage requests. Having an additional `helm_lib_module_ephemeral_storage_only_logs` include caused duplicate values in the pod resources, which breaks Deckhouse.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Remove duplicate ephemeral storage configuration from ztunnel DaemonSet
impact_level: low
```