### PR TITLE
[node-manager] Rollback inject capi conversion hook in crds as on-before-helm.

### DIFF
--- a/modules/040-node-manager/hooks/capi_crds_cabundle_injection.go
+++ b/modules/040-node-manager/hooks/capi_crds_cabundle_injection.go
@@ -50,7 +50,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		ExecutionMinInterval: 5 * time.Second,
 		ExecutionBurst:       3,
 	},
-	OnAfterHelm: &go_hook.OrderedConfig{Order: 1},
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
 	Queue:       "/modules/node-manager/capi-crds-conversions",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{

--- a/modules/040-node-manager/hooks/capi_crds_cabundle_injection.go
+++ b/modules/040-node-manager/hooks/capi_crds_cabundle_injection.go
@@ -51,7 +51,7 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 		ExecutionBurst:       3,
 	},
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 1},
-	Queue:       "/modules/node-manager/capi-crds-conversions",
+	Queue:        "/modules/node-manager/capi-crds-conversions",
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:                         "capicrds",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Rollback inject capi conversion hook for crds as on-before-helm.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: rollback inject capi conversion hook in crds as on-before-helm
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
