### PR TITLE
[user-authn] fixed openapi test in cse

### DIFF
--- a/.werf/werf-test.yaml
+++ b/.werf/werf-test.yaml
@@ -105,6 +105,9 @@ import:
   add: /images_digests.json
   to: /deckhouse/modules/040-node-manager/images_digests.json
   after: setup
-shell:
-  beforeInstall:
-  - touch $HOME/.ack-ginkgo-rc
+git:
+- add: /tools/mounts/mountfile
+  to: /root/.ack-ginkgo-rc
+  stageDependencies:
+    setup:
+    - "**/*"

--- a/.werf/werf-test.yaml
+++ b/.werf/werf-test.yaml
@@ -105,3 +105,6 @@ import:
   add: /images_digests.json
   to: /deckhouse/modules/040-node-manager/images_digests.json
   after: setup
+shell:
+  beforeInstall:
+  - touch $HOME/.ack-ginkgo-rc

--- a/ee/cse/modules/150-user-authn/openapi/openapi-case-tests.yaml
+++ b/ee/cse/modules/150-user-authn/openapi/openapi-case-tests.yaml
@@ -1,1 +1,6 @@
-../../../../../modules/150-user-authn/openapi/openapi-case-tests.yaml
+# Test stub. The directory does not contain config-values.yaml, but the tests require a check for all openapi directories.
+positive:
+  configValues:
+  - {}
+  values:
+  - { internal: {} }

--- a/ee/cse/modules/150-user-authn/openapi/openapi-case-tests.yaml
+++ b/ee/cse/modules/150-user-authn/openapi/openapi-case-tests.yaml
@@ -1,0 +1,1 @@
+../../../../../modules/150-user-authn/openapi/openapi-case-tests.yaml

--- a/testing/openapi_cases/openapi_cases_test.go
+++ b/testing/openapi_cases/openapi_cases_test.go
@@ -35,6 +35,7 @@ func TestOpenAPICases(t *testing.T) {
 }
 
 var _ = Describe("OpenAPI case tests", func() {
+	defer GinkgoRecover()
 	var err error
 
 	openAPIDirs, err := GetAllOpenAPIDirs()


### PR DESCRIPTION
## Description

1. Tests for openapi were missing in [pr](https://github.com/deckhouse/deckhouse/pull/19042). They have been added in this PR.
2. A GinkgoRecover handler has been added to `testing/openapi_cases/openapi_cases_test.go` to catch errors and log them in the test logs.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
grading tests.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix 
summary: fixed openapi test in cse
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
