### PR TITLE
[node-manager] Migrate CAPI CR's storage from v1beta1 to v1beta2 contract.

### DIFF
--- a/modules/040-node-manager/crds/cluster.yaml
+++ b/modules/040-node-manager/crds/cluster.yaml
@@ -1451,7 +1451,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -3068,6 +3068,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/modules/040-node-manager/crds/extension-config.yaml
+++ b/modules/040-node-manager/crds/extension-config.yaml
@@ -361,7 +361,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -728,6 +728,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/modules/040-node-manager/crds/machine-deployment.yaml
+++ b/modules/040-node-manager/crds/machine-deployment.yaml
@@ -751,7 +751,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       scale:
         labelSelectorPath: .status.selector
@@ -1526,7 +1526,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       scale:
         labelSelectorPath: .status.selector

--- a/modules/040-node-manager/crds/machine-drain-rule.yaml
+++ b/modules/040-node-manager/crds/machine-drain-rule.yaml
@@ -397,7 +397,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources: {}
   - additionalPrinterColumns:
     - description: Drain behavior
@@ -775,5 +775,5 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources: {}

--- a/modules/040-node-manager/crds/machine-health-check.yaml
+++ b/modules/040-node-manager/crds/machine-health-check.yaml
@@ -411,7 +411,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -841,6 +841,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/modules/040-node-manager/crds/machine-pools.yaml
+++ b/modules/040-node-manager/crds/machine-pools.yaml
@@ -624,7 +624,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       scale:
         specReplicasPath: .spec.replicas
@@ -1275,7 +1275,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       scale:
         specReplicasPath: .spec.replicas

--- a/modules/040-node-manager/crds/machine-sets.yaml
+++ b/modules/040-node-manager/crds/machine-sets.yaml
@@ -662,7 +662,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       scale:
         labelSelectorPath: .status.selector
@@ -1339,7 +1339,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       scale:
         labelSelectorPath: .status.selector

--- a/modules/040-node-manager/crds/machine.yaml
+++ b/modules/040-node-manager/crds/machine.yaml
@@ -650,7 +650,7 @@ spec:
             type: object
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -1313,6 +1313,6 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}

--- a/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
@@ -99,7 +99,6 @@ spec:
         - --feature-gates=MachinePool=true,ClusterResourceSet=false,ClusterTopology=false,RuntimeSDK=false
         - --health-addr=127.0.0.1:9442
         - --webhook-port=4200
-        - --skip-crd-migration-phases=StorageVersionMigration,CleanupManagedFields # disabled for now
         - -v=3
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr allow to save in etcd storage CAPI CR's instances to v1beta2 contract/API version, also allow to migrate old CAPI CR's instances from v1beta1 to v1beta2 contract.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We must migrate all cr's which use v1beta1 to v1beta2 contract, because the implementation of the new v1beta2 version of the Cluster API contract MUST be completed before compatibility support for the v1beta1 version of the Cluster API, beta1 contract will be removed tentatively in April 2028.

**_This pr must be merge ONLY in next release after this https://github.com/deckhouse/deckhouse/pull/16153 ._**

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: migrate storage to beta2 capi cr's
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
