### PR TITLE
[node-manager] mcm aws spot instance timeout

### DIFF
--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -743,6 +743,8 @@ const (
 	vcdCAPISymlink      = "/deckhouse/modules/040-node-manager/capi/vcd"
 )
 
+var nodeManagerAWSSpot = strings.Replace(nodeManagerAWS, "      instanceType: t2.medium\n", "      instanceType: t2.medium\n      spot: true\n", 1)
+
 var _ = Describe("Module :: node-manager :: helm template ::", func() {
 	f := SetupHelmConfig(``)
 
@@ -940,6 +942,27 @@ var _ = Describe("Module :: node-manager :: helm template ::", func() {
 			Expect(roleBindings["bashible-mcm-bootstrapped-nodes"].Exists()).To(BeTrue())
 
 			assertBashibleAPIServerTLS(f)
+		})
+	})
+
+	Context("AWS spot", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("nodeManager", nodeManagerConfigValues+nodeManagerAWSSpot)
+			setBashibleAPIServerTLSValues(f)
+			f.HelmRender()
+		})
+
+		It("sets creation timeout for spot node groups", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			machineDeploymentA := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "myprefix-worker-02320933")
+			machineDeploymentB := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "myprefix-worker-6bdb5b0d")
+
+			Expect(machineDeploymentA.Exists()).To(BeTrue())
+			Expect(machineDeploymentA.Field("spec.template.spec.creationTimeout").String()).To(Equal("5m"))
+
+			Expect(machineDeploymentB.Exists()).To(BeTrue())
+			Expect(machineDeploymentB.Field("spec.template.spec.creationTimeout").String()).To(Equal("5m"))
 		})
 	})
 

--- a/modules/040-node-manager/templates/node-group/_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_machine_deployment.tpl
@@ -1,3 +1,17 @@
+{{- define "node_group_spot_creation_timeout" -}}
+{{- $context := index . 0 -}}
+{{- $ng := index . 1 -}}
+{{- if eq $context.Values.nodeManager.internal.cloudProvider.type "aws" -}}
+  {{- if hasKey $ng "instanceClass" -}}
+    {{- if hasKey $ng.instanceClass "spot" -}}
+      {{- if $ng.instanceClass.spot -}}
+3m
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "node_group_machine_deployment" }}
   {{- $context := index . 0 }}
   {{- $ng := index . 1 }}
@@ -72,6 +86,10 @@ spec:
   {{- else }}
       drainTimeout: 600s
       maxEvictRetries: 30
+  {{- end }}
+  {{- $creationTimeout := include "node_group_spot_creation_timeout" (list $context $ng) }}
+  {{- if $creationTimeout }}
+      creationTimeout: {{ $creationTimeout }}
   {{- end }}
       nodeTemplate:
         metadata:

--- a/modules/040-node-manager/templates/node-group/_machine_deployment.tpl
+++ b/modules/040-node-manager/templates/node-group/_machine_deployment.tpl
@@ -5,7 +5,7 @@
   {{- if hasKey $ng "instanceClass" -}}
     {{- if hasKey $ng.instanceClass "spot" -}}
       {{- if $ng.instanceClass.spot -}}
-3m
+5m
       {{- end -}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
## Description

Adds  `node_group_spot_creation_timeout` helper that injects `creationTimeout: 5m` into `MachineDeployment` spec when the cloud provider is AWS and the NodeGroup uses spot instances.

## Why do we need it, and what problem does it solve?

When AWS has no spot capacity, node creation used to hang for ~20 minutes before MCM declared it failed. Now it fails faster after 5 minutes and retries sooner.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Reduced MachineDeployment creationTimeout to 5m for AWS spot instances.
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
