### PR TITLE
[control-plane-manager] Add maintenance mode to ControlPlaneNode controller

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/src/docs/controller-control-plane-node.md
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/docs/controller-control-plane-node.md
@@ -18,6 +18,15 @@ This controller is node-local (`NODE_NAME` env) and processes only objects with 
 | `ControlPlaneNode` | generation changed | self |
 | owned `ControlPlaneOperation` | status changed | owner `ControlPlaneNode` |
 
+## Maintenance Mode
+
+When a `ControlPlaneNode` has the `maintenance` label, the controller:
+- still updates `CPN.status` from current operations (preserving operation results and component state)
+- skips creation of new operations for drift or cert-renewal
+- allows manual node maintenance while preserving visibility into operation progress
+
+This mode is useful for manual node maintenance or administrative operations without automatic operation creation interference.
+
 ## Reconciliation Stages
 
 1. Load `CPN` and all CPOs for this node.
@@ -32,12 +41,13 @@ This controller is node-local (`NODE_NAME` env) and processes only objects with 
 - apply cert dates from completed operations that include `CertObserve` command, in monotonic `observedAt` order
 - update per-component `status.components.<component>.lastObservedAt` (and keep root `status.lastObservedAt` as latest observed timestamp)
 - update component conditions, `CASynced`, `CertsRenewal`
-4. Create missing drift CPOs for components where `spec != status`.
-5. Ensure cert-renewal CPO exists for components expiring within threshold (30 days):
+4. Check for maintenance mode (label `maintenance`); if present, exit reconciliation (operations remain unchanged).
+5. Create missing drift CPOs for components where `spec != status`.
+6. Ensure cert-renewal CPO exists for components expiring within threshold (30 days):
 - only when component is in-sync (`spec/config,pki,ca == status/config,pki,ca`)
 - only when there is no active CPO for this component
 - renewal CPO is created with the same `DesiredConfig/PKI/CA` checksums tuple as current component state
-6. Ensure periodic observe-only CPO exists per deployed static-pod component (interval: 7 days):
+7. Ensure periodic observe-only CPO exists per deployed static-pod component (interval: 7 days):
 - `spec.component=<real component>`
 - `spec.commands=[CertObserve]`
 - `spec.approved=true`

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
@@ -32,6 +32,7 @@ const (
 	EtcdArbiterNodeLabelKey             = "node.deckhouse.io/etcd-arbiter"
 	ControlPlaneNodeNameLabelKey        = "control-plane.deckhouse.io/node"
 	ControlPlaneComponentLabelKey       = "control-plane.deckhouse.io/component"
+	MaintenanceModeLabelKey             = "control-plane-manager.deckhouse.io/maintenance"
 	ConfigChecksumAnnotationKey         = "control-plane-manager.deckhouse.io/config-checksum"
 	PKIChecksumAnnotationKey            = "control-plane-manager.deckhouse.io/pki-checksum"
 	CAChecksumAnnotationKey             = "control-plane-manager.deckhouse.io/ca-checksum"

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
@@ -1085,6 +1085,6 @@ func findExpiringCertsMessage(cpn *controlplanev1alpha1.ControlPlaneNode) string
 }
 
 func isMaintenanceMode(cpn *controlplanev1alpha1.ControlPlaneNode) bool {
-	_, exists := cpn.Labels["maintenance"]
+	_, exists := cpn.Labels[constants.MaintenanceModeLabelKey]
 	return exists
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
@@ -160,6 +160,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
+	if isMaintenanceMode(cpn) {
+		return reconcile.Result{}, nil
+	}
+
 	currentOps, err = r.ensureOperationsExist(ctx, cpn, states, currentOps, logger)
 	if err != nil {
 		return reconcile.Result{}, err
@@ -1078,4 +1082,9 @@ func findExpiringCertsMessage(cpn *controlplanev1alpha1.ControlPlaneNode) string
 		}
 	}
 	return ""
+}
+
+func isMaintenanceMode(cpn *controlplanev1alpha1.ControlPlaneNode) bool {
+	_, exists := cpn.Labels["maintenance"]
+	return exists
 }


### PR DESCRIPTION
## Description

Adds support for maintenance mode in the `control-plane-node` controller. When a `ControlPlaneNode` has the `maintenance` label, the controller:
- skips creation of new `ControlPlaneOperation` resources
- preserves existing operation status without reconciling drift
- allows manual node maintenance without automatic operation interference

## Why do we need it, and what problem does it solve?

The `control-plane-node` controller continuously reconciles drift by creating new operations for components with changed configurations or expiring certificates. During administrative operations like node maintenance, data migrations, or manual troubleshooting, this automatic reconciliation can interfere with planned maintenance workflows.

The maintenance mode label provides a simple, non-disruptive way to pause operation creation during maintenance windows while preserving operation history and component status in the node state.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Add maintenance mode label support to ControlPlaneNode for pause operation creation during maintenance
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
