### PR TITLE
[registrypackages][control-plane-manager] Add vex for CVE-2026-39883

### DIFF
--- a/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-f80cd91b36d545749726987cea9ab19348fca2ab9f04d7af8b0d3021bd9ca032",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 5,
   "statements": [
     {

--- a/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/containerd/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-f80cd91b36d545749726987cea9ab19348fca2ab9f04d7af8b0d3021bd9ca032",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 4,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 5,
   "statements": [
     {
       "vulnerability": {
@@ -31,8 +31,22 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в рамках Deckhouse: containerd не использует path-based авторизационные интерцепторы (grpc/authz или аналоги) с deny-правилами и fallback allow, что является обязательным условием для эксплуатации. Все входящие gRPC-запросы поступают от kubelet через стандартную клиентскую библиотеку, которая автоматически добавляет leading slash в :path pseudo-header, исключая возможность отправки невалидного запроса через штатный интерфейс.",
       "timestamp": "2026-03-24T09:23:21.903246Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:21:34.39521Z"
     }
   ],
   "timestamp": "2026-03-04T09:36:23Z",
-  "last_updated": "2026-03-24T09:24:38Z"
+  "last_updated": "2026-04-10T08:21:34Z"
 }

--- a/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-5a7af0f8c8656570f312693f05dd9d0c8f523f7fa16225650a88b0a022e5a27c",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 7,
   "statements": [
     {

--- a/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/crictl/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-5a7af0f8c8656570f312693f05dd9d0c8f523f7fa16225650a88b0a022e5a27c",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 6,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 7,
   "statements": [
     {
       "vulnerability": {
@@ -73,8 +73,22 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в рамках Deckhouse: crictl является gRPC-клиентом, а не сервером. Уязвимость затрагивает исключительно серверную часть gRPC-Go, которая не используется в crictl. Кроме того, эксплуатация требует наличия path-based авторизационных интерцепторов с deny-правилами и fallback allow на стороне сервера, что не является частью архитектуры crictl.",
       "timestamp": "2026-03-24T09:30:46.588349Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:11:57.791025Z"
     }
   ],
   "timestamp": "2026-01-21T10:25:02Z",
-  "last_updated": "2026-03-24T09:30:59Z"
+  "last_updated": "2026-04-10T08:11:57Z"
 }

--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 14,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 15,
   "statements": [
     {
       "vulnerability": {
@@ -241,8 +241,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-24051 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды ioreg, которая является специфичной для операционной системы macOS (Darwin) и отсутствует в ядре Linux.",
       "timestamp": "2026-03-04T09:39:02.45541Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk@v1.40.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux",
+      "timestamp": "2026-04-10T08:22:34.246444Z"
     }
   ],
   "timestamp": "2026-01-16T12:00:00Z",
-  "last_updated": "2026-03-04T09:39:02Z"
+  "last_updated": "2026-04-10T08:22:34Z"
 }

--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 15,
   "statements": [
     {

--- a/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-965feae7158c81b99d9011ec6c79e82c8b8b4a7ae9dc9ea04a3e07a5218773a2",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 3,
   "statements": [
     {

--- a/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubeadm/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-965feae7158c81b99d9011ec6c79e82c8b8b4a7ae9dc9ea04a3e07a5218773a2",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 2,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -59,8 +59,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-24051 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды ioreg, которая является специфичной для операционной системы macOS (Darwin) и отсутствует в ядре Linux.",
       "timestamp": "2026-03-04T09:37:31.735203Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:23:17.720535Z"
     }
   ],
   "timestamp": "2025-10-09T09:57:48Z",
-  "last_updated": "2026-03-04T09:37:31Z"
+  "last_updated": "2026-04-10T08:23:17Z"
 }

--- a/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 3,
   "statements": [
     {

--- a/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/kubelet/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 2,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -143,8 +143,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-24051 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды ioreg, которая является специфичной для операционной системы macOS (Darwin) и отсутствует в ядре Linux.",
       "timestamp": "2026-03-04T09:36:57.014617Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:23:04.885732Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-04T09:36:57Z"
+  "last_updated": "2026-04-10T08:23:04Z"
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-8672d6eafe61e4f890bf57dfe22d2a4475b99af4354ceed6f3f9ae9a9ff2f1ed",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 5,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 6,
   "statements": [
     {
       "vulnerability": {
@@ -45,8 +45,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в рамках Deckhouse: компонент controller (controlPlaneManager) не поднимает gRPC-сервер с path-based авторизационными интерцепторами. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с deny-правилами и fallback allow в данном компоненте не задействован.",
       "timestamp": "2026-03-24T09:40:38.893711Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:25:16.130934Z"
     }
   ],
   "timestamp": "2025-10-28T18:45:30Z",
-  "last_updated": "2026-03-24T09:40:45Z"
+  "last_updated": "2026-04-10T08:25:16Z"
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/control-plane-manager/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-8672d6eafe61e4f890bf57dfe22d2a4475b99af4354ceed6f3f9ae9a9ff2f1ed",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 6,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-41a5cb02200a981d0e152bffdd0754addf47f69efe2db1b00812aff0a07fe3f3",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 2,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -31,8 +31,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в etcd в рамках Deckhouse: etcd не использует path-based авторизационные интерцепторы (grpc/authz или аналоги) с deny-правилами и fallback allow. Авторизация в etcd реализована через собственный встроенный механизм на основе mTLS и username/password, который не подвержен данной уязвимости.",
       "timestamp": "2026-03-24T10:09:40.852754Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:25:27.328749Z"
     }
   ],
   "timestamp": "2026-03-04T09:42:58Z",
-  "last_updated": "2026-03-24T10:09:40Z"
+  "last_updated": "2026-04-10T08:25:27Z"
 }

--- a/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-41a5cb02200a981d0e152bffdd0754addf47f69efe2db1b00812aff0a07fe3f3",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 3,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 4,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 5,
   "statements": [
     {
       "vulnerability": {
@@ -115,8 +115,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в kube-apiserver в рамках Deckhouse: kube-apiserver использует HTTP/REST для внешнего API, а не path-based gRPC авторизационные интерцепторы. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с deny-правилами и fallback allow не задействован.",
       "timestamp": "2026-03-24T10:15:42.400004Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:26:57.044194Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-24T10:15:54Z"
+  "last_updated": "2026-04-10T08:26:57Z"
 }

--- a/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-apiserver/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 5,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-4967f958f1248545eec7a13485884e349b6110e4acb5fe1825953bd6a8abef98",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 5,
   "statements": [
     {

--- a/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-controller-manager/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-4967f958f1248545eec7a13485884e349b6110e4acb5fe1825953bd6a8abef98",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 4,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 5,
   "statements": [
     {
       "vulnerability": {
@@ -115,8 +115,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в kube-controller-manager в рамках Deckhouse: компонент не использует path-based gRPC авторизационные интерцепторы с deny-правилами и fallback allow. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с уязвимой логикой не задействован.",
       "timestamp": "2026-03-24T10:17:34.610919Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:27:48.174579Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-24T10:17:38Z"
+  "last_updated": "2026-04-10T08:27:48Z"
 }

--- a/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 4,
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 5,
   "statements": [
     {
       "vulnerability": {
@@ -115,8 +115,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в kube-scheduler в рамках Deckhouse: компонент не использует path-based gRPC авторизационные интерцепторы с deny-правилами и fallback allow. grpc-go присутствует как транзитивная зависимость, однако серверный путь исполнения с уязвимой логикой не задействован.",
       "timestamp": "2026-03-24T10:19:29.339272Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды kenv, которая является специфичной для операционных систем на базе BSD и Solaris и отсутвует в Linux.",
+      "timestamp": "2026-04-10T08:27:39.297274Z"
     }
   ],
   "timestamp": "2025-11-07T13:55:00Z",
-  "last_updated": "2026-03-24T10:19:35Z"
+  "last_updated": "2026-04-10T08:27:39Z"
 }

--- a/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/kube-scheduler/known_vulnerabilities.vex
@@ -1,7 +1,7 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-83ad327013f034fdd863cf73303584cf735337893acf934c4c3d37ba8b0609f3",
-  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "author": "Deckhouse <contact@deckhouse.io>",
   "version": 5,
   "statements": [
     {


### PR DESCRIPTION
## Description
This PR adds vex [CVE-2026-39883](https://github.com/advisories/GHSA-hfvc-g4fc-pqhx) for registrypackages and control-plane-manager components.

## Why do we need it, and what problem does it solve?
This vex addresses vulnerability [CVE-2026-39883](https://github.com/advisories/GHSA-hfvc-g4fc-pqhx) which only affects BSD/Solaris.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: chore
summary: Added vex for vulnerability CVE-2026-39883
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
