### PR TITLE
[docs] Fixed the scrolling, the status bar opening and the code block style

### DIFF
--- a/docs/site/_sass/components/_resources.scss
+++ b/docs/site/_sass/components/_resources.scss
@@ -2,6 +2,11 @@
 @use "components/common/_mixins";
 
 .resources {
+
+  .resources__attrs {
+    padding-left: 1px;
+  }
+
   ul, ol, li {
     & p:not(.resources__attrs) {
       font-size: 14px;

--- a/docs/site/assets/css/docs.scss
+++ b/docs/site/assets/css/docs.scss
@@ -2715,6 +2715,10 @@ select#contact-select {
       list-style-type: none;
       color: #9e9e9e;
 
+      @include breakpoints.max-w(s) {
+        line-height: 16px;
+      }
+
       li {
         padding: 0;
         margin: 0;

--- a/docs/site/assets/css/docs.scss
+++ b/docs/site/assets/css/docs.scss
@@ -1649,11 +1649,10 @@ a.comparison-table__module-proprietaryOkmeter::after {
     .code__transfer {
       scrollbar-color: #CFD2D8 #f1f1f1;
       padding-right: 70px;
-      margin-left: 48px;
+      margin-left: 37px;
 
       @include breakpoints.max-w(xl) {
         padding-right: 50px;
-        margin-left: 40px;
       }
     }
 }

--- a/docs/site/assets/js/customscripts.js
+++ b/docs/site/assets/js/customscripts.js
@@ -239,6 +239,14 @@ $(document).ready(function () {
     .on('click.resourcesToggleLink', '.resources__prop_wrap .anchorjs-link', function (e) {
       e.stopPropagation();
     });
+    
+  const hash = decodeURIComponent(window.location.hash.replace('#', ''));
+  const container = hash ? document.getElementById(hash) : null;
+  const toggleableClosedItem = container ? container.closest('li.top-level-toggleable.closed') : null;
+
+  if (toggleableClosedItem) {
+    toggleableClosedItem.classList.remove('closed');
+  }
 
   $(document)
     .off('click.resourcesToggle', '.resources__prop_name')

--- a/docs/site/assets/js/faq.js
+++ b/docs/site/assets/js/faq.js
@@ -54,17 +54,40 @@ document.addEventListener('DOMContentLoaded', function () {
             return;
         }
 
+        function getScrollOffset() {
+            const header = document.querySelector('header');
+            const navigation = document.querySelector('.navigation__container');
+            const headerHeight = header ? header.offsetHeight : 0;
+            const navigationHeight = navigation && !navigation.classList.contains('hidden') ? navigation.offsetHeight : 0;
+
+            return headerHeight + navigationHeight + 10;
+        }
+
+        function alignTitleWithViewport() {
+            const scrollTop = title.getBoundingClientRect().top + window.scrollY - getScrollOffset();
+            window.scrollTo(0, Math.max(0, scrollTop));
+        }
+
         if (onlyTarget) {
-            sectionMap.forEach((content, title) => {
-                title.classList.toggle('hide');
-                content.classList.toggle('hidden');
+            sectionMap.forEach((contentItem, titleItem) => {
+                const isTarget = titleItem === title;
+
+                titleItem.classList.toggle('hide', !isTarget);
+                if (contentItem) {
+                    contentItem.classList.toggle('hidden', !isTarget);
+                }
             });
+            requestAnimationFrame(alignTitleWithViewport);
             return;
         }
 
         const content = sectionMap.get(title);
         title.classList.remove('hide');
-        content.classList.remove('hidden');
+        if (content) {
+            content.classList.remove('hidden');
+        }
+
+        requestAnimationFrame(alignTitleWithViewport);
     }
 
     faqTitle.forEach(title => {

--- a/docs/site/assets/js/navigation.js
+++ b/docs/site/assets/js/navigation.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function applyHeaderOffsets() {
         const header = document.querySelector('header');
-        const headerHeight = header.offsetHeight;
+        const headerHeight = header.getBoundingClientRect().height;
         navigationContainer.style.top = `${headerHeight}px`;
         sidebarAndToc.forEach(e => {
             e.style.top = `${headerHeight}px`;
@@ -33,6 +33,23 @@ document.addEventListener('DOMContentLoaded', () => {
             e.classList.remove('top');
             e.style.removeProperty('--scroll-top');
         });
+    }
+
+    function hideNavigationOnAnchor() {
+        const hash = decodeURIComponent(window.location.hash.replace('#', ''));
+        if (!hash) {
+            return;
+        }
+
+        if (!document.getElementById(hash)) {
+            return;
+        }
+
+        isScroll = false;
+        hideNavigation();
+        setTimeout(() => {
+            isScroll = true;
+        }, 500);
     }
 
     function scrollHandler(newTopValue) {
@@ -63,7 +80,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const tocLink = target.closest('.toc-sidebar__item-link');
-        if (!tocLink) {
+        const anchorLink = target.closest('.anchorjs-link');
+        if (!tocLink && !anchorLink) {
             return;
         }
 
@@ -87,7 +105,12 @@ document.addEventListener('DOMContentLoaded', () => {
         scrollHandler(newTop)
     });
 
+    window.addEventListener('hashchange', hideNavigationOnAnchor);
+    window.addEventListener('load', hideNavigationOnAnchor);
+
     if (window.scrollY > 0) {
         hideNavigation();
     }
+
+    hideNavigationOnAnchor();
 });


### PR DESCRIPTION
## Description

Fixed the scrolling in the  FAQ, the status bar opening when clicking on an anchor, and the code block style.

**Navigation and Anchor Link Handling:**

* Added logic to automatically hide the navigation sidebar when navigating to an anchor link (e.g., via table of contents or direct URL), ensuring the content is fully visible and not overlapped by navigation elements. This includes new event handlers for `hashchange` and `load` events and a function to check for anchor presence. [[1]](diffhunk://#diff-136abad84dea376eda5c27faa73e55086632deadad3fba4e64919017bff0eb9eR38-R54) [[2]](diffhunk://#diff-136abad84dea376eda5c27faa73e55086632deadad3fba4e64919017bff0eb9eR108-R115)
* Improved detection of anchor link clicks to include both table of contents and anchor links, ensuring consistent navigation behavior.

**FAQ Section Usability:**

* Enhanced FAQ navigation so that when a specific section is targeted, it is scrolled into view below the fixed header and navigation, improving accessibility and user experience. This includes calculating offsets dynamically and aligning the section title with the viewport.

**Resource and Code Section Styling:**

* Adjusted left padding for the `.resources__attrs` class to improve alignment in resource lists.
* Reduced left margin for `.code__transfer` to optimize code block appearance, especially on smaller screens.
* Added a responsive line-height for resource lists on small screens to enhance readability.

**Other Improvements:**

* Ensured that when navigating directly to a resource via URL hash, any closed toggleable sections containing the target are automatically opened for visibility.
* Improved header height calculation in navigation logic by using `getBoundingClientRect().height` for more accurate positioning.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fixed the scrolling in the  FAQ, the status bar opening when clicking on an anchor, and the code block style.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
