### PR TITLE
[descheduler| node-manager] 1.73 fix vex for grpc

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/known_vulnerabilities.vex
+++ b/modules/040-node-manager/images/cluster-autoscaler/known_vulnerabilities.vex
@@ -125,11 +125,8 @@
       },
       "products": [
         {
-          "@id": "pkg:golang/google.golang.org/grpc@v1.59.0"
+          "@id": "pkg:golang/google.golang.org/grpc"
         },
-        {
-          "@id": "pkg:golang/google.golang.org/grpc@v1.65.0"
-        }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",

--- a/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
+++ b/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
@@ -10,7 +10,7 @@
       },
       "products": [
         {
-          "@id": "pkg:golang/google.golang.org/grpc@v1.65.0"
+          "@id": "pkg:golang/google.golang.org/grpc"
         }
       ],
       "status": "not_affected",


### PR DESCRIPTION
## Description
Change recording about vex for [CVE-2026-33186](https://defectdojo.flant.ru/finding/4181269)

## Why do we need it, and what problem does it solve?
This changes helps to avoid trivy alerting for known vulnerabilities

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type: chore
summary: change vex CVE-2026-33186
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
