### PR TITLE
[dhctl] Fix panic in infrastructure plan

### DIFF
--- a/dhctl/pkg/infrastructure/runner.go
+++ b/dhctl/pkg/infrastructure/runner.go
@@ -523,13 +523,12 @@ func (r *Runner) Plan(ctx context.Context, destroy, noout bool) error {
 				}
 			} else {
 				report, err := r.getPlanDestructiveChanges(ctx, tmpFile.Name())
-				destructiveChanges := report.changes
 				if err != nil {
 					return err
 				}
-				if destructiveChanges != nil {
+				if report.changes != nil {
 					r.changesInPlan = plan.HasDestructiveChanges
-					r.planDestructiveChanges = destructiveChanges
+					r.planDestructiveChanges = report.changes
 					r.hasVMDestruction = report.hasVMChanges
 				}
 			}

--- a/dhctl/pkg/infrastructure/runner_test.go
+++ b/dhctl/pkg/infrastructure/runner_test.go
@@ -16,6 +16,7 @@ package infrastructure
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	infraexec "github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/exec"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -191,6 +193,75 @@ func TestCheckRunnerHandleChanges(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunnerPlan(t *testing.T) {
+	tests := []struct {
+		name                       string
+		showResp                   fakeResponse
+		planResp                   fakeResponse
+		vmResource                 string
+		expectedChangesInPlan      int
+		expectedDestructiveChanges *plan.DestructiveChanges
+		expectedHasVMDestruction   bool
+		expectedErrSubstring       string
+	}{
+		{
+			name:                       "non-destructive changes",
+			showResp:                   fakeResponse{resp: []byte("{\"format_version\":\"0.1\",\"resource_changes\":[]}")},
+			planResp:                   fakeResponse{code: infraexec.HasChangesExitCode},
+			expectedChangesInPlan:      plan.HasChanges,
+			expectedDestructiveChanges: nil,
+			expectedHasVMDestruction:   false,
+		},
+		{
+			name:                       "destructive changes",
+			showResp:                   fakeResponse{resp: mustReadFile(t, "./mocks/checkplan/destructively_changed.json")},
+			planResp:                   fakeResponse{code: infraexec.HasChangesExitCode},
+			vmResource:                 "yandex_compute_instance",
+			expectedChangesInPlan:      plan.HasDestructiveChanges,
+			expectedDestructiveChanges: destructivelyChanged,
+			expectedHasVMDestruction:   true,
+		},
+		{
+			name:                  "show error returns without panic",
+			showResp:              fakeResponse{err: errors.New("show failed")},
+			planResp:              fakeResponse{code: infraexec.HasChangesExitCode},
+			expectedChangesInPlan: plan.HasChanges,
+			expectedErrSubstring:  "show failed",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := newTestRunner(&fakeExecutor{
+				showResp:   tc.showResp,
+				planResp:   tc.planResp,
+				VMResource: tc.vmResource,
+			})
+
+			err := runner.Plan(context.Background(), false, false)
+			if tc.expectedErrSubstring != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.expectedErrSubstring)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tc.expectedChangesInPlan, runner.GetChangesInPlan())
+			require.Equal(t, tc.expectedDestructiveChanges, runner.GetPlanDestructiveChanges())
+			require.Equal(t, tc.expectedHasVMDestruction, runner.HasVMDestruction())
+		})
+	}
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return data
 }
 
 type sleepExecutor struct {


### PR DESCRIPTION
## Description

Fix panic in `dhctl` infrastructure plan processing when destructive changes report returns error. Add unit test for `Runner.Plan` destructive and error paths.

## Why do we need it, and what problem does it solve?

Before this change, `Runner.Plan` accessed `report.changes` before checking `err` from `getPlanDestructiveChanges`. If plan show or plan JSON parsing failed, it could panic with nil pointer dereference instead of returning error.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed a panic in infrastructure plan processing when the destructive changes report returns an error.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
