### PR TITLE
[docs] HTML escaping for meta tags and inline SVG icons

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -9,8 +9,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on&nbsp;the ability to&nbsp;use signature verification policies for container images and the ability to&nbsp;prohibit the launch of&nbsp;containers with vulnerabilities",
-        "ru": "Ограничение на&nbsp;возможность использования политик проверки подписи образов контейнеров и&nbsp;возможность установки запрета на&nbsp;запуск контейнеров с&nbsp;уязвимостями"
+        "en": "Restriction on the ability to use signature verification policies for container images and the ability to prohibit the launch of containers with vulnerabilities",
+        "ru": "Ограничение на возможность использования политик проверки подписи образов контейнеров и возможность установки запрета на запуск контейнеров с уязвимостями"
       }
     }
   },
@@ -39,8 +39,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on&nbsp;the ability to&nbsp;configure fault tolerant Egress Gateways",
-        "ru": "Ограничение на&nbsp;возможность настройки отказоустойчивых выходных узлов (Egress Gateway)"
+        "en": "Restriction on the ability to configure fault tolerant Egress Gateways",
+        "ru": "Ограничение на возможность настройки отказоустойчивых выходных узлов (Egress Gateway)"
       }
     }
   },
@@ -57,7 +57,7 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A&nbsp;separate license is&nbsp;required",
+        "en": "A separate license is required",
         "ru": "Требуется отдельная лицензия"
       }
     },
@@ -155,7 +155,7 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A&nbsp;separate license is&nbsp;required",
+        "en": "A separate license is required",
         "ru": "Требуется отдельная лицензия"
       }
     },
@@ -214,8 +214,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
+        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
       }
     },
     "external": "true",
@@ -231,8 +231,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
+        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
       }
     },
     "external": "true",
@@ -248,8 +248,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
+        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
       }
     },
     "external": "true",
@@ -306,8 +306,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on&nbsp;the use of&nbsp;federation and multicluster features",
-        "ru": "Ограничение на&nbsp;использование федерации и&nbsp;мультикластерной конфигурации"
+        "en": "Restriction on the use of federation and multicluster features",
+        "ru": "Ограничение на использование федерации и мультикластерной конфигурации"
       }
     }
   },
@@ -320,8 +320,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on&nbsp;the use of&nbsp;the BGP load balancer for services",
-        "ru": "Ограничение на&nbsp;использование BGP-балансировщика для сервисов"
+        "en": "Restriction on the use of the BGP load balancer for services",
+        "ru": "Ограничение на использование BGP-балансировщика для сервисов"
       }
     },
     "path": "modules/metallb/"
@@ -336,8 +336,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
+        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
       }
     },
     "external": "true",
@@ -362,7 +362,7 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A&nbsp;separate license is&nbsp;required",
+        "en": "A separate license is required",
         "ru": "Требуется отдельная лицензия"
       }
     },
@@ -380,8 +380,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
+        "en": "Not included in the edition. Can be used as a module from <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#module-source'>external source</a>",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый <a href='/products/kubernetes-platform/documentation/v1/architecture/module-development/run/#источник-модулей'>из внешнего источника</a>"
       }
     },
     "external": "true",
@@ -443,8 +443,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on&nbsp;the ability to&nbsp;create snapshots and volume&nbsp;wiping",
-        "ru": "Ограничение на&nbsp;возможность создания снимков и затирание&nbsp;томов"
+        "en": "Restriction on the ability to create snapshots and volume wiping",
+        "ru": "Ограничение на возможность создания снимков и затирание томов"
       }
     },
     "external": "true",
@@ -474,8 +474,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on&nbsp;the ability to&nbsp;create snapshots",
-        "ru": "Ограничение на&nbsp;возможность создания снимков"
+        "en": "Restriction on the ability to create snapshots",
+        "ru": "Ограничение на возможность создания снимков"
       }
     },
     "external": "true",
@@ -551,16 +551,16 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A&nbsp;separate license is&nbsp;required",
+        "en": "A separate license is required",
         "ru": "Требуется отдельная лицензия"
       },
       "cse-lite": {
-        "en": "A&nbsp;separate&nbsp;license is&nbsp;required&nbsp;for&nbsp;Deckhouse&nbsp;Stronghold&nbsp;CSE. There&nbsp;are&nbsp;functionality&nbsp;limitations",
-        "ru": "Требуется&nbsp;отдельная&nbsp;лицензия на&nbsp;Deckhouse Stronghold CSE. Есть ограничения функциональности"
+        "en": "A separate license is required for Deckhouse Stronghold CSE. There are functionality limitations",
+        "ru": "Требуется отдельная лицензия на Deckhouse Stronghold CSE. Есть ограничения функциональности"
       },
       "cse-pro": {
-        "en": "A&nbsp;separate&nbsp;license is&nbsp;required&nbsp;for&nbsp;Deckhouse&nbsp;Stronghold&nbsp;CSE. There&nbsp;are&nbsp;functionality&nbsp;limitations",
-        "ru": "Требуется&nbsp;отдельная&nbsp;лицензия на&nbsp;Deckhouse Stronghold CSE. Есть ограничения функциональности"
+        "en": "A separate license is required for Deckhouse Stronghold CSE. There are functionality limitations",
+        "ru": "Требуется отдельная лицензия на Deckhouse Stronghold CSE. Есть ограничения функциональности"
       }
     },
     "external": "true",
@@ -584,8 +584,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on&nbsp;the use of&nbsp;namespace filtering in&nbsp;the role-based access model",
-        "ru": "Ограничение на&nbsp;использование фильтрации по&nbsp;пространствам имен в&nbsp;ролевой модели доступа"
+        "en": "Restriction on the use of namespace filtering in the role-based access model",
+        "ru": "Ограничение на использование фильтрации по пространствам имен в ролевой модели доступа"
       }
     },
     "path": "modules/user-authz/"

--- a/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
+++ b/docs/documentation/_includes/SUPPORTED_VERSIONS.liquid
@@ -9,6 +9,18 @@
 {%- assign partially_supported_img_url = '/images/icons/intermediate_v2.svg' %}
 {%- assign notes_img_url = '/images/icons/note_v2.svg' %}
 {%- assign not_supported_img_url = '/images/icons/not_supported_v2.svg' %}
+{%- capture supported_img_inline -%}
+<svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ supported_img_url }}" width="32" height="32" /></svg>
+{%- endcapture %}
+{%- capture partially_supported_img_inline -%}
+<svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ partially_supported_img_url }}" width="32" height="32" /></svg>
+{%- endcapture %}
+{%- capture notes_img_inline -%}
+<svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ notes_img_url }}" width="32" height="32" /></svg>
+{%- endcapture %}
+{%- capture not_supported_img_inline -%}
+<svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ not_supported_img_url }}" width="32" height="32" /></svg>
+{%- endcapture %}
 
 ## Linux
 
@@ -48,7 +60,7 @@
     {%- assign osVersionsList = osData.versions | default: osItem[1] %}
     {%- assign langSupport = site.data.supported_versions.osDistributions[osKey][langSupportKey] %}
     {%- if langSupport == false %}{% continue %}{% endif %}
-    {%- include partials/supported-table-line.liquid osItem=osItem osName=osName osKey=osKey osVersions=osVersionsList supported_img_url=supported_img_url partially_supported_img_url=partially_supported_img_url notes_img_url=notes_img_url not_supported_img_url=not_supported_img_url %}
+    {%- include partials/supported-table-line.liquid osItem=osItem osName=osName osKey=osKey osVersions=osVersionsList supported_img_inline=supported_img_inline partially_supported_img_inline=partially_supported_img_inline notes_img_inline=notes_img_inline not_supported_img_inline=not_supported_img_inline %}
     {% endfor %}
     </tbody>
   </table>
@@ -71,10 +83,13 @@
     {%- for k8sItem in k8sVersions %}
     {%- assign k8sStatus = k8sItem[1].status | default: 'preview' %}
     {%- assign iconStatus = k8sStatus| append: '.svg' | prepend: '/images/icons/' %}
+    {%- capture iconStatusInline -%}
+    <svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ iconStatus }}" width="32" height="32" /></svg>
+    {%- endcapture %}
     <tr {%- if k8sItem[1].default %} class="highlight-default"{% endif %}>
       <td style="text-align: center">
         <div class="icon">
-          <img src="{{ iconStatus }}" alt="" />
+          {{ iconStatusInline }}
         </div>
       </td>
       <td style="text-align: center; font-weight:bold">{{ k8sItem[0] }}</td>

--- a/docs/documentation/_includes/partials/supported-table-line.liquid
+++ b/docs/documentation/_includes/partials/supported-table-line.liquid
@@ -75,9 +75,9 @@
     {% endfor %}
     {% assign commonExists = false %}
   </td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
   <td>
     <div class="icon">
       {%- assign hasNotes = false %}
@@ -95,7 +95,7 @@
         {%- endif %}
       {%- endfor %}
       {% if hasNotes %}
-      <img src="{{ notes_img_url }}" data-tippy-content="{{ notesContent }}">
+      <span data-tippy-content="{{ notesContent }}">{{ include.notes_img_inline }}</span>
       {% endif %}
     </div>
   </td>
@@ -110,9 +110,9 @@
     {% endfor %}
     {% assign cseExists = false %}
   </td>
-  <td><div class="icon"><img src="{{ partially_supported_img_url }}" data-tippy-content="Работоспособность в Community Edition не гарантируется."></div></td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><span data-tippy-content="Работоспособность в Community Edition не гарантируется.">{{ include.partially_supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
   <td>
     <div class="icon">
       {%- assign hasNotes = false %}
@@ -130,7 +130,7 @@
         {%- endif %}
       {%- endfor %}
       {% if hasNotes %}
-      <img src="{{ notes_img_url }}" data-tippy-content="{{ notesContent }}">
+      <span data-tippy-content="{{ notesContent }}">{{ include.notes_img_inline }}</span>
       {% endif %}
     </div>
   </td>
@@ -145,9 +145,9 @@
     {% endfor %}
     {% assign ceExists = false %}
   </td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
-  <td><div class="icon"><img src="{{ not_supported_img_url }}"></div></td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.not_supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
   <td>
     <div class="icon">
       {%- assign hasNotes = false %}
@@ -165,7 +165,7 @@
         {%- endif %}
       {%- endfor %}
       {% if hasNotes %}
-      <img src="{{ notes_img_url }}" data-tippy-content="{{ notesContent }}">
+      <span data-tippy-content="{{ notesContent }}">{{ include.notes_img_inline }}</span>
       {% endif %}
     </div>
   </td>
@@ -180,9 +180,9 @@
     {% endfor %}
     {% assign bePlusExists = false %}
   </td>
-  <td><div class="icon"><img src="{{ partially_supported_img_url }}" data-tippy-content="Работоспособность в Community Edition не гарантируется."></div></td>
-  <td><div class="icon"><img src="{{ not_supported_img_url }}"></div></td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><span data-tippy-content="Работоспособность в Community Edition не гарантируется.">{{ include.partially_supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.not_supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
   <td>
     <div class="icon">
       {%- assign hasNotes = false %}
@@ -200,7 +200,7 @@
         {%- endif %}
       {%- endfor %}
       {% if hasNotes %}
-      <img src="{{ notes_img_url }}" data-tippy-content="{{ notesContent }}">
+      <span data-tippy-content="{{ notesContent }}">{{ include.notes_img_inline }}</span>
       {% endif %}
     </div>
   </td>
@@ -218,14 +218,14 @@
   <td>
     <div class="icon">
       {% if site.data.supported_versions.osDistributions[osKey]['ru_support'] == true %}
-      <img src="{{ partially_supported_img_url }}" data-tippy-content="Работоспособность в Community Edition не гарантируется.">
+      <span data-tippy-content="Работоспособность в Community Edition не гарантируется.">{{ include.partially_supported_img_inline }}</span>
       {% else %}
-      <img src="{{ supported_img_url }}">
+      <span>{{ include.supported_img_inline }}</span>
       {% endif %}
     </div>
   </td>
-  <td><div class="icon"><img src="{{ not_supported_img_url }}"></div></td>
-  <td><div class="icon"><img src="{{ supported_img_url }}"></div></td>
+  <td><div class="icon"><span>{{ include.not_supported_img_inline }}</span></div></td>
+  <td><div class="icon"><span>{{ include.supported_img_inline }}</span></div></td>
   <td>
     <div class="icon">
       {%- assign hasNotes = false %}
@@ -243,7 +243,7 @@
         {%- endif %}
       {%- endfor %}
       {% if hasNotes %}
-      <img src="{{ notes_img_url }}" data-tippy-content="{{ notesContent }}">
+      <span data-tippy-content="{{ notesContent }}">{{ include.notes_img_inline }}</span>
       {% endif %}
     </div>
   </td>
@@ -271,7 +271,7 @@
   </td>
   <td style="text-align: center; width: 170px;">
     <div class="icon">
-      <img src="{{ supported_img_url }}">
+      <span>{{ include.supported_img_inline }}</span>
     </div>
   </td>
   <td style="text-align: center;">
@@ -291,7 +291,7 @@
         {%- endif %}
       {%- endfor %}
       {% if hasNotes %}
-      <img src="{{ notes_img_url }}" data-tippy-content="{{ notesContent }}">
+      <span data-tippy-content="{{ notesContent }}">{{ include.notes_img_inline }}</span>
       {% endif %}
     </div>
   </td>

--- a/docs/documentation/_includes/revision_comparison_detail_table.liquid
+++ b/docs/documentation/_includes/revision_comparison_detail_table.liquid
@@ -111,11 +111,11 @@
                   <span class="table__asterisk"
                         data-tippy-content="{{ restrictionComment }}">{{ partially_supported_img_inline }}</span>
                {%- else %}
-                 {{ supported_img_inline }}
+                 <span>{{ supported_img_inline }}</span>
                {%- endif %}
 
           {%- else %}
-            {{ notsupported_img_inline }}
+            <span>{{ notsupported_img_inline }}</span>
           {%- endif %}
         </td>
       {%- endfor %}

--- a/docs/documentation/_includes/revision_comparison_detail_table.liquid
+++ b/docs/documentation/_includes/revision_comparison_detail_table.liquid
@@ -2,6 +2,15 @@
 {%- assign supported_img_url = '/images/icons/supported_v2.svg' %}
 {%- assign notsupported_img_url = '/images/icons/not_supported_v2.svg' %}
 {%- assign partially_supported_img_url = '/images/icons/intermediate_v2.svg' %}
+{%- capture supported_img_inline -%}
+<svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ supported_img_url }}" width="32" height="32" /></svg>
+{%- endcapture %}
+{%- capture notsupported_img_inline -%}
+<svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ notsupported_img_url }}" width="32" height="32" /></svg>
+{%- endcapture %}
+{%- capture partially_supported_img_inline -%}
+<svg viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ partially_supported_img_url }}" width="32" height="32" /></svg>
+{%- endcapture %}
 {%- assign siteD8Edition = 'ee' %}
 {%- assign editionsWeight = site.data.modules.editions-weight %}
 {%- if site.mode == 'module' and site.d8Revision %}
@@ -99,14 +108,14 @@
                   {%- if module[1].editionsWithRestrictionsComments[currentEdition] %}
                      {%- assign restrictionComment = module[1].editionsWithRestrictionsComments[currentEdition][page.lang] %}
                   {%- endif %}
-                  <span class="table__asterisk"><img src="{{ partially_supported_img_url }}"
-                                                    data-tippy-content="{{ restrictionComment }}"></span>
+                  <span class="table__asterisk"
+                        data-tippy-content="{{ restrictionComment }}">{{ partially_supported_img_inline }}</span>
                {%- else %}
-                 <img src="{{ supported_img_url }}">
+                 {{ supported_img_inline }}
                {%- endif %}
 
           {%- else %}
-            <img src="{{ notsupported_img_url }}">
+            {{ notsupported_img_inline }}
           {%- endif %}
         </td>
       {%- endfor %}

--- a/docs/documentation/assets/css/supported_versions.css
+++ b/docs/documentation/assets/css/supported_versions.css
@@ -22,9 +22,21 @@
    font-weight: normal;
 }
 
-.supported_versions img {
+.supported_versions img,
+.supported_versions svg {
+   display: block;
+   width: 100%;
+   height: 100%;
    max-height: 40px;
    max-width: 40px;
+}
+
+.supported_versions .icon > span {
+   display: flex;
+   width: 100%;
+   height: 100%;
+   align-items: center;
+   justify-content: center;
 }
 
 .supported_versions td.versions {

--- a/docs/site/_includes/dvp/comparison.liquid
+++ b/docs/site/_includes/dvp/comparison.liquid
@@ -1,5 +1,19 @@
-{% assign not_supported = '<img class="zoom-image-disable" src="/images/icons/not_supported_v2.svg" alt="">' %}
-{% assign supported = '<img class="zoom-image-disable" src="/images/icons/supported_v2.svg" alt="">' %}
+{% assign not_supported_img_url = '/images/icons/not_supported_v2.svg' %}
+{% assign supported_img_url = '/images/icons/supported_v2.svg' %}
+{% assign planned_img_url = '/images/icons/clock.svg' %}
+{% assign partly_supported_img_url = '/images/icons/partly_supported.svg' %}
+{% capture not_supported %}
+<svg class="zoom-image-disable" viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ not_supported_img_url }}" width="32" height="32" /></svg>
+{% endcapture %}
+{% capture supported %}
+<svg class="zoom-image-disable" viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ supported_img_url }}" width="32" height="32" /></svg>
+{% endcapture %}
+{% capture planned %}
+<svg class="zoom-image-disable" viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ planned_img_url }}" width="32" height="32" /></svg>
+{% endcapture %}
+{% capture partly_supported %}
+<svg class="zoom-image-disable" viewBox="0 0 32 32" width="32" height="32" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><image href="{{ partly_supported_img_url }}" width="32" height="32" /></svg>
+{% endcapture %}
 {% assign comparison_colspan = 7 %}
 {% if page.lang == 'en' %}
   {% assign comparison_colspan = 5 %}
@@ -61,15 +75,15 @@
         <div class="icon" style="padding: 0 0;">
           {% case feature.editions[edition] %}
             {% when "supported" %}
-              {{ supported }}
+              <span>{{ supported }}</span>
             {% when "not_supported" %}
-              {{ not_supported }}
+              <span>{{ not_supported }}</span>
             {% when "planned" %}
-              <img class="zoom-image-disable" src="/images/icons/clock.svg" alt="" data-tippy-content="{{ feature.restriction_message[edition][page.lang] | replace: '"', "'" }}" aria-expanded="false">
+              <span data-tippy-content="{{ feature.restriction_message[edition][page.lang] | replace: '"', "'" }}" aria-expanded="false">{{ planned }}</span>
             {% when "partly" %}
-              <img class="zoom-image-disable" src="/images/icons/partly_supported.svg" alt="" data-tippy-content="{{ feature.restriction_message[edition][page.lang] | replace: '"', "'" }}" aria-expanded="false">
+              <span data-tippy-content="{{ feature.restriction_message[edition][page.lang] | replace: '"', "'" }}" aria-expanded="false">{{ partly_supported }}</span>
             {% else %}
-              <img class="zoom-image-disable" src="/images/icons/partly_supported.svg" alt="" data-tippy-content="{{ feature.restriction_message[edition][page.lang] | replace: '"', "'" }}" aria-expanded="false">
+              <span data-tippy-content="{{ feature.restriction_message[edition][page.lang] | replace: '"', "'" }}" aria-expanded="false">{{ partly_supported }}</span>
           {% endcase %}
         </div>
       </td>

--- a/docs/site/_includes/head-site.html
+++ b/docs/site/_includes/head-site.html
@@ -63,11 +63,31 @@
     tippy('[data-tippy-content]', {
       interactive: true,
       interactiveDebounce: 75,
-      placement: 'right-start',
+      appendTo: () => document.body,
+      placement: 'bottom-start',
       maxWidth: 700,
       theme: 'light-large',
       allowHTML: true,
       arrow: '<svg width="10" height="14" viewBox="0 0 10 14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 7L1 1L1 13L9 7Z" fill="#EFF3F9"/><path d="M1 1L9 7L1 13" stroke="#C4CAD4" stroke-linecap="round"/></svg>',
+      popperOptions: {
+        strategy: 'fixed',
+        modifiers: [
+          {
+            name: 'flip',
+            options: {
+              fallbackPlacements: ['left-start', 'bottom', 'top'],
+            },
+          },
+          {
+            name: 'preventOverflow',
+            options: {
+              boundary: 'viewport',
+              altAxis: true,
+              padding: 8,
+            },
+          },
+        ],
+      },
     });
   });
 </script>

--- a/docs/site/_includes/head.html
+++ b/docs/site/_includes/head.html
@@ -136,23 +136,28 @@
   {% endif %}
   {%- assign page_meta_url = page_url_without_lang | relative_url | prepend: '/products' %}
 {% endif %}
+{%- capture raw_keywords %}{{page.tags}}{% if page.tags %}, {% endif %}{% if page.keywords %}{{page.keywords}}, {% endif %}{% if page.search %}{{page.search}}{% endif %}{% endcapture -%}
+{%- assign escaped_page_meta_url = page_meta_url | escape_once -%}
+{%- assign escaped_meta_title = meta_title | strip | escape_once -%}
+{%- assign escaped_description = description | strip | escape_once -%}
+{%- assign escaped_keywords = raw_keywords | strip | escape_once -%}
 <!-- multilang -->
 {%- if page.multilang %}
-    <link data-proofer-ignore rel="alternate" hreflang="ru" href="{{ site.urls['ru'] }}{{ page_meta_url }}" />
-    <link data-proofer-ignore rel="alternate" hreflang="en" href="{{ site.urls['en'] }}{{ page_meta_url }}" />
+    <link data-proofer-ignore rel="alternate" hreflang="ru" href="{{ site.urls['ru'] }}{{ escaped_page_meta_url }}" />
+    <link data-proofer-ignore rel="alternate" hreflang="en" href="{{ site.urls['en'] }}{{ escaped_page_meta_url }}" />
 {%- endif %}
 
 <!-- Primary Meta Tags -->
-<link rel="canonical" href="{{ site.urls[page.lang] }}{{ page_meta_url }}" />
-<meta name="title" content="{{ meta_title }}">
-<meta name="description" content="{{ description }}">
-<meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %}{% if page.keywords %}{{page.keywords}}, {% endif %}{% if page.search %}{{page.search}}{% endif %}">
+<link rel="canonical" href="{{ site.urls[page.lang] }}{{ escaped_page_meta_url }}" />
+<meta name="title" content="{{ escaped_meta_title }}">
+<meta name="description" content="{{ escaped_description }}">
+<meta name="keywords" content="{{ escaped_keywords }}">
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="article">
-<meta property="og:url" content="{{ site.urls[page.lang] }}{{ page_meta_url }}">
-<meta property="og:title" content="{{ meta_title }}">
-<meta property="og:description" content="{{ description }}">
+<meta property="og:url" content="{{ site.urls[page.lang] }}{{ escaped_page_meta_url }}">
+<meta property="og:title" content="{{ escaped_meta_title }}">
+<meta property="og:description" content="{{ escaped_description }}">
 
 {%- if page.product_code == 'stronghold' or page.product_code == "virtualization-platform" or page.product_code == "code" or page.product_code == "delivery-kit" or page.product_code == "kubernetes-platform" or page.product_code == "observability-platform" or page.product_code == "prompp" %}
 <meta property="og:image" content="{{ site.urls[page.lang] }}/images/og/{{ page.product_code }}.png">

--- a/docs/site/_sass/components/_table-supported.scss
+++ b/docs/site/_sass/components/_table-supported.scss
@@ -97,6 +97,22 @@
             width: 28px;
             height: 28px;
         }
+
+        > span {
+            display: flex;
+            width: 100%;
+            height: 100%;
+            align-items: center;
+            justify-content: center;
+        }
+
+        img,
+        svg {
+            display: block;
+            width: 100%;
+            height: 100%;
+            flex: 0 0 auto;
+        }
     }
 }
 

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -15,8 +15,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A separate license is required",
-        "ru": "Требуется отдельная лицензия"
+        "en": "A separate license is required",
+        "ru": "Требуется отдельная лицензия"
       }
     },
     "commercialBadgeMessage": {
@@ -120,8 +120,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from external source",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
+        "en": "Not included in the edition. Can be used as a module from external source",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
       }
     },
     "tags": [
@@ -142,8 +142,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from external source",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
+        "en": "Not included in the edition. Can be used as a module from external source",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
       }
     },
     "external": "true",
@@ -173,8 +173,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from external source",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
+        "en": "Not included in the edition. Can be used as a module from external source",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
       }
     },
     "tags": [
@@ -311,8 +311,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from external source",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
+        "en": "Not included in the edition. Can be used as a module from external source",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
       }
     },
     "tags": [
@@ -369,8 +369,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "cse-pro": {
-        "en": "Not included in the edition. Can be used as a module from external source",
-        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
+        "en": "Not included in the edition. Can be used as a module from external source",
+        "ru": "Не входит в состав редакции. Может быть использован как модуль, подключаемый из внешнего источника"
       }
     },
     "tags": [
@@ -450,8 +450,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Restriction on the ability to create snapshots and volume wiping",
-        "ru": "Ограничение на возможность создания снимков и затирание томов"
+        "en": "Restriction on the ability to create snapshots and volume wiping",
+        "ru": "Ограничение на возможность создания снимков и затирание томов"
       }
     },
     "tags": [
@@ -560,8 +560,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A separate license is required",
-        "ru": "Требуется отдельная лицензия"
+        "en": "A separate license is required",
+        "ru": "Требуется отдельная лицензия"
       }
     },
     "commercialBadgeMessage": {

--- a/docs/site/backends/docs-builder-template/layouts/_partials/head.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/head.html
@@ -35,16 +35,22 @@
   {{- end }}
 {{- end }}
 
+{{- $escapedCanonicalURL := $canonicalURL | htmlEscape }}
+{{- $escapedDescription := $description | htmlEscape }}
+{{- $escapedMetaTitle := $metaTitle | htmlEscape }}
+{{- $ogURL := strings.TrimSuffix "readme.html" .Permalink }}
+{{- $escapedOGURL := $ogURL | htmlEscape }}
+
 <title>{{ $metaTitle }}</title>
-<link rel="canonical" href="{{ $canonicalURL }}" />
-<meta name="description" content="{{  $description }}">
-<meta name="title" content="{{ $metaTitle }}">
+<link rel="canonical" {{ printf "href=\"%s\"" $escapedCanonicalURL | safeHTMLAttr }} />
+<meta name="description" {{ printf "content=\"%s\"" $escapedDescription | safeHTMLAttr }}>
+<meta name="title" {{ printf "content=\"%s\"" $escapedMetaTitle | safeHTMLAttr }}>
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="article">
-<meta property="og:url" content="{{ strings.TrimSuffix "readme.html" .Permalink  }}">
-<meta property="og:title" content="{{ $metaTitle }}">
-<meta property="og:description" content="{{ $description }}">
+<meta property="og:url" {{ printf "content=\"%s\"" $escapedOGURL | safeHTMLAttr }}>
+<meta property="og:title" {{ printf "content=\"%s\"" $escapedMetaTitle | safeHTMLAttr }}>
+<meta property="og:description" {{ printf "content=\"%s\"" $escapedDescription | safeHTMLAttr }}>
 <meta property="og:image" content="{{ if eq site.Params.mode "module" }}/{{ else }}{{ site.BaseURL }}{{ end }}images/og/kubernetes-platform.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="628">


### PR DESCRIPTION
## Description

This pull request focuses on improving the robustness and accessibility of the documentation site by escaping meta tag content, inlining SVG icons for support status, and enhancing the handling of URLs and metadata. These changes help prevent potential HTML injection issues, improve SEO, and make the documentation more maintainable.

**Meta tag escaping and SEO improvements:**
* [`docs/site/_includes/head.html`](diffhunk://#diff-ef8ba0f1c259c4ccc05c62959e24cd018ee93e46b359ed073c529ed4e2b6849dR139-R160): All meta tag contents (title, description, keywords, canonical URL) are now properly escaped to prevent HTML injection and ensure correct rendering. Open Graph tags are also updated to use escaped values.
* [`docs/site/backends/docs-builder-template/layouts/_partials/head.html`](diffhunk://#diff-468bcda494289ba8783ddc4d8ccbb2f36d2384496c876fbdb11d326170d48799R38-R53): Hugo template updated to escape all meta tag content and canonical/Open Graph URLs, improving security and SEO.

**SVG icon inlining for support status:**
* [`docs/documentation/_includes/revision_comparison_detail_table.liquid`](diffhunk://#diff-901b9174f984e8c1d0dea4e84a6b71d377b6a59f1f691759593b1455b6f1dbc5R5-R13): Support status icons (supported, not supported, partially supported) are now inlined as SVGs instead of using `<img>` tags, improving accessibility and reducing external requests. [[1]](diffhunk://#diff-901b9174f984e8c1d0dea4e84a6b71d377b6a59f1f691759593b1455b6f1dbc5R5-R13) [[2]](diffhunk://#diff-901b9174f984e8c1d0dea4e84a6b71d377b6a59f1f691759593b1455b6f1dbc5L102-R118)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: HTML escaping for meta tags and inline SVG icons.
impact_level: low
```
