### PR TITLE
[control-plane-manager] Add operation-approver controller

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
@@ -21,8 +21,6 @@ import (
 	"slices"
 
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 const (
@@ -107,7 +105,7 @@ func partitionOperationsByApprovalState(operations []controlplanev1alpha1.Contro
 	pending = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
 
 	for _, operation := range operations {
-		if operation.Spec.Approved && !meta.IsStatusConditionTrue(operation.Status.Conditions, "Ready") { // TODO: взять функцию из operations-controller
+		if operation.IsCompleted() {
 			seed = append(seed, operation)
 			continue
 		}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
@@ -1,0 +1,232 @@
+package operationsapprover
+
+import (
+	"cmp"
+	"slices"
+
+	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+)
+
+const (
+	maxPerComponentPerNodeOperations = 1
+)
+
+var approvePipeline = []pipelineStage{
+	{
+		components: []controlplanev1alpha1.OperationComponent{
+			controlplanev1alpha1.OperationComponentEtcd,
+		},
+		concurrencyLimitFn: etcdConcurrencyLimit,
+	},
+	{
+		components: []controlplanev1alpha1.OperationComponent{
+			controlplanev1alpha1.OperationComponentKubeAPIServer,
+		},
+		concurrencyLimitFn: controlPlaneWorkloadConcurrencyLimit,
+	},
+	{
+		components: []controlplanev1alpha1.OperationComponent{
+			controlplanev1alpha1.OperationComponentKubeControllerManager,
+			controlplanev1alpha1.OperationComponentKubeScheduler,
+		},
+		concurrencyLimitFn: controlPlaneWorkloadConcurrencyLimit,
+	},
+}
+
+// pipelineStage is one level of the approve chain: components that share the same link and advance together.
+// This slice is the single source of truth for stage order, membership, and per-stage concurrency policy.
+type pipelineStage struct {
+	components         []controlplanev1alpha1.OperationComponent
+	concurrencyLimitFn func(nodesCount int) int
+}
+
+// pipelineStageIndex returns the stage index of c in controlPlaneApprovePipeline, or -1 if unknown.
+func pipelineStageIndex(c controlplanev1alpha1.OperationComponent) int {
+	for i, stage := range approvePipeline {
+		if slices.Contains(stage.components, c) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+type approver struct {
+	approveChain *approveLink
+	approveQueue []controlplanev1alpha1.ControlPlaneOperation
+}
+
+type approveLink struct {
+	components map[controlplanev1alpha1.OperationComponent]*component
+	nextLink   *approveLink
+}
+
+type component struct {
+	concurrencyLimit          int
+	approvedOperationsTotal   int
+	approvedOperationsPerNode map[string]int
+}
+
+// newApprover builds an approver for one reconcile pass: partitions operations into
+// in-flight seeds (approved && !Ready) and pending (!approved), sorts both by pipeline stage,
+// seeds the chain, and exposes pending operations via approveQueue iteration order.
+func newApprover(nodesCount int, operations []controlplanev1alpha1.ControlPlaneOperation) *approver {
+	approvedOperations, pendingOperations := partitionOperationsByApprovalState(operations)
+	sortOperationsByPipelineOrder(approvedOperations)
+	sortOperationsByPipelineOrder(pendingOperations)
+
+	approveChain := buildApproveChain(nodesCount)
+	approveChain.seedApprovedOperations(approvedOperations)
+
+	return &approver{
+		approveChain: approveChain,
+		approveQueue: pendingOperations,
+	}
+}
+
+func partitionOperationsByApprovalState(operations []controlplanev1alpha1.ControlPlaneOperation) (seed, pending []controlplanev1alpha1.ControlPlaneOperation) {
+	seed = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
+	pending = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
+
+	for _, operation := range operations {
+		if operation.Spec.Approved && !meta.IsStatusConditionTrue(operation.Status.Conditions, "Ready") { // TODO: взять функцию из operations-controller
+			seed = append(seed, operation)
+			continue
+		}
+
+		if !operation.Spec.Approved {
+			pending = append(pending, operation)
+		}
+	}
+
+	return seed, pending
+}
+
+// sortOperationsByPipelineOrder orders operations by pipelineStageIndex (see controlPlaneApprovePipeline).
+// Within the same stage, order is stable by resource name.
+func sortOperationsByPipelineOrder(operations []controlplanev1alpha1.ControlPlaneOperation) {
+	slices.SortFunc(operations, func(a, b controlplanev1alpha1.ControlPlaneOperation) int {
+		if c := cmp.Compare(pipelineStageIndex(a.Spec.Component), pipelineStageIndex(b.Spec.Component)); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+}
+
+func buildApproveChain(nodesCount int) *approveLink {
+	if len(approvePipeline) == 0 {
+		return nil
+	}
+
+	links := make([]*approveLink, len(approvePipeline))
+	for i, stage := range approvePipeline {
+		limit := stage.concurrencyLimitFn(nodesCount)
+		components := make(map[controlplanev1alpha1.OperationComponent]*component, len(stage.components))
+
+		for _, c := range stage.components {
+			components[c] = &component{
+				concurrencyLimit:          limit,
+				approvedOperationsPerNode: make(map[string]int, nodesCount),
+			}
+		}
+
+		links[i] = &approveLink{components: components}
+		if i > 0 {
+			links[i-1].nextLink = links[i]
+		}
+	}
+
+	return links[0]
+}
+
+func (a *approver) tryApprove(operation controlplanev1alpha1.ControlPlaneOperation) bool {
+	return a.approveChain.tryReserveApproval(operation)
+}
+
+func (link *approveLink) seedApprovedOperations(approvedOperations []controlplanev1alpha1.ControlPlaneOperation) {
+	for _, approvedOperation := range approvedOperations {
+		link.seedApprovedOperation(approvedOperation)
+	}
+}
+
+func (link *approveLink) seedApprovedOperation(approvedOperation controlplanev1alpha1.ControlPlaneOperation) {
+	if link == nil {
+		return
+	}
+
+	if !link.containsComponent(approvedOperation.Spec.Component) {
+		link.nextLink.seedApprovedOperation(approvedOperation)
+		return
+	}
+
+	component := link.components[approvedOperation.Spec.Component]
+
+	if _, exists := component.approvedOperationsPerNode[approvedOperation.Spec.NodeName]; !exists {
+		component.approvedOperationsPerNode[approvedOperation.Spec.NodeName] = 0
+	}
+
+	component.approvedOperationsTotal++
+	component.approvedOperationsPerNode[approvedOperation.Spec.NodeName] = component.approvedOperationsPerNode[approvedOperation.Spec.NodeName] + 1
+}
+
+func (link *approveLink) tryReserveApproval(unapprovedOperation controlplanev1alpha1.ControlPlaneOperation) bool {
+	if link == nil {
+		return false
+	}
+
+	if !link.containsComponent(unapprovedOperation.Spec.Component) {
+		if link.hasAnyApprovedOperation() {
+			return false
+		}
+
+		return link.nextLink.tryReserveApproval(unapprovedOperation)
+	}
+
+	component := link.components[unapprovedOperation.Spec.Component]
+
+	if component.approvedOperationsTotal >= component.concurrencyLimit {
+		return false
+	}
+
+	if _, exists := component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName]; !exists {
+		component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] = 0
+	}
+
+	if component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] >= maxPerComponentPerNodeOperations {
+		return false
+	}
+
+	component.approvedOperationsTotal++
+	component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] = component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] + 1
+
+	return true
+}
+
+func (link *approveLink) containsComponent(component controlplanev1alpha1.OperationComponent) bool {
+	if _, exists := link.components[component]; !exists {
+		return false
+	}
+
+	return true
+}
+
+func (link *approveLink) hasAnyApprovedOperation() bool {
+	for _, component := range link.components {
+		if component.approvedOperationsTotal > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func etcdConcurrencyLimit(nodesCount int) int {
+	_ = nodesCount
+	return 1
+}
+
+func controlPlaneWorkloadConcurrencyLimit(nodesCount int) int {
+	return max(1, nodesCount-1)
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
@@ -105,7 +105,7 @@ func partitionOperationsByApprovalState(operations []controlplanev1alpha1.Contro
 	unapprovedOperations = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
 
 	for _, operation := range operations {
-		if operation.Spec.Approved && !operation.IsCompleted() {
+		if operation.Spec.Approved && !operation.IsTerminal() {
 			approvedOperations = append(approvedOperations, operation)
 			continue
 		}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
@@ -84,38 +84,38 @@ type component struct {
 }
 
 // newApprover builds an approver for one reconcile pass: partitions operations into
-// in-flight seeds (approved && !Ready) and pending (!approved), sorts both by pipeline stage,
-// seeds the chain, and exposes pending operations via approveQueue iteration order.
+// approved && !Completed and unapproved, sorts both by pipeline stage,
+// seeds the chain, and exposes unapproved operations via approveQueue iteration order.
 func newApprover(nodesCount int, operations []controlplanev1alpha1.ControlPlaneOperation) *approver {
-	approvedOperations, pendingOperations := partitionOperationsByApprovalState(operations)
+	approvedOperations, unapprovedOperations := partitionOperationsByApprovalState(operations)
 	sortOperationsByPipelineOrder(approvedOperations)
-	sortOperationsByPipelineOrder(pendingOperations)
+	sortOperationsByPipelineOrder(unapprovedOperations)
 
 	approveChain := buildApproveChain(nodesCount)
 	approveChain.seedApprovedOperations(approvedOperations)
 
 	return &approver{
 		approveChain: approveChain,
-		approveQueue: pendingOperations,
+		approveQueue: unapprovedOperations,
 	}
 }
 
-func partitionOperationsByApprovalState(operations []controlplanev1alpha1.ControlPlaneOperation) (seed, pending []controlplanev1alpha1.ControlPlaneOperation) {
-	seed = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
-	pending = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
+func partitionOperationsByApprovalState(operations []controlplanev1alpha1.ControlPlaneOperation) (approvedOperations, unapprovedOperations []controlplanev1alpha1.ControlPlaneOperation) {
+	approvedOperations = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
+	unapprovedOperations = make([]controlplanev1alpha1.ControlPlaneOperation, 0, len(operations))
 
 	for _, operation := range operations {
-		if operation.IsCompleted() {
-			seed = append(seed, operation)
+		if operation.Spec.Approved && !operation.IsCompleted() {
+			approvedOperations = append(approvedOperations, operation)
 			continue
 		}
 
 		if !operation.Spec.Approved {
-			pending = append(pending, operation)
+			unapprovedOperations = append(unapprovedOperations, operation)
 		}
 	}
 
-	return seed, pending
+	return approvedOperations, unapprovedOperations
 }
 
 // sortOperationsByPipelineOrder orders operations by pipelineStageIndex (see controlPlaneApprovePipeline).

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package operationsapprover
 
 import (

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
@@ -1,0 +1,189 @@
+package operationsapprover
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+)
+
+func TestNewApprover_ConcurrencyLimits(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single node uses workload limit 1", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(1, nil)
+		etcd := a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd]
+		require.Equal(t, 1, etcd.concurrencyLimit)
+		api := a.approveChain.nextLink.components[controlplanev1alpha1.OperationComponentKubeAPIServer]
+		require.Equal(t, 1, api.concurrencyLimit)
+	})
+
+	t.Run("three nodes workload limit is nodesCount-1", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		api := a.approveChain.nextLink.components[controlplanev1alpha1.OperationComponentKubeAPIServer]
+		require.Equal(t, 2, api.concurrencyLimit)
+	})
+}
+
+func TestApprover_TryApprove_Etcd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allows first etcd operation", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		op := newOperation("etcd-1", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)
+		require.True(t, a.tryApprove(op))
+	})
+
+	t.Run("rejects second etcd while first is reserved in same approver", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("etcd-1", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)))
+		require.False(t, a.tryApprove(newOperation("etcd-2", "node-b", controlplanev1alpha1.OperationComponentEtcd, false)))
+	})
+
+	t.Run("rejects second etcd on same node", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("etcd-1", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)))
+		require.False(t, a.tryApprove(newOperation("etcd-2", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)))
+	})
+
+	t.Run("seed in-flight etcd blocks another etcd", func(t *testing.T) {
+		t.Parallel()
+		seed := []controlplanev1alpha1.ControlPlaneOperation{
+			newOperation("etcd-running", "node-a", controlplanev1alpha1.OperationComponentEtcd, true),
+		}
+		a := newApprover(3, seed)
+		require.False(t, a.tryApprove(newOperation("etcd-new", "node-b", controlplanev1alpha1.OperationComponentEtcd, false)))
+	})
+}
+
+func TestApprover_TryApprove_StageOrdering(t *testing.T) {
+	t.Parallel()
+
+	t.Run("blocks apiserver while etcd stage has reservation", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("e1", "n1", controlplanev1alpha1.OperationComponentEtcd, false)))
+		require.False(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+	})
+
+	t.Run("allows apiserver when etcd stage is empty", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+	})
+
+	t.Run("blocks kcm while apiserver stage has reservation", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+		require.False(t, a.tryApprove(newOperation("k1", "n1", controlplanev1alpha1.OperationComponentKubeControllerManager, false)))
+	})
+
+	t.Run("allows kcm and scheduler concurrently on same pipeline stage", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("k1", "n1", controlplanev1alpha1.OperationComponentKubeControllerManager, false)))
+		require.True(t, a.tryApprove(newOperation("s1", "n2", controlplanev1alpha1.OperationComponentKubeScheduler, false)))
+	})
+}
+
+func TestApprover_TryApprove_WorkloadConcurrencyAndPerNode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allows up to workload concurrency limit on distinct nodes", func(t *testing.T) {
+		t.Parallel()
+		// 3 nodes -> limit 2 for apiserver
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+		require.True(t, a.tryApprove(newOperation("a2", "n2", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+		require.False(t, a.tryApprove(newOperation("a3", "n3", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+	})
+
+	t.Run("rejects second apiserver on same node", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+		require.False(t, a.tryApprove(newOperation("a2", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
+	})
+}
+
+func TestApprover_TryApprove_OutOfChainComponents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HotReload is not approvable via default chain", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.False(t, a.tryApprove(newOperation("hr1", "n1", controlplanev1alpha1.OperationComponentHotReload, false)))
+	})
+
+	t.Run("PKI is not approvable via default chain", func(t *testing.T) {
+		t.Parallel()
+		a := newApprover(3, nil)
+		require.False(t, a.tryApprove(newOperation("pki1", "n1", controlplanev1alpha1.OperationComponentPKI, false)))
+	})
+}
+
+func TestNewApprover_PartitionAndOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unapproved operation is only in approveQueue", func(t *testing.T) {
+		t.Parallel()
+		op := newOperation("x", "n1", controlplanev1alpha1.OperationComponentEtcd, false)
+		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{op})
+		require.Empty(t, a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd].approvedOperationsPerNode)
+		require.Len(t, a.approveQueue, 1)
+		require.Equal(t, "x", a.approveQueue[0].Name)
+	})
+
+	t.Run("approved without Ready is seed only empty queue", func(t *testing.T) {
+		t.Parallel()
+		op := newOperation("x", "n1", controlplanev1alpha1.OperationComponentEtcd, true)
+		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{op})
+		require.Empty(t, a.approveQueue)
+		require.Equal(t, 1, a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd].approvedOperationsTotal)
+	})
+
+	t.Run("approved with Ready=True is excluded from seed and queue", func(t *testing.T) {
+		t.Parallel()
+		op := newOperation("x", "n1", controlplanev1alpha1.OperationComponentEtcd, true)
+		meta.SetStatusCondition(&op.Status.Conditions, metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionTrue,
+			Reason:             "Test",
+			LastTransitionTime: metav1.Now(),
+		})
+		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{op})
+		require.Empty(t, a.approveQueue)
+		require.Zero(t, a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd].approvedOperationsTotal)
+	})
+
+	t.Run("approveQueue sorted by pipeline stage then name", func(t *testing.T) {
+		t.Parallel()
+		api := newOperation("aaa-apiserver", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)
+		etcd := newOperation("zzz-etcd", "n2", controlplanev1alpha1.OperationComponentEtcd, false)
+		kcm := newOperation("m-kcm", "n1", controlplanev1alpha1.OperationComponentKubeControllerManager, false)
+		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{api, etcd, kcm})
+		require.Equal(t, []string{"zzz-etcd", "aaa-apiserver", "m-kcm"}, []string{
+			a.approveQueue[0].Name, a.approveQueue[1].Name, a.approveQueue[2].Name,
+		})
+	})
+}
+
+func newOperation(name, node string, component controlplanev1alpha1.OperationComponent, approved bool) controlplanev1alpha1.ControlPlaneOperation {
+	return controlplanev1alpha1.ControlPlaneOperation{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: controlplanev1alpha1.ControlPlaneOperationSpec{
+			NodeName:  node,
+			Component: component,
+			Approved:  approved,
+		},
+	}
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
@@ -139,12 +139,6 @@ func TestApprover_TryApprove_OutOfChainComponents(t *testing.T) {
 		a := newApprover(3, nil)
 		require.False(t, a.tryApprove(newOperation("hr1", "n1", controlplanev1alpha1.OperationComponentHotReload, false)))
 	})
-
-	t.Run("PKI is not approvable via default chain", func(t *testing.T) {
-		t.Parallel()
-		a := newApprover(3, nil)
-		require.False(t, a.tryApprove(newOperation("pki1", "n1", controlplanev1alpha1.OperationComponentPKI, false)))
-	})
 }
 
 func TestNewApprover_PartitionAndOrder(t *testing.T) {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package operationsapprover
 
 import (

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
@@ -153,7 +153,7 @@ func TestNewApprover_PartitionAndOrder(t *testing.T) {
 		require.Equal(t, "x", a.approveQueue[0].Name)
 	})
 
-	t.Run("approved without Ready is seed only empty queue", func(t *testing.T) {
+	t.Run("approved and incompleted is seed only empty queue", func(t *testing.T) {
 		t.Parallel()
 		op := newOperation("x", "n1", controlplanev1alpha1.OperationComponentEtcd, true)
 		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{op})
@@ -161,7 +161,7 @@ func TestNewApprover_PartitionAndOrder(t *testing.T) {
 		require.Equal(t, 1, a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd].approvedOperationsTotal)
 	})
 
-	t.Run("approved with Ready=True is excluded from seed and queue", func(t *testing.T) {
+	t.Run("approved and completed is excluded from seed and queue", func(t *testing.T) {
 		t.Parallel()
 		op := newOperation("x", "n1", controlplanev1alpha1.OperationComponentEtcd, true)
 		meta.SetStatusCondition(&op.Status.Conditions, metav1.Condition{

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
@@ -110,15 +110,15 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	approver := newApprover(len(nodes.Items), operations.Items)
 
-	for _, pendingOperation := range approver.approveQueue {
-		canApprove := approver.tryApprove(pendingOperation)
+	for _, unapprovedOperation := range approver.approveQueue {
+		canApprove := approver.tryApprove(unapprovedOperation)
 
 		if canApprove {
-			original := pendingOperation.DeepCopy()
-			pendingOperation.Spec.Approved = true
+			original := unapprovedOperation.DeepCopy()
+			unapprovedOperation.Spec.Approved = true
 
-			if err := r.client.Patch(ctx, &pendingOperation, client.MergeFrom(original)); err != nil {
-				return reconcile.Result{}, fmt.Errorf("failed to approve ControlPlaneOperation %q: %w", pendingOperation.Name, err)
+			if err := r.client.Patch(ctx, &unapprovedOperation, client.MergeFrom(original)); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to approve ControlPlaneOperation %q: %w", unapprovedOperation.Name, err)
 			}
 		}
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
@@ -99,6 +99,8 @@ func getPredicates() predicate.Predicate {
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger.Info("Reconcile started")
+
 	nodes := &controlplanev1alpha1.ControlPlaneNodeList{}
 	if err := r.client.List(ctx, nodes, &client.ListOptions{}); err != nil {
 		return reconcile.Result{}, err

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
@@ -75,7 +75,18 @@ func getPredicates() predicate.Predicate {
 		CreateFunc: func(event.CreateEvent) bool {
 			return true
 		},
-		UpdateFunc: func(event.UpdateEvent) bool {
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldOperation, okOld := e.ObjectOld.(*controlplanev1alpha1.ControlPlaneOperation)
+			newOperation, okNew := e.ObjectNew.(*controlplanev1alpha1.ControlPlaneOperation)
+
+			if !okOld || !okNew {
+				return false
+			}
+
+			if !oldOperation.IsTerminal() && newOperation.IsTerminal() {
+				return true
+			}
+
 			return false
 		},
 		DeleteFunc: func(event.DeleteEvent) bool {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
@@ -1,0 +1,111 @@
+package operationsapprover
+
+import (
+	"context"
+	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+	"fmt"
+	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"golang.org/x/time/rate"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	maxConcurrentReconciles = 1
+	cacheSyncTimeout        = 3 * time.Minute
+)
+
+var logger = log.NewLogger().Named("operations-approver-controller")
+
+type reconciler struct {
+	client client.Client
+}
+
+func Register(mgr manager.Manager) error {
+	r := &reconciler{
+		client: mgr.GetClient(),
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.TypedOptions[reconcile.Request]{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+			CacheSyncTimeout:        cacheSyncTimeout,
+			RateLimiter: workqueue.NewTypedMaxOfRateLimiter(
+				workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](100*time.Millisecond, 3*time.Second),
+				&workqueue.TypedBucketRateLimiter[reconcile.Request]{
+					Limiter: rate.NewLimiter(rate.Limit(1), 1),
+				},
+			),
+		}).
+		Named("operations_approver_controller").
+		For(
+			&controlplanev1alpha1.ControlPlaneOperation{},
+			builder.WithPredicates(getPredicates()),
+		).
+		Complete(r)
+}
+
+func getPredicates() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	nodes := &controlplanev1alpha1.ControlPlaneNodeList{}
+	if err := r.client.List(ctx, nodes, &client.ListOptions{}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if len(nodes.Items) == 0 {
+		logger.Warn("no control plane nodes found")
+		return reconcile.Result{}, nil
+	}
+
+	operations := &controlplanev1alpha1.ControlPlaneOperationList{}
+	if err := r.client.List(ctx, operations); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if len(operations.Items) == 0 {
+		logger.Warn("no control plane operations found")
+		return reconcile.Result{}, nil
+	}
+
+	approver := newApprover(len(nodes.Items), operations.Items)
+
+	for _, pendingOperation := range approver.approveQueue {
+		canApprove := approver.tryApprove(pendingOperation)
+
+		if canApprove {
+			original := pendingOperation.DeepCopy()
+			pendingOperation.Spec.Approved = true
+
+			if err := r.client.Patch(ctx, &pendingOperation, client.MergeFrom(original)); err != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to approve ControlPlaneOperation %q: %w", pendingOperation.Name, err)
+			}
+		}
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package operationsapprover
 
 import (

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
@@ -1,0 +1,119 @@
+package operationsapprover
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+)
+
+var testScheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(controlplanev1alpha1.AddToScheme(testScheme))
+}
+
+func TestReconciler_Reconcile(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("no control plane nodes returns without error", func(t *testing.T) {
+		t.Parallel()
+		cl := fake.NewClientBuilder().WithScheme(testScheme).Build()
+		r := &reconciler{client: cl}
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		require.NoError(t, err)
+	})
+
+	t.Run("no operations returns without error", func(t *testing.T) {
+		t.Parallel()
+		cl := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(testControlPlaneNode("n1")).
+			Build()
+		r := &reconciler{client: cl}
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		require.NoError(t, err)
+	})
+
+	t.Run("patches Spec.Approved when approver allows", func(t *testing.T) {
+		t.Parallel()
+		op := newOperation("op-etcd", "n1", controlplanev1alpha1.OperationComponentEtcd, false)
+		cl := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(testControlPlaneNode("n1"), &op).
+			WithStatusSubresource(&controlplanev1alpha1.ControlPlaneOperation{}).
+			Build()
+		r := &reconciler{client: cl}
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		require.NoError(t, err)
+
+		var updated controlplanev1alpha1.ControlPlaneOperation
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-etcd"}, &updated))
+		require.True(t, updated.Spec.Approved)
+	})
+
+	t.Run("does not patch second operation in same reconcile when stage blocks", func(t *testing.T) {
+		t.Parallel()
+		// Three nodes so apiserver stage is reachable after etcd is idle; in one pass etcd reserves pipeline first.
+		etcdOp := newOperation("zzz-etcd", "n1", controlplanev1alpha1.OperationComponentEtcd, false)
+		apiOp := newOperation("aaa-apiserver", "n2", controlplanev1alpha1.OperationComponentKubeAPIServer, false)
+		cl := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(
+				testControlPlaneNode("n1"),
+				testControlPlaneNode("n2"),
+				testControlPlaneNode("n3"),
+				&etcdOp,
+				&apiOp,
+			).
+			WithStatusSubresource(&controlplanev1alpha1.ControlPlaneOperation{}).
+			Build()
+		r := &reconciler{client: cl}
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		require.NoError(t, err)
+
+		var etcdUpdated controlplanev1alpha1.ControlPlaneOperation
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "zzz-etcd"}, &etcdUpdated))
+		require.True(t, etcdUpdated.Spec.Approved)
+
+		var apiUpdated controlplanev1alpha1.ControlPlaneOperation
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "aaa-apiserver"}, &apiUpdated))
+		require.False(t, apiUpdated.Spec.Approved)
+	})
+
+	t.Run("does not patch when approver rejects", func(t *testing.T) {
+		t.Parallel()
+		seed := newOperation("etcd-running", "n1", controlplanev1alpha1.OperationComponentEtcd, true)
+		pending := newOperation("etcd-next", "n2", controlplanev1alpha1.OperationComponentEtcd, false)
+		cl := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(testControlPlaneNode("n1"), testControlPlaneNode("n2"), &seed, &pending).
+			WithStatusSubresource(&controlplanev1alpha1.ControlPlaneOperation{}).
+			Build()
+		r := &reconciler{client: cl}
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		require.NoError(t, err)
+
+		var updated controlplanev1alpha1.ControlPlaneOperation
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "etcd-next"}, &updated))
+		require.False(t, updated.Spec.Approved)
+	})
+}
+
+func testControlPlaneNode(name string) *controlplanev1alpha1.ControlPlaneNode {
+	return &controlplanev1alpha1.ControlPlaneNode{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package operationsapprover
 
 import (

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/manager.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/manager.go
@@ -32,6 +32,7 @@ import (
 	controlplaneconfiguration "control-plane-manager/internal/controllers/control-plane-configuration"
 	controlplanenode "control-plane-manager/internal/controllers/control-plane-node"
 	controlplaneoperation "control-plane-manager/internal/controllers/control-plane-operation"
+	operationsapprover "control-plane-manager/internal/controllers/operations-approver"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"k8s.io/klog/v2/textlogger"
@@ -95,11 +96,11 @@ func NewManager(ctx context.Context, pprof bool) (*Manager, error) {
 					},
 				},
 				&corev1.Pod{}: {
-				Namespaces: map[string]cache.Config{
-					constants.KubeSystemNamespace: {},
+					Namespaces: map[string]cache.Config{
+						constants.KubeSystemNamespace: {},
+					},
 				},
-			},
-			&corev1.Node{}: {
+				&corev1.Node{}: {
 					Transform: func(in any) (any, error) {
 						node, ok := in.(*corev1.Node)
 						if !ok {
@@ -138,6 +139,10 @@ func NewManager(ctx context.Context, pprof bool) (*Manager, error) {
 
 	if err = controlplaneoperation.Register(runtimeManager); err != nil {
 		return nil, fmt.Errorf("register control-plane-operation controller: %w", err)
+	}
+
+	if err = operationsapprover.Register(runtimeManager); err != nil {
+		return nil, fmt.Errorf("register operations-approver controller: %w", err)
 	}
 
 	return &Manager{


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
For https://github.com/deckhouse/deckhouse/pull/17798

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Add operation approver controller
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
