### PR TITLE
[backport][cloud-provider-dvp][terraform-manager] Suppress destructive changes when add/remove/change labels and annotations for cloud resources via opentofu

### DIFF
--- a/dhctl/pkg/infrastructure/tofu/cmd.go
+++ b/dhctl/pkg/infrastructure/tofu/cmd.go
@@ -71,6 +71,8 @@ func tofuCmd(ctx context.Context, params RunExecutorParams, workingDir string, a
 		fmt.Sprintf("TF_DATA_DIR=%s", dataDir),
 	)
 
+	envs = appendLogEnvs(envs)
+
 	cmd.Env = infraexec.ReplaceHomeDirEnv(envs, params.RootDir)
 
 	// always use dug log for write its to debug log file
@@ -86,4 +88,39 @@ func tofuCmd(ctx context.Context, params RunExecutorParams, workingDir string, a
 	log.DebugF("Tofu Command envs:\n %s\n", strings.Join(cmd.Env, " "))
 
 	return cmd
+}
+
+
+func appendLogEnvs(envs []string) []string {
+	const (
+		coreEnv     = "TF_LOG_CORE"
+		providerEnv = "TF_LOG_PROVIDER"
+	)
+
+	coreVal := "INFO"
+	providerVal := "INFO"
+
+	for _, e := range envs {
+		if strings.HasPrefix(e, coreEnv) {
+			log.DebugF("Found opentofu core log env %s\n", e)
+			coreVal = ""
+			continue
+		}
+
+		if strings.HasPrefix(e, providerEnv) {
+			log.DebugF("Found opentofu provider log env %s\n", e)
+			providerVal = ""
+			continue
+		}
+	}
+
+	if coreVal != "" {
+		envs = append(envs, fmt.Sprintf("%s=%s", coreEnv, coreVal))
+	}
+
+	if providerVal != "" {
+		envs = append(envs, fmt.Sprintf("%s=%s", providerEnv, providerVal))
+	}
+
+	return envs
 }

--- a/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch‎
+++ b/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch‎
@@ -154,7 +154,7 @@ index 0000000000..c4a5ee921f
 +	}
 +}
 diff --git a/internal/tofu/node_resource_abstract_instance.go b/internal/tofu/node_resource_abstract_instance.go
-index 3200163e81..789b0bc9b3 100644
+index 3200163e81..3d53c53006 100644
 --- a/internal/tofu/node_resource_abstract_instance.go
 +++ b/internal/tofu/node_resource_abstract_instance.go
 @@ -6,12 +6,16 @@
@@ -208,8 +208,8 @@ index 3200163e81..789b0bc9b3 100644
 -				return true
 +				if n.allowDataDepsChanges(d, change, providerSchema) {
 +					pendingDeps[d.String()] = struct{}{}
++					break
 +				}
-+				break
  			}
  		}
  	}

--- a/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch‎
+++ b/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/003-skip-some-depends_on-for-data-sources.patch‎
@@ -1,0 +1,405 @@
+diff --git a/internal/tofu/map.go b/internal/tofu/map.go
+new file mode 100644
+index 0000000000..c4a5ee921f
+--- /dev/null
++++ b/internal/tofu/map.go
+@@ -0,0 +1,149 @@
++// got from https://github.com/name212/go-cmp-utils
++// tested in repo
++package tofu
++
++import (
++	"fmt"
++	"regexp"
++
++	"github.com/google/go-cmp/cmp"
++)
++
++type MapPathComparator interface {
++	Compare(indx int, keyPathPart string) bool
++	Parts() int
++}
++
++type MapPath MapPathComparator
++
++func MapKeysFilter(paths ...MapPath) cmp.Option {
++	if len(paths) == 0 {
++		return filterOption(noFilter)
++	}
++
++	filters := make([]filter, 0, len(paths))
++	for _, p := range paths {
++		filters = append(filters, constructFilter(p))
++	}
++
++	composeFilter := func(p cmp.Path) bool {
++		for _, f := range filters {
++			if f(p) {
++				return true
++			}
++		}
++
++		return false
++	}
++
++	return filterOption(composeFilter)
++}
++
++type MapPathStringComparator []string
++
++func NewMapPathStringComparator(parts ...string) MapPathStringComparator {
++	res := make(MapPathStringComparator, 0, len(parts))
++	res = append(res, parts...)
++
++	return res
++}
++
++func (c MapPathStringComparator) Parts() int {
++	return len(c)
++}
++
++func (c MapPathStringComparator) Compare(indx int, keyPathPart string) bool {
++	if indx >= c.Parts() {
++		return false
++	}
++
++	return c[indx] == keyPathPart
++}
++
++type MapPathReComparator []*regexp.Regexp
++
++func NewMapPathReComparator(parts ...string) (MapPathReComparator, error) {
++	res := make(MapPathReComparator, 0, len(parts))
++
++	var errors []error
++	for i, pp := range parts {
++		re, err := regexp.Compile(pp)
++		if err != nil {
++			errors = append(errors, fmt.Errorf("failed to compile part %d: %w", i, err))
++			continue
++		}
++		res = append(res, re)
++	}
++
++	if len(errors) == 0 {
++		return res, nil
++	}
++
++	resError := errors[0]
++	for i := 1; i < len(errors); i++ {
++		resError = fmt.Errorf("%w\n%w", resError, errors[i])
++	}
++
++	return nil, resError
++}
++
++func NewMapPathReComparatorFromRe(parts ...*regexp.Regexp) MapPathReComparator {
++	res := make(MapPathReComparator, 0, len(parts))
++	res = append(res, parts...)
++
++	return res
++}
++
++func (c MapPathReComparator) Parts() int {
++	return len(c)
++}
++
++func (c MapPathReComparator) Compare(indx int, keyPathPart string) bool {
++	if indx >= c.Parts() {
++		return false
++	}
++
++	return c[indx].MatchString(keyPathPart)
++}
++
++type filter = func(p cmp.Path) bool
++
++func noFilter(p cmp.Path) bool {
++	return false
++}
++
++func filterOption(f filter) cmp.Option {
++	return cmp.FilterPath(f, cmp.Ignore())
++}
++
++func constructFilter(path MapPath) filter {
++	l := path.Parts()
++
++	if l == 0 {
++		return noFilter
++	}
++
++	return func(p cmp.Path) bool {
++		if len(p) != 2*l {
++			return false
++		}
++
++		result := true
++
++		for i := range l {
++			num := (2 * i) + 1
++			index, ok := p.Index(num).(cmp.MapIndex)
++			if !ok {
++				result = false
++				break
++			}
++
++			if !path.Compare(i, index.Key().String()) {
++				result = false
++				break
++			}
++		}
++
++		return result
++	}
++}
+diff --git a/internal/tofu/node_resource_abstract_instance.go b/internal/tofu/node_resource_abstract_instance.go
+index 3200163e81..789b0bc9b3 100644
+--- a/internal/tofu/node_resource_abstract_instance.go
++++ b/internal/tofu/node_resource_abstract_instance.go
+@@ -6,12 +6,16 @@
+ package tofu
+ 
+ import (
++	"encoding/json"
+ 	"fmt"
+ 	"log"
++	"os"
+ 	"strings"
+ 
++	gocmp "github.com/google/go-cmp/cmp"
+ 	"github.com/hashicorp/hcl/v2"
+ 	"github.com/zclconf/go-cty/cty"
++	ctyjson "github.com/zclconf/go-cty/cty/json"
+ 
+ 	"github.com/opentofu/opentofu/internal/addrs"
+ 	"github.com/opentofu/opentofu/internal/checks"
+@@ -1844,7 +1848,7 @@ func (n *NodeAbstractResourceInstance) planDataSource(ctx EvalContext, checkRule
+ 	}
+ 
+ 	configKnown := configVal.IsWhollyKnown()
+-	depsPending := n.dependenciesHavePendingChanges(ctx)
++	depsPending := n.dependenciesHavePendingChanges(ctx, providerSchema)
+ 	// If our configuration contains any unknown values, or we depend on any
+ 	// unknown values then we must defer the read to the apply phase by
+ 	// producing a "Read" change for this resource, and a placeholder value for
+@@ -1997,7 +2001,7 @@ func (n *NodeAbstractResourceInstance) nestedInCheckBlock() (*configs.Check, boo
+ // receiver depends on has a change pending in the plan, in which case we'd
+ // need to override the usual behavior of immediately reading from the data
+ // source where possible, and instead defer the read until the apply step.
+-func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalContext) bool {
++func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalContext, providerSchema providers.ProviderSchema) bool {
+ 	nModInst := n.Addr.Module
+ 	nMod := nModInst.Module()
+ 
+@@ -2018,6 +2022,8 @@ func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalCo
+ 		}
+ 	}
+ 
++	pendingDeps := make(map[string]struct{})
++
+ 	for _, d := range depsToUse {
+ 		if d.Resource.Mode == addrs.DataResourceMode {
+ 			// Data sources have no external side effects, so they pose a need
+@@ -2041,11 +2047,199 @@ func (n *NodeAbstractResourceInstance) dependenciesHavePendingChanges(ctx EvalCo
+ 			}
+ 
+ 			if change != nil && change.Action != plans.NoOp {
+-				return true
++				if n.allowDataDepsChanges(d, change, providerSchema) {
++					pendingDeps[d.String()] = struct{}{}
++				}
++				break
+ 			}
+ 		}
+ 	}
+-	return false
++
++	return n.handleDataHavePendingDeps(pendingDeps)
++}
++
++var (
++	handleDataSourceChangesProvider          = "kubernetes"
++	handleDataSourceChangesMetadataResources = map[string]struct{}{
++		"module.additional-disk.kubernetes_manifest.additional_disk":           {},
++		"module.ipv4-address.kubernetes_manifest.ipv4_address":                 {},
++		"module.kubernetes-data-disk.kubernetes_manifest.kubernetes-data-disk": {},
++		"module.master.kubernetes_manifest.vm":                                 {},
++		"module.static-node.kubernetes_manifest.vm":                            {},
++	}
++	handleDataSourceChangesMetadataResourcesCompareOpts = MapKeysFilter(
++		NewMapPathStringComparator("metadata", "annotations"),
++		NewMapPathStringComparator("metadata", "labels"),
++	)
++)
++
++func (n *NodeAbstractResourceInstance) allowDataDepsChanges(d addrs.ConfigResource, change *plans.ResourceInstanceChangeSrc, providerSchema providers.ProviderSchema) bool {
++	depPath := d.String()
++
++	logDebug := func(f string, args ...any) {
++		f = fmt.Sprintf("[DEBUG] planDataSource handleDataDepsChanges: %s/%s: ", n.Addr, depPath) + f
++		log.Printf(f, args...)
++	}
++
++	logDebugAndAllowChange := func(f string, args ...any) bool {
++		f = f + " allow change as pending"
++		logDebug(f, args...)
++		return true
++	}
++
++	providerName := n.Config.Provider.Type
++	if providerName != handleDataSourceChangesProvider {
++		return logDebugAndAllowChange("provider '%s' should not handle changes", providerName)
++	}
++
++	if _, ok := handleDataSourceChangesMetadataResources[depPath]; !ok {
++		return logDebugAndAllowChange("dep should not handle changes")
++	}
++
++	resourceSchema, _ := providerSchema.SchemaForResourceAddr(d.Resource)
++
++	iType := resourceSchema.ImpliedType()
++
++	totalChanges, err := change.DeepCopy().Decode(iType)
++	if err != nil {
++		return logDebugAndAllowChange("cannot decode total changes: %v", err)
++	}
++
++	totalChanges.Before, _ = totalChanges.Before.UnmarkDeep()
++	totalChanges.After, _ = totalChanges.After.UnmarkDeep()
++
++	manifestMap := func(ch cty.Value) (map[string]any, error) {
++		if ch == cty.NilVal {
++			logDebug("change value is null. Returns nil")
++			return nil, nil
++		}
++
++		if ch.IsNull() {
++			logDebug("change value is null. Returns nil")
++			return nil, nil
++		}
++
++		path := cty.Path{
++			cty.GetAttrStep{Name: "manifest"},
++		}
++
++		manifest, err := path.Apply(ch)
++		if err != nil {
++			return nil, fmt.Errorf("cannot apply manifest path change for `%#v`: '%w'", manifest, err)
++		}
++
++		jv := ctyjson.SimpleJSONValue{Value: manifest}
++
++		jb, err := jv.MarshalJSON()
++		if err != nil {
++			return nil, fmt.Errorf("cannot marshal manifest `%#v`: '%w'", manifest, err)
++		}
++
++		var m map[string]any
++
++		err = json.Unmarshal(jb, &m)
++		if err != nil {
++			return nil, fmt.Errorf("cannot unmarshal manifest to map: %w", err)
++		}
++
++		return m, nil
++	}
++
++	beforeManifest, err := manifestMap(totalChanges.Before)
++	if err != nil {
++		return logDebugAndAllowChange("cannot get before manifest: %v", err)
++	}
++
++	afterManifest, err := manifestMap(totalChanges.After)
++	if err != nil {
++		return logDebugAndAllowChange("cannot get after manifest: %v", err)
++	}
++
++	marshalPretty := func(m map[string]any) string {
++		b, err := json.MarshalIndent(m, "", "  ")
++		if err != nil {
++			return fmt.Sprintf("%v", m)
++		}
++
++		return string(b)
++	}
++
++	logDebug(
++		"before manifest:\n%v\nafter manifest:\n%s",
++		marshalPretty(beforeManifest),
++		marshalPretty(afterManifest),
++	)
++
++	diffWithoutFilters := gocmp.Diff(beforeManifest, afterManifest)
++	diffWithFilters := gocmp.Diff(beforeManifest, afterManifest, handleDataSourceChangesMetadataResourcesCompareOpts)
++
++	logDebug(
++		"diff manifests:\nWithout filters:\n%s\nWith filters:\n%s",
++		diffWithoutFilters,
++		diffWithFilters,
++	)
++
++	if diffWithFilters == "" {
++		msg := "have not full diff"
++		if diffWithoutFilters != "" {
++			msg = fmt.Sprintf("have diff only in labels and/or annotations:\n%s", diffWithoutFilters)
++		}
++
++		logDebug("skip mark as pending because %s", msg)
++		return false
++	}
++
++	return logDebugAndAllowChange("have diff not in labels and/or annotations:\n%s\n", diffWithFilters)
++}
++
++func (n *NodeAbstractResourceInstance) handleDataHavePendingDeps(pendingDeps map[string]struct{}) bool {
++	logDebug := func(f string, args ...any) {
++		f = fmt.Sprintf("[DEBUG] planDataSource: %s handleDataHavePendingDeps: ", n.Addr) + f
++		log.Printf(f, args...)
++	}
++
++	withDefaultCheck := func(f string, args ...any) bool {
++		res := len(pendingDeps) > 0
++		f = f + fmt.Sprintf(" use default check result %v; pending deps %v", res, pendingDeps)
++		logDebug(f, args...)
++		return res
++	}
++
++	providerName := n.Config.Provider.Type
++
++	envProvider := strings.TrimSpace(os.Getenv("TF_SKIP_DEPS_FOR_DATA_SOURCES_PROVIDER"))
++	if envProvider == "" || envProvider != providerName {
++		return withDefaultCheck("provider '%s' not provided or not match with '%s'", envProvider, providerName)
++	}
++
++	logDebug("should handle skip deps for provider %s", providerName)
++
++	if len(pendingDeps) != 1 {
++		return withDefaultCheck("have no one pending deps")
++	}
++
++	skipDepsStr := os.Getenv("TF_SKIP_DEPS_FOR_DATA_SOURCES")
++	skipDepsRaw := strings.Split(skipDepsStr, ";")
++	skippedDeps := make([]string, 0, len(skipDepsRaw))
++	for _, dep := range skipDepsRaw {
++		if trimmed := strings.TrimSpace(dep); trimmed != "" {
++			skippedDeps = append(skippedDeps, trimmed)
++		}
++	}
++
++	if len(skippedDeps) == 0 {
++		return withDefaultCheck("parse zero deps from env '%s'", skipDepsStr)
++	}
++
++	for _, dep := range skippedDeps {
++		if _, ok := pendingDeps[dep]; ok {
++			logDebug("found dep for skip: '%s'. Returns do not have pending deps", dep)
++			return false
++		}
++	}
++
++	logDebug("all passed skipped deps not not match with %v. Returns have pending deps", pendingDeps)
++	return true
+ }
+ 
+ // apply deals with the main part of the data resource lifecycle: either

--- a/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/README.md
+++ b/modules/040-terraform-manager/images/base-terraform-manager/patches/opentofu/README.md
@@ -8,3 +8,36 @@ By default, opentofu persists state every 20 seconds.
 And it is minimum if we try to redeclare with env opentofu
 will return error. We set default to 0 and remove additional
 checks for this duration.
+
+## 003-skip-some-depends_on-for-data-sources.patch
+
+In some cases, when we add new resource to depends_on meta-argument, we can get
+destructive changes. For example, when we added `kubernetes_resource_ready_v1` resource
+to cloud provider dvp we should add this resource as dependency to data source, otherwise
+opentofu reads not ready resource. In updating deckhouse, user could get destructive plan 
+with recreating all vm's. To avoid it, we patched opentofu.
+In this patch, we provide `TF_SKIP_DEPS_FOR_DATA_SOURCES_PROVIDER` for filter providers that
+use skipping depend on's in data sources (now we need it in dvp, and we should not affect another
+providers). Also, we handle `TF_SKIP_DEPS_FOR_DATA_SOURCES` that contains `;` separated
+resources for skip in data sources. Unfortunately we cannot get full diff of data source
+in place when we check deps. Opentofu produce diff change (and re-read) for data source if depended on
+resource has no operations (it called pending update). And now, we are doing our check
+when if we have only one pending dependencies, if has multiple - mark as pending update.
+
+Also, for dvp cloud provider we added skip changes for calculate pending data source deps.
+In this patch we skip changes in labels and annotations.
+We need it because changes in labels and annotations provide pending deps for data sources.
+When opentofu re-read data source, we got full re-read object
+```
+ + object      = (known after apply)
+```
+for ip for example.
+Because we get IP-address for virtual machine from data source, because address will available
+only after full creating (k8s controller set address for resource) and IP-address has in 
+destructive hash for virtual machines and IP data source not fully known before re-reading,
+we get destructive changes for virtual machine.
+Unfortunately, we cannot patch provider, because opentofu makes a decision about
+re-reading data source depends on resource change.
+Also, this changes have direct link to provider. We do not come up with generic solution.
+Generic solution can add some meta-attributes in opentofu data source resource, but it complex
+for implementation.


### PR DESCRIPTION
## Description
Backport of https://github.com/deckhouse/deckhouse/pull/19079

Also, backport changes for enable different log level for opentofu core and providers for debugging
porposes.

## Why do we need it, and what problem does it solve?
See here https://github.com/deckhouse/deckhouse/pull/19079

## Why do we need it in the patch release (if we do)?
Destructive changes in control-plane and static nodes after upgrade to 1.75 from 1.74.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: terraform-manager
type: feature
summary: Suppress destructive changes when add/remove/change labels and annotations for cloud resources via opentofu.
impact: |
  These changes prevent unnecessary or destructive plan updates that could occur when data sources depend on changing labels and annotations. The behavior of other cloud providers is not affected.
  If you encounter unexpected converge plans or cluster bootstrap issues when using OpenTofu-based providers (such as dvp, dynamics, zvirt, or yandex), please report them to Deckhouse Technical Support.
impact_level: high
---
section: cloud-provider-dvp
type: fix
summary: Suppress destructive changes when add/remove/change labels and annotations for cloud resources via opentofu.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
