### PR TITLE
[docs] Add LTS channel entry to version switcher

### DIFF
--- a/docs/documentation/_includes/nav-breadcrumbs.html
+++ b/docs/documentation/_includes/nav-breadcrumbs.html
@@ -26,7 +26,6 @@
       {% include nav-breadcrumbs-pagepath.html %}
     </ol>
   </div>
-  {% if page.searchBageEnabled %}
     <!--start search-->
     {%- if site.mode == 'module' %}
       {%- assign cachingTime = '180' %}
@@ -34,6 +33,7 @@
       {%- assign cachingTime = '1440' %}
     {%- endif -%}
     <div class="searchV3">
+    {% if page.searchBageEnabled %}
       <div class="container">
         <div class="input-wrapper">
           <input type="text" id="search-input" placeholder="{{ site.data.i18n.common.search_placeholder_text[page.lang] }}" class="input"
@@ -48,8 +48,10 @@
           <div id="search-results" class="results" style="display: none"></div>
         </div>
       </div>
+      {%- endif %}
     </div>
     <!--end search-->
+  {% if page.searchBageEnabled %}
     <!--loading search JS-->
     {%- assign assetHash = site.time | date: "%Y-%m-%d %H:%M:%S" | sha256 -%}
     <script type="text/javascript" src="/assets/js/fuse.min.js?v={{ assetHash }}"></script>

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -17,6 +17,9 @@ site_description:
   ru: "Deckhouse. Позволяет создавать идентичные Kubernetes-кластеры в любой инфраструктуре и полностью, «автомагически» управляет ими."
 github_repo_path: /deckhouse/deckhouse
 d8Revision: EE
+LTSChannel:
+  version: v1.73-cse
+  versionName: v1.73 (CSE)
 
 metrics:
   google: G-4X28CEP7W2

--- a/docs/site/_includes/channel-menu-v2.html
+++ b/docs/site/_includes/channel-menu-v2.html
@@ -8,8 +8,17 @@
 <a data-proofer-ignore href="#" class="highlight">
   {{- if eq $current.Version "v1" }}stable{{- else }}{{ $current.Version }}{{- end }}</a>
 </a>
+{% endraw %}
 <div class="submenu-container">
     <ul class="submenu">
+      <li class="submenu-item">
+          <a data-proofer-ignore class="submenu-item-link" href="/products/kubernetes-platform/documentation/{{ site.LTSChannel.version }}/">
+              <span class="submenu-item-channel">LTS</span>
+              <span class="submenu-item-dot"></span>
+              <span class="submenu-item-release">{{ site.LTSChannel.versionName }}</span>
+          </a>
+      </li>
+{% raw %}
     {{- range (slice .VersionItems 1) }}
       {{- $majMinVersion := regexReplaceAll "(v[0-9]+\\.[0-9]+)\\..+" .Version "$1" }}
       {{- if not (and (eq .Version "latest") (eq $majMinVersion $prevVersion)) }}

--- a/docs/site/_includes/channel-menu-v2.html
+++ b/docs/site/_includes/channel-menu-v2.html
@@ -6,11 +6,12 @@
 {{- $current := index .VersionItems 0 }}
 {{- if eq $current.Version "rock-solid" }}{{ $prevVersion = "rock-solid" }}{{- end }}
 <a data-proofer-ignore href="#" class="highlight">
-  {{- if eq $current.Version "v1" }}stable{{- else }}{{ $current.Version }}{{- end }}</a>
+  {{- if eq $current.Version "v1" }}stable{{- else if hasSuffix "-cse" $current.Version }}LTS{{- else }}{{ $current.Version }}{{- end }}</a>
 </a>
 {% endraw %}
 <div class="submenu-container">
     <ul class="submenu">
+{%- if page.lang == 'ru' %}
       <li class="submenu-item">
           <a data-proofer-ignore class="submenu-item-link" href="/products/kubernetes-platform/documentation/{{ site.LTSChannel.version }}/">
               <span class="submenu-item-channel">LTS</span>
@@ -18,6 +19,7 @@
               <span class="submenu-item-release">{{ site.LTSChannel.versionName }}</span>
           </a>
       </li>
+{%- endif %}
 {% raw %}
     {{- range (slice .VersionItems 1) }}
       {{- $majMinVersion := regexReplaceAll "(v[0-9]+\\.[0-9]+)\\..+" .Version "$1" }}


### PR DESCRIPTION
## Description

This pull request introduces support for displaying a new "LTS" (Long Term Support) channel in the documentation site, adds the LTS channel version information to the site configuration, and refines the logic for rendering the search bar in navigation breadcrumbs. The changes primarily focus on improving version/channel visibility and UI logic for the documentation site.

Channel menu and versioning improvements:

* Updated the channel menu (`channel-menu-v2.html`) to display "LTS" instead of the raw version string for versions ending with `-cse`, and added a submenu entry for the LTS channel when the language is Russian.
* Added the `LTSChannel` configuration (with version and versionName) to `_config.yml` for use in templates and navigation.

UI logic refinement:

* Adjusted the logic in `nav-breadcrumbs.html` to ensure the search bar and related JavaScript are only rendered if `page.searchBageEnabled` is true, fixing previous unconditional rendering.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add LTS channel entry to version switcher
impact_level: low
```
