### PR TITLE
[docs] Network ports for hostNetwork virtualization components actualization

### DIFF
--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -372,6 +372,11 @@ groups:
     description:
       en: "`sds-replicated-volume` CSI controller metrics"
       ru: "Метрики CSI-контроллера модуля `sds-replicated-volume`"
+  - ports: "4135-4199"
+    protocol: TCP
+    description:
+      en: "`virtualization` KubeVirt live migration tunnels between cluster nodes"
+      ru: "Туннели live migration KubeVirt модуля `virtualization` между узлами кластера"
   - ports: "4280"
     protocol: TCP
     description:
@@ -449,6 +454,38 @@ groups:
         **Обратите внимание,** что в таких кластерах включение модуля `virtualization` на DKP до версии 1.70 меняет порт:
         - включение модуля `virtualization` на DKP версии 1.63 и ниже изменит его на `8469/UDP` и не изменит при последующих обновлениях DKP
         - включение модуля `virtualization` на DKP, начиная с версии 1.64, изменит его на `4298/UDP` и не изменит при последующих обновлениях DKP
+
+- group: VirtualizationStaticPorts
+  description:
+    en: Static `virtualization` ports on cluster nodes (`4100-4134/TCP` reserved)
+    ru: Статические порты модуля `virtualization` на узлах кластера (зарезервирован диапазон `4100-4134/TCP`)
+  destinations:
+  - ports: "4100"
+    protocol: TCP
+    description:
+      en: "`virtualization` `virt-handler` healthz and metrics"
+      ru: "Healthz и метрики `virt-handler` модуля `virtualization`"
+  - ports: "4101"
+    protocol: TCP
+    description:
+      en: "`virtualization` `virt-handler` console server"
+      ru: "Сервер консоли `virt-handler` модуля `virtualization`"
+  - ports: "4105"
+    protocol: TCP
+    description:
+      en: "`virtualization` `vm-route-forge` liveness and readiness probes"
+      ru: "Порты liveness и readiness проб `vm-route-forge` модуля `virtualization`"
+  - ports: "4106"
+    protocol: TCP
+    description:
+      en: "`virtualization` `vm-route-forge` pprof in debug mode"
+      ru: "Порт pprof компонента `vm-route-forge` модуля `virtualization` в debug-режиме"
+  - ports: "4107"
+    protocol: TCP
+    description:
+      en: "`virtualization` `virtualization-dra` gRPC liveness and readiness probes"
+      ru: "Порты gRPC liveness и readiness проб `virtualization-dra` модуля `virtualization`"
+
 - group: ExternalToMaster
   description:
     en: External traffic to master nodes

--- a/docs/documentation/_data/deckhouse-ports.yml
+++ b/docs/documentation/_data/deckhouse-ports.yml
@@ -375,8 +375,8 @@ groups:
   - ports: "4135-4199"
     protocol: TCP
     description:
-      en: "`virtualization` KubeVirt live migration tunnels between cluster nodes"
-      ru: "Туннели live migration KubeVirt модуля `virtualization` между узлами кластера"
+      en: "`virtualization` live migration tunnels between cluster nodes"
+      ru: "Туннели live migration модуля `virtualization` между узлами кластера"
   - ports: "4280"
     protocol: TCP
     description:


### PR DESCRIPTION
## Description
Network ports for hostNetwork virtualization components actualization

## Why do we need it, and what problem does it solve?
We need the actual used port list in the documentation.


## Why do we need it in the patch release (if we do)?
Our clients must get actual information for their security teams

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Network ports for hostNetwork virtualization components actualization
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
