### PR TITLE
[docs-builder] improving graceful shutdown handling

### DIFF
--- a/docs/site/backends/docs-builder/main.go
+++ b/docs/site/backends/docs-builder/main.go
@@ -124,6 +124,11 @@ func main() {
 		logger.Error("goroutine error", log.Err(waitErr))
 	}
 
+	// Remove the kubernetes lease to signal that this instance is no longer active.
+	// Uses its own context with a 5-second timeout to ensure it completes even if
+	// the shutdown context was already canceled. Do not remove this — the lease
+	// must be released so that another instance can take over, otherwise we'll have
+	// a split-brain situation where two instances think they are the leader.
 	removeCtx, removeCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer removeCancel()
 	if err := lManager.Remove(removeCtx); err != nil {

--- a/docs/site/backends/docs-builder/main.go
+++ b/docs/site/backends/docs-builder/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"net/http"
 	"os"
@@ -99,22 +100,25 @@ func main() {
 
 	logger.Info("stopping application")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err = lManager.Remove(ctx)
-	if err != nil {
+	eg.Go(func() error {
+		return srv.Shutdown(shutdownCtx)
+	})
+	eg.Go(func() error {
+		return metricsSrv.Shutdown(shutdownCtx)
+	})
+
+	waitErr := eg.Wait()
+	if waitErr != nil && !errors.Is(waitErr, context.Canceled) {
+		logger.Error("goroutine error", log.Err(waitErr))
+	}
+
+	removeCtx, removeCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer removeCancel()
+	if err := lManager.Remove(removeCtx); err != nil {
 		logger.Error("lease removing failed", log.Err(err))
-	}
-
-	err = srv.Shutdown(ctx)
-	if err != nil {
-		logger.Error("shutdown failed", log.Err(err))
-	}
-
-	err = eg.Wait()
-	if err != nil {
-		logger.Error("error due stopping application", log.Err(err))
 	}
 
 	logger.Info("application stopped")

--- a/docs/site/backends/docs-builder/main.go
+++ b/docs/site/backends/docs-builder/main.go
@@ -100,17 +100,26 @@ func main() {
 
 	logger.Info("stopping application")
 
+	// Create a new context with timeout for graceful shutdown.
+	// The signal context (ctx) may already be canceled (e.g., if one of the goroutines failed).
+	// In that case, shutdown would immediately exit — which is not what we want.
+	// A separate context allows all shutdown goroutines to complete correctly,
+	// even if one of them fails — the error won't cancel the context for others.
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	eg.Go(func() error {
+	// New errgroup for shutdown — the main eg may have already exited with an error
+	// (and consequently canceled its context). Reusing it for shutdown is not allowed.
+	shutdownEg, shutdownCtx := errgroup.WithContext(shutdownCtx)
+
+	shutdownEg.Go(func() error {
 		return srv.Shutdown(shutdownCtx)
 	})
-	eg.Go(func() error {
+	shutdownEg.Go(func() error {
 		return metricsSrv.Shutdown(shutdownCtx)
 	})
 
-	waitErr := eg.Wait()
+	waitErr := shutdownEg.Wait()
 	if waitErr != nil && !errors.Is(waitErr, context.Canceled) {
 		logger.Error("goroutine error", log.Err(waitErr))
 	}


### PR DESCRIPTION
## Description

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Improve graceful shutdown handling in `docs-builder` to ensure all components terminate cleanly and reliably.

### Changes

* Graceful shutdown now applies to both HTTP and metrics servers (previously only HTTP server was handled)
* Both servers are stopped in parallel with a shared 10s timeout
* Leases manager shutdown now uses a dedicated context with its own 5s timeout instead of a cancelled parent context
* Added helper logic to coordinate parallel shutdown and timeout handling

## Why do we need it, and what problem does it solve?

<!---
  This is the most important paragraph.
-->

**Before:**

* Only the main HTTP server was shut down gracefully; the metrics server could continue running
* Leases manager received a cancelled context, which could interrupt cleanup and lead to incomplete resource release

**After:**

* Both HTTP and metrics servers are gracefully shut down in parallel within a controlled timeout
* Leases manager receives a fresh, bounded context, ensuring proper cleanup execution

This improves shutdown reliability and prevents resource leaks or inconsistent termination behavior in `docs-builder`.

## Checklist

* [ ] The code is covered by unit tests.
* [ ] e2e tests passed.
* [ ] Documentation updated according to the changes.
* [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Improve graceful shutdown handling — parallel shutdown of HTTP and metrics servers with proper timeout and dedicated cleanup context.
impact_level: low
```
