### PR TITLE
[cloud-provider-vsphere] Add module hook and template rendering tests for Hybrid clusters

### DIFF
--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/discover_test.go
@@ -178,6 +178,54 @@ data:
   "discovery-data.json": %s
 `, base64.StdEncoding.EncodeToString([]byte(discoveryData)))
 
+	storageClassesState := `---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: deckhouse-gold
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-vsphere
+provisioner: csi.vsphere.vmware.com
+allowedTopologies:
+- matchLabelExpressions:
+  - key: failure-domain.beta.kubernetes.io/zone
+    values:
+    - zone-b
+    - zone-a
+    - zone-b
+parameters:
+  DatastoreURL: ds:///vmfs/volumes/gold/
+  StoragePolicyName: Gold Policy
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: deckhouse-default
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-vsphere
+provisioner: csi.vsphere.vmware.com
+allowedTopologies:
+- matchLabelExpressions:
+  - key: failure-domain.beta.kubernetes.io/zone
+    values:
+    - zone-c
+parameters:
+  DatastoreURL: ds:///vmfs/volumes/default/
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: manual
+  labels:
+    heritage: deckhouse
+    module: other-module
+provisioner: csi.vsphere.vmware.com
+parameters:
+  DatastoreURL: ds:///vmfs/volumes/manual/
+`
+
 	f := HookExecutionConfigInit(initValuesStringA, `{}`)
 
 	Context("Empty cluster", func() {
@@ -349,6 +397,54 @@ data:
 		It("Should result empty storageClasses list", func() {
 			Expect(e).To(ExecuteSuccessfully())
 			Expect(e.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`[]`))
+		})
+	})
+
+	g := HookExecutionConfigInit(initValuesStringA, `{}`)
+
+	Context("Cluster without discovery data secret, but with deckhouse storage classes", func() {
+		BeforeEach(func() {
+			g.BindingContexts.Set(g.KubeStateSet(storageClassesState))
+			g.BindingContexts.Set(g.GenerateBeforeHelmContext())
+			g.RunHook()
+		})
+
+		It("Should restore storageClasses from storage class snapshots", func() {
+			Expect(g).To(ExecuteSuccessfully())
+			Expect(g.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
+    "name": "deckhouse-default",
+    "path": "",
+    "zones": ["zone-c"],
+    "datastoreType": "",
+    "datastoreURL": "ds:///vmfs/volumes/default/",
+    "storagePolicyName": ""
+  },
+  {
+    "name": "deckhouse-gold",
+    "path": "",
+    "zones": ["zone-a", "zone-b"],
+    "datastoreType": "",
+    "datastoreURL": "ds:///vmfs/volumes/gold/",
+    "storagePolicyName": "Gold Policy"
+  }
+]
+`))
+		})
+	})
+
+	h := HookExecutionConfigInit(initValuesStringA, `{}`)
+
+	Context("Cluster without discovery data secret and without deckhouse storage classes", func() {
+		BeforeEach(func() {
+			h.BindingContexts.Set(h.GenerateBeforeHelmContext())
+			h.RunHook()
+		})
+
+		It("Should not fail and should keep storageClasses empty", func() {
+			Expect(h).To(ExecuteSuccessfully())
+			Expect(h.ValuesGet("cloudProviderVsphere.internal.storageClasses").String()).To(BeEmpty())
 		})
 	})
 })

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/hooks/vsphere_cluster_configuration_test.go
@@ -348,6 +348,18 @@ cloudProviderVsphere:
 			Expect(b.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData").String()).To(MatchJSON("{}"))
 		})
 	})
+	Context("Cluster with module configuration, without secret", func() {
+		BeforeEach(func() {
+			b.BindingContexts.Set(b.KubeStateSet(""))
+			b.RunHook()
+		})
+
+		It("Should fill values from module configuration", func() {
+			Expect(b).To(ExecuteSuccessfully())
+			Expect(b.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfiguration2))
+			Expect(b.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData").String()).To(MatchJSON("{}"))
+		})
+	})
 	Context("Cluster with module configuration, with secret (without nsx-t)", func() {
 		BeforeEach(func() {
 			b.BindingContexts.Set(b.KubeStateSet(notEmptyProviderClusterConfigurationState))
@@ -422,9 +434,32 @@ cloudProviderVsphere:
 			Expect(d).To(Not(ExecuteSuccessfully()))
 		})
 	})
+	Context("Cluster with module configuration without zones, without secret", func() {
+		BeforeEach(func() {
+			d.BindingContexts.Set(d.KubeStateSet(""))
+			d.RunHook()
+		})
+
+		It("Should fail", func() {
+			Expect(d).To(Not(ExecuteSuccessfully()))
+		})
+	})
 	Context("Cluster with module configuration with zones, but without zoneTagCategory and regionTagCategory, with empty secret", func() {
 		BeforeEach(func() {
 			d.BindingContexts.Set(d.KubeStateSet(emptyProviderClusterConfigurationState))
+			d.ValuesSet("cloudProviderVsphere.zones", []string{"test"})
+			d.RunHook()
+		})
+
+		It("Should fill values from module configuration", func() {
+			Expect(d).To(ExecuteSuccessfully())
+			Expect(d.ValuesGet("cloudProviderVsphere.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfiguration4))
+			Expect(d.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData").String()).To(MatchJSON("{}"))
+		})
+	})
+	Context("Cluster with module configuration with zones, but without zoneTagCategory and regionTagCategory, without secret", func() {
+		BeforeEach(func() {
+			d.BindingContexts.Set(d.KubeStateSet(""))
 			d.ValuesSet("cloudProviderVsphere.zones", []string{"test"})
 			d.RunHook()
 		})
@@ -445,6 +480,31 @@ cloudProviderVsphere:
 		It("Should fill values from secret", func() {
 			Expect(e).To(ExecuteSuccessfully())
 			Expect(e.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData").String()).To(MatchJSON(stateECloudDiscoveryData))
+		})
+	})
+
+	f := HookExecutionConfigInit(filledValues, `{}`)
+	Context("Cluster with module configuration and inline discovery data, without secret", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("cloudProviderVsphere.internal.providerDiscoveryData", []byte(`
+apiVersion: deckhouse.io/v1
+kind: VsphereCloudDiscoveryData
+vmFolderPath: module-test
+resourcePoolPath: module-pool
+datacenter: MODULE-DC
+zones:
+- module-zone
+`))
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+
+		It("Should preserve inline discovery data", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData.vmFolderPath").String()).To(Equal("module-test"))
+			Expect(f.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData.resourcePoolPath").String()).To(Equal("module-pool"))
+			Expect(f.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData.datacenter").String()).To(Equal("MODULE-DC"))
+			Expect(f.ValuesGet("cloudProviderVsphere.internal.providerDiscoveryData.zones").String()).To(MatchJSON(`["module-zone"]`))
 		})
 	})
 })

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
@@ -62,6 +62,28 @@ const globalValues = `
     kubernetesVersion: "%s.1"
 `
 
+const hybridGlobalValues = `
+  enabledModules: ["vertical-pod-autoscaler"]
+  clusterConfiguration:
+    apiVersion: deckhouse.io/v1
+    clusterDomain: cluster.local
+    clusterType: Static
+    defaultCRI: Containerd
+    kind: ClusterConfiguration
+    kubernetesVersion: "%s"
+    podSubnetCIDR: 10.111.0.0/16
+    podSubnetNodeCIDRPrefix: "24"
+    serviceSubnetCIDR: 10.222.0.0/16
+  modules:
+    placement: {}
+  discovery:
+    d8SpecificNodeCountByRole:
+      worker: 1
+      master: 3
+    podSubnet: 10.0.1.0/16
+    kubernetesVersion: "%s.1"
+`
+
 const moduleValuesA = `
     internal:
       storageClasses:
@@ -223,6 +245,45 @@ const moduleValuesD = `
           - name: class1
             ipPoolName: pool2
             tcpAppProfileName: profile1
+`
+
+const moduleValuesHybrid = `
+    internal:
+      storageClasses:
+      - name: mydsname1
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/hash1/
+        path: /my/ds/path/mydsname1
+        zones: ["zonea", "zoneb"]
+      - name: mydsname2
+        datastoreType: Datastore
+        datastoreURL: ds:///vmfs/volumes/hash2/
+        path: /my/ds/path/mydsname2
+        zones: ["zonea", "zoneb"]
+      compatibilityFlag: ""
+      providerDiscoveryData:
+        datacenter: X1
+        zones: ["aaa", "bbb"]
+      providerClusterConfiguration:
+        provider:
+          server: myhost
+          username: myuname
+          password: myPaSsWd
+          insecure: true
+        regionTagCategory: myregtagcat
+        zoneTagCategory: myzonetagcat
+        region: myreg
+        zones: ["zone-a", "zone-b"]
+        sshPublicKey: mysshkey1
+        vmFolderPath: dev/test
+        masterNodeGroup:
+          instanceClass:
+            datastore: dev/lun_1
+            mainNetwork: k8s-msk/test_187
+            memory: 8192
+            numCPUs: 4
+            template: dev/golden_image
+          replicas: 1
 `
 
 const tolerationsAnyNodeWithUninitialized = `
@@ -403,6 +464,75 @@ storageclass.kubernetes.io/is-default-class: "true"
 			Expect(cddDeployment.Exists()).To(BeTrue())
 			Expect(cddDeployment.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 			Expect(cddDeployment.Field("spec.template.spec.tolerations").String()).To(MatchYAML(tolerationsAnyNodeWithUninitialized))
+		})
+	})
+
+	Context("Hybrid vSphere", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", fmt.Sprintf(hybridGlobalValues, "1.31", "1.31"))
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderVsphere", moduleValuesHybrid)
+			f.HelmRender()
+		})
+
+		It("renders resources for hybrid clusters", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")
+			Expect(providerRegistrationSecret.Exists()).To(BeTrue())
+			Expect(providerRegistrationSecret.Field(fmt.Sprintf("metadata.labels.%s", registrationLabelKey)).String()).To(Equal(""))
+			Expect(providerRegistrationSecret.Field(fmt.Sprintf("metadata.labels.%s", nameLabelKey)).String()).To(Equal(providerID))
+
+			providerSpecificRegistrationSecret := f.KubernetesResource("Secret", "kube-system", fmt.Sprintf("d8-node-manager-cloud-provider-%s", providerID))
+			Expect(providerSpecificRegistrationSecret.Exists()).To(BeTrue())
+			Expect(providerSpecificRegistrationSecret.Field(fmt.Sprintf("metadata.labels.%s", registrationLabelKey)).String()).To(Equal(""))
+			Expect(providerSpecificRegistrationSecret.Field(fmt.Sprintf("metadata.labels.%s", nameLabelKey)).String()).To(Equal(providerID))
+
+			expectedProviderRegistrationJSON := `{
+          "server": "myhost",
+          "insecure": true,
+          "password": "myPaSsWd",
+          "region": "myreg",
+          "regionTagCategory": "myregtagcat",
+          "instanceClassDefaults": {
+            "datastore": "dev/lun_1",
+            "template": "dev/golden_image",
+            "disableTimesync": true
+          },
+          "instances": {
+            "mainNetwork": "k8s-msk/test_187"
+          },
+          "sshKey": "mysshkey1",
+          "username": "myuname",
+          "vmFolderPath": "dev/test",
+          "zoneTagCategory": "myzonetagcat"
+        }`
+
+			providerRegistrationData, err := base64.StdEncoding.DecodeString(providerRegistrationSecret.Field("data.vsphere").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(providerRegistrationData)).To(MatchJSON(expectedProviderRegistrationJSON))
+
+			providerSpecificRegistrationData, err := base64.StdEncoding.DecodeString(providerSpecificRegistrationSecret.Field("data.vsphere").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(providerSpecificRegistrationData)).To(MatchJSON(expectedProviderRegistrationJSON))
+
+			zonesRegistrationData, err := base64.StdEncoding.DecodeString(providerRegistrationSecret.Field("data.zones").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(zonesRegistrationData)).To(Equal(`["zone-a","zone-b"]`))
+
+			cloudDataDiscovererSecret := f.KubernetesResource("Secret", moduleNamespace, "cloud-data-discoverer")
+			Expect(cloudDataDiscovererSecret.Exists()).To(BeTrue())
+
+			zonesDiscovererData, err := base64.StdEncoding.DecodeString(cloudDataDiscovererSecret.Field("data.zones").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(zonesDiscovererData)).To(Equal("zone-a,zone-b"))
+
+			Expect(f.KubernetesResource("Secret", "kube-system", fmt.Sprintf("d8-cloud-provider-%s-mcm", providerID)).Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Secret", "kube-system", fmt.Sprintf("d8-cloud-provider-%s-bashible-bootstrap", providerID)).Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Deployment", moduleNamespace, "cloud-controller-manager").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Deployment", moduleNamespace, "cloud-data-discoverer").Exists()).To(BeTrue())
+			Expect(f.KubernetesResource("Deployment", moduleNamespace, "csi-controller").Exists()).To(BeTrue())
+			Expect(f.KubernetesGlobalResource("CSIDriver", "csi.vsphere.vmware.com").Exists()).To(BeTrue())
 		})
 	})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add module hook and template rendering tests for Hybrid clusters with vSphere cloud provider

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

These tests increase the code coverage of tests, allow you to check more cases (in this case, hybrid configuration of clusters)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: chore
summary: Added module hook and template rendering tests for hybrid clusters with the vSphere cloud provider.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
