### PR TITLE
[cni-simple-bridge] Refactor python image source and pip exclusion

### DIFF
--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -6,7 +6,7 @@ import:
   add: /relocate
   to: /
   before: setup
-- image: common-base-python-artifact
+- from: {{ index $.Images "base/python" }}
   add: /
   to: /
   includePaths:
@@ -14,6 +14,8 @@ import:
   - usr/bin/python3*
   - usr/lib/python3*
   - usr/lib/libc.so
+  excludePaths:
+  - usr/lib/python3*/site-packages/pip-25.3*
   before: install
 - image: registrypackages/d8-curl-artifact-8-9-1
   add: /d8-curl


### PR DESCRIPTION
## Description

This PR refactors the `cni-simple-bridge` module's `werf.inc.yaml` to switch the Python image source from `common-base-python-artifact` to the `base/python` shared image. Additionally, it adds an exclusion for `pip-25.3*` during the artifact installation process to prevent conflicts.

These changes serve as a necessary technical prerequisite for upcoming dependency updates to mitigate identified security vulnerabilities (CVE-2026-26007, CVE-2026-34073, CVE-2026-1703, CVE-2026-27459, CVE-2026-27448).

## Why do we need it, and what problem does it solve?

We are preparing the environment to address several high and low-severity CVEs in the `cryptography`, `pip`, and `pyOpenSSL` packages. Moving to the standardized `base/python` image and excluding legacy pip versions is required to control the dependency environment effectively and resolve the security issues in subsequent steps.

## Why do we need it in the patch release?

These changes are required in the patch release to support the infrastructure hardening process and enable the deployment of patched dependencies for `simple-bridge`.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-simple-bridge
type: fix
summary: Refactored python image source and pip exclusion.
impact_level: default
```