### PR TITLE
[docs] Update DKP RN 1.75

### DIFF
--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
@@ -10,6 +10,11 @@
   - IngressNginxController v1.9
   - Istio v1.19
 
+- Istio version support changes:
+  - Support for Istio 1.19 has been discontinued.
+  - Istio 1.21 is now considered deprecated, and support for this version will be discontinued in the upcoming DKP releases.
+    To update Istio, follow the [instruction](https://deckhouse.io/modules/istio/v1.75/examples.html#upgrading-istio).
+
 - Starting with Kubernetes 1.35, cluster nodes must use cgroup v2.
   The previous version (cgroup v1) is [considered deprecated](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#no-really-you-must-read-this-before-you-upgrade-1).
   If cgroup v2 is not supported on a node, the [D8NodeCgroupV2NotSupported](https://deckhouse.io/products/kubernetes-platform/documentation/v1.75/reference/alerts.html#node-manager-d8nodecgroupv2notsupported) alert will be triggered.
@@ -162,11 +167,6 @@
 - [IngressNginxController](https://deckhouse.io/modules/ingress-nginx/v1.75/) version support changes:
   - Support for v1.9 has been discontinued.
   - Support for v1.14 has been added.
-
-- Istio version support changes:
-  - Support for Istio 1.19 has been discontinued.
-  - Istio 1.21 is now considered deprecated, and support for this version will be discontinued in the upcoming DKP releases.
-    To update Istio, follow the [instruction](https://deckhouse.io/modules/istio/v1.75/examples.html#upgrading-istio).
 
 The complete list of changes, including the updated components,
 is available in the [changelog](https://github.com/deckhouse/deckhouse/blob/main/CHANGELOG/CHANGELOG-v1.75.md) on GitHub.

--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES.md
@@ -163,7 +163,10 @@
   - Support for v1.9 has been discontinued.
   - Support for v1.14 has been added.
 
-- Support for Istio 1.19 has been discontinued.
+- Istio version support changes:
+  - Support for Istio 1.19 has been discontinued.
+  - Istio 1.21 is now considered deprecated, and support for this version will be discontinued in the upcoming DKP releases.
+    To update Istio, follow the [instruction](https://deckhouse.io/modules/istio/v1.75/examples.html#upgrading-istio).
 
 The complete list of changes, including the updated components,
 is available in the [changelog](https://github.com/deckhouse/deckhouse/blob/main/CHANGELOG/CHANGELOG-v1.75.md) on GitHub.

--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
@@ -174,7 +174,10 @@
   - прекращена поддержка IngressNginxController v1.9;
   - добавлена поддержка IngressNginxController v1.14.
 
-- Прекращена поддержка Istio 1.19.
+- Изменения в поддержке версий Istio:
+  - прекращена поддержка Istio 1.19;
+  - версия Istio 1.21 признана устаревшей, и её поддержка будет прекращена в будущих версиях DKP.
+    Чтобы обновить Istio, воспользуйтесь [инструкцией](https://deckhouse.ru/modules/istio/v1.75/examples.html#обновление-istio).
 
 Полный список изменений, включая перечень обновлённых компонентов,
 доступен в [журнале изменений (changelog)](https://github.com/deckhouse/deckhouse/blob/main/CHANGELOG/CHANGELOG-v1.75.md) на GitHub.

--- a/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
+++ b/docs/documentation/_includes/release-notes/RELEASE-NOTES_RU.md
@@ -11,6 +11,11 @@
   - IngressNginxController v1.9;
   - Istio v1.19.
 
+- Изменения в поддержке версий Istio:
+  - прекращена поддержка Istio 1.19;
+  - версия Istio 1.21 признана устаревшей, и её поддержка будет прекращена в будущих версиях DKP.
+    Чтобы обновить Istio, воспользуйтесь [инструкцией](https://deckhouse.ru/modules/istio/v1.75/examples.html#обновление-istio).
+
 - Начиная с Kubernetes 1.35, на узлах кластера DKP должен использоваться механизм cgroup v2.
   Предыдущая версия (cgroup v1) [объявлена устаревшей](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.35.md#no-really-you-must-read-this-before-you-upgrade-1).
   В случае, если на узле не поддерживается cgroup v2, появится алерт [D8NodeCgroupV2NotSupported](https://deckhouse.ru/products/kubernetes-platform/documentation/v1.75/reference/alerts.html#node-manager-d8nodecgroupv2notsupported).
@@ -173,11 +178,6 @@
 - Изменения в поддержке версий [IngressNginxController](https://deckhouse.ru/modules/ingress-nginx/v1.75/):
   - прекращена поддержка IngressNginxController v1.9;
   - добавлена поддержка IngressNginxController v1.14.
-
-- Изменения в поддержке версий Istio:
-  - прекращена поддержка Istio 1.19;
-  - версия Istio 1.21 признана устаревшей, и её поддержка будет прекращена в будущих версиях DKP.
-    Чтобы обновить Istio, воспользуйтесь [инструкцией](https://deckhouse.ru/modules/istio/v1.75/examples.html#обновление-istio).
 
 Полный список изменений, включая перечень обновлённых компонентов,
 доступен в [журнале изменений (changelog)](https://github.com/deckhouse/deckhouse/blob/main/CHANGELOG/CHANGELOG-v1.75.md) на GitHub.


### PR DESCRIPTION
## Description

This PR adds information about the deprecated Istio 1.21 support in DKP.

## Changelog entries

```changes
section: docs
type: chore
summary: Updated DKP RN 1.75.
impact_level: low
```