### PR TITLE
[ci] Switch to DDK

### DIFF
--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -1,7 +1,9 @@
 {!{ define "werf_envs" }!}
 # <template: werf_envs>
-WERF_VERSION: "v2.57.1"
+DECKHOUSE_CLI_VERSION: "v0.29.20"
+WERF_VERSION: "v2.63.1"
 WERF_ENV: "FE"
+WERF_TELEMETRY: "1"
 WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
 TEST_TIMEOUT: "15m"
 # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -66,6 +66,7 @@ steps:
   {!{ tmpl.Exec "login_rw_registry_step" $ctx | strings.Indent 2 }!}
   {!{ end }!}
   {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 2 }!}
+  {!{ tmpl.Exec "d8cli_install_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "add_ssh_keys" $ctx | strings.Indent 2 }!}
 
   - name: Set up Go 1.25
@@ -196,7 +197,7 @@ steps:
 
       # The Git tag may contain a '+' sign, so use slugify for this situation.
       # Slugify doesn't change a tag with safe-only characters.
-      IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+      IMAGE_TAG=$(d8 dk slugify --format docker-tag "${CI_COMMIT_TAG}")
       export WERF_DISABLE_META_TAGS=true
     {!{- else if eq $buildType "pre-release" }!}
       # The Git tag may contain a '+' sign, so use slugify for this situation.
@@ -216,8 +217,8 @@ steps:
       IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
     {!{- end }!}
 
-      type werf && source $(werf ci-env github --verbose --as-file)
-      werf build \
+      type d8 && source $(d8 dk ci-env github --verbose --as-file)
+      d8 dk build \
         --parallel=true --parallel-tasks-limit=10 \
         --save-build-report=true \
         --build-report-path images_tags_werf.json

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -65,7 +65,6 @@ steps:
   {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_rw_registry_step" $ctx | strings.Indent 2 }!}
   {!{ end }!}
-  {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "d8cli_install_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "add_ssh_keys" $ctx | strings.Indent 2 }!}
 

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -560,9 +560,6 @@ check_e2e_labels:
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_stage_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 4 }!}
-{!{ if not (has $commanderProviders $provider) }!}
-  {!{ tmpl.Exec "werf_install_step" . | strings.Indent 4 }!}
-{!{- end }!}
 
     - name: Setup
       id: setup
@@ -974,7 +971,6 @@ check_e2e_labels:
 {!{ tmpl.Exec "login_dev_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_stage_registry_step" . | strings.Indent 4 }!}
 {!{ tmpl.Exec "login_rw_registry_step" . | strings.Indent 4 }!}
-{!{ tmpl.Exec "werf_install_step" . | strings.Indent 4 }!}
 
     - name: Setup
       id: setup

--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -224,8 +224,6 @@
 {!{ define "d8cli_install_step" }!}
 # <template: d8cli_install_step>
 - name: Install d8 CLI
-  env:
-    DECKHOUSE_CLI_VERSION: "v0.29.25"
   run: |
     mkdir -p bin
     INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"

--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -224,14 +224,12 @@
 {!{ define "d8cli_install_step" }!}
 # <template: d8cli_install_step>
 - name: Install d8 CLI
-  uses: werf/trdl/actions/setup-app@main
-  with:
-    repo: d8
-    url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-    root-version: 1
-    root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-    group: 0
-    channel: stable
+  env:
+    DECKHOUSE_CLI_VERSION: "v0.29.25"
+  run: |
+    mkdir -p bin
+    INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+    echo "$(pwd)/bin" >> "$GITHUB_PATH"
 # </template: d8cli_install_step>
 {!{- end -}!}
 

--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -221,6 +221,20 @@
 # </template: werf_install_step>
 {!{- end -}!}
 
+{!{ define "d8cli_install_step" }!}
+# <template: d8cli_install_step>
+- name: Install d8 CLI
+  uses: werf/trdl/actions/setup-app@main
+  with:
+    repo: d8
+    url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+    root-version: 1
+    root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+    group: 0
+    channel: stable
+# </template: d8cli_install_step>
+{!{- end -}!}
+
 {!{ define "started_at_output" }!}
 # <template: started_at_output>
 - name: Job started timestamp

--- a/.github/scripts/registry-deckhouse-cleanup.sh
+++ b/.github/scripts/registry-deckhouse-cleanup.sh
@@ -29,4 +29,4 @@ EOL
 export DOCKER_CONFIG="${PWD}/docker"
 export WERF_PARALLEL_TASKS_LIMIT=21
 export REGISTRY_URL="${DECKHOUSE_REGISTRY_STAGE_HOST}/${REGISTRY_PATH}"
-werf cleanup --config werf_cleanup.yaml --without-kube --disable-auto-host-cleanup=true --log-color-mode='off' --repo "${REGISTRY_URL}"
+d8 dk cleanup --config werf_cleanup.yaml --without-kube --disable-auto-host-cleanup=true --log-color-mode='off' --repo "${REGISTRY_URL}"

--- a/.github/workflow_templates/stage_registry_clean.yml
+++ b/.github/workflow_templates/stage_registry_clean.yml
@@ -51,7 +51,7 @@ jobs:
       {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
       {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 4 }!}
-      {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 4 }!}
+      {!{ tmpl.Exec "d8cli_install_step" $ctx | strings.Indent 4 }!}
       {!{ tmpl.Exec "login_stage_registry_step" $ctx | strings.Indent 4 }!}
 
     - name: RM Deckhouse image

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -452,14 +452,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -755,14 +753,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1057,14 +1053,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1359,14 +1353,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1661,14 +1653,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1963,14 +1953,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -2265,14 +2253,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -450,13 +450,6 @@ jobs:
       # </template: login_dev_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -760,13 +753,6 @@ jobs:
       # </template: login_dev_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -1068,13 +1054,6 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1378,13 +1357,6 @@ jobs:
       # </template: login_dev_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -1686,13 +1658,6 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1996,13 +1961,6 @@ jobs:
       # </template: login_dev_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -2304,13 +2262,6 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -457,6 +457,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -590,8 +602,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -755,6 +767,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -888,8 +912,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1052,6 +1076,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1185,8 +1221,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1349,6 +1385,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1482,8 +1530,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1646,6 +1694,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1779,8 +1839,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1943,6 +2003,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -2076,8 +2148,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -2240,6 +2312,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -2373,8 +2457,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -27,8 +27,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.
@@ -452,8 +454,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -753,8 +753,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1053,8 +1051,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1353,8 +1349,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1653,8 +1647,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1953,8 +1945,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -2253,8 +2243,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -234,6 +234,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -366,8 +378,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -28,8 +28,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.
@@ -229,8 +231,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -229,14 +229,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -227,13 +227,6 @@ jobs:
       # </template: login_dev_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -226,13 +226,6 @@ jobs:
       # </template: login_stage_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -545,13 +538,6 @@ jobs:
       # </template: login_stage_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -862,13 +848,6 @@ jobs:
           logout: false
       # </template: login_stage_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1181,13 +1160,6 @@ jobs:
       # </template: login_stage_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -1498,13 +1470,6 @@ jobs:
           logout: false
       # </template: login_stage_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1817,13 +1782,6 @@ jobs:
       # </template: login_stage_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -2134,13 +2092,6 @@ jobs:
           logout: false
       # </template: login_stage_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -233,6 +233,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -365,8 +377,8 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -540,6 +552,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -672,8 +696,8 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -846,6 +870,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -978,8 +1014,8 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1152,6 +1188,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1284,8 +1332,8 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1458,6 +1506,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1590,8 +1650,8 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1764,6 +1824,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1896,8 +1968,8 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -2070,6 +2142,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -2202,8 +2286,8 @@ jobs:
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -27,8 +27,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.
@@ -228,8 +230,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -538,8 +538,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -847,8 +845,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1156,8 +1152,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1465,8 +1459,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1774,8 +1766,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -2083,8 +2073,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -228,14 +228,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -540,14 +538,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -851,14 +847,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1162,14 +1156,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1473,14 +1465,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1784,14 +1774,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -2095,14 +2083,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -387,14 +387,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -782,14 +780,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1177,14 +1173,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1560,14 +1554,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -1943,14 +1935,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>
@@ -2326,14 +2316,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -44,8 +44,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.
@@ -387,8 +389,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -780,8 +780,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1173,8 +1171,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1554,8 +1550,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -1935,8 +1929,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
@@ -2316,8 +2308,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -392,6 +392,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -532,11 +544,11 @@ jobs:
 
           # The Git tag may contain a '+' sign, so use slugify for this situation.
           # Slugify doesn't change a tag with safe-only characters.
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          IMAGE_TAG=$(d8 dk slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -782,6 +794,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -922,11 +946,11 @@ jobs:
 
           # The Git tag may contain a '+' sign, so use slugify for this situation.
           # Slugify doesn't change a tag with safe-only characters.
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          IMAGE_TAG=$(d8 dk slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1172,6 +1196,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1312,11 +1348,11 @@ jobs:
 
           # The Git tag may contain a '+' sign, so use slugify for this situation.
           # Slugify doesn't change a tag with safe-only characters.
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          IMAGE_TAG=$(d8 dk slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1550,6 +1586,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -1690,11 +1738,11 @@ jobs:
 
           # The Git tag may contain a '+' sign, so use slugify for this situation.
           # Slugify doesn't change a tag with safe-only characters.
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          IMAGE_TAG=$(d8 dk slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -1928,6 +1976,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -2068,11 +2128,11 @@ jobs:
 
           # The Git tag may contain a '+' sign, so use slugify for this situation.
           # Slugify doesn't change a tag with safe-only characters.
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          IMAGE_TAG=$(d8 dk slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json
@@ -2306,6 +2366,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -2446,11 +2518,11 @@ jobs:
 
           # The Git tag may contain a '+' sign, so use slugify for this situation.
           # Slugify doesn't change a tag with safe-only characters.
-          IMAGE_TAG=$(werf slugify --format docker-tag "${CI_COMMIT_TAG}")
+          IMAGE_TAG=$(d8 dk slugify --format docker-tag "${CI_COMMIT_TAG}")
           export WERF_DISABLE_META_TAGS=true
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -385,13 +385,6 @@ jobs:
       # </template: login_rw_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -786,13 +779,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1189,13 +1175,6 @@ jobs:
       # </template: login_rw_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -1578,13 +1557,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1969,13 +1941,6 @@ jobs:
       # </template: login_rw_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main
@@ -2358,13 +2323,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -41,8 +41,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -41,8 +41,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -41,8 +41,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -41,8 +41,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -41,8 +41,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test10.yml
+++ b/.github/workflows/deploy-web-test10.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test2.yml
+++ b/.github/workflows/deploy-web-test2.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test3.yml
+++ b/.github/workflows/deploy-web-test3.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test4.yml
+++ b/.github/workflows/deploy-web-test4.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test5.yml
+++ b/.github/workflows/deploy-web-test5.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test6.yml
+++ b/.github/workflows/deploy-web-test6.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test7.yml
+++ b/.github/workflows/deploy-web-test7.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test8.yml
+++ b/.github/workflows/deploy-web-test8.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/deploy-web-test9.yml
+++ b/.github/workflows/deploy-web-test9.yml
@@ -46,8 +46,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -271,13 +271,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -598,13 +591,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -927,13 +913,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1254,13 +1233,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1583,13 +1555,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1910,13 +1875,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2239,13 +2197,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2566,13 +2517,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2895,13 +2839,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3222,13 +3159,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3551,13 +3481,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3878,13 +3801,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -273,13 +273,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -606,13 +599,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -941,13 +927,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1274,13 +1253,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1609,13 +1581,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1942,13 +1907,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2277,13 +2235,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2610,13 +2561,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2945,13 +2889,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3278,13 +3215,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3613,13 +3543,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3946,13 +3869,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-dvp.yml
+++ b/.github/workflows/e2e-abort-dvp.yml
@@ -270,13 +270,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -594,13 +587,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -920,13 +906,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1244,13 +1223,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1570,13 +1542,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1894,13 +1859,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2220,13 +2178,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2544,13 +2495,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2870,13 +2814,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3194,13 +3131,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3520,13 +3450,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3844,13 +3767,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-dvp.yml
+++ b/.github/workflows/e2e-abort-dvp.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -269,13 +269,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -625,13 +618,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -983,13 +969,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1339,13 +1318,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1697,13 +1669,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2053,13 +2018,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2411,13 +2369,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2767,13 +2718,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3125,13 +3069,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3481,13 +3418,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3839,13 +3769,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -4195,13 +4118,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -270,13 +270,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -595,13 +588,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -922,13 +908,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1247,13 +1226,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1574,13 +1546,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1899,13 +1864,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2226,13 +2184,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2551,13 +2502,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2878,13 +2822,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3203,13 +3140,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3530,13 +3460,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3855,13 +3778,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -270,13 +270,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -594,13 +587,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -920,13 +906,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1244,13 +1223,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1570,13 +1542,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1894,13 +1859,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2220,13 +2178,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2544,13 +2495,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2870,13 +2814,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3194,13 +3131,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3520,13 +3450,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3844,13 +3767,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -272,13 +272,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -602,13 +595,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -934,13 +920,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1264,13 +1243,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1596,13 +1568,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1926,13 +1891,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2258,13 +2216,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2588,13 +2539,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2920,13 +2864,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3250,13 +3187,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3582,13 +3512,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3912,13 +3835,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -275,13 +275,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -614,13 +607,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -955,13 +941,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1294,13 +1273,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1635,13 +1607,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1974,13 +1939,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2315,13 +2273,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2654,13 +2605,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2995,13 +2939,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3334,13 +3271,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3675,13 +3605,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -4014,13 +3937,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -272,13 +272,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -602,13 +595,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -934,13 +920,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1264,13 +1243,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1596,13 +1568,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1926,13 +1891,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2258,13 +2216,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2588,13 +2539,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2920,13 +2864,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3250,13 +3187,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3582,13 +3512,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3912,13 +3835,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -272,13 +272,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -602,13 +595,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -934,13 +920,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1264,13 +1243,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1596,13 +1568,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1926,13 +1891,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2258,13 +2216,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2588,13 +2539,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2920,13 +2864,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3250,13 +3187,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3582,13 +3512,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3912,13 +3835,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-abort-zvirt.yml
+++ b/.github/workflows/e2e-abort-zvirt.yml
@@ -272,13 +272,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -599,13 +592,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -928,13 +914,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1255,13 +1234,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1584,13 +1556,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1911,13 +1876,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2240,13 +2198,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2567,13 +2518,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2896,13 +2840,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3223,13 +3160,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -3552,13 +3482,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3879,13 +3802,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-abort-zvirt.yml
+++ b/.github/workflows/e2e-abort-zvirt.yml
@@ -40,8 +40,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -450,7 +450,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -939,7 +938,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1430,7 +1428,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1919,7 +1916,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2410,7 +2406,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2899,7 +2894,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3390,7 +3384,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3879,7 +3872,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4370,7 +4362,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4859,7 +4850,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5350,7 +5340,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5839,7 +5828,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -452,7 +452,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -951,7 +950,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1452,7 +1450,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1951,7 +1948,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2452,7 +2448,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2951,7 +2946,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3452,7 +3446,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3951,7 +3944,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4452,7 +4444,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4951,7 +4942,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5452,7 +5442,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5951,7 +5940,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -25,8 +25,10 @@ env:
   WERF_DRY_RUN: "false"
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -282,7 +282,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -685,14 +684,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1220,7 +1211,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1633,7 +1623,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2039,7 +2028,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2449,7 +2437,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2851,7 +2838,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3265,7 +3251,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3691,7 +3676,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4100,7 +4084,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4502,7 +4485,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-dvp.yml
+++ b/.github/workflows/e2e-dvp.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-dvp.yml
+++ b/.github/workflows/e2e-dvp.yml
@@ -449,7 +449,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -933,7 +932,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1419,7 +1417,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1903,7 +1900,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2389,7 +2385,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2873,7 +2868,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3359,7 +3353,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3843,7 +3836,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4329,7 +4321,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4813,7 +4804,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5299,7 +5289,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5783,7 +5772,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -448,14 +448,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -1076,14 +1068,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -1706,14 +1690,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -2334,14 +2310,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -2964,14 +2932,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -3592,14 +3552,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -4222,14 +4174,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -4850,14 +4794,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -5480,14 +5416,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -6108,14 +6036,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup
@@ -6738,14 +6658,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       - name: Setup
         id: setup
         env:
@@ -7366,14 +7278,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
-
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -449,7 +449,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -934,7 +933,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1421,7 +1419,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1906,7 +1903,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2393,7 +2389,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2878,7 +2873,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3365,7 +3359,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3850,7 +3843,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4337,7 +4329,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4822,7 +4813,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5309,7 +5299,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5794,7 +5783,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -449,7 +449,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -933,7 +932,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1419,7 +1417,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1903,7 +1900,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2389,7 +2385,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2873,7 +2868,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3359,7 +3353,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3843,7 +3836,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4329,7 +4321,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4813,7 +4804,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5299,7 +5289,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5783,7 +5772,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -453,7 +453,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -946,7 +945,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1441,7 +1439,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1934,7 +1931,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2429,7 +2425,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2922,7 +2917,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3417,7 +3411,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3910,7 +3903,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4405,7 +4397,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4898,7 +4889,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5393,7 +5383,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5886,7 +5875,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -454,7 +454,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -963,7 +962,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1474,7 +1472,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1983,7 +1980,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2494,7 +2490,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3003,7 +2998,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3514,7 +3508,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4023,7 +4016,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4534,7 +4526,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5043,7 +5034,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5554,7 +5544,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -6063,7 +6052,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -451,7 +451,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -945,7 +944,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1441,7 +1439,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1935,7 +1932,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2431,7 +2427,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2925,7 +2920,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3421,7 +3415,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3915,7 +3908,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4411,7 +4403,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4905,7 +4896,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5401,7 +5391,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5895,7 +5884,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -451,7 +451,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -945,7 +944,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1441,7 +1439,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1935,7 +1932,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2431,7 +2427,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2925,7 +2920,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3421,7 +3415,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3915,7 +3908,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4411,7 +4403,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4905,7 +4896,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5401,7 +5391,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5895,7 +5884,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-zvirt.yml
+++ b/.github/workflows/e2e-zvirt.yml
@@ -57,8 +57,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/e2e-zvirt.yml
+++ b/.github/workflows/e2e-zvirt.yml
@@ -451,7 +451,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -939,7 +938,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -1429,7 +1427,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -1917,7 +1914,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -2407,7 +2403,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -2895,7 +2890,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -3385,7 +3379,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -3873,7 +3866,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -4363,7 +4355,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -4851,7 +4842,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup
@@ -5341,7 +5331,6 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
-
       - name: Setup
         id: setup
         env:
@@ -5829,7 +5818,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: false
       # </template: login_rw_registry_step>
-
 
       - name: Setup
         id: setup

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -25,8 +25,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.
@@ -91,8 +93,6 @@ jobs:
 
     # <template: d8cli_install_step>
     - name: Install d8 CLI
-      env:
-        DECKHOUSE_CLI_VERSION: "v0.29.25"
       run: |
         mkdir -p bin
         INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -89,12 +89,17 @@ jobs:
 
     # </template: checkout_step>
 
-    # <template: werf_install_step>
-    - name: Install werf CLI
-      uses: werf/actions/install@v2
+    # <template: d8cli_install_step>
+    - name: Install d8 CLI
+      uses: werf/trdl/actions/setup-app@main
       with:
-        version: ${{env.WERF_VERSION}}
-    # </template: werf_install_step>
+        repo: d8
+        url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+        root-version: 1
+        root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+        group: 0
+        channel: stable
+    # </template: d8cli_install_step>
 
     # <template: login_stage_registry_step>
     - name: Check stage registry credentials

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -91,14 +91,12 @@ jobs:
 
     # <template: d8cli_install_step>
     - name: Install d8 CLI
-      uses: werf/trdl/actions/setup-app@main
-      with:
-        repo: d8
-        url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-        root-version: 1
-        root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-        group: 0
-        channel: stable
+      env:
+        DECKHOUSE_CLI_VERSION: "v0.29.25"
+      run: |
+        mkdir -p bin
+        INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+        echo "$(pwd)/bin" >> "$GITHUB_PATH"
     # </template: d8cli_install_step>
 
     # <template: login_stage_registry_step>

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -38,8 +38,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -38,8 +38,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -38,8 +38,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -38,8 +38,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -38,8 +38,10 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -219,6 +219,18 @@ jobs:
           version: ${{env.WERF_VERSION}}
       # </template: werf_install_step>
 
+      # <template: d8cli_install_step>
+      - name: Install d8 CLI
+        uses: werf/trdl/actions/setup-app@main
+        with:
+          repo: d8
+          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
+          root-version: 1
+          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
+          group: 0
+          channel: stable
+      # </template: d8cli_install_step>
+
       # <template: add_ssh_keys>
       - name: Start ssh-agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -351,8 +363,8 @@ jobs:
           # Use it as image tag. Add suffix to not overlap with PRs in main repo.
           IMAGE_TAG=${CI_COMMIT_REF_SLUG}${IMAGE_EDITION:+-${IMAGE_EDITION}}${REPO_SUFFIX:+-${REPO_SUFFIX}}
 
-          type werf && source $(werf ci-env github --verbose --as-file)
-          werf build \
+          type d8 && source $(d8 dk ci-env github --verbose --as-file)
+          d8 dk build \
             --parallel=true --parallel-tasks-limit=10 \
             --save-build-report=true \
             --build-report-path images_tags_werf.json

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -30,8 +30,10 @@ permissions:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.57.1"
+  DECKHOUSE_CLI_VERSION: "v0.29.20"
+  WERF_VERSION: "v2.63.1"
   WERF_ENV: "FE"
+  WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
   TEST_TIMEOUT: "15m"
   # Use fixed string 'sys/deckhouse-oss' for repo name. ${CI_PROJECT_PATH} is not available here in GitHub.
@@ -214,8 +216,6 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        env:
-          DECKHOUSE_CLI_VERSION: "v0.29.25"
         run: |
           mkdir -p bin
           INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -214,14 +214,12 @@ jobs:
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
-        uses: werf/trdl/actions/setup-app@main
-        with:
-          repo: d8
-          url: https://deckhouse.ru/downloads/deckhouse-cli-trdl
-          root-version: 1
-          root-sha512: 343bd5f0d8811254e5f0b6fe292372a7b7eda08d276ff255229200f84e58a8151ab2729df3515cb11372dc3899c70df172a4e54c8a596a73d67ae790466a0491
-          group: 0
-          channel: stable
+        env:
+          DECKHOUSE_CLI_VERSION: "v0.29.25"
+        run: |
+          mkdir -p bin
+          INSTALL_DIR="$(pwd)/bin" VERSION=${DECKHOUSE_CLI_VERSION} FORCE=yes bash -c "$(curl -fsSL https://raw.githubusercontent.com/deckhouse/deckhouse-cli/main/tools/install.sh)"
+          echo "$(pwd)/bin" >> "$GITHUB_PATH"
       # </template: d8cli_install_step>
 
       # <template: add_ssh_keys>

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -212,13 +212,6 @@ jobs:
       # </template: login_dev_registry_step>
 
 
-      # <template: werf_install_step>
-      - name: Install werf CLI
-        uses: werf/actions/install@v2
-        with:
-          version: ${{env.WERF_VERSION}}
-      # </template: werf_install_step>
-
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         uses: werf/trdl/actions/setup-app@main

--- a/tools/images_tags/main.go
+++ b/tools/images_tags/main.go
@@ -72,8 +72,13 @@ func main() {
 
 	digests := make(map[string]map[string]string)
 
-	// Run werf config render to get config file from which  we calculate images names
-	cmd := exec.Command("werf", "config", "render", "--dev", "--log-quiet")
+	// Run render command to get config file from which we calculate images names.
+	// Prefer d8 dk when available, fallback to werf.
+	cmdArgs := []string{"werf", "config", "render", "--dev", "--log-quiet"}
+	if _, lookPathErr := exec.LookPath("d8"); lookPathErr == nil {
+		cmdArgs = []string{"d8", "dk", "config", "render", "--dev", "--log-quiet"}
+	}
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env,
 		"CI_COMMIT_REF_NAME=",


### PR DESCRIPTION
## Description
Switch to Deckhouse Delivery Kit for use in builds
Test: https://github.com/deckhouse/deckhouse-test-2/actions/runs/24388143367

## Why do we need it, and what problem does it solve?
This change is necessary as a part of future shift to signed builds.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: feature
summary: Switch to DDK
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
