### PR TITLE
[candi] added cluster_configuration.yaml in cse

### DIFF
--- a/ee/cse/candi/openapi/.build.yaml
+++ b/ee/cse/candi/openapi/.build.yaml
@@ -1,0 +1,1 @@
+cluster_configuration.yaml

--- a/ee/cse/candi/openapi/README.md
+++ b/ee/cse/candi/openapi/README.md
@@ -1,0 +1,6 @@
+# CSE edit
+
+## cluster_configuration.yaml
+
+1. Unnecessary versions have been removed from `kubernetesVersion`. Only 1.31 (for updates) and 1.33 (the current version for this release) remain.
+2. Only DVP remains in `cloud.provider`.

--- a/ee/cse/candi/openapi/cluster_configuration.yaml
+++ b/ee/cse/candi/openapi/cluster_configuration.yaml
@@ -1,0 +1,245 @@
+kind: ClusterConfiguration
+apiVersions:
+- apiVersion: deckhouse.io/v1
+  openAPISpec:
+    type: object
+    description: |
+      General parameters of a cluster.
+
+      Defines, for example, network and CRI parameters, control plane version, etc. Some parameters can be changed after the cluster is bootstrapped, during its operation.
+
+      To change the `ClusterConfiguration` resource in a running cluster, run the following command:
+
+      ```shell
+      d8 system edit cluster-configuration
+      ```
+    additionalProperties: false
+    required: [apiVersion, kind, clusterType, kubernetesVersion, podSubnetCIDR, serviceSubnetCIDR, clusterDomain]
+    x-examples:
+    - apiVersion: deckhouse.io/v1
+      kind: ClusterConfiguration
+      podSubnetNodeCIDRPrefix: "24"
+      podSubnetCIDR: 10.244.0.0/16
+      serviceSubnetCIDR: 192.168.0.0/16
+      kubernetesVersion: "1.31"
+      clusterDomain: k8s.internal
+      clusterType: "Cloud"
+      cloud:
+        prefix: k8s-dev
+        provider: Yandex
+      proxy:
+        httpProxy: https://user:password@proxy.company.my:8443
+        httpsProxy: https://user:password@proxy.company.my:8443
+        noProxy:
+        - company.my
+    properties:
+      apiVersion:
+        type: string
+        description: Version of the Deckhouse API.
+        enum: [deckhouse.io/v1, deckhouse.io/v1alpha1]
+      kind:
+        type: string
+        enum: [ClusterConfiguration]
+      clusterType:
+        type: string
+        x-unsafe: true
+        description: |
+          Type of the cluster infrastructure:
+          - `Static` — a cluster on bare metal (physical servers) or virtual machines. In the case of virtual machines, it is assumed that Deckhouse doesn't have access to the API for managing virtual machines (they are managed by the administrator using the usual cloud infrastructure tools);
+          - `Cloud` — a cluster deployed on the resources of a cloud infrastructure. This type implies that Deckhouse has access to the cloud infrastructure API for managing virtual machines.
+        enum: [Cloud, Static]
+      cloud:
+        type: object
+        x-unsafe: true
+        description: |
+          Cloud provider-related settings (if the `Cloud` [clusterType](#clusterconfiguration-clustertype) is used).
+        required: [provider]
+        additionalProperties: false
+        properties:
+          provider:
+            type: string
+            description: |
+              Cloud provider.
+            enum:
+            - "DVP"
+          prefix:
+            type: string
+            description: |
+              A prefix of the objects to be created in the cloud.
+
+              Is used, for example, to distinguish objects created for different clusters, to configure routing, etc.
+            pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+      podSubnetCIDR:
+        type: string
+        x-unsafe: true
+        description: |
+          Address space of the cluster's Pods.
+
+          > **Warning!** Changing this parameter in a running cluster is **extremely dangerous** and can lead to complete cluster failure. The change is blocked by default. To bypass this protection, use `dhctl config edit cluster-configuration --yes-i-am-sane-and-i-understand-what-i-am-doing` command. However, it is **strongly recommended to recreate the cluster** instead of changing this parameter. See [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/#modifying-protected-parameters) for details.
+      podSubnetNodeCIDRPrefix:
+        type: string
+        description: |
+          The prefix size of the Pod network allocated to each node.
+
+          This parameter determines how many IP addresses are available for Pods on each individual node. For example, if `podSubnetCIDR: 10.111.0.0/16` and `podSubnetNodeCIDRPrefix: "24"`, each node will receive a `/24` subnet (e.g., `10.111.0.0/24`, `10.111.1.0/24`, etc.), providing up to 254 IP addresses per node (253 usable for Pods, accounting for network and broadcast addresses).
+
+          **Calculation examples:**
+          - With `/16` network and `/24` prefix: maximum **256 nodes** (2^(24-16) = 256)
+          - With `/16` network and `/25` prefix: maximum **512 nodes**, but only **126 IPs per node**
+          - Each Pod network IP can support up to 2 Pods (one running + one terminating)
+
+          > **Warning!** Changing this parameter in a running cluster is **extremely dangerous** and can lead to complete cluster failure. The change is blocked by default. To bypass this protection, use `dhctl config edit cluster-configuration --yes-i-am-sane-and-i-understand-what-i-am-doing` command. However, it is **strongly recommended to recreate the cluster** instead of changing this parameter. See [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/#modifying-protected-parameters) for details.
+        default: "24"
+      serviceSubnetCIDR:
+        type: string
+        x-unsafe: true
+        description: |
+          Address space of the cluster's services.
+
+          > **Warning!** Changing this parameter in a running cluster is **extremely dangerous** and can lead to complete cluster failure. The change is blocked by default. To bypass this protection, use `dhctl config edit cluster-configuration --yes-i-am-sane-and-i-understand-what-i-am-doing` command. However, it is **strongly recommended to recreate the cluster** instead of changing this parameter. See [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/#modifying-protected-parameters) for details.
+      clusterDomain:
+        type: string
+        description: |
+          Cluster domain (used for local routing).
+
+          **Please note:** the domain must not match the domain used in the DNS name template in the [publicDomainTemplate](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-publicdomaintemplate) parameter. For example, you cannot set `cluster Domain: cluster.local` and `publicDomainTemplate: %s.cluster.local` at the same time.
+
+          > If you need to change a parameter in a running cluster, it is recommended to use [instructions](/modules/kube-dns/faq.html#how-do-i-replace-the-cluster-domain-with-minimal-downtime)
+        default: "cluster.local"
+      defaultCRI:
+        type: string
+        description: |
+          The container runtime type that used on cluster nodes (NodeGroups) by default.
+
+          If the value `NotManaged` is used, then Deckhouse does not manage the container runtime (and doesn't install it).
+          In this case, it is necessary to use images for NodeGroups on which the container runtime is already installed.
+
+          If `ContainerdV2` is set, `CgroupsV2` will be used (providing improved security and resource management). To use `ContainerdV2` as the container runtime, cluster nodes must meet the following requirements:
+
+          - Support for `CgroupsV2`.
+          - Linux kernel version `5.8` or newer.
+          - Systemd version `244` or newer.
+          - Support for `erofs` kernel module.
+        enum:
+        - "Containerd"
+        - "ContainerdV2"
+        - "NotManaged"
+        default: "Containerd"
+      kubernetesVersion:
+        type: string
+        description: |
+          Kubernetes version (control plane components of the cluster).
+
+          Changing a parameter in a running cluster will [automatically update](https://deckhouse.io/modules/control-plane-manager/#version-control) the cluster's control plane version.
+
+          If `Automatic` is specified, then the control plane version is used, which is considered stable at the moment. If the stable version of control plane is less than the maximum version that has ever been installed in the cluster, more than 1 minor version, then the version of the cluster will not be changed.
+          The version may change when the minor version of the Deckhouse release is changed (see a corresponding release message).
+        enum:
+        - "1.31"
+        - "1.33"
+        - "Automatic"
+      encryptionAlgorithm:
+        type: string
+        description: |
+          Starting from version **1.31**, kubeadm use the specified asymmetric encryption algorithm
+          when generating keys and certificates for the following control-plane components:
+
+          - `apiserver`
+          - `apiserver-kubelet-client`
+          - `apiserver-etcd-client`
+          - `front-proxy-client`
+          - `etcd-server`
+          - `etcd-peer`
+          - `etcd-healthcheck-client`
+
+          Certificates for the components listed above will be reissued using the selected algorithm and key length.
+
+          > **Warning.** When reissuing certificates, the root certificate (**CA**) is not rotated. The root certificate is created with the selected algorithm only during the initial cluster bootstrap.
+        enum:
+        - "RSA-2048"
+        - "RSA-3072"
+        - "RSA-4096"
+        - "ECDSA-P256"
+        default: "RSA-2048"
+      proxy:
+        x-doc-d8Editions:
+          - be
+          - se
+          - se+
+          - ee
+          - cse-lite
+          - cse-pro
+        type: object
+        description: |
+          Global proxy setup (mainly for working in air-gapped environments).
+
+          The parameters described in this section will be translated into the environment variables `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` for all cluster nodes and Deckhouse components. This will result in HTTP(S) requests (curl, git, registry, etc.) to all resources not listed in the `noProxy` parameter being made through a proxy. Note that the `podSubnetCIDR` and `serviceSubnetCIDR` subnets, as well as the `clusterDomain` domain are added to `noProxy` automatically.
+
+          > **Caution!** To avoid using proxies in requests between pods and services located in the cluster node network, make sure you list all the host subnets in the `noProxy` parameter.
+        additionalProperties: false
+        properties:
+          httpProxy:
+            type: string
+            x-doc-d8Editions:
+              - be
+              - se
+              - se+
+              - ee
+              - cse-lite
+              - cse-pro
+            pattern: ^https?://([!*'();&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$
+            description: |
+              Proxy URL for HTTP requests.
+
+              If necessary, specify the proxy server's username, password, and port.
+            x-examples:
+            - 'http://proxy.company.my'
+            - 'https://user:password@proxy.company.my:8443'
+            - 'https://DOMAIN%5Cuser:password@proxy.company.my:8443'
+            - 'https://user%40domain.local:password@proxy.company.my:8443'
+          httpsProxy:
+            type: string
+            x-doc-d8Editions:
+              - be
+              - se
+              - se+
+              - ee
+              - cse-lite
+              - cse-pro
+            pattern: ^https?://([!*'();&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+(\:[!*'();:@&=+$,/?%#\[\]0-9a-zA-Z\.\-\_]+)?@)?[0-9a-zA-Z\.\-]+(\:[0-9]{1,5})?$
+            description: |
+              Proxy URL for HTTPS requests.
+
+              If necessary, specify the proxy server's username, password, and port.
+            x-examples:
+            - 'http://proxy.company.my'
+            - 'https://user:password@proxy.company.my:8443'
+            - 'https://DOMAIN%5Cuser:password@proxy.company.my:8443'
+            - 'https://user%40domain.local:password@proxy.company.my:8443'
+          noProxy:
+            x-doc-d8Editions:
+              - be
+              - se
+              - se+
+              - ee
+              - cse-lite
+              - cse-pro
+            description: |
+              List of no proxy IP and domain entries.
+
+              For wildcard domains, use a domain name with a dot prefix, e.g., ".example.com".
+
+              > **Caution.** If the cluster is supposed to have pods interacting with services located in the cluster node network, then specify the list of subnets that are used on the nodes.
+            type: array
+            items:
+              type: string
+              pattern: '^[a-z0-9\-\./]+$'
+    oneOf:
+    - properties:
+        clusterType:
+           enum: [Static]
+    - properties:
+        clusterType:
+           enum: [Cloud]
+      cloud: {}
+      required: [cloud]

--- a/ee/cse/candi/openapi/doc-ru-cluster_configuration.yaml
+++ b/ee/cse/candi/openapi/doc-ru-cluster_configuration.yaml
@@ -1,0 +1,1 @@
+../../../../candi/openapi/doc-ru-cluster_configuration.yaml

--- a/tools/build_includes/candi-CSE.yaml
+++ b/tools/build_includes/candi-CSE.yaml
@@ -14,3 +14,8 @@
   stageDependencies:
     install:
         - '**/*'
+- add: /ee/cse/candi/openapi/cluster_configuration.yaml
+  to: /deckhouse/candi/openapi/cluster_configuration.yaml
+  stageDependencies:
+    install:
+        - '**/*'


### PR DESCRIPTION
## Description
A stripped-down cluster configuration has been added for the CSE edition.
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
A truncated configuration is used for CSE
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: added cluster_configuration.yaml in cse
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
