### PR TITLE
[node-manager] fix node-manager draining hook event note generation

### DIFF
--- a/modules/040-node-manager/hooks/handle_draining.go
+++ b/modules/040-node-manager/hooks/handle_draining.go
@@ -49,6 +49,9 @@ const (
 	drainedAnnotationKey  = "update.node.deckhouse.io/drained"
 	nodeGroupLabel        = "node.deckhouse.io/group"
 	defaultDrainTimeout   = 10 * time.Minute
+	defaultDrainFailNote  = "Node draining failed"
+	maxEventNoteLength    = 1024
+	eventNoteSuffix       = "..."
 )
 
 var nodeGroupResource = schema.GroupVersionResource{Group: "deckhouse.io", Version: "v1", Resource: "nodegroups"}
@@ -314,11 +317,28 @@ func (dr drainedNodeRes) buildEvent() *eventsv1.Event {
 			APIVersion: "deckhouse.io/v1",
 		},
 		Reason:              "DrainFailed",
-		Note:                dr.Err.Error(),
+		Note:                buildDrainEventNote(dr.Err),
 		Type:                "Warning",
 		EventTime:           v1.MicroTime{Time: time.Now()},
 		Action:              "Binding",
 		ReportingInstance:   "deckhouse",
 		ReportingController: "deckhouse",
 	}
+}
+
+func buildDrainEventNote(err error) string {
+	if err == nil {
+		return defaultDrainFailNote
+	}
+
+	note := err.Error()
+	if note == "" {
+		return defaultDrainFailNote
+	}
+
+	if len(note) > maxEventNoteLength {
+		return note[:maxEventNoteLength-len(eventNoteSuffix)] + eventNoteSuffix
+	}
+
+	return note
 }


### PR DESCRIPTION
## Description

Fix node-manager draining hook event note generation.

## Why do we need it, and what problem does it solve?

Kubernetes rejects `events.k8s.io/v1` Events when `note` is empty or exceeds 1024 bytes.
This could make the draining hook fail while reporting a drain error.
The change normalizes the event note by using a fallback message for empty errors and truncating oversized messages.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: fix draining hook event generation
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
