### PR TITLE
[control-plane-manager] Account only voting etcd members in etcdServers

### DIFF
--- a/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
@@ -137,8 +137,6 @@ func handleRecicleEtcdMembers(_ context.Context, input *go_hook.HookInput, dc de
 		etcdServersEndpoints = append(etcdServersEndpoints, fmt.Sprintf("https://%s:2379", node.IP))
 	}
 
-	input.Values.Set("controlPlaneManager.internal.etcdServers", etcdServersEndpoints)
-
 	// etcd
 	etcdcli, err := getETCDClient(input, dc, etcdServersEndpoints)
 	if err != nil {
@@ -153,6 +151,17 @@ func handleRecicleEtcdMembers(_ context.Context, input *go_hook.HookInput, dc de
 	if err != nil {
 		return errors.Wrap(err, "list etcd members failed")
 	}
+
+	etcdVotingMembers := make([]string, 0, len(etcdMembersResp.Members))
+	for _, mem := range etcdMembersResp.Members {
+		if mem.IsLearner {
+			continue
+		}
+		if ip, ok := discoveredEtcdNodesMap[mem.Name]; ok {
+			etcdVotingMembers = append(etcdVotingMembers, fmt.Sprintf("https://%s:2379", ip))
+		}
+	}
+	input.Values.Set("controlPlaneManager.internal.etcdServers", etcdVotingMembers)
 
 	removeListIDs := make([]uint64, 0)
 	for _, mem := range etcdMembersResp.Members {

--- a/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
+++ b/modules/040-control-plane-manager/hooks/reconcile_etcd_members.go
@@ -155,6 +155,7 @@ func handleRecicleEtcdMembers(_ context.Context, input *go_hook.HookInput, dc de
 	etcdVotingMembers := make([]string, 0, len(etcdMembersResp.Members))
 	for _, mem := range etcdMembersResp.Members {
 		if mem.IsLearner {
+			input.Logger.Warn("found learner etcd member, will be skipped", slog.Uint64("memberID", mem.ID), slog.String("memberName", mem.Name))
 			continue
 		}
 		if ip, ok := discoveredEtcdNodesMap[mem.Name]; ok {


### PR DESCRIPTION
## Description

Fixed `reconcile_etcd_members` hook to only populate `controlPlaneManager.internal.etcdServers` with voting members, excluding learner nodes. The assignment was moved to occur *after* querying etcd member status.

## Why do we need it, and what problem does it solve?

Previously, the hook set `etcdServers` before checking member status, potentially including learner members that should not participate in voting or quorum decisions. Now only confirmed voting members are included.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Excluded learner etcd members from the kube-apiserver etcd member list.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
