### PR TITLE
[deckhouse] return setting notified for mr

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -1195,6 +1195,7 @@ func (r *reconciler) runReleaseDeploy(ctx context.Context, release *v1alpha1.Mod
 	err := ctrlutils.UpdateWithRetry(ctx, r.client, release, func() error {
 		annotations := map[string]string{
 			v1alpha1.ModuleReleaseAnnotationIsUpdating: "true",
+			v1alpha1.ModuleReleaseAnnotationNotified:   "true",
 		}
 
 		if len(release.Annotations) == 0 {

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-force-release.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-force-release.yaml
@@ -53,6 +53,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-pending-releases.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/apply-pending-releases.yaml
@@ -72,6 +72,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
@@ -124,6 +125,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-mode.yaml
@@ -62,6 +62,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-minor-update.yaml
@@ -62,6 +62,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode-minor-release-approved.yaml
@@ -62,6 +62,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/auto-patch-mode.yaml
@@ -61,6 +61,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/clean-up-outdated-module-releases-when-deploy.yaml
@@ -125,6 +125,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
     release.deckhouse.io/notified: "false"
   creationTimestamp: null
   finalizers:

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/dVersion-suitable.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-deployed-above-from.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-deployed-above-from.yaml
@@ -106,6 +106,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-jump.yaml
@@ -106,6 +106,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-several-update-specs-must-choose-constrainted-release.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-several-update-specs-must-choose-constrainted-release.yaml
@@ -110,6 +110,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-to-less-than-deployed.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/from-to-to-less-than-deployed.yaml
@@ -27,6 +27,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
@@ -56,6 +57,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/kVersion-suitable.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-major-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-major-jump.yaml
@@ -52,6 +52,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-minor-jump.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-minor-jump.yaml
@@ -26,6 +26,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-multiple-versions.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/lts-channel-multiple-versions.yaml
@@ -52,6 +52,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
@@ -80,6 +81,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/manual-mode-release-approved.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/manual-mode-release-approved.yaml
@@ -27,6 +27,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/reinstall-annotation.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-auto.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-auto.yaml
@@ -100,6 +100,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-pending.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor-pending.yaml
@@ -65,6 +65,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
@@ -103,6 +104,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-minor.yaml
@@ -65,6 +65,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-patch.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-patch.yaml
@@ -65,6 +65,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-pending.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/sequential-processing-pending.yaml
@@ -29,6 +29,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
@@ -67,6 +68,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered
@@ -105,6 +107,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/simple.yaml
@@ -31,6 +31,7 @@ kind: ModuleRelease
 metadata:
   annotations:
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/update-major-version-0-1.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/update-major-version-0-1.yaml
@@ -60,6 +60,7 @@ metadata:
   annotations:
     modules.deckhouse.io/approved: "true"
     modules.deckhouse.io/isUpdating: "false"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/metrics-registered

--- a/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/testdata/releases/golden/with-annotation.yaml
@@ -28,6 +28,7 @@ metadata:
   annotations:
     a: b
     modules.deckhouse.io/isUpdating: "true"
+    modules.deckhouse.io/notified: "true"
   creationTimestamp: null
   finalizers:
   - modules.deckhouse.io/exist-on-fs


### PR DESCRIPTION
## Description
It is related with [it](https://github.com/deckhouse/deckhouse/pull/19169), but its better to set it explicitly true

## Why do we need it, and what problem does it solve?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Return setting notified for mr.
impact_level: low
```