### PR TITLE
[node-manager] Migrate caps to lib helm defines

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.71.6
-digest: sha256:0547ecdb8cef8e435757b401dd1fb1ba8976bc04a81e63ef82de053c8b2b6be7
-generated: "2026-03-31T16:36:39.703635+07:00"
+  version: 1.71.7
+digest: sha256:368838131e44f991eac5f9c856fe3f962dea3dc3159f34b01a791b0dc0b8ee3b
+generated: "2026-04-01T20:52:47.566569+07:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.71.6"
+    version: "1.71.7"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.71.6
+version: 1.71.7

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -38,6 +38,7 @@
 | [helm_lib_cloud_controller_manager_manifests](#helm_lib_cloud_controller_manager_manifests) |
 | **Cloud Data Discoverer** |
 | [helm_lib_cloud_data_discoverer_manifests](#helm_lib_cloud_data_discoverer_manifests) |
+| [helm_lib_cloud_data_discoverer_pod_monitor](#helm_lib_cloud_data_discoverer_pod_monitor) |
 | **Csi Controller** |
 | [helm_lib_csi_image_with_common_fallback](#helm_lib_csi_image_with_common_fallback) |
 | **Dns Policy** |
@@ -489,6 +490,7 @@ list:
  Includes Deployment, VerticalPodAutoscaler (optional) and PodDisruptionBudget (optional). 
  Supported configuration parameters: 
  + fullname (required) — resource base name used for Deployment, PDB, VPA, and by default for the main container name. 
+ + namespace (optional, default: `d8-{{ $context.Chart.Name }}`) — resource base namespace. 
  + image (required) — image for the main container. 
  + capiProviderName (required) — value for the cluster.x-k8s.io/provider label in selectors and pod labels. 
  + resources (optional, default: `{cpu: 25m, memory: 50Mi}`) — main container resource requests used when VPA is disabled. 
@@ -535,6 +537,7 @@ list:
  Includes Deployment, VerticalPodAutoscaler (optional), PodDisruptionBudget (optional), and SecurityPolicyException (optional). 
  Supported configuration parameters: 
  + fullname (optional, default: `"cloud-controller-manager"`) — resource base name used for Deployment, PDB, VPA, SecurityPolicyException, and the main container name by default. 
+ + namespace (optional, default: `d8-{{ $context.Chart.Name }}`) — resource base namespace. 
  + image (required) — image for the main container. 
  + resources (optional, default: `{cpu: 25m, memory: 50Mi}`) — main container resource requests used when VPA is disabled. 
  + priorityClassName (optional, default: `"system-cluster-critical"`) — Pod priority class name. 
@@ -579,6 +582,7 @@ list:
  Includes Deployment, VerticalPodAutoscaler (optional) and PodDisruptionBudget (optional). 
  Supported configuration parameters: 
  + fullname (optional, default: `"cloud-data-discoverer"`) — resource base name used for Deployment, PDB, VPA, and the main container name by default. 
+ + namespace (optional, default: `d8-{{ $context.Chart.Name }}`) — resource base namespace. 
  + image (required) — image for the main container. 
  + resources (optional, default: `{cpu: 25m, memory: 50Mi}`) — main container resource requests used when VPA is disabled. 
  + replicas (optional, default: `1`) — number of Deployment replicas. 
@@ -612,6 +616,20 @@ list:
 list:
 -  Template context with .Values, .Chart, etc. 
 -  Configuration dict for the Cloud Data Discoverer. 
+
+
+### helm_lib_cloud_data_discoverer_pod_monitor
+
+ Renders PodMonitor manifest for provider-specific Cloud Data Discoverers. 
+ Supported configuration parameters: 
+ + fullname (optional, default: `"cloud-data-discoverer"`) — PodMonitor base name. 
+ + targetNamespace (required) — target pod namespace for selector. 
+ + additionalRelabelings (optional, default: `[]`) — additional rules for labels rewriting. 
+
+#### Usage
+
+`{{ include "helm_lib_cloud_data_discoverer_pod_monitor" (list . $config) }} `
+
 
 ## Csi Controller
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_capi_controller_manager.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_capi_controller_manager.tpl
@@ -29,6 +29,7 @@ periodSeconds: 10
 {{- /* Includes Deployment, VerticalPodAutoscaler (optional) and PodDisruptionBudget (optional). */ -}}
 {{- /* Supported configuration parameters: */ -}}
 {{- /* + fullname (required) — resource base name used for Deployment, PDB, VPA, and by default for the main container name. */ -}}
+{{- /* + namespace (optional, default: `d8-{{ $context.Chart.Name }}`) — resource base namespace. */ -}}
 {{- /* + image (required) — image for the main container. */ -}}
 {{- /* + capiProviderName (required) — value for the cluster.x-k8s.io/provider label in selectors and pod labels. */ -}}
 {{- /* + resources (optional, default: `{cpu: 25m, memory: 50Mi}`) — main container resource requests used when VPA is disabled. */ -}}
@@ -61,6 +62,7 @@ periodSeconds: 10
   {{- $config := index . 1 -}} {{- /* Configuration dict for the CAPI Controller Manager. */ -}}
 
   {{- $fullname := required "helm_lib_capi_controller_manager_manifests: fullname is required" $config.fullname -}}
+  {{- $namespace := dig "namespace" (printf "d8-%s" $context.Chart.Name) $config -}}
   {{- $image := required "helm_lib_capi_controller_manager_manifests: image is required" $config.image -}}
   {{- $capiProviderName := required "helm_lib_capi_controller_manager_manifests: $capiProviderName is required" $config.capiProviderName -}}
   {{- $resources := dig "resources" (include "capi_controller_manager_resources" $context | fromYaml) $config -}}
@@ -95,7 +97,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   targetRef:
@@ -119,7 +121,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   maxUnavailable: {{ $pdbMaxUnavailable }}
@@ -133,7 +135,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" $context | nindent 2 }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_controller_manager.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_controller_manager.tpl
@@ -29,6 +29,7 @@ httpGet:
 {{- /* Includes Deployment, VerticalPodAutoscaler (optional), PodDisruptionBudget (optional), and SecurityPolicyException (optional). */ -}}
 {{- /* Supported configuration parameters: */ -}}
 {{- /* + fullname (optional, default: `"cloud-controller-manager"`) — resource base name used for Deployment, PDB, VPA, SecurityPolicyException, and the main container name by default. */ -}}
+{{- /* + namespace (optional, default: `d8-{{ $context.Chart.Name }}`) — resource base namespace. */ -}}
 {{- /* + image (required) — image for the main container. */ -}}
 {{- /* + resources (optional, default: `{cpu: 25m, memory: 50Mi}`) — main container resource requests used when VPA is disabled. */ -}}
 {{- /* + priorityClassName (optional, default: `"system-cluster-critical"`) — Pod priority class name. */ -}}
@@ -59,6 +60,7 @@ httpGet:
   {{- $config := index . 1 -}} {{- /* Configuration dict for the Cloud Controller Manager. */ -}}
 
   {{- $fullname := dig "fullname" "cloud-controller-manager" $config }}
+  {{- $namespace := dig "namespace" (printf "d8-%s" $context.Chart.Name) $config -}}
   {{- $image := $config.image | required "image is required" }}
   {{- $resources := dig "resources" (include "cloud_controller_manager_resources" $context | fromYaml) $config }}
   {{- $priorityClassName := dig "priorityClassName" "system-cluster-critical" $config }}
@@ -91,7 +93,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   targetRef:
@@ -115,7 +117,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
   {{- with $additionalPDBAnnotations }}
   annotations:
@@ -133,7 +135,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" $context | nindent 2 }}
@@ -225,7 +227,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicyException
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
 spec:
   {{- if $hostNetwork }}
   network:

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_data_discoverer.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_data_discoverer.tpl
@@ -27,6 +27,7 @@ httpGet:
 {{- /* Includes Deployment, VerticalPodAutoscaler (optional) and PodDisruptionBudget (optional). */ -}}
 {{- /* Supported configuration parameters: */ -}}
 {{- /* + fullname (optional, default: `"cloud-data-discoverer"`) — resource base name used for Deployment, PDB, VPA, and the main container name by default. */ -}}
+{{- /* + namespace (optional, default: `d8-{{ $context.Chart.Name }}`) — resource base namespace. */ -}}
 {{- /* + image (required) — image for the main container. */ -}}
 {{- /* + resources (optional, default: `{cpu: 25m, memory: 50Mi}`) — main container resource requests used when VPA is disabled. */ -}}
 {{- /* + replicas (optional, default: `1`) — number of Deployment replicas. */ -}}
@@ -55,6 +56,7 @@ httpGet:
   {{- $config := index . 1 -}} {{- /* Configuration dict for the Cloud Data Discoverer. */ -}}
   
   {{- $fullname := dig "fullname" "cloud-data-discoverer" $config -}}
+  {{- $namespace := dig "namespace" (printf "d8-%s" $context.Chart.Name) $config -}}
   {{- $image := required "helm_lib_cloud_data_discoverer_manifests: image is required" $config.image -}}
   {{- $resources := dig "resources" (include "cloud_data_discoverer_resources" $context | fromYaml) $config -}}
   {{- $replicas := dig "replicas" 1 $config -}}
@@ -85,7 +87,7 @@ apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   targetRef:
@@ -110,7 +112,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   maxUnavailable: {{ $pdbMaxUnavailable }}
@@ -124,7 +126,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullname }}
-  namespace: d8-{{ $context.Chart.Name }}
+  namespace: {{ $namespace }}
   {{- include "helm_lib_module_labels" (list $context (dict "app" $fullname)) | nindent 2 }}
 spec:
   replicas: {{ $replicas }}
@@ -219,7 +221,7 @@ spec:
                 path: /
                 authorization:
                   resourceAttributes:
-                    namespace: d8-{{ $context.Chart.Name }}
+                    namespace: {{ $namespace }}
                     apiGroup: apps
                     apiVersion: v1
                     resource: deployments
@@ -249,6 +251,11 @@ spec:
 
 
 {{- /* Usage: {{ include "helm_lib_cloud_data_discoverer_pod_monitor" (list . $config) }} */ -}}
+{{- /* Renders PodMonitor manifest for provider-specific Cloud Data Discoverers. */ -}}
+{{- /* Supported configuration parameters: */ -}}
+{{- /* + fullname (optional, default: `"cloud-data-discoverer"`) — PodMonitor base name. */ -}}
+{{- /* + targetNamespace (required) — target pod namespace for selector. */ -}}
+{{- /* + additionalRelabelings (optional, default: `[]`) — additional rules for labels rewriting. */ -}}
 {{- define "helm_lib_cloud_data_discoverer_pod_monitor" -}}
   {{- $context := index . 0 -}}
   {{- $config := index . 1 -}}

--- a/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/deployment.yaml
@@ -1,124 +1,49 @@
-{{- define "static_controller_manager_resources" }}
-cpu: 25m
-memory: 50Mi
+# TODO remove after rewrite caps
+{{- define "static_controller_manager_args" }}
+- --leader-elect-lease-duration=3m
+- --leader-elect-renew-deadline=2m50s
+- --leader-elect-retry-period=5s
+- --sync-period=1m
+{{- end }}
+
+{{- define "static_controller_manager_ports" }}
+- containerPort: 9443
+  name: webhook-server
+  protocol: TCP
+{{- end }}
+
+{{- define "static_controller_manager_volume_mounts" }}
+- mountPath: /tmp/k8s-webhook-server/serving-certs
+  name: cert
+  readOnly: true
+- mountPath: /tmp
+  name: tmp
+{{- end }}
+
+{{- define "static_controller_manager_volumes" }}
+- name: cert
+  secret:
+    defaultMode: 420
+    secretName: caps-controller-manager-webhook-tls
+- name: tmp
+  emptyDir: {}
 {{- end }}
 
 {{- if .Values.nodeManager.internal.capsControllerManagerEnabled }}
-  {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: caps-controller-manager
-  namespace: d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list . (dict "app" "caps-controller-manager")) | nindent 2 }}
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: caps-controller-manager
-  updatePolicy:
-    updateMode: "InPlaceOrRecreate"
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "caps-controller-manager"
-      minAllowed:
-        {{- include "static_controller_manager_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 50m
-        memory: 50Mi
-  {{- end }}
+  {{- $capsConfig := dict -}}
+  {{- $_ := set $capsConfig "fullname" "caps-controller-manager" -}}
+  {{- $_ := set $capsConfig "namespace" "d8-cloud-instance-manager" -}}
+  {{- $_ := set $capsConfig "image" (include "helm_lib_module_image" (list . "capsControllerManager")) -}}
+  {{- $_ := set $capsConfig "capiProviderName" "infrastructure-static" -}}
+  {{- $_ := set $capsConfig "serviceAccountName" "caps-controller-manager" -}}
+  {{- $_ := set $capsConfig "nodeSelectorStrategy" "master" -}}
+  {{- $_ := set $capsConfig "tolerationsStrategies" (list "any-node" "uninitialized") -}}
+  {{- $_ := set $capsConfig "terminationGracePeriodSeconds" 10 -}}
+  {{- $_ := set $capsConfig "additionalArgs" (include "static_controller_manager_args" . | fromYamlArray) -}}
+  {{- $_ := set $capsConfig "additionalPorts" (include "static_controller_manager_ports" . | fromYamlArray) -}}
+  {{- $_ := set $capsConfig "additionalVolumeMounts" (include "static_controller_manager_volume_mounts" . | fromYamlArray) -}}
+  {{- $_ := set $capsConfig "additionalVolumes" (include "static_controller_manager_volumes" . | fromYamlArray) -}}
+  {{- $_ := set $capsConfig "vpaEnabled" true -}}
 
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: caps-controller-manager
-  namespace: d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list . (dict "app" "caps-controller-manager")) | nindent 2 }}
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: caps-controller-manager
-
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: caps-controller-manager
-  namespace: d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list . (dict "app" "caps-controller-manager")) | nindent 2 }}
-spec:
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      app: caps-controller-manager
-      cluster.x-k8s.io/provider: infrastructure-static
-      control-plane: controller-manager
-  template:
-    metadata:
-      labels:
-        app: caps-controller-manager
-        cluster.x-k8s.io/provider: infrastructure-static
-        control-plane: controller-manager
-    spec:
-      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "uninitialized") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
-      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "caps-controller-manager")) | nindent 6 }}
-      automountServiceAccountToken: true
-      serviceAccountName: caps-controller-manager
-      imagePullSecrets:
-        - name: deckhouse-registry
-      terminationGracePeriodSeconds: 10
-      containers:
-      - name: caps-controller-manager
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible"  dict | nindent 8 }}
-        image: {{ include "helm_lib_module_image" (list . "capsControllerManager") }}
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
-        volumeMounts:
-          - mountPath: /tmp/k8s-webhook-server/serving-certs
-            name: cert
-            readOnly: true
-          - mountPath: /tmp
-            name: tmp
-        args:
-          - "--leader-elect"
-          # Todo remove after rewrite caps
-          - "--leader-elect-lease-duration=3m"
-          - "--leader-elect-renew-deadline=2m50s"
-          - "--leader-elect-retry-period=5s"
-          - "--sync-period=1m"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          requests:
-            {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "static_controller_manager_resources" . | nindent 12 }}
-  {{- end }}
-      volumes:
-        - name: cert
-          secret:
-            defaultMode: 420
-            secretName: caps-controller-manager-webhook-tls
-        - name: tmp
-          emptyDir: {}
+  {{ include "helm_lib_capi_controller_manager_manifests" (list . $capsConfig) }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Migrates CAPS controller manager templates to shared lib-helm defines and bumps helm_lib version.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Cloud provider modules contained a lot of duplicated Helm templates with the same manifest structure and only small provider-specific differences.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Migrated CAPS controller manager to lib-helm defines.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
