### PR TITLE
fix: allow service-with-healthchecks namespace in default policy

### DIFF
--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -91,6 +91,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -88,6 +88,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
@@ -205,6 +205,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
@@ -201,6 +201,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
@@ -61,6 +61,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
@@ -58,6 +58,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
@@ -243,6 +243,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
@@ -239,6 +239,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -94,6 +94,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -91,6 +91,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
@@ -293,6 +293,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
@@ -289,6 +289,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
@@ -92,6 +92,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
@@ -89,6 +89,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
@@ -196,6 +196,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
@@ -192,6 +192,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
@@ -206,6 +206,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
@@ -202,6 +202,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
@@ -294,6 +294,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
@@ -290,6 +290,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
@@ -243,6 +243,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
@@ -239,6 +239,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:


### PR DESCRIPTION
## Description
Updated the default project template to allow ingress traffic from the `d8-service-with-healthchecks` namespace. This is needed for the ServiceWithHealthChecks module agents, which run in a separate namespace and must be able to connect to workloads inside user projects.

## Why do we need it, and what problem does it solve?
By default, user projects are created in isolated mode, where all ingress traffic is denied unless explicitly allowed. The ServiceWithHealthChecks agents need to probe services in user projects to decide whether traffic should be routed or not. Without this NetworkPolicy exception, these probes are blocked and the module cannot work correctly.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: deckhouse-controller
type: feature
summary: Allow ServiceWithHealthChecks agents to access isolated user projects
impact_level: low