### PR TITLE
[cilium-hubble] Added UI authorization

### DIFF
--- a/modules/500-cilium-hubble/images/ui/patches/003--auth.backend.patch
+++ b/modules/500-cilium-hubble/images/ui/patches/003--auth.backend.patch
@@ -1,0 +1,882 @@
+diff --git a/backend/go.mod b/backend/go.mod
+index 8a62b3bb..8fc35622 100644
+--- a/backend/go.mod
++++ b/backend/go.mod
+@@ -9,6 +9,7 @@ require (
+ 	github.com/julienschmidt/httprouter v1.3.0
+ 	github.com/pkg/errors v0.9.1
+ 	github.com/sirupsen/logrus v1.9.3
++	golang.org/x/sync v0.19.0
+ 	golang.org/x/sys v0.39.0
+ 	google.golang.org/grpc v1.79.3
+ 	google.golang.org/protobuf v1.36.10
+@@ -100,7 +101,6 @@ require (
+ 	golang.org/x/exp v0.0.0-20250210185358-939b2ce775ac // indirect
+ 	golang.org/x/net v0.48.0 // indirect
+ 	golang.org/x/oauth2 v0.34.0 // indirect
+-	golang.org/x/sync v0.19.0 // indirect
+ 	golang.org/x/term v0.38.0 // indirect
+ 	golang.org/x/text v0.32.0 // indirect
+ 	golang.org/x/time v0.10.0 // indirect
+diff --git a/backend/internal/api_clients/api_clients.go b/backend/internal/api_clients/api_clients.go
+index 776d1d3f..ebd0d67e 100644
+--- a/backend/internal/api_clients/api_clients.go
++++ b/backend/internal/api_clients/api_clients.go
+@@ -3,6 +3,9 @@ package api_clients
+ import (
+ 	"context"
+ 
++	"k8s.io/client-go/kubernetes"
++	"k8s.io/client-go/rest"
++
+ 	"github.com/cilium/hubble-ui/backend/internal/ns_watcher"
+ 	"github.com/cilium/hubble-ui/backend/internal/relay_client"
+ )
+@@ -10,4 +13,6 @@ import (
+ type APIClientsInterface interface {
+ 	RelayClient() relay_client.RelayClientInterface
+ 	NSWatcher(context.Context, ns_watcher.NSWatcherOptions) (ns_watcher.NSWatcherInterface, error)
++	K8sRESTConfig() *rest.Config
++	K8sServiceClientset() kubernetes.Interface
+ }
+diff --git a/backend/internal/api_clients/api_clients_prod.go b/backend/internal/api_clients/api_clients_prod.go
+index 1a6242af..8a9ef6d0 100644
+--- a/backend/internal/api_clients/api_clients_prod.go
++++ b/backend/internal/api_clients/api_clients_prod.go
+@@ -6,6 +6,7 @@ import (
+ 	"github.com/pkg/errors"
+ 	"github.com/sirupsen/logrus"
+ 	"k8s.io/client-go/kubernetes"
++	"k8s.io/client-go/rest"
+ 
+ 	cilium "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
+ 
+@@ -19,8 +20,9 @@ type APIClients struct {
+ 	cfg *config.Config
+ 	log logrus.FieldLogger
+ 
+-	k8s    kubernetes.Interface
+-	cilium *cilium.Clientset
++	k8sREST *rest.Config
++	k8s     kubernetes.Interface
++	cilium  *cilium.Clientset
+ 
+ 	// TODO: GRPCClient can be refactored to be a generalized connection pool
+ 	// for both Relay/Timescape clients
+@@ -42,6 +44,7 @@ func New(
+ 		return nil, errors.Wrap(err, "k8s clientset init failed")
+ 	}
+ 
++	clients.k8sREST = k8sConfig
+ 	clients.k8s = k8s
+ 
+ 	ciliumClientset, err := initCiliumClientset(k8sConfig)
+@@ -80,3 +83,17 @@ func (c *APIClients) RelayClient() relay_client.RelayClientInterface {
+ 
+ 	return cl
+ }
++
++func (c *APIClients) K8sRESTConfig() *rest.Config {
++	if c == nil || c.k8sREST == nil {
++		return nil
++	}
++	return rest.CopyConfig(c.k8sREST)
++}
++
++func (c *APIClients) K8sServiceClientset() kubernetes.Interface {
++	if c == nil {
++		return nil
++	}
++	return c.k8s
++}
+diff --git a/backend/internal/apiserver/api_info.go b/backend/internal/apiserver/api_info.go
+new file mode 100644
+index 00000000..ef86ed40
+--- /dev/null
++++ b/backend/internal/apiserver/api_info.go
+@@ -0,0 +1,46 @@
++package apiserver
++
++import (
++	"encoding/json"
++	"net/http"
++	"strings"
++
++	"github.com/julienschmidt/httprouter"
++)
++
++type apiInfoResponse struct {
++	Username string `json:"username"`
++}
++
++func (srv *APIServer) handleAPIInfo(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
++	if r.Method != http.MethodGet {
++		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
++		return
++	}
++
++	authz := strings.TrimSpace(r.Header.Get("Authorization"))
++	if authz == "" {
++		http.Error(w, `missing "Authorization"`, http.StatusUnauthorized)
++		return
++	}
++
++	token := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
++	if token == "" {
++		http.Error(w, "missing bearer token", http.StatusUnauthorized)
++		return
++	}
++
++	username, err := usernameFromJWTBearerToken(token)
++	if err != nil {
++		srv.log.WithError(err).Debug("api/info: failed to read username from JWT")
++		http.Error(w, "invalid token", http.StatusUnauthorized)
++		return
++	}
++
++	w.Header().Set("Content-Type", "application/json")
++	w.WriteHeader(http.StatusOK)
++
++	if err := json.NewEncoder(w).Encode(apiInfoResponse{Username: username}); err != nil {
++		srv.log.WithError(err).Warn("api/info: failed to write JSON body")
++	}
++}
+diff --git a/backend/internal/apiserver/apiserver.go b/backend/internal/apiserver/apiserver.go
+index d8f30776..5a6085f7 100644
+--- a/backend/internal/apiserver/apiserver.go
++++ b/backend/internal/apiserver/apiserver.go
+@@ -12,6 +12,7 @@ import (
+ 	"github.com/sirupsen/logrus"
+ 
+ 	"github.com/cilium/hubble-ui/backend/internal/api_clients"
++	"github.com/cilium/hubble-ui/backend/internal/apiserver/auth"
+ 	"github.com/cilium/hubble-ui/backend/internal/apiserver/cors"
+ 	"github.com/cilium/hubble-ui/backend/internal/config"
+ 	"github.com/cilium/hubble-ui/backend/internal/customprotocol/router"
+@@ -27,6 +28,8 @@ type APIServer struct {
+ 	clients           api_clients.APIClientsInterface
+ 	handlerMiddleware HttpHandlerMiddleware
+ 
++	AuthCache *auth.Cache
++
+ 	instance *http.Server
+ 	router   *router.Router
+ }
+@@ -76,6 +79,7 @@ func New(
+ 		baseContext:       bctx,
+ 		clients:           clients,
+ 		handlerMiddleware: handlerMiddleware,
++		AuthCache:         auth.NewCache(),
+ 	}
+ 
+ 	if err := srv.prepareRoutes(); err != nil {
+@@ -91,6 +95,10 @@ func (srv *APIServer) Listen() error {
+ 	rootRoute := srv.rootRoute + "/:RouteName"
+ 
+ 	mux := httprouter.New()
++	if srv.cfg.EnableAuth {
++		mux.GET(srv.rootRoute+"/info", srv.handleAPIInfo)
++		srv.log.WithField("path", srv.rootRoute+"/info").Info("registered auth user info endpoint")
++	}
+ 	mux.Handler(http.MethodPost, rootRoute, srv.router)
+ 
+ 	var handler http.Handler = mux
+diff --git a/backend/internal/apiserver/auth/auth_cache.go b/backend/internal/apiserver/auth/auth_cache.go
+new file mode 100644
+index 00000000..1067ded6
+--- /dev/null
++++ b/backend/internal/apiserver/auth/auth_cache.go
+@@ -0,0 +1,138 @@
++// Package auth holds helpers for HTTP bearer auth against the Kubernetes API.
++package auth
++
++import (
++	"context"
++	"crypto/sha256"
++	"encoding/hex"
++	"sync"
++	"time"
++
++	"golang.org/x/sync/singleflight"
++)
++
++// DefaultCacheTTL is used when Cache.TTL is zero.
++const DefaultCacheTTL = 5 * time.Minute
++
++// Cache stores namespace allowlists keyed by a hash of the bearer token (the raw
++// token is never stored). Successful results and failed resolutions (empty allowlist)
++// are cached until TTL so callers do not hammer the API or logs on repeated polls.
++type Cache struct {
++	ttl  time.Duration
++	mu   sync.Mutex
++	data map[string]entry
++	sf   singleflight.Group
++}
++
++type entry struct {
++	namespaces map[string]struct{}
++	expires    time.Time
++}
++
++// NewCache returns a ready-to-use cache (safe concurrent use).
++func NewCache() *Cache {
++	return &Cache{
++		ttl: DefaultCacheTTL,
++	}
++}
++
++// SnapshotIfCached returns a fresh copy of the namespace allowlist when the
++// bearerToken already has a non-expired cache entry. Otherwise it returns nil, false.
++// Use this to skip heavier work (e.g. context timeouts, SAR) on hot paths.
++func (c *Cache) SnapshotIfCached(bearerToken string) (map[string]struct{}, bool) {
++	return c.getEntry(bearerTokenHash(bearerToken))
++}
++
++// AllowedNamespaces runs compute on miss/expiry. compute sees the same ctx the
++// caller passed; its result is cached under a hash of bearerToken.
++// If compute returns an error, an empty allowlist is cached for the same TTL and
++// onComputeError is invoked once for that cache fill (not on later cache hits).
++func (c *Cache) AllowedNamespaces(
++	ctx context.Context,
++	bearerToken string,
++	compute func(context.Context) (map[string]struct{}, error),
++	onComputeError func(err error),
++) (map[string]struct{}, error) {
++	key := bearerTokenHash(bearerToken)
++
++	if ns, ok := c.getEntry(key); ok {
++		return ns, nil
++	}
++
++	v, err, _ := c.sf.Do(key, func() (interface{}, error) {
++		if ns, ok := c.getEntry(key); ok {
++			return ns, nil
++		}
++
++		ns, computeErr := compute(ctx)
++		if computeErr != nil {
++			if onComputeError != nil {
++				onComputeError(computeErr)
++			}
++			empty := map[string]struct{}{}
++			c.setEntry(key, empty)
++			return empty, nil
++		}
++
++		c.setEntry(key, ns)
++		// ns is not retained by the cache; callers receive a copy below (singleflight shares one pointer).
++		return ns, nil
++	})
++
++	if err != nil {
++		return nil, err
++	}
++
++	out, _ := v.(map[string]struct{})
++	// singleflight shares one result pointer across waiters; give each caller an owned map.
++	return copyNamespaceSet(out), nil
++}
++
++func bearerTokenHash(token string) string {
++	sum := sha256.Sum256([]byte(token))
++	return hex.EncodeToString(sum[:])
++}
++
++func copyNamespaceSet(m map[string]struct{}) map[string]struct{} {
++	if m == nil {
++		return map[string]struct{}{}
++	}
++	out := make(map[string]struct{}, len(m))
++	for k := range m {
++		out[k] = struct{}{}
++	}
++	return out
++}
++
++func (c *Cache) getEntry(key string) (map[string]struct{}, bool) {
++	c.mu.Lock()
++	defer c.mu.Unlock()
++
++	if c.data == nil {
++		return nil, false
++	}
++
++	e, ok := c.data[key]
++	if !ok || time.Now().After(e.expires) {
++		if ok {
++			delete(c.data, key)
++		}
++		return nil, false
++	}
++
++	return copyNamespaceSet(e.namespaces), true
++}
++
++func (c *Cache) setEntry(key string, namespaces map[string]struct{}) {
++	c.mu.Lock()
++	defer c.mu.Unlock()
++
++	if c.data == nil {
++		c.data = make(map[string]entry)
++	}
++
++	c.data[key] = entry{
++		namespaces: copyNamespaceSet(namespaces),
++		expires:    time.Now().Add(c.ttl),
++	}
++}
+diff --git a/backend/internal/apiserver/auth/namespace_filter.go b/backend/internal/apiserver/auth/namespace_filter.go
+new file mode 100644
+index 00000000..60b370fb
+--- /dev/null
++++ b/backend/internal/apiserver/auth/namespace_filter.go
+@@ -0,0 +1,72 @@
++package auth
++
++import (
++	pbFlow "github.com/cilium/cilium/api/v1/flow"
++
++	ns_common "github.com/cilium/hubble-ui/backend/internal/ns_watcher/common"
++)
++
++func FilterNSEventsByAllowlist(nss []*ns_common.NSEvent, allowed map[string]struct{}) []*ns_common.NSEvent {
++	if len(allowed) == 0 {
++		return nil
++	}
++	out := make([]*ns_common.NSEvent, 0, len(nss))
++	for _, n := range nss {
++		name := n.GetNamespaceStr()
++		if name == "" {
++			continue
++		}
++		if _, ok := allowed[name]; ok {
++			out = append(out, n)
++		}
++	}
++	return out
++}
++
++func FilterFlowsByAllowedNamespaces(flows []*pbFlow.Flow, allowed map[string]struct{}) []*pbFlow.Flow {
++	if len(flows) == 0 || len(allowed) == 0 {
++		return nil
++	}
++	out := make([]*pbFlow.Flow, 0, len(flows))
++	for _, f := range flows {
++		if flowInvolvesAllowedNamespace(f, allowed) {
++			out = append(out, f)
++		}
++	}
++	return out
++}
++
++func flowInvolvesAllowedNamespace(f *pbFlow.Flow, allowed map[string]struct{}) bool {
++	if f == nil || len(allowed) == 0 {
++		return false
++	}
++	if src := f.GetSource(); src != nil {
++		if ns := src.GetNamespace(); ns != "" {
++			if _, ok := allowed[ns]; ok {
++				return true
++			}
++		}
++	}
++	if dst := f.GetDestination(); dst != nil {
++		if ns := dst.GetNamespace(); ns != "" {
++			if _, ok := allowed[ns]; ok {
++				return true
++			}
++		}
++	}
++	if ss := f.GetSourceService(); ss != nil {
++		if ns := ss.GetNamespace(); ns != "" {
++			if _, ok := allowed[ns]; ok {
++				return true
++			}
++		}
++	}
++	if ds := f.GetDestinationService(); ds != nil {
++		if ns := ds.GetNamespace(); ns != "" {
++			if _, ok := allowed[ns]; ok {
++				return true
++			}
++		}
++	}
++	return false
++}
+diff --git a/backend/internal/apiserver/auth_middleware.go b/backend/internal/apiserver/auth_middleware.go
+new file mode 100644
+index 00000000..b54ee01a
+--- /dev/null
++++ b/backend/internal/apiserver/auth_middleware.go
+@@ -0,0 +1,161 @@
++package apiserver
++
++import (
++	"context"
++	"fmt"
++	"strings"
++	"time"
++
++	cp "github.com/cilium/hubble-ui/backend/internal/customprotocol"
++	"github.com/cilium/hubble-ui/backend/internal/customprotocol/message"
++	"github.com/sirupsen/logrus"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/client-go/kubernetes"
++
++	authv1 "k8s.io/api/authorization/v1"
++)
++
++type authMiddleware struct {
++	srv     *APIServer
++	handler string
++}
++
++func (srv *APIServer) authMiddleware(handler string) cp.ChannelMiddleware {
++	return &authMiddleware{
++		srv:     srv,
++		handler: handler,
++	}
++}
++
++func (m *authMiddleware) Clone() cp.ChannelMiddleware {
++	return &authMiddleware{
++		srv:     m.srv,
++		handler: m.handler,
++	}
++}
++
++func (m *authMiddleware) pollLog(ch *cp.Channel) logrus.FieldLogger {
++	log := m.srv.log.WithField("channelId", ch.Id)
++	if m.handler != "" {
++		log = log.WithField("handler", m.handler)
++	}
++	return log
++}
++
++func (m *authMiddleware) RunBeforePolling(ch *cp.Channel, msg *message.Message) error {
++	rctx, err := m.srv.ensureHandlerData(ch)
++	if err != nil {
++		return err
++	}
++
++	log := m.pollLog(ch)
++
++	headers := msg.HttpRequest.Header
++	if headers == nil {
++		log.Error("HTTP request headers missing")
++		rctx.SetAllowedNamespaces(map[string]struct{}{})
++		return nil
++	}
++
++	authHeader := headers.Get("Authorization")
++	if authHeader == "" {
++		log.Warn(`missing empty "Authorization" header`)
++		rctx.SetAllowedNamespaces(map[string]struct{}{})
++		return nil
++	}
++
++	token := strings.TrimSpace(strings.TrimPrefix(authHeader, "Bearer"))
++	if token == "" {
++		log.Warn(`missing empty Bearer token`)
++		rctx.SetAllowedNamespaces(map[string]struct{}{})
++		return nil
++	}
++
++	if allowed, ok := m.srv.AuthCache.SnapshotIfCached(token); ok {
++		rctx.SetAllowedNamespaces(allowed)
++		return nil
++	}
++
++	ctx, cancel := context.WithTimeout(ch.Context(), 60*time.Second)
++	defer cancel()
++
++	allowed, err := m.srv.AuthCache.AllowedNamespaces(ctx, token, func(cctx context.Context) (map[string]struct{}, error) {
++		base := m.srv.clients.K8sRESTConfig()
++		if base == nil {
++			return nil, fmt.Errorf("kubernetes client configuration is not available")
++		}
++		base.BearerToken = token
++		base.BearerTokenFile = ""
++
++		userClient, err := kubernetes.NewForConfig(base)
++		if err != nil {
++			return nil, fmt.Errorf("kubernetes client: %w", err)
++		}
++
++		nsLister := m.srv.clients.K8sServiceClientset()
++		return ComputeNamespacePodListAllowlist(cctx, nsLister, userClient, log)
++	}, func(computeErr error) {
++		log.WithError(computeErr).Warn(
++			"failed to resolve namespace access; caching empty allowlist for this token until cache TTL",
++		)
++	})
++	if err != nil {
++		log.WithError(err).Warn("namespace access cache internal error")
++		rctx.SetAllowedNamespaces(map[string]struct{}{})
++		return nil
++	}
++
++	rctx.SetAllowedNamespaces(allowed)
++
++	return nil
++}
++
++// ComputeNamespacePodListAllowlist returns namespaces where SelfSubjectAccessReview
++// for list pods is allowed for the user behind authClient.
++//
++// Namespace names come from namespaceLister (typically the backend service account).
++// If namespaceLister is nil, authClient is used for Namespace.List (legacy / mocks).
++// authClient must carry the end-user credentials for SAR.
++func ComputeNamespacePodListAllowlist(
++	ctx context.Context,
++	namespaceLister kubernetes.Interface,
++	authClient kubernetes.Interface,
++	log logrus.FieldLogger,
++) (map[string]struct{}, error) {
++	if namespaceLister == nil {
++		namespaceLister = authClient
++	}
++
++	nsList, err := namespaceLister.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
++	if err != nil {
++		return nil, err
++	}
++
++	allowed := make(map[string]struct{}, len(nsList.Items))
++
++	for _, ns := range nsList.Items {
++		review := &authv1.SelfSubjectAccessReview{
++			Spec: authv1.SelfSubjectAccessReviewSpec{
++				ResourceAttributes: &authv1.ResourceAttributes{
++					Namespace: ns.Name,
++					Verb:      "list",
++					Resource:  "pods",
++				},
++			},
++		}
++
++		resp, err := authClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
++		if err != nil {
++			log.WithError(err).Warnf("SAR failed for namespace %s", ns.Name)
++			continue
++		}
++
++		if resp.Status.Allowed {
++			allowed[ns.Name] = struct{}{}
++		}
++	}
++
++	log.WithField("namespacesCount", len(allowed)).Debug("namespace access calculated")
++
++	return allowed, nil
++}
+diff --git a/backend/internal/apiserver/control_stream.go b/backend/internal/apiserver/control_stream.go
+index e86f2fe7..7e483460 100644
+--- a/backend/internal/apiserver/control_stream.go
++++ b/backend/internal/apiserver/control_stream.go
+@@ -4,6 +4,7 @@ import (
+ 	"time"
+ 
+ 	"github.com/cilium/hubble-ui/backend/internal/api_helpers"
++	"github.com/cilium/hubble-ui/backend/internal/apiserver/auth"
+ 	"github.com/cilium/hubble-ui/backend/internal/apiserver/notifications"
+ 	"github.com/cilium/hubble-ui/backend/internal/apiserver/req_context"
+ 	cp "github.com/cilium/hubble-ui/backend/internal/customprotocol"
+@@ -72,6 +73,12 @@ F:
+ 			nsDebounce.Touch()
+ 		case <-nsDebounce.Triggered():
+ 			nss := dataStash.FlushNamespaces()
++			if enabled, allowed := rctx.GetAllowedNamespaces(); enabled {
++				nss = auth.FilterNSEventsByAllowlist(nss, allowed)
++			}
++			if len(nss) == 0 {
++				continue
++			}
+ 			nsResponse := responseFromNSEvents(nss)
+ 			log.
+ 				WithField("response", nsResponse).
+diff --git a/backend/internal/apiserver/jwt_username.go b/backend/internal/apiserver/jwt_username.go
+new file mode 100644
+index 00000000..20c311f8
+--- /dev/null
++++ b/backend/internal/apiserver/jwt_username.go
+@@ -0,0 +1,67 @@
++package apiserver
++
++import (
++	"encoding/base64"
++	"encoding/json"
++	"fmt"
++	"strings"
++)
++
++// usernameFromJWTBearerToken extracts a display name from an unverified JWT payload.
++// The token is assumed to have been validated at the edge (e.g. oauth2-proxy) when
++// ENABLE_AUTH is enabled; this is for UI display only.
++func usernameFromJWTBearerToken(token string) (string, error) {
++	token = strings.TrimSpace(token)
++	if token == "" {
++		return "", fmt.Errorf("empty token")
++	}
++
++	parts := strings.Split(token, ".")
++	if len(parts) != 3 {
++		return "", fmt.Errorf("jwt: expected 3 segments")
++	}
++
++	raw, err := decodeJWTSegment(parts[1])
++	if err != nil {
++		return "", err
++	}
++
++	var claims map[string]json.RawMessage
++	if err := json.Unmarshal(raw, &claims); err != nil {
++		return "", err
++	}
++
++	for _, key := range []string{"preferred_username", "email", "name", "sub"} {
++		rawVal, ok := claims[key]
++		if !ok {
++			continue
++		}
++		var s string
++		if err := json.Unmarshal(rawVal, &s); err != nil || strings.TrimSpace(s) == "" {
++			continue
++		}
++		return s, nil
++	}
++
++	return "", fmt.Errorf("jwt: no username claim")
++}
++
++func decodeJWTSegment(seg string) ([]byte, error) {
++	seg = strings.TrimSpace(seg)
++	if seg == "" {
++		return nil, fmt.Errorf("jwt: empty payload segment")
++	}
++
++	if b, err := base64.RawURLEncoding.DecodeString(seg); err == nil {
++		return b, nil
++	}
++
++	if pad := len(seg) % 4; pad != 0 {
++		seg += strings.Repeat("=", 4-pad)
++	}
++	if b, err := base64.URLEncoding.DecodeString(seg); err == nil {
++		return b, nil
++	}
++
++	return nil, fmt.Errorf("jwt: payload base64 decode failed")
++}
+diff --git a/backend/internal/apiserver/req_context/req_context.go b/backend/internal/apiserver/req_context/req_context.go
+index 50cadf23..2aeb55f9 100644
+--- a/backend/internal/apiserver/req_context/req_context.go
++++ b/backend/internal/apiserver/req_context/req_context.go
+@@ -12,6 +12,8 @@ type Context struct {
+ 
+ 	mx  sync.Mutex
+ 	ctx context.Context
++
++	allowedNamespaces map[string]struct{}
+ }
+ 
+ func New(ctx context.Context) *Context {
+@@ -30,3 +32,30 @@ func (c *Context) SetLogger(log logrus.FieldLogger) *Context {
+ 	c.Log = log
+ 	return c
+ }
++
++// GetAllowedNamespaces returns whether namespace allowlisting is active for this
++// channel (set by bearer auth middleware) and a copy of the allowlist
++func (c *Context) GetAllowedNamespaces() (enabled bool, allowed map[string]struct{}) {
++	c.mx.Lock()
++	defer c.mx.Unlock()
++	if c.allowedNamespaces == nil {
++		return false, nil
++	}
++	out := make(map[string]struct{}, len(c.allowedNamespaces))
++	for k := range c.allowedNamespaces {
++		out[k] = struct{}{}
++	}
++	return true, out
++}
++
++// SetAllowedNamespaces stores the allowlist for the current bearer token. The caller
++// must not mutate allowed after this call
++func (c *Context) SetAllowedNamespaces(allowed map[string]struct{}) {
++	c.mx.Lock()
++	defer c.mx.Unlock()
++	if allowed == nil {
++		c.allowedNamespaces = map[string]struct{}{}
++		return
++	}
++	c.allowedNamespaces = allowed
++}
+diff --git a/backend/internal/apiserver/service_map_stream.go b/backend/internal/apiserver/service_map_stream.go
+index 472b9358..7f7c1313 100644
+--- a/backend/internal/apiserver/service_map_stream.go
++++ b/backend/internal/apiserver/service_map_stream.go
+@@ -6,6 +6,7 @@ import (
+ 	"time"
+ 
+ 	pb_flow "github.com/cilium/cilium/api/v1/flow"
++	"github.com/cilium/hubble-ui/backend/internal/apiserver/auth"
+ 	"github.com/cilium/hubble-ui/backend/proto/ui"
+ 
+ 	"github.com/cilium/hubble-ui/backend/domain/cache"
+@@ -87,6 +88,11 @@ func (srv *APIServer) ServiceMapStream(
+ 	flushFlows := func() error {
+ 		// NOTE: take links and services from flow
+ 		wflows := flow.Wrap(flows.Flush())
++		if enabled, allowed := rctx.GetAllowedNamespaces(); enabled {
++			pbFlows := flow.Unwrap(wflows)
++			pbFlows = auth.FilterFlowsByAllowedNamespaces(pbFlows, allowed)
++			wflows = flow.Wrap(pbFlows)
++		}
+ 		var svcs []cache.Result[*service.Service]
+ 		var links []cache.Result[*link.Link]
+ 
+diff --git a/backend/internal/apiserver/setup_routes.go b/backend/internal/apiserver/setup_routes.go
+index 0a567302..ebd60ede 100644
+--- a/backend/internal/apiserver/setup_routes.go
++++ b/backend/internal/apiserver/setup_routes.go
+@@ -38,24 +38,33 @@ func (srv *APIServer) prepareRoutes() error {
+ 
+ func (srv *APIServer) setRouteHandlers() error {
+ 	srv.router.Route("control-stream").
+-		Middlewares([]cp.ChannelMiddleware{
+-			srv.loggerMiddleware("ControlStream"),
+-		}).
++		Middlewares(srv.streamMiddlewares("ControlStream")).
+ 		Stream(
+ 			srv.wrapHandler(srv.ControlStream, WrappedRouteOptions{}),
+ 		)
+ 
+ 	srv.router.Route("service-map-stream").
+-		Middlewares([]cp.ChannelMiddleware{
+-			srv.loggerMiddleware("ServiceMapStream"),
+-		}).
++		Middlewares(srv.streamMiddlewares("ServiceMapStream")).
+ 		Stream(
+ 			srv.wrapHandler(srv.ServiceMapStream, WrappedRouteOptions{}),
+ 		)
+ 
++	if srv.cfg.EnableAuth {
++		srv.log.Info("authorization is enabled")
++	}
++
+ 	return nil
+ }
+ 
++func (srv *APIServer) streamMiddlewares(handler string) []cp.ChannelMiddleware {
++	out := make([]cp.ChannelMiddleware, 0, 2)
++	if srv.cfg.EnableAuth {
++		out = append(out, srv.authMiddleware(handler))
++	}
++	out = append(out, srv.loggerMiddleware(handler))
++	return out
++}
++
+ func (srv *APIServer) wrapHandler(
+ 	handler WrappedRouteHandler,
+ 	_opts WrappedRouteOptions,
+diff --git a/backend/internal/config/builder.go b/backend/internal/config/builder.go
+index 6e5d96c1..24ce9212 100644
+--- a/backend/internal/config/builder.go
++++ b/backend/internal/config/builder.go
+@@ -38,6 +38,10 @@ func (b *ConfigBuilder) Build() (*Config, error) {
+ 		return nil, err
+ 	}
+ 
++	if err := b.initEnableAuth(cfg); err != nil {
++		return nil, err
++	}
++
+ 	if err := b.initTestModeFlags(cfg); err != nil {
+ 		return nil, err
+ 	}
+@@ -208,6 +212,18 @@ func (b *ConfigBuilder) initWebServer(cfg *Config) error {
+ 	return nil
+ }
+ 
++func (b *ConfigBuilder) initEnableAuth(cfg *Config) error {
++	enabled := b.props.EnableAuth()
++	if err := enabled.Err(); err != nil {
++		return err
++	}
++
++	enabled.LogIfFallback(b.logger)
++	cfg.EnableAuth = enabled.Value
++
++	return nil
++}
++
+ func (b *ConfigBuilder) initTestModeFlags(cfg *Config) error {
+ 	e2eMode := b.props.E2ETestModeEnabled()
+ 	if err := e2eMode.Err(); err != nil {
+diff --git a/backend/internal/config/config.go b/backend/internal/config/config.go
+index af598b05..9f541d6c 100644
+--- a/backend/internal/config/config.go
++++ b/backend/internal/config/config.go
+@@ -24,6 +24,9 @@ type Config struct {
+ 	// Enables CORS headers on http routes
+ 	CORSEnabled bool
+ 
++	// Enables bearer-token namespace allowlisting on UI API streams (ENABLE_AUTH).
++	EnableAuth bool
++
+ 	E2ETestMode         bool
+ 	E2ELogFilesBasePath string
+ 
+diff --git a/backend/internal/config/prop_getters.go b/backend/internal/config/prop_getters.go
+index ed949287..4e597bd9 100644
+--- a/backend/internal/config/prop_getters.go
++++ b/backend/internal/config/prop_getters.go
+@@ -13,6 +13,7 @@ type PropGetters struct {
+ 	GopsEnabled              EnvVarGetter[bool]
+ 	GopsPort                 EnvVarGetter[uint16]
+ 	CorsEnabled              EnvVarGetter[bool]
++	EnableAuth               EnvVarGetter[bool]
+ 	DebugLogs                EnvVarGetter[bool]
+ 	RelayAddr                EnvVarGetter[string]
+ 	UIServerPort             EnvVarGetter[uint16]
+diff --git a/backend/internal/mock/clients/clients.go b/backend/internal/mock/clients/clients.go
+index 0d69ec33..6082a78f 100644
+--- a/backend/internal/mock/clients/clients.go
++++ b/backend/internal/mock/clients/clients.go
+@@ -5,6 +5,8 @@ import (
+ 	"sync"
+ 
+ 	"github.com/sirupsen/logrus"
++	"k8s.io/client-go/kubernetes"
++	"k8s.io/client-go/rest"
+ 
+ 	"github.com/cilium/hubble-ui/backend/internal/api_clients"
+ 	"github.com/cilium/hubble-ui/backend/internal/mock/sources"
+@@ -114,6 +116,14 @@ func (cl *Clients) NSWatcher(ctx context.Context, opts ns_watcher.NSWatcherOptio
+ 	return nsw, nil
+ }
+ 
++func (cl *Clients) K8sRESTConfig() *rest.Config {
++	return nil
++}
++
++func (cl *Clients) K8sServiceClientset() kubernetes.Interface {
++	return nil
++}
++
+ func (cl *Clients) duplicateSource() sources.MockedSource {
+ 	if cl.src == nil {
+ 		return nil
+diff --git a/backend/main.go b/backend/main.go
+index b62c3a4c..e384acfb 100644
+--- a/backend/main.go
++++ b/backend/main.go
+@@ -17,6 +17,7 @@ func main() {
+ 		GopsEnabled:              config.BoolOr("GOPS_ENABLED", false),
+ 		GopsPort:                 config.Uint16Or("GOPS_PORT", 0),
+ 		CorsEnabled:              config.BoolOr("CORS_ENABLED", false),
++		EnableAuth:               config.BoolOr("ENABLE_AUTH", false),
+ 		DebugLogs:                config.BoolOr("DEBUG_LOGS", false),
+ 		UIServerPort:             config.Uint16Or("EVENTS_SERVER_PORT", 8090),
+ 		ClientPollDelays:         []time.Duration{200 * time.Millisecond, 5 * time.Second},

--- a/modules/500-cilium-hubble/images/ui/patches/003--auth.frontend.patch
+++ b/modules/500-cilium-hubble/images/ui/patches/003--auth.frontend.patch
@@ -1,0 +1,472 @@
+diff --git a/src/api/auth-user-info.ts b/src/api/auth-user-info.ts
+new file mode 100644
+index 00000000..3512bb45
+--- /dev/null
++++ b/src/api/auth-user-info.ts
+@@ -0,0 +1,42 @@
++export type AuthUserInfo = {
++  username: string;
++};
++
++/**
++ * GET /api/info when ENABLE_AUTH is true on the backend. Returns null if the
++ * endpoint is absent, the request fails, or the response is not a successful JSON body.
++ */
++export async function fetchAuthUserInfo(apiRoot: string): Promise<AuthUserInfo | null> {
++  const base = apiRoot.replace(/\/+$/, '');
++  const url = `${base}/info`;
++
++  try {
++    const res = await fetch(url, {
++      method: 'GET',
++      credentials: 'include',
++      headers: { Accept: 'application/json' },
++    });
++
++    if (!res.ok) {
++      return null;
++    }
++
++    const data: unknown = await res.json();
++    if (
++      typeof data !== 'object' ||
++      data === null ||
++      typeof (data as { username?: unknown }).username !== 'string'
++    ) {
++      return null;
++    }
++
++    const username = (data as { username: string }).username.trim();
++    if (username.length === 0) {
++      return null;
++    }
++
++    return { username };
++  } catch {
++    return null;
++  }
++}
+diff --git a/src/api/customprotocol/control-stream.ts b/src/api/customprotocol/control-stream.ts
+index 411b24b1..e46c9dc4 100644
+--- a/src/api/customprotocol/control-stream.ts
++++ b/src/api/customprotocol/control-stream.ts
+@@ -54,7 +54,8 @@ export class ControlStream extends Stream<Handlers> {
+   }
+ 
+   private emitNamespaces(nss?: uipb.GetControlStreamResponse_NamespaceStates) {
+-    const changes = nss?.namespaces.reduce((acc, ns) => {
++    const pbNamespaces = nss?.namespaces ?? [];
++    const changes = pbNamespaces.reduce((acc, ns) => {
+       const nsDesc = helpers.namespaces.fromPb(ns.namespace);
+       if (nsDesc == null) return acc;
+ 
+@@ -64,8 +65,6 @@ export class ControlStream extends Stream<Handlers> {
+       });
+     }, [] as NamespaceChange[]);
+ 
+-    if (!changes?.length) return;
+-
+     this.emit(Event.NamespaceChanges, changes);
+   }
+ 
+diff --git a/src/components/ServiceMapApp/WelcomeScreen.scss b/src/components/ServiceMapApp/WelcomeScreen.scss
+index 492af190..8557a957 100644
+--- a/src/components/ServiceMapApp/WelcomeScreen.scss
++++ b/src/components/ServiceMapApp/WelcomeScreen.scss
+@@ -64,3 +64,24 @@
+   display: flex;
+   justify-content: flex-start;
+ }
++
++.errorPanel {
++  margin: 20px 24px 0;
++  max-width: 520px;
++  text-align: center;
++}
++
++.errorTitle {
++  margin: 0 0 12px;
++  font-size: 16px;
++  line-height: 22px;
++  font-weight: 600;
++  color: #c23030;
++}
++
++.errorDetail {
++  margin: 0;
++  font-size: 14px;
++  line-height: 20px;
++  color: #5c7080;
++}
+diff --git a/src/components/ServiceMapApp/WelcomeScreen.tsx b/src/components/ServiceMapApp/WelcomeScreen.tsx
+index 29f58ff9..95ef86b7 100644
+--- a/src/components/ServiceMapApp/WelcomeScreen.tsx
++++ b/src/components/ServiceMapApp/WelcomeScreen.tsx
+@@ -1,4 +1,4 @@
+-import React from 'react';
++import React, { useEffect, useState } from 'react';
+ import { Spinner } from '@blueprintjs/core';
+ import { observer } from 'mobx-react';
+ 
+@@ -8,30 +8,58 @@ import { NamespaceSelectorDropdown } from '../TopBar/NamespaceSelectorDropdown';
+ import css from './WelcomeScreen.scss';
+ import hubbleLogo from '~/assets/images/hubble-logo.png';
+ 
++const NAMESPACES_WAIT_MS = 5_000;
++
+ export interface Props {
+   namespaces: NamespaceDescriptor[];
+   onNamespaceChange: (namespace: NamespaceDescriptor) => void;
++  hasReceivedControlStreamNamespaceBatch: boolean;
+ }
+ 
+ export const WelcomeScreen = observer(function WelcomeScreen(props: Props) {
+   const someNamespacesLoaded = props.namespaces.length > 0;
++  const [timedOut, setTimedOut] = useState(false);
++
++  useEffect(() => {
++    if (someNamespacesLoaded) {
++      setTimedOut(false);
++      return;
++    }
++
++    const id = window.setTimeout(() => setTimedOut(true), NAMESPACES_WAIT_MS);
++    return () => window.clearTimeout(id);
++  }, [someNamespacesLoaded]);
++
++  const showEmptyError = !someNamespacesLoaded && (props.hasReceivedControlStreamNamespaceBatch || timedOut);
+ 
+   return (
+     <div className={css.wrapper}>
+       <div className={css.content}>
+         <img src={hubbleLogo} className={css.logo} />
+         <h1 className={css.title}>Welcome!</h1>
+-        <p className={css.description}>To begin select one of the namespaces:</p>
+-        {someNamespacesLoaded ? (
+-          <NamespaceSelectorDropdown
+-            namespaces={props.namespaces}
+-            currentNamespace={null}
+-            onChange={props.onNamespaceChange}
+-          />
+-        ) : (
+-          <div className={css.spinnerWrapper}>
+-            <Spinner size={48} intent="primary" />
++        {showEmptyError ? (
++          <div className={css.errorPanel} role="alert">
++            <p className={css.errorTitle}>No namespaces available</p>
++            <p className={css.errorDetail}>
++              Hubble did not report any namespaces you can open. Check that your account is allowed to see namespaces,
++                and that the cluster has namespaces to observe.
++            </p>
+           </div>
++        ) : (
++          <>
++            <p className={css.description}>To begin select one of the namespaces:</p>
++            {someNamespacesLoaded ? (
++              <NamespaceSelectorDropdown
++                namespaces={props.namespaces}
++                currentNamespace={null}
++                onChange={props.onNamespaceChange}
++              />
++            ) : (
++              <div className={css.spinnerWrapper}>
++                <Spinner size={48} intent="primary" />
++              </div>
++            )}
++          </>
+         )}
+       </div>
+     </div>
+diff --git a/src/components/ServiceMapApp/index.tsx b/src/components/ServiceMapApp/index.tsx
+index 2ecc11a3..119eea8f 100644
+--- a/src/components/ServiceMapApp/index.tsx
++++ b/src/components/ServiceMapApp/index.tsx
+@@ -176,6 +176,7 @@ export const ServiceMapApp = observer(function ServiceMapApp() {
+         <WelcomeScreen
+           namespaces={store.availableNamespaces}
+           onNamespaceChange={ns => ui.controls.namespaceChanged(ns?.namespace)}
++          hasReceivedControlStreamNamespaceBatch={store.namespaces.hasReceivedControlStreamNamespaceBatch}
+         />
+       </div>
+     );
+diff --git a/src/components/TopBar/index.tsx b/src/components/TopBar/index.tsx
+index 3079cc3d..49903efd 100644
+--- a/src/components/TopBar/index.tsx
++++ b/src/components/TopBar/index.tsx
+@@ -1,5 +1,9 @@
+-import React from 'react';
++import React, { useEffect, useState } from 'react';
+ import { observer } from 'mobx-react';
++import { Icon } from '@blueprintjs/core';
++
++import { useApplication } from '~/application';
++import { fetchAuthUserInfo } from '~/api/auth-user-info';
+ 
+ import { Verdict } from '~/domain/hubble';
+ import { FilterEntry } from '~/domain/filtering';
+@@ -13,6 +17,8 @@ import { VisualFiltersDropdown } from './VisualFiltersDropdown';
+ import { NamespaceSelectorDropdown } from './NamespaceSelectorDropdown';
+ import { ConnectionIndicator } from './ConnectionIndicator';
+ 
++import { LOGOUT_PATH } from '~/router/LogoutRedirect';
++
+ import css from './styles.scss';
+ 
+ export interface Props {
+@@ -37,7 +43,35 @@ export interface Props {
+   onShowPrometheusAppToggle: () => void;
+ }
+ 
++type AuthAreaState =
++  | { phase: 'loading' }
++  | { phase: 'off' }
++  | { phase: 'on'; username: string };
++
+ export const TopBar = observer(function TopBar(props: Props) {
++  const { dataLayer } = useApplication();
++  const [authArea, setAuthArea] = useState<AuthAreaState>({ phase: 'loading' });
++
++  useEffect(() => {
++    let cancelled = false;
++
++    void (async () => {
++      const info = await fetchAuthUserInfo(dataLayer.getApiBaseUrl());
++      if (cancelled) {
++        return;
++      }
++      if (info == null) {
++        setAuthArea({ phase: 'off' });
++      } else {
++        setAuthArea({ phase: 'on', username: info.username });
++      }
++    })();
++
++    return () => {
++      cancelled = true;
++    };
++  }, [dataLayer]);
++
+   const RenderedFilters = (
+     <>
+       <div className={css.spacer} />
+@@ -76,6 +110,18 @@ export const TopBar = observer(function TopBar(props: Props) {
+         <div className={css.spacer} />
+ 
+         <ConnectionIndicator transferState={props.transferState} />
++
++        {authArea.phase === 'on' ? (
++          <>
++            <div className={css.spacer} />
++            <div className={css.spacer} />
++            <span className={css.userName} title={authArea.username}>
++              {authArea.username}
++            </span>
++            <div className={css.spacer} />
++            <a href={LOGOUT_PATH} className={css.signOffLink}><Icon icon="log-out" className={css.signOffIcon} iconSize={14} /></a>
++          </>
++        ) : null}
+       </div>
+     </div>
+   );
+diff --git a/src/components/TopBar/styles.scss b/src/components/TopBar/styles.scss
+index f33cf0df..dba519cb 100644
+--- a/src/components/TopBar/styles.scss
++++ b/src/components/TopBar/styles.scss
+@@ -43,6 +43,41 @@
+     @include row(flex-end, center);
+   }
+ 
++  .userName {
++    flex-shrink: 1;
++    max-width: 220px;
++    overflow: hidden;
++    text-overflow: ellipsis;
++    white-space: nowrap;
++    font-size: 14px;
++    line-height: 30px;
++    font-weight: 500;
++    color: #5c7080;
++  }
++
++  .signOffLink {
++    display: inline-flex;
++    align-items: center;
++    gap: 6px;
++    flex-shrink: 0;
++    font-size: 14px;
++    line-height: 30px;
++    font-weight: 500;
++    color: #5c7080;
++    text-decoration: none;
++    cursor: pointer;
++
++    &:hover {
++      color: #c23030;
++      text-decoration: none;
++    }
++  }
++
++  .signOffIcon {
++    flex-shrink: 0;
++    color: inherit;
++  }
++
+   .namespacesDropdownButton {
+     display: flex;
+     flex-wrap: nowrap;
+diff --git a/src/data-layer/controls.ts b/src/data-layer/controls.ts
+index fc5d7830..a20054f5 100644
+--- a/src/data-layer/controls.ts
++++ b/src/data-layer/controls.ts
+@@ -58,6 +58,7 @@ export class Controls extends EventEmitter<Handlers> {
+     this.controlStream = this.backendAPI
+       .controlStream()
+       .onNamespaceChanges(nsChanges => {
++        this.store.namespaces.markControlStreamNamespaceBatchReceived();
+         nsChanges.forEach(nsChange => {
+           const { namespace: nsDescriptor } = nsChange;
+           this.store.applyNamespaceChange(nsDescriptor);
+diff --git a/src/data-layer/data-layer.ts b/src/data-layer/data-layer.ts
+index b0fe448b..6f9da7a4 100644
+--- a/src/data-layer/data-layer.ts
++++ b/src/data-layer/data-layer.ts
+@@ -54,12 +54,13 @@ export class DataLayer extends EventEmitter<Handlers> {
+       useJSON: opts.customProtocolMessagesInJSON,
+     });
+ 
+-    return new DataLayer(opts.store, backendAPI);
++    return new DataLayer(opts.store, backendAPI, opts.customProtocolBaseURL);
+   }
+ 
+   constructor(
+     private store: Store,
+     private backendAPI: BackendAPI,
++    private readonly customProtocolBaseURL: string,
+   ) {
+     super(true);
+ 
+@@ -73,6 +74,10 @@ export class DataLayer extends EventEmitter<Handlers> {
+     mobx.makeObservable(this);
+   }
+ 
++  public getApiBaseUrl(): string {
++    return this.customProtocolBaseURL.replace(/\/+$/, '');
++  }
++
+   private get commonOpts(): Options {
+     return {
+       store: this.store,
+diff --git a/src/router/LogoutRedirect.tsx b/src/router/LogoutRedirect.tsx
+new file mode 100644
+index 00000000..b0984015
+--- /dev/null
++++ b/src/router/LogoutRedirect.tsx
+@@ -0,0 +1,58 @@
++import React, { useEffect } from 'react';
++
++/**
++ * Registered at /logout so the SPA router does not show a 404 when the user
++ * lands on /logout (e.g. after a full-page navigation or ingress routing the first
++ * request to the SPA shell). Performs a same-origin GET with redirect: 'manual'
++ * so ingress / oauth2-proxy can respond with 302 + Set-Cookie without loading
++ * more client bundle for the redirect target.
++ */
++export const LOGOUT_PATH = '/logout';
++
++export function LogoutRedirect() {
++  useEffect(() => {
++    let cancelled = false;
++
++    const run = async () => {
++      try {
++        const res = await fetch(LOGOUT_PATH, {
++          method: 'GET',
++          credentials: 'include',
++          redirect: 'manual',
++        });
++        if (cancelled) {
++          return;
++        }
++
++        const next = res.headers.get('Location');
++        if (next) {
++          window.location.replace(next);
++          return;
++        }
++      } catch {}
++      if (!cancelled) {
++        window.location.replace('/');
++      }
++    };
++
++    void run();
++    return () => {
++      cancelled = true;
++    };
++  }, []);
++
++  return (
++    <div
++      style={{
++        display: 'flex',
++        alignItems: 'center',
++        justifyContent: 'center',
++        minHeight: '40vh',
++        fontSize: 14,
++        color: '#5c7080',
++      }}
++    >
++      Logout…
++    </div>
++  );
++}
+diff --git a/src/router/Routes.tsx b/src/router/Routes.tsx
+index 891f6fff..3a0ba98e 100644
+--- a/src/router/Routes.tsx
++++ b/src/router/Routes.tsx
+@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+ import { ServiceMapApp } from '~/components/ServiceMapApp';
+ 
+ import { Router, ApplicationPath } from './router';
++import { LogoutRedirect } from './LogoutRedirect';
+ 
+ export type Props = {
+   router: Router;
+@@ -20,6 +21,10 @@ export const Routes = function Routes(props: Props) {
+           path: ApplicationPath.ServiceMap,
+           element: <ServiceMapApp />,
+         },
++        {
++          path: 'logout',
++          element: <LogoutRedirect />,
++        },
+       ],
+     },
+   ]);
+diff --git a/src/store/stores/namespace.ts b/src/store/stores/namespace.ts
+index 252d522b..6d4e9f27 100644
+--- a/src/store/stores/namespace.ts
++++ b/src/store/stores/namespace.ts
+@@ -7,12 +7,22 @@ export class NamespaceStore {
+   private _relayNamespaces: Map<string, NamespaceDescriptor> = new Map();
+   private _currentNamespace: string | null = null;
+ 
++  private _hasReceivedControlStreamNamespaceBatch = false;
++
+   constructor() {
+     makeAutoObservable(this, void 0, {
+       autoBind: true,
+     });
+   }
+ 
++  public get hasReceivedControlStreamNamespaceBatch(): boolean {
++    return this._hasReceivedControlStreamNamespaceBatch;
++  }
++
++  public markControlStreamNamespaceBatchReceived(): void {
++    this._hasReceivedControlStreamNamespaceBatch = true;
++  }
++
+   public clear() {
+     this._relayNamespaces.clear();
+   }

--- a/modules/500-cilium-hubble/images/ui/patches/README.md
+++ b/modules/500-cilium-hubble/images/ui/patches/README.md
@@ -14,3 +14,11 @@ Hubble UI:
 ## 002--gomod-gosum.backend.patch
 
 Updated go dependencies to fix vulnerabilities.
+
+## 003--auth.backend.patch
+
+Added backend authorization logic.
+
+## 003--auth.frontend.patch
+
+Added frontend authorization logic.

--- a/modules/500-cilium-hubble/images/ui/werf.inc.yaml
+++ b/modules/500-cilium-hubble/images/ui/werf.inc.yaml
@@ -1,4 +1,5 @@
 {{- $hubbleUIVersion := include "get_oss_version_by_id" (list "cilium-hubble-ui" $ )  -}}
+{{- $hubbleUIFrontendAssetsVersion := "0.13.2-auth" -}}
 ---
 # Based on https://github.com/cilium/cilium/blob/v1.17.4/install/kubernetes/cilium/values.yaml#L1698
 # and on https://github.com/cilium/cilium/blob/v1.17.4/install/kubernetes/cilium/values.yaml#L1732
@@ -26,7 +27,7 @@ shell:
   # CSE
   - find /src/hubble-ui -mindepth 1 -maxdepth 1 ! -name 'backend' -exec rm -rf {} +
   # also, there is README.md in repo ;)
-  - git clone --depth 1 --branch v{{ $hubbleUIVersion }} $(cat /run/secrets/SOURCE_REPO)/cilium/hubble-ui-frontend-assets.git /src/frontend_prebuilt
+  - git clone --depth 1 --branch v{{ $hubbleUIFrontendAssetsVersion }} $(cat /run/secrets/SOURCE_REPO)/cilium/hubble-ui-frontend-assets.git /src/frontend_prebuilt
   - rm -r /src/frontend_prebuilt/.git
   - mkdir -p /src/server/public
   - mv /src/frontend_prebuilt/static/* /src/server/public

--- a/modules/500-cilium-hubble/templates/ui/authenticator.yaml
+++ b/modules/500-cilium-hubble/templates/ui/authenticator.yaml
@@ -8,6 +8,8 @@ metadata:
   name: "cilium-hubble"
   namespace: "d8-cni-cilium"
   {{- include "helm_lib_module_labels" (list . (dict "app" "dex-authenticator" "name" "cilium-hubble" )) | nindent 2 }}
+  annotations:
+    dexauthenticator.deckhouse.io/allow-access-to-kubernetes: "true"
 spec:
   applicationDomain: {{ include "helm_lib_module_public_domain" (list . "hubble") }}
   {{- if (include "helm_lib_module_https_ingress_tls_enabled" .) }}
@@ -18,6 +20,8 @@ spec:
     {{- end }}
   {{- end }}
   applicationIngressClassName: {{ include "helm_lib_module_ingress_class" . | quote }}
+  signOutURL: "/logout"
+  sendAuthorizationHeader: true
   {{- with .Values.ciliumHubble.auth.allowedUserEmails }}
   allowedEmails:
   {{- . | toYaml | nindent 2 }}

--- a/modules/500-cilium-hubble/templates/ui/deployment.yaml
+++ b/modules/500-cilium-hubble/templates/ui/deployment.yaml
@@ -123,6 +123,10 @@ spec:
           value: /var/lib/hubble-ui/certs/client.crt
         - name: TLS_RELAY_CLIENT_KEY_FILE
           value: /var/lib/hubble-ui/certs/client.key
+        {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication }}
+        - name: ENABLE_AUTH
+          value: "true"
+        {{- end }}
         ports:
         - name: grpc
           containerPort: 8090

--- a/modules/500-cilium-hubble/templates/ui/httproute.yaml
+++ b/modules/500-cilium-hubble/templates/ui/httproute.yaml
@@ -61,6 +61,7 @@ metadata:
     alb.network.deckhouse.io/response-headers-to-add: '{"Strict-Transport-Security":"max-age=31536000; includeSubDomains"}'
   {{- end }}
   {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication }}
+    alb.network.deckhouse.io/auth-response-headers: Authorization
     alb.network.deckhouse.io/auth-signin: {{ replace "$host" (include "helm_lib_module_public_domain" (list . "hubble")) .Values.ciliumHubble.auth.externalAuthentication.authSignInURL | quote }}
     alb.network.deckhouse.io/auth-url: {{ .Values.ciliumHubble.auth.externalAuthentication.authURL | quote }}
   {{- else }}

--- a/modules/500-cilium-hubble/templates/ui/ingress.yaml
+++ b/modules/500-cilium-hubble/templates/ui/ingress.yaml
@@ -14,6 +14,7 @@ metadata:
     nginx.ingress.kubernetes.io/affinity-mode: persistent
     nginx.ingress.kubernetes.io/session-cookie-name: d8-hubble-affinity
     {{- if and (ne (include "helm_lib_module_https_mode" .) "Disabled") .Values.ciliumHubble.auth.externalAuthentication }}
+    nginx.ingress.kubernetes.io/auth-response-headers: Authorization
     nginx.ingress.kubernetes.io/auth-signin: {{ .Values.ciliumHubble.auth.externalAuthentication.authSignInURL | quote }}
     nginx.ingress.kubernetes.io/auth-url: {{ .Values.ciliumHubble.auth.externalAuthentication.authURL | quote }}
     {{- else }}


### PR DESCRIPTION
## Description
This PR **added authorization logic to Cilium Hubble UI**.
When OAuth authentication is enabled, the backend additionally checks which `flows` are accessible to the authenticated user and returns only the data that matches this allowed list.

As a result, after authentication:
1. **A user without permissions sees an error:**
<img width="558" height="283" alt="image" src="https://github.com/user-attachments/assets/ccd9402b-aa88-40c8-b9b2-660f96ea028a" />

2. **A user with access to a specific namespace sees **only the `flows` from that namespace**:**
<img width="296" height="391" alt="image" src="https://github.com/user-attachments/assets/a0afe860-180d-437f-96d0-b6ad2db6e193" />

✨ Additionally, for better user experience, has been added a logout button and field with displaying the username of the current session. The logout action terminates the current session and prompts the user to re-authenticate.

<img width="1728" height="53" alt="image" src="https://github.com/user-attachments/assets/9a84ee1d-0f69-44c5-9815-759b920c2d07" />


## Why do we need it, and what problem does it solve?
Previously, any authenticated user could view `flows` across all namespaces, even without basic read access to those namespaces.
This created a potential security risk and was not acceptable from an information security standpoint.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cilium-hubble
type: feature
summary: Added authorization to the Cilium Hubble UI.
impact_level: default
```