### PR TITLE
[network-gateway] Update python image source and exclude vulnerable pip

### DIFF
--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -18,7 +18,7 @@ import:
   add: /relocate
   to: /
   before: setup
-- image: common-base-python-artifact
+- from: {{ index $.Images "base/python" }}
   add: /
   to: /
   before: install
@@ -27,3 +27,5 @@ import:
   - usr/bin/python3*
   - usr/lib/python3*
   - usr/lib/libc.so
+  excludePaths:
+  - usr/lib/python3*/site-packages/pip-25.3*


### PR DESCRIPTION
## Description

This PR updates the `network-gateway` module's `werf.inc.yaml` to use the shared `base/python` image instead of `common-base-python-artifact`. It also excludes the `pip-25.3*` package to mitigate CVE-2026-1703.

## Why do we need it, and what problem does it solve?

We need to mitigate critical security vulnerabilities found in the bundled Python packages. Switching to the centralized `base/python` image allows for proper dependency management, and excluding the vulnerable `pip-25.3*` version directly addresses the security risk identified in the latest scan (CVE-2026-1703).

## Why do we need it in the patch release?

These changes are required to address critical security vulnerabilities immediately and ensure the security of the platform.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: network-gateway
type: fix
summary: Updated python image source and mitigated pip CVE-2026-1703
impact_level: default
```