### PR TITLE
[user-authz] add USAGE section for all-namespaces access

### DIFF
--- a/modules/140-user-authz/docs/FAQ.md
+++ b/modules/140-user-authz/docs/FAQ.md
@@ -14,8 +14,6 @@ To limit a user's rights to specific namespaces in the experimental role-based m
 
 In the current role-based model, use the `namespaceSelector` or `limitNamespaces` (deprecated) parameters in the [`ClusterAuthorizationRule`](../../modules/user-authz/cr.html#clusterauthorizationrule) CR.
 
-<div style="height: 0;" id="what-if-there-are-two-clusterauthorizationrules-matching-to-a-single-user"></div>
-
 ## What if there are two ClusterAuthorizationRules matching to a single user?
 
 In the example, the user `jane.doe@example.com` is in the `administrators` group. There are two cluster authorization rules:

--- a/modules/140-user-authz/docs/FAQ.md
+++ b/modules/140-user-authz/docs/FAQ.md
@@ -14,6 +14,8 @@ To limit a user's rights to specific namespaces in the experimental role-based m
 
 In the current role-based model, use the `namespaceSelector` or `limitNamespaces` (deprecated) parameters in the [`ClusterAuthorizationRule`](../../modules/user-authz/cr.html#clusterauthorizationrule) CR.
 
+<div style="height: 0;" id="what-if-there-are-two-clusterauthorizationrules-matching-to-a-single-user"></div>
+
 ## What if there are two ClusterAuthorizationRules matching to a single user?
 
 In the example, the user `jane.doe@example.com` is in the `administrators` group. There are two cluster authorization rules:

--- a/modules/140-user-authz/docs/FAQ_RU.md
+++ b/modules/140-user-authz/docs/FAQ_RU.md
@@ -12,7 +12,7 @@ title: "Модуль user-authz: FAQ"
 
 Чтобы ограничить права пользователя конкретными пространствами имён в экспериментальной ролевой модели, используйте в `RoleBinding` [use-роль](./#use-роли) с соответствующим уровнем доступа. [Пример...](usage.html#пример-назначения-административных-прав-пользователю-в-рамках-пространства-имён).
 
-В текущей ролевой модели используйте параметры `namespaceSelector` или `limitNamespaces` (устарел) в кастомном ресурсе [`ClusterAuthorizationRule`](../../modules/user-authz/cr.html#clusterauthorizationrule).
+В текущей ролевой модели используйте параметры `namespaceSelector` или `limitNamespaces` (устарел) в кастомном ресурсе [ClusterAuthorizationRule](cr.html#clusterauthorizationrule).
 
 ## Что, если два ClusterAuthorizationRules подходят для одного пользователя?
 

--- a/modules/140-user-authz/docs/FAQ_RU.md
+++ b/modules/140-user-authz/docs/FAQ_RU.md
@@ -14,8 +14,6 @@ title: "Модуль user-authz: FAQ"
 
 В текущей ролевой модели используйте параметры `namespaceSelector` или `limitNamespaces` (устарел) в кастомном ресурсе [`ClusterAuthorizationRule`](../../modules/user-authz/cr.html#clusterauthorizationrule).
 
-<div style="height: 0;" id="что-если-два-clusterauthorizationrules-подходят-для-одного-пользователя"></div>
-
 ## Что, если два ClusterAuthorizationRules подходят для одного пользователя?
 
 В примере пользователь `jane.doe@example.com` состоит в группе `administrators`. Созданы два ClusterAuthorizationRules:

--- a/modules/140-user-authz/docs/FAQ_RU.md
+++ b/modules/140-user-authz/docs/FAQ_RU.md
@@ -12,7 +12,9 @@ title: "Модуль user-authz: FAQ"
 
 Чтобы ограничить права пользователя конкретными пространствами имён в экспериментальной ролевой модели, используйте в `RoleBinding` [use-роль](./#use-роли) с соответствующим уровнем доступа. [Пример...](usage.html#пример-назначения-административных-прав-пользователю-в-рамках-пространства-имён).
 
-В текущей ролевой модули используйте параметры `namespaceSelector` или `limitNamespaces` (устарел) в кастомном ресурсе [`ClusterAuthorizationRule`](../../modules/user-authz/cr.html#clusterauthorizationrule).
+В текущей ролевой модели используйте параметры `namespaceSelector` или `limitNamespaces` (устарел) в кастомном ресурсе [`ClusterAuthorizationRule`](../../modules/user-authz/cr.html#clusterauthorizationrule).
+
+<div style="height: 0;" id="что-если-два-clusterauthorizationrules-подходят-для-одного-пользователя"></div>
 
 ## Что, если два ClusterAuthorizationRules подходят для одного пользователя?
 

--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -261,9 +261,11 @@ spec:
 The example refers to the [current role-based model](readme.html#current-role-based-model).
 {% endalert %}
 
-In [multi-tenancy](configuration.html#parameters-enablemultitenancy) mode (`userAuthz.enableMultiTenancy`), namespace-based restrictions are configured using the [`ClusterAuthorizationRule`](cr.html#clusterauthorizationrule-v1-spec-namespaceselector) resource fields.
+In [multi-tenancy](configuration.html#parameters-enablemultitenancy) mode (`userAuthz.enableMultiTenancy`), namespace-based restrictions are configured using the [ClusterAuthorizationRule](cr.html#clusterauthorizationrule-v1-spec-namespaceselector) resource fields.
 
-- **All namespaces, including system namespaces** (`kube-*`, `d8-*`, `loghouse`, `default`, etc.): set `spec.namespaceSelector.matchAny: true`. In that case, `limitNamespaces` and `allowAccessToSystemNamespaces` are **ignored** if `namespaceSelector` is set.
+Configuration options:
+
+- **Allow access to all namespaces, including system namespaces** (`kube-*`, `d8-*`, `loghouse`, `default`, etc.). To allow access to all namespaces, including system namespaces,  set `spec.namespaceSelector.matchAny: true`. If the `namespaceSelector` parameter is specified, the `limitNamespaces` and `allowAccessToSystemNamespaces` values are **ignored**.
 
   Example:
 
@@ -281,9 +283,9 @@ In [multi-tenancy](configuration.html#parameters-enablemultitenancy) mode (`user
       matchAny: true
   ```
 
-- **All namespaces except system namespaces** (if none of `namespaceSelector`, `limitNamespaces`, or `allowAccessToSystemNamespaces` are set): the user gets access to every non-system namespace; the list of system namespaces is given in the [CR field descriptions](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
+- **Allow access to all namespaces except system namespaces**. To grant a user access to all namespaces except system namespaces, do not specify `namespaceSelector`, `limitNamespaces`, or `allowAccessToSystemNamespaces` when creating a ClusterAuthorizationRule. For a list of system namespaces, see the [CR field description](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
 
-The `SuperAdmin` access level **does not** lift namespace restrictions (`namespaceSelector`, `limitNamespaces`): grant the intended scope explicitly, including via `namespaceSelector.matchAny`, if access to all namespaces is required.
+> The `SuperAdmin` access level **does not lift** the namespace restrictions specified in the `namespaceSelector` and `limitNamespaces` parameters. If you need to grant access to all namespaces, specify the scope explicitly, including via [`namespaceSelector.matchAny`](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
 
 If several `ClusterAuthorizationRule` resources match the same subject, the allowed namespaces are **unioned**; the effective `accessLevel` is the **most powerful** among all matching rules. For details, refer to the [FAQ](faq.html#what-if-there-are-two-clusterauthorizationrules-matching-to-a-single-user).
 

--- a/modules/140-user-authz/docs/USAGE.md
+++ b/modules/140-user-authz/docs/USAGE.md
@@ -255,6 +255,46 @@ spec:
         team: frontend
 ```
 
+## Example of granting access to all namespaces
+
+{% alert level="info" %}
+The example refers to the [current role-based model](readme.html#current-role-based-model).
+{% endalert %}
+
+In [multi-tenancy](configuration.html#parameters-enablemultitenancy) mode (`userAuthz.enableMultiTenancy`), namespace-based restrictions are configured using the [`ClusterAuthorizationRule`](cr.html#clusterauthorizationrule-v1-spec-namespaceselector) resource fields.
+
+- **All namespaces, including system namespaces** (`kube-*`, `d8-*`, `loghouse`, `default`, etc.): set `spec.namespaceSelector.matchAny: true`. In that case, `limitNamespaces` and `allowAccessToSystemNamespaces` are **ignored** if `namespaceSelector` is set.
+
+  Example:
+
+  ```yaml
+  apiVersion: deckhouse.io/v1
+  kind: ClusterAuthorizationRule
+  metadata:
+    name: all-namespaces-including-system
+  spec:
+    subjects:
+    - kind: User
+      name: user@example.com
+    accessLevel: Editor
+    namespaceSelector:
+      matchAny: true
+  ```
+
+- **All namespaces except system namespaces** (if none of `namespaceSelector`, `limitNamespaces`, or `allowAccessToSystemNamespaces` are set): the user gets access to every non-system namespace; the list of system namespaces is given in the [CR field descriptions](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
+
+The `SuperAdmin` access level **does not** lift namespace restrictions (`namespaceSelector`, `limitNamespaces`): grant the intended scope explicitly, including via `namespaceSelector.matchAny`, if access to all namespaces is required.
+
+If several `ClusterAuthorizationRule` resources match the same subject, the allowed namespaces are **unioned**; the effective `accessLevel` is the **most powerful** among all matching rules. For details, refer to the [FAQ](faq.html#what-if-there-are-two-clusterauthorizationrules-matching-to-a-single-user).
+
+{% alert level="warning" %}
+Namespace restrictions from `ClusterAuthorizationRule` are enforced by the authorization webhook chain. If the webhook is unavailable, these restrictions **do not apply** until the webhook is reachable again. For more information, see the [module description](readme.html#current-role-based-model).
+{% endalert %}
+
+{% offtopic title="Experimental role-based model" %}
+`d8:use:role:*` roles must be bound with `RoleBinding` in a **specific** namespace — use one `RoleBinding` per namespace (or automate the process). `d8:manage:*` roles do not cover namespaces for user workloads; they only apply to system namespaces (`d8-*`, `kube-*`) within the subsystem.
+{% endofftopic %}
+
 ## Creating a user
 
 There are two types of users in Kubernetes:

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -255,15 +255,17 @@ spec:
         team: frontend
 ```
 
-## Пример выдачи прав на все пространства имён
+## Пример выдачи прав на все неймспейсы
 
 {% alert level="info" %}
 Пример относится к [текущей ролевой модели](readme.html#текущая-ролевая-модель).
 {% endalert %}
 
-В режиме [multi-tenancy](configuration.html#parameters-enablemultitenancy) (`userAuthz.enableMultiTenancy`) ограничение доступа по пространствам имён задаётся полями ресурса [`ClusterAuthorizationRule`](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
+В режиме [multi-tenancy](configuration.html#parameters-enablemultitenancy) (`userAuthz.enableMultiTenancy`) ограничение доступа по неймспейсам задаётся полями ресурса [ClusterAuthorizationRule](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
 
-- **Все пространства имён, включая системные** (`kube-*`, `d8-*`, `loghouse`, `default` и т. п.): укажите `spec.namespaceSelector.matchAny: true`. При этом значения `limitNamespaces` и `allowAccessToSystemNamespaces` **игнорируются**, если задан `namespaceSelector`.
+Варианты настройки:
+
+- **Разрешить доступ во все неймспейсы, включая системные** (`kube-*`, `d8-*`, `loghouse`, `default` и т. п.). Чтобы разрешить доступ во все неймспейсы, включая системные,  укажите `spec.namespaceSelector.matchAny: true`. Если параметр `namespaceSelector` задан, значения `limitNamespaces` и `allowAccessToSystemNamespaces` **игнорируются**.
 
   Пример:
 
@@ -281,18 +283,18 @@ spec:
       matchAny: true
   ```
 
-- **Все пространства имён, кроме системных** (если не указаны ни `namespaceSelector`, ни `limitNamespaces`, ни `allowAccessToSystemNamespaces`): пользователь получает доступ ко всем несистемным пространствам имён; перечень системных см. в [описании полей CR](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
+- **Разрешить доступ во все неймспейсы, кроме системных**. Чтобы разрешить пользователю доступ во все неймспейсы, кроме системных, при создании ClusterAuthorizationRule не указывайте ни `namespaceSelector`, ни `limitNamespaces`, ни `allowAccessToSystemNamespaces`. Перечень системных неймспейсов — в [описании полей CR](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
 
-Уровень доступа `SuperAdmin` **не снимает** ограничения по пространствам имён (`namespaceSelector`, `limitNamespaces`): при необходимости доступа ко всем пространствам имён задайте область явно, в том числе через `namespaceSelector.matchAny`.
+> Уровень доступа `SuperAdmin` **не снимает** ограничения по нейспейсам, заданные в параметрах `namespaceSelector` и `limitNamespaces`. При необходимости предоставления доступа ко всем неймспейсам задайте область явно, в том числе через [`namespaceSelector.matchAny`](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
 
-Если одному субъекту соответствует несколько ресурсов `ClusterAuthorizationRule`, набор разрешённых пространств имён **объединяется**; эффективный `accessLevel` — **самый сильный** среди всех подходящих правил. Подробнее — в [FAQ](faq.html#что-если-два-clusterauthorizationrules-подходят-для-одного-пользователя).
+Если одному субъекту соответствует несколько ресурсов `ClusterAuthorizationRule`, набор разрешённых нейспейсов **объединяется**; эффективный `accessLevel` — **самый сильный** среди всех подходящих правил. Подробнее — в [FAQ](faq.html#что-если-два-clusterauthorizationrules-подходят-для-одного-пользователя).
 
 {% alert level="warning" %}
-Ограничения по пространствам имён из `ClusterAuthorizationRule` реализованы в цепочке авторизации с webhook. Если webhook недоступен, эти ограничения **не применяются**, пока webhook снова не станет доступен. Подробнее см. [описание модуля](readme.html#текущая-ролевая-модель).
+Ограничения по неймспейсам из `ClusterAuthorizationRule` реализованы в цепочке авторизации с вебхуком. Если вебхук недоступен, эти ограничения **не применяются**, пока вебхук снова не станет доступен. Подробнее — в [описании модуля](readme.html#текущая-ролевая-модель).
 {% endalert %}
 
 {% offtopic title="Экспериментальная ролевая модель" %}
-Роли `d8:use:role:*` назначаются только через `RoleBinding` в **конкретном** пространстве имён — отдельное `RoleBinding` нужно на каждое пространство имён (или автоматизируйте выдачу). Роли `d8:manage:*` не распространяются на пространства имён пользовательских приложений — только на системные (`d8-*`, `kube-*`) в рамках подсистемы.
+Роли `d8:use:role:*` назначаются только через `RoleBinding` в **конкретном** неймспейсе — отдельное `RoleBinding` нужно на каждый неймспейс (или автоматизируйте выдачу). Роли `d8:manage:*` не распространяются на неймспейсы пользовательских приложений — только на системные (`d8-*`, `kube-*`) в рамках подсистемы.
 {% endofftopic %}
 
 ## Создание пользователя

--- a/modules/140-user-authz/docs/USAGE_RU.md
+++ b/modules/140-user-authz/docs/USAGE_RU.md
@@ -255,6 +255,46 @@ spec:
         team: frontend
 ```
 
+## Пример выдачи прав на все пространства имён
+
+{% alert level="info" %}
+Пример относится к [текущей ролевой модели](readme.html#текущая-ролевая-модель).
+{% endalert %}
+
+В режиме [multi-tenancy](configuration.html#parameters-enablemultitenancy) (`userAuthz.enableMultiTenancy`) ограничение доступа по пространствам имён задаётся полями ресурса [`ClusterAuthorizationRule`](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
+
+- **Все пространства имён, включая системные** (`kube-*`, `d8-*`, `loghouse`, `default` и т. п.): укажите `spec.namespaceSelector.matchAny: true`. При этом значения `limitNamespaces` и `allowAccessToSystemNamespaces` **игнорируются**, если задан `namespaceSelector`.
+
+  Пример:
+
+  ```yaml
+  apiVersion: deckhouse.io/v1
+  kind: ClusterAuthorizationRule
+  metadata:
+    name: all-namespaces-including-system
+  spec:
+    subjects:
+    - kind: User
+      name: user@example.com
+    accessLevel: Editor
+    namespaceSelector:
+      matchAny: true
+  ```
+
+- **Все пространства имён, кроме системных** (если не указаны ни `namespaceSelector`, ни `limitNamespaces`, ни `allowAccessToSystemNamespaces`): пользователь получает доступ ко всем несистемным пространствам имён; перечень системных см. в [описании полей CR](cr.html#clusterauthorizationrule-v1-spec-namespaceselector).
+
+Уровень доступа `SuperAdmin` **не снимает** ограничения по пространствам имён (`namespaceSelector`, `limitNamespaces`): при необходимости доступа ко всем пространствам имён задайте область явно, в том числе через `namespaceSelector.matchAny`.
+
+Если одному субъекту соответствует несколько ресурсов `ClusterAuthorizationRule`, набор разрешённых пространств имён **объединяется**; эффективный `accessLevel` — **самый сильный** среди всех подходящих правил. Подробнее — в [FAQ](faq.html#что-если-два-clusterauthorizationrules-подходят-для-одного-пользователя).
+
+{% alert level="warning" %}
+Ограничения по пространствам имён из `ClusterAuthorizationRule` реализованы в цепочке авторизации с webhook. Если webhook недоступен, эти ограничения **не применяются**, пока webhook снова не станет доступен. Подробнее см. [описание модуля](readme.html#текущая-ролевая-модель).
+{% endalert %}
+
+{% offtopic title="Экспериментальная ролевая модель" %}
+Роли `d8:use:role:*` назначаются только через `RoleBinding` в **конкретном** пространстве имён — отдельное `RoleBinding` нужно на каждое пространство имён (или автоматизируйте выдачу). Роли `d8:manage:*` не распространяются на пространства имён пользовательских приложений — только на системные (`d8-*`, `kube-*`) в рамках подсистемы.
+{% endofftopic %}
+
 ## Создание пользователя
 
 В Kubernetes есть две категории пользователей:


### PR DESCRIPTION
## Description

New USAGE / USAGE_RU section on granting access to all namespaces with `ClusterAuthorizationRule`

## Why do we need it, and what problem does it solve?

Gives operators one clear place that explains namespace scope for the current role model and how to allow all namespaces, so `ClusterAuthorizationRule` is easier to set correctly.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: chore
summary: Document ClusterAuthorizationRule options for access to all namespaces in user-authz USAGE.
impact_level: low
```