### PR TITLE
[vertical-pod-autoscaler] Replace recommender flag from humanize-memory to round-memory-bytes

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -71,9 +71,9 @@ spec:
         - --recommender-interval={{ $doubledScrapeInterval }}
         - --stderrthreshold=0
         - --memory-saver=true
-{{/*        this option is buggy. It provides some huge memory values, which are not correct (like: 3135326126080m)*/}}
-{{/*        - https://github.com/kubernetes/autoscaler/issues/7770*/}}
-        - --humanize-memory=false
+{{/*        --humanize-memory is deprecated (https://github.com/kubernetes/autoscaler/pull/8400)*/}}
+{{/*        --round-memory-bytes replaces it and rounds recommendations up to the nearest 64Mi*/}}
+        - --round-memory-bytes=67108864
         - --storage=prometheus
         - --prometheus-address=https://aggregating-proxy.d8-monitoring.svc.{{ .Values.global.discovery.clusterDomain }}
         - --prometheus-insecure=true


### PR DESCRIPTION
## Description
Replace the deprecated `--humanize-memory` flag with the new `--round-memory-bytes` flag in the VPA recommender deployment.

The `--humanize-memory` flag was previously disabled (`=false`) due to a known bug ([kubernetes/autoscaler#7770](https://github.com/kubernetes/autoscaler/issues/7770)) that produced incorrect huge memory values (e.g. `3135326126080m`). The new `--round-memory-bytes` flag, introduced in [kubernetes/autoscaler#8298](https://github.com/kubernetes/autoscaler/pull/8298), provides correct rounding of memory recommendations to the nearest specified byte value.

The rounding value is set to `67108864` bytes (64 MiB), which means memory recommendations will be rounded up to the nearest 64 MiB (e.g. 64Mi, 128Mi, 192Mi, 256Mi, ...).

This change does not affect any critical cluster components and does not cause restarts.

## Why do we need it, and what problem does it solve?
The `--humanize-memory` flag has been [deprecated upstream](https://github.com/kubernetes/autoscaler/pull/8400) since VPA 1.5.0 and will be removed in a future version. It was already disabled in Deckhouse due to buggy behavior.

The replacement `--round-memory-bytes` flag solves the problem of unreadable and unstable memory recommendations from VPA. Without rounding, recommendations look like `577578214` or `143236632` — raw byte values that are hard to interpret and cause frequent unnecessary pod restarts due to minor fluctuations.

With `--round-memory-bytes=67108864` (64 MiB), recommendations become clean, human-readable values (64Mi, 128Mi, 192Mi, ...) and small memory fluctuations no longer trigger restarts.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: vertical-pod-autoscaler
type: feature
summary: Replaced deprecated `--humanize-memory` flag with `--round-memory-bytes=67108864` (64Mi) for human-readable memory recommendations.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
