### PR TITLE
[dhctl] Fix NG readiness output

### DIFF
--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -765,9 +765,13 @@ func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, conf
 }
 
 func BootstrapTerraNodes(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, infrastructureContext *infrastructure.Context) error {
-	return log.Process("bootstrap", "Create CloudPermanent NG", func() error {
-		return operations.ParallelCreateNodeGroup(ctx, kubeCl, metaConfig, terraNodeGroups, infrastructureContext)
-	})
+	if len(terraNodeGroups) > 0 {
+		return log.Process("bootstrap", "Create CloudPermanent NG", func() error {
+			return operations.ParallelCreateNodeGroup(ctx, kubeCl, metaConfig, terraNodeGroups, infrastructureContext)
+		})
+	}
+
+	return nil
 }
 
 func SaveBastionHostToCache(host string) {


### PR DESCRIPTION
## Description

Hide output of CloudPermanent NodeGroup in case of no CloudPermanent NGs were put.

## Why do we need it, and what problem does it solve?

UX improvement during bootstrap process, if we have no CloudPermanent NGs, we still see output like this:
```
┌ ⛵ ~ Bootstrap: Create CloudPermanent NG
│ ┌ 🛸 ~ Converge: Create NodeGroups
│ │ ┌ Waiting for NodeGroups [] to become Ready
│ │ │ Nodes Ready 0 of 0
│ │ │
│ │ │ 🎉 Succeeded!
│ │ └ Waiting for NodeGroups [] to become Ready (0.14 seconds)
│ └ 🛸 ~ Converge: Create NodeGroups  (0.17 seconds)
└ ⛵ ~ Bootstrap: Create CloudPermanent NG (0.18 seconds)
```
In case like this, we should not show any CloudPermanent NGs related output at all.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Hide empty CloudPermanent NGs related output during dhctl bootstrap process.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
