### PR TITLE
[dhctl] Delete webhook configurations before destroying Deckhouse deployment.

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -41,8 +41,8 @@ const (
 	deckhouseDeploymentName      = "deckhouse"
 )
 
-func DeleteWebhookConfigurations(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete webhook configurations", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+func DeleteValidatingWebhookConfigurations(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete validating webhook configurations", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		vwcs, err := kubeCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
 			LabelSelector: "heritage=deckhouse",
 		})
@@ -56,21 +56,6 @@ func DeleteWebhookConfigurations(ctx context.Context, kubeCl *client.KubernetesC
 				return err
 			}
 			log.InfoF("ValidatingWebhookConfiguration/%s\n", vwc.Name)
-		}
-
-		mwcs, err := kubeCl.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
-			LabelSelector: "heritage=deckhouse",
-		})
-		if err != nil {
-			return err
-		}
-
-		for _, mwc := range mwcs.Items {
-			err := kubeCl.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, mwc.Name, metav1.DeleteOptions{})
-			if err != nil && !errors.IsNotFound(err) {
-				return err
-			}
-			log.InfoF("MutatingWebhookConfiguration/%s\n", mwc.Name)
 		}
 
 		return nil

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -41,6 +41,42 @@ const (
 	deckhouseDeploymentName      = "deckhouse"
 )
 
+func DeleteWebhookConfigurations(ctx context.Context, kubeCl *client.KubernetesClient) error {
+	return retry.NewLoop("Delete webhook configurations", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+		vwcs, err := kubeCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
+			LabelSelector: "heritage=deckhouse",
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, vwc := range vwcs.Items {
+			err := kubeCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, vwc.Name, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			log.InfoF("ValidatingWebhookConfiguration/%s\n", vwc.Name)
+		}
+
+		mwcs, err := kubeCl.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{
+			LabelSelector: "heritage=deckhouse",
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, mwc := range mwcs.Items {
+			err := kubeCl.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, mwc.Name, metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			log.InfoF("MutatingWebhookConfiguration/%s\n", mwc.Name)
+		}
+
+		return nil
+	})
+}
+
 func DeleteDeckhouseDeployment(ctx context.Context, kubeCl *client.KubernetesClient) error {
 	return retry.NewLoop("Delete Deckhouse", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		foregroundPolicy := metav1.DeletePropagationForeground

--- a/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
+++ b/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
@@ -156,7 +156,12 @@ func (d *Destroyer) deleteResources(ctx context.Context, logger log.Logger) erro
 }
 
 func (d *Destroyer) deleteEntities(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	err := deckhouse.DeleteDeckhouseDeployment(ctx, kubeCl)
+	err := deckhouse.DeleteWebhookConfigurations(ctx, kubeCl)
+	if err != nil {
+		return err
+	}
+
+	err = deckhouse.DeleteDeckhouseDeployment(ctx, kubeCl)
 	if err != nil {
 		return err
 	}
@@ -212,6 +217,11 @@ func (d *Destroyer) deleteEntities(ctx context.Context, kubeCl *client.Kubernete
 	}
 
 	err = deckhouse.DeleteMachinesIfResourcesExist(ctx, kubeCl)
+	if err != nil {
+		return err
+	}
+
+	err = deckhouse.DeleteWebhookConfigurations(ctx, kubeCl)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
+++ b/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
@@ -156,7 +156,7 @@ func (d *Destroyer) deleteResources(ctx context.Context, logger log.Logger) erro
 }
 
 func (d *Destroyer) deleteEntities(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	err := deckhouse.DeleteWebhookConfigurations(ctx, kubeCl)
+	err := deckhouse.DeleteValidatingWebhookConfigurations(ctx, kubeCl)
 	if err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (d *Destroyer) deleteEntities(ctx context.Context, kubeCl *client.Kubernete
 		return err
 	}
 
-	err = deckhouse.DeleteWebhookConfigurations(ctx, kubeCl)
+	err = deckhouse.DeleteValidatingWebhookConfigurations(ctx, kubeCl)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add deletion of all Deckhouse-managed ValidatingWebhookConfiguration and MutatingWebhookConfiguration resources as the first and last step of the cluster destroy pipeline.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When nodes running Deckhouse module pods become unavailable, ValidatingWebhookConfigurations with failurePolicy: Fail remain in the cluster while their backing services are unreachable, causing the API server to reject all matching requests and deadlocking dhctl destroy. Removing all Deckhouse-managed webhook configurations before deletion of resources unblocks the API server and allows the destroy process to proceed.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Added deletion of webhook configurations before destroying a Deckhouse deployment.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
