### PR TITLE
[keepalived] Exclude vulnerable pip version from the final image for CVE-2026-1703

### DIFF
--- a/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
+++ b/ee/modules/450-keepalived/images/keepalived/werf.inc.yaml
@@ -75,3 +75,5 @@ import:
   - usr/bin/python3*
   - usr/lib/python3*
   - usr/lib/libc.so
+  excludePaths:
+  - usr/lib/python3*/site-packages/pip-25.3*


### PR DESCRIPTION
## Description

This PR modifies the `werf.inc.yaml` configuration for the `keepalived` image in the `keepalived` module. It explicitly excludes the vulnerable `pip` version (`pip-25.3*`) from the final production image to address CVE-2026-1703 by ensuring the insecure package manager is not included in the runtime artifacts.

## Why do we need it, and what problem does it solve?

This change mitigates CVE-2026-1703. By excluding the vulnerable `pip` version (25.3) from the final image, we ensure that security vulnerabilities associated with `pip` do not affect our production containers. The `pip` tool is used during the build process to install dependencies and is not needed in the production runtime, so its exclusion is a security best practice.

## Why do we need it in the patch release?

This is a security vulnerability that must be addressed immediately to ensure the security of the platform and protect our production environments from known exploits.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: keepalived
type: fix
summary: Excluded vulnerable pip-25.3 from keepalived final image to fix CVE-2026-1703
impact_level: default
```