### PR TITLE
[dhctl] nodeReady check

### DIFF
--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -245,11 +245,19 @@ func WaitForSingleNodeBecomeReady(ctx context.Context, kubeCl *client.Kubernetes
 				return err
 			}
 
-			for _, c := range node.Status.Conditions {
-				if c.Type == corev1.NodeReady {
-					if c.Status == corev1.ConditionTrue {
-						return nil
-					}
+			msg := fmt.Sprintf("Node %q conditions:\n", nodeName)
+			for _, cond := range node.Status.Conditions {
+				msg += fmt.Sprintf("  %s: %s", cond.Type, cond.Status)
+				if cond.Message != "" {
+					msg += fmt.Sprintf(" (%s)", cond.Message)
+				}
+				msg += "\n"
+			}
+			log.InfoF("%s", msg)
+
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+					return nil
 				}
 			}
 

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -245,18 +245,16 @@ func WaitForSingleNodeBecomeReady(ctx context.Context, kubeCl *client.Kubernetes
 				return err
 			}
 
-			msg := fmt.Sprintf("Node %q conditions:\n", nodeName)
 			for _, cond := range node.Status.Conditions {
-				msg += fmt.Sprintf("  %s: %s", cond.Type, cond.Status)
-				if cond.Message != "" {
-					msg += fmt.Sprintf(" (%s)", cond.Message)
+				if cond.Type != corev1.NodeReady {
+					continue
 				}
-				msg += "\n"
-			}
-			log.InfoF("%s", msg)
-
-			for _, cond := range node.Status.Conditions {
-				if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				if cond.Message != "" {
+					log.InfoF("Node %q Ready: %s (%s)\n", nodeName, cond.Status, cond.Message)
+				} else {
+					log.InfoF("Node %q Ready: %s\n", nodeName, cond.Status)
+				}
+				if cond.Status == corev1.ConditionTrue {
 					return nil
 				}
 			}

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
@@ -66,13 +66,18 @@ func waitEtcdHasMember(ctx context.Context, client *flantkubeclient.Client, node
 }
 
 func waitEtcdHasNoMember(ctx context.Context, client *flantkubeclient.Client, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to leave etcd", nodeName), 45, 5*time.Second).RunContext(ctx, func() error {
-		// exclude the node we are checking
+	const maxAttempts = 45
+	attempt := 0
+
+	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to leave etcd", nodeName), maxAttempts, 5*time.Second).RunContext(ctx, func() error {
+		attempt++
 		fieldSelector := fields.OneTermNotEqualSelector("spec.nodeName", nodeName).String()
 
 		ok, err := isEtcdHasMember(ctx, client, nodeName, fieldSelector)
 		if err != nil {
-			log.DebugF("etcd check transient error while waiting for '%s' to leave: %v\n", nodeName, err)
+			if attempt == maxAttempts {
+				return fmt.Errorf("checking etcd membership for '%s': %w", nodeName, err)
+			}
 			return fmt.Errorf("node '%s' is still listed as etcd cluster member", nodeName)
 		}
 
@@ -112,25 +117,26 @@ func getEtcdMembers(ctx context.Context, client *flantkubeclient.Client, fieldSe
 		return nil, fmt.Errorf("etcd pods not found")
 	}
 
-	pod := pods.Items[0]
-	found := false
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.Name != "etcd" {
-			continue
+	var pod *corev1.Pod
+	for i := range pods.Items {
+		for _, cs := range pods.Items[i].Status.ContainerStatuses {
+			if cs.Name == "etcd" && cs.State.Running != nil {
+				pod = &pods.Items[i]
+				break
+			}
 		}
-		found = true
-		if cs.State.Running == nil {
-			return nil, fmt.Errorf("etcd container is not running yet")
+		if pod != nil {
+			break
 		}
 	}
-	if !found {
-		return nil, fmt.Errorf("etcd container status not found in pod %s", pod.Name)
+	if pod == nil {
+		return nil, fmt.Errorf("no etcd pod with running container found")
 	}
 
 	req := client.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Namespace("kube-system").
-		Name(pods.Items[0].Name).
+		Name(pod.Name).
 		SubResource("exec")
 
 	command := []string{

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
@@ -70,7 +70,8 @@ func waitEtcdHasNoMember(ctx context.Context, client *flantkubeclient.Client, no
 
 		ok, err := isEtcdHasMember(ctx, client, nodeName, fieldSelector)
 		if err != nil {
-			return err
+			log.DebugF("etcd check transient error while waiting for '%s' to leave: %v\n", nodeName, err)
+			return fmt.Errorf("node '%s' is still listed as etcd cluster member", nodeName)
 		}
 
 		if ok {

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
@@ -34,29 +34,31 @@ import (
 )
 
 func waitEtcdHasMember(ctx context.Context, client *flantkubeclient.Client, nodeName string) error {
-	printed := false
+	attempt := 0
 
 	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to join etcd", nodeName), 100, 20*time.Second).RunContext(ctx, func() error {
+		attempt++
+
 		members, err := getEtcdMembers(ctx, client, "")
 		if err != nil {
 			return fmt.Errorf("getting etcd members: %w", err)
 		}
 
 		names := make([]string, 0, len(members))
+		hasMember := false
 		for _, m := range members {
 			names = append(names, m.Name)
+			if m.Name == nodeName {
+				hasMember = true
+			}
 		}
 
-		if !printed {
-			printed = true
+		if attempt == 1 || hasMember {
 			log.InfoF("Current members: [%s]\n", strings.Join(names, ", "))
 		}
 
-		for _, m := range members {
-			if m.Name == nodeName {
-				log.InfoF("Current members: [%s]\n", strings.Join(names, ", "))
-				return nil
-			}
+		if hasMember {
+			return nil
 		}
 
 		return fmt.Errorf("'%s' is not yet a member", nodeName)

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	flantkubeclient "github.com/flant/kube-client/client"
@@ -28,26 +29,42 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
 func waitEtcdHasMember(ctx context.Context, client *flantkubeclient.Client, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Check the master node '%s' is listed as etcd cluster member", nodeName), 100, 20*time.Second).RunContext(ctx, func() error {
-		ok, err := isEtcdHasMember(ctx, client, nodeName, "")
+	printed := false
+
+	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to join etcd", nodeName), 100, 20*time.Second).RunContext(ctx, func() error {
+		members, err := getEtcdMembers(ctx, client, "")
 		if err != nil {
-			return fmt.Errorf("failed to check etcd cluster member: %s", err)
+			return fmt.Errorf("getting etcd members: %w", err)
 		}
 
-		if !ok {
-			return fmt.Errorf("node '%s' is not listed as etcd cluster member", nodeName)
+		names := make([]string, 0, len(members))
+		for _, m := range members {
+			names = append(names, m.Name)
 		}
 
-		return nil
+		if !printed {
+			printed = true
+			log.InfoF("Current members: [%s]\n", strings.Join(names, ", "))
+		}
+
+		for _, m := range members {
+			if m.Name == nodeName {
+				log.InfoF("Current members: [%s]\n", strings.Join(names, ", "))
+				return nil
+			}
+		}
+
+		return fmt.Errorf("'%s' is not yet a member", nodeName)
 	})
 }
 
 func waitEtcdHasNoMember(ctx context.Context, client *flantkubeclient.Client, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Check the master node '%s' is no longer listed as etcd cluster member", nodeName), 45, 5*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to leave etcd", nodeName), 45, 5*time.Second).RunContext(ctx, func() error {
 		// exclude the node we are checking
 		fieldSelector := fields.OneTermNotEqualSelector("spec.nodeName", nodeName).String()
 
@@ -65,16 +82,46 @@ func waitEtcdHasNoMember(ctx context.Context, client *flantkubeclient.Client, no
 }
 
 func isEtcdHasMember(ctx context.Context, client *flantkubeclient.Client, nodeName string, fieldSelector string) (bool, error) {
+	members, err := getEtcdMembers(ctx, client, fieldSelector)
+	if err != nil {
+		return false, err
+	}
+
+	for _, m := range members {
+		if m.Name == nodeName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func getEtcdMembers(ctx context.Context, client *flantkubeclient.Client, fieldSelector string) ([]etcdMember, error) {
 	pods, err := client.CoreV1().Pods("kube-system").List(ctx, v1.ListOptions{
 		LabelSelector: "component=etcd,tier=control-plane",
 		FieldSelector: fieldSelector,
 	})
 	if err != nil {
-		return false, fmt.Errorf("failed to get etcd pods: %s", err)
+		return nil, fmt.Errorf("failed to get etcd pods: %w", err)
 	}
 
 	if len(pods.Items) == 0 {
-		return false, fmt.Errorf("etcd pods not found")
+		return nil, fmt.Errorf("etcd pods not found")
+	}
+
+	pod := pods.Items[0]
+	found := false
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name != "etcd" {
+			continue
+		}
+		found = true
+		if cs.State.Running == nil {
+			return nil, fmt.Errorf("etcd container is not running yet")
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("etcd container status not found in pod %s", pod.Name)
 	}
 
 	req := client.CoreV1().RESTClient().Post().
@@ -103,7 +150,7 @@ func isEtcdHasMember(ctx context.Context, client *flantkubeclient.Client, nodeNa
 
 	executor, err := remotecommand.NewSPDYExecutor(client.RestConfig(), "POST", req.URL())
 	if err != nil {
-		return false, fmt.Errorf("failed to create `Executor`: %v", err)
+		return nil, fmt.Errorf("failed to create executor: %w", err)
 	}
 
 	var stdout bytes.Buffer
@@ -114,27 +161,21 @@ func isEtcdHasMember(ctx context.Context, client *flantkubeclient.Client, nodeNa
 		Tty:    false,
 	})
 	if err != nil {
-		return false, fmt.Errorf("failed to execute in `Stream`: %v", err)
+		return nil, fmt.Errorf("failed to execute etcdctl: %w", err)
 	}
 
 	var members memberListOutput
-
-	err = json.Unmarshal(stdout.Bytes(), &members)
-	if err != nil {
-		return false, fmt.Errorf("failed to unmarshal etcd member list: %s", err)
+	if err = json.Unmarshal(stdout.Bytes(), &members); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal etcd member list: %w", err)
 	}
 
-	for _, member := range members.Members {
-		if member.Name == nodeName {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return members.Members, nil
 }
 
 type memberListOutput struct {
-	Members []struct {
-		Name string `json:"name"`
-	} `json:"members"`
+	Members []etcdMember `json:"members"`
+}
+
+type etcdMember struct {
+	Name string `json:"name"`
 }

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -30,6 +30,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/entity"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infrastructure/hook"
@@ -183,7 +184,7 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 
 	outputs, err := infrastructure.GetMasterNodeResult(ctx, runner)
 	if err != nil {
-		return fmt.Errorf("failed to get master node pipeline outputs: %v", err)
+		return fmt.Errorf("failed to get master node pipeline outputs: %w", err)
 	}
 
 	if !h.commanderMode {
@@ -202,18 +203,23 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 	// we need to store the path to the Kubernetes data device to avoid deadlock.
 	err = h.saveKubernetesDataDevicePath(ctx, outputs.KubeDataDevicePath)
 	if err != nil {
-		return fmt.Errorf("failed to save kubernetes data device path: %v", err)
+		return fmt.Errorf("failed to save kubernetes data device path: %w", err)
+	}
+
+	err = entity.WaitForSingleNodeBecomeReady(ctx, h.kubeGetter.KubeClient(), h.nodeToConverge)
+	if err != nil {
+		return fmt.Errorf("failed to wait for the master node '%s' to become Ready: %w", h.nodeToConverge, err)
 	}
 
 	err = waitEtcdHasMember(ctx, h.kubeGetter.KubeClient().KubeClient.(*flantkubeclient.Client), h.nodeToConverge)
 	if err != nil {
-		return fmt.Errorf("failed to wait for the master node '%s' to be listed as etcd cluster member: %v", h.nodeToConverge, err)
+		return fmt.Errorf("failed to wait for the master node '%s' to be listed as etcd cluster member: %w", h.nodeToConverge, err)
 	}
 
-	err = retry.NewLoop(fmt.Sprintf("Check control-plane is ready on node '%s'", h.nodeToConverge), 45, 10*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(fmt.Sprintf("Check control-plane is ready on node '%s'", h.nodeToConverge), 45, 10*time.Second).RunContext(ctx, func() error {
 		ready, err := NewManagerReadinessChecker(h.kubeGetter).IsReady(ctx, h.nodeToConverge)
 		if err != nil {
-			return fmt.Errorf("failed to check the master node '%s' readiness: %v", h.nodeToConverge, err)
+			return fmt.Errorf("failed to check the master node '%s' readiness: %w", h.nodeToConverge, err)
 		}
 
 		if !ready {
@@ -222,11 +228,6 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (h *HookForUpdatePipeline) IsReady() error {
@@ -272,11 +273,6 @@ func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context
 
 	return retry.NewLoop(fmt.Sprintf("Save Kubernetes data device path for node '%s'", h.nodeToConverge), 45, 10*time.Second).
 		RunContext(ctx, func() error {
-			err := task.CreateOrUpdate()
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return task.CreateOrUpdate()
 		})
 }

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -30,7 +30,6 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/entity"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infrastructure/hook"
@@ -206,17 +205,12 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 		return fmt.Errorf("failed to save kubernetes data device path: %v", err)
 	}
 
-	err = entity.WaitForSingleNodeBecomeReady(ctx, h.kubeGetter.KubeClient(), h.nodeToConverge)
-	if err != nil {
-		return fmt.Errorf("failed to wait for the master node '%s' to become Ready: %w", h.nodeToConverge, err)
-	}
-
 	err = waitEtcdHasMember(ctx, h.kubeGetter.KubeClient().KubeClient.(*flantkubeclient.Client), h.nodeToConverge)
 	if err != nil {
 		return fmt.Errorf("failed to wait for the master node '%s' to be listed as etcd cluster member: %v", h.nodeToConverge, err)
 	}
 
-	err = retry.NewLoop(fmt.Sprintf("Check the master node '%s' is ready", h.nodeToConverge), 45, 10*time.Second).RunContext(ctx, func() error {
+	err = retry.NewLoop(fmt.Sprintf("Check control-plane is ready on node '%s'", h.nodeToConverge), 45, 10*time.Second).RunContext(ctx, func() error {
 		ready, err := NewManagerReadinessChecker(h.kubeGetter).IsReady(ctx, h.nodeToConverge)
 		if err != nil {
 			return fmt.Errorf("failed to check the master node '%s' readiness: %v", h.nodeToConverge, err)

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -30,6 +30,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/entity"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/infrastructure/hook"
@@ -203,6 +204,11 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 	err = h.saveKubernetesDataDevicePath(ctx, outputs.KubeDataDevicePath)
 	if err != nil {
 		return fmt.Errorf("failed to save kubernetes data device path: %v", err)
+	}
+
+	err = entity.WaitForSingleNodeBecomeReady(ctx, h.kubeGetter.KubeClient(), h.nodeToConverge)
+	if err != nil {
+		return fmt.Errorf("failed to wait for the master node '%s' to become Ready: %w", h.nodeToConverge, err)
 	}
 
 	err = waitEtcdHasMember(ctx, h.kubeGetter.KubeClient().KubeClient.(*flantkubeclient.Client), h.nodeToConverge)


### PR DESCRIPTION
## Description

Add waiting for `NodeReady` in dhctl control-plane converge.
Improve output for etcd checks

## Why do we need it, and what problem does it solve?

Now dhctl waits for `NodeReady` before etcd membership check. Output of etcd checks is also more clear during waiting.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Added a NodeReady wait to dhctl converge and improved etcd check output.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
