### PR TITLE
[cloud-provider-dvp] fix dvp finalizers drift

### DIFF
--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
@@ -40,7 +40,8 @@ resource "kubernetes_manifest" "additional_disk" {
 
   lifecycle {
     ignore_changes = [
-      object.spec.persistentVolumeClaim.storageClassName
+      object.spec.persistentVolumeClaim.storageClassName,
+      object.metadata.finalizers,
     ]
   }
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/ipv4-address/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/ipv4-address/main.tf
@@ -41,8 +41,6 @@ resource "kubernetes_manifest" "ipv4_address" {
   lifecycle {
     ignore_changes = [
       object.metadata.finalizers,
-      object.metadata.labels,
-      object.metadata.annotations,
     ]
   }
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/ipv4-address/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/ipv4-address/main.tf
@@ -37,6 +37,14 @@ resource "kubernetes_manifest" "ipv4_address" {
     update = var.timeouts.update
     delete = var.timeouts.delete
   }
+
+  lifecycle {
+    ignore_changes = [
+      object.metadata.finalizers,
+      object.metadata.labels,
+      object.metadata.annotations,
+    ]
+  }
 }
 
 data "kubernetes_resource" "ipv4_address" {

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
@@ -37,7 +37,8 @@ resource "kubernetes_manifest" "kubernetes-data-disk" {
   }
   lifecycle {
     ignore_changes = [
-      object.spec.persistentVolumeClaim.storageClassName
+      object.spec.persistentVolumeClaim.storageClassName,
+      object.metadata.finalizers,
     ]
   }
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
@@ -128,6 +128,14 @@ resource "kubernetes_manifest" "vm" {
     update = var.timeouts.update
     delete = var.timeouts.delete
   }
+
+  lifecycle {
+    ignore_changes = [
+      object.metadata.finalizers,
+      object.metadata.labels,
+      object.metadata.annotations,
+    ]
+  }
 }
 
 data "kubernetes_resource" "vm_data" {

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
@@ -27,7 +27,9 @@ resource "kubernetes_secret" "cloudinit-secret" {
   type = "provisioning.virtualization.deckhouse.io/cloud-init"
   lifecycle {
     ignore_changes = [
-      data
+      data,
+      metadata[0].labels,
+      metadata[0].annotations,
     ]
   }
 }
@@ -132,8 +134,6 @@ resource "kubernetes_manifest" "vm" {
   lifecycle {
     ignore_changes = [
       object.metadata.finalizers,
-      object.metadata.labels,
-      object.metadata.annotations,
     ]
   }
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
@@ -44,7 +44,8 @@ resource "kubernetes_manifest" "root-disk" {
   }
   lifecycle {
     ignore_changes = [
-      object.spec.persistentVolumeClaim.storageClassName
+      object.spec.persistentVolumeClaim.storageClassName,
+      object.metadata.finalizers,
     ]
   }
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
@@ -120,6 +120,14 @@ resource "kubernetes_manifest" "vm" {
     update = var.timeouts.update
     delete = var.timeouts.delete
   }
+
+  lifecycle {
+    ignore_changes = [
+      object.metadata.finalizers,
+      object.metadata.labels,
+      object.metadata.annotations,
+    ]
+  }
 }
 
 data "kubernetes_resource" "vm_data" {

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
@@ -27,7 +27,9 @@ resource "kubernetes_secret" "cloudinit-secret" {
   type = "provisioning.virtualization.deckhouse.io/cloud-init"
   lifecycle {
     ignore_changes = [
-      data
+      data,
+      metadata[0].labels,
+      metadata[0].annotations,
     ]
   }
 }
@@ -124,8 +126,6 @@ resource "kubernetes_manifest" "vm" {
   lifecycle {
     ignore_changes = [
       object.metadata.finalizers,
-      object.metadata.labels,
-      object.metadata.annotations,
     ]
   }
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: fix dvp finalizers drift
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
