### PR TITLE
[control-plane-manager] Account for arbiter nodes in approve concurrency calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .settings
 .idea/
 .vscode
+.cursor
 __debug_bin*
 venv/
 out/

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/docs/controller-operations-approver.md
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/docs/controller-operations-approver.md
@@ -21,8 +21,10 @@ The controller recomputes approvals for the full operation set on each trigger.
 Approval pipeline stages:
 
 1. `Etcd` (global concurrency limit = `1`)
-2. `KubeAPIServer` (limit = `max(1, nodesCount-1)`)
+   - Calculated from total quorum membership: `masters + arbiters`
+2. `KubeAPIServer` (limit = `max(1, masters-1)`)
 3. `KubeControllerManager`, `KubeScheduler` (same limit as stage 2)
+   - Workload components run exclusively on master nodes
 
 Rules:
 
@@ -34,18 +36,23 @@ Rules:
 
 ## Reconciliation Logic
 
-1. List all `ControlPlaneNode` objects to get node count.
+1. Query node topology to determine:
+   - Count of master nodes (labeled with `node.deckhouse.io/control-plane=""`)
+   - Count of arbiter nodes (labeled with `node.deckhouse.io/etcd-arbiter=""`)
 2. List all `ControlPlaneOperation` objects.
 3. Split operations into:
-- approved and non-terminal (already occupy slots)
-- unapproved (approval queue)
+   - approved and non-terminal (already occupy slots)
+   - unapproved (approval queue)
 4. Seed stage counters from approved non-terminal operations.
 5. Iterate queue and try to reserve slot for each operation.
 6. Patch `spec.approved=true` when reservation succeeds.
 
 ## Logic Basis
 
-- Safety first for etcd: strict single-flight.
-- Control-plane workload rollout: allow `N-1` parallel updates, keep at least one node not updating in multi-node setups.
-- Determinism: stable sort and explicit stage graph.
+- **Node topology awareness**: Master and arbiter nodes are counted separately:
+  - Etcd limit includes both masters and arbiters (full quorum for etcd safety)
+  - Workload component limits use only master node count (apiserver, controller-manager, scheduler run on masters only)
+- **Safety first for etcd**: Strict single-flight to maintain quorum consensus safety.
+- **Control-plane workload rollout**: Allow `N-1` parallel updates (where N = master count), keep at least one node not updating in multi-node setups.
+- **Determinism**: Stable sort and explicit stage graph.
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
@@ -232,7 +232,7 @@ type nodeCounts struct {
 	arbiters int
 }
 
-func (c nodeCounts) equalZero() bool {
+func (c nodeCounts) isZero() bool {
 	return c.masters+c.arbiters == 0
 }
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver.go
@@ -32,20 +32,20 @@ var approvePipeline = []pipelineStage{
 		components: []controlplanev1alpha1.OperationComponent{
 			controlplanev1alpha1.OperationComponentEtcd,
 		},
-		concurrencyLimitFn: etcdConcurrencyLimit,
+		concurrencyLimitFn: getConcurrencyLimit,
 	},
 	{
 		components: []controlplanev1alpha1.OperationComponent{
 			controlplanev1alpha1.OperationComponentKubeAPIServer,
 		},
-		concurrencyLimitFn: controlPlaneWorkloadConcurrencyLimit,
+		concurrencyLimitFn: getConcurrencyLimit,
 	},
 	{
 		components: []controlplanev1alpha1.OperationComponent{
 			controlplanev1alpha1.OperationComponentKubeControllerManager,
 			controlplanev1alpha1.OperationComponentKubeScheduler,
 		},
-		concurrencyLimitFn: controlPlaneWorkloadConcurrencyLimit,
+		concurrencyLimitFn: getConcurrencyLimit,
 	},
 }
 
@@ -53,7 +53,7 @@ var approvePipeline = []pipelineStage{
 // This slice is the single source of truth for stage order, membership, and per-stage concurrency policy.
 type pipelineStage struct {
 	components         []controlplanev1alpha1.OperationComponent
-	concurrencyLimitFn func(nodesCount int) int
+	concurrencyLimitFn func(nodes nodeCounts, c controlplanev1alpha1.OperationComponent) int
 }
 
 // pipelineStageIndex returns the stage index of c in controlPlaneApprovePipeline, or -1 if unknown.
@@ -86,12 +86,12 @@ type component struct {
 // newApprover builds an approver for one reconcile pass: partitions operations into
 // approved && !Completed and unapproved, sorts both by pipeline stage,
 // seeds the chain, and exposes unapproved operations via approveQueue iteration order.
-func newApprover(nodesCount int, operations []controlplanev1alpha1.ControlPlaneOperation) *approver {
+func newApprover(nodes nodeCounts, operations []controlplanev1alpha1.ControlPlaneOperation) *approver {
 	approvedOperations, unapprovedOperations := partitionOperationsByApprovalState(operations)
 	sortOperationsByPipelineOrder(approvedOperations)
 	sortOperationsByPipelineOrder(unapprovedOperations)
 
-	approveChain := buildApproveChain(nodesCount)
+	approveChain := buildApproveChain(nodes)
 	approveChain.seedApprovedOperations(approvedOperations)
 
 	return &approver{
@@ -129,20 +129,19 @@ func sortOperationsByPipelineOrder(operations []controlplanev1alpha1.ControlPlan
 	})
 }
 
-func buildApproveChain(nodesCount int) *approveLink {
+func buildApproveChain(nodes nodeCounts) *approveLink {
 	if len(approvePipeline) == 0 {
 		return nil
 	}
 
 	links := make([]*approveLink, len(approvePipeline))
 	for i, stage := range approvePipeline {
-		limit := stage.concurrencyLimitFn(nodesCount)
 		components := make(map[controlplanev1alpha1.OperationComponent]*component, len(stage.components))
 
 		for _, c := range stage.components {
 			components[c] = &component{
-				concurrencyLimit:          limit,
-				approvedOperationsPerNode: make(map[string]int, nodesCount),
+				concurrencyLimit:          stage.concurrencyLimitFn(nodes, c),
+				approvedOperationsPerNode: make(map[string]int),
 			}
 		}
 
@@ -177,12 +176,8 @@ func (link *approveLink) seedApprovedOperation(approvedOperation controlplanev1a
 
 	component := link.components[approvedOperation.Spec.Component]
 
-	if _, exists := component.approvedOperationsPerNode[approvedOperation.Spec.NodeName]; !exists {
-		component.approvedOperationsPerNode[approvedOperation.Spec.NodeName] = 0
-	}
-
 	component.approvedOperationsTotal++
-	component.approvedOperationsPerNode[approvedOperation.Spec.NodeName] = component.approvedOperationsPerNode[approvedOperation.Spec.NodeName] + 1
+	component.approvedOperationsPerNode[approvedOperation.Spec.NodeName]++
 }
 
 func (link *approveLink) tryReserveApproval(unapprovedOperation controlplanev1alpha1.ControlPlaneOperation) bool {
@@ -204,16 +199,12 @@ func (link *approveLink) tryReserveApproval(unapprovedOperation controlplanev1al
 		return false
 	}
 
-	if _, exists := component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName]; !exists {
-		component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] = 0
-	}
-
 	if component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] >= maxPerComponentPerNodeOperations {
 		return false
 	}
 
 	component.approvedOperationsTotal++
-	component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] = component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName] + 1
+	component.approvedOperationsPerNode[unapprovedOperation.Spec.NodeName]++
 
 	return true
 }
@@ -236,11 +227,34 @@ func (link *approveLink) hasAnyApprovedOperation() bool {
 	return false
 }
 
-func etcdConcurrencyLimit(nodesCount int) int {
-	_ = nodesCount
+type nodeCounts struct {
+	masters  int
+	arbiters int
+}
+
+func (c nodeCounts) equalZero() bool {
+	return c.masters+c.arbiters == 0
+}
+
+// Arbiters run etcd only; workload components (apiserver, etc.) run on master nodes exclusively.
+// For etcd the limit accounts for the full quorum membership (masters + arbiters).
+// For all other components only master nodes count.
+func getConcurrencyLimit(nodes nodeCounts, c controlplanev1alpha1.OperationComponent) int {
+	switch c {
+	case controlplanev1alpha1.OperationComponentEtcd:
+		return etcdConcurrencyLimit(nodes.masters + nodes.arbiters)
+	default:
+		return controlPlaneWorkloadConcurrencyLimit(nodes.masters)
+	}
+}
+
+// TODO: the limit is hardcoded to 1 until we settle on a quorum-safe formula,
+// e.g. (n-1)/2 for a cluster of n etcd members (masters + arbiters).
+func etcdConcurrencyLimit(nodes int) int {
+	_ = nodes
 	return 1
 }
 
-func controlPlaneWorkloadConcurrencyLimit(nodesCount int) int {
-	return max(1, nodesCount-1)
+func controlPlaneWorkloadConcurrencyLimit(nodes int) int {
+	return max(1, nodes-1)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
@@ -31,7 +31,7 @@ func TestNewApprover_ConcurrencyLimits(t *testing.T) {
 
 	t.Run("single node uses workload limit 1", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(1, nil)
+		a := newApprover(nodeCounts{masters: 1}, nil)
 		etcd := a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd]
 		require.Equal(t, 1, etcd.concurrencyLimit)
 		api := a.approveChain.nextLink.components[controlplanev1alpha1.OperationComponentKubeAPIServer]
@@ -40,7 +40,7 @@ func TestNewApprover_ConcurrencyLimits(t *testing.T) {
 
 	t.Run("three nodes workload limit is nodesCount-1", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		api := a.approveChain.nextLink.components[controlplanev1alpha1.OperationComponentKubeAPIServer]
 		require.Equal(t, 2, api.concurrencyLimit)
 	})
@@ -51,21 +51,21 @@ func TestApprover_TryApprove_Etcd(t *testing.T) {
 
 	t.Run("allows first etcd operation", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		op := newOperation("etcd-1", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)
 		require.True(t, a.tryApprove(op))
 	})
 
 	t.Run("rejects second etcd while first is reserved in same approver", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("etcd-1", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)))
 		require.False(t, a.tryApprove(newOperation("etcd-2", "node-b", controlplanev1alpha1.OperationComponentEtcd, false)))
 	})
 
 	t.Run("rejects second etcd on same node", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("etcd-1", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)))
 		require.False(t, a.tryApprove(newOperation("etcd-2", "node-a", controlplanev1alpha1.OperationComponentEtcd, false)))
 	})
@@ -75,7 +75,7 @@ func TestApprover_TryApprove_Etcd(t *testing.T) {
 		seed := []controlplanev1alpha1.ControlPlaneOperation{
 			newOperation("etcd-running", "node-a", controlplanev1alpha1.OperationComponentEtcd, true),
 		}
-		a := newApprover(3, seed)
+		a := newApprover(nodeCounts{masters: 3}, seed)
 		require.False(t, a.tryApprove(newOperation("etcd-new", "node-b", controlplanev1alpha1.OperationComponentEtcd, false)))
 	})
 }
@@ -85,27 +85,27 @@ func TestApprover_TryApprove_StageOrdering(t *testing.T) {
 
 	t.Run("blocks apiserver while etcd stage has reservation", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("e1", "n1", controlplanev1alpha1.OperationComponentEtcd, false)))
 		require.False(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
 	})
 
 	t.Run("allows apiserver when etcd stage is empty", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
 	})
 
 	t.Run("blocks kcm while apiserver stage has reservation", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
 		require.False(t, a.tryApprove(newOperation("k1", "n1", controlplanev1alpha1.OperationComponentKubeControllerManager, false)))
 	})
 
 	t.Run("allows kcm and scheduler concurrently on same pipeline stage", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("k1", "n1", controlplanev1alpha1.OperationComponentKubeControllerManager, false)))
 		require.True(t, a.tryApprove(newOperation("s1", "n2", controlplanev1alpha1.OperationComponentKubeScheduler, false)))
 	})
@@ -117,7 +117,7 @@ func TestApprover_TryApprove_WorkloadConcurrencyAndPerNode(t *testing.T) {
 	t.Run("allows up to workload concurrency limit on distinct nodes", func(t *testing.T) {
 		t.Parallel()
 		// 3 nodes -> limit 2 for apiserver
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
 		require.True(t, a.tryApprove(newOperation("a2", "n2", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
 		require.False(t, a.tryApprove(newOperation("a3", "n3", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
@@ -125,7 +125,7 @@ func TestApprover_TryApprove_WorkloadConcurrencyAndPerNode(t *testing.T) {
 
 	t.Run("rejects second apiserver on same node", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.True(t, a.tryApprove(newOperation("a1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
 		require.False(t, a.tryApprove(newOperation("a2", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)))
 	})
@@ -136,7 +136,7 @@ func TestApprover_TryApprove_OutOfChainComponents(t *testing.T) {
 
 	t.Run("HotReload is not approvable via default chain", func(t *testing.T) {
 		t.Parallel()
-		a := newApprover(3, nil)
+		a := newApprover(nodeCounts{masters: 3}, nil)
 		require.False(t, a.tryApprove(newOperation("hr1", "n1", controlplanev1alpha1.OperationComponentHotReload, false)))
 	})
 }
@@ -147,7 +147,7 @@ func TestNewApprover_PartitionAndOrder(t *testing.T) {
 	t.Run("unapproved operation is only in approveQueue", func(t *testing.T) {
 		t.Parallel()
 		op := newOperation("x", "n1", controlplanev1alpha1.OperationComponentEtcd, false)
-		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{op})
+		a := newApprover(nodeCounts{masters: 1}, []controlplanev1alpha1.ControlPlaneOperation{op})
 		require.Empty(t, a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd].approvedOperationsPerNode)
 		require.Len(t, a.approveQueue, 1)
 		require.Equal(t, "x", a.approveQueue[0].Name)
@@ -156,7 +156,7 @@ func TestNewApprover_PartitionAndOrder(t *testing.T) {
 	t.Run("approved and incompleted is seed only empty queue", func(t *testing.T) {
 		t.Parallel()
 		op := newOperation("x", "n1", controlplanev1alpha1.OperationComponentEtcd, true)
-		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{op})
+		a := newApprover(nodeCounts{masters: 1}, []controlplanev1alpha1.ControlPlaneOperation{op})
 		require.Empty(t, a.approveQueue)
 		require.Equal(t, 1, a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd].approvedOperationsTotal)
 	})
@@ -170,7 +170,7 @@ func TestNewApprover_PartitionAndOrder(t *testing.T) {
 			Reason:             "Test",
 			LastTransitionTime: metav1.Now(),
 		})
-		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{op})
+		a := newApprover(nodeCounts{masters: 1}, []controlplanev1alpha1.ControlPlaneOperation{op})
 		require.Empty(t, a.approveQueue)
 		require.Zero(t, a.approveChain.components[controlplanev1alpha1.OperationComponentEtcd].approvedOperationsTotal)
 	})
@@ -180,7 +180,7 @@ func TestNewApprover_PartitionAndOrder(t *testing.T) {
 		api := newOperation("aaa-apiserver", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)
 		etcd := newOperation("zzz-etcd", "n2", controlplanev1alpha1.OperationComponentEtcd, false)
 		kcm := newOperation("m-kcm", "n1", controlplanev1alpha1.OperationComponentKubeControllerManager, false)
-		a := newApprover(1, []controlplanev1alpha1.ControlPlaneOperation{api, etcd, kcm})
+		a := newApprover(nodeCounts{masters: 1}, []controlplanev1alpha1.ControlPlaneOperation{api, etcd, kcm})
 		require.Equal(t, []string{"zzz-etcd", "aaa-apiserver", "m-kcm"}, []string{
 			a.approveQueue[0].Name, a.approveQueue[1].Name, a.approveQueue[2].Name,
 		})

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	"golang.org/x/time/rate"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -107,9 +108,9 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		logger.Error("failed to get node count", log.Err(err))
 		return reconcile.Result{}, err
 	}
-	if nodes.equalZero() {
-		logger.Warn("nodes not found, skipping reconcile")
-		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+	if nodes.isZero() {
+		logger.Warn("nodes not found")
+		return reconcile.Result{}, nil
 	}
 
 	operations := &controlplanev1alpha1.ControlPlaneOperationList{}
@@ -140,24 +141,19 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 func (r *reconciler) getNodeCounts(ctx context.Context) (nodeCounts, error) {
-	nodeList := &controlplanev1alpha1.ControlPlaneNodeList{}
-	if err := r.client.List(ctx, nodeList, &client.ListOptions{}); err != nil {
-		return nodeCounts{}, err
-	}
-
-	if len(nodeList.Items) == 0 {
-		logger.Warn("no control plane nodes found")
-		return nodeCounts{}, nil
-	}
-
 	var nodes nodeCounts
-	for _, node := range nodeList.Items {
-		if _, exists := node.Labels[constants.EtcdArbiterNodeLabelKey]; exists {
-			nodes.arbiters++
-		} else {
-			nodes.masters++
-		}
+
+	masterList := &corev1.NodeList{}
+	if err := r.client.List(ctx, masterList, client.MatchingLabels{constants.ControlPlaneNodeLabelKey: ""}); err != nil {
+		return nodeCounts{}, fmt.Errorf("failed to list master nodes: %w", err)
 	}
+	nodes.masters = len(masterList.Items)
+
+	arbiterList := &corev1.NodeList{}
+	if err := r.client.List(ctx, arbiterList, client.MatchingLabels{constants.EtcdArbiterNodeLabelKey: ""}); err != nil {
+		return nodeCounts{}, fmt.Errorf("failed to list arbiter nodes: %w", err)
+	}
+	nodes.arbiters = len(arbiterList.Items)
 
 	return nodes, nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller.go
@@ -19,6 +19,7 @@ package operationsapprover
 import (
 	"context"
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+	"control-plane-manager/internal/constants"
 	"fmt"
 	"time"
 
@@ -101,27 +102,26 @@ func getPredicates() predicate.Predicate {
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger.Info("Reconcile started")
 
-	nodes := &controlplanev1alpha1.ControlPlaneNodeList{}
-	if err := r.client.List(ctx, nodes, &client.ListOptions{}); err != nil {
+	nodes, err := r.getNodeCounts(ctx)
+	if err != nil {
+		logger.Error("failed to get node count", log.Err(err))
 		return reconcile.Result{}, err
 	}
-
-	if len(nodes.Items) == 0 {
-		logger.Warn("no control plane nodes found")
-		return reconcile.Result{}, nil
+	if nodes.equalZero() {
+		logger.Warn("nodes not found, skipping reconcile")
+		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	operations := &controlplanev1alpha1.ControlPlaneOperationList{}
 	if err := r.client.List(ctx, operations); err != nil {
 		return reconcile.Result{}, err
 	}
-
 	if len(operations.Items) == 0 {
 		logger.Warn("no control plane operations found")
 		return reconcile.Result{}, nil
 	}
 
-	approver := newApprover(len(nodes.Items), operations.Items)
+	approver := newApprover(nodes, operations.Items)
 
 	for _, unapprovedOperation := range approver.approveQueue {
 		canApprove := approver.tryApprove(unapprovedOperation)
@@ -137,4 +137,27 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *reconciler) getNodeCounts(ctx context.Context) (nodeCounts, error) {
+	nodeList := &controlplanev1alpha1.ControlPlaneNodeList{}
+	if err := r.client.List(ctx, nodeList, &client.ListOptions{}); err != nil {
+		return nodeCounts{}, err
+	}
+
+	if len(nodeList.Items) == 0 {
+		logger.Warn("no control plane nodes found")
+		return nodeCounts{}, nil
+	}
+
+	var nodes nodeCounts
+	for _, node := range nodeList.Items {
+		if _, exists := node.Labels[constants.EtcdArbiterNodeLabelKey]; exists {
+			nodes.arbiters++
+		} else {
+			nodes.masters++
+		}
+	}
+
+	return nodes, nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
@@ -20,7 +20,10 @@ import (
 	"context"
 	"testing"
 
+	"control-plane-manager/internal/constants"
+
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -35,6 +38,7 @@ var testScheme = runtime.NewScheme()
 
 func init() {
 	utilruntime.Must(controlplanev1alpha1.AddToScheme(testScheme))
+	utilruntime.Must(corev1.AddToScheme(testScheme))
 }
 
 func TestReconciler_Reconcile(t *testing.T) {
@@ -58,6 +62,45 @@ func TestReconciler_Reconcile(t *testing.T) {
 		r := &reconciler{client: cl}
 		_, err := r.Reconcile(ctx, reconcile.Request{})
 		require.NoError(t, err)
+	})
+
+	t.Run("workload components ignore arbiters", func(t *testing.T) {
+		t.Parallel()
+		// 2 masters + 5 arbiters.
+		// For KubeAPIServer, the limit is max(1, masters-1) = max(1, 2-1) = 1.
+		// Arbiters should be ignored for workload components.
+		op1 := newOperation("op-api-1", "n1", controlplanev1alpha1.OperationComponentKubeAPIServer, false)
+		op2 := newOperation("op-api-2", "n2", controlplanev1alpha1.OperationComponentKubeAPIServer, false)
+
+		cl := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithObjects(
+				testControlPlaneNode("n1"),
+				testControlPlaneNode("n2"),
+				testArbiterNode("a1"),
+				testArbiterNode("a2"),
+				testArbiterNode("a3"),
+				testArbiterNode("a4"),
+				testArbiterNode("a5"),
+				&op1,
+				&op2,
+			).
+			WithStatusSubresource(&controlplanev1alpha1.ControlPlaneOperation{}).
+			Build()
+		r := &reconciler{client: cl}
+
+		_, err := r.Reconcile(ctx, reconcile.Request{})
+		require.NoError(t, err)
+
+		var updated1 controlplanev1alpha1.ControlPlaneOperation
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-api-1"}, &updated1))
+		// First one should be approved (limit is 1)
+		require.True(t, updated1.Spec.Approved)
+
+		var updated2 controlplanev1alpha1.ControlPlaneOperation
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-api-2"}, &updated2))
+		// Second one should NOT be approved because limit is 1 (based only on 2 masters), despite 5 arbiters
+		require.False(t, updated2.Spec.Approved)
 	})
 
 	t.Run("patches Spec.Approved when approver allows", func(t *testing.T) {
@@ -128,8 +171,20 @@ func TestReconciler_Reconcile(t *testing.T) {
 	})
 }
 
-func testControlPlaneNode(name string) *controlplanev1alpha1.ControlPlaneNode {
-	return &controlplanev1alpha1.ControlPlaneNode{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+func testControlPlaneNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{constants.ControlPlaneNodeLabelKey: ""},
+		},
+	}
+}
+
+func testArbiterNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{constants.EtcdArbiterNodeLabelKey: ""},
+		},
 	}
 }


### PR DESCRIPTION
## Description

Updates the `operations-approver` controller to distinguish between master and arbiter nodes when calculating concurrency limits for control-plane operations. Introduces a `nodeCounts` struct that tracks both node types separately, allowing component-specific concurrency logic.

- etcd operations now account for the full quorum membership (masters + arbiters)
- workload component operations (API server, scheduler, controller manager) account for master nodes only
- controller reconciliation classifies nodes by `EtcdArbiterNodeLabelKey` label
- simplified map initialization and per-node operation counter logic

## Why do we need it, and what problem does it solve?

Previously, the approver calculated concurrency limits based only on a simple node count, treating all control-plane nodes identically. This ignored the architectural distinction between master nodes (which run all control-plane components) and arbiter nodes (which run etcd only).

Arbiters are essential to etcd quorum but do not run workload components like the API server or scheduler. This means:

- etcd concurrency limits must account for the full quorum (all masters + all arbiters), to avoid degrading the etcd consensus
- workload component concurrency limits should account only for master nodes, since arbiters cannot execute these operations

Without this distinction, concurrency scheduling could be incorrect: etcd limits could be computed without including arbiters in quorum size, or workload operations could wait unnecessarily for node slots that arbiters cannot use.

This fix ensures that approval scheduling respects the actual topology and operational constraints of the cluster, improving reliability of control-plane operation rollout.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: fix
summary: Account for arbiter nodes separately in control-plane operation concurrency limits
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->