### PR TITLE
[deckhouse] do not reset notified annotation in runReleaseDeploy

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -1168,6 +1168,7 @@ func (r *reconciler) runReleaseDeploy(ctx context.Context, release *v1alpha1.Mod
 	err := ctrlutils.UpdateWithRetry(ctx, r.client, release, func() error {
 		annotations := map[string]string{
 			v1alpha1.ModuleReleaseAnnotationIsUpdating: "true",
+			v1alpha1.ModuleReleaseAnnotationNotified:   "true",
 		}
 
 		if len(release.Annotations) == 0 {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -1168,7 +1168,6 @@ func (r *reconciler) runReleaseDeploy(ctx context.Context, release *v1alpha1.Mod
 	err := ctrlutils.UpdateWithRetry(ctx, r.client, release, func() error {
 		annotations := map[string]string{
 			v1alpha1.ModuleReleaseAnnotationIsUpdating: "true",
-			v1alpha1.ModuleReleaseAnnotationNotified:   "false",
 		}
 
 		if len(release.Annotations) == 0 {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-force-release.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-force-release.yaml
@@ -52,6 +52,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-force-release.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-force-release.yaml
@@ -52,7 +52,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-pending-releases.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-pending-releases.yaml
@@ -72,6 +72,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -123,6 +124,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-pending-releases.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-pending-releases.yaml
@@ -72,7 +72,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -124,7 +123,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
@@ -61,6 +61,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
@@ -61,7 +61,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
@@ -61,6 +61,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
@@ -61,7 +61,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
@@ -61,6 +61,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
@@ -61,7 +61,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
@@ -60,6 +60,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
@@ -60,7 +60,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
@@ -125,6 +125,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
@@ -125,7 +125,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
@@ -31,7 +31,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-deployed-above-from.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-deployed-above-from.yaml
@@ -101,6 +101,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-deployed-above-from.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-deployed-above-from.yaml
@@ -101,7 +101,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-jump.yaml
@@ -101,6 +101,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-jump.yaml
@@ -101,7 +101,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-several-update-specs-must-choose-constrainted-release.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-several-update-specs-must-choose-constrainted-release.yaml
@@ -105,6 +105,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-several-update-specs-must-choose-constrainted-release.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-several-update-specs-must-choose-constrainted-release.yaml
@@ -105,7 +105,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-to-less-than-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-to-less-than-deployed.yaml
@@ -27,6 +27,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -55,6 +56,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-to-less-than-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-to-less-than-deployed.yaml
@@ -27,7 +27,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -56,7 +55,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
@@ -31,7 +31,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-major-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-major-jump.yaml
@@ -51,6 +51,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-major-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-major-jump.yaml
@@ -51,7 +51,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-minor-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-minor-jump.yaml
@@ -26,6 +26,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-minor-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-minor-jump.yaml
@@ -26,7 +26,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-multiple-versions.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-multiple-versions.yaml
@@ -51,6 +51,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -78,6 +79,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-multiple-versions.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-multiple-versions.yaml
@@ -51,7 +51,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -79,7 +78,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/manual-mode-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/manual-mode-release-approved.yaml
@@ -27,6 +27,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/manual-mode-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/manual-mode-release-approved.yaml
@@ -27,7 +27,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
@@ -31,7 +31,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-auto.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-auto.yaml
@@ -97,6 +97,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-auto.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-auto.yaml
@@ -97,7 +97,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-pending.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-pending.yaml
@@ -64,6 +64,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -101,6 +102,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-pending.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-pending.yaml
@@ -64,7 +64,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -102,7 +101,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor.yaml
@@ -64,6 +64,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor.yaml
@@ -64,7 +64,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-patch.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-patch.yaml
@@ -64,6 +64,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-patch.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-patch.yaml
@@ -64,7 +64,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-pending.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-pending.yaml
@@ -29,6 +29,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -66,6 +67,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -103,6 +105,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-pending.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-pending.yaml
@@ -29,7 +29,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -67,7 +66,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs
@@ -105,7 +103,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
@@ -31,7 +31,6 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/update-major-version-0-1.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/update-major-version-0-1.yaml
@@ -59,6 +59,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/update-major-version-0-1.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/update-major-version-0-1.yaml
@@ -59,7 +59,6 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
@@ -28,7 +28,6 @@ metadata:
   annotations:
     a: b
     modules.deckhouse.io/isUpdating: "true"
-    modules.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
@@ -28,6 +28,7 @@ metadata:
   annotations:
     a: b
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Remove notified=false annotation reset from runReleaseDeploy in the module release controller.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When runReleaseDeploy fails between updating annotations and setting Phase=Deployed, the release is left in Pending with notified=false. On the next reconcile, checkNotify sees notified=false and postpones the release for the full minimalNotificationTime (e.g. 192h) again — even though the old release is already Superseded. This leaves the module without a Deployed release for days.

Removing the reset fixes the race condition: if deploy is retried, the notified annotation retains its value from PreApplyReleaseCheck, and checkNotify does not re-delay the release.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Remove notified=false annotation reset from runReleaseDeploy in the module release controller.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
