### PR TITLE
[docs] Remove beta badge from GUI installer tab

### DIFF
--- a/docs/site/pages/getting_started/getting_started_ru.html
+++ b/docs/site/pages/getting_started/getting_started_ru.html
@@ -15,7 +15,6 @@ toc: false
     <button id="tab-button-manual-install" class="main-tab active" onclick="openInstallTab(event, 'tab-manual-install');">Вручную из командной строки</button>
     <button id="tab-button-gui-install" class="main-tab" onclick="openInstallTab(event, 'tab-gui-install');">
       C помощью графического установщика
-      <span class="main-beta-badge">Beta</span>
     </button>
   </div>
 </div>


### PR DESCRIPTION
## Description

This pull request makes a minor update to the Getting Started documentation by removing the "Beta" badge from the graphical installer tab.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Remove beta badge from GUI installer tab.
impact_level: low
```
