### PR TITLE
[docs] Update hugepages example at sdn documentation

### DIFF
--- a/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE.md
+++ b/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE.md
@@ -484,6 +484,8 @@ kind: NodeGroupConfiguration
 metadata:
   name: hugepages-for-dpdk
 spec:
+  bundles:
+    - '*'  # Apply to all OS bundles.
   nodeGroups:
     - "*"  # Apply to all node groups.
   weight: 100

--- a/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE.md
+++ b/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE.md
@@ -485,7 +485,7 @@ metadata:
   name: hugepages-for-dpdk
 spec:
   bundles:
-    - '*'  # Apply to all OS bundles.
+    - "*"  # Apply to all OS bundles.
   nodeGroups:
     - "*"  # Apply to all node groups.
   weight: 100

--- a/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE_RU.md
+++ b/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE_RU.md
@@ -486,6 +486,8 @@ kind: NodeGroupConfiguration
 metadata:
   name: hugepages-for-dpdk
 spec:
+  bundles:
+    - '*'  # Применить ко всем bundle'ам ОС.
   nodeGroups:
     - '*'  # Применить ко всем группам узлов.
   weight: 100

--- a/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE_RU.md
+++ b/docs/documentation/pages/admin/configuration/network/sdn/CONFIGURE_RU.md
@@ -487,9 +487,9 @@ metadata:
   name: hugepages-for-dpdk
 spec:
   bundles:
-    - '*'  # Применить ко всем bundle'ам ОС.
+    - "*"  # Применить ко всем bundle'ам ОС.
   nodeGroups:
-    - '*'  # Применить ко всем группам узлов.
+    - "*"  # Применить ко всем группам узлов.
   weight: 100
   content: |
     #!/bin/bash


### PR DESCRIPTION
## Description
Updated hugepages example at sdn documentation.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Updated hugepages example at sdn documentation.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
