### PR TITLE
[descheduler] Add VEX for CVE-2026-39883 in descheduler

### DIFF
--- a/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
+++ b/modules/400-descheduler/images/descheduler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-95caeb00c03a501857d0b423a0bc2296ad7048120f6cf4f12510866919a323d5",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 5,
+  "version": 6,
   "statements": [
     {
       "vulnerability": {
@@ -59,8 +59,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Эта неэксплуатируемая уязвимость относится. Deckhouse не использует SSH agent функциональность в своих компонентах. Уязвимый код присутствует в зависимостях, но не вызывается ни в одном пути выполнения.",
       "timestamp": "2026-01-12T11:54:06.501135Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 связана с вызовом команды kenv по неабсолютному пути на операционных системах BSD и Solaris (PATH hijacking, CWE-426). Компоненты Deckhouse, включая Descheduler, собираются с GOOS=linux и выполняются в контейнерах на Linux; уязвимый путь выполнения в этой среде отсутствует.",
+      "timestamp": "2026-04-16T15:43:34.356000Z"
     }
   ],
   "timestamp": "2026-01-12T11:51:20Z",
-  "last_updated": "2026-03-23T09:21:02Z"
+  "last_updated": "2026-04-16T15:43:34Z"
 }


### PR DESCRIPTION
## Description
Add recording into vex for [CVE-2026-39883](https://nvd.nist.gov/vuln/detail/CVE-2026-39883)

## Why do we need it, and what problem does it solve?
The entry marks go.opentelemetry.io/otel/sdk (as shipped in the descheduler image) as not_affected, with justification vulnerable_code_not_in_execute_path, and documents why the issue does not apply in Deckhouse’s Linux deployment model (see [GHSA-hfvc-g4fc-pqhx](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-hfvc-g4fc-pqhx)).

This change does not alter runtime behavior of the descheduler or other cluster components—only vulnerability metadata consumed by scanners and reporting.

Dependency scanners flag the transitive OpenTelemetry Go SDK used by the descheduler image for CVE-2026-39883. According to the advisory, the flaw is an untrusted search path / PATH hijacking issue involving the kenv command on BSD and Solaris (incomplete follow-up to the Darwin ioreg fix in CVE-2026-24051). The descheduler image is built with GOOS=linux and runs in Linux containers, so that execution path is not applicable here. Recording this in OpenVEX gives a precise, reviewable statement for tooling and reduces false positives without waiting for an upstream dependency bump.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: descheduler
type:  chore
summary: Add recording into vex for CVE-2026-39883
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
