### PR TITLE
[cloud-provider-aws] Handle UnsupportedOperation for DescribeInstanceTopology in unsupported regions

### DIFF
--- a/modules/030-cloud-provider-aws/images/cloud-data-discoverer/src/discoverer.go
+++ b/modules/030-cloud-provider-aws/images/cloud-data-discoverer/src/discoverer.go
@@ -95,7 +95,16 @@ func (d *Discoverer) CheckCloudConditions(ctx context.Context) ([]v1alpha1.Cloud
 		if !errors.As(err, &awsErr) {
 			return nil, fmt.Errorf("DescribeInstanceTopology AWS IAM permission check error: %v", err)
 		}
-		if awsErr.Code() != "DryRunOperation" {
+
+		switch awsErr.Code() {
+		case "DryRunOperation":
+		case "UnsupportedOperation":
+			d.logger.Warn("DescribeInstanceTopology is not supported in this region, skipping permission check",
+				"region", d.region,
+				"aws_error_code", awsErr.Code(),
+				"aws_error_message", awsErr.Message(),
+			)
+		default:
 			res = append(res, v1alpha1.CloudCondition{
 				Name:    "INSUFFICIENT_AWS_SA_PERMISSIONS",
 				Message: "DescribeInstanceTopology is not allowed",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix incorrect error handling for DescribeInstanceTopology in AWS regions where the API is not yet available.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In new AWS regions the DescribeInstanceTopology API is not supported, which caused false-positive permission alerts in monitoring. This fix correctly distinguishes a regional limitation from a real IAM issue.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: fix
summary: Fixed detection of regional limitations versus IAM issues.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
