### PR TITLE
[ingress-nginx] backport hpa readonlyrootfilesystem

### DIFF
--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/hpa.yaml
@@ -91,8 +91,15 @@ spec:
           requests:
             cpu: 10m
             memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       imagePullSecrets:
       - name: deckhouse-registry
+      securityContext:
+        runAsGroup: 64535
+        runAsNonRoot: true
+        runAsUser: 64535
       tolerations:
       - key: dedicated.deckhouse.io
         operator: Equal

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/hpa.yaml
@@ -91,8 +91,15 @@ spec:
           requests:
             cpu: 10m
             memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       imagePullSecrets:
       - name: deckhouse-registry
+      securityContext:
+        runAsGroup: 64535
+        runAsNonRoot: true
+        runAsUser: 64535
       tolerations:
       - key: dedicated.deckhouse.io
         operator: Equal

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/hpa.yaml
@@ -91,8 +91,15 @@ spec:
           requests:
             cpu: 10m
             memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       imagePullSecrets:
       - name: deckhouse-registry
+      securityContext:
+        runAsGroup: 64535
+        runAsNonRoot: true
+        runAsUser: 64535
       tolerations:
       - key: dedicated.deckhouse.io
         operator: Equal

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/hpa.yaml
@@ -91,8 +91,15 @@ spec:
           requests:
             cpu: 10m
             memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       imagePullSecrets:
       - name: deckhouse-registry
+      securityContext:
+        runAsGroup: 64535
+        runAsNonRoot: true
+        runAsUser: 64535
       tolerations:
       - key: dedicated.deckhouse.io
         operator: Equal

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/hpa.yaml
@@ -91,8 +91,15 @@ spec:
           requests:
             cpu: 10m
             memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       imagePullSecrets:
       - name: deckhouse-registry
+      securityContext:
+        runAsGroup: 64535
+        runAsNonRoot: true
+        runAsUser: 64535
       tolerations:
       - key: dedicated.deckhouse.io
         operator: Equal

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/hpa.yaml
@@ -91,8 +91,15 @@ spec:
           requests:
             cpu: 10m
             memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       imagePullSecrets:
       - name: deckhouse-registry
+      securityContext:
+        runAsGroup: 64535
+        runAsNonRoot: true
+        runAsUser: 64535
       tolerations:
       - key: dedicated.deckhouse.io
         operator: Equal

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/hpa.yaml
@@ -91,8 +91,15 @@ spec:
           requests:
             cpu: 10m
             memory: 1Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       imagePullSecrets:
       - name: deckhouse-registry
+      securityContext:
+        runAsGroup: 64535
+        runAsNonRoot: true
+        runAsUser: 64535
       tolerations:
       - key: dedicated.deckhouse.io
         operator: Equal

--- a/modules/402-ingress-nginx/templates/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/templates/controller/hpa.yaml
@@ -90,11 +90,13 @@ spec:
                     values:
                       - {{ $name }}
               topologyKey: kubernetes.io/hostname
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       imagePullSecrets:
         - name: deckhouse-registry
       containers:
         - name: hpa-scaler
           image: {{ include "helm_lib_module_common_image" (list $context "pause") }}
+      {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 10 }}
           resources:
             requests:
               cpu: "10m"


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backports missing pod security context to hpa scaler pods.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

To comply with security requirements.

## Why do we need it in the patch release (if we do)?

It's safe to update hpa scaler pods.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Backported missing pod security context settings to hpa scaler pods.
impact: HPA scaler pods will be restarted.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->