### PR TITLE
[registrypackages] Crictl remediate CVE-2026-32285 for 1.73

### DIFF
--- a/modules/007-registrypackages/images/crictl/patches/1.31.1/go_mod.patch
+++ b/modules/007-registrypackages/images/crictl/patches/1.31.1/go_mod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index eccb4b8f..98ee3080 100644
+index eccb4b8f..ff28f45f 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,12 +1,12 @@
@@ -33,6 +33,15 @@ index eccb4b8f..98ee3080 100644
  	google.golang.org/grpc v1.65.0
  	google.golang.org/protobuf v1.34.2
  	gopkg.in/yaml.v3 v3.0.1
+@@ -45,7 +45,7 @@ require (
+ 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/blang/semver/v4 v4.0.0 // indirect
+-	github.com/buger/jsonparser v1.1.1 // indirect
++	github.com/buger/jsonparser v1.1.2 // indirect
+ 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+ 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 @@ -87,8 +87,8 @@ require (
  	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
  	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect

--- a/modules/007-registrypackages/images/crictl/patches/1.31.1/go_mod.patch
+++ b/modules/007-registrypackages/images/crictl/patches/1.31.1/go_mod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index eccb4b8f..ff28f45f 100644
+index eccb4b8f..e10615b7 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,12 +1,12 @@
@@ -54,9 +54,20 @@ index eccb4b8f..ff28f45f 100644
  	golang.org/x/tools v0.24.0 // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20240701130421-f6361c86f094 // indirect
 diff --git a/go.sum b/go.sum
-index a61b196c..12737d5e 100644
+index a61b196c..1e60e9ba 100644
 --- a/go.sum
 +++ b/go.sum
+@@ -10,8 +10,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
++github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
++github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 @@ -26,8 +26,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
  github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
  github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=

--- a/modules/007-registrypackages/images/crictl/patches/1.32.0/go_mod.patch
+++ b/modules/007-registrypackages/images/crictl/patches/1.32.0/go_mod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index 4b607f50..477d9a78 100644
+index 4b607f50..9ba2f2c6 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,6 +1,6 @@
@@ -23,6 +23,15 @@ index 4b607f50..477d9a78 100644
  	google.golang.org/grpc v1.68.1
  	google.golang.org/protobuf v1.35.2
  	gopkg.in/yaml.v3 v3.0.1
+@@ -42,7 +42,7 @@ require (
+ 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/blang/semver/v4 v4.0.0 // indirect
+-	github.com/buger/jsonparser v1.1.1 // indirect
++	github.com/buger/jsonparser v1.1.2 // indirect
+ 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+ 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 @@ -84,8 +84,8 @@ require (
  	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.32.0 // indirect
  	go.opentelemetry.io/otel/metric v1.32.0 // indirect
@@ -35,9 +44,20 @@ index 4b607f50..477d9a78 100644
  	golang.org/x/tools v0.26.0 // indirect
  	google.golang.org/genproto/googleapis/api v0.0.0-20241104194629-dd2ea8efbc28 // indirect
 diff --git a/go.sum b/go.sum
-index d02d11ca..e1da736a 100644
+index d02d11ca..10d0847f 100644
 --- a/go.sum
 +++ b/go.sum
+@@ -10,8 +10,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
++github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
++github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 @@ -180,10 +180,10 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/modules/007-registrypackages/images/crictl/patches/1.33.0/go_mod.patch
+++ b/modules/007-registrypackages/images/crictl/patches/1.33.0/go_mod.patch
@@ -1,0 +1,28 @@
+diff --git a/go.mod b/go.mod
+index 117d5023..461ee79a 100644
+--- a/go.mod
++++ b/go.mod
+@@ -41,7 +41,7 @@ require (
+ 	github.com/bahlo/generic-list-go v0.2.0 // indirect
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/blang/semver/v4 v4.0.0 // indirect
+-	github.com/buger/jsonparser v1.1.1 // indirect
++	github.com/buger/jsonparser v1.1.2 // indirect
+ 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+ 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+ 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
+diff --git a/go.sum b/go.sum
+index 214e9b23..37e78c02 100644
+--- a/go.sum
++++ b/go.sum
+@@ -10,8 +10,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
++github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
++github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
+ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Description
Bump jsonparser dependency to 1.1.2.
Tested manually, `crictl` works.
## Why do we need it, and what problem does it solve?
To fix [CVE-2026-32285](https://github.com/advisories/GHSA-6g7g-w4f8-9c9x).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: fix
summary: Remediated CVE-2026-32285 in crictl dependencies.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
