### PR TITLE
[node-local-dns] Add VEX statement for CVE-2026-39883

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/coredns/known_vulnerabilities.vex
+++ b/ee/be/modules/350-node-local-dns/images/coredns/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b7f1dd6c80424d99d565815dc1b763c0cea2d579a014fe4a378580b87ffb0071",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Данная уязвимость специфична только для систем семейства BSD и Solaris, где используется команда kenv для получения идентификатора хоста. Образы Deckhouse работают на базе Linux, в которых данный код не компилируется и не исполняется, что делает эксплуатацию вектора атаки через PATH hijacking невозможной.",
+      "timestamp": "2026-04-14T14:37:21.591261Z"
+    }
+  ],
+  "timestamp": "2026-04-14T14:37:21Z"
+}

--- a/modules/000-common/images/coredns/known_vulnerabilities.vex
+++ b/modules/000-common/images/coredns/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b7f1dd6c80424d99d565815dc1b763c0cea2d579a014fe4a378580b87ffb0071",
+  "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Данная уязвимость специфична только для систем семейства BSD и Solaris, где используется команда kenv для получения идентификатора хоста. Образы Deckhouse работают на базе Linux, в которых данный код не компилируется и не исполняется, что делает эксплуатацию вектора атаки через PATH hijacking невозможной.",
+      "timestamp": "2026-04-14T14:37:21.591261Z"
+    }
+  ],
+  "timestamp": "2026-04-14T14:37:21Z"
+}


### PR DESCRIPTION
## Description

This PR adds a vulnerability explanation (VEX) file for `CVE-2026-39883` to the `node-local-dns` and `coredns` modules. It explicitly marks this vulnerability as `not_affected` for our environment.

## Why do we need it, and what problem does it solve?

Automated vulnerability scanners (like Trivy) report `CVE-2026-39883` in the `go.opentelemetry.io/otel/sdk` package. This vulnerability specifically affects BSD and Solaris platforms where the `kenv` command is used. Since our Deckhouse images run on Linux, this code path is not compiled or executed. This VEX file suppresses false-positive security warnings.

## Why do we need it in the patch release?

It is necessary to keep our security compliance reports clean and prevent unnecessary noise in automated vulnerability monitoring during patch releases.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-local-dns
type: chore
summary: Added VEX statement for CVE-2026-39883 to suppress false-positive alerts.
impact_level: low
```