### PR TITLE
[control-plane-manager] Update observer progress

### DIFF
--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
@@ -27,11 +27,12 @@ import (
 )
 
 type ControlPlaneState struct {
-	DesiredComponentCount int
-	StepsCompleted        int
-	Phase                 ControlPlanePhase
-	MasterNodes           map[string]*MasterNode
-	versions              *version.UniqueAggregator
+	DesiredComponentCount  int
+	UpToDateComponentCount int
+	StepsCompleted         int
+	Phase                  ControlPlanePhase
+	MasterNodes            map[string]*MasterNode
+	versions               *version.UniqueAggregator
 }
 
 type ControlPlanePhase string
@@ -60,7 +61,7 @@ func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion, sour
 }
 
 func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion string) {
-	var upToDateCount, desiredCount, desiredComponentsCount, stepsCompleted int
+	var upToDateCount, desiredCount, desiredComponentsCount, upToDateComponentsCount, stepsCompleted int
 	var phase ControlPlanePhase
 
 	for _, masterNode := range s.MasterNodes {
@@ -80,6 +81,7 @@ func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion st
 				updatingComponents++
 				stepsCompleted += version.ComponentSteps(component.Version, sourceVersion, desiredVersion)
 			case ControlPlaneComponentUpToDate:
+				upToDateComponentsCount++
 				stepsCompleted += version.ComponentSteps(component.Version, sourceVersion, desiredVersion)
 			}
 		}
@@ -107,6 +109,7 @@ func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion st
 	}
 
 	s.DesiredComponentCount = desiredComponentsCount
+	s.UpToDateComponentCount = upToDateComponentsCount
 	s.StepsCompleted = stepsCompleted
 	s.Phase = phase
 }

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
@@ -27,14 +27,12 @@ import (
 )
 
 type ControlPlaneState struct {
-	DesiredCount           int
-	UpToDateCount          int
-	DesiredComponentCount  int
-	UpToDateComponentCount int
-	StepsCompleted         int
-	Phase                  ControlPlanePhase
-	MasterNodes            map[string]*MasterNode
-	versions               *version.UniqueAggregator
+	DesiredCount          int
+	DesiredComponentCount int
+	StepsCompleted        int
+	Phase                 ControlPlanePhase
+	MasterNodes           map[string]*MasterNode
+	versions              *version.UniqueAggregator
 }
 
 type ControlPlanePhase string
@@ -64,7 +62,7 @@ func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion, sour
 }
 
 func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion string) {
-	var desiredCount, upToDateCount, desiredComponentsCount, upToDateComponentsCount, stepsCompleted int
+	var desiredCount, upToDateCount, desiredComponentsCount, stepsCompleted int
 	var phase ControlPlanePhase
 
 	for _, masterNode := range s.MasterNodes {
@@ -82,11 +80,10 @@ func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion st
 				descriptions = append(descriptions, fmt.Sprintf("%s: %s", componentName, component.Description))
 			case ControlPlaneComponentUpdating:
 				updatingComponents++
+				stepsCompleted += version.ComponentSteps(component.Version, sourceVersion, desiredVersion)
 			case ControlPlaneComponentUpToDate:
-				upToDateComponentsCount++
+				stepsCompleted += version.ComponentSteps(component.Version, sourceVersion, desiredVersion)
 			}
-
-			stepsCompleted += version.ComponentSteps(component.Version, sourceVersion, desiredVersion)
 		}
 
 		switch {
@@ -112,9 +109,7 @@ func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion st
 	}
 
 	s.DesiredCount = desiredCount
-	s.UpToDateCount = upToDateCount
 	s.DesiredComponentCount = desiredComponentsCount
-	s.UpToDateComponentCount = upToDateComponentsCount
 	s.StepsCompleted = stepsCompleted
 	s.Phase = phase
 }

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
@@ -27,7 +27,6 @@ import (
 )
 
 type ControlPlaneState struct {
-	DesiredCount          int
 	DesiredComponentCount int
 	StepsCompleted        int
 	Phase                 ControlPlanePhase
@@ -51,9 +50,8 @@ func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion, sour
 	}
 
 	res := &ControlPlaneState{
-		DesiredCount: len(masterNodes),
-		MasterNodes:  masterNodes,
-		versions:     version.NewUniqueAggregator(),
+		MasterNodes: masterNodes,
+		versions:    version.NewUniqueAggregator(),
 	}
 
 	res.aggregateNodesState(sourceVersion, desiredVersion)
@@ -62,7 +60,7 @@ func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion, sour
 }
 
 func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion string) {
-	var desiredCount, upToDateCount, desiredComponentsCount, stepsCompleted int
+	var upToDateCount, desiredCount, desiredComponentsCount, stepsCompleted int
 	var phase ControlPlanePhase
 
 	for _, masterNode := range s.MasterNodes {
@@ -108,7 +106,6 @@ func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion st
 		phase = ControlPlaneUpToDate
 	}
 
-	s.DesiredCount = desiredCount
 	s.DesiredComponentCount = desiredComponentsCount
 	s.StepsCompleted = stepsCompleted
 	s.Phase = phase

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
@@ -31,6 +31,7 @@ type ControlPlaneState struct {
 	UpToDateCount          int
 	DesiredComponentCount  int
 	UpToDateComponentCount int
+	StepsCompleted         int
 	Phase                  ControlPlanePhase
 	MasterNodes            map[string]*MasterNode
 	versions               *version.UniqueAggregator
@@ -45,7 +46,7 @@ const (
 	ControlPlaneVersionDrift ControlPlanePhase = "VersionDrift"
 )
 
-func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion string) (*ControlPlaneState, error) {
+func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion, sourceVersion string) (*ControlPlaneState, error) {
 	masterNodes, err := buildControlPlaneTopology(controlPlanePods, desiredVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get components state: %w", err)
@@ -57,13 +58,24 @@ func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion strin
 		versions:     version.NewUniqueAggregator(),
 	}
 
-	res.aggregateNodesState()
+	res.aggregateNodesState(sourceVersion, desiredVersion)
 
 	return res, nil
 }
 
-func (s *ControlPlaneState) aggregateNodesState() {
-	var desiredCount, upToDateCount, desiredComponentsCount, upToDateComponentsCount int
+func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion string) {
+	srcMinor, hasSrc := version.MinorInt(sourceVersion)
+	dstMinor, hasDst := version.MinorInt(desiredVersion)
+
+	hops := 0
+	if hasSrc && hasDst && srcMinor != dstMinor {
+		hops = dstMinor - srcMinor
+		if hops < 0 {
+			hops = -hops
+		}
+	}
+
+	var desiredCount, upToDateCount, desiredComponentsCount, upToDateComponentsCount, stepsCompleted int
 	var phase ControlPlanePhase
 
 	for _, masterNode := range s.MasterNodes {
@@ -83,6 +95,10 @@ func (s *ControlPlaneState) aggregateNodesState() {
 				updatingComponents++
 			case ControlPlaneComponentUpToDate:
 				upToDateComponentsCount++
+			}
+
+			if hops > 0 {
+				stepsCompleted += version.ComponentSteps(component.Version, srcMinor, dstMinor)
 			}
 		}
 
@@ -112,5 +128,6 @@ func (s *ControlPlaneState) aggregateNodesState() {
 	s.UpToDateCount = upToDateCount
 	s.DesiredComponentCount = desiredComponentsCount
 	s.UpToDateComponentCount = upToDateComponentsCount
+	s.StepsCompleted = stepsCompleted
 	s.Phase = phase
 }

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/controlplane.go
@@ -64,17 +64,6 @@ func GetControlPlaneState(controlPlanePods *corev1.PodList, desiredVersion, sour
 }
 
 func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion string) {
-	srcMinor, hasSrc := version.MinorInt(sourceVersion)
-	dstMinor, hasDst := version.MinorInt(desiredVersion)
-
-	hops := 0
-	if hasSrc && hasDst && srcMinor != dstMinor {
-		hops = dstMinor - srcMinor
-		if hops < 0 {
-			hops = -hops
-		}
-	}
-
 	var desiredCount, upToDateCount, desiredComponentsCount, upToDateComponentsCount, stepsCompleted int
 	var phase ControlPlanePhase
 
@@ -97,9 +86,7 @@ func (s *ControlPlaneState) aggregateNodesState(sourceVersion, desiredVersion st
 				upToDateComponentsCount++
 			}
 
-			if hops > 0 {
-				stepsCompleted += version.ComponentSteps(component.Version, srcMinor, dstMinor)
-			}
+			stepsCompleted += version.ComponentSteps(component.Version, sourceVersion, desiredVersion)
 		}
 
 		switch {

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/nodes.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/nodes.go
@@ -25,14 +25,26 @@ import (
 )
 
 type NodesState struct {
-	DesiredCount  int
-	UpToDateCount int
-	versions      *version.UniqueAggregator
+	DesiredCount   int
+	UpToDateCount  int
+	StepsCompleted int
+	versions       *version.UniqueAggregator
 }
 
-func GetNodesState(nodes []corev1.Node, desiredVersion string) (*NodesState, error) {
+func GetNodesState(nodes []corev1.Node, desiredVersion, sourceVersion string) (*NodesState, error) {
 	res := &NodesState{
 		versions: version.NewUniqueAggregator(),
+	}
+
+	srcMinor, hasSrc := version.MinorInt(sourceVersion)
+	dstMinor, hasDst := version.MinorInt(desiredVersion)
+
+	hops := 0
+	if hasSrc && hasDst && srcMinor != dstMinor {
+		hops = dstMinor - srcMinor
+		if hops < 0 {
+			hops = -hops
+		}
 	}
 
 	var err error
@@ -49,6 +61,10 @@ func GetNodesState(nodes []corev1.Node, desiredVersion string) (*NodesState, err
 		}
 
 		res.versions.Set(v)
+
+		if hops > 0 {
+			res.StepsCompleted += version.ComponentSteps(v, srcMinor, dstMinor)
+		}
 	}
 
 	return res, nil

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/nodes.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/nodes.go
@@ -36,17 +36,6 @@ func GetNodesState(nodes []corev1.Node, desiredVersion, sourceVersion string) (*
 		versions: version.NewUniqueAggregator(),
 	}
 
-	srcMinor, hasSrc := version.MinorInt(sourceVersion)
-	dstMinor, hasDst := version.MinorInt(desiredVersion)
-
-	hops := 0
-	if hasSrc && hasDst && srcMinor != dstMinor {
-		hops = dstMinor - srcMinor
-		if hops < 0 {
-			hops = -hops
-		}
-	}
-
 	var err error
 	for _, node := range nodes {
 		res.DesiredCount++
@@ -61,10 +50,7 @@ func GetNodesState(nodes []corev1.Node, desiredVersion, sourceVersion string) (*
 		}
 
 		res.versions.Set(v)
-
-		if hops > 0 {
-			res.StepsCompleted += version.ComponentSteps(v, srcMinor, dstMinor)
-		}
+		res.StepsCompleted += version.ComponentSteps(v, sourceVersion, desiredVersion)
 	}
 
 	return res, nil

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
@@ -90,14 +90,7 @@ func (s *State) calculateProgress(sourceVersion string) {
 	}
 
 	hops := version.Hops(src, s.Spec.DesiredVersion)
-	if hops == 0 {
-		s.Progress = common.CalculateProgress(
-			s.ControlPlaneState.UpToDateComponentCount+s.NodesState.UpToDateCount,
-			totalComponents)
-		return
-	}
-
-	totalSteps := hops * totalComponents
+	totalSteps := max(hops, 1) * totalComponents
 	completedSteps := s.ControlPlaneState.StepsCompleted + s.NodesState.StepsCompleted
 
 	s.Progress = common.CalculateProgress(completedSteps, totalSteps)

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
@@ -90,9 +90,13 @@ func (s *State) calculateProgress(sourceVersion string) {
 	}
 
 	hops := version.Hops(src, s.Spec.DesiredVersion)
-	totalSteps := max(hops, 1) * totalComponents
-	completedSteps := s.ControlPlaneState.StepsCompleted + s.NodesState.StepsCompleted
+	if hops == 0 {
+		s.Progress = common.CalculateProgress(s.ControlPlaneState.UpToDateComponentCount+s.NodesState.UpToDateCount, totalComponents)
+		return
+	}
 
+	totalSteps := hops * totalComponents
+	completedSteps := s.ControlPlaneState.StepsCompleted + s.NodesState.StepsCompleted
 	s.Progress = common.CalculateProgress(completedSteps, totalSteps)
 }
 

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
@@ -26,7 +26,7 @@ type State struct {
 	Status
 }
 
-func GetState(cfg *Configuration, nodes *NodesState, controlPlane *ControlPlaneState, versionSettings VersionSettings, maxUsedVersion string, downgradeInProgress bool) *State {
+func GetState(cfg *Configuration, nodes *NodesState, controlPlane *ControlPlaneState, versionSettings VersionSettings, maxUsedVersion, sourceVersion string, downgradeInProgress bool) *State {
 	currentVersion := determineCurrentVersion(nodes.versions, controlPlane.versions, downgradeInProgress)
 
 	state := &State{
@@ -45,7 +45,7 @@ func GetState(cfg *Configuration, nodes *NodesState, controlPlane *ControlPlaneS
 	}
 
 	state.determineStatePhase()
-	state.calculateProgress()
+	state.calculateProgress(sourceVersion)
 
 	return state
 }
@@ -81,10 +81,33 @@ func (s *State) determineStatePhase() {
 	s.Phase = phase
 }
 
-func (s *State) calculateProgress() {
-	s.Progress = common.CalculateProgress(
-		s.ControlPlaneState.UpToDateComponentCount+s.NodesState.UpToDateCount,
-		s.ControlPlaneState.DesiredComponentCount+s.NodesState.DesiredCount)
+func (s *State) calculateProgress(sourceVersion string) {
+	totalComponents := s.ControlPlaneState.DesiredComponentCount + s.NodesState.DesiredCount
+
+	src := sourceVersion
+	if src == "" {
+		src = s.CurrentVersion
+	}
+
+	srcMinor, hasSrc := version.MinorInt(src)
+	dstMinor, hasDst := version.MinorInt(s.Spec.DesiredVersion)
+
+	if !hasSrc || !hasDst || srcMinor == dstMinor {
+		s.Progress = common.CalculateProgress(
+			s.ControlPlaneState.UpToDateComponentCount+s.NodesState.UpToDateCount,
+			totalComponents)
+		return
+	}
+
+	hops := dstMinor - srcMinor
+	if hops < 0 {
+		hops = -hops
+	}
+
+	totalSteps := hops * totalComponents
+	completedSteps := s.ControlPlaneState.StepsCompleted + s.NodesState.StepsCompleted
+
+	s.Progress = common.CalculateProgress(completedSteps, totalSteps)
 }
 
 func determineCurrentVersion(nodes *version.UniqueAggregator, controlPlane *version.UniqueAggregator, downgradeInProgress bool) string {

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/state.go
@@ -89,19 +89,12 @@ func (s *State) calculateProgress(sourceVersion string) {
 		src = s.CurrentVersion
 	}
 
-	srcMinor, hasSrc := version.MinorInt(src)
-	dstMinor, hasDst := version.MinorInt(s.Spec.DesiredVersion)
-
-	if !hasSrc || !hasDst || srcMinor == dstMinor {
+	hops := version.Hops(src, s.Spec.DesiredVersion)
+	if hops == 0 {
 		s.Progress = common.CalculateProgress(
 			s.ControlPlaneState.UpToDateComponentCount+s.NodesState.UpToDateCount,
 			totalComponents)
 		return
-	}
-
-	hops := dstMinor - srcMinor
-	if hops < 0 {
-		hops = -hops
 	}
 
 	totalSteps := hops * totalComponents

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/state_test.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/state_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// makeNode creates a Node with the given kubelet version.
+func makeNode(name, kubeletVersion string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.NodeStatus{
+			NodeInfo: corev1.NodeSystemInfo{KubeletVersion: kubeletVersion},
+		},
+	}
+}
+
+// makePod creates a healthy Running control-plane pod with the given version annotation.
+func makePod(name, nodeName, component, kubeVersion string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "kube-system",
+			Labels:    map[string]string{componentLabelKey: component},
+			Annotations: map[string]string{
+				kubeVersionAnnotation: kubeVersion,
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func masterPods(nodeName string, apiserverVer, schedulerVer, controllerManagerVer string) *corev1.PodList {
+	return &corev1.PodList{
+		Items: []corev1.Pod{
+			makePod("kube-apiserver-"+nodeName, nodeName, "kube-apiserver", apiserverVer),
+			makePod("kube-scheduler-"+nodeName, nodeName, "kube-scheduler", schedulerVer),
+			makePod("kube-controller-manager-"+nodeName, nodeName, "kube-controller-manager", controllerManagerVer),
+		},
+	}
+}
+
+var defaultVersionSettings = VersionSettings{
+	Supported: []string{"1.31", "1.32", "1.33", "1.34", "1.35"},
+	Automatic: "1.33",
+}
+
+var defaultCfg = &Configuration{
+	DesiredVersion: "1.33",
+	UpdateMode:     UpdateModeAutomatic,
+}
+
+// buildState is a helper that constructs a cluster State from raw node/pod data.
+func buildState(t *testing.T, cfg *Configuration, nodes []corev1.Node, pods *corev1.PodList, sourceVersion string) *State {
+	t.Helper()
+
+	nodesState, err := GetNodesState(nodes, cfg.DesiredVersion, sourceVersion)
+	require.NoError(t, err)
+
+	cpState, err := GetControlPlaneState(pods, cfg.DesiredVersion, sourceVersion)
+	require.NoError(t, err)
+
+	return GetState(cfg, nodesState, cpState, defaultVersionSettings, sourceVersion, sourceVersion, false)
+}
+
+func TestProgress_UpgradeOneVersionAtATime(t *testing.T) {
+	// Upgrading from 1.31 to 1.33: 2 hops
+	// 1 master + 1 worker = 5 trackable components (3 CP pods + 2 node kubelets)
+	// totalSteps = 2 * 5 = 10
+
+	t.Run("nothing updated yet — 0%", func(t *testing.T) {
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.31.0"),
+			makeNode("worker-0", "v1.31.0"),
+		}
+		pods := masterPods("master-0", "v1.31.0", "v1.31.0", "v1.31.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.31")
+
+		assert.Equal(t, "0%", state.Progress)
+		assert.Equal(t, Phase(ClusterControlPlaneUpdating), state.Phase)
+	})
+
+	t.Run("one CP component at 1.32 — 10%", func(t *testing.T) {
+		// completedSteps: apiserver(1) + scheduler(0) + CM(0) + master-node(0) + worker(0) = 1
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.31.0"),
+			makeNode("worker-0", "v1.31.0"),
+		}
+		pods := masterPods("master-0", "v1.32.0", "v1.31.0", "v1.31.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.31")
+
+		assert.Equal(t, "10%", state.Progress)
+	})
+
+	t.Run("all CP components at 1.32 — 30%", func(t *testing.T) {
+		// completedSteps: 3 CP(1 each) + 2 nodes(0 each) = 3
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.31.0"),
+			makeNode("worker-0", "v1.31.0"),
+		}
+		pods := masterPods("master-0", "v1.32.0", "v1.32.0", "v1.32.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.31")
+
+		assert.Equal(t, "30%", state.Progress)
+	})
+
+	t.Run("CP at 1.33, nodes at 1.32 — 80%", func(t *testing.T) {
+		// completedSteps: 3 CP(2 each) + 2 nodes(1 each) = 6+2 = 8
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.32.0"),
+			makeNode("worker-0", "v1.32.0"),
+		}
+		pods := masterPods("master-0", "v1.33.0", "v1.33.0", "v1.33.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.31")
+
+		assert.Equal(t, "80%", state.Progress)
+		assert.Equal(t, Phase(ClusterNodesUpdating), state.Phase)
+	})
+
+	t.Run("everything at 1.33 — 100%", func(t *testing.T) {
+		// completedSteps: 3 CP(2 each) + 2 nodes(2 each) = 6+4 = 10
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.33.0"),
+			makeNode("worker-0", "v1.33.0"),
+		}
+		pods := masterPods("master-0", "v1.33.0", "v1.33.0", "v1.33.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.31")
+
+		assert.Equal(t, "100%", state.Progress)
+		assert.Equal(t, Phase(ClusterUpToDate), state.Phase)
+	})
+}
+
+func TestProgress_IdleNoUpgrade(t *testing.T) {
+	// source == desired -> falls back to upToDateCount/totalCount logic
+	t.Run("all components at desired version — 100%", func(t *testing.T) {
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.33.0"),
+			makeNode("worker-0", "v1.33.0"),
+		}
+		pods := masterPods("master-0", "v1.33.0", "v1.33.0", "v1.33.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.33")
+
+		assert.Equal(t, "100%", state.Progress)
+		assert.Equal(t, Phase(ClusterUpToDate), state.Phase)
+	})
+}

--- a/modules/040-control-plane-manager/images/update-observer/src/cluster/state_test.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/cluster/state_test.go
@@ -167,6 +167,80 @@ func TestProgress_UpgradeOneVersionAtATime(t *testing.T) {
 	})
 }
 
+func TestProgress_UpgradeThreeHops(t *testing.T) {
+	// Upgrading from 1.30 to 1.33: 3 hops
+	// 1 master + 1 worker = 5 trackable components (3 CP pods + 2 node kubelets)
+	// totalSteps = 3 * 5 = 15
+
+	t.Run("nothing updated yet — 0%", func(t *testing.T) {
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.30.0"),
+			makeNode("worker-0", "v1.30.0"),
+		}
+		pods := masterPods("master-0", "v1.30.0", "v1.30.0", "v1.30.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.30")
+
+		assert.Equal(t, "0%", state.Progress)
+	})
+
+	t.Run("all CP at 1.31, nodes at 1.30 — 20%", func(t *testing.T) {
+		// completedSteps: 3 CP(1 each) + 2 nodes(0 each) = 3
+		// 3/15 = 20%
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.30.0"),
+			makeNode("worker-0", "v1.30.0"),
+		}
+		pods := masterPods("master-0", "v1.31.0", "v1.31.0", "v1.31.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.30")
+
+		assert.Equal(t, "20%", state.Progress)
+	})
+
+	t.Run("all CP at 1.32, nodes at 1.31 — 53%", func(t *testing.T) {
+		// completedSteps: 3 CP(2 each) + 2 nodes(1 each) = 6+2 = 8
+		// 8/15 = 53%
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.31.0"),
+			makeNode("worker-0", "v1.31.0"),
+		}
+		pods := masterPods("master-0", "v1.32.0", "v1.32.0", "v1.32.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.30")
+
+		assert.Equal(t, "53%", state.Progress)
+	})
+
+	t.Run("all CP at 1.33, nodes at 1.32 — 86%", func(t *testing.T) {
+		// completedSteps: 3 CP(3 each) + 2 nodes(2 each) = 9+4 = 13
+		// 13/15 = 86%
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.32.0"),
+			makeNode("worker-0", "v1.32.0"),
+		}
+		pods := masterPods("master-0", "v1.33.0", "v1.33.0", "v1.33.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.30")
+
+		assert.Equal(t, "86%", state.Progress)
+	})
+
+	t.Run("everything at 1.33 — 100%", func(t *testing.T) {
+		// completedSteps: 3 CP(3 each) + 2 nodes(3 each) = 9+6 = 15
+		nodes := []corev1.Node{
+			makeNode("master-0", "v1.33.0"),
+			makeNode("worker-0", "v1.33.0"),
+		}
+		pods := masterPods("master-0", "v1.33.0", "v1.33.0", "v1.33.0")
+
+		state := buildState(t, defaultCfg, nodes, pods, "1.30")
+
+		assert.Equal(t, "100%", state.Progress)
+		assert.Equal(t, Phase(ClusterUpToDate), state.Phase)
+	})
+}
+
 func TestProgress_IdleNoUpgrade(t *testing.T) {
 	// source == desired -> falls back to upToDateCount/totalCount logic
 	t.Run("all components at desired version — 100%", func(t *testing.T) {

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/cluster.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/cluster.go
@@ -32,12 +32,14 @@ import (
 )
 
 func (r *reconciler) getClusterState(ctx context.Context, cfg *cluster.Configuration, configmapLabels map[string]string, downgradeInProgress bool) (*cluster.State, error) {
-	nodesState, err := r.getNodesState(ctx, cfg.DesiredVersion)
+	sourceVersion := configmapLabels[common.K8sVersionLabelKey]
+
+	nodesState, err := r.getNodesState(ctx, cfg.DesiredVersion, sourceVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get nodes state: %w", err)
 	}
 
-	controlPlaneState, err := r.getControlPlaneState(ctx, cfg.DesiredVersion)
+	controlPlaneState, err := r.getControlPlaneState(ctx, cfg.DesiredVersion, sourceVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get control plane state: %w", err)
 	}
@@ -48,7 +50,7 @@ func (r *reconciler) getClusterState(ctx context.Context, cfg *cluster.Configura
 		return nil, fmt.Errorf("failed to parse versions from env: %w", err)
 	}
 
-	return cluster.GetState(cfg, nodesState, controlPlaneState, versionSettings, maxUsedVersion, downgradeInProgress), nil
+	return cluster.GetState(cfg, nodesState, controlPlaneState, versionSettings, maxUsedVersion, sourceVersion, downgradeInProgress), nil
 }
 
 func (r *reconciler) getClusterConfiguration(ctx context.Context) (*cluster.Configuration, error) {
@@ -64,23 +66,23 @@ func (r *reconciler) getClusterConfiguration(ctx context.Context) (*cluster.Conf
 	return cluster.GetConfiguration(secret)
 }
 
-func (r *reconciler) getNodesState(ctx context.Context, desiredVersion string) (*cluster.NodesState, error) {
+func (r *reconciler) getNodesState(ctx context.Context, desiredVersion, sourceVersion string) (*cluster.NodesState, error) {
 	list := &corev1.NodeList{}
 	err := r.client.List(ctx, list)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
-	return cluster.GetNodesState(list.Items, desiredVersion)
+	return cluster.GetNodesState(list.Items, desiredVersion, sourceVersion)
 }
 
-func (r *reconciler) getControlPlaneState(ctx context.Context, desiredVersion string) (*cluster.ControlPlaneState, error) {
+func (r *reconciler) getControlPlaneState(ctx context.Context, desiredVersion, sourceVersion string) (*cluster.ControlPlaneState, error) {
 	pods, err := r.getControlPlanePods(ctx, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get control plane pods: %w", err)
 	}
 
-	return cluster.GetControlPlaneState(pods, desiredVersion)
+	return cluster.GetControlPlaneState(pods, desiredVersion, sourceVersion)
 }
 
 func (r *reconciler) getControlPlanePods(ctx context.Context, isRetry bool) (*corev1.PodList, error) {

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/configmap.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/configmap.go
@@ -115,7 +115,7 @@ func fillConfigMap(configMap *corev1.ConfigMap, clusterState *cluster.State, rec
 
 	annotations := configMap.GetAnnotations()
 	labels := configMap.GetLabels()
-	now := time.Now().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
 
 	annotations[common.LastReconciliationTime] = now
 	annotations[common.CauseLabelKey] = string(reconcileTrigger)

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/controller_test.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/controller_test.go
@@ -108,6 +108,16 @@ func (suite *ControllerTestSuite) TestConfigMapIsValid() {
 
 			require.NoError(suite.T(), err)
 		})
+		suite.Run("When upgrade is in progress across multiple versions", func() {
+			suite.setupController(suite.fetchTestFileData("upgrade-three-hops.yaml"))
+
+			_, err := suite.controller.Reconcile(
+				suite.ctx,
+				reconcile.Request{},
+			)
+
+			require.NoError(suite.T(), err)
+		})
 	})
 }
 

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/cases/upgrade-three-hops.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/cases/upgrade-three-hops.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  cluster-configuration.yaml: |
+    YXBpVmVyc2lvbjogZGVja2hvdXNlLmlvL3YxCmtpbmQ6IENsdXN0ZXJDb25maWd1cmF0aW9uCmt1YmVybmV0ZXNWZXJzaW9uOiBBdXRvbWF0aWM=
+  # v1.35
+  deckhouseDefaultKubernetesVersion: djEuMzU=
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    cause: upgradeK8s
+    lastReconciliationTime: '2026-01-01T00:00:00Z'
+  labels:
+    heritage: deckhouse
+    k8s-version: "1.32"
+    max-k8s-version: "1.32"
+  name: d8-cluster-kubernetes
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: master-1
+status:
+  nodeInfo:
+    kubeletVersion: v1.32.0
+---
+apiVersion: v1
+kind: Node
+metadata:
+  name: worker-1
+status:
+  nodeInfo:
+    kubeletVersion: v1.32.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-apiserver-master-1
+  namespace: kube-system
+  labels:
+    component: kube-apiserver
+  annotations:
+    control-plane-manager.deckhouse.io/kubernetes-version: v1.33.0
+spec:
+  nodeName: master-1
+status:
+  phase: Running
+  containerStatuses:
+    - containerID: containerd://ca4b72fae2d83e56cca8add30a09f815f3c595e5e93c614f0094f0a41d823b72
+      ready: true
+      state:
+        running:
+          startedAt: "2026-01-28T06:34:19Z"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-scheduler-master-1
+  namespace: kube-system
+  labels:
+    component: kube-scheduler
+  annotations:
+    control-plane-manager.deckhouse.io/kubernetes-version: v1.33.0
+spec:
+  nodeName: master-1
+status:
+  phase: Running
+  containerStatuses:
+    - containerID: containerd://ca4b72fae2d83e56cca8add30a09f815f3c595e5e93c614f0094f0a41d823b72
+      ready: true
+      state:
+        running:
+          startedAt: "2026-01-28T06:34:19Z"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager-master-1
+  namespace: kube-system
+  labels:
+    component: kube-controller-manager
+  annotations:
+    control-plane-manager.deckhouse.io/kubernetes-version: v1.33.0
+spec:
+  nodeName: master-1
+status:
+  phase: Running
+  containerStatuses:
+    - containerID: containerd://ca4b72fae2d83e56cca8add30a09f815f3c595e5e93c614f0094f0a41d823b72
+      ready: true
+      state:
+        running:
+          startedAt: "2026-01-28T06:34:19Z"

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/init-up-to-date.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/init-up-to-date.yaml
@@ -35,7 +35,7 @@ data:
 metadata:
   annotations:
     cause: init
-    lastReconciliationTime: "2000-01-01T04:00:00+04:00"
+    lastReconciliationTime: "2000-01-01T00:00:00Z"
   labels:
     heritage: deckhouse
     k8s-version: "1.35"

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/pods-failed.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/pods-failed.yaml
@@ -38,7 +38,7 @@ data:
 metadata:
   annotations:
     cause: idle
-    lastReconciliationTime: "2000-01-01T04:00:30+04:00"
+    lastReconciliationTime: "2000-01-01T00:00:30Z"
     lastUpToDateTime: "2026-01-01T00:00:00Z"
   labels:
     heritage: deckhouse

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/upgrade-three-hops.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/upgrade-three-hops.yaml
@@ -1,0 +1,42 @@
+---
+data:
+  spec: |
+    desiredVersion: "1.35"
+    updateMode: Automatic
+  status: |
+    currentVersion: "1.32"
+    supportedVersions:
+    - "1.31"
+    - "1.32"
+    - "1.33"
+    - "1.34"
+    - "1.35"
+    availableVersions:
+    - "1.31"
+    - "1.32"
+    - "1.33"
+    - "1.34"
+    - "1.35"
+    automaticVersion: "1.33"
+    phase: ControlPlaneUpdating
+    progress: 20%
+    controlPlane:
+    - name: master-1
+      phase: Updating
+      components:
+        kube-apiserver: "1.33"
+        kube-controller-manager: "1.33"
+        kube-scheduler: "1.33"
+    nodes:
+      desiredCount: 2
+      upToDateCount: 0
+metadata:
+  annotations:
+    cause: upgradeK8s
+    lastReconciliationTime: "2000-01-01T00:00:30Z"
+  labels:
+    heritage: deckhouse
+    k8s-version: "1.32"
+    max-k8s-version: "1.32"
+  name: d8-cluster-kubernetes
+  namespace: kube-system

--- a/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/versions-with-env.yaml
+++ b/modules/040-control-plane-manager/images/update-observer/src/controller/testdata/golden/versions-with-env.yaml
@@ -31,7 +31,7 @@ data:
 metadata:
   annotations:
     cause: downgradeK8s
-    lastReconciliationTime: "2000-01-01T04:00:30+04:00"
+    lastReconciliationTime: "2000-01-01T00:00:30Z"
     lastUpToDateTime: "2026-01-01T00:00:00Z"
   labels:
     heritage: deckhouse

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -125,6 +125,10 @@ func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int 
 	}
 
 	if hops == 0 {
+		// No version migration in progress: track component health instead of version steps.
+		// Callers exclude Failed components before calling this function, so reaching here
+		// means the component is Updating or UpToDate. Returning 1 when at the desired
+		// version means "healthy and done"; 0 means "not yet at desired version".
 		if compMinor == dstMinor {
 			return 1
 		}

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -125,10 +125,10 @@ func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int 
 	}
 
 	if hops == 0 {
-		// No version migration in progress: track component health instead of version steps.
-		// Callers exclude Failed components before calling this function, so reaching here
-		// means the component is Updating or UpToDate. Returning 1 when at the desired
-		// version means "healthy and done"; 0 means "not yet at desired version".
+		// No version migration in progress: track whether the component reached the desired
+		// version. For control-plane components, Failed ones are excluded by the caller so
+		// this effectively measures health. For nodes there is no Failed state — a node is
+		// always counted, so 1 simply means "kubelet is at the desired version".
 		if compMinor == dstMinor {
 			return 1
 		}

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -140,5 +140,5 @@ func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int 
 	} else {
 		steps = srcMinor - compMinor
 	}
-	return max(0, min(steps, hops))
+	return min(steps, hops)
 }

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -105,19 +105,24 @@ func Hops(sourceVersion, desiredVersion string) int {
 
 // ComponentSteps returns how many minor-version upgrade steps the given component
 // has already completed relative to the sourceVersion->desiredVersion migration.
+// When hops == 0 (versions equal or sourceVersion unparseable), returns 1 if the
+// component is at the desired version and 0 otherwise.
 func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int {
+	dstMinor, hasDst := MinorInt(desiredVersion)
+	compMinor, hasComp := MinorInt(componentVersion)
+	if !hasDst || !hasComp {
+		return 0
+	}
+
 	hops := Hops(sourceVersion, desiredVersion)
 	if hops == 0 {
+		if compMinor == dstMinor {
+			return 1
+		}
 		return 0
 	}
 
 	srcMinor, _ := MinorInt(sourceVersion)
-	dstMinor, _ := MinorInt(desiredVersion)
-	compMinor, ok := MinorInt(componentVersion)
-	if !ok {
-		return 0
-	}
-
 	var steps int
 	if dstMinor > srcMinor {
 		steps = compMinor - srcMinor

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -88,6 +88,14 @@ func MinorInt(v string) (int, bool) {
 	return int(sv.Minor()), true
 }
 
+func calculateHops(src, dst int) int {
+	h := dst - src
+	if h < 0 {
+		h = -h
+	}
+	return h
+}
+
 // Hops returns the absolute number of minor version steps between sourceVersion
 // and desiredVersion. Returns 0 if either version is unparseable or they are equal.
 func Hops(sourceVersion, desiredVersion string) int {
@@ -96,11 +104,7 @@ func Hops(sourceVersion, desiredVersion string) int {
 	if !hasSrc || !hasDst {
 		return 0
 	}
-	h := dstMinor - srcMinor
-	if h < 0 {
-		h = -h
-	}
-	return h
+	return calculateHops(srcMinor, dstMinor)
 }
 
 // ComponentSteps returns how many minor-version upgrade steps the given component
@@ -108,13 +112,18 @@ func Hops(sourceVersion, desiredVersion string) int {
 // When hops == 0 (versions equal or sourceVersion unparseable), returns 1 if the
 // component is at the desired version and 0 otherwise.
 func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int {
+	srcMinor, hasSrc := MinorInt(sourceVersion)
 	dstMinor, hasDst := MinorInt(desiredVersion)
 	compMinor, hasComp := MinorInt(componentVersion)
 	if !hasDst || !hasComp {
 		return 0
 	}
 
-	hops := Hops(sourceVersion, desiredVersion)
+	hops := 0
+	if hasSrc {
+		hops = calculateHops(srcMinor, dstMinor)
+	}
+
 	if hops == 0 {
 		if compMinor == dstMinor {
 			return 1
@@ -122,7 +131,6 @@ func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int 
 		return 0
 	}
 
-	srcMinor, _ := MinorInt(sourceVersion)
 	var steps int
 	if dstMinor > srcMinor {
 		steps = compMinor - srcMinor

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -125,10 +125,9 @@ func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int 
 	}
 
 	if hops == 0 {
-		// No version migration in progress: track whether the component reached the desired
-		// version. For control-plane components, Failed ones are excluded by the caller so
-		// this effectively measures health. For nodes there is no Failed state — a node is
-		// always counted, so 1 simply means "kubelet is at the desired version".
+		// No version migration in progress (source == desired or source is unknown).
+		// Return 1 if the component is already at the desired version so that
+		// StepsCompleted / totalSteps reflects 100% for a healthy, idle cluster.
 		if compMinor == dstMinor {
 			return 1
 		}

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -88,15 +88,36 @@ func MinorInt(v string) (int, bool) {
 	return int(sv.Minor()), true
 }
 
-func ComponentSteps(componentVersion string, srcMinor, dstMinor int) int {
+// Hops returns the absolute number of minor version steps between sourceVersion
+// and desiredVersion. Returns 0 if either version is unparseable or they are equal.
+func Hops(sourceVersion, desiredVersion string) int {
+	srcMinor, hasSrc := MinorInt(sourceVersion)
+	dstMinor, hasDst := MinorInt(desiredVersion)
+	if !hasSrc || !hasDst {
+		return 0
+	}
+	h := dstMinor - srcMinor
+	if h < 0 {
+		h = -h
+	}
+	return h
+}
+
+// ComponentSteps returns how many minor-version upgrade steps the given component
+// has already completed relative to the sourceVersion->desiredVersion migration.
+func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int {
+	hops := Hops(sourceVersion, desiredVersion)
+	if hops == 0 {
+		return 0
+	}
+
+	srcMinor, _ := MinorInt(sourceVersion)
+	dstMinor, _ := MinorInt(desiredVersion)
 	compMinor, ok := MinorInt(componentVersion)
 	if !ok {
 		return 0
 	}
-	hops := dstMinor - srcMinor
-	if hops < 0 {
-		hops = -hops
-	}
+
 	var steps int
 	if dstMinor > srcMinor {
 		steps = compMinor - srcMinor

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -79,3 +79,29 @@ func GetMin(v, w string) string {
 func majorMinor(v *semver.Version) string {
 	return fmt.Sprintf("%d.%d", v.Major(), v.Minor())
 }
+
+func MinorInt(v string) (int, bool) {
+	sv, err := semver.NewVersion(v)
+	if err != nil {
+		return 0, false
+	}
+	return int(sv.Minor()), true
+}
+
+func ComponentSteps(componentVersion string, srcMinor, dstMinor int) int {
+	compMinor, ok := MinorInt(componentVersion)
+	if !ok {
+		return 0
+	}
+	hops := dstMinor - srcMinor
+	if hops < 0 {
+		hops = -hops
+	}
+	var steps int
+	if dstMinor > srcMinor {
+		steps = compMinor - srcMinor
+	} else {
+		steps = srcMinor - compMinor
+	}
+	return max(0, min(steps, hops))
+}

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -109,30 +109,21 @@ func Hops(sourceVersion, desiredVersion string) int {
 
 // ComponentSteps returns how many minor-version upgrade steps the given component
 // has already completed relative to the sourceVersion->desiredVersion migration.
-// When hops == 0 (versions equal or sourceVersion unparseable), returns 1 if the
-// component is at the desired version and 0 otherwise.
+// The result is always within [0, Hops(sourceVersion, desiredVersion)].
+// Returns 0 if any version is unparseable or if there is no migration in progress
+// (hops == 0); the idle "healthy cluster = 100%" interpretation belongs to the
+// caller that computes the overall progress ratio.
 func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int {
-	srcMinor, hasSrc := MinorInt(sourceVersion)
-	dstMinor, hasDst := MinorInt(desiredVersion)
-	compMinor, hasComp := MinorInt(componentVersion)
-	if !hasDst || !hasComp {
+	src, okSrc := MinorInt(sourceVersion)
+	dst, okDst := MinorInt(desiredVersion)
+	comp, okComp := MinorInt(componentVersion)
+	if !okSrc || !okDst || !okComp {
 		return 0
 	}
 
-	hops := 0
-	if hasSrc {
-		hops = calculateHops(srcMinor, dstMinor)
-	}
-
+	hops := calculateHops(src, dst)
 	if hops == 0 {
-		// No version migration in progress (source == desired or source is unknown).
-		// Return 1 if the component is already at the desired version so that
-		// StepsCompleted / totalSteps reflects 100% for a healthy, idle cluster.
-		if compMinor == dstMinor {
-			return 1
-		}
 		return 0
 	}
-
-	return min(calculateHops(srcMinor, compMinor), hops)
+	return min(calculateHops(src, comp), hops)
 }

--- a/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
+++ b/modules/040-control-plane-manager/images/update-observer/src/pkg/version/compare.go
@@ -134,11 +134,5 @@ func ComponentSteps(componentVersion, sourceVersion, desiredVersion string) int 
 		return 0
 	}
 
-	var steps int
-	if dstMinor > srcMinor {
-		steps = compMinor - srcMinor
-	} else {
-		steps = srcMinor - compMinor
-	}
-	return min(steps, hops)
+	return min(calculateHops(srcMinor, compMinor), hops)
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix progress calculation in UpdateObserver to reflect actual upgrade progress across intermediate versions.
Added correct progress logic and unit tests for progress calculation.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Previously, progress stayed at 0% until components reached the target version, making intermediate upgrade stages invisible.
Now progress increases proportionally and reflects real upgrade state.
 
<details>
<summary>Upgrade 1.33 -> 1.35 (screens)</summary>

<img width="1512" height="982" alt="Screenshot 2026-04-17 at 12 35 47" src="https://github.com/user-attachments/assets/7d0a4c05-f2d5-46a1-88be-431acd98d8cf" />
<img width="1512" height="982" alt="Screenshot 2026-04-17 at 12 43 53" src="https://github.com/user-attachments/assets/1ea812f9-34c2-427f-b92a-165fe4e25386" />
<img width="1512" height="982" alt="Screenshot 2026-04-17 at 12 48 05" src="https://github.com/user-attachments/assets/b0e3a418-c6e9-4252-b15a-11565308a6f3" />

</details>

<details>
<summary>Upgrade 1.33 -> 1.35 (in text)</summary>

```yml
apiVersion: v1
data:
  spec: |
    desiredVersion: "1.35"
    updateMode: Manual
  status: |
    currentVersion: "1.33"
    supportedVersions:
    - "1.31"
    - "1.32"
    - "1.33"
    - "1.34"
    - "1.35"
    availableVersions:
    - "1.32"
    - "1.33"
    - "1.34"
    - "1.35"
    automaticVersion: "1.33"
    phase: ControlPlaneUpdating
    progress: 0%
    controlPlane:
    - name: borovets-ob-master-0
      phase: Updating
      components:
        kube-apiserver: "1.33"
        kube-controller-manager: "1.33"
        kube-scheduler: "1.33"
    nodes:
      desiredCount: 2
      upToDateCount: 0
kind: ConfigMap
metadata:
  annotations:
    cause: upgradeK8s
    lastReconciliationTime: "2026-04-17T09:35:12Z"
    lastUpToDateTime: "2026-04-15T13:43:59Z"
  creationTimestamp: "2026-04-15T12:12:21Z"
  labels:
    heritage: deckhouse
    k8s-version: "1.33"
    max-k8s-version: "1.33"
  name: d8-cluster-kubernetes
  namespace: kube-system
  resourceVersion: "1725142"
  uid: 5ffac848-7f5b-4c08-9c34-396c16a75631
---
...
---
apiVersion: v1
data:
  spec: |
    desiredVersion: "1.35"
    updateMode: Manual
  status: |
    currentVersion: "1.34"
    supportedVersions:
    - "1.31"
    - "1.32"
    - "1.33"
    - "1.34"
    - "1.35"
    availableVersions:
    - "1.33"
    - "1.34"
    - "1.35"
    automaticVersion: "1.33"
    phase: ControlPlaneUpdating
    progress: 60%
    controlPlane:
    - name: borovets-ob-master-0
      phase: Updating
      components:
        kube-apiserver: "1.35"
        kube-controller-manager: "1.34"
        kube-scheduler: "1.34"
    nodes:
      desiredCount: 2
      upToDateCount: 0
kind: ConfigMap
metadata:
  annotations:
    cause: upgradeK8s
    lastReconciliationTime: "2026-04-17T09:43:08Z"
    lastUpToDateTime: "2026-04-15T13:43:59Z"
  creationTimestamp: "2026-04-15T12:12:21Z"
  labels:
    heritage: deckhouse
    k8s-version: "1.33"
    max-k8s-version: "1.33"
  name: d8-cluster-kubernetes
  namespace: kube-system
  resourceVersion: "1753458"
  uid: 5ffac848-7f5b-4c08-9c34-396c16a75631
---
...
---
apiVersion: v1
data:
  spec: |
    desiredVersion: "1.35"
    updateMode: Manual
  status: |
    currentVersion: "1.35"
    supportedVersions:
    - "1.31"
    - "1.32"
    - "1.33"
    - "1.34"
    - "1.35"
    availableVersions:
    - "1.34"
    - "1.35"
    automaticVersion: "1.33"
    phase: UpToDate
    controlPlane:
    - name: borovets-ob-master-0
      phase: UpToDate
      components:
        kube-apiserver: "1.35"
        kube-controller-manager: "1.35"
        kube-scheduler: "1.35"
    nodes:
      desiredCount: 2
      upToDateCount: 2
kind: ConfigMap
metadata:
  annotations:
    cause: upgradeK8s
    lastReconciliationTime: "2026-04-17T09:47:37Z"
    lastUpToDateTime: "2026-04-17T09:47:37Z"
  creationTimestamp: "2026-04-15T12:12:21Z"
  labels:
    heritage: deckhouse
    k8s-version: "1.35"
    max-k8s-version: "1.35"
  name: d8-cluster-kubernetes
  namespace: kube-system
  resourceVersion: "1776599"
  uid: 5ffac848-7f5b-4c08-9c34-396c16a75631
```
</details>

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fixed incorrect UpdateObserver progress calculation during cluster upgrades.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
