### PR TITLE
[ci] Add werf fallback to workflows

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -65,6 +65,7 @@ steps:
   {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "login_rw_registry_step" $ctx | strings.Indent 2 }!}
   {!{ end }!}
+  {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "d8cli_install_step" $ctx | strings.Indent 2 }!}
   {!{ tmpl.Exec "add_ssh_keys" $ctx | strings.Indent 2 }!}
 

--- a/.github/workflow_templates/stage_registry_clean.yml
+++ b/.github/workflow_templates/stage_registry_clean.yml
@@ -51,6 +51,7 @@ jobs:
       {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
 
       {!{ tmpl.Exec "checkout_step" $ctx | strings.Indent 4 }!}
+      {!{ tmpl.Exec "werf_install_step" $ctx | strings.Indent 4 }!}
       {!{ tmpl.Exec "d8cli_install_step" $ctx | strings.Indent 4 }!}
       {!{ tmpl.Exec "login_stage_registry_step" $ctx | strings.Indent 4 }!}
 

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -452,6 +452,13 @@ jobs:
       # </template: login_dev_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -751,6 +758,13 @@ jobs:
       # </template: login_dev_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -1048,6 +1062,13 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1347,6 +1368,13 @@ jobs:
       # </template: login_dev_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -1644,6 +1672,13 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1943,6 +1978,13 @@ jobs:
       # </template: login_dev_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -2240,6 +2282,13 @@ jobs:
           logout: false
       # </template: login_dev_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -229,6 +229,13 @@ jobs:
       # </template: login_dev_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -228,6 +228,13 @@ jobs:
       # </template: login_stage_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -536,6 +543,13 @@ jobs:
       # </template: login_stage_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -842,6 +856,13 @@ jobs:
           logout: false
       # </template: login_stage_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1150,6 +1171,13 @@ jobs:
       # </template: login_stage_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -1456,6 +1484,13 @@ jobs:
           logout: false
       # </template: login_stage_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1764,6 +1799,13 @@ jobs:
       # </template: login_stage_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -2070,6 +2112,13 @@ jobs:
           logout: false
       # </template: login_stage_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -387,6 +387,13 @@ jobs:
       # </template: login_rw_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -777,6 +784,13 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1169,6 +1183,13 @@ jobs:
       # </template: login_rw_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -1547,6 +1568,13 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI
@@ -1927,6 +1955,13 @@ jobs:
       # </template: login_rw_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |
@@ -2305,6 +2340,13 @@ jobs:
           logout: false
       # </template: login_rw_registry_step>
 
+
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
 
       # <template: d8cli_install_step>
       - name: Install d8 CLI

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -91,6 +91,13 @@ jobs:
 
     # </template: checkout_step>
 
+    # <template: werf_install_step>
+    - name: Install werf CLI
+      uses: werf/actions/install@v2
+      with:
+        version: ${{env.WERF_VERSION}}
+    # </template: werf_install_step>
+
     # <template: d8cli_install_step>
     - name: Install d8 CLI
       run: |

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -214,6 +214,13 @@ jobs:
       # </template: login_dev_registry_step>
 
 
+      # <template: werf_install_step>
+      - name: Install werf CLI
+        uses: werf/actions/install@v2
+        with:
+          version: ${{env.WERF_VERSION}}
+      # </template: werf_install_step>
+
       # <template: d8cli_install_step>
       - name: Install d8 CLI
         run: |


### PR DESCRIPTION
## Description
Add werf fallback to workflows.

## Why do we need it, and what problem does it solve?
Outdated branches rely on werf, so not having it leads to failures.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Add werf fallback to workflows
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
