### PR TITLE
[istio] Relax metadataEndpoint pattern

### DIFF
--- a/ee/modules/110-istio/crds/istiofederation.yaml
+++ b/ee/modules/110-istio/crds/istiofederation.yaml
@@ -58,7 +58,7 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^https://.+$'
+                  pattern: '^https://[0-9a-zA-Z._/:-]+$'
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object

--- a/ee/modules/110-istio/crds/istiofederation.yaml
+++ b/ee/modules/110-istio/crds/istiofederation.yaml
@@ -58,7 +58,7 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^https://[0-9a-zA-Z._/-]+$'
+                  pattern: '^https://.+$'
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object

--- a/ee/modules/110-istio/crds/istiomulticluster.yaml
+++ b/ee/modules/110-istio/crds/istiomulticluster.yaml
@@ -56,7 +56,7 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^https://.+$'
+                  pattern: '^https://[0-9a-zA-Z._/:-]+$'
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object

--- a/ee/modules/110-istio/crds/istiomulticluster.yaml
+++ b/ee/modules/110-istio/crds/istiomulticluster.yaml
@@ -56,7 +56,7 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^https://[0-9a-zA-Z._/-]+$'
+                  pattern: '^https://.+$'
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object


### PR DESCRIPTION
## Description

Relaxes the validation pattern for `metadataEndpoint` in IstioFederation and IstioMulticluster CRDs to allow custom ports in HTTPS URLs.

## Why do we need it, and what problem does it solve?

Right now you cannot add a custom port to the metadata endpoint URL. The previous pattern `^https://[0-9a-zA-Z._/-]+$` did not allow colons, which prevented users from specifying non-standard ports like `https://istio.example.com:8443/metadata/`.

## Why do we need it in patch release.

There is a customer with 1.73 CSE who use non-standard port for metadataEndpoint.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Allow custom ports in metadataEndpoint URLs for IstioFederation and IstioMulticluster CRDs.
impact_level: default
```