### PR TITLE
[registrypackages] Containerd v2 patch update

### DIFF
--- a/modules/007-registrypackages/images/containerd/scripts/install_v1
+++ b/modules/007-registrypackages/images/containerd/scripts/install_v1
@@ -32,6 +32,7 @@ version = 2
 EOF
 
 cp -f containerd containerd-shim-runc-v1 containerd-shim-runc-v2 ctr runc /opt/deckhouse/bin
+rm -f /opt/deckhouse/bin/containerd-shim
 
 mkdir -p /lib/systemd/system/
 cp -f containerd.service /lib/systemd/system/containerd-deckhouse.service

--- a/modules/007-registrypackages/images/containerd/scripts/install_v2
+++ b/modules/007-registrypackages/images/containerd/scripts/install_v2
@@ -32,6 +32,7 @@ version = 3
 EOF
 
 cp -f containerd containerd-shim-runc-v2 ctr runc /opt/deckhouse/bin
+rm -f /opt/deckhouse/bin/containerd-shim-runc-v1
 
 if test -f pidumount; then
     cp -f pidumount /opt/deckhouse/bin

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $containerd_versions := list "1.7.30" "2.1.6" }}
 {{- $runc_versions := list "1.3.4" }}
 {{- $containerd2runc := dict "1.7.30" "1.3.4" "2.1.6" "1.3.4" }}
-{{- $containerd_integrity_patches_version := .IntegrityPatchesVersion | default "3" }} # may be redefine in CSE
+{{- $containerd_integrity_patches_version := .IntegrityPatchesVersion | default "4" }} # may be redefine in CSE
 
 # calculate additional build options for containerd
 # skip for v1 and not CSE. Now we calculate namespaces for integrity check


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Updated integrity patch for containerdv2:
- root hash lookup now checks **all matching configs** for a snapshot (instead of only the first match);
- added focused debug logs for snapshot/config/manifest resolution and skip reasons.

Deleted not using binaries `containerd-shim` (for containerdv1) and `containerd-shim-runc-v1` (for containerdv2)
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Some unsigned images can share the same snapshot chain with signed images.  
Previously we could pick the wrong config/manifest pair (first match), then fail with:
`failed to create containerd container: find layer root hash: no root hash found`.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not needed
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: chore
summary: Containerd v2 patch update
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
