### PR TITLE
[docs][chore] Add routing for Deckhouse CSE

### DIFF
--- a/docs/site/.helm/templates/10-cm-frontend.yaml
+++ b/docs/site/.helm/templates/10-cm-frontend.yaml
@@ -319,6 +319,37 @@ data:
             proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
         }
 
+        # Requests for DKP CSE docs version
+        location ~* ^/products/kubernetes-platform/documentation/(v[0-9]+\.[0-9]+-cse)/(.*)$ {
+            set $doc_version "$1";
+            set $doc_path "$2";
+            limit_except GET {
+                deny all;
+            }
+
+            rewrite .+/documentation/[^/]+/(images|presentations|assets)/.+$    /deckhouse-{{ $.Values.werf.env }}/$doc_version/docs-dkp/${doc_path} break;
+            rewrite /$    /deckhouse-{{ $.Values.werf.env }}/$doc_version/docs-dkp/${doc_path}index.html break;
+            rewrite [^/]$ /deckhouse-{{ $.Values.werf.env }}/$doc_version/docs-dkp/${doc_path} break;
+
+            resolver                d8-kube-dns.kube-system.svc.cluster.local ipv6=off;
+            proxy_cache             dcache;
+            proxy_cache_key         $uri;
+            proxy_intercept_errors  on;
+            proxy_buffering         on;
+            proxy_buffer_size       16k;
+            proxy_buffers           4 16k;
+            proxy_ignore_headers    Set-Cookie;
+            proxy_ignore_headers    Cache-Control;
+
+            proxy_set_header Host   {{ .Values.global.doc_s3_bucket_public_url }};
+
+            proxy_connect_timeout   30s;
+            proxy_read_timeout      30s;
+            proxy_send_timeout      30s;
+
+            proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
+        }
+
         location / {
             try_files /$lang/$uri /$lang/$uri/index.html /$lang/$uri/ $uri $uri/index.html $uri/ =404;
         }

--- a/docs/site/.helm/templates/_rewrites.tpl
+++ b/docs/site/.helm/templates/_rewrites.tpl
@@ -13,7 +13,7 @@ rewrite ^(.*)/documentation(/(v[0-9]+|v[0-9]+\.[0-9]+|latest))?/deckhouse-overvi
 rewrite ^(.*)/documentation(/(v[0-9]+|v[0-9]+\.[0-9]+|latest))?/supported_versions.html$ /products/kubernetes-platform/documentation$2/reference/supported_versions.html redirect;
 rewrite ^(.*)/documentation(/(v[0-9]+|v[0-9]+\.[0-9]+|latest))?/installing/configuration.html$ /products/kubernetes-platform/documentation$2/installing/ redirect;
 rewrite ^/documentation/(.*)$ /products/kubernetes-platform/documentation/$1 permanent;
-rewrite ^/products/kubernetes-platform/documentation/(?<doc_path>(?!v[0-9]+/|v[0-9]+\.[0-9]+/|latest/).*)$ /products/kubernetes-platform/documentation/v1/$doc_path redirect;
+rewrite ^/products/kubernetes-platform/documentation/(?<doc_path>(?!v[0-9]+/|v[0-9]+\.[0-9]+/|v[0-9]+\.[0-9]+-cse|latest/).*)$ /products/kubernetes-platform/documentation/v1/$doc_path redirect;
 rewrite ^/gs/(.*)$ /products/kubernetes-platform/gs/$1 permanent;
 rewrite ^/guides/(.*)$ /products/kubernetes-platform/guides/$1 permanent;
 rewrite ^/products/kubernetes-platform/documentation$ /products/kubernetes-platform/documentation/ permanent;


### PR DESCRIPTION
## Description

Add routing for Deckhouse CSE:
- Introduce a dedicated reverse proxy location block to handle DKP CSE-suffixed documentation version requests, matching both latest and semver patterns with a -cse qualifier.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add routing for Deckhouse CSE.
impact_level: low
```
