### PR TITLE
[cert-manager] Disable SecurityPolicyExceptions for cert-manager namespace

### DIFF
--- a/modules/101-cert-manager/templates/namespace.yaml
+++ b/modules/101-cert-manager/templates/namespace.yaml
@@ -2,8 +2,8 @@
 cert-manager.io/disable-validation: "true"
 extended-monitoring.deckhouse.io/enabled: ""
 prometheus.deckhouse.io/rules-watcher-enabled: "true"
-security.deckhouse.io/pod-policy: "restricted"
-security.deckhouse.io/enable-security-policy-check: "true"
+# security.deckhouse.io/pod-policy: "restricted"
+# security.deckhouse.io/enable-security-policy-check: "true"
 {{- end }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Description

The `cert-manager` namespace can legally contain client workloads. 
Enabling restricted mode is unacceptable. Warning and documentation for migration are required. Implementation for this NS has been postponed until client documentation is ready.


## Why do we need it, and what problem does it solve?
Bug fix
## Why do we need it in the patch release (if we do)?
Yes, for release-1.75

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section:  cert-manager
type: fix 
summary:  Disable SecurityPolicyExceptions for cert-manager namespace
impact_level: default 
```
