### PR TITLE
[go_lib/controlplane] Add result report to certs and kubeconfigs creation

### DIFF
--- a/go_lib/controlplane/kubeconfig/apply_report.go
+++ b/go_lib/controlplane/kubeconfig/apply_report.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+// KubeconfigApplyReport describes outcomes of CreateKubeconfigFiles for each requested
+// kubeconfig file. Entry order matches the order of the files slice passed to CreateKubeconfigFiles.
+type KubeconfigApplyReport struct {
+	Entries []KubeconfigApplyEntry
+}
+
+// KubeconfigApplyEntry is one row in KubeconfigApplyReport.
+type KubeconfigApplyEntry struct {
+	File   File
+	Action KubeconfigEntryAction
+}
+
+// KubeconfigEntryAction describes what happened to the kubeconfig on disk.
+type KubeconfigEntryAction uint8
+
+const (
+	// KubeconfigActionUnchanged means the existing file was kept (validation passed).
+	KubeconfigActionUnchanged KubeconfigEntryAction = iota
+	// KubeconfigActionWrittenCreated means the file was written and did not exist before.
+	KubeconfigActionWrittenCreated
+	// KubeconfigActionWrittenRegenerated means an existing file was replaced (validation failed).
+	KubeconfigActionWrittenRegenerated
+)
+
+func (r *KubeconfigApplyReport) add(file File, action KubeconfigEntryAction) {
+	r.Entries = append(r.Entries, KubeconfigApplyEntry{
+		File:   file,
+		Action: action,
+	})
+}

--- a/go_lib/controlplane/kubeconfig/kubeconfig.go
+++ b/go_lib/controlplane/kubeconfig/kubeconfig.go
@@ -52,7 +52,7 @@ type fileSpec struct {
 }
 
 // On error, the returned KubeconfigApplyReport may still contain entries for files that were
-// processed successfully before the failure...
+// processed successfully before the failure.
 func CreateKubeconfigFiles(files []File, options ...option) (KubeconfigApplyReport, error) {
 	logger.Info("creating kubeconfig files for control-plane")
 

--- a/go_lib/controlplane/kubeconfig/kubeconfig.go
+++ b/go_lib/controlplane/kubeconfig/kubeconfig.go
@@ -52,7 +52,7 @@ type fileSpec struct {
 }
 
 // On error, the returned KubeconfigApplyReport may still contain entries for files that were
-// processed successfully before the failure.
+// processed successfully before the failure...
 func CreateKubeconfigFiles(files []File, options ...option) (KubeconfigApplyReport, error) {
 	logger.Info("creating kubeconfig files for control-plane")
 

--- a/go_lib/controlplane/kubeconfig/kubeconfig.go
+++ b/go_lib/controlplane/kubeconfig/kubeconfig.go
@@ -51,30 +51,33 @@ type fileSpec struct {
 	EncryptionAlgorithm     constants.EncryptionAlgorithmType
 }
 
-func CreateKubeconfigFiles(files []File, options ...option) error {
+// On error, the returned KubeconfigApplyReport may still contain entries for files that were
+// processed successfully before the failure.
+func CreateKubeconfigFiles(files []File, options ...option) (KubeconfigApplyReport, error) {
 	logger.Info("creating kubeconfig files for control-plane")
 
 	opt, err := prepareOptions(options...)
 	if err != nil {
-		return fmt.Errorf("failed to prepare Options: %w", err)
+		return KubeconfigApplyReport{}, fmt.Errorf("failed to prepare Options: %w", err)
 	}
 
+	var rep KubeconfigApplyReport
 	for _, file := range files {
 		if file == Kubelet {
 			if err := opt.ensureNodeNameProvided(); err != nil {
-				return fmt.Errorf("failed to ensure node name for kubelet.conf: %w", err)
+				return rep, fmt.Errorf("failed to ensure node name for kubelet.conf: %w", err)
 			}
 		}
 
-		if err := createKubeConfigFile(file, opt); err != nil {
-			return fmt.Errorf("failed to create kubeconfig file %q: %w", file, err)
+		if err := createKubeConfigFile(file, opt, &rep); err != nil {
+			return rep, fmt.Errorf("failed to create kubeconfig file %q: %w", file, err)
 		}
 	}
 
-	return nil
+	return rep, nil
 }
 
-func createKubeConfigFile(file File, opt *options) error {
+func createKubeConfigFile(file File, opt *options, rep *KubeconfigApplyReport) error {
 	fileSpec, err := getFileSpec(file, opt)
 	if err != nil {
 		return fmt.Errorf("failed to get spec for %q: %w", file, err)
@@ -87,10 +90,11 @@ func createKubeConfigFile(file File, opt *options) error {
 
 	kubeConfigFilePath := filepath.Join(opt.OutDir, string(file))
 
-	if err := writeKubeConfigFileIfNeeded(kubeConfigFilePath, config); err != nil {
+	action, err := writeKubeConfigFileIfNeeded(kubeConfigFilePath, config)
+	if err != nil {
 		return err
 	}
-
+	rep.add(file, action)
 	return nil
 }
 
@@ -204,20 +208,26 @@ func newClientCertConfig(spec *fileSpec) pkiutil.CertConfig {
 	}
 }
 
-func writeKubeConfigFileIfNeeded(kubeConfigFilePath string, config *clientcmdapi.Config) error {
+func writeKubeConfigFileIfNeeded(kubeConfigFilePath string, config *clientcmdapi.Config) (KubeconfigEntryAction, error) {
+	_, statErr := os.Stat(kubeConfigFilePath)
+	fileMissing := os.IsNotExist(statErr)
+
 	err := validateCurrentKubeConfig(kubeConfigFilePath, config)
 	if err == nil {
 		logger.Info("Using existing kubeconfig file", slog.String("path", kubeConfigFilePath))
-		return nil
+		return KubeconfigActionUnchanged, nil
 	}
 
 	logger.Info("Writing new kubeconfig file", slog.String("path", kubeConfigFilePath), slog.String("reason", err.Error()))
 
 	if err := clientcmd.WriteToFile(*config, kubeConfigFilePath); err != nil {
-		return fmt.Errorf("failed to write kubeconfig %q: %w", kubeConfigFilePath, err)
+		return 0, fmt.Errorf("failed to write kubeconfig %q: %w", kubeConfigFilePath, err)
 	}
 
-	return nil
+	if fileMissing {
+		return KubeconfigActionWrittenCreated, nil
+	}
+	return KubeconfigActionWrittenRegenerated, nil
 }
 
 func validateCurrentKubeConfig(kubeConfigFilePath string, desiredConfig *clientcmdapi.Config) error {

--- a/go_lib/controlplane/kubeconfig/kubeconfig_test.go
+++ b/go_lib/controlplane/kubeconfig/kubeconfig_test.go
@@ -132,20 +132,27 @@ func TestCreateKubeConfigFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := createKubeConfigFile(tt.file, opt)
+			var rep KubeconfigApplyReport
+			err := createKubeConfigFile(tt.file, opt, &rep)
 			if tt.wantErr {
 				assert.Error(t, err)
+				assert.Empty(t, rep.Entries)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			require.Len(t, rep.Entries, 1)
+			assert.Equal(t, tt.file, rep.Entries[0].File)
+			assert.Equal(t, KubeconfigActionWrittenCreated, rep.Entries[0].Action)
 
 			// Verify file exists
 			filePath := filepath.Join(tmpDir, string(tt.file))
 			assert.FileExists(t, filePath)
 
-			// Verify we can call it again (should not fail, should log "Using existing kubeconfig file")
-			err = createKubeConfigFile(tt.file, opt)
-			assert.NoError(t, err)
+			rep = KubeconfigApplyReport{}
+			err = createKubeConfigFile(tt.file, opt, &rep)
+			require.NoError(t, err)
+			require.Len(t, rep.Entries, 1)
+			assert.Equal(t, KubeconfigActionUnchanged, rep.Entries[0].Action)
 		})
 	}
 }
@@ -191,8 +198,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 		expiredOpt = *baseOpt
 		expiredOpt.CertProvider = expiredCertProvider
 
-		err = createKubeConfigFile(file, &expiredOpt)
+		var rep KubeconfigApplyReport
+		err := createKubeConfigFile(file, &expiredOpt, &rep)
 		require.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenCreated, rep.Entries[0].Action)
 
 		// Wait to ensure file is written and modTime is set
 		stat1, err = os.Stat(filePath)
@@ -217,8 +227,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 
 		// b) Call with long-lived cert provider. It should detect that the CURRENT file has an expiring cert and recreate it.
 		time.Sleep(100 * time.Millisecond)
-		err = createKubeConfigFile(file, baseOpt)
+		rep = KubeconfigApplyReport{}
+		err = createKubeConfigFile(file, baseOpt, &rep)
 		assert.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenRegenerated, rep.Entries[0].Action)
 
 		stat2, _ := os.Stat(filePath)
 		assert.True(t, stat2.ModTime().After(stat1.ModTime()), "File should have been recreated because the existing cert was expiring")
@@ -240,8 +253,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 		filePath := filepath.Join(tmpDir, string(file))
 
 		// 1. Create initial
-		err := createKubeConfigFile(file, baseOpt)
+		var rep KubeconfigApplyReport
+		err := createKubeConfigFile(file, baseOpt, &rep)
 		require.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenCreated, rep.Entries[0].Action)
 		stat1, _ := os.Stat(filePath)
 
 		// 2. Change API server
@@ -250,8 +266,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 
 		// 3. Recreate
 		time.Sleep(100 * time.Millisecond)
-		err = createKubeConfigFile(file, &newAddrOpt)
+		rep = KubeconfigApplyReport{}
+		err = createKubeConfigFile(file, &newAddrOpt, &rep)
 		assert.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenRegenerated, rep.Entries[0].Action)
 
 		stat2, _ := os.Stat(filePath)
 		assert.True(t, stat2.ModTime().After(stat1.ModTime()), "File should have been recreated due to API server change")
@@ -270,8 +289,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 		filePath := filepath.Join(tmpDir, string(file))
 
 		// 1. Create initial
-		err := createKubeConfigFile(file, baseOpt)
+		var rep KubeconfigApplyReport
+		err := createKubeConfigFile(file, baseOpt, &rep)
 		require.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenCreated, rep.Entries[0].Action)
 		stat1, _ := os.Stat(filePath)
 
 		// 2. Change CA
@@ -286,8 +308,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 
 		// 3. Recreate
 		time.Sleep(100 * time.Millisecond)
-		err = createKubeConfigFile(file, &newCAOpt)
+		rep = KubeconfigApplyReport{}
+		err = createKubeConfigFile(file, &newCAOpt, &rep)
 		assert.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenRegenerated, rep.Entries[0].Action)
 
 		stat2, _ := os.Stat(filePath)
 		assert.True(t, stat2.ModTime().After(stat1.ModTime()), "File should have been recreated due to CA change")
@@ -301,8 +326,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 		filePath := filepath.Join(tmpDir, string(file))
 
 		// 1. Create initial
-		err := createKubeConfigFile(file, baseOpt)
+		var rep KubeconfigApplyReport
+		err := createKubeConfigFile(file, baseOpt, &rep)
 		require.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenCreated, rep.Entries[0].Action)
 
 		// 2. Corrupt file
 		err = os.WriteFile(filePath, []byte("not a kubeconfig"), 0644)
@@ -311,8 +339,11 @@ func TestCreateKubeConfigFile_Recreation(t *testing.T) {
 
 		// 3. Recreate
 		time.Sleep(100 * time.Millisecond)
-		err = createKubeConfigFile(file, baseOpt)
+		rep = KubeconfigApplyReport{}
+		err = createKubeConfigFile(file, baseOpt, &rep)
 		assert.NoError(t, err)
+		require.Len(t, rep.Entries, 1)
+		assert.Equal(t, KubeconfigActionWrittenRegenerated, rep.Entries[0].Action)
 
 		stat2, _ := os.Stat(filePath)
 		assert.True(t, stat2.ModTime().After(stat1.ModTime()), "File should have been recreated due to corruption")

--- a/go_lib/controlplane/pki/apply_report.go
+++ b/go_lib/controlplane/pki/apply_report.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+// PKIApplyReport describes outcomes of CreatePKIBundle for each logical artifact
+// (root CA, leaf certificate pair, or service account key pair). Entry order follows
+// the order in which artifacts are processed and is not guaranteed to be stable
+// across releases because it depends on map iteration.
+type PKIApplyReport struct {
+	Entries []PKIApplyEntry
+}
+
+// PKIApplyEntry is one row in PKIApplyReport. Name is the file base path relative
+// to the PKI directory (e.g. "ca", "etcd/server", "sa" for service account keys).
+type PKIApplyEntry struct {
+	Name   string
+	Kind   PKIEntryKind
+	Action PKIEntryAction
+}
+
+// PKIEntryKind classifies the artifact reported by CreatePKIBundle.
+type PKIEntryKind uint8
+
+const (
+	// PKIEntryKindRootCA is a self-signed CA certificate (e.g. ca, etcd/ca).
+	PKIEntryKindRootCA PKIEntryKind = iota
+	// PKIEntryKindLeafCert is a leaf certificate signed by a CA.
+	PKIEntryKindLeafCert
+	// PKIEntryKindServiceAccountKeys is the sa.key / sa.pub pair (not X.509).
+	PKIEntryKindServiceAccountKeys
+)
+
+// PKIEntryAction describes what happened to the artifact on disk.
+type PKIEntryAction uint8
+
+const (
+	// PKIActionUnchanged means existing material was kept (validation passed or SA pair complete).
+	PKIActionUnchanged PKIEntryAction = iota
+	// PKIActionWrittenCreated means new key material was written and there was no usable prior cert/key.
+	PKIActionWrittenCreated
+	// PKIActionWrittenRegenerated means existing leaf material was replaced (validation failed, read error, etc.).
+	PKIActionWrittenRegenerated
+	// PKIActionSAPublicKeyRestored means sa.key existed and only sa.pub was written.
+	PKIActionSAPublicKeyRestored
+)
+
+func (r *PKIApplyReport) add(name string, kind PKIEntryKind, action PKIEntryAction) {
+	r.Entries = append(r.Entries, PKIApplyEntry{
+		Name:   name,
+		Kind:   kind,
+		Action: action,
+	})
+}

--- a/go_lib/controlplane/pki/certs.go
+++ b/go_lib/controlplane/pki/certs.go
@@ -30,17 +30,17 @@ import (
 // createCertTree creates all CA and leaf certificates defined by cfg.CertTreeScheme.
 // For each CA the in-memory cert and key are passed directly to the leaf cert functions,
 // so CAs are created before their leaves within each iteration.
-func createCertTree(cfg config) error {
+func createCertTree(cfg config, rep *PKIApplyReport) error {
 	certSpecTree := renderCertSpecTree(cfg.CertTreeScheme)
 
 	for _, rootCertSpec := range certSpecTree {
-		caCert, caKey, err := createRootCertIfNotExists(cfg, rootCertSpec)
+		caCert, caKey, err := createRootCertIfNotExists(cfg, rootCertSpec, rep)
 		if err != nil {
 			return fmt.Errorf("failed to create root certificate %q: %w", rootCertSpec.BaseName, err)
 		}
 
 		for _, certSpec := range rootCertSpec.leafCerts {
-			if err := createLeafCertIfNotExists(cfg, certSpec, caCert, caKey); err != nil {
+			if err := createLeafCertIfNotExists(cfg, certSpec, caCert, caKey, rep); err != nil {
 				return fmt.Errorf("failed to create certificate %q: %w", certSpec.BaseName, err)
 			}
 		}
@@ -55,7 +55,7 @@ func createCertTree(cfg config) error {
 // if the existing CA fails validation, a CertValidationError is returned and the process stops.
 // CA certificates are never silently regenerated because doing so would invalidate all leaf
 // certificates signed by that CA, requiring a full cluster PKI rotation.
-func createRootCertIfNotExists(cfg config, spec rootCertSpec) (*x509.Certificate, crypto.Signer, error) {
+func createRootCertIfNotExists(cfg config, spec rootCertSpec, rep *PKIApplyReport) (*x509.Certificate, crypto.Signer, error) {
 	oldCert, oldKey, err := readCertAndKey(cfg.pkiDir, spec.BaseName)
 	newCertCfg := spec.BuildConfig(cfg)
 	if err == nil {
@@ -65,6 +65,7 @@ func createRootCertIfNotExists(cfg config, spec rootCertSpec) (*x509.Certificate
 				Reason:   err.Error(),
 			}
 		}
+		rep.add(spec.BaseName, PKIEntryKindRootCA, PKIActionUnchanged)
 		return oldCert, oldKey, nil
 	}
 
@@ -86,6 +87,7 @@ func createRootCertIfNotExists(cfg config, spec rootCertSpec) (*x509.Certificate
 		return nil, nil, fmt.Errorf("failed to write CA %q: %w", spec.BaseName, err)
 	}
 
+	rep.add(spec.BaseName, PKIEntryKindRootCA, PKIActionWrittenCreated)
 	return newCert, newKey, nil
 }
 
@@ -98,15 +100,19 @@ func createRootCertIfNotExists(cfg config, spec rootCertSpec) (*x509.Certificate
 // A read error other than "file not found" is currently treated the same as a missing file
 // (the certificate is regenerated). This is intentional: a corrupted cert file should not
 // block PKI initialization.
-func createLeafCertIfNotExists(cfg config, spec certSpec[LeafCertName], caCert *x509.Certificate, caKey crypto.Signer) error {
+func createLeafCertIfNotExists(cfg config, spec certSpec[LeafCertName], caCert *x509.Certificate, caKey crypto.Signer, rep *PKIApplyReport) error {
 	oldCert, _, err := readCertAndKey(cfg.pkiDir, spec.BaseName)
 	newCertCfg := spec.BuildConfig(cfg)
+	regenerate := false
 	if err == nil {
 		if err := validateCert(oldCert, newCertCfg); err == nil {
+			rep.add(spec.BaseName, PKIEntryKindLeafCert, PKIActionUnchanged)
 			return nil
 		}
+		regenerate = true
 	} else if !isNotExistError(err) {
 		log.Warn("Cert, will be recreated", slog.String("baseName", spec.BaseName), slog.String("reason", err.Error()))
+		regenerate = true
 	}
 
 	newKey, err := pkiutil.NewPrivateKey(cfg.EncryptionAlgorithmType)
@@ -123,5 +129,10 @@ func createLeafCertIfNotExists(cfg config, spec certSpec[LeafCertName], caCert *
 		return fmt.Errorf("failed to write cert %q: %w", spec.BaseName, err)
 	}
 
+	if regenerate {
+		rep.add(spec.BaseName, PKIEntryKindLeafCert, PKIActionWrittenRegenerated)
+	} else {
+		rep.add(spec.BaseName, PKIEntryKindLeafCert, PKIActionWrittenCreated)
+	}
 	return nil
 }

--- a/go_lib/controlplane/pki/certs_test.go
+++ b/go_lib/controlplane/pki/certs_test.go
@@ -28,8 +28,11 @@ func TestCreateRootCertIfNotExists_CreatesNew(t *testing.T) {
 	cfg := makeTestConfig(t, dir)
 	spec := getRootCertSpec(CACertName)
 
-	cert, key, err := createRootCertIfNotExists(cfg, spec)
+	var rep PKIApplyReport
+	cert, key, err := createRootCertIfNotExists(cfg, spec, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
 	assert.NotNil(t, cert)
 	assert.NotNil(t, key)
 	assert.True(t, cert.IsCA)
@@ -46,12 +49,18 @@ func TestCreateRootCertIfNotExists_ReusesExisting(t *testing.T) {
 	cfg := makeTestConfig(t, dir)
 	spec := getRootCertSpec(CACertName)
 
-	cert1, _, err := createRootCertIfNotExists(cfg, spec)
+	var rep PKIApplyReport
+	cert1, _, err := createRootCertIfNotExists(cfg, spec, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
 
 	// Second call must return the same certificate without regenerating.
-	cert2, _, err := createRootCertIfNotExists(cfg, spec)
+	rep = PKIApplyReport{}
+	cert2, _, err := createRootCertIfNotExists(cfg, spec, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionUnchanged, rep.Entries[0].Action)
 	assert.Equal(t, cert1.SerialNumber, cert2.SerialNumber)
 }
 
@@ -65,7 +74,8 @@ func TestCreateRootCertIfNotExists_FailsOnInvalidCA(t *testing.T) {
 	err := writeCertAndKey(dir, "ca", expiredCert, expiredKey)
 	require.NoError(t, err)
 
-	_, _, err = createRootCertIfNotExists(cfg, spec)
+	var rep PKIApplyReport
+	_, _, err = createRootCertIfNotExists(cfg, spec, &rep)
 
 	var certErr *CertValidationError
 	require.ErrorAs(t, err, &certErr)
@@ -79,8 +89,11 @@ func TestCreateLeafCertIfNotExists_CreatesNew(t *testing.T) {
 	caCert, caKey := makeTestCACert(t, "kubernetes")
 	spec := getLeafCertSpec(ApiserverCertName)
 
-	err := createLeafCertIfNotExists(cfg, spec, caCert, caKey)
+	var rep PKIApplyReport
+	err := createLeafCertIfNotExists(cfg, spec, caCert, caKey, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
 
 	cert, _, err := readCertAndKey(dir, "apiserver")
 	require.NoError(t, err)
@@ -94,15 +107,21 @@ func TestCreateLeafCertIfNotExists_SkipsValid(t *testing.T) {
 	caCert, caKey := makeTestCACert(t, "kubernetes")
 	spec := getLeafCertSpec(ApiserverCertName)
 
-	err := createLeafCertIfNotExists(cfg, spec, caCert, caKey)
+	var rep PKIApplyReport
+	err := createLeafCertIfNotExists(cfg, spec, caCert, caKey, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
 
 	cert1, _, err := readCertAndKey(dir, "apiserver")
 	require.NoError(t, err)
 
 	// Second call must not regenerate the certificate.
-	err = createLeafCertIfNotExists(cfg, spec, caCert, caKey)
+	rep = PKIApplyReport{}
+	err = createLeafCertIfNotExists(cfg, spec, caCert, caKey, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionUnchanged, rep.Entries[0].Action)
 
 	cert2, _, err := readCertAndKey(dir, "apiserver")
 	require.NoError(t, err)
@@ -122,8 +141,11 @@ func TestCreateLeafCertIfNotExists_RegeneratesInvalid(t *testing.T) {
 	require.NoError(t, err)
 
 	// Must regenerate without error.
-	err = createLeafCertIfNotExists(cfg, spec, caCert, caKey)
+	var rep PKIApplyReport
+	err = createLeafCertIfNotExists(cfg, spec, caCert, caKey, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenRegenerated, rep.Entries[0].Action)
 
 	newCert, _, err := readCertAndKey(dir, "apiserver")
 	require.NoError(t, err)

--- a/go_lib/controlplane/pki/config.go
+++ b/go_lib/controlplane/pki/config.go
@@ -161,7 +161,7 @@ func newConfig(
 }
 
 // configOption is a functional option for PKI configuration.
-// It allows passing optional parameters to CreatePKIBundle without changing its signature.
+// It supplies optional parameters to CreatePKIBundle after the required arguments.
 type configOption func(*config)
 
 // WithCertTreeScheme overrides the PKI tree structure.

--- a/go_lib/controlplane/pki/const.go
+++ b/go_lib/controlplane/pki/const.go
@@ -21,7 +21,7 @@ type RootCertName string
 const (
 	CACertName           RootCertName = "ca"
 	FrontProxyCACertName RootCertName = "front-proxy-ca"
-	EtcdCACertName       RootCertName = "etcd-ca"
+	EtcdCACertName       RootCertName = "etcd/ca"
 )
 
 type LeafCertName string
@@ -30,8 +30,8 @@ const (
 	ApiserverCertName              LeafCertName = "apiserver"
 	ApiserverKubeletClientCertName LeafCertName = "apiserver-kubelet-client"
 	FrontProxyClientCertName       LeafCertName = "front-proxy-client"
-	EtcdServerCertName             LeafCertName = "etcd-server"
-	EtcdPeerCertName               LeafCertName = "etcd-peer"
-	EtcdHealthcheckClientCertName  LeafCertName = "etcd-healthcheck-client"
+	EtcdServerCertName             LeafCertName = "etcd/server"
+	EtcdPeerCertName               LeafCertName = "etcd/peer"
+	EtcdHealthcheckClientCertName  LeafCertName = "etcd/healthcheck-client"
 	ApiserverEtcdClientCertName    LeafCertName = "apiserver-etcd-client"
 )

--- a/go_lib/controlplane/pki/pki.go
+++ b/go_lib/controlplane/pki/pki.go
@@ -35,29 +35,33 @@ import (
 //   - If a CA certificate fails validation, an error is returned — CAs are never auto-regenerated.
 //   - If a leaf certificate fails validation, it is silently regenerated.
 //   - If sa.key already exists, sa.pub is ensured to be present (restored from the key if missing).
+//
+// On error, the returned PKIApplyReport may still contain entries for artifacts that were
+// processed successfully before the failure.
 func CreatePKIBundle(
 	nodeName string,
 	dnsDomain string,
 	advertiseAddress net.IP,
 	serviceCIDR string,
 	opts ...configOption,
-) error {
+) (PKIApplyReport, error) {
 	cfg, err := newConfig(nodeName, dnsDomain, advertiseAddress, serviceCIDR, opts...)
 	if err != nil {
-		return fmt.Errorf("failed to create new config: %w", err)
+		return PKIApplyReport{}, fmt.Errorf("failed to create new config: %w", err)
 	}
 
 	return createPKIBundle(*cfg)
 }
 
-func createPKIBundle(cfg config) error {
-	if err := createCertTree(cfg); err != nil {
-		return err
+func createPKIBundle(cfg config) (PKIApplyReport, error) {
+	var rep PKIApplyReport
+	if err := createCertTree(cfg, &rep); err != nil {
+		return rep, err
 	}
 
-	if err := createSAKeysIfNotExists(cfg); err != nil {
-		return err
+	if err := createSAKeysIfNotExists(cfg, &rep); err != nil {
+		return rep, err
 	}
 
-	return nil
+	return rep, nil
 }

--- a/go_lib/controlplane/pki/pki_test.go
+++ b/go_lib/controlplane/pki/pki_test.go
@@ -45,7 +45,7 @@ var allExpectedFiles = []string{
 func TestCreatePKIBundle_CreatesAllFiles(t *testing.T) {
 	dir := t.TempDir()
 
-	err := CreatePKIBundle(
+	rep, err := CreatePKIBundle(
 		"test-node",
 		"cluster.local",
 		net.ParseIP("10.0.0.1"),
@@ -53,6 +53,10 @@ func TestCreatePKIBundle_CreatesAllFiles(t *testing.T) {
 		WithPKIDir(dir),
 	)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 11)
+	for _, e := range rep.Entries {
+		assert.Equal(t, PKIActionWrittenCreated, e.Action, "artifact %q", e.Name)
+	}
 
 	for _, f := range allExpectedFiles {
 		path := filepath.Join(dir, f)
@@ -67,13 +71,21 @@ func TestCreatePKIBundle_Idempotent(t *testing.T) {
 	opts := []configOption{WithPKIDir(dir)}
 	args := []any{"test-node", "cluster.local", net.ParseIP("10.0.0.1"), "10.96.0.0/12"}
 
-	err := CreatePKIBundle(args[0].(string), args[1].(string), args[2].(net.IP), args[3].(string), opts...)
+	rep1, err := CreatePKIBundle(args[0].(string), args[1].(string), args[2].(net.IP), args[3].(string), opts...)
 	require.NoError(t, err)
+	require.Len(t, rep1.Entries, 11)
+	for _, e := range rep1.Entries {
+		assert.Equal(t, PKIActionWrittenCreated, e.Action, "first run: %q", e.Name)
+	}
 
 	before := readAllFiles(t, dir, allExpectedFiles)
 
-	err = CreatePKIBundle(args[0].(string), args[1].(string), args[2].(net.IP), args[3].(string), opts...)
+	rep2, err := CreatePKIBundle(args[0].(string), args[1].(string), args[2].(net.IP), args[3].(string), opts...)
 	require.NoError(t, err)
+	require.Len(t, rep2.Entries, 11)
+	for _, e := range rep2.Entries {
+		assert.Equal(t, PKIActionUnchanged, e.Action, "second run: %q", e.Name)
+	}
 
 	after := readAllFiles(t, dir, allExpectedFiles)
 
@@ -94,7 +106,7 @@ func TestCreatePKIBundle_CustomScheme_EtcdOnly(t *testing.T) {
 		},
 	}
 
-	err := CreatePKIBundle(
+	rep, err := CreatePKIBundle(
 		"test-node",
 		"cluster.local",
 		net.ParseIP("10.0.0.1"),
@@ -103,6 +115,11 @@ func TestCreatePKIBundle_CustomScheme_EtcdOnly(t *testing.T) {
 		WithCertTreeScheme(etcdOnlyScheme),
 	)
 	require.NoError(t, err)
+	// One etcd CA, three leaf certs, SA key pair.
+	require.Len(t, rep.Entries, 5)
+	for _, e := range rep.Entries {
+		assert.Equal(t, PKIActionWrittenCreated, e.Action, "artifact %q", e.Name)
+	}
 
 	// Etcd files must be present.
 	for _, f := range []string{

--- a/go_lib/controlplane/pki/sa.go
+++ b/go_lib/controlplane/pki/sa.go
@@ -36,7 +36,7 @@ import (
 // Note: sa.key and sa.pub are not X.509 certificates. They are a raw asymmetric key pair
 // used by kube-controller-manager to sign ServiceAccount JWT tokens (sa.key) and by
 // kube-apiserver to verify them (sa.pub).
-func createSAKeysIfNotExists(cfg config) error {
+func createSAKeysIfNotExists(cfg config, rep *PKIApplyReport) error {
 	key, err := pkiutil.LoadKey(keyPath(cfg.pkiDir, "sa"))
 	if err != nil && !isNotExistError(err) {
 		return fmt.Errorf("failed to load SA private key: %w", err)
@@ -46,10 +46,15 @@ func createSAKeysIfNotExists(cfg config) error {
 		// sa.key exists — ensure sa.pub is also present.
 		pubPath := filepath.Join(cfg.pkiDir, "sa.pub")
 		if _, statErr := os.Stat(pubPath); statErr == nil {
+			rep.add("sa", PKIEntryKindServiceAccountKeys, PKIActionUnchanged)
 			return nil
 		}
 		// sa.pub is missing — restore it from the existing key.
-		return writeSAPublicKey(cfg.pkiDir, key)
+		if err := writeSAPublicKey(cfg.pkiDir, key); err != nil {
+			return err
+		}
+		rep.add("sa", PKIEntryKindServiceAccountKeys, PKIActionSAPublicKeyRestored)
+		return nil
 	}
 
 	// sa.key does not exist — create a new key pair.
@@ -62,5 +67,9 @@ func createSAKeysIfNotExists(cfg config) error {
 		return fmt.Errorf("failed to write SA private key: %w", err)
 	}
 
-	return writeSAPublicKey(cfg.pkiDir, key)
+	if err := writeSAPublicKey(cfg.pkiDir, key); err != nil {
+		return err
+	}
+	rep.add("sa", PKIEntryKindServiceAccountKeys, PKIActionWrittenCreated)
+	return nil
 }

--- a/go_lib/controlplane/pki/sa_test.go
+++ b/go_lib/controlplane/pki/sa_test.go
@@ -31,8 +31,13 @@ func TestCreateSAKeysIfNotExists_CreatesNewPair(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(t, dir)
 
-	err := createSAKeysIfNotExists(cfg)
+	var rep PKIApplyReport
+	err := createSAKeysIfNotExists(cfg, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, "sa", rep.Entries[0].Name)
+	assert.Equal(t, PKIEntryKindServiceAccountKeys, rep.Entries[0].Kind)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
 
 	for _, f := range []string{"sa.key", "sa.pub"} {
 		_, err := os.Stat(filepath.Join(dir, f))
@@ -44,8 +49,11 @@ func TestCreateSAKeysIfNotExists_SkipsWhenBothExist(t *testing.T) {
 	dir := t.TempDir()
 	cfg := makeTestConfig(t, dir)
 
-	err := createSAKeysIfNotExists(cfg)
+	var rep PKIApplyReport
+	err := createSAKeysIfNotExists(cfg, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
 
 	keyBefore, err := os.ReadFile(filepath.Join(dir, "sa.key"))
 	require.NoError(t, err)
@@ -53,8 +61,11 @@ func TestCreateSAKeysIfNotExists_SkipsWhenBothExist(t *testing.T) {
 	require.NoError(t, err)
 
 	// Second call must leave both files untouched.
-	err = createSAKeysIfNotExists(cfg)
+	rep = PKIApplyReport{}
+	err = createSAKeysIfNotExists(cfg, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionUnchanged, rep.Entries[0].Action)
 
 	keyAfter, err := os.ReadFile(filepath.Join(dir, "sa.key"))
 	require.NoError(t, err)
@@ -70,16 +81,22 @@ func TestCreateSAKeysIfNotExists_RestoresMissingPub(t *testing.T) {
 	cfg := makeTestConfig(t, dir)
 
 	// Create the full pair first.
-	err := createSAKeysIfNotExists(cfg)
+	var rep PKIApplyReport
+	err := createSAKeysIfNotExists(cfg, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
 
 	// Simulate sa.pub going missing (e.g. accidental deletion).
 	err = os.Remove(filepath.Join(dir, "sa.pub"))
 	require.NoError(t, err)
 
 	// Must restore sa.pub from the existing sa.key.
-	err = createSAKeysIfNotExists(cfg)
+	rep = PKIApplyReport{}
+	err = createSAKeysIfNotExists(cfg, &rep)
 	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionSAPublicKeyRestored, rep.Entries[0].Action)
 
 	pubData, err := os.ReadFile(filepath.Join(dir, "sa.pub"))
 	require.NoError(t, err, "sa.pub should have been restored")

--- a/go_lib/controlplane/pki/spec.go
+++ b/go_lib/controlplane/pki/spec.go
@@ -88,7 +88,7 @@ func getRootCertSpec(name RootCertName) rootCertSpec {
 	case CACertName:
 		return rootCertSpec{
 			certSpec: certSpec[RootCertName]{
-				BaseName: "ca",
+				BaseName: string(CACertName),
 				BuildConfig: func(cfg config) certConfig {
 					return certConfig{
 						Config: certutil.Config{
@@ -103,7 +103,7 @@ func getRootCertSpec(name RootCertName) rootCertSpec {
 	case FrontProxyCACertName:
 		return rootCertSpec{
 			certSpec: certSpec[RootCertName]{
-				BaseName: "front-proxy-ca",
+				BaseName: string(FrontProxyCACertName),
 				BuildConfig: func(cfg config) certConfig {
 					return certConfig{
 						Config: certutil.Config{
@@ -118,7 +118,7 @@ func getRootCertSpec(name RootCertName) rootCertSpec {
 	case EtcdCACertName:
 		return rootCertSpec{
 			certSpec: certSpec[RootCertName]{
-				BaseName: "etcd/ca",
+				BaseName: string(EtcdCACertName),
 				BuildConfig: func(cfg config) certConfig {
 					return certConfig{
 						Config: certutil.Config{
@@ -139,7 +139,7 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 	switch name {
 	case ApiserverCertName:
 		return certSpec[LeafCertName]{
-			BaseName: "apiserver",
+			BaseName: string(ApiserverCertName),
 			BuildConfig: func(cfg config) certConfig {
 				domain := cfg.DNSDomain
 
@@ -198,7 +198,7 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 		}
 	case ApiserverKubeletClientCertName:
 		return certSpec[LeafCertName]{
-			BaseName: "apiserver-kubelet-client",
+			BaseName: string(ApiserverKubeletClientCertName),
 			BuildConfig: func(cfg config) certConfig {
 				return certConfig{
 					Config: certutil.Config{
@@ -213,7 +213,7 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 		}
 	case FrontProxyClientCertName:
 		return certSpec[LeafCertName]{
-			BaseName: "front-proxy-client",
+			BaseName: string(FrontProxyClientCertName),
 			BuildConfig: func(cfg config) certConfig {
 				return certConfig{
 					Config: certutil.Config{
@@ -227,7 +227,7 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 		}
 	case EtcdServerCertName:
 		return certSpec[LeafCertName]{
-			BaseName: "etcd/server",
+			BaseName: string(EtcdServerCertName),
 			BuildConfig: func(cfg config) certConfig {
 				altNames := certutil.AltNames{
 					DNSNames: []string{cfg.NodeName, "localhost"},
@@ -259,7 +259,7 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 		}
 	case EtcdPeerCertName:
 		return certSpec[LeafCertName]{
-			BaseName: "etcd/peer",
+			BaseName: string(EtcdPeerCertName),
 			BuildConfig: func(cfg config) certConfig {
 				altNames := certutil.AltNames{
 					DNSNames: []string{cfg.NodeName, "localhost"},
@@ -291,7 +291,7 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 		}
 	case EtcdHealthcheckClientCertName:
 		return certSpec[LeafCertName]{
-			BaseName: "etcd/healthcheck-client",
+			BaseName: string(EtcdHealthcheckClientCertName),
 			BuildConfig: func(cfg config) certConfig {
 				return certConfig{
 					Config: certutil.Config{
@@ -305,7 +305,7 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 		}
 	case ApiserverEtcdClientCertName:
 		return certSpec[LeafCertName]{
-			BaseName: "apiserver-etcd-client",
+			BaseName: string(ApiserverEtcdClientCertName),
 			BuildConfig: func(cfg config) certConfig {
 				return certConfig{
 					Config: certutil.Config{


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
