### PR TITLE
[ingress-nginx] backport cve-2025-15566 fix

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/028-fix-cve-2025-15566.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/028-fix-cve-2025-15566.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index 873248bb22..d3fbc6b9c6 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -619,8 +619,9 @@ func buildAuthProxySetHeaders(headers map[string]string) []string {
+ 	}
+ 
+ 	for name, value := range headers {
+-		res = append(res, fmt.Sprintf("proxy_set_header '%v' '%v';", name, value))
++		res = append(res, fmt.Sprintf("proxy_set_header %q %q;", name, value))
+ 	}
++
+ 	sort.Strings(res)
+ 	return res
+ }

--- a/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/README.md
@@ -148,3 +148,9 @@ https://github.com/kubernetes/kubernetes/issues/137560
 ### 027-fix-cve-2026-4342.patch
 
 This patch fixes the CVE-2026-4342 https://github.com/kubernetes/kubernetes/issues/137893.
+
+### 028-fix-cve-2025-15566.patch
+
+This patch fixes CVE-2025-15566
+
+https://github.com/kubernetes/kubernetes/issues/136789

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -61,6 +61,7 @@ shell:
   - patch -p1 < /patches/020-fix-sorting.patch
   - patch -p1 < /patches/024-cve-03022026-controller.patch
   - patch -p1 < /patches/026-fix-rewrite-target-cve.patch
+  - patch -p1 < /patches/028-fix-cve-2025-15566.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/014-balancer-lua.patch
   - patch -p1 < /patches/003-nginx-tmpl.patch

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/025-fix-cve-2025-15566.patch
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/025-fix-cve-2025-15566.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index 873248bb22..d3fbc6b9c6 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -619,8 +619,9 @@ func buildAuthProxySetHeaders(headers map[string]string) []string {
+ 	}
+ 
+ 	for name, value := range headers {
+-		res = append(res, fmt.Sprintf("proxy_set_header '%v' '%v';", name, value))
++		res = append(res, fmt.Sprintf("proxy_set_header %q %q;", name, value))
+ 	}
++
+ 	sort.Strings(res)
+ 	return res
+ }

--- a/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-12/patches/README.md
@@ -126,3 +126,9 @@ https://github.com/kubernetes/kubernetes/issues/137560
 ### 024-fix-cve-2026-4342.patch
 
 This patch fixes the CVE-2026-4342 https://github.com/kubernetes/kubernetes/issues/137893.
+
+### 025-fix-cve-2025-15566.patch
+
+This patch fixes CVE-2025-15566
+
+https://github.com/kubernetes/kubernetes/issues/136789

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/024-fix-cve-2025-15566.patch
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/024-fix-cve-2025-15566.patch
@@ -1,0 +1,15 @@
+diff --git a/internal/ingress/controller/template/template.go b/internal/ingress/controller/template/template.go
+index 873248bb22..d3fbc6b9c6 100644
+--- a/internal/ingress/controller/template/template.go
++++ b/internal/ingress/controller/template/template.go
+@@ -619,8 +619,9 @@ func buildAuthProxySetHeaders(headers map[string]string) []string {
+ 	}
+ 
+ 	for name, value := range headers {
+-		res = append(res, fmt.Sprintf("proxy_set_header '%v' '%v';", name, value))
++		res = append(res, fmt.Sprintf("proxy_set_header %q %q;", name, value))
+ 	}
++
+ 	sort.Strings(res)
+ 	return res
+ }

--- a/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
+++ b/modules/402-ingress-nginx/images/controller-1-9/patches/ingress-nginx/README.md
@@ -107,3 +107,9 @@ This patch deletes unneeded nginx patch.
 This patch fixes rewrite-target CVE-2026-3288 in Ingress-NGINX
 
 https://github.com/kubernetes/kubernetes/issues/137560
+
+### 024-fix-cve-2025-15566.patch
+
+This patch fixes CVE-2025-15566
+
+https://github.com/kubernetes/kubernetes/issues/136789

--- a/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-9/werf.inc.yaml
@@ -78,6 +78,7 @@ shell:
   - patch -p1 < /patches/ingress-nginx/021-cve-03022026.patch
   - patch -p1 < /patches/ingress-nginx/022-remove-patch-01.patch
   - patch -p1 < /patches/ingress-nginx/023-fix-rewrite-target-cve.patch
+  - patch -p1 < /patches/ingress-nginx/024-fix-cve-2025-15566.patch
   - cd /src/ingress-nginx/rootfs
   - patch -p1 < /patches/rootfs/001-balancer-lua.patch
   - patch -p1 < /patches/rootfs/002-nginx-tmpl.patch


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backports CVE-2025-15566 fix to Ingress-NGINX controllers.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

A security fix.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

A security fix.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: CVE-2025-15566 is backported.
impact: All pods of Ingress-NGINX controller will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
