### PR TITLE
[docs] Respect nowrap default for code blocks

### DIFF
--- a/docs/site/assets/js/codeblock.js
+++ b/docs/site/assets/js/codeblock.js
@@ -158,7 +158,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
     ensureLineNumbers(code);
 
-    code.classList.add('wrap');
+    const isNowrapDefault = pre.closest('.nowrap-default') !== null;
+    if (!isNowrapDefault) {
+      code.classList.add('wrap');
+    }
 
     let button = pre.querySelector(':scope > .wrap__button');
     let wrapIcon;


### PR DESCRIPTION
## Description
Respect nowrap default for code blocks
- Introduce ancestor context check to conditionally skip automatic line wrapping when the code block resides within a designated no-wrap container
- Preserve existing wrap behaviour for all other code blocks while allowing specific sections to opt out via a parent marker class

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: feature
summary: Respect nowrap default for code blocks.
impact_level: low
```
