### PR TITLE
[backport][dhctl] Use internal node ip if bastion ip was passed in converge

### DIFF
--- a/dhctl/pkg/infrastructure/pipeline.go
+++ b/dhctl/pkg/infrastructure/pipeline.go
@@ -30,6 +30,12 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
+const (
+	masterSSHIPOutputKey    = "master_ip_address_for_ssh"
+	nodeInternalIPOutputKey = "node_internal_ip_address"
+	kubeDataPathOutputKey   = "kubernetes_data_device_path"
+)
+
 type PipelineOutputs struct {
 	InfrastructureState []byte
 	CloudDiscovery      []byte
@@ -53,26 +59,45 @@ func equalArray(a, b []string) bool {
 	return true
 }
 
-func GetMasterIPAddressForSSH(ctx context.Context, statePath string, executor OutputExecutor) (string, error) {
-	result, err := executor.Output(ctx, statePath, "master_ip_address_for_ssh")
+type OutputMasterIPs struct {
+	SSH      string
+	Internal string
+}
 
-	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
-			err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
+func GetMasterIPAddressForSSH(ctx context.Context, statePath string, executor OutputExecutor) (*OutputMasterIPs, error) {
+	res := OutputMasterIPs{}
+
+	outputs := map[string]*string{
+		masterSSHIPOutputKey:    &res.SSH,
+		nodeInternalIPOutputKey: &res.Internal,
+	}
+
+	for k, v := range outputs {
+		result, err := executor.Output(ctx, statePath, k)
+		if err != nil {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
+				err = fmt.Errorf("%s\n%v", string(ee.Stderr), err)
+			}
+			if matchNoOutput(err.Error()) {
+				*v = ""
+				continue
+			}
+
+			return nil, fmt.Errorf("Cannot extract infrastructure output for '%s': %w", k, err)
 		}
 
-		return "", fmt.Errorf("failed to get infrastructure output for 'master_ip_address_for_ssh'\n%v", err)
+		var output string
+
+		err = json.Unmarshal(result, &output)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to unmarshal infrastructure output for '%s': %w", k, err)
+		}
+
+		*v = output
 	}
 
-	var output string
-
-	err = json.Unmarshal(result, &output)
-	if err != nil {
-		return "", fmt.Errorf("failed to unmarshal infrastructure output for 'master_ip_address_for_ssh'\n%v", err)
-	}
-
-	return output, nil
+	return &res, nil
 }
 
 func ApplyPipeline(
@@ -301,17 +326,17 @@ func GetBaseInfraResult(ctx context.Context, r RunnerInterface) (*PipelineOutput
 }
 
 func GetMasterNodeResult(ctx context.Context, r RunnerInterface) (*PipelineOutputs, error) {
-	masterIPAddressForSSH, err := getStringOrIntOutput(ctx, r, "master_ip_address_for_ssh")
+	masterIPAddressForSSH, err := getStringOrIntOutput(ctx, r, masterSSHIPOutputKey)
 	if err != nil {
 		return nil, err
 	}
 
-	nodeInternalIP, err := getStringOrIntOutput(ctx, r, "node_internal_ip_address")
+	nodeInternalIP, err := getStringOrIntOutput(ctx, r, nodeInternalIPOutputKey)
 	if err != nil {
 		return nil, err
 	}
 
-	kubernetesDataDevicePath, err := getStringOrIntOutput(ctx, r, "kubernetes_data_device_path")
+	kubernetesDataDevicePath, err := getStringOrIntOutput(ctx, r, kubeDataPathOutputKey)
 	if err != nil {
 		return nil, err
 	}
@@ -336,9 +361,9 @@ func GetMasterNodeResult(ctx context.Context, r RunnerInterface) (*PipelineOutpu
 func GetMasterNodeResultNoStrict(ctx context.Context, r RunnerInterface) (*PipelineOutputs, error) {
 	res := &PipelineOutputs{}
 	toReceive := map[string]*string{
-		"master_ip_address_for_ssh":   &res.MasterIPForSSH,
-		"node_internal_ip_address":    &res.NodeInternalIP,
-		"kubernetes_data_device_path": &res.KubeDataDevicePath,
+		masterSSHIPOutputKey:    &res.MasterIPForSSH,
+		nodeInternalIPOutputKey: &res.NodeInternalIP,
+		kubeDataPathOutputKey:   &res.KubeDataDevicePath,
 	}
 
 	for k, dest := range toReceive {

--- a/dhctl/pkg/infrastructureprovider/piplines_test.go
+++ b/dhctl/pkg/infrastructureprovider/piplines_test.go
@@ -36,18 +36,6 @@ func TestPipelineGetMasterOutputsNoStrict(t *testing.T) {
 		t.Skipf("Skipping %s test", testName)
 	}
 
-	getMetaConfig := func(t *testing.T, providerName, layout string) *config.MetaConfig {
-		cfg := &config.MetaConfig{}
-		cfg.ProviderName = providerName
-		cfg.ClusterPrefix = "test"
-		cfg.Layout = layout
-		if providerName != "" {
-			cfg.UUID = "fb6dfa1c-93fd-11f0-9697-efd55958d098"
-		}
-
-		return cfg
-	}
-
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
 		testCleanup(t, testName, &params)
@@ -216,7 +204,7 @@ func TestPipelineGetMasterOutputsNoStrict(t *testing.T) {
 	}
 
 	t.Run("Tofu", func(t *testing.T) {
-		providerYandexMetaConfig := getMetaConfig(t, yandex.ProviderName, yandexTestLayout)
+		providerYandexMetaConfig := metaConfigForPipelineTest(yandex.ProviderName, yandexTestLayout)
 		providerYandex, err := getter(ctx, providerYandexMetaConfig)
 		require.NoError(t, err, "should provide meta config")
 
@@ -231,7 +219,7 @@ func TestPipelineGetMasterOutputsNoStrict(t *testing.T) {
 	})
 
 	t.Run("Terraform", func(t *testing.T) {
-		cfgProviderGCP := getMetaConfig(t, gcp.ProviderName, gcpTestLayout)
+		cfgProviderGCP := metaConfigForPipelineTest(gcp.ProviderName, gcpTestLayout)
 		providerGCP, err := getter(ctx, cfgProviderGCP)
 		require.NoError(t, err, "should provide meta config")
 
@@ -244,4 +232,169 @@ func TestPipelineGetMasterOutputsNoStrict(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestPipelineGetMasterIPs(t *testing.T) {
+	testName := "TestPipelineGetMasterIPs"
+
+	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
+		t.Skipf("Skipping %s test", testName)
+	}
+
+	params := getTestCloudProviderGetterParams(t, testName)
+	defer func() {
+		testCleanup(t, testName, &params)
+	}()
+
+	getter := CloudProviderGetter(params)
+
+	ctx := context.TODO()
+
+	type testCase struct {
+		name      string
+		hasError  bool
+		statePath string
+		expected  *infrastructure.OutputMasterIPs
+	}
+
+	assertOutputs := func(c testCase, e infrastructure.OutputExecutor) {
+		fullPath, err := filepath.Abs(c.statePath)
+		require.NoError(t, err, "abs path")
+
+		outputs, err := infrastructure.GetMasterIPAddressForSSH(ctx, fullPath, e)
+		if c.hasError {
+			require.Error(t, err, "should error")
+			return
+		}
+
+		require.NoError(t, err, "should not error")
+		require.Equal(t, c.expected, outputs, "should return correct outputs")
+	}
+
+	fullExpected := &infrastructure.OutputMasterIPs{
+		SSH:      "1.1.1.1",
+		Internal: "10.12.0.112",
+	}
+
+	emptyExpected := &infrastructure.OutputMasterIPs{
+		SSH:      "",
+		Internal: "",
+	}
+
+	cases := []testCase{
+		{
+			name:      "all present",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/all_present.json",
+			expected:  fullExpected,
+		},
+		{
+			name:      "ssh not present",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/ssh_not_present.json",
+			expected: &infrastructure.OutputMasterIPs{
+				SSH:      "",
+				Internal: fullExpected.Internal,
+			},
+		},
+		{
+			name:      "node internal not present",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/node_internal_not_present.json",
+			expected: &infrastructure.OutputMasterIPs{
+				SSH:      fullExpected.SSH,
+				Internal: "",
+			},
+		},
+		{
+			name:      "node internal only present",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/node_internal_only_present.json",
+			expected: &infrastructure.OutputMasterIPs{
+				SSH:      "",
+				Internal: fullExpected.Internal,
+			},
+		},
+		{
+			name:      "ssh ip only present",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/ssh_only_present.json",
+			expected: &infrastructure.OutputMasterIPs{
+				SSH:      fullExpected.SSH,
+				Internal: "",
+			},
+		},
+		{
+			name:      "no outputs",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/no_outputs.json",
+			expected:  emptyExpected,
+		},
+		{
+			name:      "no outputs key",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/no_outputs_key.json",
+			expected:  emptyExpected,
+		},
+		{
+			name:      "empty state",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/empty.json",
+			expected:  emptyExpected,
+		},
+
+		{
+			name:      "not exists file",
+			hasError:  false,
+			statePath: "./mocks/pipeline/nostrict/not_exists_yg65.json",
+			expected:  emptyExpected,
+		},
+		{
+			name:      "incorrect state",
+			hasError:  true,
+			statePath: "./mocks/pipeline/nostrict/incorrect_state.json",
+		},
+	}
+
+	t.Run("Tofu", func(t *testing.T) {
+		providerYandexMetaConfig := metaConfigForPipelineTest(yandex.ProviderName, yandexTestLayout)
+		providerYandex, err := getter(ctx, providerYandexMetaConfig)
+		require.NoError(t, err, "should provide meta config")
+
+		executor, err := providerYandex.Executor(ctx, infrastructure.MasterNodeStep, params.Logger)
+		require.NoError(t, err, "should create executor")
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				assertOutputs(c, executor)
+			})
+		}
+	})
+
+	t.Run("Terraform", func(t *testing.T) {
+		cfgProviderGCP := metaConfigForPipelineTest(gcp.ProviderName, gcpTestLayout)
+		providerGCP, err := getter(ctx, cfgProviderGCP)
+		require.NoError(t, err, "should provide meta config")
+
+		executor, err := providerGCP.Executor(ctx, infrastructure.MasterNodeStep, params.Logger)
+		require.NoError(t, err, "should create executor")
+
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				assertOutputs(c, executor)
+			})
+		}
+	})
+}
+
+func metaConfigForPipelineTest(providerName, layout string) *config.MetaConfig {
+	cfg := &config.MetaConfig{}
+	cfg.ProviderName = providerName
+	cfg.ClusterPrefix = "test"
+	cfg.Layout = layout
+	if providerName != "" {
+		cfg.UUID = "fb6dfa1c-93fd-11f0-9697-efd55958d098"
+	}
+
+	return cfg
 }

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -344,58 +344,29 @@ func (s *KubeClientSwitcher) replaceKubeClient(ctx context.Context, params repla
 		return err
 	}
 
-	tmpDir, err := s.tmpDirForConverger()
-	if err != nil {
-		return err
-	}
-
 	settings := sshCl.Session()
 
 	availableHosts := make([]session.Host, 0, len(params.state))
 
-	suff := rand.NewSource(time.Now().UnixNano()).Int63()
+	ipExtractor, err := newSSHIPExtractor(s)
+	if err != nil {
+		return err
+	}
 
 	for nodeName, stateBytes := range params.state {
-		metaConfig, err := s.ctx.MetaConfig()
-		if err != nil {
-			return fmt.Errorf("failed to get meta config for node %s: %w", nodeName, err)
-		}
-
-		statePath := filepath.Join(tmpDir, fmt.Sprintf("%s-%d.tfstate", nodeName, suff))
-
-		s.debug("for extracting statePath: %s", statePath)
-
-		err = os.WriteFile(statePath, stateBytes, 0o644)
-		if err != nil {
-			return fmt.Errorf("failed to write infrastructure state: %w", err)
-		}
-
-		providerGetter := infrastructureprovider.CloudProviderGetter(infrastructureprovider.CloudProviderGetterParams{
-			TmpDir:           tmpDir,
-			AdditionalParams: cloud.ProviderAdditionalParams{},
-			Logger:           s.logger,
-			IsDebug:          s.params.IsDebug,
+		ip, err := ipExtractor.getIPForSSH(s.ctx.Ctx(), &sshIPExtractorParams{
+			nodeName: nodeName,
+			state:    stateBytes,
+			settings: settings,
 		})
 
-		// yes working dir for output is not required
-		provider, err := providerGetter(s.ctx.Ctx(), metaConfig)
 		if err != nil {
-			return fmt.Errorf("Failed to create executor for node %s: %w", nodeName, err)
+			return err
 		}
 
-		executor, _ := provider.OutputExecutor(s.ctx.Ctx(), s.logger)
-
-		// do not cleanup provider after getting output executor!
-
-		ipAddress, err := infrastructure.GetMasterIPAddressForSSH(s.ctx.Ctx(), statePath, executor)
-		if err != nil {
-			s.warn("Failed to get master IP address: %v", err)
-			continue
+		if ip != "" {
+			availableHosts = append(availableHosts, session.Host{Host: ip, Name: nodeName})
 		}
-
-		availableHosts = append(availableHosts, session.Host{Host: ipAddress, Name: nodeName})
-
-		s.debug("Extracted ip address %s and node name: %s", ipAddress, nodeName)
 	}
 
 	if len(availableHosts) == 0 {
@@ -676,4 +647,128 @@ func (s *KubeClientSwitcher) warn(f string, args ...any) {
 
 func (s *KubeClientSwitcher) debugStartOperation(action string) {
 	s.debug("Starting %s", strings.ToLower(action))
+}
+
+type sshIPExtractorParams struct {
+	nodeName string
+	state    []byte
+	settings *session.Session
+}
+
+type sshIPExtractor struct {
+	switcher *KubeClientSwitcher
+	tmpDir   string
+	suffix   string
+}
+
+func newSSHIPExtractor(s *KubeClientSwitcher) (*sshIPExtractor, error) {
+	tmpDir, err := s.tmpDirForConverger()
+	if err != nil {
+		return nil, err
+	}
+
+	suff := rand.NewSource(time.Now().UnixNano()).Int63()
+
+	return &sshIPExtractor{
+		switcher: s,
+		tmpDir:   tmpDir,
+		suffix:   fmt.Sprintf("%d", suff),
+	}, nil
+}
+
+func (e *sshIPExtractor) getIPForSSH(ctx context.Context, params *sshIPExtractorParams) (string, error) {
+	executor, err := e.getExecutor(ctx, params)
+	if err != nil {
+		return "", err
+	}
+
+	// do not cleanup provider after getting output executor!
+
+	statePath, err := e.prepareState(params)
+	if err != nil {
+		return "", err
+	}
+
+	nodeName := params.nodeName
+
+	addresses, err := infrastructure.GetMasterIPAddressForSSH(ctx, statePath, executor)
+	if err != nil {
+		e.switcher.warn(
+			"Cannot extract ips for node '%s':\n%v\nSkip adding node to ssh client",
+			nodeName,
+			err,
+		)
+		return "", nil
+	}
+
+	sshIP := addresses.SSH
+	internal := addresses.Internal
+
+	if sshIP == "" && internal == "" {
+		e.switcher.warn("IPs for node '%s' not found. Skip adding node to ssh client", nodeName)
+		return "", nil
+	}
+
+	bastion := params.settings.BastionHost
+
+	if bastion != "" {
+		e.switcher.debug(
+			"Use node internal ip '%s' for node %s because bastion host '%s' was passed",
+			internal,
+			nodeName,
+			bastion,
+		)
+
+		return internal, nil
+	}
+
+	e.switcher.debug("Use direct ssh ip '%s' for node %s", sshIP, nodeName)
+
+	return sshIP, nil
+}
+
+func (e *sshIPExtractor) getExecutor(ctx context.Context, params *sshIPExtractorParams) (infrastructure.OutputExecutor, error) {
+	nodeName := params.nodeName
+
+	metaConfig, err := e.switcher.ctx.MetaConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get meta config for node %s: %w", nodeName, err)
+	}
+
+	logger := e.switcher.logger
+
+	providerGetter := infrastructureprovider.CloudProviderGetter(infrastructureprovider.CloudProviderGetterParams{
+		TmpDir:           e.tmpDir,
+		AdditionalParams: cloud.ProviderAdditionalParams{},
+		Logger:           logger,
+		IsDebug:          e.switcher.params.IsDebug,
+	})
+
+	// yes working dir for output is not required
+	provider, err := providerGetter(ctx, metaConfig)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create executor for node %s: %w", nodeName, err)
+	}
+
+	executor, err := provider.OutputExecutor(ctx, logger)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot get output executor for node %s: %w", nodeName, err)
+	}
+
+	return executor, nil
+}
+
+func (e *sshIPExtractor) prepareState(params *sshIPExtractorParams) (string, error) {
+	nodeName := params.nodeName
+
+	statePath := filepath.Join(e.tmpDir, fmt.Sprintf("%s-%s.tfstate", nodeName, e.suffix))
+
+	e.switcher.debug("State path for extracting ip for node %s: %s", nodeName, statePath)
+
+	err := os.WriteFile(statePath, params.state, 0o644)
+	if err != nil {
+		return "", fmt.Errorf("Failed to write infrastructure state for %s in %s: %w", nodeName, statePath, err)
+	}
+
+	return statePath, nil
 }


### PR DESCRIPTION
## Description
Backport  #18979

## Why do we need it, and what problem does it solve?
Backport  #18979

## Why do we need it in the patch release (if we do)?

Do not converge clusters when delete public IP from control-plane-nodes.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Use internal node ip if bastion ip was passed in converge.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
