### PR TITLE
[node-manager] Add VEX for CVE-2026-39883 in cluster-autoscaler

### DIFF
--- a/modules/040-node-manager/images/cluster-autoscaler/known_vulnerabilities.vex
+++ b/modules/040-node-manager/images/cluster-autoscaler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "merged-vex-d2a6e388d354698e1b1acd4d3508b57408c2bf9da5d566c75729a133feba1b4b",
   "author": "Deckhouse <contact@deckhouse.io>",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -132,7 +132,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость представляет собой обход авторизации на стороне gRPC-сервера через отсутствие ведущего слеша в псевдозаголовке :path. Для эксплуатации требуется, чтобы приложение запускало gRPC-сервер с перехватчиками авторизации на основе путей (grpc/authz) и имело политику с deny-правилами и fallback allow-правилом. Cluster-autoscaler использует google.golang.org/grpc исключительно как клиентскую библиотеку для подключения к API облачных провайдеров и Kubernetes API server. Он не запускает gRPC-сервер и не использует серверную авторизацию на основе путей, поэтому уязвимый код не исполняется.",
       "timestamp": "2026-03-23T14:17:46.322000Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-39883 связана с подменой PATH при вызове команды kenv на платформах BSD и Solaris в OpenTelemetry-Go. Образ cluster-autoscaler в Deckhouse собирается и выполняется под Linux; kenv относится к BSD/Solaris и в этом окружении не задействуется, эксплуатация в рамках поддерживаемого сценария невозможна.",
+      "timestamp": "2026-04-16T15:47:22.345010Z"
     }
   ],
-  "timestamp": "2026-03-10T11:10:46Z"
+  "timestamp": "2026-03-10T11:10:46Z",
+  "last_updated": "2026-04-16T15:47:22Z"
 }


### PR DESCRIPTION
## Description
Add recording into vex for [CVE-2026-39883](https://nvd.nist.gov/vuln/detail/CVE-2026-39883)

## Why do we need it, and what problem does it solve?
CVE-2026-39883 is a PATH hijacking vulnerability in OpenTelemetry-Go (versions 1.15.0 through 1.42.0) affecting the BSD kenv command on BSD and Solaris platforms. The cluster-autoscaler image includes go.opentelemetry.io/otel/sdk as a transitive dependency, which causes vulnerability scanners to flag the image. However, the cluster-autoscaler is built and runs exclusively on Linux (GOOS=linux), where the kenv command does not exist and the vulnerable code path is never executed. This VEX entry documents the not_affected status to suppress false-positive scanner alerts.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: Add recording into vex for CVE-2026-39883
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
