### PR TITLE
[dhctl] fix: dhctl must not skip namespace update, if namespace already exists

### DIFF
--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -187,17 +187,11 @@ func CreateDeckhouseManifests(
 				return manifests.DeckhouseNamespace("d8-system")
 			},
 			CreateFunc: func(manifest any) error {
-				namespace := manifest.(*apiv1.Namespace)
-				_, err := kubeCl.CoreV1().Namespaces().Get(ctx, namespace.GetName(), metav1.GetOptions{})
-				if err != nil {
-					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
-						return err
-					}
-					return err
-				}
-				log.InfoLn("Already exists. Skip!")
-				return nil
+				_, err := kubeCl.
+					CoreV1().
+					Namespaces().
+					Create(ctx, manifest.(*apiv1.Namespace), metav1.CreateOptions{})
+				return err
 			},
 			UpdateFunc: func(manifest any) error {
 				_, err := kubeCl.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

To prevent cases, when `d8-system` was created before dhctl started bootstraping deckhouse, we need to ensure than namespace `d8-system` has all needed labels via updating ns

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix 
summary: Fixed namespace updates during cluster bootstrap when the namespace already exists.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
