### PR TITLE
[cloud-provider-dvp][terraform-manager] Suppress destructive changes when add/remove/change labels and annotations for cloud resources via opentofu

### DIFF
--- a/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch
+++ b/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch
@@ -154,7 +154,7 @@ index 0000000000..c4a5ee921f
 +	}
 +}
 diff --git a/internal/tofu/node_resource_abstract_instance.go b/internal/tofu/node_resource_abstract_instance.go
-index 3200163e81..789b0bc9b3 100644
+index 3200163e81..3d53c53006 100644
 --- a/internal/tofu/node_resource_abstract_instance.go
 +++ b/internal/tofu/node_resource_abstract_instance.go
 @@ -6,12 +6,16 @@
@@ -208,8 +208,8 @@ index 3200163e81..789b0bc9b3 100644
 -				return true
 +				if n.allowDataDepsChanges(d, change, providerSchema) {
 +					pendingDeps[d.String()] = struct{}{}
++					break
 +				}
-+				break
  			}
  		}
  	}

--- a/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch
+++ b/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch
@@ -1,46 +1,355 @@
-Subject: [PATCH] add skip deps for data sources
----
-Index: internal/tofu/node_resource_abstract_instance.go
-IDEA additional info:
-Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
-<+>UTF-8
-===================================================================
+diff --git a/internal/tofu/map.go b/internal/tofu/map.go
+new file mode 100644
+index 0000000000..c4a5ee921f
+--- /dev/null
++++ b/internal/tofu/map.go
+@@ -0,0 +1,149 @@
++// got from https://github.com/name212/go-cmp-utils
++// tested in repo
++package tofu
++
++import (
++	"fmt"
++	"regexp"
++
++	"github.com/google/go-cmp/cmp"
++)
++
++type MapPathComparator interface {
++	Compare(indx int, keyPathPart string) bool
++	Parts() int
++}
++
++type MapPath MapPathComparator
++
++func MapKeysFilter(paths ...MapPath) cmp.Option {
++	if len(paths) == 0 {
++		return filterOption(noFilter)
++	}
++
++	filters := make([]filter, 0, len(paths))
++	for _, p := range paths {
++		filters = append(filters, constructFilter(p))
++	}
++
++	composeFilter := func(p cmp.Path) bool {
++		for _, f := range filters {
++			if f(p) {
++				return true
++			}
++		}
++
++		return false
++	}
++
++	return filterOption(composeFilter)
++}
++
++type MapPathStringComparator []string
++
++func NewMapPathStringComparator(parts ...string) MapPathStringComparator {
++	res := make(MapPathStringComparator, 0, len(parts))
++	res = append(res, parts...)
++
++	return res
++}
++
++func (c MapPathStringComparator) Parts() int {
++	return len(c)
++}
++
++func (c MapPathStringComparator) Compare(indx int, keyPathPart string) bool {
++	if indx >= c.Parts() {
++		return false
++	}
++
++	return c[indx] == keyPathPart
++}
++
++type MapPathReComparator []*regexp.Regexp
++
++func NewMapPathReComparator(parts ...string) (MapPathReComparator, error) {
++	res := make(MapPathReComparator, 0, len(parts))
++
++	var errors []error
++	for i, pp := range parts {
++		re, err := regexp.Compile(pp)
++		if err != nil {
++			errors = append(errors, fmt.Errorf("failed to compile part %d: %w", i, err))
++			continue
++		}
++		res = append(res, re)
++	}
++
++	if len(errors) == 0 {
++		return res, nil
++	}
++
++	resError := errors[0]
++	for i := 1; i < len(errors); i++ {
++		resError = fmt.Errorf("%w\n%w", resError, errors[i])
++	}
++
++	return nil, resError
++}
++
++func NewMapPathReComparatorFromRe(parts ...*regexp.Regexp) MapPathReComparator {
++	res := make(MapPathReComparator, 0, len(parts))
++	res = append(res, parts...)
++
++	return res
++}
++
++func (c MapPathReComparator) Parts() int {
++	return len(c)
++}
++
++func (c MapPathReComparator) Compare(indx int, keyPathPart string) bool {
++	if indx >= c.Parts() {
++		return false
++	}
++
++	return c[indx].MatchString(keyPathPart)
++}
++
++type filter = func(p cmp.Path) bool
++
++func noFilter(p cmp.Path) bool {
++	return false
++}
++
++func filterOption(f filter) cmp.Option {
++	return cmp.FilterPath(f, cmp.Ignore())
++}
++
++func constructFilter(path MapPath) filter {
++	l := path.Parts()
++
++	if l == 0 {
++		return noFilter
++	}
++
++	return func(p cmp.Path) bool {
++		if len(p) != 2*l {
++			return false
++		}
++
++		result := true
++
++		for i := range l {
++			num := (2 * i) + 1
++			index, ok := p.Index(num).(cmp.MapIndex)
++			if !ok {
++				result = false
++				break
++			}
++
++			if !path.Compare(i, index.Key().String()) {
++				result = false
++				break
++			}
++		}
++
++		return result
++	}
++}
 diff --git a/internal/tofu/node_resource_abstract_instance.go b/internal/tofu/node_resource_abstract_instance.go
---- a/internal/tofu/node_resource_abstract_instance.go	(revision 8053640205da25b2504ea64a36c951cb3fe52bcf)
-+++ b/internal/tofu/node_resource_abstract_instance.go	(date 1772566915569)
-@@ -8,6 +8,7 @@
+index 3200163e81..789b0bc9b3 100644
+--- a/internal/tofu/node_resource_abstract_instance.go
++++ b/internal/tofu/node_resource_abstract_instance.go
+@@ -6,12 +6,16 @@
+ package tofu
+ 
  import (
++	"encoding/json"
  	"fmt"
  	"log"
 +	"os"
  	"strings"
-
+ 
++	gocmp "github.com/google/go-cmp/cmp"
  	"github.com/hashicorp/hcl/v2"
-@@ -2018,6 +2019,8 @@
+ 	"github.com/zclconf/go-cty/cty"
++	ctyjson "github.com/zclconf/go-cty/cty/json"
+ 
+ 	"github.com/opentofu/opentofu/internal/addrs"
+ 	"github.com/opentofu/opentofu/internal/checks"
+@@ -1844,7 +1848,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
+ 	}
+ 
+ 	configKnown := configVal.IsWhollyKnown()
+-	depsPending := n.dependenciesHavePendingChanges(ctx)
++	depsPending := n.dependenciesHavePendingChanges(ctx, providerSchema)
+ 	// If our configuration contains any unknown values, or we depend on any
+ 	// unknown values then we must defer the read to the apply phase by
+ 	// producing a "Read" change for this resource, and a placeholder value for
+@@ -1997,7 +2001,7 @@ func (n *NodeAbstractResourceInstance) nestedInCheckBlock() (*configs.Check, boo
+ // receiver depends on has a change pending in the plan, in which case we'd
+ // need to override the usual behavior of immediately reading from the data
+ // source where possible, and instead defer the read until the apply step.
+-func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalContext) bool {
++func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalContext, providerSchema providers.ProviderSchema) bool {
+ 	nModInst := n.Addr.Module
+ 	nMod := nModInst.Module()
+ 
+@@ -2018,6 +2022,8 @@ func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalCo
  		}
  	}
-
+ 
 +	pendingDeps := make(map[string]struct{})
 +
  	for _, d := range depsToUse {
  		if d.Resource.Mode == addrs.DataResourceMode {
  			// Data sources have no external side effects, so they pose a need
-@@ -2041,11 +2044,63 @@
+@@ -2041,11 +2047,199 @@ func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalCo
  			}
-
+ 
  			if change != nil && change.Action != plans.NoOp {
 -				return true
--			}
--		}
--	}
--	return false
-+				pendingDeps[d.String()] = struct{}{}
++				if n.allowDataDepsChanges(d, change, providerSchema) {
++					pendingDeps[d.String()] = struct{}{}
++				}
 +				break
-+			}
-+		}
-+	}
+ 			}
+ 		}
+ 	}
+-	return false
 +
 +	return n.handleDataHavePendingDeps(pendingDeps)
++}
++
++var (
++	handleDataSourceChangesProvider          = "kubernetes"
++	handleDataSourceChangesMetadataResources = map[string]struct{}{
++		"module.additional-disk.kubernetes_manifest.additional_disk":           {},
++		"module.ipv4-address.kubernetes_manifest.ipv4_address":                 {},
++		"module.kubernetes-data-disk.kubernetes_manifest.kubernetes-data-disk": {},
++		"module.master.kubernetes_manifest.vm":                                 {},
++		"module.static-node.kubernetes_manifest.vm":                            {},
++	}
++	handleDataSourceChangesMetadataResourcesCompareOpts = MapKeysFilter(
++		NewMapPathStringComparator("metadata", "annotations"),
++		NewMapPathStringComparator("metadata", "labels"),
++	)
++)
++
++func (n *NodeAbstractResourceInstance) allowDataDepsChanges(d addrs.ConfigResource, change *plans.ResourceInstanceChangeSrc, providerSchema providers.ProviderSchema) bool {
++	depPath := d.String()
++
++	logDebug := func(f string, args ...any) {
++		f = fmt.Sprintf("[DEBUG] planDataSource handleDataDepsChanges: %s/%s: ", n.Addr, depPath) + f
++		log.Printf(f, args...)
++	}
++
++	logDebugAndAllowChange := func(f string, args ...any) bool {
++		f = f + " allow change as pending"
++		logDebug(f, args...)
++		return true
++	}
++
++	providerName := n.Config.Provider.Type
++	if providerName != handleDataSourceChangesProvider {
++		return logDebugAndAllowChange("provider '%s' should not handle changes", providerName)
++	}
++
++	if _, ok := handleDataSourceChangesMetadataResources[depPath]; !ok {
++		return logDebugAndAllowChange("dep should not handle changes")
++	}
++
++	resourceSchema, _ := providerSchema.SchemaForResourceAddr(d.Resource)
++
++	iType := resourceSchema.ImpliedType()
++
++	totalChanges, err := change.DeepCopy().Decode(iType)
++	if err != nil {
++		return logDebugAndAllowChange("cannot decode total changes: %v", err)
++	}
++
++	totalChanges.Before, _ = totalChanges.Before.UnmarkDeep()
++	totalChanges.After, _ = totalChanges.After.UnmarkDeep()
++
++	manifestMap := func(ch cty.Value) (map[string]any, error) {
++		if ch == cty.NilVal {
++			logDebug("change value is null. Returns nil")
++			return nil, nil
++		}
++
++		if ch.IsNull() {
++			logDebug("change value is null. Returns nil")
++			return nil, nil
++		}
++
++		path := cty.Path{
++			cty.GetAttrStep{Name: "manifest"},
++		}
++
++		manifest, err := path.Apply(ch)
++		if err != nil {
++			return nil, fmt.Errorf("cannot apply manifest path change for `%#v`: '%w'", manifest, err)
++		}
++
++		jv := ctyjson.SimpleJSONValue{Value: manifest}
++
++		jb, err := jv.MarshalJSON()
++		if err != nil {
++			return nil, fmt.Errorf("cannot marshal manifest `%#v`: '%w'", manifest, err)
++		}
++
++		var m map[string]any
++
++		err = json.Unmarshal(jb, &m)
++		if err != nil {
++			return nil, fmt.Errorf("cannot unmarshal manifest to map: %w", err)
++		}
++
++		return m, nil
++	}
++
++	beforeManifest, err := manifestMap(totalChanges.Before)
++	if err != nil {
++		return logDebugAndAllowChange("cannot get before manifest: %v", err)
++	}
++
++	afterManifest, err := manifestMap(totalChanges.After)
++	if err != nil {
++		return logDebugAndAllowChange("cannot get after manifest: %v", err)
++	}
++
++	marshalPretty := func(m map[string]any) string {
++		b, err := json.MarshalIndent(m, "", "  ")
++		if err != nil {
++			return fmt.Sprintf("%v", m)
++		}
++
++		return string(b)
++	}
++
++	logDebug(
++		"before manifest:\n%v\nafter manifest:\n%s",
++		marshalPretty(beforeManifest),
++		marshalPretty(afterManifest),
++	)
++
++	diffWithoutFilters := gocmp.Diff(beforeManifest, afterManifest)
++	diffWithFilters := gocmp.Diff(beforeManifest, afterManifest, handleDataSourceChangesMetadataResourcesCompareOpts)
++
++	logDebug(
++		"diff manifests:\nWithout filters:\n%s\nWith filters:\n%s",
++		diffWithoutFilters,
++		diffWithFilters,
++	)
++
++	if diffWithFilters == "" {
++		msg := "have not full diff"
++		if diffWithoutFilters != "" {
++			msg = fmt.Sprintf("have diff only in labels and/or annotations:\n%s", diffWithoutFilters)
++		}
++
++		logDebug("skip mark as pending because %s", msg)
++		return false
++	}
++
++	return logDebugAndAllowChange("have diff not in labels and/or annotations:\n%s\n", diffWithFilters)
 +}
 +
 +func (n *NodeAbstractResourceInstance) handleDataHavePendingDeps(pendingDeps map[string]struct{}) bool {
@@ -92,5 +401,5 @@ diff --git a/internal/tofu/node_resource_abstract_instance.go b/internal/tofu/no
 +	logDebug("all passed skipped deps not not match with %v. Returns have pending deps", pendingDeps)
 +	return true
  }
-
+ 
  // apply deals with the main part of the data resource lifecycle: either

--- a/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/README.md
+++ b/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/README.md
@@ -23,3 +23,21 @@ resources for skip in data sources. Unfortunately we cannot get full diff of dat
 in place when we check deps. Opentofu produce diff change (and re-read) for data source if depended on
 resource has no operations (it called pending update). And now, we are doing our check
 when if we have only one pending dependencies, if has multiple - mark as pending update.
+
+Also, for dvp cloud provider we added skip changes for calculate pending data source deps.
+In this patch we skip changes in labels and annotations.
+We need it because changes in labels and annotations provide pending deps for data sources.
+When opentofu re-read data source, we got full re-read object
+```
+ + object      = (known after apply)
+```
+for ip for example.
+Because we get IP-address for virtual machine from data source, because address will available
+only after full creating (k8s controller set address for resource) and IP-address has in 
+destructive hash for virtual machines and IP data source not fully known before re-reading,
+we get destructive changes for virtual machine.
+Unfortunately, we cannot patch provider, because opentofu makes a decision about
+re-reading data source depends on resource change.
+Also, this changes have direct link to provider. We do not come up with generic solution.
+Generic solution can add some meta-attributes in opentofu data source resource, but it complex
+for implementation.


### PR DESCRIPTION
## Description
We add some labels for cloud resources in dvp-cloud-provider in https://github.com/deckhouse/deckhouse/pull/17267

When upgrade deckhouse to 1.75  these changes provide pending deps for data sources.
When opentofu re-read data source, we got full re-read object
```
 + object      = (known after apply)
```
for ip for example.
Because we get IP-address for virtual machine from data source, because address will available
only after full creating (k8s controller set address for resource) and IP-address has in 
destructive hash for virtual machines and IP data source not fully known before re-reading,
we get destructive changes for virtual machine.
Unfortunately, we cannot patch provider, because opentofu makes a decision about
re-reading data source depends on resource change.
Also, this changes have direct link to provider. We do not come up with generic solution.
Generic solution can add some meta-attributes in opentofu data source resource, but it complex
for implementation.

## Why do we need it, and what problem does it solve?
Destructive changes in control-plane and static nodes after upgrade to 1.75 from 1.74.

## Why do we need it in the patch release (if we do)?
Destructive changes in control-plane and static nodes after upgrade to 1.75 from 1.74.
Backport provide in https://github.com/deckhouse/deckhouse/pull/19080

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: terraform-manager
type: feature
summary: Suppressed destructive changes when updating labels and annotations for cloud resources via OpenTofu.
impact: |
  Unnecessary or destructive plan updates that could occur when updating labels and annotations via OpenTofu should be prevented now. If you encounter unexpected converge plans or cluster bootstrap issues when using OpenTofu-based providers (such as DVP, DynamiX, zVirt, or Yandex), report them to Deckhouse Technical Support.
impact_level: high
---
section: cloud-provider-dvp
type: fix
summary: Suppressed destructive changes when updating labels and annotations for cloud resources via OpenTofu.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
