### PR TITLE
[cloud-provider-vcd] fix vCD CCM TCP health monitors removal

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/006-fix-lb-health-monitor.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/006-fix-lb-health-monitor.patch
@@ -1,0 +1,19 @@
+Subject: [PATCH] use protocol instead of app protocol for health monitor type (#376)
+---
+Index: pkg/ccm/loadbalancer.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/ccm/loadbalancer.go b/pkg/ccm/loadbalancer.go
+--- a/pkg/ccm/loadbalancer.go	(revision 2d6e9efaf23df037d4cb1d58484bf04b3f2b8935)
++++ b/pkg/ccm/loadbalancer.go	(revision 8a396644e992ee76f534eb9f25e9eed7fbf9e352)
+@@ -165,6 +166,8 @@
+ 		typeToExternalPort[strings.ToLower(port.Name)] = port.Port
+ 		if port.AppProtocol != nil {
+ 			nameToProtocol[strings.ToLower(port.Name)] = strings.ToUpper(*port.AppProtocol)
++		} else {
++			nameToProtocol[strings.ToLower(port.Name)] = strings.ToUpper(string(port.Protocol))
+ 		}
+ 	}
+ 	return typeToInternalPort, typeToExternalPort, nameToProtocol

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/README.md
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/patches/README.md
@@ -67,3 +67,13 @@ Files:
 Changes:
 
 - Add support for searching vAppTemplates in a given org
+
+### 006-fix-lb-health-monitor.patch
+
+Files:
+
+- pkg/ccm/loadbalancer.go
+
+Changes:
+
+- Fixes TCP health monitors removal during an update of the pool

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/patches/006-fix-lb-health-monitor.patch
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/patches/006-fix-lb-health-monitor.patch
@@ -1,0 +1,19 @@
+Subject: [PATCH] use protocol instead of app protocol for health monitor type (#376)
+---
+Index: pkg/ccm/loadbalancer.go
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/pkg/ccm/loadbalancer.go b/pkg/ccm/loadbalancer.go
+--- a/pkg/ccm/loadbalancer.go	(revision 2d6e9efaf23df037d4cb1d58484bf04b3f2b8935)
++++ b/pkg/ccm/loadbalancer.go	(revision 8a396644e992ee76f534eb9f25e9eed7fbf9e352)
+@@ -165,6 +166,8 @@
+ 		typeToExternalPort[strings.ToLower(port.Name)] = port.Port
+ 		if port.AppProtocol != nil {
+ 			nameToProtocol[strings.ToLower(port.Name)] = strings.ToUpper(*port.AppProtocol)
++		} else {
++			nameToProtocol[strings.ToLower(port.Name)] = strings.ToUpper(string(port.Protocol))
+ 		}
+ 	}
+ 	return typeToInternalPort, typeToExternalPort, nameToProtocol

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/patches/README.md
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/patches/README.md
@@ -23,3 +23,7 @@ Update klog to klog/v2 in other files
 ### 005-add-vapptemplate-search-by-org.patch
 
 Add support for searching vAppTemplates in a given org
+
+### 006-fix-lb-health-monitor.patch
+
+Fixes TCP health monitors removal during an update of the pool


### PR DESCRIPTION
## Description
vCD CCM patch fix for TCP health monitor (health check). 

## Why do we need it, and what problem does it solve?
This PR fixes TCP health check removal from the load balancer in VCD on node addition/removal
See https://github.com/vmware-archive/cloud-provider-for-cloud-director/issues/281

## Why do we need it in the patch release (if we do)?

Customer’s request 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: fix vCD CCM TCP health monitors removal
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
