### PR TITLE
[registrypackages][control-plane-manager] Add vex for CVE-2026-39883 in release 1.73

### DIFF
--- a/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-0a7dee882b0213b53ce1f13791d223657afca21285b99e07e15b935fa0456093",
-  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 5,
+  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 6,
   "statements": [
     {
       "vulnerability": {
@@ -102,10 +102,24 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
-      "impact_statement": "Уязвимость CVE-2026-34986 невозможно эксплуатировать в рамках Deckhouse: плтаформа не использует шифрование образов, в ней не настроен и не используется ctd-decoder, цепочка вызовов которого (containerd -> imgcrypt -> ocicrypt -> go-jose) и может привести к эксплуатации уязвимости, при всех воплощённых в ней условиях.",
+      "impact_statement": "Уязвимость CVE-2026-34986 невозможно эксплуатировать в рамках Deckhouse: плтаформа не использует шифрование образов, в ней не настроен и не используется ctd-decoder, цепочка вызовов которого (containerd -\u003e imgcrypt -\u003e ocicrypt -\u003e go-jose) и может привести к эксплуатации уязвимости, при всех воплощённых в ней условиях.",
       "timestamp": "2026-04-07T13:06:33.386247Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:12:06.165622Z"
     }
   ],
   "timestamp": "2026-03-04T12:00:38Z",
-  "last_updated": "2026-04-07T13:06:33Z"
+  "last_updated": "2026-04-10T09:12:06Z"
 }

--- a/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-0a7dee882b0213b53ce1f13791d223657afca21285b99e07e15b935fa0456093",
-  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
   "version": 6,
   "statements": [
     {

--- a/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-5a7af0f8c8656570f312693f05dd9d0c8f523f7fa16225650a88b0a022e5a27c",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 8,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 9,
   "statements": [
     {
       "vulnerability": {
@@ -99,7 +99,7 @@
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
-      "impact_statement": "Уязвимость GHSA-6g7g-w4f8-9c9x невозможно эксплуатировать в рамках Deckhouse: платформа использует исключительно клиентскую библиотеку github.com/buger/jsonparser через стандартизированные kubelet-интерфейсы, которые не используют функцию Delete при обработке JSON-входов от внешних источников, что является обязательным условием для эксплуатации. Все входящие JSON>запросы поступают от внутренних компонентов Deckhouse через валидированные protobuf-конверторы, исключая возможность отправки невалидного JSON через штатные интерфейсы управления.",
+      "impact_statement": "Уязвимость GHSA-6g7g-w4f8-9c9x невозможно эксплуатировать в рамках Deckhouse: платформа использует исключительно клиентскую библиотеку github.com/buger/jsonparser через стандартизированные kubelet-интерфейсы, которые не используют функцию Delete при обработке JSON-входов от внешних источников, что является обязательным условием для эксплуатации. Все входящие JSON\u003eзапросы поступают от внутренних компонентов Deckhouse через валидированные protobuf-конверторы, исключая возможность отправки невалидного JSON через штатные интерфейсы управления.",
       "timestamp": "2026-03-26T14:29:37.200879Z"
     },
     {
@@ -129,8 +129,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33997 невозможно эксплуатировать в рамках Deckhouse: платформа использует лишь пакет github.com/docker/docker/api/types/time. А уязвимость затрагивает часть по работе с Docker Engine при установке устаревших (legacy) плагинов Docker - установка плагинов и проверка их привилегий в crictl не выполняются.",
       "timestamp": "2026-04-07T10:45:27.439571Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:12:10.219163Z"
     }
   ],
   "timestamp": "2026-01-21T10:25:02Z",
-  "last_updated": "2026-04-07T10:45:27Z"
+  "last_updated": "2026-04-10T09:12:10Z"
 }

--- a/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-5a7af0f8c8656570f312693f05dd9d0c8f523f7fa16225650a88b0a022e5a27c",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 9,
   "statements": [
     {

--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
-  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 11,
+  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 12,
   "statements": [
     {
       "vulnerability": {
@@ -171,8 +171,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-24051 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды ioreg, которая является специфичной для операционной системы macOS (Darwin) и отсутствует в ядре Linux.",
       "timestamp": "2026-03-04T12:03:54.097426Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:11:04.735812Z"
     }
   ],
   "timestamp": "2025-10-09T14:21:14Z",
-  "last_updated": "2026-03-04T12:03:54Z"
+  "last_updated": "2026-04-10T09:11:04Z"
 }

--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
-  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
   "version": 12,
   "statements": [
     {

--- a/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-965feae7158c81b99d9011ec6c79e82c8b8b4a7ae9dc9ea04a3e07a5218773a2",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 4,
   "statements": [
     {

--- a/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-965feae7158c81b99d9011ec6c79e82c8b8b4a7ae9dc9ea04a3e07a5218773a2",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 3,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 4,
   "statements": [
     {
       "vulnerability": {
@@ -73,8 +73,22 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в рамках Deckhouse: kubeadm является CLI-инструментом и не запускает gRPC-сервер ни в каком режиме работы. Обязательное условие эксплуатации — наличие gRPC-сервера с path-based авторизационными интерцепторами и fallback allow-политикой — не выполнено, поскольку серверный компонент отсутствует как таковой.",
       "timestamp": "2026-03-27T09:20:27.339442Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:10:58.12934Z"
     }
   ],
   "timestamp": "2025-10-09T09:57:48Z",
-  "last_updated": "2026-03-27T09:20:27Z"
+  "last_updated": "2026-04-10T09:10:58Z"
 }

--- a/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 3,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 4,
   "statements": [
     {
       "vulnerability": {
@@ -108,7 +108,7 @@
       },
       "products": [
         {
-          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk@v1.28.0"
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
         }
       ],
       "status": "not_affected",
@@ -129,8 +129,22 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в рамках Deckhouse: kubelet экспонирует gRPC-интерфейсы (CRI, device plugins) без использования path-based авторизационных интерцепторов с deny-правилами и fallback allow — авторизация выполняется через webhook к kube-apiserver. Кроме того, gRPC-сокеты kubelet доступны исключительно локально через Unix-сокеты, что исключает возможность отправки произвольных raw HTTP/2 фреймов сетевым атакующим.",
       "timestamp": "2026-03-27T09:20:45.42252Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:13:01.862098Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-27T09:20:45Z"
+  "last_updated": "2026-04-10T09:13:01Z"
 }

--- a/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 4,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-8672d6eafe61e4f890bf57dfe22d2a4475b99af4354ceed6f3f9ae9a9ff2f1ed",
-  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 7,
+  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 8,
   "statements": [
     {
       "vulnerability": {
@@ -73,8 +73,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в рамках Deckhouse: kubeadm является CLI-инструментом для инициализации кластера и не поднимает долгоживущий gRPC-сервер с path-based авторизационными интерцепторами. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с deny-правилами и fallback allow в данном компоненте не задействован.",
       "timestamp": "2026-03-24T14:30:42.406256Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:13:45.629451Z"
     }
   ],
   "timestamp": "2025-10-28T18:45:30Z",
-  "last_updated": "2026-03-24T14:30:42Z"
+  "last_updated": "2026-04-10T09:13:45Z"
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-8672d6eafe61e4f890bf57dfe22d2a4475b99af4354ceed6f3f9ae9a9ff2f1ed",
-  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
   "version": 8,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-6f8aac734bc48eff1b66a4a70617115b764e90917b6c26eb8f5ac10b75b62c58",
-  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 4,
+  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 5,
   "statements": [
     {
       "vulnerability": {
@@ -59,8 +59,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в etcd в рамках Deckhouse: etcd не использует path-based авторизационные интерцепторы (grpc/authz или аналоги) с deny-правилами и fallback allow. Авторизация в etcd реализована через собственный встроенный механизм на основе mTLS и username/password, который не подвержен данной уязвимости.",
       "timestamp": "2026-03-24T14:31:34.951234Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:13:22.357899Z"
     }
   ],
   "timestamp": "2025-12-29T21:11:59Z",
-  "last_updated": "2026-03-24T14:31:34Z"
+  "last_updated": "2026-04-10T09:13:22Z"
 }

--- a/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-6f8aac734bc48eff1b66a4a70617115b764e90917b6c26eb8f5ac10b75b62c58",
-  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
   "version": 5,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 6,
+  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 7,
   "statements": [
     {
       "vulnerability": {
@@ -129,8 +129,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в kube-apiserver в рамках Deckhouse: kube-apiserver использует HTTP/REST для внешнего API, а не path-based gRPC авторизационные интерцепторы. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с deny-правилами и fallback allow не задействован.",
       "timestamp": "2026-03-24T14:32:23.906059Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:13:29.162671Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-24T14:32:23Z"
+  "last_updated": "2026-04-10T09:13:29Z"
 }

--- a/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
   "version": 7,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-4967f958f1248545eec7a13485884e349b6110e4acb5fe1825953bd6a8abef98",
-  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
   "version": 7,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-4967f958f1248545eec7a13485884e349b6110e4acb5fe1825953bd6a8abef98",
-  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 6,
+  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 7,
   "statements": [
     {
       "vulnerability": {
@@ -129,8 +129,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в kube-controller-manager в рамках Deckhouse: компонент не использует path-based gRPC авторизационные интерцепторы с deny-правилами и fallback allow. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с уязвимой логикой не задействован.",
       "timestamp": "2026-03-24T14:32:45.253542Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:13:38.125045Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-24T14:32:45Z"
+  "last_updated": "2026-04-10T09:13:38Z"
 }

--- a/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 6,
+  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 7,
   "statements": [
     {
       "vulnerability": {
@@ -129,8 +129,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в kube-scheduler в рамках Deckhouse: компонент не использует path-based gRPC авторизационные интерцепторы с deny-правилами и fallback allow. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с уязвимой логикой не задействован.",
       "timestamp": "2026-03-24T14:32:56.631802Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T09:13:33.071362Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-24T14:33:00Z"
+  "last_updated": "2026-04-10T09:13:33Z"
 }

--- a/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
   "version": 7,
   "statements": [
     {


### PR DESCRIPTION
## Description
This PR adds vex [CVE-2026-39883](https://github.com/advisories/GHSA-hfvc-g4fc-pqhx) for registrypackages and control-plane-manager components.

## Why do we need it, and what problem does it solve?
This vex addresses vulnerability [CVE-2026-39883](https://github.com/advisories/GHSA-hfvc-g4fc-pqhx) which only affects BSD/Solaris.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: chore
summary: Added vex for vulnerability CVE-2026-39883
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
