### PR TITLE
[user-authn] Added forgotten patch description

### DIFF
--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -22,7 +22,7 @@ Adding group entity to kubernetes authentication.
 This patch adds support for two-factor authentication (2FA) in Dex.
 It allows users to enable 2FA for their accounts, enhancing security by requiring a second form of verification during the login process.
 
-Upstream PR: https://github.com/dexidp/dex/pull/3712
+Upstream PR: <https://github.com/dexidp/dex/pull/3712>
 
 ### 005-password-policy.patch
 
@@ -42,7 +42,7 @@ This patch changes the Internal Error message to a human-readable 'Access Denied
 
 In the latest go versions (1.25.2, 1.24.8) the bug was fixed, and without this patch Dex fails with an error
 
-Upstream PR: https://github.com/dexidp/dex/pull/4363
+Upstream PR: <https://github.com/dexidp/dex/pull/4363>
 
 ### 008-hide-internal-500-error-details.patch
 
@@ -51,6 +51,7 @@ It replaces detailed error messages (including stack traces, database errors, an
 with safe, user-friendly messages while ensuring all error details are properly logged server-side.
 
 Key changes:
+
 - Centralized safe error messages in `server/errors.go`
 - Replaced `err.Error()` calls in HTTP responses with generic messages
 - Added proper logging for all internal errors
@@ -81,3 +82,7 @@ The flag is reset on successful password change.
 ### 013-saml-support.patch
 
 Adds refresh token support to the SAML connector. The SAML connector now implements `RefreshConnector` by caching the user identity in `ConnectorData` during initial authentication and returning it on refresh. Also persists `ConnectorData` in `OfflineSessions` for proper session management. Includes comprehensive tests.
+
+### 014-build-id-cache-invalidation.patch
+
+Added cache get parameter to main CSS file URL that gets opaque dex build identifier assigned to it. This prevents stale caches from breaking the login page.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

https://github.com/deckhouse/deckhouse/pull/18976 did not contain patch description in it's README.md and that triggers CI validations. This PR fixes that.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: chore
summary: Added forgotten patch description
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
