### PR TITLE
[ingress-nginx] backport cve-2026-4342 fix to 1.74

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/mount-points.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/mount-points.yaml
@@ -1,4 +1,5 @@
 dirs:
+- /chroot/tmp
 - /chroot/var/lib/nginx
 - /chroot/var/log/nginx
 - /chroot/etc/nginx/ssl/

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/027-fix-cve-2026-4342.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/027-fix-cve-2026-4342.patch
@@ -1,0 +1,22 @@
+diff --git a/etc/nginx/template/nginx.tmpl b/etc/nginx/template/nginx.tmpl
+index 45d1ebf7c5..3c6a5573a6 100644
+--- a/etc/nginx/template/nginx.tmpl
++++ b/etc/nginx/template/nginx.tmpl
+@@ -619,7 +619,7 @@ http {
+     {{ $applyGlobalAuth := shouldApplyGlobalAuth $location $all.Cfg.GlobalExternalAuth.URL }}
+     {{ $applyAuthUpstream := shouldApplyAuthUpstream $location $all.Cfg }}
+     {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
+-    ## start auth upstream {{ $server.Hostname }}{{ $location.Path }}
++    ## start auth upstream {{ $server.Hostname }}
+     upstream {{ buildAuthUpstreamName $location $server.Hostname }} {
+         {{- $externalAuth := $location.ExternalAuth }}
+         server {{ extractHostPort $externalAuth.URL }};
+@@ -628,7 +628,7 @@ http {
+         keepalive_requests {{ $externalAuth.KeepaliveRequests }};
+         keepalive_timeout {{ $externalAuth.KeepaliveTimeout }}s;
+     }
+-    ## end auth upstream {{ $server.Hostname }}{{ $location.Path }}
++    ## end auth upstream {{ $server.Hostname }}
+     {{ end }}
+     {{ end }}
+     {{ end }}

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -147,3 +147,7 @@ https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts
 This patch fixes rewrite-target CVE-2026-3288 in Ingress-NGINX
 
 https://github.com/kubernetes/kubernetes/issues/137560
+
+### 027-fix-cve-2026-4342.patch
+
+This patch fixes the CVE-2026-4342 https://github.com/kubernetes/kubernetes/issues/137893.

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -67,6 +67,7 @@ shell:
   - patch -p1 < /patches/003-nginx-tmpl.patch
   - patch -p1 < /patches/007-auth-cookie-always.patch
   - patch -p1 < /patches/025-cve-03022026-rootfs.patch
+  - patch -p1 < /patches/027-fix-cve-2026-4342.patch
   # pass env for build
   - cd /src/ingress-nginx
   - echo "export COMMIT_SHA=git-$(git rev-parse --short HEAD)" > .env_pass

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -353,8 +353,8 @@ shell:
   - adduser -r -u {{ $controllerUID }} -g {{ $controllerUID }} -d /usr/local/nginx -s /sbin/nologin -c {{ $controllerUser }} {{ $controllerUser }}
   - chown {{ $controllerUser }}:{{ $controllerUser }} /usr/bin/nginx
   - chown {{ $controllerUser }}:{{ $controllerUser }} /usr/bin/curl
+  - mkdir -p /chroot/var/log/valgrind /chroot/tmp/nginx
   - chmod 1777 /tmp /chroot/tmp /chroot/tmp/nginx
-  - mkdir -p /chroot/var/log/valgrind
   - setcap cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - setcap cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
   - setcap cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx

--- a/modules/402-ingress-nginx/images/controller-1-12/mount-points.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/mount-points.yaml
@@ -1,7 +1,7 @@
 dirs:
+- /chroot/tmp
 - /chroot/var/lib/nginx
 - /chroot/var/log/nginx
 - /chroot/etc/nginx/ssl/
 - /chroot/etc/nginx/webhook-ssl
 - /chroot/etc/ingress-controller
-- /var/log/valgrind

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/024-fix-cve-2026-4342.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/024-fix-cve-2026-4342.patch
@@ -1,0 +1,22 @@
+diff --git a/rootfs/etc/nginx/template/nginx.tmpl b/rootfs/etc/nginx/template/nginx.tmpl
+index 45d1ebf7c5..3c6a5573a6 100644
+--- a/rootfs/etc/nginx/template/nginx.tmpl
++++ b/rootfs/etc/nginx/template/nginx.tmpl
+@@ -619,7 +619,7 @@ http {
+     {{ $applyGlobalAuth := shouldApplyGlobalAuth $location $all.Cfg.GlobalExternalAuth.URL }}
+     {{ $applyAuthUpstream := shouldApplyAuthUpstream $location $all.Cfg }}
+     {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
+-    ## start auth upstream {{ $server.Hostname }}{{ $location.Path }}
++    ## start auth upstream {{ $server.Hostname }}
+     upstream {{ buildAuthUpstreamName $location $server.Hostname }} {
+         {{- $externalAuth := $location.ExternalAuth }}
+         server {{ extractHostPort $externalAuth.URL }};
+@@ -628,7 +628,7 @@ http {
+         keepalive_requests {{ $externalAuth.KeepaliveRequests }};
+         keepalive_timeout {{ $externalAuth.KeepaliveTimeout }}s;
+     }
+-    ## end auth upstream {{ $server.Hostname }}{{ $location.Path }}
++    ## end auth upstream {{ $server.Hostname }}
+     {{ end }}
+     {{ end }}
+     {{ end }}

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -125,3 +125,7 @@ https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts
 This patch fixes rewrite-target CVE-2026-3288 in Ingress-NGINX
 
 https://github.com/kubernetes/kubernetes/issues/137560
+
+### 024-fix-cve-2026-4342.patch
+
+This patch fixes the CVE-2026-4342 https://github.com/kubernetes/kubernetes/issues/137893.

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -619,6 +619,7 @@ shell:
   - |
     bash -eu -c '
     writeDirs=(
+      /chroot/tmp/nginx
       /chroot/etc/nginx
       /chroot/usr/local
       /chroot/etc/ingress-controller
@@ -637,7 +638,6 @@ shell:
       /chroot/var/lib/nginx/proxy
       /chroot/var/lib/nginx/scgi
       /chroot/var/lib/nginx/uwsgi
-      /chroot/tmp/nginx
     );
     for dir in "${writeDirs[@]}"; do
       mkdir -p ${dir};
@@ -892,7 +892,7 @@ import:
   - modules_mount
   - var/log
   - etc/nginx
-  - tmp/nginx
+  - tmp
   - etc/ingress-controller
   - var/log/nginx
   - sbin/nginx
@@ -973,10 +973,6 @@ import:
   - usr/bin/cat
   - usr/bin/cp
   - usr/bin/tail
-  before: install
-- image: tools/libcap
-  add: /usr/sbin/setcap
-  to: /apps/setcap
   before: install
 git:
 {{- include "image mount points" $ }}

--- a/modules/402-ingress-nginx/images/controller-1-9/mount-points.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/mount-points.yaml
@@ -1,7 +1,7 @@
 dirs:
+- /chroot/tmp
 - /chroot/var/lib/nginx
 - /chroot/var/log/nginx
 - /chroot/etc/nginx/ssl/
 - /chroot/etc/nginx/webhook-ssl
 - /chroot/etc/ingress-controller
-- /var/log/valgrind

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/005-fix-cve-2026-4342.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/005-fix-cve-2026-4342.patch
@@ -1,0 +1,22 @@
+diff --git a/etc/nginx/template/nginx.tmpl b/etc/nginx/template/nginx.tmpl
+index 45d1ebf7c5..3c6a5573a6 100644
+--- a/etc/nginx/template/nginx.tmpl
++++ b/etc/nginx/template/nginx.tmpl
+@@ -619,7 +619,7 @@ http {
+     {{ $applyGlobalAuth := shouldApplyGlobalAuth $location $all.Cfg.GlobalExternalAuth.URL }}
+     {{ $applyAuthUpstream := shouldApplyAuthUpstream $location $all.Cfg }}
+     {{ if and (eq $applyAuthUpstream true) (eq $applyGlobalAuth false) }}
+-    ## start auth upstream {{ $server.Hostname }}{{ $location.Path }}
++    ## start auth upstream {{ $server.Hostname }}
+     upstream {{ buildAuthUpstreamName $location $server.Hostname }} {
+         {{- $externalAuth := $location.ExternalAuth }}
+         server {{ extractHostPort $externalAuth.URL }};
+@@ -628,7 +628,7 @@ http {
+         keepalive_requests {{ $externalAuth.KeepaliveRequests }};
+         keepalive_timeout {{ $externalAuth.KeepaliveTimeout }}s;
+     }
+-    ## end auth upstream {{ $server.Hostname }}{{ $location.Path }}
++    ## end auth upstream {{ $server.Hostname }}
+     {{ end }}
+     {{ end }}
+     {{ end }}

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/rootfs/README.md
@@ -31,6 +31,6 @@ CVE-2026-24513
 CVE-2026-24514
 https://groups.google.com/a/kubernetes.io/g/dev/c/9RYJrB8e8ts
 
-### 005-nginx-version-02.patch
+### 005-fix-cve-2026-4342.patch
 
-Updates nginx version from 1.21.6 to 1.29.5 to fix CVEs.
+This patch fixes the CVE-2026-4342 https://github.com/kubernetes/kubernetes/issues/137893.

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -83,6 +83,7 @@ shell:
   - patch -p1 < /patches/rootfs/002-nginx-tmpl.patch
   - patch -p1 < /patches/rootfs/003-auth-cookie-always.patch
   - patch -p1 < /patches/rootfs/004-cve-03022026.patch
+  - patch -p1 < /patches/rootfs/005-fix-cve-2026-4342.patch
   - rm -r /src/dumb-init/.git
   - rm -r /src/lua-protobuf/.git
   - rm -r /src/lua-iconv/.git

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/controller.yaml
@@ -145,6 +145,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/controller.yaml
@@ -151,6 +151,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx
@@ -465,6 +467,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/controller.yaml
@@ -136,6 +136,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/controller.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/controller.yaml
@@ -137,6 +137,8 @@ spec:
           runAsGroup: 64535
           runAsNonRoot: true
           runAsUser: 64535
+          seccompProfile:
+            type: Unconfined
         volumeMounts:
         - mountPath: /chroot/var/lib/nginx
           name: var-lib-nginx

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/podmonitor.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/podmonitor.yaml
@@ -16,12 +16,12 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     metricRelabelings:
     - action: labeldrop
       regex: ingress_class
     path: /controller/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container
@@ -47,9 +47,9 @@ spec:
   - bearerTokenSecret:
       key: token
       name: prometheus-token
+    honorLabels: true
     path: /protobuf/metrics
     port: https-metrics
-    honorLabels: true
     relabelings:
     - action: labeldrop
       regex: endpoint|pod|container

--- a/modules/402-ingress-nginx/templates/controller/controller.yaml
+++ b/modules/402-ingress-nginx/templates/controller/controller.yaml
@@ -219,6 +219,8 @@ spec:
         name: controller
         {{- if and (eq $controllerVersion "1.10") $crd.spec.nginxProfilingEnabled }}
         securityContext:
+          seccompProfile:
+            type: Unconfined
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           runAsUser: 0
@@ -236,6 +238,8 @@ spec:
             - ALL
         {{- else }}
         {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 8 }}
+          seccompProfile:
+            type: Unconfined
           capabilities:
             add:
             - SYS_CHROOT

--- a/modules/402-ingress-nginx/templates/validator/deployment.yml
+++ b/modules/402-ingress-nginx/templates/validator/deployment.yml
@@ -123,6 +123,8 @@ spec:
       - name: validator
         image: {{ include "helm_lib_module_image" (list $context (printf "controller%s" ($controllerVersion | replace "." ""))) }}
         securityContext:
+          seccompProfile:
+            type: Unconfined
           readOnlyRootFilesystem: true
           capabilities:
             add:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backports CVE fix, security context hardening and werf build updates.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It backports security fixes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

It backports security fixes.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: CVE-2026-4342 fix is backported to Dechkouse 1.74.
impact: All Ingress-NGINX controller pods will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
