### PR TITLE
[node-manager] Optimize node-controller cache resources usage.

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/cmd/main.go
+++ b/modules/040-node-manager/images/node-controller/src/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -86,9 +87,16 @@ func main() {
 		Cache: cache.Options{
 			DefaultTransform: cache.TransformStripManagedFields(),
 			ByObject: map[client.Object]cache.ByObject{
+				// Only cache the single secret needed by the conversion webhook.
+				// Previously all secrets in kube-system were cached, pulling in
+				// Helm release secrets and other heavy objects unnecessarily.
 				&corev1.Secret{}: {
 					Namespaces: map[string]cache.Config{
-						"kube-system": {},
+						"kube-system": {
+							FieldSelector: fields.SelectorFromSet(fields.Set{
+								"metadata.name": "d8-provider-cluster-configuration",
+							}),
+						},
 					},
 				},
 			},

--- a/modules/040-node-manager/images/node-controller/src/cmd/main.go
+++ b/modules/040-node-manager/images/node-controller/src/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"os"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -29,6 +30,8 @@ import (
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -80,6 +83,24 @@ func main() {
 			Port: 9443,
 		}),
 		HealthProbeBindAddress: probeAddr,
+		Cache: cache.Options{
+			DefaultTransform: cache.TransformStripManagedFields(),
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					Namespaces: map[string]cache.Config{
+						"kube-system": {},
+					},
+				},
+			},
+		},
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				DisableFor: []client.Object{
+					&corev1.Node{},
+					&corev1.Endpoints{},
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/modules/040-node-manager/images/node-controller/src/cmd/main.go
+++ b/modules/040-node-manager/images/node-controller/src/cmd/main.go
@@ -20,8 +20,6 @@ import (
 	"flag"
 	"os"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -31,8 +29,6 @@ import (
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -40,6 +36,7 @@ import (
 	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
 	deckhousev1alpha1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1alpha1"
 	deckhousev1alpha2 "github.com/deckhouse/node-controller/api/deckhouse.io/v1alpha2"
+	"github.com/deckhouse/node-controller/internal/common"
 	"github.com/deckhouse/node-controller/internal/webhook"
 )
 
@@ -75,6 +72,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	cacheOpts, clientOpts := common.CacheOptions()
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
@@ -84,31 +83,8 @@ func main() {
 			Port: 9443,
 		}),
 		HealthProbeBindAddress: probeAddr,
-		Cache: cache.Options{
-			DefaultTransform: cache.TransformStripManagedFields(),
-			ByObject: map[client.Object]cache.ByObject{
-				// Only cache the single secret needed by the conversion webhook.
-				// Previously all secrets in kube-system were cached, pulling in
-				// Helm release secrets and other heavy objects unnecessarily.
-				&corev1.Secret{}: {
-					Namespaces: map[string]cache.Config{
-						"kube-system": {
-							FieldSelector: fields.SelectorFromSet(fields.Set{
-								"metadata.name": "d8-provider-cluster-configuration",
-							}),
-						},
-					},
-				},
-			},
-		},
-		Client: client.Options{
-			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{
-					&corev1.Node{},
-					&corev1.Endpoints{},
-				},
-			},
-		},
+		Cache:                  cacheOpts,
+		Client:                 clientOpts,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/modules/040-node-manager/images/node-controller/src/internal/common/cache.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/common/cache.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CacheOptions returns cache and client options for the manager.
+func CacheOptions() (cache.Options, client.Options) {
+	configSecretsReq, _ := labels.NewRequirement("name", selection.In, []string{
+		"d8-cluster-configuration",
+		"d8-provider-cluster-configuration",
+	})
+
+	cacheOpts := cache.Options{
+		DefaultTransform: cache.TransformStripManagedFields(),
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {
+				Namespaces: map[string]cache.Config{
+					"kube-system": {
+						LabelSelector: labels.NewSelector().Add(*configSecretsReq),
+					},
+				},
+			},
+		},
+	}
+
+	clientOpts := client.Options{
+		Cache: &client.CacheOptions{
+			DisableFor: []client.Object{
+				&corev1.Node{},
+				&corev1.Endpoints{},
+			},
+		},
+	}
+
+	return cacheOpts, clientOpts
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_conversion_handler.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_conversion_handler.go
@@ -121,6 +121,7 @@ func (h *NodeGroupConversionHandler) loadProviderConfig(ctx context.Context) (*P
 	config := &ProviderClusterConfiguration{}
 
 	secret := &corev1.Secret{}
+	conversionLog.V(1).Info("reading Secret", "namespace", "kube-system", "name", "d8-provider-cluster-configuration")
 	err := h.Client.Get(ctx, types.NamespacedName{
 		Namespace: "kube-system",
 		Name:      "d8-provider-cluster-configuration",

--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
@@ -459,6 +459,7 @@ func (w *NodeGroupValidator) loadClusterConfig(ctx context.Context) (*ClusterCon
 	config := &ClusterConfig{PodSubnetNodeCIDRPrefix: 24}
 
 	secret := &corev1.Secret{}
+	webhookLog.Info("reading Secret", "namespace", "kube-system", "name", "d8-cluster-configuration")
 	err := w.Client.Get(ctx, types.NamespacedName{
 		Namespace: "kube-system",
 		Name:      "d8-cluster-configuration",
@@ -506,6 +507,7 @@ func (w *NodeGroupValidator) loadProviderClusterConfig(ctx context.Context) (*Pr
 	config := &ProviderClusterConfig{}
 
 	secret := &corev1.Secret{}
+	webhookLog.Info("reading Secret", "namespace", "kube-system", "name", "d8-provider-cluster-configuration")
 	err := w.Client.Get(ctx, types.NamespacedName{
 		Namespace: "kube-system",
 		Name:      "d8-provider-cluster-configuration",
@@ -548,6 +550,7 @@ func (w *NodeGroupValidator) loadCustomTolerationKeys(ctx context.Context) ([]st
 		Kind:    "ModuleConfig",
 	})
 
+	webhookLog.Info("reading ModuleConfig", "name", "global")
 	err := w.Client.Get(ctx, types.NamespacedName{Name: "global"}, mc)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -587,6 +590,7 @@ func (w *NodeGroupValidator) loadCustomTolerationKeys(ctx context.Context) ([]st
 // Returns error for transient failures (timeout, permission denied, etc.)
 func (w *NodeGroupValidator) getKubernetesEndpointsCount(ctx context.Context) (int, error) {
 	endpoints := &corev1.Endpoints{}
+	webhookLog.Info("reading Endpoints", "namespace", "default", "name", "kubernetes")
 	err := w.Client.Get(ctx, types.NamespacedName{
 		Namespace: "default",
 		Name:      "kubernetes",
@@ -611,6 +615,7 @@ func (w *NodeGroupValidator) getKubernetesEndpointsCount(ctx context.Context) (i
 // Returns error for transient failures (timeout, permission denied, etc.)
 func (w *NodeGroupValidator) getNodesWithCustomContainerd(ctx context.Context, nodeGroupName string) ([]string, error) {
 	nodeList := &corev1.NodeList{}
+	webhookLog.Info("listing Nodes", "filter", "containerd-config=custom", "nodeGroup", nodeGroupName)
 	err := w.Client.List(ctx, nodeList, client.MatchingLabels{
 		"node.deckhouse.io/containerd-config": "custom",
 		"node.deckhouse.io/group":             nodeGroupName,
@@ -630,6 +635,7 @@ func (w *NodeGroupValidator) getNodesWithCustomContainerd(ctx context.Context, n
 // Returns error for transient failures (timeout, permission denied, etc.)
 func (w *NodeGroupValidator) getNodesWithoutContainerdV2Support(ctx context.Context, nodeGroupName string) ([]string, error) {
 	nodeList := &corev1.NodeList{}
+	webhookLog.Info("listing Nodes", "filter", "containerd-v2-unsupported", "nodeGroup", nodeGroupName)
 	err := w.Client.List(ctx, nodeList, client.MatchingLabels{
 		"node.deckhouse.io/containerd-v2-unsupported": "",
 		"node.deckhouse.io/group":                     nodeGroupName,

--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
@@ -61,8 +61,9 @@ var webhookLog = logf.Log.WithName("nodegroup-webhook")
 // NodeGroupValidator handles validation for NodeGroup resources.
 // It has access to cluster state via Client.
 type NodeGroupValidator struct {
-	Client  client.Client
-	decoder admission.Decoder
+	Client    client.Client
+	APIReader client.Reader
+	decoder   admission.Decoder
 }
 
 // SetupWithManager registers the webhooks with the manager.
@@ -73,8 +74,9 @@ func SetupWithManager(mgr ctrl.Manager) error {
 	// Validating webhook
 	hookServer.Register("/validate-deckhouse-io-v1-nodegroup", &webhook.Admission{
 		Handler: &NodeGroupValidator{
-			Client:  mgr.GetClient(),
-			decoder: decoder,
+			Client:    mgr.GetClient(),
+			APIReader: mgr.GetAPIReader(),
+			decoder:   decoder,
 		},
 	})
 
@@ -454,13 +456,16 @@ type ProviderClusterConfig struct {
 }
 
 // loadClusterConfig reads cluster configuration from d8-cluster-configuration Secret.
+// Uses APIReader (direct API call, bypassing cache) because the cache is scoped
+// to d8-provider-cluster-configuration only. Validation is infrequent, so live
+// reads are acceptable here.
 // Returns error for transient failures (timeout, permission denied, etc.)
 func (w *NodeGroupValidator) loadClusterConfig(ctx context.Context) (*ClusterConfig, error) {
 	config := &ClusterConfig{PodSubnetNodeCIDRPrefix: 24}
 
 	secret := &corev1.Secret{}
 	webhookLog.Info("reading Secret", "namespace", "kube-system", "name", "d8-cluster-configuration")
-	err := w.Client.Get(ctx, types.NamespacedName{
+	err := w.APIReader.Get(ctx, types.NamespacedName{
 		Namespace: "kube-system",
 		Name:      "d8-cluster-configuration",
 	}, secret)

--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
@@ -61,9 +61,8 @@ var webhookLog = logf.Log.WithName("nodegroup-webhook")
 // NodeGroupValidator handles validation for NodeGroup resources.
 // It has access to cluster state via Client.
 type NodeGroupValidator struct {
-	Client    client.Client
-	APIReader client.Reader
-	decoder   admission.Decoder
+	Client  client.Client
+	decoder admission.Decoder
 }
 
 // SetupWithManager registers the webhooks with the manager.
@@ -74,9 +73,8 @@ func SetupWithManager(mgr ctrl.Manager) error {
 	// Validating webhook
 	hookServer.Register("/validate-deckhouse-io-v1-nodegroup", &webhook.Admission{
 		Handler: &NodeGroupValidator{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
-			decoder:   decoder,
+			Client:  mgr.GetClient(),
+			decoder: decoder,
 		},
 	})
 
@@ -456,16 +454,13 @@ type ProviderClusterConfig struct {
 }
 
 // loadClusterConfig reads cluster configuration from d8-cluster-configuration Secret.
-// Uses APIReader (direct API call, bypassing cache) because the cache is scoped
-// to d8-provider-cluster-configuration only. Validation is infrequent, so live
-// reads are acceptable here.
 // Returns error for transient failures (timeout, permission denied, etc.)
 func (w *NodeGroupValidator) loadClusterConfig(ctx context.Context) (*ClusterConfig, error) {
 	config := &ClusterConfig{PodSubnetNodeCIDRPrefix: 24}
 
 	secret := &corev1.Secret{}
 	webhookLog.Info("reading Secret", "namespace", "kube-system", "name", "d8-cluster-configuration")
-	err := w.APIReader.Get(ctx, types.NamespacedName{
+	err := w.Client.Get(ctx, types.NamespacedName{
 		Namespace: "kube-system",
 		Name:      "d8-cluster-configuration",
 	}, secret)

--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook_test.go
@@ -139,7 +139,7 @@ func kubernetesEndpoints(addressCount int) *corev1.Endpoints {
 func TestValidation_NodeTypeImmutability(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	newNG := baseNodeGroup("worker", v1.NodeTypeCloudEphemeral)
@@ -156,7 +156,7 @@ func TestValidation_NodeTypeImmutability(t *testing.T) {
 func TestValidation_NodeTypeImmutability_SameType(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	newNG := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -170,7 +170,7 @@ func TestValidation_NodeTypeImmutability_SameType(t *testing.T) {
 func TestValidation_MinPerZoneGreaterThanMaxPerZone(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -188,7 +188,7 @@ func TestValidation_MinPerZoneGreaterThanMaxPerZone(t *testing.T) {
 func TestValidation_MinPerZoneLessOrEqualMaxPerZone(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -206,7 +206,7 @@ func TestValidation_MinPerZoneLessOrEqualMaxPerZone(t *testing.T) {
 func TestValidation_DockerCRIForbidden(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeDocker}
@@ -220,7 +220,7 @@ func TestValidation_DockerCRIForbidden(t *testing.T) {
 func TestValidation_ContainerdCRIAllowed(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeContainerd}
@@ -234,7 +234,7 @@ func TestValidation_ContainerdCRIAllowed(t *testing.T) {
 func TestValidation_CRIConfigMismatch_ContainerdConfigWithDockerType(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	maxDl := 10
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -252,7 +252,7 @@ func TestValidation_CRIConfigMismatch_ContainerdConfigWithDockerType(t *testing.
 func TestValidation_RollingUpdateOnlyForCloudEphemeral(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -268,7 +268,7 @@ func TestValidation_RollingUpdateOnlyForCloudEphemeral(t *testing.T) {
 func TestValidation_RollingUpdateAllowedForCloudEphemeral(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -290,7 +290,7 @@ func TestValidation_DuplicateTaints(t *testing.T) {
 
 	mc := moduleConfigGlobal([]string{"my-key"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects().WithRuntimeObjects(mc).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -311,7 +311,7 @@ func TestValidation_TaintsNotInCustomTolerationKeys(t *testing.T) {
 
 	mc := moduleConfigGlobal([]string{})
 	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mc).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -329,7 +329,7 @@ func TestValidation_TaintsNotInCustomTolerationKeys(t *testing.T) {
 func TestValidation_TaintsStandardKeysAllowed(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -350,7 +350,7 @@ func TestValidation_TaintsInCustomTolerationKeys(t *testing.T) {
 
 	mc := moduleConfigGlobal([]string{"custom-key", "another-key"})
 	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mc).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -371,7 +371,7 @@ func TestValidation_CloudNameLengthTooLong(t *testing.T) {
 	// prefix "my-long-cluster-prefix" = 22 chars → max ng name = 63-22-1-21 = 19
 	sec := clusterConfigSecret("Cloud", "my-long-cluster-prefix", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("this-name-is-way-too-long-for-this-cluster", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -390,7 +390,7 @@ func TestValidation_CloudNameLengthOK(t *testing.T) {
 
 	sec := clusterConfigSecret("Cloud", "short", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -410,7 +410,7 @@ func TestValidation_StaticCluster_NameLengthNotChecked(t *testing.T) {
 	// Static cluster - name length check should be skipped
 	sec := clusterConfigSecret("Static", "long-prefix-that-would-fail", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("this-name-is-very-long-but-should-be-allowed-in-static", v1.NodeTypeStatic)
 
@@ -426,7 +426,7 @@ func TestValidation_UnknownZone(t *testing.T) {
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	provSec := providerConfigSecret([]string{"eu-west-1a", "eu-west-1b"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec, provSec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -447,7 +447,7 @@ func TestValidation_ValidZones(t *testing.T) {
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	provSec := providerConfigSecret([]string{"eu-west-1a", "eu-west-1b", "eu-west-1c"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec, provSec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -468,7 +468,7 @@ func TestValidation_ZonesValidation_NoProviderConfig(t *testing.T) {
 	// No provider config secret - zones validation is skipped (no zones to check against)
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -489,7 +489,7 @@ func TestValidation_ZonesValidation_SkippedWhenNoZonesSpecified(t *testing.T) {
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	provSec := providerConfigSecret([]string{"eu-west-1a"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec, provSec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -507,7 +507,7 @@ func TestValidation_ZonesValidation_SkippedWhenNoZonesSpecified(t *testing.T) {
 func TestValidation_TopologyManagerWithoutResourceReservation(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Kubelet = &v1.KubeletSpec{
@@ -523,7 +523,7 @@ func TestValidation_TopologyManagerWithoutResourceReservation(t *testing.T) {
 func TestValidation_TopologyManagerStaticWithoutCPU(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Kubelet = &v1.KubeletSpec{
@@ -540,7 +540,7 @@ func TestValidation_TopologyManagerStaticWithoutCPU(t *testing.T) {
 func TestValidation_TopologyManagerWithValidConfig(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	cpu := intstr.FromString("500m")
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -561,7 +561,7 @@ func TestValidation_TopologyManagerWithValidConfig(t *testing.T) {
 func TestValidation_LabelSelectorImmutability(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	oldNG.Spec.StaticInstances = &v1.StaticInstancesSpec{
@@ -586,7 +586,7 @@ func TestValidation_LabelSelectorImmutability(t *testing.T) {
 func TestValidation_LabelSelectorCanBeAdded(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 
@@ -606,7 +606,7 @@ func TestValidation_LabelSelectorCanBeAdded(t *testing.T) {
 func TestValidation_LabelSelectorCannotBeRemoved(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	oldNG.Spec.StaticInstances = &v1.StaticInstancesSpec{
@@ -627,7 +627,7 @@ func TestValidation_LabelSelectorCannotBeRemoved(t *testing.T) {
 func TestValidation_DisruptionWindowsInvalidTime(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -648,7 +648,7 @@ func TestValidation_DisruptionWindowsInvalidTime(t *testing.T) {
 func TestValidation_DisruptionWindowsInvalidDay(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -669,7 +669,7 @@ func TestValidation_DisruptionWindowsInvalidDay(t *testing.T) {
 func TestValidation_ValidDisruptionWindows(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -692,7 +692,7 @@ func TestValidation_MaxPodsWarning(t *testing.T) {
 
 	sec := clusterConfigSecret("", "", "", 24)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	maxPods := int32(500)
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -712,7 +712,7 @@ func TestValidation_MaxPodsNoWarningWhenOK(t *testing.T) {
 
 	sec := clusterConfigSecret("", "", "", 24)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	maxPods := int32(100)
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -732,7 +732,7 @@ func TestValidation_MasterCRIChangeWarning_LessThan3Endpoints(t *testing.T) {
 
 	endpoints := kubernetesEndpoints(2)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(endpoints).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("master", v1.NodeTypeCloudPermanent)
 	oldNG.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeContainerd}
@@ -754,7 +754,7 @@ func TestValidation_MasterCRIChangeNoWarning_3OrMoreEndpoints(t *testing.T) {
 
 	endpoints := kubernetesEndpoints(3)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(endpoints).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("master", v1.NodeTypeCloudPermanent)
 	oldNG.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeContainerd}
@@ -774,7 +774,7 @@ func TestValidation_MasterCRIChangeNoWarning_3OrMoreEndpoints(t *testing.T) {
 func TestValidation_SimpleCreateAllowed(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 
@@ -788,7 +788,7 @@ func TestValidation_ClusterConfigNotFound_UsesDefaults(t *testing.T) {
 	s := newScheme()
 	// No d8-cluster-configuration secret
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 
@@ -803,7 +803,7 @@ func TestValidation_ProviderConfigNotFound_AnyCluster(t *testing.T) {
 	// No provider config - zones validation is skipped when no provider config exists
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -822,7 +822,7 @@ func TestValidation_ModuleConfigNotFound_TaintsValidation(t *testing.T) {
 	s := newScheme()
 	// No ModuleConfig - custom taints should be denied
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -841,7 +841,7 @@ func TestLoadClusterConfig_Success(t *testing.T) {
 	s := newScheme()
 	sec := clusterConfigSecret("Cloud", "my-prefix", "Containerd", 22)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadClusterConfig(context.Background())
 	if err != nil {
@@ -864,7 +864,7 @@ func TestLoadClusterConfig_Success(t *testing.T) {
 func TestLoadClusterConfig_SecretNotFound(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadClusterConfig(context.Background())
 	if err != nil {
@@ -879,7 +879,7 @@ func TestLoadProviderClusterConfig_Success(t *testing.T) {
 	s := newScheme()
 	sec := providerConfigSecret([]string{"zone-a", "zone-b"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadProviderClusterConfig(context.Background())
 	if err != nil {
@@ -896,7 +896,7 @@ func TestLoadProviderClusterConfig_Success(t *testing.T) {
 func TestLoadProviderClusterConfig_SecretNotFound(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadProviderClusterConfig(context.Background())
 	if err != nil {
@@ -914,7 +914,7 @@ func TestLoadProviderClusterConfig_InvalidJSON(t *testing.T) {
 		Data:       map[string][]byte{"cloud-provider-discovery-data.json": []byte("not valid json")},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
 
 	_, err := w.loadProviderClusterConfig(context.Background())
 	if err == nil {

--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook_test.go
@@ -139,7 +139,7 @@ func kubernetesEndpoints(addressCount int) *corev1.Endpoints {
 func TestValidation_NodeTypeImmutability(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	newNG := baseNodeGroup("worker", v1.NodeTypeCloudEphemeral)
@@ -156,7 +156,7 @@ func TestValidation_NodeTypeImmutability(t *testing.T) {
 func TestValidation_NodeTypeImmutability_SameType(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	newNG := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -170,7 +170,7 @@ func TestValidation_NodeTypeImmutability_SameType(t *testing.T) {
 func TestValidation_MinPerZoneGreaterThanMaxPerZone(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -188,7 +188,7 @@ func TestValidation_MinPerZoneGreaterThanMaxPerZone(t *testing.T) {
 func TestValidation_MinPerZoneLessOrEqualMaxPerZone(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -206,7 +206,7 @@ func TestValidation_MinPerZoneLessOrEqualMaxPerZone(t *testing.T) {
 func TestValidation_DockerCRIForbidden(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeDocker}
@@ -220,7 +220,7 @@ func TestValidation_DockerCRIForbidden(t *testing.T) {
 func TestValidation_ContainerdCRIAllowed(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeContainerd}
@@ -234,7 +234,7 @@ func TestValidation_ContainerdCRIAllowed(t *testing.T) {
 func TestValidation_CRIConfigMismatch_ContainerdConfigWithDockerType(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	maxDl := 10
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -252,7 +252,7 @@ func TestValidation_CRIConfigMismatch_ContainerdConfigWithDockerType(t *testing.
 func TestValidation_RollingUpdateOnlyForCloudEphemeral(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -268,7 +268,7 @@ func TestValidation_RollingUpdateOnlyForCloudEphemeral(t *testing.T) {
 func TestValidation_RollingUpdateAllowedForCloudEphemeral(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -290,7 +290,7 @@ func TestValidation_DuplicateTaints(t *testing.T) {
 
 	mc := moduleConfigGlobal([]string{"my-key"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects().WithRuntimeObjects(mc).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -311,7 +311,7 @@ func TestValidation_TaintsNotInCustomTolerationKeys(t *testing.T) {
 
 	mc := moduleConfigGlobal([]string{})
 	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mc).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -329,7 +329,7 @@ func TestValidation_TaintsNotInCustomTolerationKeys(t *testing.T) {
 func TestValidation_TaintsStandardKeysAllowed(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -350,7 +350,7 @@ func TestValidation_TaintsInCustomTolerationKeys(t *testing.T) {
 
 	mc := moduleConfigGlobal([]string{"custom-key", "another-key"})
 	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(mc).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -371,7 +371,7 @@ func TestValidation_CloudNameLengthTooLong(t *testing.T) {
 	// prefix "my-long-cluster-prefix" = 22 chars → max ng name = 63-22-1-21 = 19
 	sec := clusterConfigSecret("Cloud", "my-long-cluster-prefix", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("this-name-is-way-too-long-for-this-cluster", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -390,7 +390,7 @@ func TestValidation_CloudNameLengthOK(t *testing.T) {
 
 	sec := clusterConfigSecret("Cloud", "short", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -410,7 +410,7 @@ func TestValidation_StaticCluster_NameLengthNotChecked(t *testing.T) {
 	// Static cluster - name length check should be skipped
 	sec := clusterConfigSecret("Static", "long-prefix-that-would-fail", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("this-name-is-very-long-but-should-be-allowed-in-static", v1.NodeTypeStatic)
 
@@ -426,7 +426,7 @@ func TestValidation_UnknownZone(t *testing.T) {
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	provSec := providerConfigSecret([]string{"eu-west-1a", "eu-west-1b"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec, provSec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -447,7 +447,7 @@ func TestValidation_ValidZones(t *testing.T) {
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	provSec := providerConfigSecret([]string{"eu-west-1a", "eu-west-1b", "eu-west-1c"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec, provSec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -468,7 +468,7 @@ func TestValidation_ZonesValidation_NoProviderConfig(t *testing.T) {
 	// No provider config secret - zones validation is skipped (no zones to check against)
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -489,7 +489,7 @@ func TestValidation_ZonesValidation_SkippedWhenNoZonesSpecified(t *testing.T) {
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	provSec := providerConfigSecret([]string{"eu-west-1a"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec, provSec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -507,7 +507,7 @@ func TestValidation_ZonesValidation_SkippedWhenNoZonesSpecified(t *testing.T) {
 func TestValidation_TopologyManagerWithoutResourceReservation(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Kubelet = &v1.KubeletSpec{
@@ -523,7 +523,7 @@ func TestValidation_TopologyManagerWithoutResourceReservation(t *testing.T) {
 func TestValidation_TopologyManagerStaticWithoutCPU(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Kubelet = &v1.KubeletSpec{
@@ -540,7 +540,7 @@ func TestValidation_TopologyManagerStaticWithoutCPU(t *testing.T) {
 func TestValidation_TopologyManagerWithValidConfig(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	cpu := intstr.FromString("500m")
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -561,7 +561,7 @@ func TestValidation_TopologyManagerWithValidConfig(t *testing.T) {
 func TestValidation_LabelSelectorImmutability(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	oldNG.Spec.StaticInstances = &v1.StaticInstancesSpec{
@@ -586,7 +586,7 @@ func TestValidation_LabelSelectorImmutability(t *testing.T) {
 func TestValidation_LabelSelectorCanBeAdded(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 
@@ -606,7 +606,7 @@ func TestValidation_LabelSelectorCanBeAdded(t *testing.T) {
 func TestValidation_LabelSelectorCannotBeRemoved(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("worker", v1.NodeTypeStatic)
 	oldNG.Spec.StaticInstances = &v1.StaticInstancesSpec{
@@ -627,7 +627,7 @@ func TestValidation_LabelSelectorCannotBeRemoved(t *testing.T) {
 func TestValidation_DisruptionWindowsInvalidTime(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -648,7 +648,7 @@ func TestValidation_DisruptionWindowsInvalidTime(t *testing.T) {
 func TestValidation_DisruptionWindowsInvalidDay(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -669,7 +669,7 @@ func TestValidation_DisruptionWindowsInvalidDay(t *testing.T) {
 func TestValidation_ValidDisruptionWindows(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.Disruptions = &v1.DisruptionsSpec{
@@ -692,7 +692,7 @@ func TestValidation_MaxPodsWarning(t *testing.T) {
 
 	sec := clusterConfigSecret("", "", "", 24)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	maxPods := int32(500)
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -712,7 +712,7 @@ func TestValidation_MaxPodsNoWarningWhenOK(t *testing.T) {
 
 	sec := clusterConfigSecret("", "", "", 24)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	maxPods := int32(100)
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
@@ -732,7 +732,7 @@ func TestValidation_MasterCRIChangeWarning_LessThan3Endpoints(t *testing.T) {
 
 	endpoints := kubernetesEndpoints(2)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(endpoints).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("master", v1.NodeTypeCloudPermanent)
 	oldNG.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeContainerd}
@@ -754,7 +754,7 @@ func TestValidation_MasterCRIChangeNoWarning_3OrMoreEndpoints(t *testing.T) {
 
 	endpoints := kubernetesEndpoints(3)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(endpoints).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	oldNG := baseNodeGroup("master", v1.NodeTypeCloudPermanent)
 	oldNG.Spec.CRI = &v1.CRISpec{Type: v1.CRITypeContainerd}
@@ -774,7 +774,7 @@ func TestValidation_MasterCRIChangeNoWarning_3OrMoreEndpoints(t *testing.T) {
 func TestValidation_SimpleCreateAllowed(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 
@@ -788,7 +788,7 @@ func TestValidation_ClusterConfigNotFound_UsesDefaults(t *testing.T) {
 	s := newScheme()
 	// No d8-cluster-configuration secret
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 
@@ -803,7 +803,7 @@ func TestValidation_ProviderConfigNotFound_AnyCluster(t *testing.T) {
 	// No provider config - zones validation is skipped when no provider config exists
 	clusterSec := clusterConfigSecret("Cloud", "test", "", 0)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(clusterSec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("ephemeral", v1.NodeTypeCloudEphemeral)
 	ng.Spec.CloudInstances = &v1.CloudInstancesSpec{
@@ -822,7 +822,7 @@ func TestValidation_ModuleConfigNotFound_TaintsValidation(t *testing.T) {
 	s := newScheme()
 	// No ModuleConfig - custom taints should be denied
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	ng := baseNodeGroup("worker", v1.NodeTypeStatic)
 	ng.Spec.NodeTemplate = &v1.NodeTemplate{
@@ -841,7 +841,7 @@ func TestLoadClusterConfig_Success(t *testing.T) {
 	s := newScheme()
 	sec := clusterConfigSecret("Cloud", "my-prefix", "Containerd", 22)
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadClusterConfig(context.Background())
 	if err != nil {
@@ -864,7 +864,7 @@ func TestLoadClusterConfig_Success(t *testing.T) {
 func TestLoadClusterConfig_SecretNotFound(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadClusterConfig(context.Background())
 	if err != nil {
@@ -879,7 +879,7 @@ func TestLoadProviderClusterConfig_Success(t *testing.T) {
 	s := newScheme()
 	sec := providerConfigSecret([]string{"zone-a", "zone-b"})
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadProviderClusterConfig(context.Background())
 	if err != nil {
@@ -896,7 +896,7 @@ func TestLoadProviderClusterConfig_Success(t *testing.T) {
 func TestLoadProviderClusterConfig_SecretNotFound(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	cfg, err := w.loadProviderClusterConfig(context.Background())
 	if err != nil {
@@ -914,7 +914,7 @@ func TestLoadProviderClusterConfig_InvalidJSON(t *testing.T) {
 		Data:       map[string][]byte{"cloud-provider-discovery-data.json": []byte("not valid json")},
 	}
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(sec).Build()
-	w := &NodeGroupValidator{Client: c, APIReader: c, decoder: admission.NewDecoder(s)}
+	w := &NodeGroupValidator{Client: c, decoder: admission.NewDecoder(s)}
 
 	_, err := w.loadProviderClusterConfig(context.Background())
 	if err == nil {

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         args:
         - --metrics-bind-address=0.0.0.0:8080
         - --health-probe-bind-address=0.0.0.0:8081
-        - -v=2
+        - -v=4
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Optimize controller-runtime cache configuration for conversion and validation webhooks to reduce resource consumption on large clusters. Restrict informer scope and disable caching for resources that do not benefit from it.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without cache configuration, the conversion webhook triggers a cluster-wide LIST of all Secrets on first call, leading to excessive memory and CPU consumption on large clusters. This change restricts the informer to only kube-system Secrets and eliminates unnecessary informers for Node and Endpoints.

**Usage resources before optimization:**

**CPU Before**:
- Usage: peak ~0.010 cores, steady ~0.001-0.002
- Requests: 0.0240 cores

**Memory Before**:
- Usage: peak ~125 MiB, steady ~48 MiB
- Requests: ~152 MiB

![node-controller-cpu-before](https://github.com/user-attachments/assets/98be15db-7801-4d07-8745-ebd49d643e09)
![node-controller-memory-before](https://github.com/user-attachments/assets/cfd40615-005b-4f0d-a784-571a042b9f75)

**Usage resources after optimization:**

**CPU After**:

- Usage: peak ~0.003 cores, steady ~0.001
- Requests: 0.0240 cores

**Memory After**:

- Usage: peak ~30 MiB, steady ~20 MiB
- Requests: ~152 MiB

![node-controller-cpu-after](https://github.com/user-attachments/assets/1002e7c2-8256-4506-b1a2-369260230fff)
![node-controller-memory-after](https://github.com/user-attachments/assets/a331ec20-c1ed-4a81-be32-323edc3cdbeb)

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: optimize node-controller cache resources usage.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
