### PR TITLE
[cloud-provider-yandex] Switch default CNI to Cilium with VXLAN routing mode

### DIFF
--- a/modules/030-cloud-provider-yandex/templates/cni.yaml
+++ b/modules/030-cloud-provider-yandex/templates/cni.yaml
@@ -1,3 +1,7 @@
+{{- $ciliumConfig := `{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}` }}
 ---
 apiVersion: v1
 kind: Secret
@@ -9,5 +13,6 @@ data:
 {{- if hasKey .Values.cloudProviderYandex.internal "cniSecretData" }}
   {{- .Values.cloudProviderYandex.internal.cniSecretData | b64dec | nindent 2 }}
 {{- else }}
-  cni: {{ b64enc "simple-bridge" | quote }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ $ciliumConfig | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
## Description

Update the default CNI configuration in the `cloud-provider-yandex` module for new clusters. The configuration switches from `simple-bridge` to `cilium` using `VXLAN` tunneling mode and `BPF` masquerade mode.

## Why do we need it, and what problem does it solve?

Previously, the default CNI in Yandex Cloud was `simple-bridge`, which utilized native VPC routing. Moving to Cilium with VXLAN as the default unifies the cluster networking configuration across different infrastructure providers.

By utilizing standard VXLAN encapsulation, we eliminate the dependency on specific cloud routing mechanisms and platform limits (such as VPC Route Table quotas). This approach simplifies cluster operational support and maintenance, providing a single, predictable network profile that behaves identically in Yandex Cloud, bare-metal, and other environments.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-yandex
type: feature
summary: Switched the default CNI to Cilium with VXLAN networking mode for new clusters to unify the configuration.
impact_level: default
```