### PR TITLE
[user-authn] Add "cache" get parameter to prevent stale caches from breaking login page

### DIFF
--- a/modules/150-user-authn/images/dex/patches/014-build-id-cache-invalidation.patch
+++ b/modules/150-user-authn/images/dex/patches/014-build-id-cache-invalidation.patch
@@ -1,0 +1,223 @@
+diff --git a/server/templates.go b/server/templates.go
+index 1f9da468..09f68e1b 100644
+--- a/server/templates.go
++++ b/server/templates.go
+@@ -1,6 +1,7 @@
+ package server
+ 
+ import (
++	"crypto/sha256"
+ 	"errors"
+ 	"fmt"
+ 	"html/template"
+@@ -9,8 +10,10 @@ import (
+ 	"net/http"
+ 	"net/url"
+ 	"path"
++	"runtime/debug"
+ 	"sort"
+ 	"strings"
++	"sync"
+ 
+ 	"github.com/Masterminds/sprig/v3"
+ )
+@@ -269,24 +272,71 @@ func (n byName) Len() int           { return len(n) }
+ func (n byName) Less(i, j int) bool { return n[i].Name < n[j].Name }
+ func (n byName) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+ 
++var (
++	// buildID is used as a cache invalidating GET-parameter in the header template's URL to the main CSS file.
++	// It is represented as a substring of sha256 hash taken from the combination of the following:
++	//
++	// * Git commit hash used to build this dex binary;
++	// * Main module revison string as defined by Go compiler (usually this matches the git tag name);
++	// * Status of the VCS working tree: clean or dirty.
++	//
++	// This is used to prevent browser caches getting stuck between dex updates and can be
++	// extended onto other resources if deemed nececcsary.
++	buildID     string
++	buildIDOnce sync.Once
++)
++
++// buildIdentifier performs lazy initialization and returns a short string that
++// somewhat uniquely identifies this specific build of dex. It can be used as a
++// cache key to prevent browsers from using stale assets after an upgrade.
++//
++// See the comment on buildID field for details.
++func buildIdentifier() string {
++	buildIDOnce.Do(func() {
++		version := "dev"
++		revision := "unknown"
++		modifiedWorktree := "false"
++
++		if info, ok := debug.ReadBuildInfo(); ok {
++			if v := info.Main.Version; v != "" {
++				version = v
++			}
++			for _, s := range info.Settings {
++				if s.Key == "vcs.revision" {
++					revision = s.Value
++				}
++				if s.Key == "vcs.modified" {
++					modifiedWorktree = s.Value
++				}
++			}
++		}
++
++		sum := sha256.Sum256([]byte(version + revision + modifiedWorktree))
++		buildID = fmt.Sprintf("%x", sum[:4])
++	})
++	return buildID
++}
++
+ func (t *templates) device(r *http.Request, w http.ResponseWriter, postURL string, userCode string, lastWasInvalid bool) error {
+ 	if lastWasInvalid {
+ 		w.WriteHeader(http.StatusBadRequest)
+ 	}
+ 	data := struct {
+-		PostURL  string
+-		UserCode string
+-		Invalid  bool
+-		ReqPath  string
+-	}{postURL, userCode, lastWasInvalid, r.URL.Path}
++		PostURL         string
++		UserCode        string
++		Invalid         bool
++		ReqPath         string
++		BuildIdentifier string
++	}{postURL, userCode, lastWasInvalid, r.URL.Path, buildIdentifier()}
+ 	return renderTemplate(w, t.deviceTmpl, data)
+ }
+ 
+ func (t *templates) deviceSuccess(r *http.Request, w http.ResponseWriter, clientName string) error {
+ 	data := struct {
+-		ClientName string
+-		ReqPath    string
+-	}{clientName, r.URL.Path}
++		ClientName      string
++		ReqPath         string
++		BuildIdentifier string
++	}{clientName, r.URL.Path, buildIdentifier()}
+ 	return renderTemplate(w, t.deviceSuccessTmpl, data)
+ }
+ 
+@@ -295,22 +345,24 @@ func (t *templates) totpVerify(r *http.Request, w http.ResponseWriter, postURL,
+ 		w.WriteHeader(http.StatusUnauthorized)
+ 	}
+ 	data := struct {
+-		PostURL   string
+-		Invalid   bool
+-		Issuer    string
+-		Connector string
+-		QRCode    string
+-		ReqPath   string
+-	}{postURL, lastWasInvalid, issuer, connector, qrCode, r.URL.Path}
++		PostURL         string
++		Invalid         bool
++		Issuer          string
++		Connector       string
++		QRCode          string
++		ReqPath         string
++		BuildIdentifier string
++	}{postURL, lastWasInvalid, issuer, connector, qrCode, r.URL.Path, buildIdentifier()}
+ 	return renderTemplate(w, t.tmplTOTPVerify, data)
+ }
+ 
+ func (t *templates) login(r *http.Request, w http.ResponseWriter, connectors []connectorInfo) error {
+ 	sort.Sort(byName(connectors))
+ 	data := struct {
+-		Connectors []connectorInfo
+-		ReqPath    string
+-	}{connectors, r.URL.Path}
++		Connectors      []connectorInfo
++		ReqPath         string
++		BuildIdentifier string
++	}{connectors, r.URL.Path, buildIdentifier()}
+ 	return renderTemplate(w, t.loginTmpl, data)
+ }
+ 
+@@ -319,13 +371,14 @@ func (t *templates) password(r *http.Request, w http.ResponseWriter, postURL, la
+ 		w.WriteHeader(http.StatusUnauthorized)
+ 	}
+ 	data := struct {
+-		PostURL        string
+-		BackLink       string
+-		Username       string
+-		UsernamePrompt string
+-		Invalid        bool
+-		ReqPath        string
+-	}{postURL, backLink, lastUsername, usernamePrompt, lastWasInvalid, r.URL.Path}
++		PostURL         string
++		BackLink        string
++		Username        string
++		UsernamePrompt  string
++		Invalid         bool
++		ReqPath         string
++		BuildIdentifier string
++	}{postURL, backLink, lastUsername, usernamePrompt, lastWasInvalid, r.URL.Path, buildIdentifier()}
+ 	return renderTemplate(w, t.passwordTmpl, data)
+ }
+ 
+@@ -379,10 +432,12 @@ func (t *templates) passwordChange(r *http.Request, w http.ResponseWriter, param
+ 		PasswordPolicy struct {
+ 			ComplexityRequirements string
+ 		}
+-		ReqPath string
++		ReqPath         string
++		BuildIdentifier string
+ 	}{
+-		Username: params.Username,
+-		ReqPath:  r.URL.String(),
++		Username:        params.Username,
++		ReqPath:         r.URL.String(),
++		BuildIdentifier: buildIdentifier(),
+ 	}
+ 
+ 	switch params.ChangeReason {
+@@ -427,20 +482,22 @@ func (t *templates) approval(r *http.Request, w http.ResponseWriter, authReqID,
+ 	}
+ 	sort.Strings(accesses)
+ 	data := struct {
+-		User      string
+-		Client    string
+-		AuthReqID string
+-		Scopes    []string
+-		ReqPath   string
+-	}{username, clientName, authReqID, accesses, r.URL.Path}
++		User            string
++		Client          string
++		AuthReqID       string
++		Scopes          []string
++		ReqPath         string
++		BuildIdentifier string
++	}{username, clientName, authReqID, accesses, r.URL.Path, buildIdentifier()}
+ 	return renderTemplate(w, t.approvalTmpl, data)
+ }
+ 
+ func (t *templates) oob(r *http.Request, w http.ResponseWriter, code string) error {
+ 	data := struct {
+-		Code    string
+-		ReqPath string
+-	}{code, r.URL.Path}
++		Code            string
++		ReqPath         string
++		BuildIdentifier string
++	}{code, r.URL.Path, buildIdentifier()}
+ 	return renderTemplate(w, t.oobTmpl, data)
+ }
+ 
+diff --git a/web/templates/header.html b/web/templates/header.html
+index 8cf744e5..4b4a6f69 100644
+--- a/web/templates/header.html
++++ b/web/templates/header.html
+@@ -5,8 +5,8 @@
+     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+     <title>{{ issuer }}</title>
+     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+-    <link href="{{ url .ReqPath "static/main.css" }}" rel="stylesheet">
+-    <link href="{{ url .ReqPath "theme/styles.css" }}" rel="stylesheet">
++    <link href="{{ printf "%s?cache=%s" (url .ReqPath "static/main.css") .BuildIdentifier }}" rel="stylesheet">
++    <link href="{{ printf "%s?cache=%s" (url .ReqPath "theme/styles.css") .BuildIdentifier }}" rel="stylesheet">
+     <link rel="icon" href="{{ url .ReqPath "theme/favicon.png" }}">
+   </head>
+ 

--- a/modules/150-user-authn/images/dex/src/web/templates/header.html
+++ b/modules/150-user-authn/images/dex/src/web/templates/header.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Deckhouse</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="{{ url .ReqPath "static/main.css" }}" rel="stylesheet">
+    <link href="{{ printf "%s?cache=%s" (url .ReqPath "static/main.css") .BuildIdentifier }}" rel="stylesheet">
     <link rel="icon" href="{{ url .ReqPath "static/img/favicon.png" }}">
   </head>
 
@@ -15,4 +15,4 @@
         <div class="layout-deckhouse-title">
           <img src="{{ url .ReqPath "static/img/deckhouse-logo-title.svg" }}" />
         </div>
-        
+


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Added `cache` get parameter to main CSS file URL that gets opaque dex build identifier assigned to it

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Prevents stale caches from breaking the login page

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Add "cache" get parameter to prevent stale caches from breaking login page
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
