### PR TITLE
[admission-policy-engine] Fix high resource consumption for constraint d8denyexecheritage

### DIFF
--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/deny-exec-heritage.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/deny-exec-heritage.yaml
@@ -22,8 +22,8 @@ spec:
       rego: |
         package d8.security_policies
 
-        is_connect {
-          input.review.operation == "CONNECT"
+        is_connect { 
+          input.review.operation == "CONNECT" 
         }
         
         subresource_is(sub) {
@@ -35,29 +35,21 @@ spec:
           input.review.resource.resource == "pods"
           subresource_is("exec")
         }
-
         is_pod_exec_or_attach {
           input.review.resource.resource == "pods"
           subresource_is("attach")
         }
 
-        # Check if the target pod has heritage: deckhouse label via inventory
         is_heritage_pod {
-          namespace := input.review.namespace
-          podName := input.review.name
-          pod := data.inventory.namespace[namespace]["v1"].Pod[podName]
-          pod.metadata.labels["heritage"] == "deckhouse"
+          input.review.object.metadata.labels["heritage"] == "deckhouse"
         }
 
-        # allow-list
         is_allowed_user {
           input.review.userInfo.username == "system:sudouser"
         }
-
         is_allowed_user {
           startswith(input.review.userInfo.username, "system:serviceaccount:d8-")
         }
-
         is_allowed_user {
           startswith(input.review.userInfo.username, "system:serviceaccount:kube-")
         }
@@ -67,8 +59,6 @@ spec:
           is_pod_exec_or_attach
           is_heritage_pod
           not is_allowed_user
-          pod  := input.review.name
-          ns   := input.review.namespace
-          user := input.review.userInfo.username
-          msg  := sprintf("Exec/attach to Pod %q in namespace %q with label 'heritage: deckhouse' is forbidden for user %q", [pod, ns, user])
+          
+          msg := sprintf("Exec/attach to Pod %q is forbidden for user %q", [input.review.name, input.review.userInfo.username])
         }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/deny-exec-heritage.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/templates/security/deny-exec-heritage.yaml
@@ -22,10 +22,10 @@ spec:
       rego: |
         package d8.security_policies
 
-        is_connect { 
-          input.review.operation == "CONNECT" 
+        is_connect {
+          input.review.operation == "CONNECT"
         }
-        
+
         subresource_is(sub) {
           sr := object.get(input.review, "requestSubResource", input.review.subResource)
           sr == sub
@@ -35,30 +35,46 @@ spec:
           input.review.resource.resource == "pods"
           subresource_is("exec")
         }
+
         is_pod_exec_or_attach {
           input.review.resource.resource == "pods"
           subresource_is("attach")
         }
 
-        is_heritage_pod {
-          input.review.object.metadata.labels["heritage"] == "deckhouse"
+        connect_to_pod_exec_or_attach {
+          is_connect
+          is_pod_exec_or_attach
         }
 
         is_allowed_user {
           input.review.userInfo.username == "system:sudouser"
         }
+
         is_allowed_user {
           startswith(input.review.userInfo.username, "system:serviceaccount:d8-")
         }
+
         is_allowed_user {
           startswith(input.review.userInfo.username, "system:serviceaccount:kube-")
         }
 
-        violation[{"msg": msg}] {
-          is_connect
-          is_pod_exec_or_attach
-          is_heritage_pod
+        deny_candidate {
+          connect_to_pod_exec_or_attach
           not is_allowed_user
-          
-          msg := sprintf("Exec/attach to Pod %q is forbidden for user %q", [input.review.name, input.review.userInfo.username])
+        }
+
+        is_heritage_pod {
+          deny_candidate
+          namespace := input.review.namespace
+          podName := input.review.name
+          pod := data.inventory.namespace[namespace]["v1"].Pod[podName]
+          pod.metadata.labels["heritage"] == "deckhouse"
+        }
+
+        violation[{"msg": msg}] {
+          is_heritage_pod
+          pod  := input.review.name
+          ns   := input.review.namespace
+          user := input.review.userInfo.username
+          msg  := sprintf("Exec/attach to Pod %q in namespace %q with label 'heritage: deckhouse' is forbidden for user %q", [pod, ns, user])
         }

--- a/modules/015-admission-policy-engine/charts/constraint-templates/tests/deny-exec-heritage/constraint.yaml
+++ b/modules/015-admission-policy-engine/charts/constraint-templates/tests/deny-exec-heritage/constraint.yaml
@@ -6,7 +6,10 @@ spec:
   enforcementAction: deny
   match:
     kinds:
-      - apiGroups: ["*"]
-        kinds: ["*"]
+      - apiGroups: [""]
+        kinds: ["PodExecOptions", "PodAttachOptions"]
     scope: Namespaced
+    namespaces:
+      - "d8-*"
+      - "kube-*"
 

--- a/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
@@ -584,7 +584,7 @@ spec:
   match:
     kinds:
       - apiGroups: ["*"]
-        kinds: ["*"]
+        kinds: ["Pod"]
     scope: Namespaced
   {{- end }}
 {{- end }}

--- a/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/security-policy/constraint.yaml
@@ -583,9 +583,12 @@ spec:
   enforcementAction: deny
   match:
     kinds:
-      - apiGroups: ["*"]
-        kinds: ["Pod"]
+      - apiGroups: [""]
+        kinds: ["PodExecOptions", "PodAttachOptions"]
     scope: Namespaced
+    namespaces:
+      - "d8-*"
+      - "kube-*"
   {{- end }}
 {{- end }}
 

--- a/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
+++ b/modules/015-admission-policy-engine/templates/validatingwebhookconfiguration.yaml
@@ -91,15 +91,12 @@ webhooks:
   {{- include "validating.webhook.config" . | nindent 2 }}
 {{- end }}
 
-{{/* Webhook for deny-exec in system namespaces (heritage: deckhouse) - the main webhook excludes these */}}
+{{/* Webhook for deny-exec in namespaces whose names start with d8- or kube- (main webhook excludes them by heritage label) */}}
 {{- if ne .Values.global.deckhouseVersion "dev" }}
 - name: deny-exec-heritage.admission-policy-engine.deckhouse.io
-  namespaceSelector:
-    matchExpressions:
-    - key: heritage
-      operator: In
-      values:
-        - deckhouse
+  matchConditions:
+    - name: system-namespace-prefix
+      expression: 'request.namespace.startsWith("d8-") || request.namespace.startsWith("kube-")'
   rules:
   - apiGroups: [""]
     apiVersions: ["*"]


### PR DESCRIPTION
## Description
The current implementation of constraint `d8denyexecution` causes high CPU consumption. 
Optimizations have been made.

## Why do we need it, and what problem does it solve?

Resource optimization

## Why do we need it in the patch release (if we do)?
A patch for version 1.75 is required.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix 
summary: Fix high resource consumption for constraint d8denyexecheritage
impact_level: default 
```
