### PR TITLE
[monitoring-kubernetes] Harden kube-rbac-proxy security context in oo…

### DIFF
--- a/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
@@ -101,7 +101,7 @@ spec:
             {{- include "oom_kills_exporter_resources" . | nindent 12 }}
 {{- end }}
       - name: kube-rbac-proxy
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" . | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
         - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):4212"


### PR DESCRIPTION
## Description
Switches oom-kills-exporter kube-rbac-proxy to PSS Restricted policy. 
## Why do we need it, and what problem does it solve?
It increases security security of kube-rbac-proxy in oom-kills-exporter 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.