### PR TITLE
[dhctl] refactor: add root context to dhctl commands, some kingpin usage improvements, log-process with context

### DIFF
--- a/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/bootstrap.go
@@ -15,13 +15,13 @@
 package bootstrap
 
 import (
-	"context"
 	"fmt"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
@@ -40,8 +40,11 @@ func DefineBootstrapCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefinePostBootstrapScriptFlags(cmd)
 	app.DefinePreflight(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
+
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
 			TmpDir:            app.TmpDirName,
 			Logger:            logger,
@@ -49,8 +52,8 @@ func DefineBootstrapCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			ResetInitialState: false,
 			DirectoryConfig:   app.GetDirConfig(),
 		})
-		err := bootstraper.Bootstrap(context.Background())
-		if err != nil {
+
+		if err := bootstraper.Bootstrap(ctx); err != nil {
 			msg := fmt.Sprintf("Bootstrap failed with error: %v", err)
 			cache.GetGlobalTmpCleaner().DisableCleanup(msg)
 			return err
@@ -58,6 +61,4 @@ func DefineBootstrapCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		return nil
 	})
-
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/bootstrap/phase.go
+++ b/dhctl/cmd/dhctl/commands/bootstrap/phase.go
@@ -15,13 +15,13 @@
 package bootstrap
 
 import (
-	"context"
 	"fmt"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node"
@@ -39,12 +39,14 @@ func DefineBootstrapInstallDeckhouseCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 	app.DefineDeckhouseFlags(cmd)
 	app.DefineDeckhouseInstallFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
 
 		var sshClient node.SSHClient
 		var err error
+
 		if len(app.SSHHosts) != 0 {
 			sshClient, err = sshclient.NewClientFromFlags(ctx)
 			if err != nil {
@@ -59,10 +61,9 @@ func DefineBootstrapInstallDeckhouseCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 			IsDebug:         app.IsDebug,
 			DirectoryConfig: app.GetDirConfig(),
 		})
+
 		return bootstraper.InstallDeckhouse(ctx)
 	})
-
-	return cmd
 }
 
 func DefineBootstrapExecuteBashibleCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -71,9 +72,10 @@ func DefineBootstrapExecuteBashibleCommand(cmd *kingpin.CmdClause) *kingpin.CmdC
 	app.DefineBecomeFlags(cmd)
 	app.DefineBashibleBundleFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
 
 		sshClient, err := sshclient.NewClientFromFlagsWithHosts(ctx)
 		if err != nil {
@@ -87,10 +89,9 @@ func DefineBootstrapExecuteBashibleCommand(cmd *kingpin.CmdClause) *kingpin.CmdC
 			IsDebug:         app.IsDebug,
 			DirectoryConfig: app.GetDirConfig(),
 		})
+
 		return bootstraper.ExecuteBashible(ctx)
 	})
-
-	return cmd
 }
 
 func DefineCreateResourcesCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -100,9 +101,10 @@ func DefineCreateResourcesCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineResourcesFlags(cmd, false)
 	app.DefineKubeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
 
 		var sshClient node.SSHClient
 		var err error
@@ -121,10 +123,9 @@ func DefineCreateResourcesCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			IsDebug:         app.IsDebug,
 			DirectoryConfig: app.GetDirConfig(),
 		})
+
 		return bootstraper.CreateResources(ctx)
 	})
-
-	return cmd
 }
 
 func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -135,9 +136,9 @@ func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSanityFlags(cmd)
 	app.DefineAbortFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
 
 		sshClient, err := sshclient.NewClientFromFlags(ctx)
 		if err != nil {
@@ -152,8 +153,7 @@ func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			DirectoryConfig: app.GetDirConfig(),
 		})
 
-		err = bootstraper.Abort(context.Background(), app.ForceAbortFromCache)
-		if err != nil {
+		if err = bootstraper.Abort(ctx, app.ForceAbortFromCache); err != nil {
 			msg := fmt.Sprintf("Failed to abort cluster: %v", err)
 			cache.GetGlobalTmpCleaner().DisableCleanup(msg)
 			return err
@@ -161,8 +161,6 @@ func DefineBootstrapAbortCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		return nil
 	})
-
-	return cmd
 }
 
 func DefineBaseInfrastructureCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -170,7 +168,8 @@ func DefineBaseInfrastructureCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineCacheFlags(cmd)
 	app.DefineDropCacheFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
 		logger := log.GetDefaultLogger()
 
 		bootstraper := bootstrap.NewClusterBootstrapper(&bootstrap.Params{
@@ -180,12 +179,10 @@ func DefineBaseInfrastructureCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			DirectoryConfig: app.GetDirConfig(),
 		})
 
-		err := bootstraper.BaseInfrastructure(context.Background())
+		err := bootstraper.BaseInfrastructure(ctx)
 		cache.GetGlobalTmpCleaner().DisableCleanup("Create base infra for cluster")
 		return err
 	})
-
-	return cmd
 }
 
 func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -193,9 +190,10 @@ func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineBecomeFlags(cmd)
 	app.DefinePostBootstrapScriptFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
 
 		sshClient, err := sshclient.NewClientFromFlagsWithHosts(ctx)
 		if err != nil {
@@ -209,8 +207,7 @@ func DefineExecPostBootstrapScript(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			IsDebug:         app.IsDebug,
 			DirectoryConfig: app.GetDirConfig(),
 		})
+
 		return bootstraper.ExecPostBootstrap(ctx)
 	})
-
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/config.go
+++ b/dhctl/cmd/dhctl/commands/config.go
@@ -101,7 +101,7 @@ func DefineRenderMasterBootstrap(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		templateController := template.NewTemplateController(app.RenderBashibleBundleDir)
 		log.InfoF("Bundle Dir: %q\n\n", templateController.TmpDir)
-		return template.PrepareBootstrap(templateController, "127.0.0.1", metaConfig, app.GetDirConfig())
+		return template.PrepareBootstrap(ctx, templateController, "127.0.0.1", metaConfig, app.GetDirConfig())
 	}
 
 	return cmd.Action(func(c *kingpin.ParseContext) error {

--- a/dhctl/cmd/dhctl/commands/config.go
+++ b/dhctl/cmd/dhctl/commands/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 )
@@ -39,11 +40,11 @@ func DefineRenderBashibleBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 
-	runFunc := func() error {
+	runFunc := func(ctx context.Context) error {
 		logger := log.GetDefaultLogger()
 
 		metaConfig, err := config.LoadConfigFromFile(
-			context.TODO(),
+			ctx,
 			app.ConfigPaths,
 			infrastructureprovider.MetaConfigPreparatorProvider(
 				infrastructureprovider.NewPreparatorProviderParams(logger),
@@ -63,6 +64,7 @@ func DefineRenderBashibleBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		log.InfoF("Bundle Dir: %q\n\n", templateController.TmpDir)
 
 		return template.PrepareBashibleBundle(
+			ctx,
 			templateController,
 			templateData,
 			metaConfig.ProviderName,
@@ -71,22 +73,22 @@ func DefineRenderBashibleBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		)
 	}
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		return log.Process("bootstrap", "Prepare Bashible Bundle", runFunc)
-	})
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
 
-	return cmd
+		return log.ProcessCtx(ctx, "bootstrap", "Prepare Bashible Bundle", runFunc)
+	})
 }
 
 func DefineRenderMasterBootstrap(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 
-	runFunc := func() error {
+	runFunc := func(ctx context.Context) error {
 		logger := log.GetDefaultLogger()
 
 		metaConfig, err := config.LoadConfigFromFile(
-			context.TODO(),
+			ctx,
 			app.ConfigPaths,
 			infrastructureprovider.MetaConfigPreparatorProvider(
 				infrastructureprovider.NewPreparatorProviderParams(logger),
@@ -102,18 +104,18 @@ func DefineRenderMasterBootstrap(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		return template.PrepareBootstrap(templateController, "127.0.0.1", metaConfig, app.GetDirConfig())
 	}
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		return log.Process("bootstrap", "Prepare Bashible Bundle", runFunc)
-	})
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
 
-	return cmd
+		return log.ProcessCtx(ctx, "bootstrap", "Prepare Bashible Bundle", runFunc)
+	})
 }
 
 func DefineRenderKubeadmConfig(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineConfigFlags(cmd)
 	app.DefineRenderConfigFlags(cmd)
 
-	runFunc := func() error {
+	runFunc := func(ctx context.Context) error {
 		templateData := make(map[string]interface{})
 		var err error
 		templateData["clusterConfiguration"], err = config.ParseBashibleConfig(app.ConfigPaths, kubeadmTemplateOpenAPI)
@@ -124,20 +126,22 @@ func DefineRenderKubeadmConfig(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		templateController := template.NewTemplateController(app.RenderBashibleBundleDir)
 		log.InfoF("Bundle Dir: %q\n\n", templateController.TmpDir)
 
-		return template.PrepareKubeadmConfig(templateController, templateData, app.GetDirConfig())
+		return template.PrepareKubeadmConfig(ctx, templateController, templateData, app.GetDirConfig())
 	}
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		return log.Process("bootstrap", "Prepare Kubeadm Config", runFunc)
-	})
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
 
-	return cmd
+		return log.ProcessCtx(ctx, "bootstrap", "Prepare Kubeadm Config", runFunc)
+	})
 }
 
 func DefineCommandParseClusterConfiguration(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineInputOutputRenderFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		var err error
 		var metaConfig *config.MetaConfig
 
@@ -157,7 +161,7 @@ func DefineCommandParseClusterConfiguration(cmd *kingpin.CmdClause) *kingpin.Cmd
 			}
 
 			metaConfig, err = config.ParseConfigFromData(
-				context.TODO(),
+				ctx,
 				string(data),
 				preparatorProvider,
 				app.GetDirConfig(),
@@ -167,7 +171,7 @@ func DefineCommandParseClusterConfiguration(cmd *kingpin.CmdClause) *kingpin.Cmd
 				return err
 			}
 		} else {
-			metaConfig, err = config.ParseConfig(context.TODO(), []string{app.ParseInputFile}, preparatorProvider, app.GetDirConfig())
+			metaConfig, err = config.ParseConfig(ctx, []string{app.ParseInputFile}, preparatorProvider, app.GetDirConfig())
 			if err != nil {
 				return err
 			}
@@ -185,14 +189,14 @@ func DefineCommandParseClusterConfiguration(cmd *kingpin.CmdClause) *kingpin.Cmd
 		fmt.Print(string(output))
 		return nil
 	})
-
-	return cmd
 }
 
 func DefineCommandParseCloudDiscoveryData(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineInputOutputRenderFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		_ = kpcontext.ExtractContext(c)
+
 		var err error
 		var data []byte
 
@@ -227,8 +231,6 @@ func DefineCommandParseCloudDiscoveryData(cmd *kingpin.CmdClause) *kingpin.CmdCl
 		fmt.Print(string(output))
 		return nil
 	})
-
-	return cmd
 }
 
 func InitGlobalVars(pwd string) {

--- a/dhctl/cmd/dhctl/commands/control-plane.go
+++ b/dhctl/cmd/dhctl/commands/control-plane.go
@@ -15,13 +15,13 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -38,8 +38,9 @@ func DefineTestControlPlaneManagerReadyCommand(cmd *kingpin.CmdClause) *kingpin.
 	app.DefineKubeFlags(cmd)
 	app.DefineControlPlaneFlags(cmd, false)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -53,12 +54,9 @@ func DefineTestControlPlaneManagerReadyCommand(cmd *kingpin.CmdClause) *kingpin.
 		}
 
 		kubeCl := client.NewKubernetesClient().
-			WithNodeInterface(
-				ssh.NewNodeInterfaceWrapper(sshClient),
-			)
-		// auto init
-		err = kubeCl.Init(client.AppKubernetesInitParams())
-		if err != nil {
+			WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
+
+		if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 			return fmt.Errorf("open kubernetes connection: %v", err)
 		}
 
@@ -76,7 +74,6 @@ func DefineTestControlPlaneManagerReadyCommand(cmd *kingpin.CmdClause) *kingpin.
 
 		return nil
 	})
-	return cmd
 }
 
 func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -85,8 +82,9 @@ func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 	app.DefineKubeFlags(cmd)
 	app.DefineControlPlaneFlags(cmd, true)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -100,12 +98,9 @@ func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 		}
 
 		kubeCl := client.NewKubernetesClient().
-			WithNodeInterface(
-				ssh.NewNodeInterfaceWrapper(sshClient),
-			)
-		// auto init
-		err = kubeCl.Init(client.AppKubernetesInitParams())
-		if err != nil {
+			WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
+
+		if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 			return fmt.Errorf("open kubernetes connection: %v", err)
 		}
 
@@ -129,5 +124,4 @@ func DefineTestControlPlaneNodeReadyCommand(cmd *kingpin.CmdClause) *kingpin.Cmd
 
 		return nil
 	})
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -15,17 +15,17 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/name212/govalue"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
@@ -38,8 +38,9 @@ func DefineConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -93,7 +94,6 @@ func DefineConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		return nil
 	})
-	return cmd
 }
 
 func DefineAutoConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -102,7 +102,9 @@ func DefineAutoConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		tmpDir := app.TmpDirName
 		logger := log.GetDefaultLogger()
 		isDebug := app.IsDebug
@@ -131,9 +133,9 @@ func DefineAutoConvergeCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			IsDebug:         isDebug,
 			DirectoryConfig: app.GetDirConfig(),
 		})
-		return converger.AutoConverge(app.AutoConvergeListenAddress, app.ApplyInterval)
+
+		return converger.AutoConverge(ctx, app.AutoConvergeListenAddress, app.ApplyInterval)
 	})
-	return cmd
 }
 
 func DefineConvergeMigrationCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -142,8 +144,9 @@ func DefineConvergeMigrationCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineKubeFlags(cmd)
 	app.DefineCheckHasTerraformStateBeforeMigrateToTofu(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -190,8 +193,8 @@ func DefineConvergeMigrationCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			IsDebug:                               isDebug,
 			DirectoryConfig:                       app.GetDirConfig(),
 		})
-		err = converger.ConvergeMigration(ctx)
-		if err != nil {
+
+		if err := converger.ConvergeMigration(ctx); err != nil {
 			msg := fmt.Sprintf("ConvergeMigration failed with error: %v", err)
 			cache.GetGlobalTmpCleaner().DisableCleanup(msg)
 			return err
@@ -199,5 +202,4 @@ func DefineConvergeMigrationCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		return nil
 	})
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -15,7 +15,6 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -24,6 +23,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -37,8 +37,9 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -51,31 +52,19 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return err
 		}
 
-		err = log.Process("default", "Remove Deckhouse️", func() error {
+		return log.Process("default", "Remove Deckhouse️", func() error {
 			kubeCl := client.NewKubernetesClient().
 				WithNodeInterface(
 					ssh.NewNodeInterfaceWrapper(sshClient),
 				)
-			// auto init
-			err = kubeCl.Init(client.AppKubernetesInitParams())
-			if err != nil {
+
+			if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 				return fmt.Errorf("open kubernetes connection: %v", err)
 			}
 
-			err = deckhouse.DeleteDeckhouseDeployment(ctx, kubeCl)
-			if err != nil {
-				return err
-			}
-			return nil
+			return deckhouse.DeleteDeckhouseDeployment(ctx, kubeCl)
 		})
-		if err != nil {
-			return err
-		}
-
-		return nil
 	})
-
-	return cmd
 }
 
 func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -84,17 +73,15 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 	app.DefineConfigFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
-	var DryRun bool
-	cmd.Flag("dry-run", "Output deployment yaml").
-		BoolVar(&DryRun)
+	var dryRun bool
+	cmd.Flag("dry-run", "Output deployment yaml").BoolVar(&dryRun)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
-
-		// Load deckhouse config
 		metaConfig, err := config.ParseConfig(
-			context.TODO(),
+			ctx,
 			app.ConfigPaths,
 			infrastructureprovider.MetaConfigPreparatorProvider(
 				infrastructureprovider.NewPreparatorProviderParams(logger),
@@ -122,7 +109,7 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return err
 		}
 
-		if DryRun {
+		if dryRun {
 			manifest := deckhouse.CreateDeckhouseDeploymentManifest(installConfig)
 			out, err := yaml.Marshal(manifest)
 			if err != nil {
@@ -133,30 +120,25 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return nil
 		}
 
-		err = log.Process("bootstrap", "Create Deckhouse Deployment", func() error {
+		return log.Process("bootstrap", "Create Deckhouse Deployment", func() error {
 			kubeCl := client.NewKubernetesClient().
 				WithNodeInterface(
 					ssh.NewNodeInterfaceWrapper(sshClient),
 				)
+
 			if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 				return fmt.Errorf("open kubernetes connection: %v", err)
 			}
 
-			err = deckhouse.CreateDeckhouseDeployment(ctx, kubeCl, installConfig)
-			if err != nil {
+			if err := deckhouse.CreateDeckhouseDeployment(ctx, kubeCl, installConfig); err != nil {
 				return fmt.Errorf("deckhouse install: %v", err)
 			}
 
-			err = deckhouse.WaitForReadiness(ctx, kubeCl)
-			if err != nil {
+			if err := deckhouse.WaitForReadiness(ctx, kubeCl); err != nil {
 				return fmt.Errorf("deckhouse install: %v", err)
 			}
+
 			return nil
 		})
-		if err != nil {
-			return err
-		}
-		return nil
 	})
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -52,11 +53,9 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return err
 		}
 
-		return log.Process("default", "Remove Deckhouse️", func() error {
+		return log.ProcessCtx(ctx, "default", "Remove Deckhouse️", func(ctx context.Context) error {
 			kubeCl := client.NewKubernetesClient().
-				WithNodeInterface(
-					ssh.NewNodeInterfaceWrapper(sshClient),
-				)
+				WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
 
 			if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 				return fmt.Errorf("open kubernetes connection: %v", err)
@@ -120,7 +119,7 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause) *kingpin.CmdClause 
 			return nil
 		}
 
-		return log.Process("bootstrap", "Create Deckhouse Deployment", func() error {
+		return log.ProcessCtx(ctx, "bootstrap", "Create Deckhouse Deployment", func(ctx context.Context) error {
 			kubeCl := client.NewKubernetesClient().
 				WithNodeInterface(
 					ssh.NewNodeInterfaceWrapper(sshClient),

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -75,7 +75,7 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		if err = cache.Init(sshClient.Check().String()); err != nil {
+		if err = cache.Init(ctx, sshClient.Check().String()); err != nil {
 			return fmt.Errorf(destroyCacheErrorMessage, err)
 		}
 

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -15,13 +15,13 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/destroy"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
@@ -52,9 +52,9 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineDestroyResourcesFlags(cmd)
 	app.DefineTFResourceManagementTimeout(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
 
 		if !app.SanityCheck {
 			logger.LogWarnLn(destroyApprovalsMessage)
@@ -79,7 +79,7 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return fmt.Errorf(destroyCacheErrorMessage, err)
 		}
 
-		destroyer, err := destroy.NewClusterDestroyer(context.TODO(), &destroy.Params{
+		destroyer, err := destroy.NewClusterDestroyer(ctx, &destroy.Params{
 			NodeInterface:   ssh.NewNodeInterfaceWrapper(sshClient),
 			StateCache:      cache.Global(),
 			SkipResources:   app.SkipResources,
@@ -101,6 +101,4 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		return nil
 	})
-
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -60,9 +60,14 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 			return err
 		}
 
-		return operations.SecretEdit(kubeCl, name, "kube-system", secret, dataKey, map[string]string{
-			"name": name,
-		}, app.GetDirConfig())
+		return operations.SecretEdit(
+			ctx,
+			kubeCl,
+			name, "kube-system", secret, dataKey, map[string]string{
+				"name": name,
+			},
+			app.GetDirConfig(),
+		)
 	})
 }
 

--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -15,13 +15,13 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
@@ -40,8 +40,9 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 	app.DefineEditorConfigFlags(cmd)
 	app.DefineSanityFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -63,8 +64,6 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 			"name": name,
 		}, app.GetDirConfig())
 	})
-
-	return cmd
 }
 
 func DefineEditCommands(parent *kingpin.CmdClause, wConnFlags bool) {

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -15,7 +15,6 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/deckhouse"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -39,7 +39,9 @@ func DefineTestKubernetesAPIConnectionCommand(cmd *kingpin.CmdClause) *kingpin.C
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		doneCh := make(chan struct{})
 		tomb.RegisterOnShutdown("wait kubernetes-api-connection to stop", func() {
 			<-doneCh
@@ -57,7 +59,7 @@ func DefineTestKubernetesAPIConnectionCommand(cmd *kingpin.CmdClause) *kingpin.C
 		}
 
 		// ip is empty because we want check via ssh-hosts passed via cm args
-		ready, err := checker.IsReady(context.Background(), "")
+		ready, err := checker.IsReady(ctx, "")
 		if err != nil {
 			proxyClose()
 			return err
@@ -73,7 +75,6 @@ func DefineTestKubernetesAPIConnectionCommand(cmd *kingpin.CmdClause) *kingpin.C
 
 		return nil
 	})
-	return cmd
 }
 
 func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -89,8 +90,9 @@ func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 	cmd.Flag("name", "Deployment name").
 		StringVar(&Name)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -103,30 +105,17 @@ func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			return err
 		}
 
-		err = log.Process("bootstrap", "Wait for Deckhouse to become Ready", func() error {
+		return log.Process("bootstrap", "Wait for Deckhouse to become Ready", func() error {
 			kubeCl := client.NewKubernetesClient().
-				WithNodeInterface(
-					ssh.NewNodeInterfaceWrapper(sshClient),
-				)
-			// auto init
-			err = kubeCl.Init(client.AppKubernetesInitParams())
-			if err != nil {
+				WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
+
+			if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 				return fmt.Errorf("open kubernetes connection: %v", err)
 			}
 
-			err = deckhouse.WaitForReadiness(ctx, kubeCl)
-			if err != nil {
-				return err
-			}
-			return nil
+			return deckhouse.WaitForReadiness(ctx, kubeCl)
 		})
-		if err != nil {
-			return err
-		}
-
-		return nil
 	})
-	return cmd
 }
 
 func TestCommandDelay() {

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -105,7 +106,7 @@ func DefineWaitDeploymentReadyCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			return err
 		}
 
-		return log.Process("bootstrap", "Wait for Deckhouse to become Ready", func() error {
+		return log.ProcessCtx(ctx, "bootstrap", "Wait for Deckhouse to become Ready", func(ctx context.Context) error {
 			kubeCl := client.NewKubernetesClient().
 				WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
 

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -15,14 +15,14 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 	v1 "k8s.io/api/coordination/v1"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/lease"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/converge/lock"
@@ -46,8 +46,9 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 	app.DefineBecomeFlags(cmd)
 	app.DefineKubeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -61,9 +62,7 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 		}
 
 		kubeCl := client.NewKubernetesClient().
-			WithNodeInterface(
-				ssh.NewNodeInterfaceWrapper(sshClient),
-			)
+			WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
 		if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 			return err
 		}
@@ -80,6 +79,7 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			}
 
 			c := input.NewConfirmation()
+
 			approve := c.WithMessage(fmt.Sprintf("Do you want to release lock:\n\n%s", info)).Ask()
 			if !approve {
 				return fmt.Errorf("Don't confirm release lock")
@@ -91,5 +91,4 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 		cnf := lock.GetLockLeaseConfig("lock-releaser")
 		return lease.RemoveLease(ctx, kubeCl, cnf, confirm)
 	})
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/server.go
+++ b/dhctl/cmd/dhctl/commands/server.go
@@ -18,43 +18,50 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/settings"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/server/server/singlethreaded"
 )
 
 func DefineServerCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
-	// cmd = parent.Command(cmd.Model().Name, cmd.Model().Help)
 	app.DefineServerFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		return server.Serve(settings.ServerParams{
-			ServerGeneralParams: settings.ServerGeneralParams{
-				Network:           app.ServerNetwork,
-				Address:           app.ServerAddress,
-				TmpDir:            app.TmpDirName,
-				DownloadDirConfig: app.GetDirConfig(),
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
+		return server.Serve(
+			ctx,
+			settings.ServerParams{
+				ServerGeneralParams: settings.ServerGeneralParams{
+					Network:           app.ServerNetwork,
+					Address:           app.ServerAddress,
+					TmpDir:            app.TmpDirName,
+					DownloadDirConfig: app.GetDirConfig(),
+				},
+				ParallelTasksLimit:         app.ServerParallelTasksLimit,
+				RequestsCounterMaxDuration: app.ServerRequestsCounterMaxDuration,
 			},
-			ParallelTasksLimit:         app.ServerParallelTasksLimit,
-			RequestsCounterMaxDuration: app.ServerRequestsCounterMaxDuration,
-		})
+		)
 	})
-	return cmd
 }
 
 func DefineSingleThreadedServerCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
-	// cmd = parent.Command(cmd.Model().Name, cmd.Model().Help)
 	app.DefineServerFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		return singlethreaded.Serve(settings.ServerSingleshotParams{
-			ServerGeneralParams: settings.ServerGeneralParams{
-				Network:           app.ServerNetwork,
-				Address:           app.ServerAddress,
-				TmpDir:            app.TmpDirName,
-				DownloadDirConfig: app.GetDirConfig(),
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
+		return singlethreaded.Serve(
+			ctx,
+			settings.ServerSingleshotParams{
+				ServerGeneralParams: settings.ServerGeneralParams{
+					Network:           app.ServerNetwork,
+					Address:           app.ServerAddress,
+					TmpDir:            app.TmpDirName,
+					DownloadDirConfig: app.GetDirConfig(),
+				},
 			},
-		})
+		)
 	})
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/session.go
+++ b/dhctl/cmd/dhctl/commands/session.go
@@ -15,7 +15,6 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -29,6 +28,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
@@ -45,8 +45,9 @@ func DefineSessionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.NewConnectionConfigParser())
 	app.DefineBecomeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -68,21 +69,22 @@ func DefineSessionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		if err != nil {
 			return fmt.Errorf("open kubernetes connection: %v", err)
 		}
-		apiServerURL := fmt.Sprintf("http://localhost:%s", apiServerPort)
 
-		err = localKubeConfig(apiServerURL)
-		if err != nil {
+		apiServerURL := fmt.Sprintf("http://localhost:%s", apiServerPort)
+		if err := localKubeConfig(apiServerURL); err != nil {
 			return fmt.Errorf("error save kubeconfig: %v", err)
 		}
+
 		sigChan := make(chan os.Signal, 1)
 		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
 		sig := <-sigChan
+
+		// todo(log): why do not use logger?
 		fmt.Println("Received signal:", sig)
 		fmt.Println("Exiting SSH tunnel...")
 
 		return nil
 	})
-	return cmd
 }
 
 func localKubeConfig(apiServerURL string) error {
@@ -108,10 +110,12 @@ func localKubeConfig(apiServerURL string) error {
 	}
 	kubeConfig.CurrentContext = contextName
 
-	err = clientcmd.WriteToFile(*kubeConfig, kubeconfigPath)
-	if err != nil {
+	if err := clientcmd.WriteToFile(*kubeConfig, kubeconfigPath); err != nil {
 		return fmt.Errorf("failed to write kubeconfig: %w", err)
 	}
+
+	// todo(log): why do not use logger?
 	fmt.Printf("Kubeconfig successfully saved at: %s\n", kubeconfigPath)
+
 	return nil
 }

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -174,7 +174,8 @@ func DefineTestUploadExecCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		var stdout []byte
 		stdout, err = cmd.Execute(ctx)
 		if err != nil {
-			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
 				return fmt.Errorf("script '%s' error: %w stderr: %s", ScriptPath, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("script '%s' error: %w", ScriptPath, err)
@@ -224,7 +225,8 @@ func DefineTestBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		stdout, err := cmd.ExecuteBundle(ctx, parentDir, bundleDir)
 		if err != nil {
-			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
+			var ee *exec.ExitError
+			if errors.As(err, &ee) {
 				return fmt.Errorf("bundle '%s' error: %w\nstderr: %s\n", bundleDir, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("bundle '%s' error: %w", bundleDir, err)

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -15,17 +15,17 @@
 package commands
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"path"
 	"strings"
 
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/sshclient"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/terminal"
@@ -35,8 +35,9 @@ func DefineTestSSHConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	app.DefineSSHFlags(cmd, config.NewConnectionConfigParser())
 	app.DefineBecomeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -48,14 +49,12 @@ func DefineTestSSHConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		if err != nil {
 			return err
 		}
-		err = sshCl.Start()
-		if err != nil {
+
+		if err := sshCl.Start(); err != nil {
 			return err
 		}
 
-		err = sshCl.Check().AwaitAvailability(ctx)
-
-		if err != nil {
+		if err := sshCl.Check().AwaitAvailability(ctx); err != nil {
 			return fmt.Errorf("check connection: %v", err)
 		}
 
@@ -63,7 +62,6 @@ func DefineTestSSHConnectionCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		return nil
 	})
-	return cmd
 }
 
 func DefineTestSCPCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -79,9 +77,11 @@ func DefineTestSCPCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd.Flag("dst", "destination path").Short('d').StringVar(&DstPath)
 	cmd.Flag("data", "data to test uploadbytes method").StringVar(&Data)
 	cmd.Flag("way", "transfer direction: 'up' to upload to remote or 'down' to download from remote").Short('w').StringVar(&Direction)
-	cmd.Action(func(c *kingpin.ParseContext) error {
+
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		log.DebugLn("scp: start ssh-agent")
-		ctx := context.Background()
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -93,8 +93,8 @@ func DefineTestSCPCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		if err != nil {
 			return err
 		}
-		err = sshCl.Start()
-		if err != nil {
+
+		if err := sshCl.Start(); err != nil {
 			return err
 		}
 
@@ -138,8 +138,6 @@ func DefineTestSCPCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 
 		return nil
 	})
-
-	return cmd
 }
 
 func DefineTestUploadExecCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -153,8 +151,9 @@ func DefineTestUploadExecCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 	cmd.Flag("sudo", "source path").Short('s').
 		BoolVar(&Sudo)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -166,42 +165,45 @@ func DefineTestUploadExecCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 		if err != nil {
 			return err
 		}
+
 		cmd := sshClient.UploadScript(ScriptPath)
 		if Sudo {
 			cmd.Sudo()
 		}
+
 		var stdout []byte
 		stdout, err = cmd.Execute(ctx)
 		if err != nil {
-			var ee *exec.ExitError
-			if errors.As(err, &ee) {
+			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 				return fmt.Errorf("script '%s' error: %w stderr: %s", ScriptPath, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("script '%s' error: %w", ScriptPath, err)
 		}
+
 		log.InfoF("stdout: %s\n", strings.Trim(string(stdout), "\n "))
 		log.InfoF("Got %d symbols\n", len(stdout))
+
 		return nil
 	})
-
-	return cmd
 }
 
 func DefineTestBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
-	var ScriptName string
-	var BundleDir string
-
 	app.DefineSSHFlags(cmd, config.NewConnectionConfigParser())
 	app.DefineBecomeFlags(cmd)
+
+	var bundleDirFlag string
+	var scriptNameFlag string
+
 	cmd.Flag("bundle-dir", "path of a bundle root directory").
 		Short('d').
-		StringVar(&BundleDir)
+		StringVar(&bundleDirFlag)
 	cmd.Flag("bundle-script", "path of a bundle main script").
 		Short('s').
-		StringVar(&ScriptName)
+		StringVar(&scriptNameFlag)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
-		ctx := context.Background()
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		if err := terminal.AskBecomePassword(); err != nil {
 			return err
 		}
@@ -214,21 +216,22 @@ func DefineTestBundle(cmd *kingpin.CmdClause) *kingpin.CmdClause {
 			return err
 		}
 
-		cmd := sshClient.UploadScript(ScriptName)
+		cmd := sshClient.UploadScript(scriptNameFlag)
 		cmd.Sudo()
-		parentDir := path.Dir(BundleDir)
-		bundleDir := path.Base(BundleDir)
-		stdout, err := cmd.ExecuteBundle(context.Background(), parentDir, bundleDir)
+
+		parentDir := path.Dir(bundleDirFlag)
+		bundleDir := path.Base(bundleDirFlag)
+
+		stdout, err := cmd.ExecuteBundle(ctx, parentDir, bundleDir)
 		if err != nil {
-			var ee *exec.ExitError
-			if errors.As(err, &ee) {
+			if ee, ok := errors.AsType[*exec.ExitError](err); ok {
 				return fmt.Errorf("bundle '%s' error: %w\nstderr: %s\n", bundleDir, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("bundle '%s' error: %w", bundleDir, err)
 		}
+
 		log.InfoF("Got %d symbols\n", len(stdout))
+
 		return nil
 	})
-
-	return cmd
 }

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -15,17 +15,17 @@
 package commands
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/name212/govalue"
-	kingpin "gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
@@ -42,7 +42,9 @@ func DefineInfrastructureConvergeExporterCommand(cmd *kingpin.CmdClause) *kingpi
 	app.DefineSSHFlags(cmd, config.NewConnectionConfigParser())
 	app.DefineBecomeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
 
 		exporter := operations.NewConvergeExporter(operations.ExporterParams{
@@ -53,10 +55,11 @@ func DefineInfrastructureConvergeExporterCommand(cmd *kingpin.CmdClause) *kingpi
 			Logger:   logger,
 			IsDebug:  app.IsDebug,
 		})
-		exporter.Start(context.Background())
+
+		exporter.Start(ctx)
+
 		return nil
 	})
-	return cmd
 }
 
 func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause {
@@ -65,9 +68,10 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 	app.DefineSSHFlags(cmd, config.NewConnectionConfigParser())
 	app.DefineBecomeFlags(cmd)
 
-	cmd.Action(func(c *kingpin.ParseContext) error {
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
 		logger := log.GetDefaultLogger()
-		ctx := context.Background()
 		logger.LogInfoLn("Check started ...\n")
 
 		// Skip AskBecomePassword for terraform check as it will be requested later during SSH operations
@@ -81,7 +85,9 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 		}
 
 		if govalue.IsNil(sshClient) && !app.KubeConfigInCluster {
-			return fmt.Errorf("Not enough flags were passed to perform the operation.\nUse dhctl terraform check --help to get available flags.\nSsh host is not provided. Need to pass --ssh-host, or specify SSHHost manifest in the --connection-config file")
+			return fmt.Errorf("Not enough flags were passed to perform the operation.\n" +
+				"Use dhctl terraform check --help to get available flags.\n" +
+				"Ssh host is not provided. Need to pass --ssh-host, or specify SSHHost manifest in the --connection-config file")
 		}
 
 		kubeCl, err := kubernetes.ConnectToKubernetesAPI(ctx, ssh.NewNodeInterfaceWrapper(sshClient))
@@ -119,7 +125,12 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 		}
 
 		statistic, needMigrationToTofu, err := check.CheckState(
-			ctx, kubeCl, metaConfig, infrastructure.NewContextWithProvider(providerGetter, logger), check.CheckStateOptions{}, false,
+			ctx,
+			kubeCl,
+			metaConfig,
+			infrastructure.NewContextWithProvider(providerGetter, logger),
+			check.CheckStateOptions{},
+			false,
 		)
 		if err != nil {
 			return err
@@ -130,13 +141,14 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause) *kingpin.CmdClause
 			return fmt.Errorf("Failed to format check result: %w", err)
 		}
 
+		// todo(log): why do not use logger?
 		fmt.Print(string(data))
 
 		if provider.NeedToUseTofu() && needMigrationToTofu {
+			// todo(log): why do not use logger?
 			fmt.Printf("\nNeed migrate to tofu: %v\n", needMigrationToTofu)
 		}
 
 		return provider.Cleanup()
 	})
-	return cmd
 }

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/global/infrastructure"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/process"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
@@ -66,37 +68,37 @@ var (
 			Name:       "execute-bashible-bundle",
 			Help:       "Prepare Master node and install Kubernetes.",
 			DefineFunc: bootstrap.DefineBootstrapExecuteBashibleCommand,
-			Parrent:    "bootstrap-phase",
+			Parent:     "bootstrap-phase",
 		},
 		{
 			Name:       "create-resources",
 			Help:       "Create resources in Kubernetes cluster.",
 			DefineFunc: bootstrap.DefineCreateResourcesCommand,
-			Parrent:    "bootstrap-phase",
+			Parent:     "bootstrap-phase",
 		},
 		{
 			Name:       "install-deckhouse",
 			Help:       "Install deckhouse and wait for its readiness.",
 			DefineFunc: bootstrap.DefineBootstrapInstallDeckhouseCommand,
-			Parrent:    "bootstrap-phase",
+			Parent:     "bootstrap-phase",
 		},
 		{
 			Name:       "abort",
 			Help:       "Delete every node, which was created during bootstrap process.",
 			DefineFunc: bootstrap.DefineBootstrapAbortCommand,
-			Parrent:    "bootstrap-phase",
+			Parent:     "bootstrap-phase",
 		},
 		{
 			Name:       "base-infra",
 			Help:       "Create base infrastructure for Cloud Kubernetes cluster.",
 			DefineFunc: bootstrap.DefineBaseInfrastructureCommand,
-			Parrent:    "bootstrap-phase",
+			Parent:     "bootstrap-phase",
 		},
 		{
 			Name:       "exec-post-bootstrap",
 			Help:       "Test scp upload and ssh run uploaded script.",
 			DefineFunc: bootstrap.DefineExecPostBootstrapScript,
-			Parrent:    "bootstrap-phase",
+			Parent:     "bootstrap-phase",
 		},
 		{
 			Name:       "converge",
@@ -121,7 +123,7 @@ var (
 			Name:       "release",
 			Help:       "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful",
 			DefineFunc: commands.DefineReleaseConvergeLockCommand,
-			Parrent:    "lock",
+			Parent:     "lock",
 		},
 		{
 			Name:       "destroy",
@@ -141,64 +143,64 @@ var (
 			Name:       exporterCmd,
 			Help:       "Run infrastructure converge exporter.",
 			DefineFunc: commands.DefineInfrastructureConvergeExporterCommand,
-			Parrent:    "terraform",
+			Parent:     "terraform",
 		},
 		{
 			Name:       "check",
 			Help:       "Check differences between state of Kubernetes cluster and infrastructure state.",
 			DefineFunc: commands.DefineInfrastructureCheckCommand,
-			Parrent:    "terraform",
+			Parent:     "terraform",
 		},
 		{
 			Name: "config",
 			Help: "Load, edit and save various dhctl configurations.",
 		},
 		{
-			Name:    "parse",
-			Help:    "Parse, validate and output configurations.",
-			Parrent: "config",
+			Name:   "parse",
+			Help:   "Parse, validate and output configurations.",
+			Parent: "config",
 		},
 		{
 			Name:       "cluster-configuration",
 			Help:       "Parse configuration and print it.",
 			DefineFunc: commands.DefineCommandParseClusterConfiguration,
-			Parrent:    "parse",
+			Parent:     "parse",
 		},
 		{
 			Name:       "cloud-discovery-data",
 			Help:       "Parse cloud discovery data and print it.",
 			DefineFunc: commands.DefineCommandParseCloudDiscoveryData,
-			Parrent:    "parse",
+			Parent:     "parse",
 		},
 		{
-			Name:    "render",
-			Help:    "Render transitional configurations.",
-			Parrent: "config",
+			Name:   "render",
+			Help:   "Render transitional configurations.",
+			Parent: "config",
 		},
 		{
 			Name:       "bashible-bundle",
 			Help:       "Render bashible bundle.",
 			DefineFunc: commands.DefineRenderBashibleBundle,
-			Parrent:    "render",
+			Parent:     "render",
 		},
 		{
 			Name:       "kubeadm-config",
 			Help:       "Render kubeadm config.",
 			DefineFunc: commands.DefineRenderKubeadmConfig,
-			Parrent:    "render",
+			Parent:     "render",
 		},
 		{
 			Name:       "master-bootstrap-scripts",
 			Help:       "Render master bootstrap scripts.",
 			DefineFunc: commands.DefineRenderMasterBootstrap,
-			Parrent:    "render",
+			Parent:     "render",
 		},
 		{
-			Name:    "edit",
-			Help:    "Change configuration files in Kubernetes cluster conveniently and safely.",
-			Parrent: "config",
+			Name:   "edit",
+			Help:   "Change configuration files in Kubernetes cluster conveniently and safely.",
+			Parent: "config",
 			DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause {
-				commands.DefineEditCommands(cmd /* wConnFlags */, true)
+				commands.DefineEditCommands(cmd, true)
 				return nil
 			},
 		},
@@ -210,71 +212,71 @@ var (
 			Name:       "ssh-connection",
 			Help:       "Test connection via ssh.",
 			DefineFunc: commands.DefineTestSSHConnectionCommand,
-			Parrent:    "test",
+			Parent:     "test",
 		},
 		{
 			Name:       "kubernetes-api-connection",
 			Help:       "Test connection to kubernetes api via ssh or directly.",
 			DefineFunc: commands.DefineTestKubernetesAPIConnectionCommand,
-			Parrent:    "test",
+			Parent:     "test",
 		},
 		{
 			Name:       "scp",
 			Help:       "Test scp file operations.",
 			DefineFunc: commands.DefineTestSCPCommand,
-			Parrent:    "test",
+			Parent:     "test",
 		},
 		{
 			Name:       "upload-exec",
 			Help:       "Test scp upload and ssh run uploaded script.",
 			DefineFunc: commands.DefineTestUploadExecCommand,
-			Parrent:    "test",
+			Parent:     "test",
 		},
 		{
 			Name:       "bashible-bundle",
 			Help:       "Test upload and execute a bundle.",
 			DefineFunc: commands.DefineTestBundle,
-			Parrent:    "test",
+			Parent:     "test",
 		},
 		{
-			Name:    "control-plane",
-			Help:    "Commands to test control plane nodes.",
-			Parrent: "test",
+			Name:   "control-plane",
+			Help:   "Commands to test control plane nodes.",
+			Parent: "test",
 		},
 		{
 			Name:       "manager",
 			Help:       "Test control plane manager is ready.",
 			DefineFunc: commands.DefineTestControlPlaneManagerReadyCommand,
-			Parrent:    "control-plane",
+			Parent:     "control-plane",
 		},
 		{
 			Name:       "node",
 			Help:       "Test control plane node is ready.",
 			DefineFunc: commands.DefineTestControlPlaneNodeReadyCommand,
-			Parrent:    "control-plane",
+			Parent:     "control-plane",
 		},
 		{
-			Name:    "deckhouse",
-			Help:    "Install and uninstall deckhouse.",
-			Parrent: "test",
+			Name:   "deckhouse",
+			Help:   "Install and uninstall deckhouse.",
+			Parent: "test",
 		},
 		{
 			Name:       "create-deployment",
 			Help:       "Install deckhouse after infrastructure is applied successful.",
 			DefineFunc: commands.DefineDeckhouseCreateDeployment,
-			Parrent:    "deckhouse",
+			Parent:     "deckhouse",
 		},
 		{
 			Name:       "remove-deployment",
 			Help:       "Delete deckhouse deployment.",
 			DefineFunc: commands.DefineDeckhouseRemoveDeployment,
-			Parrent:    "deckhouse",
+			Parent:     "deckhouse",
 		},
 		{
 			Name:       "deployment-ready",
 			Help:       "Wait while deployment is ready.",
 			DefineFunc: commands.DefineWaitDeploymentReadyCommand,
-			Parrent:    "deckhouse",
+			Parent:     "deckhouse",
 		},
 	}
 )
@@ -284,6 +286,8 @@ func registerOnShutdown(title string, action onShutdownFunc) {
 }
 
 func main() {
+	appContext := context.Background()
+
 	initGlobalVars()
 
 	tracesShutdownFn, err := enableTrace()
@@ -313,11 +317,14 @@ func main() {
 		panic(err)
 	}
 
-	runApplication(kpApp)
+	runApplication(appContext, kpApp)
 }
 
-func runApplication(kpApp *kingpin.Application) {
+func runApplication(ctx context.Context, kpApp *kingpin.Application) {
 	initer := newActionIniter()
+
+	// inject context.Context to kingpin.ParseContext
+	kpApp.Action(kpcontext.SetContextToAction(ctx))
 
 	kpApp.Action(func(c *kingpin.ParseContext) error {
 		initer.setParams(actionIniterParams{

--- a/dhctl/cmd/dhctl/register.go
+++ b/dhctl/cmd/dhctl/register.go
@@ -24,11 +24,13 @@ import (
 
 var allowedCommands []string
 
+type defineFunc func(cmd *kingpin.CmdClause) *kingpin.CmdClause
+
 type Command struct {
 	Name       string
 	Help       string
-	DefineFunc func(cmd *kingpin.CmdClause) *kingpin.CmdClause
-	Parrent    string
+	DefineFunc defineFunc
+	Parent     string
 	cmd        *kingpin.CmdClause
 }
 
@@ -74,7 +76,7 @@ func getNestingDepth(cmd Command, commands []Command) (Command, int) {
 	for {
 		found := false
 		for _, c := range commands {
-			if c.Name == cmd.Parrent && !visited[c.Name] {
+			if c.Name == cmd.Parent && !visited[c.Name] {
 				visited[c.Name] = true
 				cmd = c
 				depth++
@@ -84,7 +86,7 @@ func getNestingDepth(cmd Command, commands []Command) (Command, int) {
 			}
 		}
 
-		if !found || cmd.Parrent == "" {
+		if !found || cmd.Parent == "" {
 			break
 		}
 	}
@@ -107,8 +109,8 @@ func initParent(parrentCmdIndex int, kpApp *kingpin.Application) *kingpin.CmdCla
 func registerCommands(kpApp *kingpin.Application) error {
 	// First, validate that all commands with parents have existing parents
 	for _, command := range commandList {
-		if command.Parrent != "" {
-			_, err := getParentIndex(commandList, command.Parrent)
+		if command.Parent != "" {
+			_, err := getParentIndex(commandList, command.Parent)
 			if err != nil {
 				return err
 			}
@@ -128,7 +130,7 @@ func registerCommands(kpApp *kingpin.Application) error {
 				}
 			}
 		} else {
-			parrentCmdIndex, err := getParentIndex(commandList, command.Parrent)
+			parentCmdIndex, err := getParentIndex(commandList, command.Parent)
 			if err != nil {
 				return err
 			}
@@ -136,9 +138,9 @@ func registerCommands(kpApp *kingpin.Application) error {
 			allowed, subcommands := checkCommand(firstNode.Name, allowedCommands)
 
 			if allowed && checkSubcommand(command.Name, subcommands) {
-				pcmd := initParent(parrentCmdIndex, kpApp)
+				parentCmd := initParent(parentCmdIndex, kpApp)
 
-				cmd := pcmd.Command(command.Name, command.Help)
+				cmd := parentCmd.Command(command.Name, command.Help)
 				commandList[i].cmd = cmd
 
 				if command.DefineFunc != nil {

--- a/dhctl/cmd/dhctl/register_test.go
+++ b/dhctl/cmd/dhctl/register_test.go
@@ -120,7 +120,7 @@ func TestGetParentIndex(t *testing.T) {
 	commands := []Command{
 		{Name: "bootstrap", Help: "Bootstrap cluster"},
 		{Name: "converge", Help: "Converge cluster"},
-		{Name: "install", Help: "Install component", Parrent: "bootstrap"},
+		{Name: "install", Help: "Install component", Parent: "bootstrap"},
 	}
 
 	tests := []struct {
@@ -169,9 +169,9 @@ func TestGetNestingDepth(t *testing.T) {
 	commands := []Command{
 		{Name: "bootstrap", Help: "Bootstrap cluster"},
 		{Name: "converge", Help: "Converge cluster"},
-		{Name: "install", Help: "Install component", Parrent: "bootstrap"},
-		{Name: "phase", Help: "Run phase", Parrent: "install"},
-		{Name: "step", Help: "Run step", Parrent: "phase"},
+		{Name: "install", Help: "Install component", Parent: "bootstrap"},
+		{Name: "phase", Help: "Run phase", Parent: "install"},
+		{Name: "step", Help: "Run step", Parent: "phase"},
 	}
 
 	tests := []struct {
@@ -188,25 +188,25 @@ func TestGetNestingDepth(t *testing.T) {
 		},
 		{
 			name:          "one level deep",
-			cmd:           Command{Name: "install", Help: "Install component", Parrent: "bootstrap"},
+			cmd:           Command{Name: "install", Help: "Install component", Parent: "bootstrap"},
 			expectedTop:   "bootstrap",
 			expectedDepth: 1,
 		},
 		{
 			name:          "two levels deep",
-			cmd:           Command{Name: "phase", Help: "Run phase", Parrent: "install"},
+			cmd:           Command{Name: "phase", Help: "Run phase", Parent: "install"},
 			expectedTop:   "bootstrap",
 			expectedDepth: 2,
 		},
 		{
 			name:          "three levels deep",
-			cmd:           Command{Name: "step", Help: "Run step", Parrent: "phase"},
+			cmd:           Command{Name: "step", Help: "Run step", Parent: "phase"},
 			expectedTop:   "bootstrap",
 			expectedDepth: 3,
 		},
 		{
 			name:          "orphaned command",
-			cmd:           Command{Name: "orphan", Help: "Orphaned command", Parrent: "nonexistent"},
+			cmd:           Command{Name: "orphan", Help: "Orphaned command", Parent: "nonexistent"},
 			expectedTop:   "orphan",
 			expectedDepth: 0,
 		},
@@ -267,8 +267,16 @@ func TestRegisterCommands(t *testing.T) {
 		{
 			name: "register top level commands",
 			commands: []Command{
-				{Name: "bootstrap", Help: "Bootstrap cluster", DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
-				{Name: "converge", Help: "Converge cluster", DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
+				{
+					Name:       "bootstrap",
+					Help:       "Bootstrap cluster",
+					DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd },
+				},
+				{
+					Name:       "converge",
+					Help:       "Converge cluster",
+					DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd },
+				},
 			},
 			allowedCommands: []string{},
 			expectError:     false,
@@ -276,8 +284,15 @@ func TestRegisterCommands(t *testing.T) {
 		{
 			name: "register nested commands",
 			commands: []Command{
-				{Name: "bootstrap", Help: "Bootstrap cluster", DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
-				{Name: "install", Help: "Install component", Parrent: "bootstrap", DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
+				{
+					Name:       "bootstrap",
+					Help:       "Bootstrap cluster",
+					DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
+				{
+					Name:       "install",
+					Help:       "Install component",
+					Parent:     "bootstrap",
+					DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
 			},
 			allowedCommands: []string{},
 			expectError:     false,
@@ -285,7 +300,11 @@ func TestRegisterCommands(t *testing.T) {
 		{
 			name: "error on missing parent",
 			commands: []Command{
-				{Name: "install", Help: "Install component", Parrent: "nonexistent", DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
+				{
+					Name:       "install",
+					Help:       "Install component",
+					Parent:     "nonexistent",
+					DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
 			},
 			allowedCommands: []string{"nonexistent install"},
 			expectError:     true,
@@ -293,8 +312,14 @@ func TestRegisterCommands(t *testing.T) {
 		{
 			name: "filtered commands by allowed list",
 			commands: []Command{
-				{Name: "bootstrap", Help: "Bootstrap cluster", DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
-				{Name: "converge", Help: "Converge cluster", DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
+				{
+					Name:       "bootstrap",
+					Help:       "Bootstrap cluster",
+					DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
+				{
+					Name:       "converge",
+					Help:       "Converge cluster",
+					DefineFunc: func(cmd *kingpin.CmdClause) *kingpin.CmdClause { return cmd }},
 			},
 			allowedCommands: []string{"bootstrap"},
 			expectError:     false,

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -147,17 +147,14 @@ func ParseConfig(ctx context.Context, paths []string, preparatorProvider MetaCon
 func ParseConfigFromCluster(ctx context.Context, kubeCl *client.KubernetesClient, preparatorProvider MetaConfigPreparatorProvider, dc *directoryconfig.DirectoryConfig) (*MetaConfig, error) {
 	var metaConfig *MetaConfig
 	var err error
-	err = log.Process("common", "Get Cluster configuration", func() error {
+
+	return metaConfig, log.ProcessCtx(ctx, "common", "Get Cluster configuration", func(ctx context.Context) error {
 		return retry.NewLoop("Get Cluster configuration from Kubernetes cluster", 10, 5*time.Second).
 			RunContext(ctx, func() error {
 				metaConfig, err = parseConfigFromCluster(ctx, kubeCl, preparatorProvider, dc)
 				return err
 			})
 	})
-	if err != nil {
-		return nil, err
-	}
-	return metaConfig, nil
 }
 
 func ParseConfigInCluster(ctx context.Context, kubeCl *client.KubernetesClient, preparatorProvider MetaConfigPreparatorProvider, dc *directoryconfig.DirectoryConfig) (*MetaConfig, error) {

--- a/dhctl/pkg/config/base_test.go
+++ b/dhctl/pkg/config/base_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -208,7 +207,7 @@ spec:
 	t.Run("Registry", func(t *testing.T) {
 		t.Run("InitConfiguration -> always unmanaged && legacy", func(t *testing.T) {
 			t.Run("Without CRI (module disable)", func(t *testing.T) {
-				metaConfig, err := ParseConfigFromData(context.TODO(), initConfig, DummyPreparatorProvider(), dc)
+				metaConfig, err := ParseConfigFromData(t.Context(), initConfig, DummyPreparatorProvider(), dc)
 				require.NoError(t, err)
 				require.Equal(t, true, metaConfig.Registry.LegacyMode)
 				require.Equal(t, registry_const.ModeUnmanaged, metaConfig.Registry.Settings.Mode)
@@ -220,7 +219,7 @@ spec:
 				require.Equal(t, "", registry.CA)
 			})
 			t.Run("With CRI (module enable)", func(t *testing.T) {
-				metaConfig, err := ParseConfigFromData(context.TODO(), initConfig+clusterConfig, DummyPreparatorProvider(), dc)
+				metaConfig, err := ParseConfigFromData(t.Context(), initConfig+clusterConfig, DummyPreparatorProvider(), dc)
 				require.NoError(t, err)
 				require.Equal(t, true, metaConfig.Registry.LegacyMode)
 				require.Equal(t, registry_const.ModeUnmanaged, metaConfig.Registry.Settings.Mode)
@@ -234,7 +233,7 @@ spec:
 		})
 		t.Run("Default -> CE edition registry", func(t *testing.T) {
 			t.Run("Without CRI (module disable) -> unmanaged && legacy", func(t *testing.T) {
-				metaConfig, err := ParseConfigFromData(context.TODO(), "", DummyPreparatorProvider(), dc)
+				metaConfig, err := ParseConfigFromData(t.Context(), "", DummyPreparatorProvider(), dc)
 				require.NoError(t, err)
 				require.Equal(t, true, metaConfig.Registry.LegacyMode)
 				require.Equal(t, registry_const.ModeUnmanaged, metaConfig.Registry.Settings.Mode)
@@ -246,7 +245,7 @@ spec:
 				require.Equal(t, "", registry.CA)
 			})
 			t.Run("With CRI (module enable) -> direct && not legacy", func(t *testing.T) {
-				metaConfig, err := ParseConfigFromData(context.TODO(), ""+clusterConfig, DummyPreparatorProvider(), dc)
+				metaConfig, err := ParseConfigFromData(t.Context(), ""+clusterConfig, DummyPreparatorProvider(), dc)
 				require.NoError(t, err)
 				require.Equal(t, false, metaConfig.Registry.LegacyMode)
 				require.Equal(t, registry_const.ModeDirect, metaConfig.Registry.Settings.Mode)
@@ -279,11 +278,11 @@ spec:
   version: 1
 `
 			t.Run("Without CRI (module disable) -> error", func(t *testing.T) {
-				_, err := ParseConfigFromData(context.TODO(), moduleConfigDeckhouse, DummyPreparatorProvider(), dc)
+				_, err := ParseConfigFromData(t.Context(), moduleConfigDeckhouse, DummyPreparatorProvider(), dc)
 				require.Error(t, err)
 			})
 			t.Run("With CRI (module enable) -> from moduleConfig && not legacy", func(t *testing.T) {
-				metaConfig, err := ParseConfigFromData(context.TODO(), moduleConfigDeckhouse+clusterConfig, DummyPreparatorProvider(), dc)
+				metaConfig, err := ParseConfigFromData(t.Context(), moduleConfigDeckhouse+clusterConfig, DummyPreparatorProvider(), dc)
 				require.NoError(t, err)
 				require.Equal(t, false, metaConfig.Registry.LegacyMode)
 				require.Equal(t, registry_const.ModeUnmanaged, metaConfig.Registry.Settings.Mode)
@@ -298,7 +297,7 @@ spec:
 	})
 
 	t.Run("Standard Static", func(t *testing.T) {
-		metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig, DummyPreparatorProvider(), dc)
+		metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig, DummyPreparatorProvider(), dc)
 		require.NoError(t, err)
 
 		parsedStaticConfig, err := metaConfig.StaticClusterConfigYAML()
@@ -315,7 +314,7 @@ spec:
 	})
 
 	t.Run("Static with StaticClusterConfig", func(t *testing.T) {
-		metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig, DummyPreparatorProvider(), dc)
+		metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig, DummyPreparatorProvider(), dc)
 		require.NoError(t, err)
 
 		parsedStaticConfig, err := metaConfig.StaticClusterConfigYAML()
@@ -334,7 +333,7 @@ spec:
 
 	t.Run("Module config", func(t *testing.T) {
 		t.Run("Global valid", func(t *testing.T) {
-			metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+moduleConfigGlobalValid, DummyPreparatorProvider(), dc)
+			metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+moduleConfigGlobalValid, DummyPreparatorProvider(), dc)
 			require.NoError(t, err)
 
 			require.Len(t, metaConfig.ModuleConfigs, 1)
@@ -343,12 +342,12 @@ spec:
 		})
 
 		t.Run("Global invalid", func(t *testing.T) {
-			_, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+moduleConfigGlobalInvalid, DummyPreparatorProvider(), dc)
+			_, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+moduleConfigGlobalInvalid, DummyPreparatorProvider(), dc)
 			require.Error(t, err)
 		})
 
 		t.Run("Module valid", func(t *testing.T) {
-			metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+moduleConfigCommonValid, DummyPreparatorProvider(), dc)
+			metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+moduleConfigCommonValid, DummyPreparatorProvider(), dc)
 
 			require.NoError(t, err)
 
@@ -358,24 +357,24 @@ spec:
 		})
 
 		t.Run("Module invalid", func(t *testing.T) {
-			_, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+moduleConfigCommonInvalid, DummyPreparatorProvider(), dc)
+			_, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+moduleConfigCommonInvalid, DummyPreparatorProvider(), dc)
 			require.Error(t, err)
 		})
 
 		t.Run("Module without enabled field", func(t *testing.T) {
-			_, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+moduleConfigCommonWithoutEnabled, DummyPreparatorProvider(), dc)
+			_, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+moduleConfigCommonWithoutEnabled, DummyPreparatorProvider(), dc)
 			require.Error(t, err)
 		})
 
 		t.Run("Module without settings", func(t *testing.T) {
-			metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+moduleConfigCommonWithoutSettings, DummyPreparatorProvider(), dc)
+			metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+moduleConfigCommonWithoutSettings, DummyPreparatorProvider(), dc)
 			require.NoError(t, err)
 
 			require.Len(t, metaConfig.ResourcesYAML, 0)
 		})
 
 		t.Run("Unknown module should move into resources", func(t *testing.T) {
-			metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+unknownModuleConfig, DummyPreparatorProvider(), dc)
+			metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+unknownModuleConfig, DummyPreparatorProvider(), dc)
 			require.NoError(t, err)
 
 			require.Len(t, metaConfig.ModuleConfigs, 0)
@@ -385,7 +384,7 @@ spec:
 
 	t.Run("Config with another k8s resources eg configMap", func(t *testing.T) {
 		t.Run("Should move another resources into resourcesYAML", func(t *testing.T) {
-			metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+configMapAndInstanceClass, DummyPreparatorProvider(), dc)
+			metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+configMapAndInstanceClass, DummyPreparatorProvider(), dc)
 			require.NoError(t, err)
 
 			require.Len(t, metaConfig.ModuleConfigs, 0)
@@ -416,7 +415,7 @@ spec:
 		})
 
 		t.Run("Should move resourcesYAML", func(t *testing.T) {
-			metaConfig, err := ParseConfigFromData(context.TODO(), clusterConfig+initConfig+staticConfig+ngWithTemplating, DummyPreparatorProvider(), dc)
+			metaConfig, err := ParseConfigFromData(t.Context(), clusterConfig+initConfig+staticConfig+ngWithTemplating, DummyPreparatorProvider(), dc)
 			require.NoError(t, err)
 
 			require.Len(t, metaConfig.ModuleConfigs, 0)
@@ -444,7 +443,7 @@ func TestParseConfigFromFiles(t *testing.T) {
 		DownloadCacheDir: "/tmp/cache",
 	}
 	t.Run("parse wildcard", func(t *testing.T) {
-		metaConfig, err := LoadConfigFromFile(context.TODO(), []string{"./mocks/*.yml", "./mocks/3-ModuleConfig.yaml"}, DummyPreparatorProvider(), dc)
+		metaConfig, err := LoadConfigFromFile(t.Context(), []string{"./mocks/*.yml", "./mocks/3-ModuleConfig.yaml"}, DummyPreparatorProvider(), dc)
 		require.NoError(t, err)
 		require.Equal(t, "Static", metaConfig.ClusterType)
 
@@ -463,7 +462,7 @@ func TestParseConfigFromFiles(t *testing.T) {
 
 func TestParseConfigFromCluster(t *testing.T) {
 	doParseFromClusterNoError := func(t *testing.T, tst *testParseConfigFromCluster) *MetaConfig {
-		metaConfig, err := parseConfigFromCluster(context.TODO(), tst.kubeCl, tst.preparatorProvider, nil)
+		metaConfig, err := parseConfigFromCluster(t.Context(), tst.kubeCl, tst.preparatorProvider, nil)
 
 		require.NoError(t, err)
 		require.NotNil(t, metaConfig)
@@ -478,7 +477,7 @@ func TestParseConfigFromCluster(t *testing.T) {
 	}
 
 	doParseFromClusterWithError := func(t *testing.T, tst *testParseConfigFromCluster) {
-		metaConfig, err := parseConfigFromCluster(context.TODO(), tst.kubeCl, tst.preparatorProvider, nil)
+		metaConfig, err := parseConfigFromCluster(t.Context(), tst.kubeCl, tst.preparatorProvider, nil)
 
 		require.Error(t, err)
 		require.Nil(t, metaConfig)
@@ -851,7 +850,7 @@ spec:
 ---
 `
 
-		_, err := ParseConfigFromData(context.TODO(), configWithCommentedSeparator, DummyPreparatorProvider(), dc)
+		_, err := ParseConfigFromData(t.Context(), configWithCommentedSeparator, DummyPreparatorProvider(), dc)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing '---' separator")
 		require.Contains(t, err.Error(), "InitConfiguration")
@@ -871,7 +870,7 @@ clusterType: Static
 ---
 `
 
-		_, err := ParseConfigFromData(context.TODO(), configWithoutSeparator, DummyPreparatorProvider(), dc)
+		_, err := ParseConfigFromData(t.Context(), configWithoutSeparator, DummyPreparatorProvider(), dc)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing '---' separator")
 	})
@@ -894,7 +893,7 @@ spec:
 ---
 `
 
-		metaConfig, err := ParseConfigFromData(context.TODO(), validConfig, DummyPreparatorProvider(), dc)
+		metaConfig, err := ParseConfigFromData(t.Context(), validConfig, DummyPreparatorProvider(), dc)
 		require.NoError(t, err)
 		require.NotNil(t, metaConfig)
 		require.NotEmpty(t, metaConfig.InitClusterConfig)
@@ -911,7 +910,7 @@ deckhouse:
 ---
 `
 
-		metaConfig, err := ParseConfigFromData(context.TODO(), configWithComment, DummyPreparatorProvider(), dc)
+		metaConfig, err := ParseConfigFromData(t.Context(), configWithComment, DummyPreparatorProvider(), dc)
 		require.NoError(t, err)
 		require.NotNil(t, metaConfig)
 	})
@@ -928,6 +927,6 @@ func testCreateKubeSystemSecret(t *testing.T, kubeCl *client.KubernetesClient, n
 		Data: data,
 	}
 
-	_, err := kubeCl.CoreV1().Secrets(global.ConfigsNS).Create(context.TODO(), secret, metav1.CreateOptions{})
+	_, err := kubeCl.CoreV1().Secrets(global.ConfigsNS).Create(t.Context(), secret, metav1.CreateOptions{})
 	require.NoError(t, err)
 }

--- a/dhctl/pkg/infrastructure/controller/base.go
+++ b/dhctl/pkg/infrastructure/controller/base.go
@@ -37,7 +37,7 @@ func NewBaseInfraController(metaConfig *config.MetaConfig, stateCache state.Cach
 }
 
 func (r *BaseInfraController) Destroy(ctx context.Context, clusterState []byte, autoApprove bool) error {
-	if err := saveInCacheIfNotExists(r.stateCache, "base-infrastructure.tfstate", clusterState); err != nil {
+	if err := saveInCacheIfNotExists(ctx, r.stateCache, "base-infrastructure.tfstate", clusterState); err != nil {
 		return err
 	}
 

--- a/dhctl/pkg/infrastructure/controller/cluster.go
+++ b/dhctl/pkg/infrastructure/controller/cluster.go
@@ -117,7 +117,7 @@ func (r *ClusterInfra) DestroyCluster(ctx context.Context, autoApprove bool) err
 	}
 
 	if r.PhasedExecutionContext != nil {
-		if shouldStop, err := r.PhasedExecutionContext.StartPhase(phases.AllNodesPhase, true, r.cache); err != nil {
+		if shouldStop, err := r.PhasedExecutionContext.StartPhase(ctx, phases.AllNodesPhase, true, r.cache); err != nil {
 			return err
 		} else if shouldStop {
 			return nil
@@ -138,7 +138,7 @@ func (r *ClusterInfra) DestroyCluster(ctx context.Context, autoApprove bool) err
 	}
 
 	if r.PhasedExecutionContext != nil {
-		if shouldStop, err := r.PhasedExecutionContext.SwitchPhase(phases.BaseInfraPhase, true, r.cache, nil); err != nil {
+		if shouldStop, err := r.PhasedExecutionContext.SwitchPhase(ctx, phases.BaseInfraPhase, true, r.cache, nil); err != nil {
 			return err
 		} else if shouldStop {
 			return nil
@@ -151,7 +151,7 @@ func (r *ClusterInfra) DestroyCluster(ctx context.Context, autoApprove bool) err
 	}
 
 	if r.PhasedExecutionContext != nil {
-		return r.PhasedExecutionContext.CompletePhase(r.cache, nil)
+		return r.PhasedExecutionContext.CompletePhase(ctx, r.cache, nil)
 	} else {
 		return nil
 	}

--- a/dhctl/pkg/infrastructure/controller/nodes.go
+++ b/dhctl/pkg/infrastructure/controller/nodes.go
@@ -66,7 +66,7 @@ func getNgMetaConfig(ctx context.Context, clusterMetaConfig *config.MetaConfig, 
 
 func (r *NodeGroupInfrastructureController) DestroyNode(ctx context.Context, name string, nodeState []byte, autoApprove bool) error {
 	stateName := fmt.Sprintf("%s.tfstate", name)
-	if err := saveInCacheIfNotExists(r.stateCache, stateName, nodeState); err != nil {
+	if err := saveInCacheIfNotExists(ctx, r.stateCache, stateName, nodeState); err != nil {
 		return err
 	}
 

--- a/dhctl/pkg/infrastructure/controller/utils.go
+++ b/dhctl/pkg/infrastructure/controller/utils.go
@@ -14,10 +14,14 @@
 
 package controller
 
-import "github.com/deckhouse/deckhouse/dhctl/pkg/state"
+import (
+	"context"
 
-func saveInCacheIfNotExists(cache state.Cache, name string, state []byte) error {
-	ok, err := cache.InCache(name)
+	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
+)
+
+func saveInCacheIfNotExists(ctx context.Context, cache state.Cache, name string, state []byte) error {
+	ok, err := cache.InCache(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -26,5 +30,5 @@ func saveInCacheIfNotExists(cache state.Cache, name string, state []byte) error 
 		return nil
 	}
 
-	return cache.Save(name, state)
+	return cache.Save(ctx, name, state)
 }

--- a/dhctl/pkg/infrastructure/pipeline.go
+++ b/dhctl/pkg/infrastructure/pipeline.go
@@ -112,21 +112,19 @@ func ApplyPipeline(
 	extractFn func(ctx context.Context, r RunnerInterface) (*PipelineOutputs, error),
 ) (*PipelineOutputs, error) {
 	var extractedData *PipelineOutputs
-	pipelineFunc := func() error {
-		err := r.Init(ctx)
-		if err != nil {
+
+	pipelineFunc := func(ctx context.Context) (err error) {
+		if err := r.Init(ctx); err != nil {
 			return err
 		}
 
-		err = r.Plan(ctx, false, false)
-		if err != nil {
+		if err := r.Plan(ctx, false, false); err != nil {
 			return err
 		}
 
 		defer func() { extractedData, err = extractFn(ctx, r) }()
 
-		err = r.Apply(ctx)
-		if err != nil {
+		if err := r.Apply(ctx); err != nil {
 			return err
 		}
 
@@ -135,7 +133,8 @@ func ApplyPipeline(
 	}
 
 	logger := r.GetLogger()
-	err := logger.LogProcess("infrastructure", fmt.Sprintf("Pipeline %s for %s", r.GetStep(), name), pipelineFunc)
+	err := logger.LogProcessCtx(ctx, "infrastructure", fmt.Sprintf("Pipeline %s for %s", r.GetStep(), name), pipelineFunc)
+
 	return extractedData, err
 }
 

--- a/dhctl/pkg/infrastructure/pipeline.go
+++ b/dhctl/pkg/infrastructure/pipeline.go
@@ -149,7 +149,7 @@ func CheckPipeline(
 	var destructiveChanges *plan.DestructiveChanges
 	var infrastructurePlan map[string]any
 
-	pipelineFunc := func() error {
+	pipelineFunc := func(ctx context.Context) error {
 		err := r.Init(ctx)
 		if err != nil {
 			return err
@@ -178,7 +178,13 @@ func CheckPipeline(
 
 		return nil
 	}
-	err := log.Process("infrastructure", fmt.Sprintf("Check state %s for %s", r.GetStep(), name), pipelineFunc)
+
+	err := log.ProcessCtx(
+		ctx,
+		"infrastructure",
+		fmt.Sprintf("Check state %s for %s", r.GetStep(), name),
+		pipelineFunc,
+	)
 
 	logDebugPlanIfNeed(ctx, r, name, destroy)
 
@@ -207,7 +213,7 @@ func CheckBaseInfrastructurePipeline(
 	}
 	var pl map[string]any
 
-	pipelineFunc := func() error {
+	pipelineFunc := func(ctx context.Context) error {
 		err := r.Init(ctx)
 		if err != nil {
 			return err
@@ -280,7 +286,7 @@ func CheckBaseInfrastructurePipeline(
 
 		return nil
 	}
-	err := log.Process("infrastructure", fmt.Sprintf("Check state %s for %s", r.GetStep(), name), pipelineFunc)
+	err := log.ProcessCtx(ctx, "infrastructure", fmt.Sprintf("Check state %s for %s", r.GetStep(), name), pipelineFunc)
 
 	logDebugPlanIfNeed(ctx, r, name, false)
 
@@ -288,7 +294,7 @@ func CheckBaseInfrastructurePipeline(
 }
 
 func DestroyPipeline(ctx context.Context, r RunnerInterface, name string) error {
-	pipelineFunc := func() error {
+	pipelineFunc := func(ctx context.Context) error {
 		err := r.Init(ctx)
 		if err != nil {
 			return err
@@ -299,13 +305,15 @@ func DestroyPipeline(ctx context.Context, r RunnerInterface, name string) error 
 			return nil
 		}
 
-		err = r.Destroy(ctx)
-		if err != nil {
-			return err
-		}
-		return nil
+		return r.Destroy(ctx)
 	}
-	return log.Process("infrastructure", fmt.Sprintf("Destroy %s for %s", r.GetStep(), name), pipelineFunc)
+
+	return log.ProcessCtx(
+		ctx,
+		"infrastructure",
+		fmt.Sprintf("Destroy %s for %s", r.GetStep(), name),
+		pipelineFunc,
+	)
 }
 
 func GetBaseInfraResult(ctx context.Context, r RunnerInterface) (*PipelineOutputs, error) {
@@ -523,7 +531,7 @@ func logDebugPlanIfNeed(ctx context.Context, r RunnerInterface, name string, des
 	resultsErrs := make(map[string]error, len(targets))
 
 	// always return nil
-	_ = log.Process("infrastructure", "Getting debug plans", func() error {
+	_ = log.ProcessCtx(ctx, "infrastructure", "Getting debug plans", func(ctx context.Context) error {
 		for _, target := range targets {
 			res, err := r.DebugPlanTarget(ctx, destroy, debugPlanStep, target)
 			if err != nil {

--- a/dhctl/pkg/infrastructure/runner.go
+++ b/dhctl/pkg/infrastructure/runner.go
@@ -282,7 +282,7 @@ func (r *Runner) Init(ctx context.Context) error {
 		stateName := r.stateName()
 		r.statePath = r.stateCache.GetPath(stateName)
 
-		hasState, err := r.stateCache.InCache(stateName)
+		hasState, err := r.stateCache.InCache(ctx, stateName)
 		if err != nil {
 			return err
 		}
@@ -308,7 +308,7 @@ func (r *Runner) Init(ctx context.Context) error {
 				}
 			}
 
-			stateData, err := r.stateCache.Load(stateName)
+			stateData, err := r.stateCache.Load(ctx, stateName)
 			if err != nil {
 				return err
 			}

--- a/dhctl/pkg/infrastructure/runner.go
+++ b/dhctl/pkg/infrastructure/runner.go
@@ -329,7 +329,7 @@ func (r *Runner) Init(ctx context.Context) error {
 		r.WithState(nil)
 	}
 
-	return r.logger.LogProcess("default", "infrastructure init ...", func() error {
+	return r.logger.LogProcessCtx(ctx, "default", "infrastructure init ...", func(ctx context.Context) error {
 		_, err := r.execInfrastructureUtility(ctx, func(ctx context.Context) (int, error) {
 			err := r.infraExecutor.Init(ctx)
 			return 0, err
@@ -409,7 +409,7 @@ func (r *Runner) Apply(ctx context.Context) error {
 		return ErrRunnerStopped
 	}
 
-	return r.logger.LogProcess("default", "infrastructure apply ...", func() error {
+	return r.logger.LogProcessCtx(ctx, "default", "infrastructure apply ...", func(ctx context.Context) error {
 		skip, err := r.isSkipChanges(ctx)
 		if err != nil {
 			return err
@@ -420,7 +420,7 @@ func (r *Runner) Apply(ctx context.Context) error {
 		}
 
 		if !govalue.IsNil(r.stateChecker) {
-			err = r.logger.LogProcess("default", "infrastructure state check before apply...", func() error {
+			err = r.logger.LogProcessCtx(ctx, "default", "infrastructure state check before apply...", func(ctx context.Context) error {
 				if r.statePath == "" {
 					log.InfoF("Infrastructure state path is empty. Skip infrastructure state check.\n")
 					return nil
@@ -493,7 +493,7 @@ func (r *Runner) Plan(ctx context.Context, destroy, noout bool) error {
 		return ErrRunnerStopped
 	}
 
-	return r.logger.LogProcess("default", "infrastructure plan ...", func() error {
+	return r.logger.LogProcessCtx(ctx, "default", "infrastructure plan ...", func(ctx context.Context) error {
 		tmpFile, err := os.CreateTemp(r.infraExecutor.GetStatesDir(), string(r.infraExecutor.Step())+deckhousePlanSuffix)
 		if err != nil {
 			return fmt.Errorf("Can't create temp file for plan: %w", err)
@@ -572,7 +572,7 @@ func (r *Runner) DebugPlanTarget(ctx context.Context, destroy bool, step, target
 	processName := fmt.Sprintf("infrastructure debug plan for %s...", target)
 
 	res := ""
-	err := r.logger.LogProcess("default", processName, func() error {
+	return res, r.logger.LogProcessCtx(ctx, "default", processName, func(ctx context.Context) error {
 		tmpFile, err := os.CreateTemp(r.infraExecutor.GetStatesDir(), string(r.infraExecutor.Step())+deckhouseDebugPlanSuffix)
 		if err != nil {
 			return fmt.Errorf("Can't create temp file for debug plan: %w", err)
@@ -613,12 +613,6 @@ func (r *Runner) DebugPlanTarget(ctx context.Context, destroy bool, step, target
 
 		return nil
 	})
-
-	if err != nil {
-		return "", err
-	}
-
-	return res, nil
 }
 
 func (r *Runner) GetInfrastructureOutput(ctx context.Context, output string) ([]byte, error) {
@@ -697,7 +691,7 @@ func (r *Runner) Destroy(ctx context.Context) error {
 		return err
 	}
 
-	return r.logger.LogProcess("default", "infrastructure destroy ...", func() error {
+	return r.logger.LogProcessCtx(ctx, "default", "infrastructure destroy ...", func(ctx context.Context) error {
 		err := r.stateSaver.Start(r)
 		if err != nil {
 			return err

--- a/dhctl/pkg/infrastructure/state_saver.go
+++ b/dhctl/pkg/infrastructure/state_saver.go
@@ -28,7 +28,7 @@ import (
 )
 
 type SaverDestination interface {
-	SaveState(outputs *PipelineOutputs) error
+	SaveState(ctx context.Context, outputs *PipelineOutputs) error
 }
 
 type StateSaver struct {
@@ -125,6 +125,8 @@ func (s *StateSaver) FsEventHandler(event fsnotify.Event) {
 	s.saversLock.RLock()
 	defer s.saversLock.RUnlock()
 
+	ctx := context.TODO()
+
 	if s.runner == nil {
 		log.ErrorF("Possible bug!!! The state watcher got fs event while not started!\n")
 	}
@@ -142,7 +144,7 @@ func (s *StateSaver) FsEventHandler(event fsnotify.Event) {
 		return
 	}
 
-	outputs, err := OnlyState(context.Background(), s.runner)
+	outputs, err := OnlyState(ctx, s.runner)
 	if err != nil {
 		log.ErrorF("Parse intermediate state: %v\n", err)
 		return
@@ -157,7 +159,7 @@ func (s *StateSaver) FsEventHandler(event fsnotify.Event) {
 		go func() {
 			defer wg.Done()
 
-			err = svr.SaveState(outputs)
+			err = svr.SaveState(ctx, outputs)
 			if err != nil {
 				log.ErrorF("Save intermediate state error: %v\n", err)
 				atomic.StoreInt32(&hasError, 1)
@@ -190,14 +192,14 @@ type cacheDestination struct {
 	runner *Runner
 }
 
-func (d *cacheDestination) SaveState(outputs *PipelineOutputs) error {
+func (d *cacheDestination) SaveState(ctx context.Context, outputs *PipelineOutputs) error {
 	if len(outputs.InfrastructureState) == 0 {
 		debugStateSaver("State is empty. Skip")
 		return nil
 	}
 	name := d.runner.stateName()
 	debugStateSaver("Intermediate save state %s in cache...\n", name)
-	err := d.runner.stateCache.Save(name, outputs.InfrastructureState)
+	err := d.runner.stateCache.Save(ctx, name, outputs.InfrastructureState)
 	msg := fmt.Sprintf("Intermediate state %s in cache was saved\n", name)
 	if err != nil {
 		msg = fmt.Sprintf("Intermediate state %s in cache was not saved: %v\n", name, err)

--- a/dhctl/pkg/infrastructureprovider/cloud/impl.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/impl.go
@@ -496,7 +496,7 @@ func (p *Provider) downloadPluginVersion(ctx context.Context, rootDir, version s
 		p.String(),
 	)
 
-	err = log.Process("Cloud infrastructure", "Download plugins", func() error {
+	err = log.ProcessCtx(ctx, "Cloud infrastructure", "Download plugins", func(ctx context.Context) error {
 		return p.di.InfraPluginProvider.DownloadPlugin(ctx, params, destination, p.metaConfig)
 	})
 	if err != nil {
@@ -524,7 +524,7 @@ func (p *Provider) downloadInfraUtil(ctx context.Context, rootDir, errPrefix str
 
 	var err error
 
-	_ = log.Process("Cloud infrastructure", "Preparing infrastructure util", func() error {
+	_ = log.ProcessCtx(ctx, "Cloud infrastructure", "Preparing infrastructure util", func(ctx context.Context) error {
 		if useTofu {
 			p.logger.LogDebugF("Downloading opentofu %s for %s\n", params.Version.String(), p.String())
 			err = p.di.InfraUtilProvider.DownloadOpenTofu(ctx, params, destination, p.metaConfig)

--- a/dhctl/pkg/kpcontext/kpcontext.go
+++ b/dhctl/pkg/kpcontext/kpcontext.go
@@ -1,0 +1,39 @@
+package kpcontext
+
+import (
+	"context"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func SetContextToAction(ctx context.Context) kingpin.Action {
+	return func(c *kingpin.ParseContext) error {
+		SetContextToParseContext(ctx, c)
+
+		return nil
+	}
+}
+
+func SetContextToParseContext(ctx context.Context, c *kingpin.ParseContext) {
+	for _, el := range c.Elements {
+		if _, ok := el.Clause.(context.Context); ok {
+			el.Clause = ctx
+
+			return
+		}
+	}
+
+	c.Elements = append(c.Elements, &kingpin.ParseElement{Clause: ctx})
+}
+
+func ExtractContext(c *kingpin.ParseContext) context.Context {
+	for _, el := range c.Elements {
+		if ctx, ok := el.Clause.(context.Context); ok {
+			return ctx
+		}
+	}
+
+	// fallback to context.Background(),
+	// can be helpful in cases when context is not set (e.g., not in dhctl code)
+	return context.Background()
+}

--- a/dhctl/pkg/kpcontext/kpcontext.go
+++ b/dhctl/pkg/kpcontext/kpcontext.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kpcontext
 
 import (

--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
@@ -41,13 +41,14 @@ func ConvergeDeckhouseConfigurationForCommander(ctx context.Context, kubeCl *cli
 		return err
 	}
 
-	return log.Process("default", "Converge deckhouse configuration", func() error {
+	return log.ProcessCtx(ctx, "default", "Converge deckhouse configuration", func(ctx context.Context) error {
 		for _, task := range tasks {
-			err := task.CreateOrUpdate()
+			err := task.CreateOrUpdate(ctx)
 			if err != nil {
 				return err
 			}
 		}
+
 		return nil
 	})
 }
@@ -74,12 +75,18 @@ func getTasksForRunning(ctx context.Context, kubeCl *client.KubernetesClient, co
 		{
 			Name:     `Secret "d8-cluster-configuration"`,
 			Manifest: func() interface{} { return manifests.SecretWithClusterConfig(clusterConfig) },
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("kube-system").
+					Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("kube-system").
+					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+
 				return err
 			},
 		},
@@ -88,11 +95,14 @@ func getTasksForRunning(ctx context.Context, kubeCl *client.KubernetesClient, co
 			Manifest: func() interface{} {
 				return manifests.ClusterUUIDConfigMap(clusterUUID)
 			},
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).
+					Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 				// NOTE: Uuid configmap uses "more careful" update task,
 				// NOTE: which will create configmap only if it does not exist,
 				// NOTE: or update configmap only if actual uuid in configmap does not match target uuid.
@@ -182,10 +192,10 @@ func (t *taskProviderForCluster) Cloud(ctx context.Context, metaConfig *config.M
 				providerClusterConfig, nil,
 			)
 		},
-		CreateFunc: func(manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
 			return convergeManifestsCreateSecret(ctx, kubeCl, manifest, secretName)
 		},
-		UpdateFunc: func(manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 			return convergeManifestsPatchSecret(ctx, kubeCl, manifest, secretName)
 		},
 	}, nil
@@ -211,10 +221,10 @@ func (t *taskProviderForCluster) Static(ctx context.Context, metaConfig *config.
 		Manifest: func() interface{} {
 			return manifests.SecretWithStaticClusterConfig(staticClusterConfig)
 		},
-		CreateFunc: func(manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
 			return convergeManifestsCreateSecret(ctx, kubeCl, manifest, secretName)
 		},
-		UpdateFunc: func(manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 			return convergeManifestsPatchSecret(ctx, kubeCl, manifest, secretName)
 		},
 	}, nil

--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge_test.go
@@ -449,7 +449,7 @@ func (tt *testConvergeManifests) assetAndRun(t *testing.T) {
 		assertContainsOrNotCommanderUUID(t, tasksNames, `ConfigMap "d8-commander-uuid"`)
 
 		for _, task := range tasks {
-			err := task.CreateOrUpdate()
+			err := task.CreateOrUpdate(t.Context())
 			require.NoError(t, err)
 		}
 

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -84,11 +84,11 @@ func controllerDeploymentTask(
 		Manifest: func() interface{} {
 			return CreateDeckhouseDeploymentManifest(cfg)
 		},
-		CreateFunc: func(manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
 			_, err := kubeCl.AppsV1().Deployments("d8-system").Create(ctx, manifest.(*appsv1.Deployment), metav1.CreateOptions{})
 			return err
 		},
-		UpdateFunc: func(manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 			preparedManifest, err := prepareDeckhouseDeploymentForUpdate(ctx, kubeCl, cfg, manifest.(*appsv1.Deployment))
 			if err != nil {
 				return err
@@ -144,13 +144,15 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(
 				},
 			}
 		},
-		CreateFunc: func(manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
 			cm := manifest.(*apiv1.ConfigMap)
-			_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+
+			_, err := kubeCl.
+				CoreV1().ConfigMaps("d8-system").
 				Create(ctx, cm, metav1.CreateOptions{})
 			return err
 		},
-		UpdateFunc: func(manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 			return nil
 		},
 	}, nil
@@ -186,14 +188,13 @@ func CreateDeckhouseManifests(
 			Manifest: func() any {
 				return manifests.DeckhouseNamespace("d8-system")
 			},
-			CreateFunc: func(manifest any) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
-					CoreV1().
-					Namespaces().
+					CoreV1().Namespaces().
 					Create(ctx, manifest.(*apiv1.Namespace), metav1.CreateOptions{})
 				return err
 			},
-			UpdateFunc: func(manifest any) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
 					CoreV1().
 					Namespaces().
@@ -204,8 +205,10 @@ func CreateDeckhouseManifests(
 		{
 			Name:     `Admin ClusterRole "cluster-admin"`,
 			Manifest: func() interface{} { return manifests.DeckhouseAdminClusterRole() },
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoles().Get(ctx, manifest.(*rbacv1.ClusterRole).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					RbacV1().ClusterRoles().
+					Get(ctx, manifest.(*rbacv1.ClusterRole).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						_, err = kubeCl.RbacV1().ClusterRoles().Create(ctx, manifest.(*rbacv1.ClusterRole), metav1.CreateOptions{})
@@ -213,18 +216,24 @@ func CreateDeckhouseManifests(
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoles().Update(ctx, manifest.(*rbacv1.ClusterRole), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					RbacV1().ClusterRoles().
+					Update(ctx, manifest.(*rbacv1.ClusterRole), metav1.UpdateOptions{})
+
 				return err
 			},
 		},
 		{
 			Name:     `ClusterRoleBinding "deckhouse"`,
 			Manifest: func() interface{} { return manifests.DeckhouseAdminClusterRoleBinding() },
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoleBindings().Get(ctx, manifest.(*rbacv1.ClusterRoleBinding).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					RbacV1().ClusterRoleBindings().
+					Get(ctx, manifest.(*rbacv1.ClusterRoleBinding).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						_, err = kubeCl.RbacV1().ClusterRoleBindings().Create(ctx, manifest.(*rbacv1.ClusterRoleBinding), metav1.CreateOptions{})
@@ -232,18 +241,24 @@ func CreateDeckhouseManifests(
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.RbacV1().ClusterRoleBindings().Update(ctx, manifest.(*rbacv1.ClusterRoleBinding), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					RbacV1().ClusterRoleBindings().
+					Update(ctx, manifest.(*rbacv1.ClusterRoleBinding), metav1.UpdateOptions{})
+
 				return err
 			},
 		},
 		{
 			Name:     `ServiceAccount "deckhouse"`,
 			Manifest: func() interface{} { return manifests.DeckhouseServiceAccount() },
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ServiceAccounts("d8-system").Get(ctx, manifest.(*apiv1.ServiceAccount).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().ServiceAccounts("d8-system").
+					Get(ctx, manifest.(*apiv1.ServiceAccount).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
 						_, err = kubeCl.CoreV1().ServiceAccounts("d8-system").Create(ctx, manifest.(*apiv1.ServiceAccount), metav1.CreateOptions{})
@@ -251,10 +266,14 @@ func CreateDeckhouseManifests(
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ServiceAccounts("d8-system").Update(ctx, manifest.(*apiv1.ServiceAccount), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().ServiceAccounts("d8-system").
+					Update(ctx, manifest.(*apiv1.ServiceAccount), metav1.UpdateOptions{})
+
 				return err
 			},
 		},
@@ -275,16 +294,22 @@ func CreateDeckhouseManifests(
 					},
 				}
 			},
-			CreateFunc: func(manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
 				cm := manifest.(*apiv1.ConfigMap)
-				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+
+				_, err := kubeCl.
+					CoreV1().ConfigMaps("d8-system").
 					Create(ctx, cm, metav1.CreateOptions{})
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 				cm := manifest.(*apiv1.ConfigMap)
-				_, err := kubeCl.CoreV1().ConfigMaps("d8-system").
+
+				_, err := kubeCl.
+					CoreV1().ConfigMaps("d8-system").
 					Update(ctx, cm, metav1.UpdateOptions{})
+
 				return err
 			},
 		},
@@ -307,10 +332,9 @@ func CreateDeckhouseManifests(
 		Manifest: func() any {
 			return manifests.DeckhouseRegistrySecret(deckhouseRegistrySecretData)
 		},
-		CreateFunc: func(manifest any) error {
+		CreateFunc: func(ctx context.Context, manifest any) error {
 			_, err = kubeCl.
-				CoreV1().
-				Secrets("d8-system").
+				CoreV1().Secrets("d8-system").
 				Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 
 			if err != nil && apierrors.IsAlreadyExists(err) {
@@ -319,11 +343,11 @@ func CreateDeckhouseManifests(
 			}
 			return err
 		},
-		UpdateFunc: func(manifest any) error {
+		UpdateFunc: func(ctx context.Context, manifest any) error {
 			_, err := kubeCl.
-				CoreV1().
-				Secrets("d8-system").
+				CoreV1().Secrets("d8-system").
 				Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+
 			return err
 		},
 	})
@@ -345,23 +369,23 @@ func CreateDeckhouseManifests(
 			Manifest: func() any {
 				return manifests.RegistryBashibleConfigSecret(registryBashibleConfigSecretData)
 			},
-			CreateFunc: func(manifest any) error {
+			CreateFunc: func(ctx context.Context, manifest any) error {
 				_, err = kubeCl.
-					CoreV1().
-					Secrets("d8-system").
+					CoreV1().Secrets("d8-system").
 					Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 
 				if err != nil && apierrors.IsAlreadyExists(err) {
 					log.InfoLn("Already exists. Skip!")
 					return nil
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest any) error {
+			UpdateFunc: func(ctx context.Context, manifest any) error {
 				_, err := kubeCl.
-					CoreV1().
-					Secrets("d8-system").
+					CoreV1().Secrets("d8-system").
 					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+
 				return err
 			},
 		})
@@ -371,19 +395,27 @@ func CreateDeckhouseManifests(
 		tasks = append(tasks, actions.ManifestTask{
 			Name:     `Secret "d8-cluster-terraform-state"`,
 			Manifest: func() interface{} { return manifests.SecretWithInfrastructureState(cfg.InfrastructureState) },
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("d8-system").
+					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+						_, err = kubeCl.
+							CoreV1().Secrets("d8-system").
+							Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 					}
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("d8-system").
+					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+
 				return err
 			},
 		})
@@ -396,19 +428,28 @@ func CreateDeckhouseManifests(
 		tasks = append(tasks, actions.ManifestTask{
 			Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
 			Manifest: getManifest,
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("d8-system").
+					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
+
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+						_, err = kubeCl.
+							CoreV1().Secrets("d8-system").
+							Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 					}
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("d8-system").
+					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+
 				return err
 			},
 		})
@@ -418,19 +459,27 @@ func CreateDeckhouseManifests(
 		tasks = append(tasks, actions.ManifestTask{
 			Name:     `Secret "d8-cluster-configuration"`,
 			Manifest: func() interface{} { return manifests.SecretWithClusterConfig(cfg.ClusterConfig) },
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("kube-system").
+					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+						_, err = kubeCl.
+							CoreV1().Secrets("kube-system").
+							Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 					}
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("kube-system").
+					Update(ctx, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+
 				return err
 			},
 		})
@@ -444,28 +493,37 @@ func CreateDeckhouseManifests(
 					cfg.ProviderClusterConfig, cfg.CloudDiscovery,
 				)
 			},
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("kube-system").
+					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+						_, err = kubeCl.
+							CoreV1().Secrets("kube-system").
+							Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 					}
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 				data, err := json.Marshal(manifest.(*apiv1.Secret))
 				if err != nil {
 					return err
 				}
-				_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(ctx,
-					"d8-provider-cluster-configuration",
-					types.MergePatchType,
-					data,
-					metav1.PatchOptions{},
-				)
+
+				_, err = kubeCl.
+					CoreV1().Secrets("kube-system").
+					Patch(
+						ctx,
+						"d8-provider-cluster-configuration",
+						types.MergePatchType,
+						data,
+						metav1.PatchOptions{},
+					)
 				return err
 			},
 		})
@@ -477,29 +535,37 @@ func CreateDeckhouseManifests(
 			Manifest: func() interface{} {
 				return manifests.SecretWithStaticClusterConfig(cfg.StaticClusterConfig)
 			},
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("kube-system").Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("kube-system").
+					Get(ctx, manifest.(*apiv1.Secret).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Secrets("kube-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+						_, err = kubeCl.
+							CoreV1().Secrets("kube-system").
+							Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 					}
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 				data, err := json.Marshal(manifest.(*apiv1.Secret))
 				if err != nil {
 					return err
 				}
-				_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(
-					ctx,
-					"d8-static-cluster-configuration",
-					types.MergePatchType,
-					data,
-					metav1.PatchOptions{},
-				)
+
+				_, err = kubeCl.
+					CoreV1().Secrets("kube-system").
+					Patch(
+						ctx,
+						"d8-static-cluster-configuration",
+						types.MergePatchType,
+						data,
+						metav1.PatchOptions{},
+					)
 				return err
 			},
 		})
@@ -511,12 +577,18 @@ func CreateDeckhouseManifests(
 			Manifest: func() interface{} {
 				return manifests.ClusterUUIDConfigMap(cfg.UUID)
 			},
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).
+					Create(ctx, manifest.(*apiv1.ConfigMap), metav1.CreateOptions{})
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Update(ctx, manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).
+					Update(ctx, manifest.(*apiv1.ConfigMap), metav1.UpdateOptions{})
+
 				return err
 			},
 		})
@@ -532,11 +604,15 @@ func CreateDeckhouseManifests(
 			Manifest: func() interface{} {
 				return manifests.KubeDNSService(cfg.KubeDNSAddress)
 			},
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Services("kube-system").Get(ctx, manifest.(*apiv1.Service).GetName(), metav1.GetOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Services("kube-system").
+					Get(ctx, manifest.(*apiv1.Service).GetName(), metav1.GetOptions{})
 				if err != nil {
 					if apierrors.IsNotFound(err) {
-						_, err = kubeCl.CoreV1().Services("kube-system").Create(ctx, manifest.(*apiv1.Service), metav1.CreateOptions{})
+						_, err = kubeCl.
+							CoreV1().Services("kube-system").
+							Create(ctx, manifest.(*apiv1.Service), metav1.CreateOptions{})
 						if err != nil && strings.Contains(err.Error(), "provided IP is already allocated") {
 							log.InfoLn("Service for DNS already exists. Skip!")
 							return nil
@@ -545,10 +621,14 @@ func CreateDeckhouseManifests(
 				} else {
 					log.InfoLn("Already exists. Skip!")
 				}
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Services("kube-system").Update(ctx, manifest.(*apiv1.Service), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Services("kube-system").
+					Update(ctx, manifest.(*apiv1.Service), metav1.UpdateOptions{})
+
 				return err
 			},
 		})
@@ -584,13 +664,19 @@ func CreateDeckhouseManifests(
 		}
 	}
 
-	err = log.Process("default", "Create Manifests", func() error {
+	err = log.ProcessCtx(ctx, "default", "Create Manifests", func(ctx context.Context) error {
 		for _, task := range tasks {
-			err := retry.NewSilentLoop(task.Name, 60, 5*time.Second).RunContext(ctx, task.CreateOrUpdate)
+			err := retry.NewSilentLoop(task.Name, 60, 5*time.Second).RunContext(
+				ctx,
+				func() error {
+					return task.CreateOrUpdate(ctx)
+				},
+			)
 			if err != nil {
 				return err
 			}
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -605,7 +691,7 @@ func WaitForReadiness(ctx context.Context, kubeCl *client.KubernetesClient) erro
 }
 
 func WaitForReadinessNotOnNode(ctx context.Context, kubeCl *client.KubernetesClient, excludeNode string) error {
-	return log.Process("default", "Waiting for Deckhouse to become Ready", func() error {
+	return log.ProcessCtx(ctx, "default", "Waiting for Deckhouse to become Ready", func(ctx context.Context) error {
 		ctx, cancel := context.WithTimeout(ctx, app.DeckhouseTimeout)
 		defer cancel()
 
@@ -640,7 +726,9 @@ func WaitForReadinessNotOnNode(ctx context.Context, kubeCl *client.KubernetesCli
 func CreateDeckhouseDeployment(ctx context.Context, kubeCl *client.KubernetesClient, cfg *config.DeckhouseInstaller) error {
 	task := controllerDeploymentTask(ctx, kubeCl, cfg)
 
-	return log.Process("default", "Create Deployment", task.CreateOrUpdate)
+	return log.ProcessCtx(ctx, "default", "Create Deployment", func(ctx context.Context) error {
+		return task.CreateOrUpdate(ctx)
+	})
 }
 
 func deckhouseDeploymentParamsFromCfg(cfg *config.DeckhouseInstaller) manifests.DeckhouseDeploymentParams {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
@@ -50,10 +50,11 @@ func createModuleConfigManifestTask(ctx context.Context, kubeCl *client.Kubernet
 		Manifest: func() interface{} {
 			return mcUnstruct
 		},
-		CreateFunc: func(manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
 			if createMsg != "" {
 				log.InfoLn(createMsg)
 			}
+
 			// fake client does not support cache
 			if _, ok := os.LookupEnv("DHCTL_TEST"); !ok {
 				// need for invalidate cache
@@ -76,7 +77,7 @@ func createModuleConfigManifestTask(ctx context.Context, kubeCl *client.Kubernet
 
 			return err
 		},
-		UpdateFunc: func(manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 			// fake client does not support cache
 			if _, ok := os.LookupEnv("DHCTL_TEST"); !ok {
 				// need for invalidate cache
@@ -88,14 +89,17 @@ func createModuleConfigManifestTask(ctx context.Context, kubeCl *client.Kubernet
 
 			newManifest := manifest.(*unstructured.Unstructured)
 
-			oldManifest, err := kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Get(ctx, newManifest.GetName(), metav1.GetOptions{})
+			oldManifest, err := kubeCl.
+				Dynamic().Resource(config.ModuleConfigGVR).
+				Get(ctx, newManifest.GetName(), metav1.GetOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				log.DebugF("Error getting mc: %v\n", err)
 			} else {
 				newManifest.SetResourceVersion(oldManifest.GetResourceVersion())
 			}
 
-			_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).
+			_, err = kubeCl.
+				Dynamic().Resource(config.ModuleConfigGVR).
 				Update(ctx, newManifest, metav1.UpdateOptions{})
 			if err != nil {
 				log.InfoF("Do not updating mc: %v\n", err)

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -65,7 +65,8 @@ func GetCloudConfig(ctx context.Context, kubeCl *client.KubernetesClient, nodeGr
 	var cloudData string
 
 	name := fmt.Sprintf("Waiting for %s cloud config️", nodeGroupName)
-	err := logger.LogProcess("default", name, func() error {
+
+	return cloudData, logger.LogProcessCtx(ctx, "default", name, func(ctx context.Context) error {
 		if showDeckhouseLogs {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
@@ -145,7 +146,6 @@ func GetCloudConfig(ctx context.Context, kubeCl *client.KubernetesClient, nodeGr
 		logger.LogInfoLn("Cloud configuration found!")
 		return nil
 	})
-	return cloudData, err
 }
 
 func CreateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string, logger log.Logger, data map[string]interface{}) error {

--- a/dhctl/pkg/kubernetes/actions/manager/infrastructure_auto_converger.go
+++ b/dhctl/pkg/kubernetes/actions/manager/infrastructure_auto_converger.go
@@ -22,7 +22,7 @@ import (
 )
 
 func RestartAutoConverger(ctx context.Context, kubeClProvider kubernetes.KubeClientProvider) error {
-	return log.Process("default", "Restart auto converger", func() error {
+	return log.ProcessCtx(ctx, "default", "Restart auto converger", func(ctx context.Context) error {
 		return checkAndRestartDeployment(ctx, kubeClProvider, "terraform-auto-converger")
 	})
 }

--- a/dhctl/pkg/kubernetes/actions/manager/infrastructure_state_ckecher.go
+++ b/dhctl/pkg/kubernetes/actions/manager/infrastructure_state_ckecher.go
@@ -22,7 +22,7 @@ import (
 )
 
 func RestartStateExporter(ctx context.Context, kubeClProvider kubernetes.KubeClientProvider) error {
-	return log.Process("default", "Restart state exporter", func() error {
+	return log.ProcessCtx(ctx, "default", "Restart state exporter", func(ctx context.Context) error {
 		return checkAndRestartDeployment(ctx, kubeClProvider, "terraform-state-exporter")
 	})
 }

--- a/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
+++ b/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
@@ -261,7 +261,7 @@ func (n *clusterIsBootstrapCheck) IsReady(ctx context.Context) (bool, error) {
 	}
 
 	if len(n.outputNodeGroups(ctx)) > 0 {
-		_ = logger.LogProcess("Create Resources", "NodeGroups status", func() error {
+		_ = logger.LogProcessCtx(ctx, "Create Resources", "NodeGroups status", func(ctx context.Context) error {
 			logger.LogInfoLn(n.outputNodeGroups(ctx))
 			return nil
 		})

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -265,13 +265,13 @@ func (c *Creator) createSingleResource(ctx context.Context, resource *template.R
 		manifestTask := actions.ManifestTask{
 			Name:     getUnstructuredName(docCopy),
 			Manifest: func() interface{} { return nil },
-			CreateFunc: func(manifest interface{}) error {
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
 				_, err := c.kubeCl.Dynamic().Resource(*gvr).
 					Namespace(namespace).
 					Create(ctx, docCopy, metav1.CreateOptions{})
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 				content, err := docCopy.MarshalJSON()
 				if err != nil {
 					return err
@@ -284,12 +284,13 @@ func (c *Creator) createSingleResource(ctx context.Context, resource *template.R
 			},
 		}
 
-		err := manifestTask.CreateOrUpdateSilent()
+		err := manifestTask.CreateOrUpdateSilent(ctx)
 		if err != nil {
 			if strings.Contains(err.Error(), "the server could not find the requested resource") {
 				c.kubeCl.InvalidateDiscoveryCache()
 			}
 		}
+
 		return err
 	})
 }
@@ -321,7 +322,7 @@ func CreateResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, r
 		}
 	}
 
-	_ = log.Process("Create Resources", "Resources to create", func() error {
+	_ = log.ProcessCtx(ctx, "Create Resources", "Resources to create", func(ctx context.Context) error {
 		log.InfoF("%s\n", strings.Join(resourcesToCreate, "\n"))
 		return nil
 	})
@@ -349,7 +350,7 @@ func CreateResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, r
 			if len(createdResources) > 0 {
 				msg["created"] = createdResources
 			}
-			logResources(msg)
+			logResources(ctx, msg)
 		}
 		if ready && err == nil {
 			return nil
@@ -358,7 +359,7 @@ func CreateResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, r
 		select {
 		case <-endChannel:
 			if len(resources) > 0 {
-				_ = log.Process("Create Resources", "Failed to create", func() error {
+				_ = log.ProcessCtx(ctx, "Create Resources", "Failed to create", func(ctx context.Context) error {
 					log.WarnF("%s\n", strings.Join(remained, "\n"))
 					return nil
 				})
@@ -377,8 +378,8 @@ func CreateResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, r
 	}
 }
 
-func logResources(res map[string][]string) {
-	_ = log.Process("Create Resources", "Resource readiness check", func() error {
+func logResources(ctx context.Context, res map[string][]string) {
+	_ = log.ProcessCtx(ctx, "Create Resources", "Resource readiness check", func(ctx context.Context) error {
 		remained, ok := res["remained"]
 		if ok {
 			for i, s := range remained {
@@ -386,11 +387,12 @@ func logResources(res map[string][]string) {
 					remained = slices.Delete(remained, i, i+1)
 				}
 			}
-			_ = log.Process("Create Resources", "Resource not ready", func() error {
+			_ = log.ProcessCtx(ctx, "Create Resources", "Resource not ready", func(ctx context.Context) error {
 				log.InfoF("%s\n", strings.Join(remained, "\n"))
 				return nil
 			})
 		}
+
 		created, ok := res["created"]
 		if ok {
 			for i, s := range created {
@@ -398,7 +400,7 @@ func logResources(res map[string][]string) {
 					created = slices.Delete(created, i, i+1)
 				}
 			}
-			_ = log.Process("Create Resources", "Resource ready", func() error {
+			_ = log.ProcessCtx(ctx, "Create Resources", "Resource ready", func(ctx context.Context) error {
 				log.InfoF("%s\n", strings.Join(created, "\n"))
 				return nil
 			})

--- a/dhctl/pkg/kubernetes/actions/task.go
+++ b/dhctl/pkg/kubernetes/actions/task.go
@@ -15,6 +15,7 @@
 package actions
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -26,26 +27,26 @@ import (
 
 type ManifestTask struct {
 	Name       string
-	CreateFunc func(manifest interface{}) error
-	UpdateFunc func(manifest interface{}) error
+	CreateFunc func(ctx context.Context, manifest interface{}) error
+	UpdateFunc func(ctx context.Context, manifest interface{}) error
 	Manifest   func() interface{}
 	PatchData  func() interface{}
-	PatchFunc  func(patchData []byte) error
+	PatchFunc  func(ctx context.Context, patchData []byte) error
 }
 
 // CreateOrUpdate tries to create resource with the CreateFunc. If resource is already
 // exists, it updates the resource with the UpdateFunc.
-func (task *ManifestTask) CreateOrUpdate() error {
+func (task *ManifestTask) CreateOrUpdate(ctx context.Context) error {
 	log.InfoF("Manifest for %s\n", task.Name)
 	manifest := task.Manifest()
 
-	err := task.CreateFunc(manifest)
+	err := task.CreateFunc(ctx, manifest)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("create resource: %v", err)
 		}
 		log.InfoF("%s already exists. Trying to update ... ", task.Name)
-		err = task.UpdateFunc(manifest)
+		err = task.UpdateFunc(ctx, manifest)
 		if err != nil {
 			log.ErrorLn("ERROR!")
 			return fmt.Errorf("update resource: %v", err)
@@ -55,17 +56,17 @@ func (task *ManifestTask) CreateOrUpdate() error {
 	return nil
 }
 
-func (task *ManifestTask) CreateOrUpdateSilent() error {
+func (task *ManifestTask) CreateOrUpdateSilent(ctx context.Context) error {
 	log.DebugF("Manifest for %s\n", task.Name)
 	manifest := task.Manifest()
 
-	err := task.CreateFunc(manifest)
+	err := task.CreateFunc(ctx, manifest)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("create resource: %v", err)
 		}
 		log.DebugF("%s already exists. Trying to update ... ", task.Name)
-		err = task.UpdateFunc(manifest)
+		err = task.UpdateFunc(ctx, manifest)
 		if err != nil {
 			log.ErrorLn("ERROR!")
 			return fmt.Errorf("update resource: %v", err)
@@ -75,7 +76,7 @@ func (task *ManifestTask) CreateOrUpdateSilent() error {
 	return nil
 }
 
-func (task *ManifestTask) Patch() error {
+func (task *ManifestTask) Patch(ctx context.Context) error {
 	log.DebugF("Patch for %s\n", task.Name)
 	patchData := task.PatchData()
 
@@ -84,7 +85,7 @@ func (task *ManifestTask) Patch() error {
 		return fmt.Errorf("marshal patch data: %v", err)
 	}
 
-	err = task.PatchFunc(patchBytes)
+	err = task.PatchFunc(ctx, patchBytes)
 	if err != nil {
 		return fmt.Errorf("Apply patch: %v", err)
 	}
@@ -92,7 +93,7 @@ func (task *ManifestTask) Patch() error {
 	return nil
 }
 
-func (task *ManifestTask) PatchOrCreate() error {
+func (task *ManifestTask) PatchOrCreate(ctx context.Context) error {
 	log.DebugF("Patch or create for %s\n", task.Name)
 	patchData := task.PatchData()
 
@@ -101,7 +102,7 @@ func (task *ManifestTask) PatchOrCreate() error {
 		return fmt.Errorf("marshal patch data: %v", err)
 	}
 
-	err = task.PatchFunc(patchBytes)
+	err = task.PatchFunc(ctx, patchBytes)
 	if err == nil {
 		return nil
 	}
@@ -112,7 +113,7 @@ func (task *ManifestTask) PatchOrCreate() error {
 
 	log.DebugF("%s is not found. Trying to create ... \n", task.Name)
 	manifest := task.Manifest()
-	err = task.CreateFunc(manifest)
+	err = task.CreateFunc(ctx, manifest)
 	if err != nil {
 		return fmt.Errorf("Create '%s': %v", task.Name, err)
 	}

--- a/dhctl/pkg/kubernetes/client/state_cache.go
+++ b/dhctl/pkg/kubernetes/client/state_cache.go
@@ -59,8 +59,8 @@ func NewK8sStateCache(client *KubernetesClient, namespace, secretName, tmpDir st
 	}
 }
 
-func (c *StateCache) Init() error {
-	_, err := c.populateSecret()
+func (c *StateCache) Init(ctx context.Context) error {
+	_, err := c.populateSecret(ctx)
 	return err
 }
 
@@ -69,8 +69,8 @@ func (c *StateCache) WithLabels(labels map[string]string) *StateCache {
 	return c
 }
 
-func (c *StateCache) getSecret() (*v1.Secret, error) {
-	s, err := c.populateSecret()
+func (c *StateCache) getSecret(ctx context.Context) (*v1.Secret, error) {
+	s, err := c.populateSecret(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -82,12 +82,14 @@ func (c *StateCache) getSecret() (*v1.Secret, error) {
 	return s, nil
 }
 
-func (c *StateCache) populateSecret() (*v1.Secret, error) {
+func (c *StateCache) populateSecret(ctx context.Context) (*v1.Secret, error) {
 	var secret *v1.Secret
 	var lastError error
+
 	err := retry.NewSilentLoop("get cache secret", 3, 2*time.Second).Run(func() error {
 		var err error
-		secret, err = c.secretsAPI.Get(context.TODO(), c.secretName, metav1.GetOptions{})
+
+		secret, err = c.secretsAPI.Get(ctx, c.secretName, metav1.GetOptions{})
 		if err == nil {
 			return nil
 		}
@@ -133,7 +135,7 @@ func (c *StateCache) populateSecret() (*v1.Secret, error) {
 			Data: map[string][]byte{},
 		}
 
-		secret, err = c.secretsAPI.Create(context.TODO(), secretToCreate, metav1.CreateOptions{})
+		secret, err = c.secretsAPI.Create(ctx, secretToCreate, metav1.CreateOptions{})
 		if err == nil || apierrors.IsAlreadyExists(err) {
 			return nil
 		}
@@ -149,16 +151,16 @@ func (c *StateCache) populateSecret() (*v1.Secret, error) {
 	return secret, nil
 }
 
-func (c *StateCache) update(action func(map[string][]byte) map[string][]byte) error {
+func (c *StateCache) update(ctx context.Context, action func(map[string][]byte) map[string][]byte) error {
 	return kuberetry.RetryOnConflict(kuberetry.DefaultBackoff, func() error {
-		s, err := c.getSecret()
+		s, err := c.getSecret(ctx)
 		if err != nil {
 			return err
 		}
 
 		s.Data = action(s.Data)
 
-		_, err = c.secretsAPI.Update(context.TODO(), s, metav1.UpdateOptions{})
+		_, err = c.secretsAPI.Update(ctx, s, metav1.UpdateOptions{})
 
 		return err
 	})
@@ -183,27 +185,30 @@ func (c *StateCache) prepareContent(content []byte) []byte {
 	return buf
 }
 
-func (c *StateCache) Save(name string, content []byte) error {
+func (c *StateCache) Save(ctx context.Context, name string, content []byte) error {
 	buf := c.prepareContent(content)
 
-	return c.update(func(curState map[string][]byte) map[string][]byte {
-		curState[name] = buf
-		return curState
-	})
+	return c.update(
+		ctx,
+		func(curState map[string][]byte) map[string][]byte {
+			curState[name] = buf
+			return curState
+		},
+	)
 }
 
-func (c *StateCache) SaveStruct(name string, v interface{}) error {
+func (c *StateCache) SaveStruct(ctx context.Context, name string, v interface{}) error {
 	b := new(bytes.Buffer)
 	err := gob.NewEncoder(b).Encode(v)
 	if err != nil {
 		return err
 	}
 
-	return c.Save(name, b.Bytes())
+	return c.Save(ctx, name, b.Bytes())
 }
 
-func (c *StateCache) Load(name string) ([]byte, error) {
-	s, err := c.getSecret()
+func (c *StateCache) Load(ctx context.Context, name string) ([]byte, error) {
+	s, err := c.getSecret(ctx)
 	if err != nil {
 		log.ErrorF("Cannot get secret %s val %v\n", name, err)
 		return nil, err
@@ -212,8 +217,8 @@ func (c *StateCache) Load(name string) ([]byte, error) {
 	return c.get(s, name)
 }
 
-func (c *StateCache) LoadStruct(name string, v interface{}) error {
-	d, err := c.Load(name)
+func (c *StateCache) LoadStruct(ctx context.Context, name string, v interface{}) error {
+	d, err := c.Load(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -221,49 +226,55 @@ func (c *StateCache) LoadStruct(name string, v interface{}) error {
 	return gob.NewDecoder(bytes.NewBuffer(d)).Decode(v)
 }
 
-func (c *StateCache) Delete(name string) {
-	err := c.update(func(curState map[string][]byte) map[string][]byte {
-		delete(curState, name)
+func (c *StateCache) Delete(ctx context.Context, name string) {
+	err := c.update(
+		ctx,
+		func(curState map[string][]byte) map[string][]byte {
+			delete(curState, name)
 
-		return curState
-	})
+			return curState
+		},
+	)
 	if err != nil {
 		log.ErrorF("Cannot delete cache %s val %v\n", name, err)
 	}
 }
 
-func (c *StateCache) CleanWithExceptions(excludeKeys ...string) {
-	err := c.update(func(curState map[string][]byte) map[string][]byte {
-		newState := map[string][]byte{
-			state.TombstoneKey: c.prepareContent([]byte("yes")),
-		}
-
-		for _, k := range excludeKeys {
-			v, ok := curState[k]
-			if !ok {
-				continue
+func (c *StateCache) CleanWithExceptions(ctx context.Context, excludeKeys ...string) {
+	err := c.update(
+		ctx,
+		func(curState map[string][]byte) map[string][]byte {
+			newState := map[string][]byte{
+				state.TombstoneKey: c.prepareContent([]byte("yes")),
 			}
 
-			newState[k] = v
-		}
+			for _, k := range excludeKeys {
+				v, ok := curState[k]
+				if !ok {
+					continue
+				}
 
-		return newState
-	})
+				newState[k] = v
+			}
+
+			return newState
+		},
+	)
 	if err != nil {
 		log.ErrorF("Cannot clean cache %v\n", err)
 	}
 }
 
-func (c *StateCache) Clean() {
-	c.CleanWithExceptions()
+func (c *StateCache) Clean(ctx context.Context) {
+	c.CleanWithExceptions(ctx)
 }
 
 func (c *StateCache) GetPath(name string) string {
 	return filepath.Join(c.tmpDir, name)
 }
 
-func (c *StateCache) Iterate(action func(string, []byte) error) error {
-	s, err := c.getSecret()
+func (c *StateCache) Iterate(ctx context.Context, action func(string, []byte) error) error {
+	s, err := c.getSecret(ctx)
 	if err != nil {
 		return err
 	}
@@ -296,8 +307,8 @@ func (c *StateCache) Iterate(action func(string, []byte) error) error {
 	return nil
 }
 
-func (c *StateCache) InCache(name string) (bool, error) {
-	s, err := c.getSecret()
+func (c *StateCache) InCache(ctx context.Context, name string) (bool, error) {
+	s, err := c.getSecret(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/dhctl/pkg/kubernetes/client/state_cache_test.go
+++ b/dhctl/pkg/kubernetes/client/state_cache_test.go
@@ -42,7 +42,7 @@ func TestDeckhouseInstall(t *testing.T) {
 		k8sCache := NewK8sStateCache(fakeClient, namespace, name, "/tmp/dhctl_tst").
 			WithLabels(additionalLabels)
 
-		err := k8sCache.Init()
+		err := k8sCache.Init(t.Context())
 		require.NoError(t, err)
 
 		secret, err := fakeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
@@ -80,7 +80,7 @@ func TestDeckhouseInstall(t *testing.T) {
 		require.NoError(t, err)
 
 		k8sCache := NewK8sStateCache(fakeClient, namespace, name, "/tmp/dhctl_tst")
-		err = k8sCache.Init()
+		err = k8sCache.Init(t.Context())
 		require.NoError(t, err)
 
 		list, err := fakeClient.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelKey("state")})
@@ -92,7 +92,7 @@ func TestDeckhouseInstall(t *testing.T) {
 		fakeClient := NewFakeKubernetesClient()
 
 		cacheState := NewK8sStateCache(fakeClient, "tsts", "state", "/tmp/dhctl_tst")
-		err := cacheState.Init()
+		err := cacheState.Init(t.Context())
 		require.NoError(t, err)
 
 		tests.RunStateCacheTests(t, cacheState)

--- a/dhctl/pkg/kubernetes/kube.go
+++ b/dhctl/pkg/kubernetes/kube.go
@@ -82,7 +82,8 @@ func GetMasterNodeGroupLabelSelector(selectors ...LabelSelector) (string, error)
 
 func ConnectToKubernetesAPI(ctx context.Context, nodeInterface node.Interface) (*client.KubernetesClient, error) {
 	var kubeCl *client.KubernetesClient
-	err := log.Process("common", "Connect to Kubernetes API", func() error {
+
+	err := log.ProcessCtx(ctx, "common", "Connect to Kubernetes API", func(ctx context.Context) error {
 		if wrapper, ok := nodeInterface.(*ssh.NodeInterfaceWrapper); ok && wrapper != nil {
 			if err := wrapper.Client().Check().WithDelaySeconds(1).AwaitAvailability(ctx); err != nil {
 				return fmt.Errorf("await master available: %v", err)
@@ -109,6 +110,7 @@ func ConnectToKubernetesAPI(ctx context.Context, nodeInterface node.Interface) (
 
 		return nil
 	})
+
 	if err != nil {
 		return nil, fmt.Errorf("start kubernetes proxy: %v", err)
 	}

--- a/dhctl/pkg/log/deprecated.go
+++ b/dhctl/pkg/log/deprecated.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 
@@ -118,6 +119,13 @@ func (d *DummyLogger) CreateBufferLogger(buffer *bytes.Buffer) Logger {
 
 func (d *DummyLogger) FlushAndClose() error {
 	return nil
+}
+
+func (d *DummyLogger) LogProcessCtx(ctx context.Context, p, t string, run func(ctx context.Context) error) error {
+	fmt.Println(t)
+	err := run(ctx)
+	fmt.Println(t)
+	return err
 }
 
 func (d *DummyLogger) LogProcess(_, t string, run func() error) error {

--- a/dhctl/pkg/log/deprecated_in_memory.go
+++ b/dhctl/pkg/log/deprecated_in_memory.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"regexp"
@@ -145,6 +146,13 @@ func (l *InMemoryLogger) AllMatches(m *Match) ([]string, error) {
 
 func (l *InMemoryLogger) FlushAndClose() error {
 	return nil
+}
+
+func (l *InMemoryLogger) LogProcessCtx(ctx context.Context, p string, t string, action func(ctx context.Context) error) error {
+	l.writeEntityFormatted("Start process: %s/%s", p, t)
+	err := l.parent.LogProcessCtx(ctx, p, t, action)
+	l.writeEntityFormatted("End process: %s/%s", p, t)
+	return err
 }
 
 func (l *InMemoryLogger) LogProcess(p string, t string, action func() error) error {

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"io"
 
 	external "github.com/deckhouse/lib-dhctl/pkg/log"
@@ -43,6 +44,7 @@ const (
 type Logger interface {
 	FlushAndClose() error
 
+	LogProcessCtx(context.Context, string, string, func(context.Context) error) error
 	LogProcess(string, string, func() error) error
 
 	LogInfoF(format string, a ...interface{})
@@ -225,6 +227,13 @@ func (e *ExternalLogger) FlushAndClose() error {
 	return e.logger.FlushAndClose()
 }
 
+// todo: refactor in lib-dhctl too
+func (e *ExternalLogger) LogProcessCtx(ctx context.Context, p, t string, run func(ctx context.Context) error) error {
+	return e.logger.Process(external.Process(p), t, func() error {
+		return run(ctx)
+	})
+}
+
 func (e *ExternalLogger) LogProcess(p, t string, run func() error) error {
 	return e.logger.Process(external.Process(p), t, run)
 }
@@ -283,6 +292,10 @@ func (e *ExternalLogger) Write(content []byte) (int, error) {
 
 func FlushAndClose() error {
 	return defaultLogger.FlushAndClose()
+}
+
+func ProcessCtx(ctx context.Context, p, t string, run func(ctx context.Context) error) error {
+	return defaultLogger.LogProcessCtx(ctx, p, t, run)
 }
 
 func Process(p, t string, run func() error) error {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -69,7 +69,7 @@ func (b *ClusterBootstrapper) initSSHClient(ctx context.Context) error {
 	sshClient := wrapper.Client()
 
 	if len(sshClient.Session().AvailableHosts()) == 0 {
-		mastersIPs, err := state.GetMasterHostsIPs(cache.Global())
+		mastersIPs, err := state.GetMasterHostsIPs(ctx, cache.Global())
 		if err != nil {
 			log.ErrorF("Can not load available ssh hosts: %v\n", err)
 			return err
@@ -79,7 +79,7 @@ func (b *ClusterBootstrapper) initSSHClient(ctx context.Context) error {
 		}
 	}
 
-	bastionHost, err := GetBastionHostFromCache()
+	bastionHost, err := GetBastionHostFromCache(ctx)
 	if err != nil {
 		log.ErrorF("Can not load bastion host: %v\n", err)
 		return fmt.Errorf("unable to load bastion host: %w", err)
@@ -120,19 +120,19 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 
 	cachePath := metaConfig.CachePath()
 	log.InfoF("State config for prefix %s:  %s\n", metaConfig.ClusterPrefix, cachePath)
-	if err = cache.InitWithOptions(cachePath, cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
+	if err = cache.InitWithOptions(ctx, cachePath, cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
 		return fmt.Errorf(bootstrapAbortInvalidCacheMessage, cachePath, err)
 	}
 	stateCache := cache.Global()
 
-	if err := b.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
+	if err := b.PhasedExecutionContext.InitPipeline(ctx, stateCache); err != nil {
 		return err
 	}
 	defer func() {
-		_ = b.PhasedExecutionContext.Finalize(stateCache)
+		_ = b.PhasedExecutionContext.Finalize(ctx, stateCache)
 	}()
 
-	hasUUID, err := stateCache.InCache("uuid")
+	hasUUID, err := stateCache.InCache(ctx, "uuid")
 	if err != nil {
 		return fmt.Errorf("unable to check uuid: %w", err)
 	}
@@ -146,7 +146,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 	}
 
 	err = log.ProcessCtx(ctx, "common", "Get cluster UUID from the cache", func(ctx context.Context) error {
-		uuid, err := stateCache.Load("uuid")
+		uuid, err := stateCache.Load(ctx, "uuid")
 		if err != nil {
 			return err
 		}
@@ -182,8 +182,8 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 
 	bootstrapState := NewBootstrapState(stateCache)
 
-	err = log.Process("common", "Choice abort type", func() error {
-		ok, err := bootstrapState.IsManifestsCreated()
+	err = log.ProcessCtx(ctx, "common", "Choice abort type", func(ctx context.Context) error {
+		ok, err := bootstrapState.IsManifestsCreated(ctx)
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 
 		if !b.CommanderMode {
 			if wrapper, ok := b.NodeInterface.(*ssh.NodeInterfaceWrapper); ok {
-				if err = cache.InitWithOptions(wrapper.Client().Check().String(), cache.CacheOptions{}); err != nil {
+				if err = cache.InitWithOptions(ctx, wrapper.Client().Check().String(), cache.CacheOptions{}); err != nil {
 					return fmt.Errorf(bootstrapAbortInvalidCacheMessage, wrapper.Client().Check().String(), err)
 				}
 			}
@@ -299,15 +299,15 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 		b.lastState = b.PhasedExecutionContext.GetLastState()
 		return err
 	}
-	if err := b.PhasedExecutionContext.CompletePipeline(stateCache); err != nil {
+	if err := b.PhasedExecutionContext.CompletePipeline(ctx, stateCache); err != nil {
 		b.lastState = b.PhasedExecutionContext.GetLastState()
 		return err
 	}
 	b.lastState = b.PhasedExecutionContext.GetLastState()
 
-	stateCache.Clean()
+	stateCache.Clean(ctx)
 	// Allow to reuse cache because cluster will be bootstrapped again (probably)
-	stateCache.Delete(state.TombstoneKey)
+	stateCache.Delete(ctx, state.TombstoneKey)
 
 	return nil
 }

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -48,10 +48,12 @@ func (b *ClusterBootstrapper) Abort(ctx context.Context, forceAbortFromCache boo
 		log.WarnLn(bootstrapAbortCheckMessage)
 	}
 
-	return log.Process("bootstrap", "Abort", func() error { return b.doRunBootstrapAbort(ctx, forceAbortFromCache) })
+	return log.ProcessCtx(ctx, "bootstrap", "Abort", func(ctx context.Context) error {
+		return b.doRunBootstrapAbort(ctx, forceAbortFromCache)
+	})
 }
 
-func (b *ClusterBootstrapper) initSSHClient() error {
+func (b *ClusterBootstrapper) initSSHClient(ctx context.Context) error {
 	wrapper, ok := b.NodeInterface.(*ssh.NodeInterfaceWrapper)
 	if !ok {
 		return nil // Local runs don't use ssh client.
@@ -143,7 +145,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 		return fmt.Errorf("No UUID found in the cache. Perhaps, the cluster was already bootstrapped.")
 	}
 
-	err = log.Process("common", "Get cluster UUID from the cache", func() error {
+	err = log.ProcessCtx(ctx, "common", "Get cluster UUID from the cache", func(ctx context.Context) error {
 		uuid, err := stateCache.Load("uuid")
 		if err != nil {
 			return err
@@ -157,7 +159,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 	}
 
 	// init ssh client is safe if master hosts not found (error in base infra)
-	if err := b.initSSHClient(); err != nil {
+	if err := b.initSSHClient(ctx); err != nil {
 		return err
 	}
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
@@ -58,7 +58,7 @@ func (b *ClusterBootstrapper) BaseInfrastructure(ctx context.Context) error {
 	}
 
 	cachePath := metaConfig.CachePath()
-	if err = cache.InitWithOptions(cachePath, cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
+	if err = cache.InitWithOptions(ctx, cachePath, cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
 		// TODO: it's better to ask for confirmation here
 		return fmt.Errorf(cacheMessage, cachePath, err)
 	}
@@ -66,8 +66,8 @@ func (b *ClusterBootstrapper) BaseInfrastructure(ctx context.Context) error {
 	stateCache := cache.Global()
 
 	if app.DropCache {
-		stateCache.Clean()
-		stateCache.Delete(state.TombstoneKey)
+		stateCache.Clean(ctx)
+		stateCache.Delete(ctx, state.TombstoneKey)
 	}
 
 	clusterUUID, err := generateClusterUUID(ctx, stateCache)

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
@@ -70,7 +70,7 @@ func (b *ClusterBootstrapper) BaseInfrastructure(ctx context.Context) error {
 		stateCache.Delete(state.TombstoneKey)
 	}
 
-	clusterUUID, err := generateClusterUUID(stateCache)
+	clusterUUID, err := generateClusterUUID(ctx, stateCache)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (b *ClusterBootstrapper) BaseInfrastructure(ctx context.Context) error {
 
 	defer cleanup()
 
-	return log.Process("bootstrap", "Cloud infrastructure", func() error {
+	return log.ProcessCtx(ctx, "bootstrap", "Cloud infrastructure", func(ctx context.Context) error {
 		baseRunner, err := b.Params.InfrastructureContext.GetBootstrapBaseInfraRunner(ctx, metaConfig, stateCache)
 		if err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-bashible.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-bashible.go
@@ -41,8 +41,7 @@ func (b *ClusterBootstrapper) ExecuteBashible(ctx context.Context) error {
 		return err
 	}
 
-	err = terminal.AskBecomePassword()
-	if err != nil {
+	if err := terminal.AskBecomePassword(); err != nil {
 		return err
 	}
 	if err := terminal.AskBastionPassword(); err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
@@ -43,8 +43,7 @@ func (b *ClusterBootstrapper) InstallDeckhouse(ctx context.Context) error {
 		return err
 	}
 
-	err = metaConfig.LoadInstallerVersion()
-	if err != nil {
+	if err := metaConfig.LoadInstallerVersion(); err != nil {
 		return err
 	}
 
@@ -56,8 +55,7 @@ func (b *ClusterBootstrapper) InstallDeckhouse(ctx context.Context) error {
 	installConfig.KubeadmBootstrap = app.KubeadmBootstrap
 	installConfig.MasterNodeSelector = app.MasterNodeSelector
 
-	err = terminal.AskBecomePassword()
-	if err != nil {
+	if err := terminal.AskBecomePassword(); err != nil {
 		return err
 	}
 	if err := terminal.AskBastionPassword(); err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-post-bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-post-bootstrap.go
@@ -41,7 +41,7 @@ func (b *ClusterBootstrapper) ExecPostBootstrap(ctx context.Context) error {
 		return err
 	}
 
-	if err := cache.InitWithOptions(wrapper.Client().Check().String(), cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
+	if err := cache.InitWithOptions(ctx, wrapper.Client().Check().String(), cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
 		return fmt.Errorf("Can not init cache: %v", err)
 	}
 
@@ -54,7 +54,7 @@ func (b *ClusterBootstrapper) ExecPostBootstrap(ctx context.Context) error {
 		return err
 	}
 
-	out, err := bootstrapState.PostBootstrapScriptResult()
+	out, err := bootstrapState.PostBootstrapScriptResult(ctx)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
@@ -76,11 +76,12 @@ func (b *ClusterBootstrapper) CreateResources(ctx context.Context) error {
 		}
 	}
 
-	return log.Process("bootstrap", "Create resources", func() error {
+	return log.ProcessCtx(ctx, "bootstrap", "Create resources", func(ctx context.Context) error {
 		kubeCl, err := kubernetes.ConnectToKubernetesAPI(ctx, b.NodeInterface)
 		if err != nil {
 			return err
 		}
+
 		checkers, err := resources.GetCheckers(kubeCl, resourcesToCreate, nil)
 		if err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -161,15 +161,19 @@ func (b *ClusterBootstrapper) applyParams() func() {
 	if len(b.ConfigPaths) > 0 {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.ConfigPaths, b.ConfigPaths))
 	}
+
 	if b.ResourcesTimeout != 0 {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.ResourcesTimeout, b.ResourcesTimeout))
 	}
+
 	if b.DeckhouseTimeout != 0 {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.DeckhouseTimeout, b.DeckhouseTimeout))
 	}
+
 	if b.PostBootstrapScriptPath != "" {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.PostBootstrapScriptPath, b.PostBootstrapScriptPath))
 	}
+
 	if b.UseTfCache != nil {
 		var newValue string
 		if *b.UseTfCache {
@@ -179,14 +183,17 @@ func (b *ClusterBootstrapper) applyParams() func() {
 		}
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.UseTfCache, newValue))
 	}
+
 	if b.AutoApprove != nil {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.SanityCheck, *b.AutoApprove))
 	}
+
 	if b.KubernetesInitParams != nil {
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.KubeConfigInCluster, b.KubernetesInitParams.KubeConfigInCluster))
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.KubeConfig, b.KubernetesInitParams.KubeConfig))
 		restoreFuncs = append(restoreFuncs, setWithRestore(&app.KubeConfigContext, b.KubernetesInitParams.KubeConfigContext))
 	}
+
 	return restoreFunc
 }
 
@@ -309,7 +316,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 
 	// next init cache
 	cachePath := metaConfig.CachePath()
-	if err = cache.InitWithOptions(cachePath, cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
+	if err = cache.InitWithOptions(ctx, cachePath, cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState}); err != nil {
 		// TODO: it's better to ask for confirmation here
 		return fmt.Errorf(cacheMessage, cachePath, err)
 	}
@@ -318,18 +325,18 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	configHash := state.ConfigHash(app.ConfigPaths)
 
 	if app.DropCache {
-		stateCache.Clean()
-		stateCache.Delete(state.TombstoneKey)
+		stateCache.Clean(ctx)
+		stateCache.Delete(ctx, state.TombstoneKey)
 		log.DebugLn("Cache was dropped")
 	}
 
-	if err := b.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
+	if err := b.PhasedExecutionContext.InitPipeline(ctx, stateCache); err != nil {
 		return err
 	}
 	// TODO(dhctl-for-commander): pass stateCache externally using params as in Destroyer, this variable will be unneeded then
 	b.lastState = nil
 	defer func() {
-		_ = b.PhasedExecutionContext.Finalize(stateCache)
+		_ = b.PhasedExecutionContext.Finalize(ctx, stateCache)
 	}()
 
 	printBanner()
@@ -362,7 +369,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 
 	bootstrapState := NewBootstrapState(stateCache)
 
-	if shouldStop, err := b.PhasedExecutionContext.StartPhase(phases.BaseInfraPhase, true, stateCache); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.StartPhase(ctx, phases.BaseInfraPhase, true, stateCache); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -403,7 +410,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			return err
 		}
 
-		err = log.Process("bootstrap", "Cloud infrastructure", func() error {
+		err = log.ProcessCtx(ctx, "bootstrap", "Cloud infrastructure", func(ctx context.Context) error {
 			baseRunner, err := b.InfrastructureContext.GetBootstrapBaseInfraRunner(ctx, metaConfig, stateCache)
 			if err != nil {
 				return err
@@ -453,7 +460,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 				sshClient := wrapper.Client()
 				if baseOutputs.BastionHost != "" {
 					sshClient.Session().BastionHost = baseOutputs.BastionHost
-					SaveBastionHostToCache(baseOutputs.BastionHost)
+					SaveBastionHostToCache(ctx, baseOutputs.BastionHost)
 				}
 				sshClient.Session().SetAvailableHosts([]session.Host{{Host: masterOutputs.MasterIPForSSH, Name: masterNodeName}})
 				// aks bastion pass for SSH Client Dial() with password auth
@@ -476,7 +483,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			deckhouseInstallConfig.NodesInfrastructureState[masterNodeName] = masterOutputs.InfrastructureState
 
 			masterAddressesForSSH[masterNodeName] = masterOutputs.MasterIPForSSH
-			state.SaveMasterHostsToCache(stateCache, masterAddressesForSSH)
+			state.SaveMasterHostsToCache(ctx, stateCache, masterAddressesForSSH)
 			return nil
 		})
 		if err != nil {
@@ -511,12 +518,16 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		if wrapper, ok := b.NodeInterface.(*ssh.NodeInterfaceWrapper); ok {
 			sshClient := wrapper.Client()
 			if sshClient.Session().BastionHost != "" {
-				SaveBastionHostToCache(sshClient.Session().BastionHost)
+				SaveBastionHostToCache(ctx, sshClient.Session().BastionHost)
 			}
 
-			state.SaveMasterHostsToCache(stateCache, map[string]string{
-				"first-master": sshClient.Session().Host(),
-			})
+			state.SaveMasterHostsToCache(
+				ctx,
+				stateCache,
+				map[string]string{
+					"first-master": sshClient.Session().Host(),
+				},
+			)
 		}
 	}
 
@@ -537,7 +548,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		resourcesToCreateAfterDeckhouseBootstrap = after
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.RegistryPackagesProxyPhase, false, stateCache, nil); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.RegistryPackagesProxyPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -549,7 +560,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		}
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecuteBashibleBundlePhase, false, stateCache, nil); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.ExecuteBashibleBundlePhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -569,7 +580,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		return err
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.InstallDeckhousePhase, false, stateCache, nil); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.InstallDeckhousePhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -604,7 +615,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	b.PhasedExecutionContext.CompleteSubPhase(phases.InstallDeckhouseSubPhaseWait)
 
 	if metaConfig.ClusterType == config.CloudClusterType {
-		if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.InstallAdditionalMastersAndStaticNodes, true, stateCache, nil); err != nil {
+		if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.InstallAdditionalMastersAndStaticNodes, true, stateCache, nil); err != nil {
 			return err
 		} else if shouldStop {
 			return nil
@@ -614,7 +625,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			if b.CommanderMode {
 				return action()
 			}
-			return lock.NewInLockLocalRunner(kubernetes.NewSimpleKubeClientGetter(kubeCl), "local-bootstraper").
+			return lock.NewInLockLocalRunner(ctx, kubernetes.NewSimpleKubeClientGetter(kubeCl), "local-bootstraper").
 				Run(ctx, action)
 		}
 
@@ -626,7 +637,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		}
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.CreateResourcesPhase, false, stateCache, nil); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.CreateResourcesPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -641,7 +652,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		return err
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.ExecPostBootstrapPhase, false, stateCache, nil); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.ExecPostBootstrapPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -657,7 +668,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		}
 	}
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(phases.FinalizationPhase, false, stateCache, nil); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.FinalizationPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -668,8 +679,9 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	}
 
 	if !b.DisableBootstrapClearCache {
-		_ = log.Process("bootstrap", "Clear cache", func() error {
+		_ = log.ProcessCtx(ctx, "bootstrap", "Clear cache", func(ctx context.Context) error {
 			cache.Global().CleanWithExceptions(
+				ctx,
 				state.MasterHostsCacheKey,
 				ManifestCreatedInClusterCacheKey,
 				BastionHostCacheKey,
@@ -683,7 +695,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	log.Success("Deckhouse cluster was created successfully!\n")
 
 	if metaConfig.ClusterType == config.CloudClusterType {
-		_ = log.Process("common", "Kubernetes Master Node addresses for SSH", func() error {
+		_ = log.ProcessCtx(ctx, "common", "Kubernetes Master Node addresses for SSH", func(ctx context.Context) error {
 			wrapper := b.NodeInterface.(*ssh.NodeInterfaceWrapper)
 			for nodeName, address := range masterAddressesForSSH {
 				fakeSession := wrapper.Client().Session().Copy()
@@ -695,7 +707,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		})
 	}
 
-	return b.PhasedExecutionContext.CompletePhaseAndPipeline(stateCache, nil)
+	return b.PhasedExecutionContext.CompletePhaseAndPipeline(ctx, stateCache, nil)
 }
 
 // TODO(dhctl-for-commander): pass stateCache externally using params as in Destroyer, this method will be unneeded then
@@ -715,7 +727,7 @@ func generateClusterUUID(ctx context.Context, stateCache state.Cache) (string, e
 	var clusterUUID string
 
 	return clusterUUID, log.ProcessCtx(ctx, "bootstrap", "Cluster UUID", func(ctx context.Context) error {
-		ok, err := stateCache.InCache("uuid")
+		ok, err := stateCache.InCache(ctx, "uuid")
 		if err != nil {
 			return err
 		}
@@ -727,13 +739,13 @@ func generateClusterUUID(ctx context.Context, stateCache state.Cache) (string, e
 			}
 
 			clusterUUID = genClusterUUID.String()
-			err = stateCache.Save("uuid", []byte(clusterUUID))
+			err = stateCache.Save(ctx, "uuid", []byte(clusterUUID))
 			if err != nil {
 				return err
 			}
 			log.InfoF("Generated cluster UUID: %s\n", clusterUUID)
 		} else {
-			clusterUUIDBytes, err := stateCache.Load("uuid")
+			clusterUUIDBytes, err := stateCache.Load(ctx, "uuid")
 			if err != nil {
 				return err
 			}
@@ -765,7 +777,7 @@ func bootstrapAdditionalNodesForCloudCluster(
 		return err
 	}
 
-	return log.Process("bootstrap", "Waiting for Node Groups are ready", func() error {
+	return log.ProcessCtx(ctx, "bootstrap", "Waiting for Node Groups are ready", func(ctx context.Context) error {
 		ngs := map[string]int{"master": metaConfig.MasterNodeGroupSpec.Replicas}
 		for _, ng := range terraNodeGroups {
 			if ng.Replicas > 0 {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -334,7 +334,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 
 	printBanner()
 
-	clusterUUID, err := generateClusterUUID(stateCache)
+	clusterUUID, err := generateClusterUUID(ctx, stateCache)
 	if err != nil {
 		return err
 	}
@@ -711,9 +711,10 @@ func printBanner() {
 	log.InfoLn(banner)
 }
 
-func generateClusterUUID(stateCache state.Cache) (string, error) {
+func generateClusterUUID(ctx context.Context, stateCache state.Cache) (string, error) {
 	var clusterUUID string
-	err := log.Process("bootstrap", "Cluster UUID", func() error {
+
+	return clusterUUID, log.ProcessCtx(ctx, "bootstrap", "Cluster UUID", func(ctx context.Context) error {
 		ok, err := stateCache.InCache("uuid")
 		if err != nil {
 			return err
@@ -741,10 +742,15 @@ func generateClusterUUID(stateCache state.Cache) (string, error) {
 		}
 		return nil
 	})
-	return clusterUUID, err
 }
 
-func bootstrapAdditionalNodesForCloudCluster(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, masterAddressesForSSH map[string]string, infrastructureContext *infrastructure.Context) error {
+func bootstrapAdditionalNodesForCloudCluster(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	metaConfig *config.MetaConfig,
+	masterAddressesForSSH map[string]string,
+	infrastructureContext *infrastructure.Context,
+) error {
 	if err := BootstrapAdditionalMasterNodes(ctx, kubeCl, metaConfig, masterAddressesForSSH, infrastructureContext, cache.Global()); err != nil {
 		return err
 	}
@@ -815,7 +821,7 @@ func createResources(ctx context.Context, kubeCl *client.KubernetesClient, resou
 		return nil
 	}
 
-	return log.Process("bootstrap", "Create Resources", func() error {
+	return log.ProcessCtx(ctx, "bootstrap", "Create Resources", func(ctx context.Context) error {
 		var err error
 		checkers := make([]resources.Checker, 0)
 		if !skipChecks {

--- a/dhctl/pkg/operations/bootstrap/post-script.go
+++ b/dhctl/pkg/operations/bootstrap/post-script.go
@@ -54,7 +54,7 @@ func (e *PostBootstrapScriptExecutor) Execute(ctx context.Context) error {
 			return errors.New(msg)
 		}
 
-		if err := e.state.SavePostBootstrapScriptResult(resultToSetState); err != nil {
+		if err := e.state.SavePostBootstrapScriptResult(ctx, resultToSetState); err != nil {
 			log.ErrorF("Post bootstrap script result was not saved: %v", err)
 		}
 

--- a/dhctl/pkg/operations/bootstrap/post-script.go
+++ b/dhctl/pkg/operations/bootstrap/post-script.go
@@ -47,17 +47,14 @@ func (e *PostBootstrapScriptExecutor) WithTimeout(timeout time.Duration) *PostBo
 }
 
 func (e *PostBootstrapScriptExecutor) Execute(ctx context.Context) error {
-	return log.Process("bootstrap", "Execute post-bootstrap script", func() error {
-		var err error
+	return log.ProcessCtx(ctx, "bootstrap", "Execute post-bootstrap script", func(ctx context.Context) error {
 		resultToSetState, err := e.run(ctx)
-
 		if err != nil {
 			msg := fmt.Sprintf("Post execution script was failed: %v", err)
 			return errors.New(msg)
 		}
 
-		err = e.state.SavePostBootstrapScriptResult(resultToSetState)
-		if err != nil {
+		if err := e.state.SavePostBootstrapScriptResult(resultToSetState); err != nil {
 			log.ErrorF("Post bootstrap script result was not saved: %v", err)
 		}
 
@@ -65,7 +62,7 @@ func (e *PostBootstrapScriptExecutor) Execute(ctx context.Context) error {
 	})
 }
 
-func (e *PostBootstrapScriptExecutor) run(ctx context.Context) (string, error) {
+func (e *PostBootstrapScriptExecutor) run(ctx context.Context) (result string, err error) {
 	outputFile := fs.RandomNumberSuffix("/tmp/post-bootstrap-script-output")
 	envs := map[string]string{
 		"OUTPUT": outputFile,
@@ -76,9 +73,8 @@ func (e *PostBootstrapScriptExecutor) run(ctx context.Context) (string, error) {
 	cmd.Sudo(ctx)
 	cmd.WithStderrHandler(nil)
 	cmd.WithStdoutHandler(nil)
-	err := cmd.Run(ctx)
 
-	if err != nil {
+	if err := cmd.Run(ctx); err != nil {
 		return "", fmt.Errorf("Cannot create output file for script: %v", err)
 	}
 
@@ -99,19 +95,13 @@ func (e *PostBootstrapScriptExecutor) run(ctx context.Context) (string, error) {
 	script.WithEnvs(envs)
 	script.Sudo()
 
-	_, err = script.Execute(ctx)
-
-	if err != nil {
+	if _, err := script.Execute(ctx); err != nil {
 		return "", fmt.Errorf("Running %s done with error: %w", e.path, err)
 	}
 
 	content, err := e.sshClient.File().DownloadBytes(ctx, outputFile)
 	if err != nil {
 		return "", fmt.Errorf("Cannot get output from remote file %s: %w", e.path, err)
-	}
-
-	if err != nil {
-		log.WarnLn("Post bootstrap output file '%s' did not remove from server", outputFile)
 	}
 
 	return string(content), nil

--- a/dhctl/pkg/operations/bootstrap/state.go
+++ b/dhctl/pkg/operations/bootstrap/state.go
@@ -17,6 +17,8 @@
 package bootstrap
 
 import (
+	"context"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 )
 
@@ -35,30 +37,30 @@ func NewBootstrapState(stateCache state.Cache) *State {
 	}
 }
 
-func (s *State) SavePostBootstrapScriptResult(result string) error {
-	return s.cache.Save(PostBootstrapResultCacheKey, []byte(result))
+func (s *State) SavePostBootstrapScriptResult(ctx context.Context, result string) error {
+	return s.cache.Save(ctx, PostBootstrapResultCacheKey, []byte(result))
 }
 
-func (s *State) SaveManifestsCreated() error {
-	return s.cache.Save(ManifestCreatedInClusterCacheKey, []byte("yes"))
+func (s *State) SaveManifestsCreated(ctx context.Context) error {
+	return s.cache.Save(ctx, ManifestCreatedInClusterCacheKey, []byte("yes"))
 }
 
-func (s *State) IsManifestsCreated() (bool, error) {
-	return s.cache.InCache(ManifestCreatedInClusterCacheKey)
+func (s *State) IsManifestsCreated(ctx context.Context) (bool, error) {
+	return s.cache.InCache(ctx, ManifestCreatedInClusterCacheKey)
 }
 
-func (s *State) PostBootstrapScriptResult() ([]byte, error) {
-	return s.cache.Load(PostBootstrapResultCacheKey)
+func (s *State) PostBootstrapScriptResult(ctx context.Context) ([]byte, error) {
+	return s.cache.Load(ctx, PostBootstrapResultCacheKey)
 }
 
-func (s *State) Clean() {
-	s.cache.Clean()
+func (s *State) Clean(ctx context.Context) {
+	s.cache.Clean(ctx)
 }
 
-func (s *State) Save(key string, data []byte) error {
-	return s.cache.Save(key, data)
+func (s *State) Save(ctx context.Context, key string, data []byte) error {
+	return s.cache.Save(ctx, key, data)
 }
 
-func (s *State) InCache(key string) (bool, error) {
-	return s.cache.InCache(key)
+func (s *State) InCache(ctx context.Context, key string) (bool, error) {
+	return s.cache.InCache(ctx, key)
 }

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -120,10 +120,10 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 	templateController := template.NewTemplateController("")
 	bashible := dhbashible.NewRunner(nodeInterface, loggerProvider)
 
-	err := log.Process("bootstrap", "Preparing bootstrap", func() error {
+	err := log.ProcessCtx(ctx, "bootstrap", "Preparing bootstrap", func(ctx context.Context) error {
 		log.DebugF("Rendered templates directory %s\n", templateController.TmpDir)
 
-		if err := template.PrepareBootstrap(templateController, nodeIP, cfg, dc); err != nil {
+		if err := template.PrepareBootstrap(ctx, templateController, nodeIP, cfg, dc); err != nil {
 			return fmt.Errorf("prepare bootstrap: %v", err)
 		}
 
@@ -158,7 +158,7 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 
 	defer registryPackagesProxyCleanup()
 
-	if err = PrepareBashibleBundle(nodeIP, devicePath, cfg, templateController, dc); err != nil {
+	if err = PrepareBashibleBundle(ctx, nodeIP, devicePath, cfg, templateController, dc); err != nil {
 		return err
 	}
 	tomb.RegisterOnShutdown("Delete templates temporary directory", func() {
@@ -208,7 +208,7 @@ func prepareMasterNode(ctx context.Context, nodeInterface node.Interface, contro
 		return nil
 	}
 
-	return log.Process("bootstrap", "Initial bootstrap", func() error {
+	return log.ProcessCtx(ctx, "bootstrap", "Initial bootstrap", func(ctx context.Context) error {
 		for _, bootstrapScript := range []string{"01-network-scripts.sh", "02-base-pkgs.sh"} {
 			scriptPath := filepath.Join(controller.TmpDir, "bootstrap", bootstrapScript)
 
@@ -225,16 +225,22 @@ func prepareMasterNode(ctx context.Context, nodeInterface node.Interface, contro
 	})
 }
 
-func PrepareBashibleBundle(nodeIP, devicePath string, metaConfig *config.MetaConfig, controller *template.Controller, dc *directoryconfig.DirectoryConfig) error {
-	return log.Process("bootstrap", "Prepare Bashible", func() error {
-		return template.PrepareBundle(controller, nodeIP, devicePath, metaConfig, dc)
+func PrepareBashibleBundle(
+	ctx context.Context,
+	nodeIP, devicePath string,
+	metaConfig *config.MetaConfig,
+	controller *template.Controller,
+	dc *directoryconfig.DirectoryConfig,
+) error {
+	return log.ProcessCtx(ctx, "bootstrap", "Prepare Bashible", func(ctx context.Context) error {
+		return template.PrepareBundle(ctx, controller, nodeIP, devicePath, metaConfig, dc)
 	})
 }
 
 func WaitForSSHConnectionOnMaster(ctx context.Context, sshClient node.SSHClient) error {
-	return log.Process("bootstrap", "Wait for SSH on Master become Ready", func() error {
+	return log.ProcessCtx(ctx, "bootstrap", "Wait for SSH on Master become Ready", func(ctx context.Context) error {
 		availabilityCheck := sshClient.Check()
-		_ = log.Process("default", "Connection string", func() error {
+		_ = log.ProcessCtx(ctx, "default", "Connection string", func(ctx context.Context) error {
 			log.InfoLn(availabilityCheck.String())
 			return nil
 		})
@@ -255,9 +261,15 @@ type InstallDeckhouseParams struct {
 	State               *State
 }
 
-func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, config *config.DeckhouseInstaller, params InstallDeckhouseParams) (*InstallDeckhouseResult, error) {
+func InstallDeckhouse(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	config *config.DeckhouseInstaller,
+	params InstallDeckhouseParams,
+) (*InstallDeckhouseResult, error) {
 	res := &InstallDeckhouseResult{}
-	err := log.Process("bootstrap", "Install Deckhouse", func() error {
+
+	return res, log.ProcessCtx(ctx, "bootstrap", "Install Deckhouse", func(ctx context.Context) error {
 		err := CheckPreventBreakAnotherBootstrappedCluster(ctx, kubeCl, config)
 		if err != nil {
 			return err
@@ -270,7 +282,7 @@ func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, conf
 
 		res.ManifestResult = resManifests
 
-		if err := params.State.SaveManifestsCreated(); err != nil {
+		if err := params.State.SaveManifestsCreated(ctx); err != nil {
 			return fmt.Errorf("Set manifests in cluster flag to cache: %w", err)
 		}
 
@@ -289,26 +301,28 @@ func InstallDeckhouse(ctx context.Context, kubeCl *client.KubernetesClient, conf
 
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
 }
 
-func BootstrapTerraNodes(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, infrastructureContext *infrastructure.Context) error {
-	return log.Process("bootstrap", "Create CloudPermanent NG", func() error {
+func BootstrapTerraNodes(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	metaConfig *config.MetaConfig,
+	terraNodeGroups []config.TerraNodeGroupSpec,
+	infrastructureContext *infrastructure.Context,
+) error {
+	return log.ProcessCtx(ctx, "bootstrap", "Create CloudPermanent NG", func(ctx context.Context) error {
 		return operations.ParallelCreateNodeGroup(ctx, kubeCl, metaConfig, terraNodeGroups, infrastructureContext)
 	})
 }
 
-func SaveBastionHostToCache(host string) {
-	if err := cache.Global().Save(BastionHostCacheKey, []byte(host)); err != nil {
+func SaveBastionHostToCache(ctx context.Context, host string) {
+	if err := cache.Global().Save(ctx, BastionHostCacheKey, []byte(host)); err != nil {
 		log.ErrorF("Cannot save ssh hosts: %v\n", err)
 	}
 }
 
-func GetBastionHostFromCache() (string, error) {
-	exists, err := cache.Global().InCache(BastionHostCacheKey)
+func GetBastionHostFromCache(ctx context.Context) (string, error) {
+	exists, err := cache.Global().InCache(ctx, BastionHostCacheKey)
 	if err != nil {
 		return "", err
 	}
@@ -317,7 +331,7 @@ func GetBastionHostFromCache() (string, error) {
 		return "", nil
 	}
 
-	host, err := cache.Global().Load(BastionHostCacheKey)
+	host, err := cache.Global().Load(ctx, BastionHostCacheKey)
 	if err != nil {
 		return "", err
 	}
@@ -331,7 +345,7 @@ func BootstrapAdditionalMasterNodes(ctx context.Context, kubeCl *client.Kubernet
 		return nil
 	}
 
-	return log.Process("bootstrap", "Bootstrap additional master nodes", func() error {
+	return log.ProcessCtx(ctx, "bootstrap", "Bootstrap additional master nodes", func(ctx context.Context) error {
 		masterCloudConfig, err := entity.GetCloudConfig(ctx, kubeCl, global.MasterNodeGroupName, global.ShowDeckhouseLogs, log.GetDefaultLogger())
 		if err != nil {
 			return err
@@ -344,20 +358,24 @@ func BootstrapAdditionalMasterNodes(ctx context.Context, kubeCl *client.Kubernet
 			}
 			addressTracker[fmt.Sprintf("%s-master-%d", metaConfig.ClusterPrefix, i)] = outputs.MasterIPForSSH
 
-			state.SaveMasterHostsToCache(stateCache, addressTracker)
+			state.SaveMasterHostsToCache(ctx, stateCache, addressTracker)
 		}
 
 		return nil
 	})
 }
 
-func BootstrapGetNodesFromCache(metaConfig *config.MetaConfig, stateCache state.Cache) (map[string]map[int]string, error) {
+func BootstrapGetNodesFromCache(
+	ctx context.Context,
+	metaConfig *config.MetaConfig,
+	stateCache state.Cache,
+) (map[string]map[int]string, error) {
 	nodeGroupRegex := fmt.Sprintf("^%s-(.*)-([0-9]+)\\.tfstate$", metaConfig.ClusterPrefix)
 	groupsReg, _ := regexp.Compile(nodeGroupRegex)
 
 	nodesFromCache := make(map[string]map[int]string)
 
-	err := stateCache.Iterate(func(name string, content []byte) error {
+	err := stateCache.Iterate(ctx, func(name string, content []byte) error {
 		switch {
 		case strings.HasSuffix(name, ".backup"):
 			fallthrough
@@ -389,7 +407,11 @@ func BootstrapGetNodesFromCache(metaConfig *config.MetaConfig, stateCache state.
 	return nodesFromCache, err
 }
 
-func applyPostBootstrapModuleConfigs(kubeCl *client.KubernetesClient, tasks []actions.ModuleConfigTask) error {
+func applyPostBootstrapModuleConfigs(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	tasks []actions.ModuleConfigTask,
+) error {
 	for _, task := range tasks {
 		err := retry.NewLoop(task.Title, 15, 5*time.Second).
 			Run(func() error {
@@ -409,7 +431,7 @@ func RunPostInstallTasks(ctx context.Context, kubeCl *client.KubernetesClient, r
 		return nil
 	}
 
-	return log.Process("bootstrap", "Run post bootstrap actions", func() error {
-		return applyPostBootstrapModuleConfigs(kubeCl, result.ManifestResult.PostBootstrapMCTasks)
+	return log.ProcessCtx(ctx, "bootstrap", "Run post bootstrap actions", func(ctx context.Context) error {
+		return applyPostBootstrapModuleConfigs(ctx, kubeCl, result.ManifestResult.PostBootstrapMCTasks)
 	})
 }

--- a/dhctl/pkg/operations/bootstrap/steps_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_test.go
@@ -58,7 +58,7 @@ func TestBootstrapGetNodesFromCache(t *testing.T) {
 		stateCache, err := cache.NewStateCache(dir)
 		require.NoError(t, err)
 
-		result, err := BootstrapGetNodesFromCache(&config.MetaConfig{ClusterPrefix: "test"}, stateCache)
+		result, err := BootstrapGetNodesFromCache(t.Context(), &config.MetaConfig{ClusterPrefix: "test"}, stateCache)
 		require.NoError(t, err)
 
 		require.Len(t, result["master"], 2)

--- a/dhctl/pkg/operations/bootstrap/steps_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -29,7 +30,6 @@ import (
 	registry_mocks "github.com/deckhouse/deckhouse/dhctl/pkg/config/registrymocks"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 

--- a/dhctl/pkg/operations/bootstrap/steps_test.go
+++ b/dhctl/pkg/operations/bootstrap/steps_test.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	registry_mocks "github.com/deckhouse/deckhouse/dhctl/pkg/config/registrymocks"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 

--- a/dhctl/pkg/operations/check/checker.go
+++ b/dhctl/pkg/operations/check/checker.go
@@ -123,11 +123,11 @@ func (c *Checker) Check(ctx context.Context) (*CheckResult, Cleaner, error) {
 	}
 
 	if !c.Embedded {
-		if err = c.PhasedExecutionContext.InitPipeline(c.StateCache); err != nil {
+		if err = c.PhasedExecutionContext.InitPipeline(ctx, c.StateCache); err != nil {
 			return nil, cleaner, err
 		}
 		defer func() {
-			_ = c.PhasedExecutionContext.Finalize(c.StateCache)
+			_ = c.PhasedExecutionContext.Finalize(ctx, c.StateCache)
 		}()
 	}
 
@@ -207,7 +207,7 @@ func (c *Checker) checkConfiguration(ctx context.Context, kubeCl *client.Kuberne
 		inClusterSource = "in-cluster"
 	)
 
-	defer c.switchPhase(phases.CheckConfiguration)()
+	defer c.switchPhase(ctx, phases.CheckConfiguration)()
 
 	clusterConfig, err := getClusterConfig(metaConfig, commanderSource)
 	if err != nil {
@@ -262,7 +262,7 @@ type InfraResult struct {
 }
 
 func (c *Checker) checkInfra(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, infrastructureContext *infrastructure.Context) (*InfraResult, error) {
-	defer c.switchPhase(phases.CheckInfra)()
+	defer c.switchPhase(ctx, phases.CheckInfra)()
 
 	stat, hasTerraformState, err := CheckState(
 		ctx, kubeCl, metaConfig, infrastructureContext,
@@ -348,9 +348,9 @@ func (c *Checker) GetKubeClient(ctx context.Context) (*client.KubernetesClient, 
 	return kubeCl, nil
 }
 
-func (c *Checker) switchPhase(s phases.OperationPhase) func() {
+func (c *Checker) switchPhase(ctx context.Context, s phases.OperationPhase) func() {
 	if !c.Embedded {
-		_, _ = c.PhasedExecutionContext.SwitchPhase(s, false, c.StateCache, nil)
+		_, _ = c.PhasedExecutionContext.SwitchPhase(ctx, s, false, c.StateCache, nil)
 		return func() {}
 	}
 

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -45,7 +45,7 @@ type Params struct {
 	CommanderMode         bool
 	CommanderUUID         uuid.UUID
 	SSHClient             node.SSHClient
-	OnCheckResult         func(*check.CheckResult) error
+	OnCheckResult         func(context.Context, *check.CheckResult) error
 	InfrastructureContext *infrastructure.Context
 	OnPhaseFunc           OnPhaseFunc
 	OnProgressFunc        phases.OnProgressFunc
@@ -114,14 +114,14 @@ func (i *Attacher) Attach(ctx context.Context) (*AttachResult, error) {
 
 	stateCache := cache.Global()
 
-	if err = i.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
+	if err = i.PhasedExecutionContext.InitPipeline(ctx, stateCache); err != nil {
 		return nil, err
 	}
 	defer func() {
-		_ = i.PhasedExecutionContext.Finalize(stateCache)
+		_ = i.PhasedExecutionContext.Finalize(ctx, stateCache)
 	}()
 
-	if shouldStop, err := i.PhasedExecutionContext.StartPhase(phases.CommanderAttachScanPhase, false, stateCache); err != nil {
+	if shouldStop, err := i.PhasedExecutionContext.StartPhase(ctx, phases.CommanderAttachScanPhase, false, stateCache); err != nil {
 		return nil, fmt.Errorf("unable to switch phase: %w", err)
 	} else if shouldStop {
 		return &AttachResult{}, nil
@@ -133,7 +133,7 @@ func (i *Attacher) Attach(ctx context.Context) (*AttachResult, error) {
 	}
 
 	if ptr.Deref(i.Params.ScanOnly, true) {
-		if err = i.PhasedExecutionContext.CompletePhaseAndPipeline(stateCache, PhaseData{
+		if err = i.PhasedExecutionContext.CompletePhaseAndPipeline(ctx, stateCache, PhaseData{
 			ScanResult: scanResult,
 		}); err != nil {
 			return nil, fmt.Errorf("unable to complete phase: %w", err)
@@ -142,6 +142,7 @@ func (i *Attacher) Attach(ctx context.Context) (*AttachResult, error) {
 	}
 
 	if shouldStop, err := i.PhasedExecutionContext.SwitchPhase(
+		ctx,
 		phases.CommanderAttachCapturePhase,
 		false,
 		stateCache,
@@ -158,6 +159,7 @@ func (i *Attacher) Attach(ctx context.Context) (*AttachResult, error) {
 	}
 
 	if shouldStop, err := i.PhasedExecutionContext.SwitchPhase(
+		ctx,
 		phases.CommanderAttachCheckPhase,
 		false,
 		stateCache,
@@ -174,7 +176,7 @@ func (i *Attacher) Attach(ctx context.Context) (*AttachResult, error) {
 		log.WarnF("Can't check attached cluster: %s\n", err)
 	}
 
-	if err = i.PhasedExecutionContext.CompletePhaseAndPipeline(stateCache, PhaseData{
+	if err = i.PhasedExecutionContext.CompletePhaseAndPipeline(ctx, stateCache, PhaseData{
 		CheckResult: checkResult,
 	}); err != nil {
 		return nil, fmt.Errorf("unable to complete phase: %w", err)
@@ -193,7 +195,7 @@ func (i *Attacher) prepare(ctx context.Context) (*client.KubernetesClient, *conf
 		metaConfig *config.MetaConfig
 	)
 
-	err := log.Process("attach", "Prepare cluster attach", func() error {
+	return kubeClient, metaConfig, log.ProcessCtx(ctx, "attach", "Prepare cluster attach", func(ctx context.Context) error {
 		var err error
 
 		kubeClient, err = kubernetes.ConnectToKubernetesAPI(ctx, ssh.NewNodeInterfaceWrapper(i.Params.SSHClient))
@@ -223,14 +225,12 @@ func (i *Attacher) prepare(ctx context.Context) (*client.KubernetesClient, *conf
 		}
 
 		cachePath := metaConfig.CachePath()
-		if err = cache.InitWithOptions(cachePath, cache.CacheOptions{InitialState: nil, ResetInitialState: true}); err != nil {
+		if err := cache.InitWithOptions(ctx, cachePath, cache.CacheOptions{InitialState: nil, ResetInitialState: true}); err != nil {
 			return fmt.Errorf("unable to init cache: %w", err)
 		}
 
 		return nil
 	})
-
-	return kubeClient, metaConfig, err
 }
 
 func (i *Attacher) scan(
@@ -240,7 +240,7 @@ func (i *Attacher) scan(
 ) (*ScanResult, error) {
 	var res *ScanResult
 
-	err := log.Process("commander/attach", "Scan cluster", func() error {
+	return res, log.ProcessCtx(ctx, "commander/attach", "Scan cluster", func(ctx context.Context) error {
 		var err error
 		stateCache := cache.Global()
 
@@ -255,7 +255,7 @@ func (i *Attacher) scan(
 			return fmt.Errorf("unable to get cluster uuid: %w", err)
 		}
 
-		if err = stateCache.Save("uuid", []byte(metaConfig.UUID)); err != nil {
+		if err = stateCache.Save(ctx, "uuid", []byte(metaConfig.UUID)); err != nil {
 			return fmt.Errorf("unable to save cluster uuid to cache: %w", err)
 		}
 
@@ -298,7 +298,7 @@ func (i *Attacher) scan(
 			return fmt.Errorf("unable get cluster tf state: %w", err)
 		}
 
-		if err = stateCache.Save("base-infrastructure.tfstate", clusterState); err != nil {
+		if err = stateCache.Save(ctx, "base-infrastructure.tfstate", clusterState); err != nil {
 			return fmt.Errorf("unable to save cluster tf state to cache: %w", err)
 		}
 
@@ -306,7 +306,7 @@ func (i *Attacher) scan(
 		for _, ngState := range nodesState {
 			for node, nState := range ngState.State {
 				key := fmt.Sprintf("%s.tfstate", node)
-				if err = stateCache.Save(key, nState); err != nil {
+				if err = stateCache.Save(ctx, key, nState); err != nil {
 					return fmt.Errorf("unable to save node tf state to cache: %w", err)
 				}
 
@@ -315,28 +315,27 @@ func (i *Attacher) scan(
 				if err != nil {
 					return fmt.Errorf("unable to parse master ssh hosts: %w", err)
 				}
+
 				if state.Outputs.MasterIPAddressForSSH.Value != "" {
 					hosts[node] = state.Outputs.MasterIPAddressForSSH.Value
 				}
 			}
 		}
 
-		err = stateCache.SaveStruct("cluster-hosts", hosts)
+		err = stateCache.SaveStruct(ctx, "cluster-hosts", hosts)
 		if err != nil {
 			return fmt.Errorf("unable to save master ssh hosts: %w", err)
 		}
 
 		return nil
 	})
-
-	return res, err
 }
 
 func (i *Attacher) capture(
 	ctx context.Context,
 	kubeClient *client.KubernetesClient,
 ) error {
-	return log.Process("commander/attach", "Capture cluster", func() error {
+	return log.ProcessCtx(ctx, "commander/attach", "Capture cluster", func(ctx context.Context) error {
 		attachResources, err := template.ParseResourcesContent(
 			i.Params.AttachResources.Template,
 			i.Params.AttachResources.Values,
@@ -366,7 +365,7 @@ func (i *Attacher) check(
 ) (*check.CheckResult, error) {
 	var res *check.CheckResult
 
-	err := log.Process("commander/attach", "Check cluster", func() error {
+	return res, log.ProcessCtx(ctx, "commander/attach", "Check cluster", func(ctx context.Context) error {
 		var err error
 
 		checker := check.NewChecker(&check.Params{
@@ -393,15 +392,13 @@ func (i *Attacher) check(
 		}
 
 		if i.Params.OnCheckResult != nil {
-			if err = i.Params.OnCheckResult(res); err != nil {
+			if err = i.Params.OnCheckResult(ctx, res); err != nil {
 				return fmt.Errorf("OnCheckResult error: %w", err)
 			}
 		}
 
 		return nil
 	})
-
-	return res, err
 }
 
 func extractSSHPublicKey(providerName string, providerConfig map[string]json.RawMessage) (string, error) {

--- a/dhctl/pkg/operations/commander/detach/detacher.go
+++ b/dhctl/pkg/operations/commander/detach/detacher.go
@@ -31,7 +31,7 @@ import (
 type Params struct {
 	DeleteDetachResources DetachResources
 	CreateDetachResources DetachResources
-	OnCheckResult         func(*check.CheckResult) error
+	OnCheckResult         func(context.Context, *check.CheckResult) error
 	OnPhaseFunc           phases.DefaultOnPhaseFunc
 	OnProgressFunc        phases.OnProgressFunc
 }
@@ -61,23 +61,23 @@ func NewDetacher(checker *check.Checker, sshClient node.SSHClient, params *Param
 	}
 }
 
-func (op *Detacher) Detach(ctx context.Context) error {
+func (op *Detacher) Detach(ctx context.Context) (err error) {
 	providerCleanup := func() error {
 		return nil
 	}
 
 	stateCache := cache.Global()
 
-	if err := op.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
+	if err := op.PhasedExecutionContext.InitPipeline(ctx, stateCache); err != nil {
 		return err
 	}
 	defer func() {
-		_ = op.PhasedExecutionContext.Finalize(stateCache)
+		_ = op.PhasedExecutionContext.Finalize(ctx, stateCache)
 	}()
 
-	_, _ = op.PhasedExecutionContext.StartPhase(phases.CommanderDetachCheckPhase, false, stateCache)
+	_, _ = op.PhasedExecutionContext.StartPhase(ctx, phases.CommanderDetachCheckPhase, false, stateCache)
 
-	err := log.Process("commander/detach", "Check cluster", func() error {
+	err = log.ProcessCtx(ctx, "commander/detach", "Check cluster", func(ctx context.Context) error {
 		op.Checker.SetExternalPhasedContext(op.PhasedExecutionContext)
 
 		checkRes, cleanup, err := op.Checker.Check(ctx)
@@ -87,7 +87,7 @@ func (op *Detacher) Detach(ctx context.Context) error {
 		}
 
 		if op.OnCheckResult != nil {
-			if err := op.OnCheckResult(checkRes); err != nil {
+			if err := op.OnCheckResult(ctx, checkRes); err != nil {
 				return fmt.Errorf("oncheckResult callback failed: %w", err)
 			}
 		}
@@ -105,9 +105,9 @@ func (op *Detacher) Detach(ctx context.Context) error {
 		return err
 	}
 
-	_, _ = op.PhasedExecutionContext.SwitchPhase(phases.CommanderDetachDetachPhase, false, stateCache, nil)
+	_, _ = op.PhasedExecutionContext.SwitchPhase(ctx, phases.CommanderDetachDetachPhase, false, stateCache, nil)
 
-	err = log.Process("commander/detach", "Update resources", func() error {
+	err = log.ProcessCtx(ctx, "commander/detach", "Update resources", func(ctx context.Context) error {
 		detachResources, err := template.ParseResourcesContent(
 			op.CreateDetachResources.Template,
 			op.CreateDetachResources.Values,
@@ -137,7 +137,7 @@ func (op *Detacher) Detach(ctx context.Context) error {
 		return err
 	}
 
-	err = log.Process("commander/detach", "Remove commander resources", func() error {
+	err = log.ProcessCtx(ctx, "commander/detach", "Remove commander resources", func(ctx context.Context) error {
 		detachResources, err := template.ParseResourcesContent(
 			op.DeleteDetachResources.Template,
 			op.DeleteDetachResources.Values,

--- a/dhctl/pkg/operations/commander/helpers.go
+++ b/dhctl/pkg/operations/commander/helpers.go
@@ -72,12 +72,17 @@ func ConstructManagedByCommanderConfigMapTask(ctx context.Context, commanderUUID
 		Manifest: func() interface{} {
 			return manifests.CommanderUUIDConfigMap(commanderUUID.String())
 		},
-		CreateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Create(ctx, manifest.(*v1.ConfigMap), metav1.CreateOptions{})
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			_, err := kubeCl.
+				CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).
+				Create(ctx, manifest.(*v1.ConfigMap), metav1.CreateOptions{})
+
 			return err
 		},
-		UpdateFunc: func(manifest interface{}) error {
-			existingCm, err := kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Get(ctx, manifests.CommanderUUIDCm, metav1.GetOptions{})
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			existingCm, err := kubeCl.
+				CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).
+				Get(ctx, manifests.CommanderUUIDCm, metav1.GetOptions{})
 			if err != nil {
 				return fmt.Errorf("unable to get existing cm: %w", err)
 			}
@@ -88,7 +93,10 @@ func ConstructManagedByCommanderConfigMapTask(ctx context.Context, commanderUUID
 			}
 
 			if shouldUpdate {
-				_, err = kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Update(ctx, manifest.(*v1.ConfigMap), metav1.UpdateOptions{})
+				_, err = kubeCl.
+					CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).
+					Update(ctx, manifest.(*v1.ConfigMap), metav1.UpdateOptions{})
+
 				return err
 			}
 			return nil
@@ -100,7 +108,9 @@ func DeleteManagedByCommanderConfigMap(ctx context.Context, kubeCl *client.Kuber
 	return retry.NewLoop("Delete commander-uuid ConfigMap", 20, 5*time.Second).
 		WithShowError(false).
 		RunContext(ctx, func() error {
-			err := kubeCl.CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).Delete(ctx, manifests.CommanderUUIDCm, metav1.DeleteOptions{})
+			err := kubeCl.
+				CoreV1().ConfigMaps(manifests.CommanderUUIDCmNamespace).
+				Delete(ctx, manifests.CommanderUUIDCm, metav1.DeleteOptions{})
 			if err != nil && !errors.IsNotFound(err) {
 				return err
 			}

--- a/dhctl/pkg/operations/commander/meta_config.go
+++ b/dhctl/pkg/operations/commander/meta_config.go
@@ -25,7 +25,7 @@ import (
 )
 
 func ParseMetaConfig(ctx context.Context, stateCache state.Cache, params *CommanderModeParams, logger log.Logger) (*config.MetaConfig, error) {
-	clusterUUIDBytes, err := stateCache.Load("uuid")
+	clusterUUIDBytes, err := stateCache.Load(ctx, "uuid")
 	if err != nil {
 		return nil, fmt.Errorf("error loading cluster uuid from state cache: %w", err)
 	}

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -81,7 +81,7 @@ func (s *KubeClientSwitcher) SwitchToNodeUser(ctx context.Context, nodesState ma
 		return nil
 	}
 
-	return s.logger.LogProcess("default", action, func() error {
+	return s.logger.LogProcessCtx(ctx, "default", action, func(ctx context.Context) error {
 		convergeState, err := s.createNodeUser(ctx)
 		if err != nil {
 			return err
@@ -100,7 +100,8 @@ func (s *KubeClientSwitcher) CleanupNodeUser() error {
 		return nil
 	}
 
-	return s.logger.LogProcess("default", action, func() error {
+	// todo(ctx): does it's real need to use s.ctx.Ctx() instead of param context?
+	return s.logger.LogProcessCtx(s.ctx.Ctx(), "default", action, func(ctx context.Context) error {
 		err := s.ctx.deleteConvergeState()
 		if err != nil {
 			return err
@@ -121,7 +122,7 @@ func (s *KubeClientSwitcher) SwitchToFirstMaster(ctx context.Context) error {
 		return nil
 	}
 
-	return s.logger.LogProcess("default", action, func() error {
+	return s.logger.LogProcessCtx(ctx, "default", action, func(ctx context.Context) error {
 		convergeState, err := s.ctx.ConvergeState()
 		if err != nil {
 			return fmt.Errorf("Cannot get converge state: %w", err)
@@ -163,7 +164,7 @@ func (s *KubeClientSwitcher) SwitchToNotFirstMaster(ctx context.Context) error {
 		return nil
 	}
 
-	return s.logger.LogProcess("default", action, func() error {
+	return s.logger.LogProcessCtx(ctx, "default", action, func(ctx context.Context) error {
 		convergeState, err := s.ctx.ConvergeState()
 		if err != nil {
 			return fmt.Errorf("Cannot get converge state: %w", err)
@@ -222,7 +223,7 @@ func (s *KubeClientSwitcher) SwitchClientsToAnotherNodeIfNeed(ctx context.Contex
 		return nil
 	}
 
-	return s.logger.LogProcess("default", action, func() error {
+	return s.logger.LogProcessCtx(ctx, "default", action, func(ctx context.Context) error {
 		convergeState, err := s.ctx.ConvergeState()
 		if err != nil {
 			return fmt.Errorf("Cannot get converge state: %w", err)
@@ -298,7 +299,7 @@ func (s *KubeClientSwitcher) SwitchWhenDecreaseMastersIfNeed(ctx context.Context
 		return nil
 	}
 
-	return s.logger.LogProcess("default", action, func() error {
+	return s.logger.LogProcessCtx(ctx, "default", action, func(ctx context.Context) error {
 		convergeState, err := s.ctx.ConvergeState()
 		if err != nil {
 			return fmt.Errorf("Cannot get converge state: %w", err)

--- a/dhctl/pkg/operations/converge/context/context.go
+++ b/dhctl/pkg/operations/converge/context/context.go
@@ -182,20 +182,20 @@ func (c *Context) ProviderGetter() infrastructure.CloudProviderGetter {
 	return c.providerGetter
 }
 
-func (c *Context) StarExecutionPhase(phase phases.OperationPhase, isCritical bool) (bool, error) {
+func (c *Context) StarExecutionPhase(ctx context.Context, phase phases.OperationPhase, isCritical bool) (bool, error) {
 	if c.phaseContext == nil {
 		return false, nil
 	}
 
-	return c.phaseContext.StartPhase(phase, isCritical, c.stateCache)
+	return c.phaseContext.StartPhase(ctx, phase, isCritical, c.stateCache)
 }
 
-func (c *Context) CompleteExecutionPhase(data any) error {
+func (c *Context) CompleteExecutionPhase(ctx context.Context, data any) error {
 	if c.phaseContext == nil {
 		return nil
 	}
 
-	return c.phaseContext.CompletePhase(c.stateCache, data)
+	return c.phaseContext.CompletePhase(ctx, c.stateCache, data)
 }
 
 func (c *Context) MetaConfig() (*config.MetaConfig, error) {

--- a/dhctl/pkg/operations/converge/context/converge_state.go
+++ b/dhctl/pkg/operations/converge/context/converge_state.go
@@ -15,6 +15,7 @@
 package context
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -51,29 +52,34 @@ func newInSecretStateStore() *inSecretStateStore {
 	return &inSecretStateStore{}
 }
 
-func (s *inSecretStateStore) GetState(ctx *Context) (*State, error) {
+func (s *inSecretStateStore) GetState(convergeCtx *Context) (*State, error) {
 	var state State
 
-	err := retry.NewLoop("Get converge state from Kubernetes cluster", 5, 5*time.Second).RunContext(ctx.Ctx(), func() error {
-		c, cancel := ctx.WithTimeout(10 * time.Second)
-		defer cancel()
+	err := retry.NewLoop("Get converge state from Kubernetes cluster", 5, 5*time.Second).
+		RunContext(
+			convergeCtx.Ctx(),
+			func() error {
+				c, cancel := convergeCtx.WithTimeout(10 * time.Second)
+				defer cancel()
 
-		convergeStateSecret, err := ctx.KubeClient().CoreV1().Secrets("d8-system").Get(c, stateSecretName, metav1.GetOptions{})
-		if err != nil {
-			if k8errors.IsNotFound(err) {
+				convergeStateSecret, err := convergeCtx.KubeClient().
+					CoreV1().Secrets("d8-system").
+					Get(c, stateSecretName, metav1.GetOptions{})
+				if err != nil {
+					if k8errors.IsNotFound(err) {
+						return nil
+					}
+
+					return fmt.Errorf("failed to get secret: %w", err)
+				}
+
+				err = json.Unmarshal(convergeStateSecret.Data["state.json"], &state)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal state: %w", err)
+				}
+
 				return nil
-			}
-
-			return fmt.Errorf("failed to get secret: %w", err)
-		}
-
-		err = json.Unmarshal(convergeStateSecret.Data["state.json"], &state)
-		if err != nil {
-			return fmt.Errorf("failed to unmarshal state: %w", err)
-		}
-
-		return nil
-	})
+			})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get `%s` secret: %w", stateSecretName, err)
 	}
@@ -81,25 +87,30 @@ func (s *inSecretStateStore) GetState(ctx *Context) (*State, error) {
 	return &state, nil
 }
 
-func (s *inSecretStateStore) Delete(ctx *Context) error {
-	return retry.NewLoop("Cleanup converge state from Kubernetes cluster", 5, 5*time.Second).RunContext(ctx.Ctx(), func() error {
-		c, cancel := ctx.WithTimeout(10 * time.Second)
-		defer cancel()
+func (s *inSecretStateStore) Delete(convergeCtx *Context) error {
+	return retry.NewLoop("Cleanup converge state from Kubernetes cluster", 5, 5*time.Second).
+		RunContext(
+			convergeCtx.Ctx(),
+			func() error {
+				c, cancel := convergeCtx.WithTimeout(10 * time.Second)
+				defer cancel()
 
-		err := ctx.KubeClient().CoreV1().Secrets("d8-system").Delete(c, stateSecretName, metav1.DeleteOptions{})
-		if err != nil {
-			if k8errors.IsNotFound(err) {
+				err := convergeCtx.KubeClient().
+					CoreV1().Secrets("d8-system").
+					Delete(c, stateSecretName, metav1.DeleteOptions{})
+				if err != nil {
+					if k8errors.IsNotFound(err) {
+						return nil
+					}
+
+					return fmt.Errorf("failed to delete state secret: %w", err)
+				}
+
 				return nil
-			}
-
-			return fmt.Errorf("failed to delete state secret: %w", err)
-		}
-
-		return nil
-	})
+			})
 }
 
-func (s *inSecretStateStore) SetState(ctx *Context, state *State) error {
+func (s *inSecretStateStore) SetState(convergeCtx *Context, state *State) error {
 	stateBytes, err := json.Marshal(state)
 	if err != nil {
 		return fmt.Errorf("failed to marshal state: %w", err)
@@ -110,22 +121,24 @@ func (s *inSecretStateStore) SetState(ctx *Context, state *State) error {
 		Manifest: func() interface{} {
 			return manifests.SecretConvergeState(stateBytes)
 		},
-		CreateFunc: func(manifest interface{}) error {
-			c, cancel := ctx.WithTimeout(10 * time.Second)
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			c, cancel := convergeCtx.WithTimeout(10 * time.Second)
 			defer cancel()
 
-			_, err := ctx.KubeClient().CoreV1().Secrets("d8-system").Create(c, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+			_, err := convergeCtx.KubeClient().CoreV1().Secrets("d8-system").Create(c, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to create secret: %w", err)
 			}
 
 			return nil
 		},
-		UpdateFunc: func(manifest interface{}) error {
-			c, cancel := ctx.WithTimeout(10 * time.Second)
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			c, cancel := convergeCtx.WithTimeout(10 * time.Second)
 			defer cancel()
 
-			_, err := ctx.KubeClient().CoreV1().Secrets("d8-system").Update(c, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
+			_, err := convergeCtx.KubeClient().
+				CoreV1().Secrets("d8-system").
+				Update(c, manifest.(*apiv1.Secret), metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to update secret: %w", err)
 			}
@@ -134,5 +147,11 @@ func (s *inSecretStateStore) SetState(ctx *Context, state *State) error {
 		},
 	}
 
-	return retry.NewLoop("Save dhctl converge state", 45, 10*time.Second).RunContext(ctx.Ctx(), task.CreateOrUpdate)
+	return retry.NewLoop("Save dhctl converge state", 45, 10*time.Second).
+		RunContext(
+			convergeCtx.Ctx(),
+			func() error {
+				return task.CreateOrUpdate(convergeCtx.Ctx())
+			},
+		)
 }

--- a/dhctl/pkg/operations/converge/controller/master_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/master_node_group.go
@@ -306,7 +306,7 @@ func (c *MasterNodeGroupController) addNewNodesToCache(ctx *context.Context, mas
 
 	// Get current master hosts from cache
 	stateCache := ctx.StateCache()
-	currentHosts, err := state.GetMasterHostsIPs(stateCache)
+	currentHosts, err := state.GetMasterHostsIPs(ctx.Ctx(), stateCache)
 	if err != nil {
 		log.DebugF("Could not load current master hosts from cache (this is OK for first master): %v\n", err)
 		currentHosts = []session.Host{}
@@ -324,7 +324,7 @@ func (c *MasterNodeGroupController) addNewNodesToCache(ctx *context.Context, mas
 
 	log.DebugF("Saving updated master hosts to cache: %v\n", hostsMap)
 
-	state.SaveMasterHostsToCache(stateCache, hostsMap)
+	state.SaveMasterHostsToCache(ctx.Ctx(), stateCache, hostsMap)
 
 	log.DebugF("Successfully updated master hosts cache with %d new masters. hostsMap: %v\n", len(masterIPForSSHList), hostsMap)
 }
@@ -417,7 +417,7 @@ func (c *MasterNodeGroupController) updateNode(ctx *context.Context, nodeName st
 
 		// Get current master hosts from cache
 		stateCache := ctx.StateCache()
-		currentHosts, err := state.GetMasterHostsIPs(stateCache)
+		currentHosts, err := state.GetMasterHostsIPs(ctx.Ctx(), stateCache)
 		if err != nil {
 			log.DebugF("Could not load current master hosts from cache (this is OK for first master): %v\n", err)
 			currentHosts = []session.Host{}
@@ -433,7 +433,7 @@ func (c *MasterNodeGroupController) updateNode(ctx *context.Context, nodeName st
 
 		log.DebugF("Saving updated master hosts to cache: %v\n", hostsMap)
 
-		state.SaveMasterHostsToCache(stateCache, hostsMap)
+		state.SaveMasterHostsToCache(ctx.Ctx(), stateCache, hostsMap)
 
 		log.DebugF("Successfully updated master hosts cache with node %s IP %s. hostsMap: %v\n", nodeName, outputs.MasterIPForSSH, hostsMap)
 	} else {
@@ -500,7 +500,7 @@ func (c *MasterNodeGroupController) deleteNodes(ctx *context.Context, nodesToDel
 
 			// Get current master hosts from cache
 			stateCache := ctx.StateCache()
-			currentHosts, cacheErr := state.GetMasterHostsIPs(stateCache)
+			currentHosts, cacheErr := state.GetMasterHostsIPs(ctx.Ctx(), stateCache)
 			if cacheErr != nil {
 				log.DebugF("Could not load current master hosts from cache: %v\n", cacheErr)
 				return err
@@ -520,7 +520,7 @@ func (c *MasterNodeGroupController) deleteNodes(ctx *context.Context, nodesToDel
 
 			log.DebugF("Saving updated master hosts to cache after deletion: %v\n", hostsMap)
 
-			state.SaveMasterHostsToCache(stateCache, hostsMap)
+			state.SaveMasterHostsToCache(ctx.Ctx(), stateCache, hostsMap)
 
 			log.DebugF("Successfully updated master hosts cache after deleting %d masters. hostsMap: %v\n", len(nodesToDelete), hostsMap)
 		}

--- a/dhctl/pkg/operations/converge/controller/node_group_controller.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller.go
@@ -234,7 +234,7 @@ func (c *NodeGroupController) deleteRedundantNodes(
 			continue
 		}
 
-		if err := infrastructurestate.DeleteNodeInfrastructureStateFromCache(nodeToDeleteInfo.name, ctx.StateCache()); err != nil {
+		if err := infrastructurestate.DeleteNodeInfrastructureStateFromCache(ctx.Ctx(), nodeToDeleteInfo.name, ctx.StateCache()); err != nil {
 			allErrs = multierror.Append(allErrs, fmt.Errorf("unable to delete node %s infrastructure state from cache: %w", nodeToDeleteInfo.name, err))
 			continue
 		}

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -55,7 +55,7 @@ type Params struct {
 	CommanderUUID uuid.UUID
 	*commander.CommanderModeParams
 	Checker                    *check.Checker
-	OnCheckResult              func(*check.CheckResult) error
+	OnCheckResult              func(context.Context, *check.CheckResult) error
 	ApproveDestructiveChangeID string
 
 	InfrastructureContext *infrastructure.Context
@@ -116,7 +116,7 @@ func (c *Converger) applyParams() error {
 func (c *Converger) ConvergeMigration(ctx context.Context) error {
 	{
 		// TODO(dhctl-for-commander): pass stateCache externally using params as in the Destroyer, this block will be unneeded then
-		state, err := phases.ExtractDhctlState(cache.Global())
+		state, err := phases.ExtractDhctlState(ctx, cache.Global())
 		if err != nil {
 			return fmt.Errorf("unable to extract dhctl state: %w", err)
 		}
@@ -175,7 +175,7 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 			return fmt.Errorf("Incorrect cache identity. Need to pass --ssh-host or --kube-client-from-cluster or --kubeconfig")
 		}
 
-		err = cache.InitWithOptions(cacheIdentity, cache.CacheOptions{})
+		err = cache.InitWithOptions(ctx, cacheIdentity, cache.CacheOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to initialize cache %s: %w", cacheIdentity, err)
 		}
@@ -183,12 +183,12 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 
 	stateCache := cache.Global()
 
-	if err := c.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
+	if err := c.PhasedExecutionContext.InitPipeline(ctx, stateCache); err != nil {
 		return err
 	}
 	c.lastState = nil
 	defer func() {
-		_ = c.PhasedExecutionContext.Finalize(stateCache)
+		_ = c.PhasedExecutionContext.Finalize(ctx, stateCache)
 	}()
 
 	var convergeCtx *convergectx.Context
@@ -233,7 +233,7 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 	var inLockRunner *lock.InLockRunner
 	// No need for converge-lock in commander mode for bootstrap and converge operations
 	if !c.CommanderMode {
-		inLockRunner = lock.NewInLockLocalRunner(convergeCtx, "local-converger")
+		inLockRunner = lock.NewInLockLocalRunner(ctx, convergeCtx, "local-converger")
 	}
 
 	switcher := convergectx.NewKubeClientSwitcher(convergeCtx, nil, convergectx.KubeClientSwitcherParams{
@@ -252,7 +252,7 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 		return fmt.Errorf("converge problem: %v", err)
 	}
 
-	if err := c.PhasedExecutionContext.CompletePipeline(stateCache); err != nil {
+	if err := c.PhasedExecutionContext.CompletePipeline(ctx, stateCache); err != nil {
 		return err
 	}
 
@@ -262,7 +262,7 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 	{
 		// TODO(dhctl-for-commander): pass stateCache externally using params as in the Destroyer, this block will be unneeded then
-		state, err := phases.ExtractDhctlState(cache.Global())
+		state, err := phases.ExtractDhctlState(ctx, cache.Global())
 		if err != nil {
 			return nil, fmt.Errorf("unable to extract dhctl state: %w", err)
 		}
@@ -307,7 +307,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 			return nil, fmt.Errorf("Incorrect cache identity. Need to pass --ssh-host or --kube-client-from-cluster or --kubeconfig")
 		}
 
-		err = cache.InitWithOptions(cacheIdentity, cache.CacheOptions{})
+		err = cache.InitWithOptions(ctx, cacheIdentity, cache.CacheOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("unable to initialize cache %s: %w", cacheIdentity, err)
 		}
@@ -315,12 +315,12 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 
 	stateCache := cache.Global()
 
-	if err := c.PhasedExecutionContext.InitPipeline(stateCache); err != nil {
+	if err := c.PhasedExecutionContext.InitPipeline(ctx, stateCache); err != nil {
 		return nil, err
 	}
 	c.lastState = nil
 	defer func() {
-		_ = c.PhasedExecutionContext.Finalize(stateCache)
+		_ = c.PhasedExecutionContext.Finalize(ctx, stateCache)
 	}()
 
 	hasTerraformState := false
@@ -356,7 +356,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 	if c.CommanderMode {
 		c.Checker.SetExternalPhasedContext(c.PhasedExecutionContext)
 
-		if shouldStop, err := c.PhasedExecutionContext.StartPhase(phases.ConvergeCheckPhase, false, stateCache); err != nil {
+		if shouldStop, err := c.PhasedExecutionContext.StartPhase(ctx, phases.ConvergeCheckPhase, false, stateCache); err != nil {
 			return nil, fmt.Errorf("unable to switch phase: %w", err)
 		} else if shouldStop {
 			return nil, nil
@@ -383,7 +383,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 		log.InfoF("Has terraform state: %v\n", hasTerraformState)
 
 		if c.Params.OnCheckResult != nil {
-			if err := c.Params.OnCheckResult(checkRes); err != nil {
+			if err := c.Params.OnCheckResult(ctx, checkRes); err != nil {
 				return nil, cleanWithLog(err)
 			}
 		}
@@ -442,7 +442,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 	var inLockRunner *lock.InLockRunner
 	// No need for converge-lock in commander mode for bootstrap and converge operations
 	if !c.CommanderMode {
-		inLockRunner = lock.NewInLockLocalRunner(convergeCtx, "local-converger")
+		inLockRunner = lock.NewInLockLocalRunner(ctx, convergeCtx, "local-converger")
 	}
 
 	kubectlSwitcher := convergectx.NewKubeClientSwitcher(convergeCtx, inLockRunner, convergectx.KubeClientSwitcherParams{
@@ -478,7 +478,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 		return nil, fmt.Errorf("converge problem: %v", err)
 	}
 
-	if err := c.PhasedExecutionContext.CompletePipeline(stateCache); err != nil {
+	if err := c.PhasedExecutionContext.CompletePipeline(ctx, stateCache); err != nil {
 		return nil, err
 	}
 

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -151,10 +151,6 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 			return err
 		}
 
-		if err != nil {
-			return err
-		}
-
 		kubeCl = client.NewKubernetesClient().WithNodeInterface(ssh.NewNodeInterfaceWrapper(sshClient))
 		if err := kubeCl.Init(client.AppKubernetesInitParams()); err != nil {
 			return err
@@ -491,7 +487,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 	}, nil
 }
 
-func (c *Converger) AutoConverge(listenAddress string, checkInterval time.Duration) error {
+func (c *Converger) AutoConverge(ctx context.Context, listenAddress string, checkInterval time.Duration) error {
 	if err := c.applyParams(); err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -242,7 +242,7 @@ func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context
 	task := actions.ManifestTask{
 		Name:     `Secret "d8-masters-kubernetes-data-device-path"`,
 		Manifest: getDevicePathManifest,
-		CreateFunc: func(manifest interface{}) error {
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
 			_, err := h.kubeGetter.KubeClient().CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
 			if err != nil {
 				return err
@@ -250,7 +250,7 @@ func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context
 
 			return nil
 		},
-		UpdateFunc: func(manifest interface{}) error {
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 			data, err := json.Marshal(manifest.(*apiv1.Secret))
 			if err != nil {
 				return err
@@ -273,6 +273,6 @@ func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context
 
 	return retry.NewLoop(fmt.Sprintf("Save Kubernetes data device path for node '%s'", h.nodeToConverge), 45, 10*time.Second).
 		RunContext(ctx, func() error {
-			return task.CreateOrUpdate()
+			return task.CreateOrUpdate(ctx)
 		})
 }

--- a/dhctl/pkg/operations/converge/infrastructure/hook/node.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/node.go
@@ -42,7 +42,7 @@ func IsNodeReady(ctx context.Context, checkers []NodeChecker, nodeName, sourceCo
 
 	err := retry.NewLoop(title, 30, 10*time.Second).RunContext(ctx, func() error {
 		for _, check := range checkers {
-			err := log.Process(sourceCommandName, check.Name(), func() error {
+			err := log.ProcessCtx(ctx, sourceCommandName, check.Name(), func(ctx context.Context) error {
 				isReady, err := check.IsReady(ctx, nodeName)
 				if err != nil {
 					return err

--- a/dhctl/pkg/operations/converge/lock/lock.go
+++ b/dhctl/pkg/operations/converge/lock/lock.go
@@ -55,8 +55,8 @@ func NewInLockRunner(getter kubernetes.KubeClientProvider, identity string) *InL
 	}
 }
 
-func NewInLockLocalRunner(getter kubernetes.KubeClientProvider, identity string) *InLockRunner {
-	localIdentity := getLocalConvergeLockIdentity(identity)
+func NewInLockLocalRunner(ctx context.Context, getter kubernetes.KubeClientProvider, identity string) *InLockRunner {
+	localIdentity := getLocalConvergeLockIdentity(ctx, identity)
 	return NewInLockRunner(getter, localIdentity)
 }
 
@@ -121,7 +121,7 @@ func (r *InLockRunner) Stop() {
 }
 
 func LockConverge(ctx context.Context, provider kubernetes.KubeClientProvider, identity string) (func(bool), error) {
-	localIdentity := getLocalConvergeLockIdentity(identity)
+	localIdentity := getLocalConvergeLockIdentity(ctx, identity)
 	lockConfig := GetLockLeaseConfig(localIdentity)
 	return LockConvergeWithConfig(ctx, provider, lockConfig)
 }
@@ -185,20 +185,20 @@ func GetLockLeaseConfig(identity string) *lease.LeaseLockConfig {
 	}
 }
 
-func getLocalConvergeLockIdentity(pref string) string {
+func getLocalConvergeLockIdentity(ctx context.Context, pref string) string {
 	const cacheKey = "lock-identifier"
 
 	cache := statecache.Global()
 
-	if hasID, err := cache.InCache(cacheKey); err == nil && hasID {
-		id, err := cache.Load(cacheKey)
+	if hasID, err := cache.InCache(ctx, cacheKey); err == nil && hasID {
+		id, err := cache.Load(ctx, cacheKey)
 		if err == nil && len(id) > 0 {
 			return string(id)
 		}
 	}
 
 	id := fmt.Sprintf("%v-%v", pref, uuid.New().String())
-	if err := cache.Save(cacheKey, []byte(id)); err != nil {
+	if err := cache.Save(ctx, cacheKey, []byte(id)); err != nil {
 		panic(err)
 	}
 

--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -171,7 +171,7 @@ func populateNodesState(ctx *context.Context) (map[string]state.NodeGroupInfrast
 }
 
 func (r *runner) migrateTerraNodes(ctx *context.Context, metaConfig *config.MetaConfig, nodesState map[string]state.NodeGroupInfrastructureState) error {
-	if shouldStop, err := ctx.StarExecutionPhase(phases.AllNodesPhase, true); err != nil {
+	if shouldStop, err := ctx.StarExecutionPhase(ctx.Ctx(), phases.AllNodesPhase, true); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -206,11 +206,11 @@ func (r *runner) migrateTerraNodes(ctx *context.Context, metaConfig *config.Meta
 		}
 	}
 
-	return ctx.CompleteExecutionPhase(nil)
+	return ctx.CompleteExecutionPhase(ctx.Ctx(), nil)
 }
 
 func (r *runner) convergeTerraNodes(ctx *context.Context, metaConfig *config.MetaConfig, nodesState map[string]state.NodeGroupInfrastructureState) error {
-	if shouldStop, err := ctx.StarExecutionPhase(phases.AllNodesPhase, true); err != nil {
+	if shouldStop, err := ctx.StarExecutionPhase(ctx.Ctx(), phases.AllNodesPhase, true); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -274,7 +274,7 @@ func (r *runner) convergeTerraNodes(ctx *context.Context, metaConfig *config.Met
 		}
 	}
 
-	return ctx.CompleteExecutionPhase(nil)
+	return ctx.CompleteExecutionPhase(ctx.Ctx(), nil)
 }
 
 func (r *runner) convergeDeckhouseConfiguration(ctx *context.Context, commanderUUID uuid.UUID) error {
@@ -283,7 +283,7 @@ func (r *runner) convergeDeckhouseConfiguration(ctx *context.Context, commanderU
 		return err
 	}
 
-	if shouldStop, err := ctx.StarExecutionPhase(phases.InstallDeckhousePhase, false); err != nil {
+	if shouldStop, err := ctx.StarExecutionPhase(ctx.Ctx(), phases.InstallDeckhousePhase, false); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -293,7 +293,7 @@ func (r *runner) convergeDeckhouseConfiguration(ctx *context.Context, commanderU
 		return fmt.Errorf("unable to update deckhouse configuration: %w", err)
 	}
 
-	return ctx.CompleteExecutionPhase(nil)
+	return ctx.CompleteExecutionPhase(ctx.Ctx(), nil)
 }
 
 func (r *runner) convergeMigration(ctx *context.Context, checkHasTerraformStateBeforeMigration bool) error {
@@ -464,7 +464,7 @@ func (r *runner) converge(ctx *context.Context) error {
 }
 
 func (r *runner) updateClusterState(ctx *context.Context, metaConfig *config.MetaConfig) error {
-	if shouldStop, err := ctx.StarExecutionPhase(phases.BaseInfraPhase, true); err != nil {
+	if shouldStop, err := ctx.StarExecutionPhase(ctx.Ctx(), phases.BaseInfraPhase, true); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -511,5 +511,5 @@ func (r *runner) updateClusterState(ctx *context.Context, metaConfig *config.Met
 		return err
 	}
 
-	return ctx.CompleteExecutionPhase(nil)
+	return ctx.CompleteExecutionPhase(ctx.Ctx(), nil)
 }

--- a/dhctl/pkg/operations/destroy/abort_static_test.go
+++ b/dhctl/pkg/operations/destroy/abort_static_test.go
@@ -153,7 +153,7 @@ func testCreateAbortStaticProviderTest(t *testing.T, params testAbortStaticTestP
 	stateCache := cache.NewTestCache()
 
 	pec := phases.NewDefaultPhasedExecutionContext(phases.OperationBootstrap, nil, nil)
-	require.NoError(t, pec.InitPipeline(stateCache))
+	require.NoError(t, pec.InitPipeline(t.Context(), stateCache))
 
 	abortParams := &GetAbortDestroyerParams{
 		MetaConfig:             metaConfig,

--- a/dhctl/pkg/operations/destroy/cloud/destroyer.go
+++ b/dhctl/pkg/operations/destroy/cloud/destroyer.go
@@ -66,7 +66,7 @@ func (d *Destroyer) Prepare(ctx context.Context) error {
 		return nil
 	}
 
-	locked, err := d.params.State.IsConvergeLocked()
+	locked, err := d.params.State.IsConvergeLocked(ctx)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (d *Destroyer) Prepare(ctx context.Context) error {
 		return err
 	}
 
-	if err := d.params.State.SetConvergeLocked(); err != nil {
+	if err := d.params.State.SetConvergeLocked(ctx); err != nil {
 		// try to unlock because we cannot save in state
 		d.unlockConverge(true)
 		return err

--- a/dhctl/pkg/operations/destroy/cloud/state.go
+++ b/dhctl/pkg/operations/destroy/cloud/state.go
@@ -15,6 +15,8 @@
 package cloud
 
 import (
+	"context"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 )
 
@@ -32,10 +34,10 @@ func NewDestroyState(stateCache state.Cache) *State {
 	}
 }
 
-func (s *State) IsConvergeLocked() (bool, error) {
-	return s.cache.InCache(convergeLocked)
+func (s *State) IsConvergeLocked(ctx context.Context) (bool, error) {
+	return s.cache.InCache(ctx, convergeLocked)
 }
 
-func (s *State) SetConvergeLocked() error {
-	return s.cache.Save(convergeLocked, []byte("yes"))
+func (s *State) SetConvergeLocked(ctx context.Context) error {
+	return s.cache.Save(ctx, convergeLocked, []byte("yes"))
 }

--- a/dhctl/pkg/operations/destroy/common_test.go
+++ b/dhctl/pkg/operations/destroy/common_test.go
@@ -810,7 +810,7 @@ func (ts *baseTest) stateCacheKeys(t *testing.T) []string {
 
 	keys := make([]string, 0)
 
-	err := ts.stateCache.Iterate(func(k string, _ []byte) error {
+	err := ts.stateCache.Iterate(t.Context(), func(k string, _ []byte) error {
 		keys = append(keys, k)
 		return nil
 	})
@@ -838,7 +838,7 @@ func (ts *baseTest) clean(t *testing.T) {
 func (ts *baseTest) setResourcesDestroyed(t *testing.T) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	err := deckhouse.NewState(ts.stateCache).SetResourcesDestroyed()
+	err := deckhouse.NewState(ts.stateCache).SetResourcesDestroyed(t.Context())
 	require.NoError(t, err, "resources destroyed should save in cache")
 }
 
@@ -846,14 +846,14 @@ func (ts *baseTest) saveMetaConfigToCache(t *testing.T) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 	require.False(t, govalue.IsNil(ts.metaConfig))
 
-	err := ts.stateCache.SaveStruct(metaConfigKey, ts.metaConfig)
+	err := ts.stateCache.SaveStruct(t.Context(), metaConfigKey, ts.metaConfig)
 	require.NoError(t, err, "metaconfig should be saved in cache")
 }
 
 func (ts *baseTest) assertHasMetaConfigInCache(t *testing.T, saved bool) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	inCache, err := ts.stateCache.InCache(metaConfigKey)
+	inCache, err := ts.stateCache.InCache(t.Context(), metaConfigKey)
 
 	if !saved {
 		require.NoError(t, err, "metaconfig should not save in cache")
@@ -867,7 +867,7 @@ func (ts *baseTest) assertHasMetaConfigInCache(t *testing.T, saved bool) {
 func (ts *baseTest) assertResourcesSetDestroyedInCache(t *testing.T, destroyed bool) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	destroyedInCache, err := deckhouse.NewState(ts.stateCache).IsResourcesDestroyed()
+	destroyedInCache, err := deckhouse.NewState(ts.stateCache).IsResourcesDestroyed(t.Context())
 	require.NoError(t, err, "resources destroyed flag should be set")
 	require.Equal(t, destroyed, destroyedInCache, "resources destroyed should be set correct flag")
 }
@@ -932,16 +932,16 @@ const (
 func testAddCloudStatesToCache(t *testing.T, stateCache dhctlstate.Cache, uuid string) {
 	require.False(t, govalue.IsNil(stateCache))
 
-	err := stateCache.Save(uuidKey, []byte(uuid))
+	err := stateCache.Save(t.Context(), uuidKey, []byte(uuid))
 	require.NoError(t, err, "uuid should save")
 
-	err = stateCache.Save(baseInfraKey, []byte(`{}`))
+	err = stateCache.Save(t.Context(), baseInfraKey, []byte(`{}`))
 	require.NoError(t, err, "base infra should save")
 
-	err = stateCache.Save(nodeBackupStateKey, []byte(`{"a": "b"}`))
+	err = stateCache.Save(t.Context(), nodeBackupStateKey, []byte(`{"a": "b"}`))
 	require.NoError(t, err, "backup should save")
 
-	err = stateCache.Save(nodeStateKey, []byte(`{}`))
+	err = stateCache.Save(t.Context(), nodeStateKey, []byte(`{}`))
 	require.NoError(t, err, "master state should save")
 }
 

--- a/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
+++ b/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
@@ -150,7 +150,7 @@ func (d *Destroyer) deleteResources(ctx context.Context, logger log.Logger) erro
 		return err
 	}
 
-	return logger.LogProcess("common", "Delete resources from the Kubernetes cluster", func() error {
+	return logger.LogProcessCtx(ctx, "common", "Delete resources from the Kubernetes cluster", func(ctx context.Context) error {
 		return d.deleteEntities(ctx, kubeCl)
 	})
 }

--- a/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
+++ b/dhctl/pkg/operations/destroy/deckhouse/destroyer.go
@@ -62,7 +62,7 @@ func (d *Destroyer) CheckCommanderUUID(ctx context.Context) error {
 		return nil
 	}
 
-	uuidInCache, err := d.State.CommanderUUID()
+	uuidInCache, err := d.State.CommanderUUID(ctx)
 	if err != nil {
 		return err
 	}
@@ -88,8 +88,8 @@ func (d *Destroyer) CheckCommanderUUID(ctx context.Context) error {
 		return fmt.Errorf("UUID consistency check failed: %w", err)
 	}
 
-	return d.PhasedActionProvider().Run(phases.CommanderUUIDWasChecked, false, func() (phases.DefaultContextType, error) {
-		return nil, d.State.SetCommanderUUID(passedUUID)
+	return d.PhasedActionProvider().Run(ctx, phases.CommanderUUIDWasChecked, false, func() (phases.DefaultContextType, error) {
+		return nil, d.State.SetCommanderUUID(ctx, passedUUID)
 	})
 }
 
@@ -100,17 +100,17 @@ func (d *Destroyer) CheckAndDeleteResources(ctx context.Context) error {
 		return nil
 	}
 
-	return d.PhasedActionProvider().Run(phases.DeleteResourcesPhase, false, func() (phases.DefaultContextType, error) {
+	return d.PhasedActionProvider().Run(ctx, phases.DeleteResourcesPhase, false, func() (phases.DefaultContextType, error) {
 		return nil, d.deleteResources(ctx, logger)
 	})
 }
 
-func (d *Destroyer) Finalize(context.Context) error {
+func (d *Destroyer) Finalize(ctx context.Context) error {
 	if d.isSkipResources("Finalize") {
 		return nil
 	}
 
-	alreadyDestroyed, err := d.State.IsResourcesDestroyed()
+	alreadyDestroyed, err := d.State.IsResourcesDestroyed(ctx)
 	if err != nil {
 		return err
 	}
@@ -122,8 +122,8 @@ func (d *Destroyer) Finalize(context.Context) error {
 		return nil
 	}
 
-	err = d.PhasedActionProvider().Run(phases.SetDeckhouseResourcesDeletedPhase, false, func() (phases.DefaultContextType, error) {
-		return nil, d.State.SetResourcesDestroyed()
+	err = d.PhasedActionProvider().Run(ctx, phases.SetDeckhouseResourcesDeletedPhase, false, func() (phases.DefaultContextType, error) {
+		return nil, d.State.SetResourcesDestroyed(ctx)
 	})
 
 	if err != nil {
@@ -135,7 +135,7 @@ func (d *Destroyer) Finalize(context.Context) error {
 }
 
 func (d *Destroyer) deleteResources(ctx context.Context, logger log.Logger) error {
-	resourcesDestroyed, err := d.State.IsResourcesDestroyed()
+	resourcesDestroyed, err := d.State.IsResourcesDestroyed(ctx)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/operations/destroy/deckhouse/state.go
+++ b/dhctl/pkg/operations/destroy/deckhouse/state.go
@@ -15,6 +15,7 @@
 package deckhouse
 
 import (
+	"context"
 	"strings"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
@@ -35,16 +36,16 @@ func NewState(stateCache state.Cache) *State {
 	}
 }
 
-func (s *State) IsResourcesDestroyed() (bool, error) {
-	return s.cache.InCache(resourcesDestroyedKey)
+func (s *State) IsResourcesDestroyed(ctx context.Context) (bool, error) {
+	return s.cache.InCache(ctx, resourcesDestroyedKey)
 }
 
-func (s *State) SetResourcesDestroyed() error {
-	return s.cache.Save(resourcesDestroyedKey, []byte("yes"))
+func (s *State) SetResourcesDestroyed(ctx context.Context) error {
+	return s.cache.Save(ctx, resourcesDestroyedKey, []byte("yes"))
 }
 
-func (s *State) CommanderUUID() (string, error) {
-	inCache, err := s.cache.InCache(commanderUUIDCheckedKey)
+func (s *State) CommanderUUID(ctx context.Context) (string, error) {
+	inCache, err := s.cache.InCache(ctx, commanderUUIDCheckedKey)
 	if err != nil {
 		return "", err
 	}
@@ -52,7 +53,7 @@ func (s *State) CommanderUUID() (string, error) {
 		return "", nil
 	}
 
-	uuidInCache, err := s.cache.Load(commanderUUIDCheckedKey)
+	uuidInCache, err := s.cache.Load(ctx, commanderUUIDCheckedKey)
 	if err != nil {
 		return "", err
 	}
@@ -60,6 +61,6 @@ func (s *State) CommanderUUID() (string, error) {
 	return strings.TrimSpace(string(uuidInCache)), nil
 }
 
-func (s *State) SetCommanderUUID(uuid string) error {
-	return s.cache.Save(commanderUUIDCheckedKey, []byte(uuid))
+func (s *State) SetCommanderUUID(ctx context.Context, uuid string) error {
+	return s.cache.Save(ctx, commanderUUIDCheckedKey, []byte(uuid))
 }

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -247,7 +247,7 @@ func NewClusterDestroyer(ctx context.Context, params *Params) (*ClusterDestroyer
 }
 
 func (d *ClusterDestroyer) DestroyCluster(ctx context.Context, autoApprove bool) error {
-	return d.pipeline.Run(func(switcher phases.DefaultPipelinePhaseSwitcher) error {
+	return d.pipeline.Run(ctx, func(switcher phases.DefaultPipelinePhaseSwitcher) error {
 		return d.destroy(ctx, autoApprove)
 	})
 }
@@ -299,7 +299,7 @@ func (d *ClusterDestroyer) destroy(ctx context.Context, autoApprove bool) error 
 		return err
 	}
 
-	d.stateCache.Clean()
+	d.stateCache.Clean(ctx)
 
 	return nil
 }

--- a/dhctl/pkg/operations/destroy/destroy_cloud_test.go
+++ b/dhctl/pkg/operations/destroy/destroy_cloud_test.go
@@ -493,7 +493,7 @@ func TestCloudDestroy(t *testing.T) {
 				before: setAllInCache,
 				assert: func(t *testing.T, tst *testCloudDestroyTest) {
 					require.False(t, govalue.IsNil(tst.d8State))
-					inCacheUUID, err := tst.d8State.CommanderUUID()
+					inCacheUUID, err := tst.d8State.CommanderUUID(t.Context())
 					require.NoError(t, err)
 					require.Equal(t, tst.params.commanderUUIDInCluster.String(), inCacheUUID, "in cache commander UUID should same in cluster")
 				},
@@ -598,7 +598,7 @@ type testCloudDestroyTest struct {
 func (ts *testCloudDestroyTest) saveInfraStateKeys(t *testing.T) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	err := ts.stateCache.Save(clusterStateKey, []byte(`{}`))
+	err := ts.stateCache.Save(t.Context(), clusterStateKey, []byte(`{}`))
 	require.NoError(t, err)
 
 	nodesState := map[string]state.NodeGroupInfrastructureState{
@@ -609,21 +609,21 @@ func (ts *testCloudDestroyTest) saveInfraStateKeys(t *testing.T) {
 		},
 	}
 
-	err = ts.stateCache.SaveStruct(nodesStateKey, nodesState)
+	err = ts.stateCache.SaveStruct(t.Context(), nodesStateKey, nodesState)
 	require.NoError(t, err)
 }
 
 func (ts *testCloudDestroyTest) setCommanderUUIDInCache(t *testing.T, uuid string) {
 	require.False(t, govalue.IsNil(ts.d8State))
 
-	err := ts.d8State.SetCommanderUUID(uuid)
+	err := ts.d8State.SetCommanderUUID(t.Context(), uuid)
 	require.NoError(t, err, "resources destroyed should save in cache")
 }
 
 func (ts *testCloudDestroyTest) assertInfraStateInCache(t *testing.T, inCache bool) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	clusterState, err := ts.stateCache.Load(clusterStateKey)
+	clusterState, err := ts.stateCache.Load(t.Context(), clusterStateKey)
 	require.NoError(t, err)
 	assert := require.Empty
 	if inCache {
@@ -633,7 +633,7 @@ func (ts *testCloudDestroyTest) assertInfraStateInCache(t *testing.T, inCache bo
 
 	var nodesState map[string]state.NodeGroupInfrastructureState
 
-	err = ts.stateCache.LoadStruct(nodesStateKey, &nodesState)
+	err = ts.stateCache.LoadStruct(t.Context(), nodesStateKey, &nodesState)
 
 	assertNodesState := require.Error
 	if inCache {
@@ -645,14 +645,14 @@ func (ts *testCloudDestroyTest) assertInfraStateInCache(t *testing.T, inCache bo
 func (ts *testCloudDestroyTest) setConvergeLock(t *testing.T) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	err := cloud.NewDestroyState(ts.stateCache).SetConvergeLocked()
+	err := cloud.NewDestroyState(ts.stateCache).SetConvergeLocked(t.Context())
 	require.NoError(t, err)
 }
 
 func (ts *testCloudDestroyTest) assertConvergeLockSetInCache(t *testing.T, locked bool) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	lockedInCache, err := cloud.NewDestroyState(ts.stateCache).IsConvergeLocked()
+	lockedInCache, err := cloud.NewDestroyState(ts.stateCache).IsConvergeLocked(t.Context())
 	require.NoError(t, err)
 
 	require.Equal(t, locked, lockedInCache, "should be converge locked or not")

--- a/dhctl/pkg/operations/destroy/destroy_static_test.go
+++ b/dhctl/pkg/operations/destroy/destroy_static_test.go
@@ -1330,7 +1330,7 @@ type testStaticDestroyTest struct {
 func (ts *testStaticDestroyTest) setNodeUserExistsInCache(t *testing.T) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	err := static.NewDestroyState(ts.stateCache).SetNodeUserExists()
+	err := static.NewDestroyState(ts.stateCache).SetNodeUserExists(t.Context())
 	require.NoError(t, err, "node user exists flag should in cache")
 }
 
@@ -1368,7 +1368,7 @@ func (ts *testStaticDestroyTest) generateAndSaveNodeUserToCache(t *testing.T, pa
 		ProcessedIPS: params.processedIPs,
 	}
 
-	err := static.NewDestroyState(ts.stateCache).SaveNodeUser(credsToSave)
+	err := static.NewDestroyState(ts.stateCache).SaveNodeUser(t.Context(), credsToSave)
 	require.NoError(t, err, "creds should save in cache")
 
 	ts.nodeUserCreds = credsToSave
@@ -1386,7 +1386,7 @@ func (ts *testStaticDestroyTest) assertNodeUserIsNotUpdated(t *testing.T, checkI
 	require.False(t, govalue.IsNil(ts.stateCache))
 	require.False(t, govalue.IsNil(ts.nodeUserCreds))
 
-	nodeUserCreds, err := static.NewDestroyState(ts.stateCache).NodeUser()
+	nodeUserCreds, err := static.NewDestroyState(ts.stateCache).NodeUser(t.Context())
 	require.NoError(t, err, "node user should save in cache")
 	require.Equal(t, *ts.nodeUserCreds, *nodeUserCreds, "node user should not change")
 
@@ -1409,7 +1409,7 @@ func (ts *testStaticDestroyTest) assertNodeUserIsNotUpdated(t *testing.T, checkI
 func (ts *testStaticDestroyTest) assertNodeUserExistsSavedInCache(t *testing.T, saved bool) {
 	require.False(t, govalue.IsNil(ts.stateCache))
 
-	exists := static.NewDestroyState(ts.stateCache).IsNodeUserExists()
+	exists := static.NewDestroyState(ts.stateCache).IsNodeUserExists(t.Context())
 	require.Equal(t, saved, exists, "node user exists flag")
 }
 
@@ -1417,7 +1417,7 @@ func (ts *testStaticDestroyTest) assertNodeUserSavedInCache(t *testing.T, saved 
 	require.False(t, govalue.IsNil(ts.stateCache))
 
 	state := static.NewDestroyState(ts.stateCache)
-	nodeUser, err := state.NodeUser()
+	nodeUser, err := state.NodeUser(t.Context())
 	if !saved {
 		require.Error(t, err, "node user should not save in cache")
 		return nil

--- a/dhctl/pkg/operations/destroy/static/destroyer.go
+++ b/dhctl/pkg/operations/destroy/static/destroyer.go
@@ -177,14 +177,17 @@ func (d *Destroyer) destroyCluster(ctx context.Context, autoApprove bool) error 
 	}
 
 	if len(ips) > 0 {
-		err := logger.LogProcess("default", "Get internal node IP for passed control-plane host", func() error {
+		err := logger.LogProcessCtx(ctx, "default", "Get internal node IP for passed control-plane host", func(ctx context.Context) error {
 			file := sshClient.File()
+
 			bytes, err := file.DownloadBytes(ctx, "/var/lib/bashible/discovered-node-ip")
 			if err != nil {
 				return err
 			}
+
 			hostToExclude = strings.TrimSpace(string(bytes))
 			logger.LogDebugF("Got internal node IP for passed control-plane host: %s\n", hostToExclude)
+
 			return nil
 		})
 		if err != nil {

--- a/dhctl/pkg/operations/destroy/static/destroyer.go
+++ b/dhctl/pkg/operations/destroy/static/destroyer.go
@@ -105,7 +105,7 @@ func (d *Destroyer) Prepare(ctx context.Context) error {
 
 	var err error
 
-	d.nodesWithCredentials, err = d.params.State.NodeUser()
+	d.nodesWithCredentials, err = d.params.State.NodeUser(ctx)
 
 	if err != nil {
 		if !errors.Is(err, errNotFoundCredentials) {
@@ -137,7 +137,7 @@ func (d *Destroyer) DestroyCluster(ctx context.Context, autoApprove bool) error 
 		return errors.New("Internal error. SSH provider did not pass")
 	}
 
-	return d.params.PhasedActionProvider().Run(phases.AllNodesPhase, true, func() (phases.DefaultContextType, error) {
+	return d.params.PhasedActionProvider().Run(ctx, phases.AllNodesPhase, true, func() (phases.DefaultContextType, error) {
 		err := d.destroyCluster(ctx, autoApprove)
 		if err != nil {
 			return nil, err
@@ -305,7 +305,7 @@ func (d *Destroyer) processStaticHost(ctx context.Context, sshClient node.SSHCli
 		return err
 	}
 
-	return d.addHostAsProcessed(host)
+	return d.addHostAsProcessed(ctx, host)
 }
 
 func (d *Destroyer) switchToNodeUser(ctx context.Context, oldSSHClient node.SSHClient, settings *session.Session) (node.SSHClient, error) {
@@ -414,12 +414,12 @@ func (d *Destroyer) waitNodeUserExists(ctx context.Context) error {
 
 	logger := d.logger()
 
-	if d.params.State.IsNodeUserExists() {
+	if d.params.State.IsNodeUserExists(ctx) {
 		logger.LogDebugLn("NodeUser for static destroyer exists getting from cache")
 		return nil
 	}
 
-	return d.params.PhasedActionProvider().Run(phases.WaitStaticDestroyerNodeUserPhase, false, func() (phases.DefaultContextType, error) {
+	return d.params.PhasedActionProvider().Run(ctx, phases.WaitStaticDestroyerNodeUserPhase, false, func() (phases.DefaultContextType, error) {
 		if !isSingleMaster(d.nodesWithCredentials.IPs) {
 			// waiter checks if nil params
 			waiter := entity.NewConvergerNodeUserExistsWaiter(d.params.KubeProvider).
@@ -432,7 +432,7 @@ func (d *Destroyer) waitNodeUserExists(ctx context.Context) error {
 			logger.LogDebugLn("No wait NodeUser for single-master cluster")
 		}
 
-		return nil, d.params.State.SetNodeUserExists()
+		return nil, d.params.State.SetNodeUserExists(ctx)
 	})
 }
 
@@ -476,7 +476,7 @@ func (d *Destroyer) createAndSaveCredentials(ctx context.Context, logger log.Log
 	// always create node user creds so we have only master
 	var nodesWithCredentials *NodesWithCredentials
 
-	err = d.params.PhasedActionProvider().Run(phases.CreateStaticDestroyerNodeUserPhase, false, func() (phases.DefaultContextType, error) {
+	err = d.params.PhasedActionProvider().Run(ctx, phases.CreateStaticDestroyerNodeUserPhase, false, func() (phases.DefaultContextType, error) {
 		nodeUserCredentials, err := d.createNodeUserCredentials(ctx, nodeIPs, logger)
 		if err != nil {
 			return nil, err
@@ -487,7 +487,7 @@ func (d *Destroyer) createAndSaveCredentials(ctx context.Context, logger log.Log
 			IPs:      nodeIPs,
 		}
 
-		if err := d.params.State.SaveNodeUser(nodesWithCredentials); err != nil {
+		if err := d.params.State.SaveNodeUser(ctx, nodesWithCredentials); err != nil {
 			return nil, err
 		}
 
@@ -511,16 +511,16 @@ func (d *Destroyer) hostProcessed(host session.Host) bool {
 	return d.nodesWithCredentials.SetHostAsProcessed(host)
 }
 
-func (d *Destroyer) addHostAsProcessed(host session.Host) error {
+func (d *Destroyer) addHostAsProcessed(ctx context.Context, host session.Host) error {
 	// for abort we do not have nodesWithCredentials
 	if d.nodesWithCredentials == nil {
 		return nil
 	}
 
-	return d.params.PhasedActionProvider().Run(phases.UpdateStaticDestroyerIPs, false, func() (phases.DefaultContextType, error) {
+	return d.params.PhasedActionProvider().Run(ctx, phases.UpdateStaticDestroyerIPs, false, func() (phases.DefaultContextType, error) {
 		d.nodesWithCredentials.AddToProcessed(host)
 
-		if err := d.params.State.SaveNodeUser(d.nodesWithCredentials); err != nil {
+		if err := d.params.State.SaveNodeUser(ctx, d.nodesWithCredentials); err != nil {
 			return nil, err
 		}
 

--- a/dhctl/pkg/operations/destroy/static/state.go
+++ b/dhctl/pkg/operations/destroy/static/state.go
@@ -15,6 +15,7 @@
 package static
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -40,16 +41,16 @@ func NewDestroyState(stateCache state.Cache) *State {
 	}
 }
 
-func (s *State) SaveNodeUser(credentials *NodesWithCredentials) error {
-	if err := s.cache.SaveStruct(nodeUserKey, credentials); err != nil {
+func (s *State) SaveNodeUser(ctx context.Context, credentials *NodesWithCredentials) error {
+	if err := s.cache.SaveStruct(ctx, nodeUserKey, credentials); err != nil {
 		return fmt.Errorf("Cannot save node user credentials for static destroyer: %w", err)
 	}
 
 	return nil
 }
 
-func (s *State) NodeUser() (*NodesWithCredentials, error) {
-	exists, err := s.cache.InCache(nodeUserKey)
+func (s *State) NodeUser(ctx context.Context) (*NodesWithCredentials, error) {
+	exists, err := s.cache.InCache(ctx, nodeUserKey)
 
 	if err != nil {
 		return nil, err
@@ -61,23 +62,23 @@ func (s *State) NodeUser() (*NodesWithCredentials, error) {
 
 	creds := NodesWithCredentials{}
 
-	if err := s.cache.LoadStruct(nodeUserKey, &creds); err != nil {
+	if err := s.cache.LoadStruct(ctx, nodeUserKey, &creds); err != nil {
 		return nil, fmt.Errorf("Cannot load node user credentials for static destroyer: %w", err)
 	}
 
 	return &creds, nil
 }
 
-func (s *State) SetNodeUserExists() error {
-	if err := s.cache.Save(nodeUserExistsKey, []byte("yes")); err != nil {
+func (s *State) SetNodeUserExists(ctx context.Context) error {
+	if err := s.cache.Save(ctx, nodeUserExistsKey, []byte("yes")); err != nil {
 		return fmt.Errorf("Cannot save node user exists flag for static destroyer: %w", err)
 	}
 
 	return nil
 }
 
-func (s *State) IsNodeUserExists() bool {
-	if exists, err := s.cache.InCache(nodeUserExistsKey); err != nil || !exists {
+func (s *State) IsNodeUserExists(ctx context.Context) bool {
+	if exists, err := s.cache.InCache(ctx, nodeUserExistsKey); err != nil || !exists {
 		return false
 	}
 

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -109,7 +109,7 @@ func BootstrapAdditionalNode(
 
 func BootstrapSequentialTerraNodes(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, terraNodeGroups []config.TerraNodeGroupSpec, infrastructureContext *infrastructure.Context) error {
 	for _, ng := range terraNodeGroups {
-		err := log.Process("bootstrap", fmt.Sprintf("Create %s NodeGroup", ng.Name), func() error {
+		err := log.ProcessCtx(ctx, "bootstrap", fmt.Sprintf("Create %s NodeGroup", ng.Name), func(ctx context.Context) error {
 			err := entity.CreateNodeGroup(ctx, kubeCl, ng.Name, log.GetDefaultLogger(), metaConfig.NodeGroupManifest(ng))
 			if err != nil {
 				return err
@@ -128,6 +128,7 @@ func BootstrapSequentialTerraNodes(ctx context.Context, kubeCl *client.Kubernete
 			}
 			return nil
 		})
+
 		if err != nil {
 			return err
 		}
@@ -315,7 +316,7 @@ func ParallelCreateNodeGroup(
 		msg += fmt.Sprintf("%s (replicas: %v)️; ", group.Name, group.Replicas)
 	}
 
-	return log.Process("converge", msg, func() error {
+	return log.ProcessCtx(ctx, "converge", msg, func(ctx context.Context) error {
 		var (
 			mu sync.Mutex
 			wg sync.WaitGroup

--- a/dhctl/pkg/operations/phases/dhctl_state.go
+++ b/dhctl/pkg/operations/phases/dhctl_state.go
@@ -15,13 +15,15 @@
 package phases
 
 import (
+	"context"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 )
 
 type DhctlState map[string][]byte
 
-func ExtractDhctlState(stateCache state.Cache) (res DhctlState, err error) {
-	err = stateCache.Iterate(func(k string, v []byte) error {
+func ExtractDhctlState(ctx context.Context, stateCache state.Cache) (res DhctlState, err error) {
+	err = stateCache.Iterate(ctx, func(k string, v []byte) error {
 		if res == nil {
 			res = make(map[string][]byte)
 		}

--- a/dhctl/pkg/operations/phases/phased_execution_context.go
+++ b/dhctl/pkg/operations/phases/phased_execution_context.go
@@ -15,6 +15,7 @@
 package phases
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -36,14 +37,14 @@ type (
 	OnPhaseFunc[OperationPhaseDataT any] func(data OnPhaseFuncData[OperationPhaseDataT]) error
 
 	PhasedExecutionContext[OperationPhaseDataT any] interface {
-		InitPipeline(stateCache dstate.Cache) error
-		Finalize(stateCache dstate.Cache) error
-		StartPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error)
-		CompletePhase(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error
-		CompletePipeline(stateCache dstate.Cache) error
-		SwitchPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) (bool, error)
+		InitPipeline(ctx context.Context, stateCache dstate.Cache) error
+		Finalize(ctx context.Context, stateCache dstate.Cache) error
+		StartPhase(ctx context.Context, phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error)
+		CompletePhase(ctx context.Context, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error
+		CompletePipeline(ctx context.Context, stateCache dstate.Cache) error
+		SwitchPhase(ctx context.Context, phase OperationPhase, isCritical bool, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) (bool, error)
 		CompleteSubPhase(completedSubPhase OperationSubPhase)
-		CompletePhaseAndPipeline(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error
+		CompletePhaseAndPipeline(ctx context.Context, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error
 		GetLastState() DhctlState
 		SetClusterConfig(cfg ClusterConfig)
 	}
@@ -79,8 +80,8 @@ func NewPhasedExecutionContext[OperationPhaseDataT any](
 	}
 }
 
-func (pec *phasedExecutionContext[OperationPhaseDataT]) setLastState(stateCache dstate.Cache) error {
-	state, err := ExtractDhctlState(stateCache)
+func (pec *phasedExecutionContext[OperationPhaseDataT]) setLastState(ctx context.Context, stateCache dstate.Cache) error {
+	state, err := ExtractDhctlState(ctx, stateCache)
 	if err != nil {
 		return fmt.Errorf("unable to extract dhctl state: %w", err)
 	}
@@ -88,7 +89,7 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) setLastState(stateCache 
 	return nil
 }
 
-func (pec *phasedExecutionContext[OperationPhaseDataT]) callOnPhase(completedPhase OperationPhase, completedPhaseState DhctlState, completedPhaseData OperationPhaseDataT, nextPhase OperationPhase, nextPhaseIsCritical bool, stateCache dstate.Cache) (bool, error) {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) callOnPhase(ctx context.Context, completedPhase OperationPhase, completedPhaseState DhctlState, completedPhaseData OperationPhaseDataT, nextPhase OperationPhase, nextPhaseIsCritical bool, stateCache dstate.Cache) (bool, error) {
 	lastCompletedPhase, skipped := pec.progressTracker.FindLastCompletedPhase(completedPhase, nextPhase)
 	opts := ProgressOpts{}
 	if skipped {
@@ -113,7 +114,7 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) callOnPhase(completedPha
 	})
 
 	if onPhaseErr != nil {
-		if err := pec.setLastState(stateCache); err != nil {
+		if err := pec.setLastState(ctx, stateCache); err != nil {
 			return false, err
 		}
 
@@ -137,8 +138,8 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) SetClusterConfig(cfg Clu
 
 // InitPipeline initializes phasedExecutionContext before usage.
 // It is not possible to use phasedExecutionContext before InitPipeline called.
-func (pec *phasedExecutionContext[OperationPhaseDataT]) InitPipeline(stateCache dstate.Cache) error {
-	if err := pec.setLastState(stateCache); err != nil {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) InitPipeline(ctx context.Context, stateCache dstate.Cache) error {
+	if err := pec.setLastState(ctx, stateCache); err != nil {
 		return err
 	}
 	pec.pipelineCompletionCounter++
@@ -149,7 +150,7 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) InitPipeline(stateCache 
 // Call Finalize in the same scope where InitPipeline has been called.
 //
 // It is not possible to use phasedExecutionContext after Finalize called.
-func (pec *phasedExecutionContext[OperationPhaseDataT]) Finalize(stateCache dstate.Cache) error {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) Finalize(ctx context.Context, stateCache dstate.Cache) error {
 	if pec.stopOperationCondition {
 		return nil
 	}
@@ -159,32 +160,32 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) Finalize(stateCache dsta
 		log.ErrorF("Failed to complete progress: %v", err)
 	}
 
-	return pec.setLastState(stateCache)
+	return pec.setLastState(ctx, stateCache)
 }
 
 // StartPhase starts a new phase of some process behind current phasedExecutionContext.
 // StartPhase could be called either after InitPipeline to start first phase or after CompletePhase to start N-th phase.
-func (pec *phasedExecutionContext[OperationPhaseDataT]) StartPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error) {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) StartPhase(ctx context.Context, phase OperationPhase, isCritical bool, stateCache dstate.Cache) (bool, error) {
 	if pec.stopOperationCondition {
 		return true, nil
 	}
 
-	if err := pec.setLastState(stateCache); err != nil {
+	if err := pec.setLastState(ctx, stateCache); err != nil {
 		return false, err
 	}
 
 	pec.currentPhase = phase
-	return pec.callOnPhase(pec.completedPhase, pec.lastState, pec.completedPhaseData, phase, isCritical, stateCache)
+	return pec.callOnPhase(ctx, pec.completedPhase, pec.lastState, pec.completedPhaseData, phase, isCritical, stateCache)
 }
 
 // CompletePhase stops previously started phase and saves current snapshot of state::Cache into the phasedExecutionContext.
-func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePhase(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePhase(ctx context.Context, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error {
 	if pec.stopOperationCondition {
 		return nil
 	}
 	pec.completedPhase = pec.currentPhase
 	pec.completedPhaseData = completedPhaseData
-	return pec.setLastState(stateCache)
+	return pec.setLastState(ctx, stateCache)
 }
 
 // CompleteSubPhase completes specified sub phase.
@@ -198,7 +199,7 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) CompleteSubPhase(complet
 // CompletePipeline stops whole phased process execution pipeline (onPhaseFunc will be called).
 // CompletePipeline or CompletePhaseAndPipeline could be called only once for a given phasedExecutionContext.
 // CompletePipeline or CompletePhaseAndPipeline should be called in the same scope where InitPipeline has been called.
-func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePipeline(stateCache dstate.Cache) error {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePipeline(ctx context.Context, stateCache dstate.Cache) error {
 	pec.pipelineCompletionCounter--
 	if pec.stopOperationCondition {
 		return nil
@@ -210,28 +211,28 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePipeline(stateCa
 		return nil
 	}
 	if pec.pipelineCompletionCounter == 0 {
-		_, err := pec.callOnPhase(pec.completedPhase, pec.lastState, pec.completedPhaseData, "", false, stateCache)
+		_, err := pec.callOnPhase(ctx, pec.completedPhase, pec.lastState, pec.completedPhaseData, "", false, stateCache)
 		return err
 	}
 	return nil
 }
 
 // SwitchPhase is a shortcut to complete current phase & start next phase in one-step.
-func (pec *phasedExecutionContext[OperationPhaseDataT]) SwitchPhase(phase OperationPhase, isCritical bool, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) (bool, error) {
-	if err := pec.CompletePhase(stateCache, completedPhaseData); err != nil {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) SwitchPhase(ctx context.Context, phase OperationPhase, isCritical bool, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) (bool, error) {
+	if err := pec.CompletePhase(ctx, stateCache, completedPhaseData); err != nil {
 		return false, err
 	}
-	return pec.StartPhase(phase, isCritical, stateCache)
+	return pec.StartPhase(ctx, phase, isCritical, stateCache)
 }
 
 // CompletePhaseAndPipeline is a shortcut to commit current phase & complete phasedExecutionContext phased process execution pipeline.
 // Complete or CompletePhaseAndPipeline could be called only once for a given phasedExecutionContext.
 // Complete or CompletePhaseAndPipeline should be called in the same scope where InitPipeline has been called.
-func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePhaseAndPipeline(stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error {
-	if err := pec.CompletePhase(stateCache, completedPhaseData); err != nil {
+func (pec *phasedExecutionContext[OperationPhaseDataT]) CompletePhaseAndPipeline(ctx context.Context, stateCache dstate.Cache, completedPhaseData OperationPhaseDataT) error {
+	if err := pec.CompletePhase(ctx, stateCache, completedPhaseData); err != nil {
 		return err
 	}
-	return pec.CompletePipeline(stateCache)
+	return pec.CompletePipeline(ctx, stateCache)
 }
 
 // GetLastState gets last committed state from phasedExecutionContext.

--- a/dhctl/pkg/operations/phases/wrappers.go
+++ b/dhctl/pkg/operations/phases/wrappers.go
@@ -15,6 +15,7 @@
 package phases
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -38,7 +39,7 @@ type (
 	PhaseAction[OperationPhaseDataT any] interface {
 		// Run
 		// if action should stop run should return ErrShouldStop
-		Run(phase OperationPhase, isCritical bool, action ActionFunc[OperationPhaseDataT]) error
+		Run(ctx context.Context, phase OperationPhase, isCritical bool, action ActionFunc[OperationPhaseDataT]) error
 		CompleteSub(phase OperationSubPhase) error
 	}
 
@@ -75,8 +76,8 @@ func NewDefaultPhaseActionProviderWithStateCache(context DefaultPhasedExecutionC
 	}
 }
 
-func (a *PhaseActionWithStateCache[OperationPhaseDataT]) Run(phase OperationPhase, isCritical bool, action ActionFunc[OperationPhaseDataT]) error {
-	if shouldStop, err := a.phaseContext.StartPhase(phase, isCritical, a.stateCache); err != nil {
+func (a *PhaseActionWithStateCache[OperationPhaseDataT]) Run(ctx context.Context, phase OperationPhase, isCritical bool, action ActionFunc[OperationPhaseDataT]) error {
+	if shouldStop, err := a.phaseContext.StartPhase(ctx, phase, isCritical, a.stateCache); err != nil {
 		return err
 	} else if shouldStop {
 		return ErrShouldStop
@@ -88,7 +89,7 @@ func (a *PhaseActionWithStateCache[OperationPhaseDataT]) Run(phase OperationPhas
 		return err
 	}
 
-	return a.phaseContext.CompletePhase(a.stateCache, completeData)
+	return a.phaseContext.CompletePhase(ctx, a.stateCache, completeData)
 }
 
 func (a *PhaseActionWithStateCache[OperationPhaseDataT]) CompleteSub(phase OperationSubPhase) error {
@@ -98,7 +99,7 @@ func (a *PhaseActionWithStateCache[OperationPhaseDataT]) CompleteSub(phase Opera
 
 type dummyPhaseAction[OperationPhaseDataT any] struct{}
 
-func (a *dummyPhaseAction[OperationPhaseDataT]) Run(_ OperationPhase, _ bool, action ActionFunc[OperationPhaseDataT]) error {
+func (a *dummyPhaseAction[OperationPhaseDataT]) Run(_ context.Context, _ OperationPhase, _ bool, action ActionFunc[OperationPhaseDataT]) error {
 	_, err := action()
 	return err
 }
@@ -117,7 +118,7 @@ func newPhaseActionWithError[OperationPhaseDataT any](err error) PhaseAction[Ope
 	}
 }
 
-func (a *phaseActionWithError[OperationPhaseDataT]) Run(phase OperationPhase, _ bool, _ ActionFunc[OperationPhaseDataT]) error {
+func (a *phaseActionWithError[OperationPhaseDataT]) Run(ctx context.Context, phase OperationPhase, _ bool, _ ActionFunc[OperationPhaseDataT]) error {
 	return fmt.Errorf("Phase '%s' cannot be run: %w", phase, a.err)
 }
 
@@ -126,7 +127,7 @@ func (a *phaseActionWithError[OperationPhaseDataT]) CompleteSub(phase OperationS
 }
 
 type (
-	PipelinePhaseSwitcher[OperationPhaseDataT any] func(phase OperationPhase, isCritical bool, completedPhaseData OperationPhaseDataT) error
+	PipelinePhaseSwitcher[OperationPhaseDataT any] func(ctx context.Context, phase OperationPhase, isCritical bool, completedPhaseData OperationPhaseDataT) error
 
 	PipelineAction[OperationPhaseDataT any] func(switcher PipelinePhaseSwitcher[OperationPhaseDataT]) error
 
@@ -134,7 +135,7 @@ type (
 		// Run
 		// should return ErrPipelineAlreadyFinished if call after run
 		// should return ErrPipelineAlreadyStarted if call run inside run
-		Run(action PipelineAction[OperationPhaseDataT]) error
+		Run(ctx context.Context, action PipelineAction[OperationPhaseDataT]) error
 		GetLastState() DhctlState
 		// ActionInPipeline
 		// can return with actions which returns ErrPipelineDidNotStart if call before call run
@@ -201,7 +202,7 @@ func newDummyPipeline[OperationPhaseDataT any](opts ...PipelineOptsFunc) Pipelin
 	return NewPipelineWithStateCache[OperationPhaseDataT](nil, nil, opts...)
 }
 
-func (p *PipelineWithStateCache[OperationPhaseDataT]) Run(action PipelineAction[OperationPhaseDataT]) error {
+func (p *PipelineWithStateCache[OperationPhaseDataT]) Run(ctx context.Context, action PipelineAction[OperationPhaseDataT]) error {
 	if p.isFinished() {
 		return p.wrapError(ErrPipelineAlreadyFinished)
 	}
@@ -210,7 +211,7 @@ func (p *PipelineWithStateCache[OperationPhaseDataT]) Run(action PipelineAction[
 		return p.wrapError(ErrPipelineAlreadyStarted)
 	}
 
-	if err := p.initPipeline(); err != nil {
+	if err := p.initPipeline(ctx); err != nil {
 		return err
 	}
 
@@ -218,13 +219,13 @@ func (p *PipelineWithStateCache[OperationPhaseDataT]) Run(action PipelineAction[
 	defer p.setFinished()
 
 	defer func() {
-		p.finalize()
+		p.finalize(ctx)
 	}()
 
 	err := action(p.phaseSwitcher)
 
 	if govalue.IsNil(err) {
-		return p.complete()
+		return p.complete(ctx)
 	}
 
 	if errors.Is(err, ErrShouldStop) {
@@ -266,12 +267,12 @@ func (p *PipelineWithStateCache[OperationPhaseDataT]) ActionInPipeline() PhaseAc
 	return NewPhaseActionWithStateCache(p.phaseContext, p.stateCache)
 }
 
-func (p *PipelineWithStateCache[OperationPhaseDataT]) phaseSwitcher(phase OperationPhase, isCritical bool, completedPhaseData OperationPhaseDataT) error {
+func (p *PipelineWithStateCache[OperationPhaseDataT]) phaseSwitcher(ctx context.Context, phase OperationPhase, isCritical bool, completedPhaseData OperationPhaseDataT) error {
 	if govalue.IsNil(p.phaseContext) {
 		return nil
 	}
 
-	if shouldStop, err := p.phaseContext.SwitchPhase(phase, isCritical, p.stateCache, completedPhaseData); err != nil {
+	if shouldStop, err := p.phaseContext.SwitchPhase(ctx, phase, isCritical, p.stateCache, completedPhaseData); err != nil {
 		return err
 	} else if shouldStop {
 		return ErrShouldStop
@@ -280,30 +281,30 @@ func (p *PipelineWithStateCache[OperationPhaseDataT]) phaseSwitcher(phase Operat
 	return nil
 }
 
-func (p *PipelineWithStateCache[OperationPhaseDataT]) complete() error {
+func (p *PipelineWithStateCache[OperationPhaseDataT]) complete(ctx context.Context) error {
 	if govalue.IsNil(p.phaseContext) {
 		return nil
 	}
 
-	return p.phaseContext.CompletePipeline(p.stateCache)
+	return p.phaseContext.CompletePipeline(ctx, p.stateCache)
 }
 
-func (p *PipelineWithStateCache[OperationPhaseDataT]) finalize() {
+func (p *PipelineWithStateCache[OperationPhaseDataT]) finalize(ctx context.Context) {
 	if govalue.IsNil(p.phaseContext) {
 		return
 	}
 
-	if err := p.phaseContext.Finalize(p.stateCache); err != nil {
+	if err := p.phaseContext.Finalize(ctx, p.stateCache); err != nil {
 		log.SafeProvideLogger(p.opts.LoggerProvider).LogWarnF("Cannot finalize pipeline '%s': %v\n", p.opts.PipelineName, err)
 	}
 }
 
-func (p *PipelineWithStateCache[OperationPhaseDataT]) initPipeline() error {
+func (p *PipelineWithStateCache[OperationPhaseDataT]) initPipeline(ctx context.Context) error {
 	if govalue.IsNil(p.phaseContext) {
 		return nil
 	}
 
-	if err := p.phaseContext.InitPipeline(p.stateCache); err != nil {
+	if err := p.phaseContext.InitPipeline(ctx, p.stateCache); err != nil {
 		return p.wrapError(fmt.Errorf("cannot init pipline: %w", err))
 	}
 

--- a/dhctl/pkg/operations/phases/wrappers_test.go
+++ b/dhctl/pkg/operations/phases/wrappers_test.go
@@ -73,7 +73,7 @@ func TestPipelineWrapper(t *testing.T) {
 	)
 
 	writeTestState := func(state dstate.Cache) error {
-		return state.Save(testKey, []byte(testVal))
+		return state.Save(t.Context(), testKey, []byte(testVal))
 	}
 
 	getDhctlStateWithTest := func() DhctlState {
@@ -196,7 +196,7 @@ func TestPipelineWrapper(t *testing.T) {
 						return err
 					}
 
-					if err := switcher(WaitStaticDestroyerNodeUserPhase, false, nil); err != nil {
+					if err := switcher(t.Context(), WaitStaticDestroyerNodeUserPhase, false, nil); err != nil {
 						return err
 					}
 
@@ -227,7 +227,7 @@ func TestPipelineWrapper(t *testing.T) {
 			pipeline := pipelineProvider()
 
 			action := tt.actionProvider(t, tt.name, state, pipeline)
-			err := pipeline.Run(action)
+			err := pipeline.Run(t.Context(), action)
 			assertTypedError(t, err, tt.actionErr, "action")
 
 			err = tt.afterRun(tt.name, state, pipeline)()
@@ -246,10 +246,10 @@ func TestPipelineWrapper(t *testing.T) {
 
 		notChanged := true
 
-		err := actionNotStart.Run(WaitStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
+		err := actionNotStart.Run(t.Context(), WaitStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
 			logger.LogInfoLn("Start actionNotStart never printed")
 
-			err := state.Save("not saved", []byte("yes"))
+			err := state.Save(t.Context(), "not saved", []byte("yes"))
 			require.NoError(t, err)
 
 			notChanged = false
@@ -271,7 +271,7 @@ func TestPipelineWrapper(t *testing.T) {
 		notChanged := true
 		var switcherErr error
 
-		err := pipeline.Run(func(switcher switcherType) error {
+		err := pipeline.Run(t.Context(), func(switcher switcherType) error {
 			logger.LogInfoLn("Start pipeline phase switcher returns should stop")
 			if err := writeTestState(state); err != nil {
 				return err
@@ -280,16 +280,16 @@ func TestPipelineWrapper(t *testing.T) {
 			logger.LogInfoLn("Set should stop")
 			ctx.stopOperationCondition = true
 
-			if err := switcher(WaitStaticDestroyerNodeUserPhase, false, nil); err != nil {
+			if err := switcher(t.Context(), WaitStaticDestroyerNodeUserPhase, false, nil); err != nil {
 				switcherErr = err
 				return err
 			}
 
 			actionNotStart := pipeline.ActionInPipeline()
-			return actionNotStart.Run(DeleteResourcesPhase, false, func() (contextType, error) {
+			return actionNotStart.Run(t.Context(), DeleteResourcesPhase, false, func() (contextType, error) {
 				logger.LogInfoLn("Start actionNotStart never printed")
 				notChanged = false
-				return nil, state.Save("not saved", []byte("yes"))
+				return nil, state.Save(t.Context(), "not saved", []byte("yes"))
 			})
 		})
 
@@ -304,11 +304,11 @@ func TestPipelineWrapper(t *testing.T) {
 		pipelineProvider, ctx := getPipeline("should stop returns nil and not continue", state)
 		pipeline := pipelineProvider()
 
-		err := pipeline.Run(func(switcher switcherType) error {
+		err := pipeline.Run(t.Context(), func(switcher switcherType) error {
 			logger.LogInfoLn("Start pipeline should stop action")
 			actionWithState := pipeline.ActionInPipeline()
 
-			err := actionWithState.Run(CreateStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
+			err := actionWithState.Run(t.Context(), CreateStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
 				logger.LogInfoLn("Start actionWithState")
 				return nil, writeTestState(state)
 			})
@@ -322,10 +322,10 @@ func TestPipelineWrapper(t *testing.T) {
 
 			notChanged := true
 
-			err = actionShouldStop.Run(WaitStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
+			err = actionShouldStop.Run(t.Context(), WaitStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
 				logger.LogInfoLn("Start actionShouldStop never printed")
 
-				err := state.Save("not saved", []byte("yes"))
+				err := state.Save(t.Context(), "not saved", []byte("yes"))
 				require.NoError(t, err)
 
 				notChanged = false
@@ -350,11 +350,11 @@ func TestPipelineWrapper(t *testing.T) {
 		errorAction := pipeline.ActionInPipeline()
 
 		notChanged := true
-		err := errorAction.Run(CreateStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
+		err := errorAction.Run(t.Context(), CreateStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
 			logger.LogInfoLn("Does not print")
 
 			notChanged = false
-			err := state.Save("not saved", []byte("yes"))
+			err := state.Save(t.Context(), "not saved", []byte("yes"))
 			require.NoError(t, err)
 
 			return nil, nil
@@ -363,25 +363,25 @@ func TestPipelineWrapper(t *testing.T) {
 		require.True(t, errors.Is(err, ErrPipelineDidNotStart), "dummy pipeline should follow interface")
 		require.True(t, notChanged)
 		require.Equal(t, DhctlState(nil), pipeline.GetLastState())
-		notSaved, err := state.InCache("not saved")
+		notSaved, err := state.InCache(t.Context(), "not saved")
 		require.NoError(t, err)
 		require.False(t, notSaved)
 
-		err = pipeline.Run(func(switcher switcherType) error {
+		err = pipeline.Run(t.Context(), func(switcher switcherType) error {
 			logger.LogInfoLn("Start dummy pipeline action")
 			actionWithState := pipeline.ActionInPipeline()
 
-			err := actionWithState.Run(CreateStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
+			err := actionWithState.Run(t.Context(), CreateStaticDestroyerNodeUserPhase, false, func() (contextType, error) {
 				logger.LogInfoLn("Start actionWithState")
 				return nil, writeTestState(state)
 			})
 			require.NoError(t, err)
 			require.Equal(t, DhctlState(nil), pipeline.GetLastState())
-			inCacheState, err := ExtractDhctlState(state)
+			inCacheState, err := ExtractDhctlState(t.Context(), state)
 			require.NoError(t, err)
 			require.Equal(t, getDhctlStateWithTest(), inCacheState)
 
-			err = switcher(DeleteResourcesPhase, false, nil)
+			err = switcher(t.Context(), DeleteResourcesPhase, false, nil)
 			require.NoError(t, err, "dummy switcher does not panic")
 
 			return nil
@@ -390,7 +390,7 @@ func TestPipelineWrapper(t *testing.T) {
 		require.NoError(t, err)
 
 		notChanged = true
-		err = pipeline.Run(func(switcher switcherType) error {
+		err = pipeline.Run(t.Context(), func(switcher switcherType) error {
 			logger.LogInfoLn("Should not printed")
 			notChanged = false
 			return nil

--- a/dhctl/pkg/operations/phases/wrappers_test.go
+++ b/dhctl/pkg/operations/phases/wrappers_test.go
@@ -109,7 +109,7 @@ func TestPipelineWrapper(t *testing.T) {
 			actionProvider: func(t *testing.T, testName string, state dstate.Cache, pipeline pipelineType) actionType {
 				return func(switcher switcherType) error {
 					logger.LogInfoF("action run: %s\n", testName)
-					return pipeline.Run(actionWithTestState(testName, state, "pipeline already started"))
+					return pipeline.Run(t.Context(), actionWithTestState(testName, state, "pipeline already started"))
 				}
 			},
 			actionErr: ErrPipelineAlreadyStarted,
@@ -123,7 +123,7 @@ func TestPipelineWrapper(t *testing.T) {
 			afterRun: func(testName string, state dstate.Cache, pipeline pipelineType) beforeAfterTestType {
 				return func() error {
 					logger.LogInfoF("after run: %s\n", testName)
-					return pipeline.Run(actionWithTestState(testName, state, "double start"))
+					return pipeline.Run(t.Context(), actionWithTestState(testName, state, "double start"))
 				}
 			},
 			afterRunError: ErrPipelineAlreadyFinished,

--- a/dhctl/pkg/operations/secretedit.go
+++ b/dhctl/pkg/operations/secretedit.go
@@ -47,11 +47,12 @@ var emptySecret = &v1.Secret{
 }
 
 func SecretEdit(
+	ctx context.Context,
 	kubeCl *client.KubernetesClient, name string, namespace string, secret string, dataKey string,
 	labels map[string]string,
 	dirConfig *directoryconfig.DirectoryConfig,
 ) error {
-	config, err := kubeCl.CoreV1().Secrets(namespace).Get(context.TODO(), secret, metav1.GetOptions{})
+	config, err := kubeCl.CoreV1().Secrets(namespace).Get(ctx, secret, metav1.GetOptions{})
 	switch {
 	case errors.IsNotFound(err):
 		log.DebugF("Secret %s in namespace %s was not found, and will be created\n", secret, namespace)
@@ -72,7 +73,7 @@ func SecretEdit(
 	configData := config.Data[dataKey]
 
 	var modifiedData []byte
-	err = dh_config.PrepareCandiDir(context.Background(), kubeCl, log.GetDefaultLogger(), dirConfig)
+	err = dh_config.PrepareCandiDir(ctx, kubeCl, log.GetDefaultLogger(), dirConfig)
 	if err != nil {
 		return err
 	}
@@ -86,9 +87,11 @@ func SecretEdit(
 		addUnsafeAnnotation(config)
 	}
 
-	return log.Process(
+	return log.ProcessCtx(
+		ctx,
 		"common",
-		fmt.Sprintf("Save %s to the Kubernetes cluster", name), func() error {
+		fmt.Sprintf("Save %s to the Kubernetes cluster", name),
+		func(ctx context.Context) error {
 			if string(configData) == string(modifiedData) {
 				log.InfoLn("Configurations are equal. Nothing to update.")
 				return nil
@@ -99,11 +102,11 @@ func SecretEdit(
 			return retry.
 				NewLoop(fmt.Sprintf("Apply %s secret", secret), 5, 5*time.Second).
 				Run(func() error {
-					_, err = kubeCl.CoreV1().Secrets(namespace).Update(context.TODO(), config, metav1.UpdateOptions{})
+					_, err = kubeCl.CoreV1().Secrets(namespace).Update(ctx, config, metav1.UpdateOptions{})
 					switch {
 					case errors.IsNotFound(err):
 						log.DebugF("Creating new Secret %s in namespace %s\n", secret, namespace)
-						if _, err = kubeCl.CoreV1().Secrets(namespace).Create(context.TODO(), config, metav1.CreateOptions{}); err != nil {
+						if _, err = kubeCl.CoreV1().Secrets(namespace).Create(ctx, config, metav1.CreateOptions{}); err != nil {
 							return err
 						}
 					case err != nil:
@@ -116,7 +119,7 @@ func SecretEdit(
 
 						_, err = kubeCl.CoreV1().
 							Secrets(namespace).
-							Update(context.TODO(), config, metav1.UpdateOptions{})
+							Update(ctx, config, metav1.UpdateOptions{})
 					}
 
 					return err

--- a/dhctl/pkg/operations/secretedit_test.go
+++ b/dhctl/pkg/operations/secretedit_test.go
@@ -62,6 +62,7 @@ func TestSecretEdit(t *testing.T) {
 
 		abstractEditing = EditMock
 		err := SecretEdit(
+			t.Context(),
 			f, "test", secretTest.Namespace, secretTest.Name, "cluster-configuration.yaml",
 			map[string]string{"name": "test"},
 			nil,

--- a/dhctl/pkg/preflight/preflight.go
+++ b/dhctl/pkg/preflight/preflight.go
@@ -32,8 +32,8 @@ type Preflight struct {
 }
 
 type cache interface {
-	Save(string, []byte) error
-	InCache(string) (bool, error)
+	Save(context.Context, string, []byte) error
+	InCache(context.Context, string) (bool, error)
 }
 
 func New(suites ...Suite) *Preflight {
@@ -77,11 +77,14 @@ func (p *Preflight) Run(ctx context.Context, phase Phase) error {
 	if err != nil {
 		return err
 	}
+
 	phaseLabel := fmt.Sprintf("(%s)", phase)
-	runFunc := func() error {
+
+	runFunc := func(ctx context.Context) error {
 		return p.runChecks(ctx, checks)
 	}
-	return log.Process(log.ProcessPreflight, phaseLabel, runFunc)
+
+	return log.ProcessCtx(ctx, log.ProcessPreflight, phaseLabel, runFunc)
 }
 
 func (p *Preflight) runChecks(ctx context.Context, checks []Check) error {
@@ -100,7 +103,7 @@ func (p *Preflight) runChecks(ctx context.Context, checks []Check) error {
 func (p *Preflight) runCheck(ctx context.Context, check Check) error {
 	if p.cache != nil {
 		key := p.cacheKey(check.Name)
-		if ok, err := p.cache.InCache(key); err == nil && ok {
+		if ok, err := p.cache.InCache(ctx, key); err == nil && ok {
 			log.InfoF("✓ %s: %s (cached)\n", check.Name, check.Description)
 			return nil
 		}
@@ -112,7 +115,7 @@ func (p *Preflight) runCheck(ctx context.Context, check Check) error {
 	log.InfoF("✓ %s: %s\n", check.Name, check.Description)
 
 	if p.cache != nil {
-		if err := p.cache.Save(p.cacheKey(check.Name), []byte("yes")); err != nil {
+		if err := p.cache.Save(ctx, p.cacheKey(check.Name), []byte("yes")); err != nil {
 			log.WarnF("cannot cache result of %s: %v\n", check.Name, err)
 		}
 	}

--- a/dhctl/pkg/server/pkg/helper/cluster_connections.go
+++ b/dhctl/pkg/server/pkg/helper/cluster_connections.go
@@ -34,36 +34,47 @@ type ClusterConnectionsOptions struct {
 	SSHConnectionConfig string
 }
 
-func InitializeClusterConnections(ctx context.Context, opts ClusterConnectionsOptions) (*client.KubernetesClient, node.SSHClient, func() error, error) {
+func InitializeClusterConnections(
+	ctx context.Context,
+	opts ClusterConnectionsOptions,
+) (
+	*client.KubernetesClient,
+	node.SSHClient,
+	func() error, // cleanup function
+	error,
+) {
+	var cleanup = func() error { return nil }
+
 	if opts.CommanderMode && opts.APIServerURL != "" {
 		kubeCl, err := CreateKubeClient(ctx, opts.APIServerURL, opts.APIServerOptions)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("error creating kubernetes client: %w", err)
 		}
-		return kubeCl, nil, func() error { return nil }, nil
-	} else {
-		var sshClient node.SSHClient
-		var cleanup func() error
 
-		err := log.Process("default", "Preparing SSH client", func() error {
-			connectionConfig, err := config.ParseConnectionConfig(
-				opts.SSHConnectionConfig,
-				opts.SchemaStore,
-				config.ValidateOptionCommanderMode(opts.CommanderMode),
-				config.ValidateOptionStrictUnmarshal(opts.CommanderMode),
-				config.ValidateOptionValidateExtensions(opts.CommanderMode),
-			)
-			if err != nil {
-				return fmt.Errorf("parsing connection config: %w", err)
-			}
-
-			sshClient, cleanup, err = CreateSSHClient(ctx, connectionConfig)
-			if err != nil {
-				return fmt.Errorf("preparing ssh client: %w", err)
-			}
-			return nil
-		})
-
-		return nil, sshClient, cleanup, err
+		return kubeCl, nil, cleanup, nil
 	}
+
+	var sshClient node.SSHClient
+
+	err := log.ProcessCtx(ctx, "default", "Preparing SSH client", func(ctx context.Context) error {
+		connectionConfig, err := config.ParseConnectionConfig(
+			opts.SSHConnectionConfig,
+			opts.SchemaStore,
+			config.ValidateOptionCommanderMode(opts.CommanderMode),
+			config.ValidateOptionStrictUnmarshal(opts.CommanderMode),
+			config.ValidateOptionValidateExtensions(opts.CommanderMode),
+		)
+		if err != nil {
+			return fmt.Errorf("parsing connection config: %w", err)
+		}
+
+		sshClient, cleanup, err = CreateSSHClient(ctx, connectionConfig)
+		if err != nil {
+			return fmt.Errorf("preparing ssh client: %w", err)
+		}
+
+		return nil
+	})
+
+	return nil, sshClient, cleanup, err
 }

--- a/dhctl/pkg/server/pkg/helper/ssh_client.go
+++ b/dhctl/pkg/server/pkg/helper/ssh_client.go
@@ -62,7 +62,7 @@ func CreateSSHClient(ctx context.Context, config *config.ConnectionConfig) (node
 			sshHosts = append(sshHosts, session.Host{Host: h.Host, Name: h.Host})
 		}
 	} else {
-		mastersIPs, err := state.GetMasterHostsIPs(cache.Global())
+		mastersIPs, err := state.GetMasterHostsIPs(ctx, cache.Global())
 		if err != nil {
 			return nil, cleanuper.AsFunc(), err
 		}

--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -282,7 +282,7 @@ func (s *Service) abort(ctx context.Context, p *abortParams) *pb.AbortResult {
 	})
 
 	abortErr := bootstrapper.Abort(ctx, false)
-	state, stateErr := extractLastState()
+	state, stateErr := extractLastState(ctx)
 	err = errors.Join(abortErr, stateErr)
 
 	return &pb.AbortResult{State: string(state), Err: util.ErrToString(err)}

--- a/dhctl/pkg/server/rpc/dhctl/abort.go
+++ b/dhctl/pkg/server/rpc/dhctl/abort.go
@@ -187,7 +187,8 @@ func (s *Service) abort(ctx context.Context, p *abortParams) *pb.AbortResult {
 		configPath  string
 		cleanup     func() error
 	)
-	err = loggerFor.LogProcess("default", "Preparing configuration", func() error {
+
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing configuration", func(ctx context.Context) error {
 		for _, cfg := range []string{
 			p.request.ClusterConfig,
 			p.request.InitConfig,
@@ -215,7 +216,7 @@ func (s *Service) abort(ctx context.Context, p *abortParams) *pb.AbortResult {
 	}
 
 	var initialState phases.DhctlState
-	err = loggerFor.LogProcess("default", "Preparing DHCTL state", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		if p.request.State != "" {
 			err = json.Unmarshal([]byte(p.request.State), &initialState)
 			if err != nil {
@@ -229,7 +230,7 @@ func (s *Service) abort(ctx context.Context, p *abortParams) *pb.AbortResult {
 	}
 
 	var sshClient node.SSHClient
-	err = loggerFor.LogProcess("default", "Preparing SSH client", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing SSH client", func(ctx context.Context) error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			p.request.ConnectionConfig,
 			s.params.SchemaStore,

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -188,7 +188,7 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 		postBootstrapScriptPath string
 		cleanup                 func() error
 	)
-	err = loggerFor.LogProcess("default", "Preparing configuration", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing configuration", func(ctx context.Context) error {
 		for _, cfg := range []string{
 			p.request.ClusterConfig,
 			p.request.InitConfig,
@@ -230,7 +230,7 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 	}
 
 	var initialState phases.DhctlState
-	err = loggerFor.LogProcess("default", "Preparing DHCTL state", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		if p.request.State != "" {
 			err = json.Unmarshal([]byte(p.request.State), &initialState)
 			if err != nil {
@@ -244,7 +244,7 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 	}
 
 	var sshClient node.SSHClient
-	err = loggerFor.LogProcess("default", "Preparing SSH client", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing SSH client", func(ctx context.Context) error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			p.request.ConnectionConfig,
 			s.params.SchemaStore,

--- a/dhctl/pkg/server/rpc/dhctl/bootstrap.go
+++ b/dhctl/pkg/server/rpc/dhctl/bootstrap.go
@@ -306,7 +306,7 @@ func (s *Service) bootstrap(ctx context.Context, p *bootstrapParams) *pb.Bootstr
 	})
 
 	bootstrapErr := bootstrapper.Bootstrap(ctx)
-	state, stateErr := extractLastState()
+	state, stateErr := extractLastState(ctx)
 	err = errors.Join(bootstrapErr, stateErr)
 
 	return &pb.BootstrapResult{State: string(state), Err: util.ErrToString(err)}

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -186,6 +186,7 @@ func (s *Service) check(ctx context.Context, p *checkParams) *pb.CheckResult {
 
 	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		cachePath := metaConfig.CachePath()
+
 		var initialState phases.DhctlState
 		if p.request.State != "" {
 			err = json.Unmarshal([]byte(p.request.State), &initialState)
@@ -193,13 +194,17 @@ func (s *Service) check(ctx context.Context, p *checkParams) *pb.CheckResult {
 				return fmt.Errorf("unmarshalling dhctl state: %w", err)
 			}
 		}
+
 		err = cache.InitWithOptions(
+			ctx,
 			cachePath,
 			cache.CacheOptions{InitialState: initialState, ResetInitialState: true},
 		)
+
 		if err != nil {
 			return fmt.Errorf("initializing cache at %s: %w", cachePath, err)
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -274,13 +279,13 @@ func (s *Service) check(ctx context.Context, p *checkParams) *pb.CheckResult {
 	}()
 
 	resultData, marshalErr := json.Marshal(result)
-	state, stateErr := extractLastState()
+	state, stateErr := extractLastState(ctx)
 
 	err = errors.Join(checkErr, marshalErr, stateErr)
 
 	if result != nil {
 		// todo: move onCheckResult call to check.Check() func (as in converge)
-		_ = onCheckResult(result)
+		_ = onCheckResult(ctx, result)
 	}
 
 	return &pb.CheckResult{

--- a/dhctl/pkg/server/rpc/dhctl/check.go
+++ b/dhctl/pkg/server/rpc/dhctl/check.go
@@ -163,7 +163,7 @@ func (s *Service) check(ctx context.Context, p *checkParams) *pb.CheckResult {
 	defer logBeforeExit()
 
 	var metaConfig *config.MetaConfig
-	err = loggerFor.LogProcess("default", "Parsing cluster config", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Parsing cluster config", func(ctx context.Context) error {
 		metaConfig, err = config.ParseConfigFromData(
 			ctx,
 			input.CombineYAMLs(p.request.ClusterConfig, p.request.ProviderSpecificClusterConfig),
@@ -184,7 +184,7 @@ func (s *Service) check(ctx context.Context, p *checkParams) *pb.CheckResult {
 		return &pb.CheckResult{Err: err.Error()}
 	}
 
-	err = loggerFor.LogProcess("default", "Preparing DHCTL state", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		cachePath := metaConfig.CachePath()
 		var initialState phases.DhctlState
 		if p.request.State != "" {

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -182,7 +182,7 @@ func (s *Service) commanderAttach(ctx context.Context, p *attachParams) *pb.Comm
 	defer logBeforeExit()
 
 	var sshClient node.SSHClient
-	err = loggerFor.LogProcess("default", "Preparing SSH client", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing SSH client", func(ctx context.Context) error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			p.request.ConnectionConfig,
 			s.params.SchemaStore,

--- a/dhctl/pkg/server/rpc/dhctl/commander_attach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_attach.go
@@ -240,7 +240,7 @@ func (s *Service) commanderAttach(ctx context.Context, p *attachParams) *pb.Comm
 
 	result, attachErr := attacher.Attach(ctx)
 	resultData, marshalResultErr := json.Marshal(result)
-	state, stateErr := extractLastState()
+	state, stateErr := extractLastState(ctx)
 
 	err = errors.Join(attachErr, stateErr, marshalResultErr)
 

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -189,6 +189,7 @@ func (s *Service) commanderDetach(ctx context.Context, p *detachParams) *pb.Comm
 
 	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		cachePath := metaConfig.CachePath()
+
 		var initialState phases.DhctlState
 		if p.request.State != "" {
 			err = json.Unmarshal([]byte(p.request.State), &initialState)
@@ -196,13 +197,17 @@ func (s *Service) commanderDetach(ctx context.Context, p *detachParams) *pb.Comm
 				return fmt.Errorf("unmarshalling dhctl state: %w", err)
 			}
 		}
+
 		err = cache.InitWithOptions(
+			ctx,
 			cachePath,
 			cache.CacheOptions{InitialState: initialState, ResetInitialState: true},
 		)
+
 		if err != nil {
 			return fmt.Errorf("initializing cache at %s: %w", cachePath, err)
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -289,7 +294,7 @@ func (s *Service) commanderDetach(ctx context.Context, p *detachParams) *pb.Comm
 	})
 
 	detachErr := detacher.Detach(ctx)
-	state, stateErr := extractLastState()
+	state, stateErr := extractLastState(ctx)
 
 	err = errors.Join(detachErr, stateErr)
 

--- a/dhctl/pkg/server/rpc/dhctl/commander_detach.go
+++ b/dhctl/pkg/server/rpc/dhctl/commander_detach.go
@@ -166,7 +166,7 @@ func (s *Service) commanderDetach(ctx context.Context, p *detachParams) *pb.Comm
 	defer logBeforeExit()
 
 	var metaConfig *config.MetaConfig
-	err = loggerFor.LogProcess("default", "Parsing cluster config", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Parsing cluster config", func(ctx context.Context) error {
 		metaConfig, err = config.ParseConfigFromData(
 			ctx,
 			input.CombineYAMLs(p.request.ClusterConfig, p.request.ProviderSpecificClusterConfig),
@@ -187,7 +187,7 @@ func (s *Service) commanderDetach(ctx context.Context, p *detachParams) *pb.Comm
 		return &pb.CommanderDetachResult{Err: err.Error()}
 	}
 
-	err = loggerFor.LogProcess("default", "Preparing DHCTL state", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		cachePath := metaConfig.CachePath()
 		var initialState phases.DhctlState
 		if p.request.State != "" {
@@ -210,7 +210,7 @@ func (s *Service) commanderDetach(ctx context.Context, p *detachParams) *pb.Comm
 	}
 
 	var sshClient node.SSHClient
-	err = loggerFor.LogProcess("default", "Preparing SSH client", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing SSH client", func(ctx context.Context) error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			p.request.ConnectionConfig,
 			s.params.SchemaStore,

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -219,6 +219,7 @@ func (s *Service) converge(ctx context.Context, p *convergeParams) *pb.ConvergeR
 			}
 		}
 		err = cache.InitWithOptions(
+			ctx,
 			cachePath,
 			cache.CacheOptions{InitialState: initialState, ResetInitialState: true},
 		)
@@ -328,7 +329,7 @@ func (s *Service) converge(ctx context.Context, p *convergeParams) *pb.ConvergeR
 
 	result, convergeErr := converger.Converge(ctx)
 	resultData, marshalResultErr := json.Marshal(result)
-	state, stateErr := extractLastState()
+	state, stateErr := extractLastState(ctx)
 
 	err = errors.Join(convergeErr, stateErr, marshalResultErr)
 

--- a/dhctl/pkg/server/rpc/dhctl/converge.go
+++ b/dhctl/pkg/server/rpc/dhctl/converge.go
@@ -188,7 +188,7 @@ func (s *Service) converge(ctx context.Context, p *convergeParams) *pb.ConvergeR
 	defer logBeforeExit()
 
 	var metaConfig *config.MetaConfig
-	err = loggerFor.LogProcess("default", "Parsing cluster config", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Parsing cluster config", func(ctx context.Context) error {
 		metaConfig, err = config.ParseConfigFromData(
 			ctx,
 			input.CombineYAMLs(p.request.ClusterConfig, p.request.ProviderSpecificClusterConfig),
@@ -209,7 +209,7 @@ func (s *Service) converge(ctx context.Context, p *convergeParams) *pb.ConvergeR
 		return &pb.ConvergeResult{Err: err.Error()}
 	}
 
-	err = loggerFor.LogProcess("default", "Preparing DHCTL state", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		cachePath := metaConfig.CachePath()
 		var initialState phases.DhctlState
 		if p.request.State != "" {

--- a/dhctl/pkg/server/rpc/dhctl/destroy.go
+++ b/dhctl/pkg/server/rpc/dhctl/destroy.go
@@ -210,6 +210,7 @@ func (s *Service) destroy(ctx context.Context, p *destroyParams) *pb.DestroyResu
 
 	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		cachePath := metaConfig.CachePath()
+
 		var initialState phases.DhctlState
 		if p.request.State != "" {
 			err = json.Unmarshal([]byte(p.request.State), &initialState)
@@ -217,13 +218,17 @@ func (s *Service) destroy(ctx context.Context, p *destroyParams) *pb.DestroyResu
 				return fmt.Errorf("unmarshalling dhctl state: %w", err)
 			}
 		}
+
 		err = cache.InitWithOptions(
+			ctx,
 			cachePath,
 			cache.CacheOptions{InitialState: initialState, ResetInitialState: true},
 		)
+
 		if err != nil {
 			return fmt.Errorf("initializing cache at %s: %w", cachePath, err)
 		}
+
 		return nil
 	})
 	if err != nil {
@@ -285,7 +290,7 @@ func (s *Service) destroy(ctx context.Context, p *destroyParams) *pb.DestroyResu
 	}
 
 	destroyErr := destroyer.DestroyCluster(ctx, true)
-	state, stateErr := extractLastState()
+	state, stateErr := extractLastState(ctx)
 
 	err = errors.Join(destroyErr, stateErr)
 

--- a/dhctl/pkg/server/rpc/dhctl/destroy.go
+++ b/dhctl/pkg/server/rpc/dhctl/destroy.go
@@ -187,7 +187,7 @@ func (s *Service) destroy(ctx context.Context, p *destroyParams) *pb.DestroyResu
 	defer logBeforeExit()
 
 	var metaConfig *config.MetaConfig
-	err = loggerFor.LogProcess("default", "Parsing cluster config", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Parsing cluster config", func(ctx context.Context) error {
 		metaConfig, err = config.ParseConfigFromData(
 			ctx,
 			input.CombineYAMLs(p.request.ClusterConfig, p.request.InitConfig, p.request.ProviderSpecificClusterConfig),
@@ -208,7 +208,7 @@ func (s *Service) destroy(ctx context.Context, p *destroyParams) *pb.DestroyResu
 		return &pb.DestroyResult{Err: err.Error()}
 	}
 
-	err = loggerFor.LogProcess("default", "Preparing DHCTL state", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing DHCTL state", func(ctx context.Context) error {
 		cachePath := metaConfig.CachePath()
 		var initialState phases.DhctlState
 		if p.request.State != "" {
@@ -231,7 +231,7 @@ func (s *Service) destroy(ctx context.Context, p *destroyParams) *pb.DestroyResu
 	}
 
 	var sshClient node.SSHClient
-	err = loggerFor.LogProcess("default", "Preparing SSH client", func() error {
+	err = loggerFor.LogProcessCtx(ctx, "default", "Preparing SSH client", func(ctx context.Context) error {
 		connectionConfig, err := config.ParseConnectionConfig(
 			p.request.ConnectionConfig,
 			s.params.SchemaStore,

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -187,7 +187,7 @@ func (b *fsmPhaseSwitcher[T, OperationPhaseDataT]) switchPhase(ctx context.Conte
 	}
 }
 
-func onCheckResult(checkRes *check.CheckResult) error {
+func onCheckResult(ctx context.Context, checkRes *check.CheckResult) error {
 	printableCheckRes := *checkRes
 	printableCheckRes.StatusDetails.InfrastructurePlan = nil
 
@@ -196,7 +196,7 @@ func onCheckResult(checkRes *check.CheckResult) error {
 		return fmt.Errorf("unable to encode check result json: %w", err)
 	}
 
-	_ = log.Process("default", "Check result", func() error {
+	_ = log.ProcessCtx(ctx, "default", "Check result", func(ctx context.Context) error {
 		log.InfoF("%s\n", printableCheckResDump)
 		return nil
 	})
@@ -204,8 +204,8 @@ func onCheckResult(checkRes *check.CheckResult) error {
 	return nil
 }
 
-func extractLastState() ([]byte, error) {
-	state, err := phases.ExtractDhctlState(cache.Global())
+func extractLastState(ctx context.Context) ([]byte, error) {
+	state, err := phases.ExtractDhctlState(ctx, cache.Global())
 	if err != nil {
 		return nil, fmt.Errorf("extracting last state: %w", err)
 	}
@@ -230,7 +230,7 @@ func panicResult(ctx context.Context, p any) ([]byte, error) {
 		fmt.Errorf("panic: %v, %s", p, stack),
 	}
 
-	lastState, err := extractLastState()
+	lastState, err := extractLastState(ctx)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/dhctl/pkg/server/server/server.go
+++ b/dhctl/pkg/server/server/server.go
@@ -42,7 +42,7 @@ import (
 const SinglethreadedMethodsPrefix = "/dhctl.DHCTL" // full method example: /dhctl.DHCTL/Check
 
 // Serve starts GRPC server
-func Serve(params settings.ServerParams) error {
+func Serve(ctx context.Context, params settings.ServerParams) error {
 	if err := params.Validate(); err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func Serve(params settings.ServerParams) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	defer close(done)
 	sem := make(chan struct{}, params.ParallelTasksLimit)

--- a/dhctl/pkg/server/server/singlethreaded/server.go
+++ b/dhctl/pkg/server/server/singlethreaded/server.go
@@ -42,7 +42,7 @@ import (
 )
 
 // Serve starts GRPC server
-func Serve(params settings.ServerSingleshotParams) error {
+func Serve(ctx context.Context, params settings.ServerSingleshotParams) error {
 	if err := params.Validate(); err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func Serve(params settings.ServerSingleshotParams) error {
 	lvl.Set(slog.LevelDebug)
 	log := logger.NewLogger(lvl).With(slog.String("component", "singlethreaded_server"))
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
 	defer close(done)
 

--- a/dhctl/pkg/state/cache.go
+++ b/dhctl/pkg/state/cache.go
@@ -14,22 +14,24 @@
 
 package state
 
+import "context"
+
 const TombstoneKey = ".tombstone"
 
 type Cache interface {
-	Save(string, []byte) error
-	SaveStruct(string, interface{}) error
+	Save(context.Context, string, []byte) error
+	SaveStruct(context.Context, string, interface{}) error
 
-	Load(string) ([]byte, error)
-	LoadStruct(string, interface{}) error
+	Load(context.Context, string) ([]byte, error)
+	LoadStruct(context.Context, string, interface{}) error
 
-	Delete(string)
-	Clean()
-	CleanWithExceptions(excludeKeys ...string)
+	Delete(context.Context, string)
+	Clean(ctx context.Context)
+	CleanWithExceptions(ctx context.Context, excludeKeys ...string)
 
 	GetPath(string) string
-	Iterate(func(string, []byte) error) error
-	InCache(string) (bool, error)
+	Iterate(context.Context, func(string, []byte) error) error
+	InCache(context.Context, string) (bool, error)
 
 	NeedIntermediateSave() bool
 

--- a/dhctl/pkg/state/cache/init.go
+++ b/dhctl/pkg/state/cache/init.go
@@ -15,6 +15,7 @@
 package cache
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -41,9 +42,10 @@ var (
 
 var globalCache state.Cache = &cache.DummyCache{}
 
-func choiceCache(identity string, opts CacheOptions) (state.Cache, error) {
+func choiceCache(ctx context.Context, identity string, opts CacheOptions) (state.Cache, error) {
 	tmpDir := filepath.Join(app.GetCacheDir(), stringsutil.Sha256Encode(identity))
 	log.InfoF("State cache directory: %s\n", tmpDir)
+
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
 		return nil, fmt.Errorf("Can't create cache directory: %w", err)
 	}
@@ -75,12 +77,12 @@ func choiceCache(identity string, opts CacheOptions) (state.Cache, error) {
 	k8sCache := client.NewK8sStateCache(kubeCl, app.CacheKubeNamespace, secretName, tmpDir).
 		WithLabels(app.CacheKubeLabels)
 
-	err = k8sCache.Init()
+	err = k8sCache.Init(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	hasTombstone, err := k8sCache.InCache(state.TombstoneKey)
+	hasTombstone, err := k8sCache.InCache(ctx, state.TombstoneKey)
 	if err != nil {
 		return nil, err
 	}
@@ -93,14 +95,14 @@ func choiceCache(identity string, opts CacheOptions) (state.Cache, error) {
 	return k8sCache, nil
 }
 
-func initCache(identity string, opts CacheOptions) error {
+func initCache(ctx context.Context, identity string, opts CacheOptions) error {
 	var err error
 
 	if opts.ResetInitialState {
-		globalCache, err = choiceCache(identity, opts)
+		globalCache, err = choiceCache(ctx, identity, opts)
 	} else {
 		once.Do(func() {
-			globalCache, err = choiceCache(identity, opts)
+			globalCache, err = choiceCache(ctx, identity, opts)
 		})
 	}
 
@@ -112,12 +114,12 @@ type CacheOptions struct {
 	ResetInitialState bool
 }
 
-func Init(identity string) error {
-	return initCache(identity, CacheOptions{})
+func Init(ctx context.Context, identity string) error {
+	return initCache(ctx, identity, CacheOptions{})
 }
 
-func InitWithOptions(identity string, opts CacheOptions) error {
-	return initCache(identity, opts)
+func InitWithOptions(ctx context.Context, identity string, opts CacheOptions) error {
+	return initCache(ctx, identity, opts)
 }
 
 func Global() state.Cache {

--- a/dhctl/pkg/state/hosts.go
+++ b/dhctl/pkg/state/hosts.go
@@ -15,6 +15,7 @@
 package state
 
 import (
+	"context"
 	"sort"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -25,14 +26,14 @@ const (
 	MasterHostsCacheKey = "cluster-hosts"
 )
 
-func SaveMasterHostsToCache(cache Cache, hosts map[string]string) {
-	if err := cache.SaveStruct(MasterHostsCacheKey, hosts); err != nil {
+func SaveMasterHostsToCache(ctx context.Context, cache Cache, hosts map[string]string) {
+	if err := cache.SaveStruct(ctx, MasterHostsCacheKey, hosts); err != nil {
 		log.WarnF("Cannot save ssh hosts %v\n", err)
 	}
 }
 
-func GetMasterHostsIPs(cache Cache) ([]session.Host, error) {
-	inCache, err := cache.InCache(MasterHostsCacheKey)
+func GetMasterHostsIPs(ctx context.Context, cache Cache) ([]session.Host, error) {
+	inCache, err := cache.InCache(ctx, MasterHostsCacheKey)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +42,7 @@ func GetMasterHostsIPs(cache Cache) ([]session.Host, error) {
 		return make([]session.Host, 0), nil
 	}
 	var hosts map[string]string
-	err = cache.LoadStruct(MasterHostsCacheKey, &hosts)
+	err = cache.LoadStruct(ctx, MasterHostsCacheKey, &hosts)
 	if err != nil {
 		return nil, err
 	}

--- a/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
+++ b/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
@@ -222,7 +222,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 		return nil
 	}
 
-	base, ngs, err := getNodesFromCache(t.commanderMode.MetaConfig, t.commanderMode.Cache)
+	base, ngs, err := getNodesFromCache(ctx, t.commanderMode.MetaConfig, t.commanderMode.Cache)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 		RunContext(ctx, func() error {
 			name := baseInfraBackupSecretName + ".terraform.backup"
 
-			ok, err := t.commanderMode.Cache.InCache(name)
+			ok, err := t.commanderMode.Cache.InCache(ctx, name)
 			if err != nil {
 				return err
 			}
@@ -241,7 +241,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 				return nil
 			}
 
-			return t.commanderMode.Cache.Save(name, base)
+			return t.commanderMode.Cache.Save(ctx, name, base)
 		})
 
 	if err != nil {
@@ -256,7 +256,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 					RunContext(ctx, func() error {
 						name := "tf-" + node + ".terraform.backup"
 
-						ok, err := t.commanderMode.Cache.InCache(name)
+						ok, err := t.commanderMode.Cache.InCache(ctx, name)
 						if err != nil {
 							return err
 						}
@@ -265,7 +265,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 							return nil
 						}
 
-						return t.commanderMode.Cache.Save(name, st)
+						return t.commanderMode.Cache.Save(ctx, name, st)
 					})
 
 				if err != nil {

--- a/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
+++ b/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
@@ -140,7 +140,7 @@ func (t *TofuMigrationStateBackuper) doBackupStates(ctx context.Context) error {
 }
 
 func (t *TofuMigrationStateBackuper) BackupStates(ctx context.Context) error {
-	return t.logger.LogProcess("default", "Backup infrastructure states before migrate to opentofu", func() error {
+	return t.logger.LogProcessCtx(ctx, "default", "Backup infrastructure states before migrate to opentofu", func(ctx context.Context) error {
 		return t.doBackupStates(ctx)
 	})
 }
@@ -249,7 +249,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 	}
 
 	for ngName, ng := range ngs {
-		err = t.logger.LogProcess("default", fmt.Sprintf("Save infrastructure backup nodes states for commander for node group %s", ngName), func() error {
+		err = t.logger.LogProcessCtx(ctx, "default", fmt.Sprintf("Save infrastructure backup nodes states for commander for node group %s", ngName), func(ctx context.Context) error {
 			for node, st := range ng.State {
 				err := retry.NewLoop(fmt.Sprintf("Save infrastructure backup state for node %s states for commander", node), 1, 5*time.Second).
 					WithLogger(t.logger).

--- a/dhctl/pkg/state/infrastructure/before_tofu_state_backup_test.go
+++ b/dhctl/pkg/state/infrastructure/before_tofu_state_backup_test.go
@@ -211,12 +211,12 @@ func TestBackupStates(t *testing.T) {
 }
 
 func saveCacheState(t *testing.T, c state.Cache, key string, val string) {
-	err := c.Save(key, []byte(val))
+	err := c.Save(t.Context(), key, []byte(val))
 	require.NoError(t, err)
 }
 
 func assertCacheState(t *testing.T, c state.Cache, key string, val string) {
-	baseBackup, err := c.Load(key)
+	baseBackup, err := c.Load(t.Context(), key)
 	require.NoError(t, err)
 	require.Equal(t, baseBackup, []byte(val))
 }

--- a/dhctl/pkg/state/infrastructure/cached.go
+++ b/dhctl/pkg/state/infrastructure/cached.go
@@ -47,10 +47,10 @@ func (s *FileTerraStateLoader) PopulateClusterState(ctx context.Context) ([]byte
 		return nil, nil, err
 	}
 
-	return getNodesFromCache(metaConfig, s.stateCache)
+	return getNodesFromCache(ctx, metaConfig, s.stateCache)
 }
 
-func getNodesFromCache(metaConfig *config.MetaConfig, stateCache state.Cache) ([]byte, map[string]state.NodeGroupInfrastructureState, error) {
+func getNodesFromCache(ctx context.Context, metaConfig *config.MetaConfig, stateCache state.Cache) ([]byte, map[string]state.NodeGroupInfrastructureState, error) {
 	nodeGroupRegex := fmt.Sprintf("^%s-(.*)-([0-9]+)\\.tfstate$", metaConfig.ClusterPrefix)
 	groupsReg, _ := regexp.Compile(nodeGroupRegex)
 
@@ -58,7 +58,7 @@ func getNodesFromCache(metaConfig *config.MetaConfig, stateCache state.Cache) ([
 
 	var baseInfraState []byte
 
-	err := stateCache.Iterate(func(name string, content []byte) error {
+	err := stateCache.Iterate(ctx, func(name string, content []byte) error {
 		switch {
 		case strings.HasPrefix(name, "base-infrastructure"):
 			baseInfraState = content
@@ -90,14 +90,14 @@ func getNodesFromCache(metaConfig *config.MetaConfig, stateCache state.Cache) ([
 	return baseInfraState, nodesFromCache, err
 }
 
-func DeleteNodeInfrastructureStateFromCache(nodeName string, stateCache state.Cache) error {
+func DeleteNodeInfrastructureStateFromCache(ctx context.Context, nodeName string, stateCache state.Cache) error {
 	keysToDelete := []string{
 		fmt.Sprintf("%s.tfstate", nodeName),
 		fmt.Sprintf("%s.tfstate.backup", nodeName),
 	}
 
 	for _, key := range keysToDelete {
-		stateCache.Delete(key)
+		stateCache.Delete(ctx, key)
 	}
 
 	return nil

--- a/dhctl/pkg/state/infrastructure/cluster_cached.go
+++ b/dhctl/pkg/state/infrastructure/cluster_cached.go
@@ -58,13 +58,13 @@ func (s *KubeTerraStateLoader) PopulateMetaConfig(ctx context.Context, dc *direc
 		WithMessage("Do you want to continue with Cluster configuration from local cache?").
 		WithYesByDefault()
 
-	ok, err := s.stateCache.InCache("cluster-config")
+	ok, err := s.stateCache.InCache(ctx, "cluster-config")
 	if err != nil {
 		return nil, err
 	}
 
 	if ok && (s.forceFromCache || confirmation.Ask()) {
-		if err := s.stateCache.LoadStruct("cluster-config", &metaConfig); err != nil {
+		if err := s.stateCache.LoadStruct(ctx, "cluster-config", &metaConfig); err != nil {
 			return nil, err
 		}
 		return metaConfig, nil
@@ -92,7 +92,7 @@ func (s *KubeTerraStateLoader) PopulateMetaConfig(ctx context.Context, dc *direc
 		return nil, err
 	}
 
-	if err := s.stateCache.SaveStruct("cluster-config", metaConfig); err != nil {
+	if err := s.stateCache.SaveStruct(ctx, "cluster-config", metaConfig); err != nil {
 		return nil, err
 	}
 
@@ -122,13 +122,13 @@ func (s *KubeTerraStateLoader) getNodesState(ctx context.Context) (map[string]st
 		WithMessage("Do you want to continue with Nodes state from local cache?").
 		WithYesByDefault()
 
-	ok, err := s.stateCache.InCache("nodes-state")
+	ok, err := s.stateCache.InCache(ctx, "nodes-state")
 	if err != nil {
 		return nil, err
 	}
 
 	if ok && (s.forceFromCache || confirmation.Ask()) {
-		if err := s.stateCache.LoadStruct("nodes-state", &nodesState); err != nil {
+		if err := s.stateCache.LoadStruct(ctx, "nodes-state", &nodesState); err != nil {
 			return nil, err
 		}
 	} else {
@@ -139,7 +139,7 @@ func (s *KubeTerraStateLoader) getNodesState(ctx context.Context) (map[string]st
 		if err != nil {
 			return nil, err
 		}
-		err := s.stateCache.SaveStruct("nodes-state", nodesState)
+		err := s.stateCache.SaveStruct(ctx, "nodes-state", nodesState)
 		if err != nil {
 			return nil, err
 		}
@@ -157,13 +157,13 @@ func (s *KubeTerraStateLoader) getClusterState(ctx context.Context) ([]byte, err
 		WithMessage("Do you want to continue with Cluster state from local cache?").
 		WithYesByDefault()
 
-	ok, err := s.stateCache.InCache("cluster-state")
+	ok, err := s.stateCache.InCache(ctx, "cluster-state")
 	if err != nil {
 		return nil, err
 	}
 
 	if ok && (s.forceFromCache || confirmation.Ask()) {
-		clusterState, err = s.stateCache.Load("cluster-state")
+		clusterState, err = s.stateCache.Load(ctx, "cluster-state")
 		if err != nil || len(clusterState) == 0 {
 			return nil, fmt.Errorf("can't load cluster state from cache")
 		}
@@ -175,7 +175,7 @@ func (s *KubeTerraStateLoader) getClusterState(ctx context.Context) ([]byte, err
 		if err != nil {
 			return nil, err
 		}
-		if err := s.stateCache.Save("cluster-state", clusterState); err != nil {
+		if err := s.stateCache.Save(ctx, "cluster-state", clusterState); err != nil {
 			return nil, err
 		}
 	}

--- a/dhctl/pkg/state/infrastructure/state.go
+++ b/dhctl/pkg/state/infrastructure/state.go
@@ -264,7 +264,13 @@ func extractNodesStatesFromSecrets(secrets []*v1.Secret) (map[string]state.NodeG
 	return extractedState, nil
 }
 
-func SaveNodeInfrastructureState(ctx context.Context, kubeCl *client.KubernetesClient, nodeName, nodeGroup string, tfState, settings []byte, logger log.Logger) error {
+func SaveNodeInfrastructureState(
+	ctx context.Context,
+	kubeCl *client.KubernetesClient,
+	nodeName, nodeGroup string,
+	tfState, settings []byte,
+	logger log.Logger,
+) error {
 	if len(tfState) == 0 {
 		return ErrNoInfrastructureState
 	}
@@ -274,17 +280,24 @@ func SaveNodeInfrastructureState(ctx context.Context, kubeCl *client.KubernetesC
 		Manifest: func() interface{} {
 			return manifests.SecretWithNodeInfrastructureState(nodeName, nodeGroup, tfState, settings)
 		},
-		CreateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			_, err := kubeCl.
+				CoreV1().Secrets("d8-system").
+				Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+
 			return err
 		},
-		UpdateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			_, err := kubeCl.
+				CoreV1().Secrets("d8-system").
+				Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
+
 			return err
 		},
 	}
 	return retry.NewLoop(fmt.Sprintf("Save infrastructure state for Node %q", nodeName), 45, 10*time.Second).
-		WithLogger(logger).RunContext(ctx, task.CreateOrUpdate)
+		WithLogger(logger).
+		RunContext(ctx, func() error { return task.CreateOrUpdate(ctx) })
 }
 
 func SaveMasterNodeInfrastructureState(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string, tfState, devicePath []byte) error {
@@ -303,27 +316,37 @@ func SaveMasterNodeInfrastructureState(ctx context.Context, kubeCl *client.Kuber
 		{
 			Name:     fmt.Sprintf(`Secret "d8-node-terraform-state-%s"`, nodeName),
 			Manifest: getInfrastructureStateManifest,
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("d8-system").
+					Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("d8-system").
+					Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
+
 				return err
 			},
 		},
 		{
 			Name:     `Secret "d8-masters-kubernetes-data-device-path"`,
 			Manifest: getDevicePathManifest,
-			CreateFunc: func(manifest interface{}) error {
-				_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+			CreateFunc: func(ctx context.Context, manifest interface{}) error {
+				_, err := kubeCl.
+					CoreV1().Secrets("d8-system").
+					Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+
 				return err
 			},
-			UpdateFunc: func(manifest interface{}) error {
+			UpdateFunc: func(ctx context.Context, manifest interface{}) error {
 				data, err := json.Marshal(manifest.(*v1.Secret))
 				if err != nil {
 					return err
 				}
+
 				_, err = kubeCl.CoreV1().Secrets("d8-system").Patch(
 					ctx,
 					"d8-masters-kubernetes-data-device-path",
@@ -336,15 +359,19 @@ func SaveMasterNodeInfrastructureState(ctx context.Context, kubeCl *client.Kuber
 		},
 	}
 
-	return retry.NewLoop(fmt.Sprintf("Save infrastructure state for master Node %s", nodeName), 45, 10*time.Second).RunContext(ctx, func() error {
-		var allErrs *multierror.Error
-		for _, task := range tasks {
-			if err := task.CreateOrUpdate(); err != nil {
-				allErrs = multierror.Append(allErrs, err)
-			}
-		}
-		return allErrs.ErrorOrNil()
-	})
+	return retry.NewLoop(fmt.Sprintf("Save infrastructure state for master Node %s", nodeName), 45, 10*time.Second).
+		RunContext(
+			ctx,
+			func() error {
+				var allErrs *multierror.Error
+				for _, task := range tasks {
+					if err := task.CreateOrUpdate(ctx); err != nil {
+						allErrs = multierror.Append(allErrs, err)
+					}
+				}
+				return allErrs.ErrorOrNil()
+			},
+		)
 }
 
 func SaveClusterInfrastructureState(ctx context.Context, kubeCl *client.KubernetesClient, outputs *infrastructure.PipelineOutputs) error {
@@ -355,17 +382,29 @@ func SaveClusterInfrastructureState(ctx context.Context, kubeCl *client.Kubernet
 	task := actions.ManifestTask{
 		Name:     `Secret "d8-cluster-terraform-state"`,
 		Manifest: func() interface{} { return manifests.SecretWithInfrastructureState(outputs.InfrastructureState) },
-		CreateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			_, err := kubeCl.
+				CoreV1().Secrets("d8-system").
+				Create(ctx, manifest.(*v1.Secret), metav1.CreateOptions{})
+
 			return err
 		},
-		UpdateFunc: func(manifest interface{}) error {
-			_, err := kubeCl.CoreV1().Secrets("d8-system").Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
+		UpdateFunc: func(ctx context.Context, manifest interface{}) error {
+			_, err := kubeCl.
+				CoreV1().Secrets("d8-system").
+				Update(ctx, manifest.(*v1.Secret), metav1.UpdateOptions{})
+
 			return err
 		},
 	}
 
-	err := retry.NewLoop("Save Cluster infrastructure state", 45, 10*time.Second).RunContext(ctx, task.CreateOrUpdate)
+	err := retry.NewLoop("Save Cluster infrastructure state", 45, 10*time.Second).
+		RunContext(
+			ctx,
+			func() error {
+				return task.CreateOrUpdate(ctx)
+			},
+		)
 	if err != nil {
 		return err
 	}

--- a/dhctl/pkg/state/infrastructure/state_saver.go
+++ b/dhctl/pkg/state/infrastructure/state_saver.go
@@ -62,7 +62,7 @@ func NewClusterStateSaver(getter kubernetes.KubeClientProvider) *ClusterStateSav
 	}
 }
 
-func (s *ClusterStateSaver) SaveState(outputs *infrastructure.PipelineOutputs) error {
+func (s *ClusterStateSaver) SaveState(ctx context.Context, outputs *infrastructure.PipelineOutputs) error {
 	if outputs == nil || len(outputs.InfrastructureState) == 0 {
 		return nil
 	}
@@ -72,7 +72,7 @@ func (s *ClusterStateSaver) SaveState(outputs *infrastructure.PipelineOutputs) e
 		PatchData: func() interface{} {
 			return manifests.PatchWithInfrastructureState(outputs.InfrastructureState)
 		},
-		PatchFunc: func(patch []byte) error {
+		PatchFunc: func(ctx context.Context, patch []byte) error {
 			ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
 			defer cancel()
 			// MergePatch is used because we need to replace one field in "data".
@@ -88,7 +88,11 @@ func (s *ClusterStateSaver) SaveState(outputs *infrastructure.PipelineOutputs) e
 	}
 
 	log.DebugF("Intermediate save base infra in cluster...\n")
-	err := retry.NewSilentLoop("Save Cluster intermediate infrastructure state", 15, 3*time.Second).Run(task.Patch)
+	err := retry.NewSilentLoop("Save Cluster intermediate infrastructure state", 15, 3*time.Second).Run(
+		func() error {
+			return task.Patch(ctx)
+		},
+	)
 	msg := "Intermediate base infra was saved in cluster\n"
 	if err != nil {
 		msg = fmt.Sprintf("Intermediate base infra was not saved in cluster: %v\n", err)
@@ -121,7 +125,7 @@ func NewNodeStateSaver(getter kubernetes.KubeClientProvider, nodeName, nodeGroup
 //
 // The difference between master node and static node: master node has
 // no key "node-group-settings.json" with group settings.
-func (s *NodeStateSaver) SaveState(outputs *infrastructure.PipelineOutputs) error {
+func (s *NodeStateSaver) SaveState(ctx context.Context, outputs *infrastructure.PipelineOutputs) error {
 	if outputs == nil || len(outputs.InfrastructureState) == 0 {
 		return nil
 	}
@@ -131,27 +135,41 @@ func (s *NodeStateSaver) SaveState(outputs *infrastructure.PipelineOutputs) erro
 		Manifest: func() interface{} {
 			return manifests.SecretWithNodeInfrastructureState(s.nodeName, s.nodeGroup, outputs.InfrastructureState, s.nodeGroupSettings)
 		},
-		CreateFunc: func(manifest interface{}) error {
-			ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+		CreateFunc: func(ctx context.Context, manifest interface{}) error {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
-			_, err := s.getter.KubeClient().CoreV1().Secrets("d8-system").Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+
+			_, err := s.getter.KubeClient().
+				CoreV1().Secrets("d8-system").
+				Create(ctx, manifest.(*apiv1.Secret), metav1.CreateOptions{})
+
 			return err
 		},
 		PatchData: func() interface{} {
 			return manifests.PatchWithNodeInfrastructureState(outputs.InfrastructureState)
 		},
-		PatchFunc: func(patchData []byte) error {
+		PatchFunc: func(ctx context.Context, patchData []byte) error {
 			secretName := manifests.SecretNameForNodeInfrastructureState(s.nodeName)
-			ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
+
 			// MergePatch is used because we need to replace one field in "data".
-			_, err := s.getter.KubeClient().CoreV1().Secrets("d8-system").Patch(ctx, secretName, types.MergePatchType, patchData, metav1.PatchOptions{})
+			_, err := s.getter.KubeClient().
+				CoreV1().Secrets("d8-system").
+				Patch(ctx, secretName, types.MergePatchType, patchData, metav1.PatchOptions{})
+
 			return err
 		},
 	}
+
 	taskName := fmt.Sprintf("Save intermediate infrastructure state for Node %q", s.nodeName)
 	log.DebugF("Intermediate save state for node %s in cluster...\n", s.nodeName)
-	err := retry.NewSilentLoop(taskName, 15, 3*time.Second).Run(task.PatchOrCreate)
+
+	err := retry.NewSilentLoop(taskName, 15, 3*time.Second).Run(func() error {
+		return task.PatchOrCreate(ctx)
+	})
+
 	msg := fmt.Sprintf("Intermediate state for node %s was saved in cluster\n", s.nodeName)
 	if err != nil {
 		msg = fmt.Sprintf("Intermediate state for node %s was not saved in cluster: %v\n", s.nodeName, err)

--- a/dhctl/pkg/state/infrastructure/state_saver.go
+++ b/dhctl/pkg/state/infrastructure/state_saver.go
@@ -73,7 +73,7 @@ func (s *ClusterStateSaver) SaveState(ctx context.Context, outputs *infrastructu
 			return manifests.PatchWithInfrastructureState(outputs.InfrastructureState)
 		},
 		PatchFunc: func(ctx context.Context, patch []byte) error {
-			ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 			// MergePatch is used because we need to replace one field in "data".
 			_, err := s.getter.KubeClient().CoreV1().Secrets("d8-system").Patch(

--- a/dhctl/pkg/template/bootstrap.go
+++ b/dhctl/pkg/template/bootstrap.go
@@ -15,6 +15,7 @@
 package template
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -26,11 +27,18 @@ import (
 
 const bootstrapDir = "/bootstrap"
 
-func PrepareBootstrap(templateController *Controller, nodeIP string, metaConfig *config.MetaConfig, dc *directoryconfig.DirectoryConfig) error {
+func PrepareBootstrap(
+	ctx context.Context,
+	templateController *Controller,
+	nodeIP string,
+	metaConfig *config.MetaConfig,
+	dc *directoryconfig.DirectoryConfig,
+) error {
 	bashibleData, err := metaConfig.ConfigForBashibleBundleTemplate(nodeIP)
 	if err != nil {
 		return err
 	}
+
 	_, err = os.Stat(candiDir)
 	if err != nil {
 		if dc == nil {
@@ -39,6 +47,7 @@ func PrepareBootstrap(templateController *Controller, nodeIP string, metaConfig 
 		candiDir = filepath.Join(dc.DownloadDir, "deckhouse", "candi")
 		candiBashibleDir = filepath.Join(candiDir, "bashible")
 	}
+
 	saveInfo := []saveFromTo{
 		{
 			from: filepath.Join(candiBashibleDir, "bootstrap"),
@@ -55,13 +64,14 @@ func PrepareBootstrap(templateController *Controller, nodeIP string, metaConfig 
 		},
 	}
 
-	return log.Process("default", "Render bootstrap templates", func() error {
+	return log.ProcessCtx(ctx, "default", "Render bootstrap templates", func(ctx context.Context) error {
 		for _, info := range saveInfo {
 			log.InfoF("From %q to %q\n", info.from, info.to)
 			if err := templateController.RenderAndSaveTemplates(info.from, info.to, info.data, info.ignorePaths); err != nil {
 				return err
 			}
 		}
+
 		return nil
 	})
 }

--- a/dhctl/pkg/template/bundle.go
+++ b/dhctl/pkg/template/bundle.go
@@ -15,6 +15,7 @@
 package template
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -66,6 +67,7 @@ func logTemplatesData(name string, data map[string]interface{}) {
 }
 
 func PrepareBundle(
+	ctx context.Context,
 	templateController *Controller,
 	nodeIP string,
 	devicePath string,
@@ -84,11 +86,11 @@ func PrepareBundle(
 	}
 	logTemplatesData("bashible", bashibleData)
 
-	if err := PrepareBashibleBundle(templateController, bashibleData, metaConfig.ProviderName, devicePath, dc); err != nil {
+	if err := PrepareBashibleBundle(ctx, templateController, bashibleData, metaConfig.ProviderName, devicePath, dc); err != nil {
 		return err
 	}
 
-	if err := PrepareKubeadmConfig(templateController, kubeadmData, dc); err != nil {
+	if err := PrepareKubeadmConfig(ctx, templateController, kubeadmData, dc); err != nil {
 		return err
 	}
 
@@ -107,6 +109,7 @@ func PrepareBundle(
 
 //nolint:prealloc
 func PrepareBashibleBundle(
+	ctx context.Context,
 	templateController *Controller,
 	templateData map[string]interface{},
 	provider string,
@@ -170,7 +173,12 @@ func GetKubeadmVersion(kubernetesVersion string) (string, error) {
 	return kubeadmV1Beta4, nil
 }
 
-func PrepareKubeadmConfig(templateController *Controller, templateData map[string]interface{}, dc *directoryconfig.DirectoryConfig) error {
+func PrepareKubeadmConfig(
+	ctx context.Context,
+	templateController *Controller,
+	templateData map[string]interface{},
+	dc *directoryconfig.DirectoryConfig,
+) error {
 	_, err := os.Stat(candiDir)
 	if err != nil {
 		// fallback to alternative

--- a/dhctl/pkg/tests/cache_test_utils.go
+++ b/dhctl/pkg/tests/cache_test_utils.go
@@ -24,7 +24,7 @@ import (
 
 func assertCacheKeys(t *testing.T, stateCache state.Cache, expectedKeys []string) {
 	var objectsInCacheAfterClean []string
-	err := stateCache.Iterate(func(s string, _ []byte) error {
+	err := stateCache.Iterate(t.Context(), func(s string, _ []byte) error {
 		objectsInCacheAfterClean = append(objectsInCacheAfterClean, s)
 		return nil
 	})
@@ -47,21 +47,21 @@ func RunStateCacheTests(t *testing.T, stateCache state.Cache) {
 	}
 
 	for _, k := range simpleKeys {
-		err = stateCache.Save(k.key, k.value)
+		err = stateCache.Save(t.Context(), k.key, k.value)
 		require.NoError(t, err)
 
-		ok, err := stateCache.InCache(k.key)
+		ok, err := stateCache.InCache(t.Context(), k.key)
 		require.NoError(t, err)
 		require.True(t, ok)
 
-		content, err := stateCache.Load(k.key)
+		content, err := stateCache.Load(t.Context(), k.key)
 
 		require.NoError(t, err)
 		require.Equal(t, k.value, content)
 	}
 
 	var iterateValues []testCase
-	err = stateCache.Iterate(func(k string, v []byte) error {
+	err = stateCache.Iterate(t.Context(), func(k string, v []byte) error {
 		iterateValues = append(iterateValues, testCase{
 			key:   k,
 			value: v,
@@ -73,17 +73,17 @@ func RunStateCacheTests(t *testing.T, stateCache state.Cache) {
 	require.Equal(t, iterateValues, simpleKeys)
 
 	structForTest := map[string]int{"abc": 10, "def": 1000, "xyz": 10}
-	err = stateCache.SaveStruct("test-struct", structForTest)
+	err = stateCache.SaveStruct(t.Context(), "test-struct", structForTest)
 	require.NoError(t, err)
 
 	var test map[string]int
-	err = stateCache.LoadStruct("test-struct", &test)
+	err = stateCache.LoadStruct(t.Context(), "test-struct", &test)
 	require.NoError(t, err)
 
 	require.Equal(t, structForTest, test)
 
 	var objectsInCache []string
-	err = stateCache.Iterate(func(s string, _ []byte) error {
+	err = stateCache.Iterate(t.Context(), func(s string, _ []byte) error {
 		objectsInCache = append(objectsInCache, s)
 		return nil
 	})
@@ -91,22 +91,22 @@ func RunStateCacheTests(t *testing.T, stateCache state.Cache) {
 
 	require.Equal(t, []string{"test", "test-struct", "test.tfstate", "test2.tfstate"}, objectsInCache)
 
-	stateCache.Delete("test")
+	stateCache.Delete(t.Context(), "test")
 	assertCacheKeys(t, stateCache, []string{"test-struct", "test.tfstate", "test2.tfstate"})
 
-	stateCache.Clean()
+	stateCache.Clean(t.Context())
 	assertCacheKeys(t, stateCache, []string{".tombstone"})
 
-	stateCache.Delete(".tombstone")
-	err = stateCache.Save("a", []byte("a-test"))
+	stateCache.Delete(t.Context(), ".tombstone")
+	err = stateCache.Save(t.Context(), "a", []byte("a-test"))
 	require.NoError(t, err)
 
-	err = stateCache.Save("b", []byte("b-test"))
+	err = stateCache.Save(t.Context(), "b", []byte("b-test"))
 	require.NoError(t, err)
 
-	err = stateCache.Save("c", []byte("c-test"))
+	err = stateCache.Save(t.Context(), "c", []byte("c-test"))
 	require.NoError(t, err)
 
-	stateCache.CleanWithExceptions("b")
+	stateCache.CleanWithExceptions(t.Context(), "b")
 	assertCacheKeys(t, stateCache, []string{".tombstone", "b"})
 }

--- a/dhctl/pkg/util/cache/cache.go
+++ b/dhctl/pkg/util/cache/cache.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"bytes"
+	"context"
 	"encoding/gob"
 	"fmt"
 	"os"
@@ -88,7 +89,7 @@ func NewStateCacheWithInitialState(dir string, initialState map[string][]byte) (
 }
 
 // SaveStruct saves bytes to a file
-func (s *StateCache) Save(name string, content []byte) error {
+func (s *StateCache) Save(ctx context.Context, name string, content []byte) error {
 	path := s.GetPath(name)
 	if err := os.WriteFile(path, content, 0o600); err != nil {
 		return err
@@ -100,18 +101,18 @@ func (s *StateCache) Save(name string, content []byte) error {
 }
 
 // SaveStruct saves go struct into the cache as a blob
-func (s *StateCache) SaveStruct(name string, v interface{}) error {
+func (s *StateCache) SaveStruct(ctx context.Context, name string, v interface{}) error {
 	b := new(bytes.Buffer)
 	err := gob.NewEncoder(b).Encode(v)
 	if err != nil {
 		return err
 	}
 
-	return s.Save(name, b.Bytes())
+	return s.Save(ctx, name, b.Bytes())
 }
 
 // InCache checks is file in cache or not
-func (s *StateCache) InCache(name string) (bool, error) {
+func (s *StateCache) InCache(ctx context.Context, name string) (bool, error) {
 	info, err := os.Stat(s.GetPath(name))
 	if os.IsNotExist(err) {
 		return false, nil
@@ -119,7 +120,7 @@ func (s *StateCache) InCache(name string) (bool, error) {
 	return !info.IsDir(), nil
 }
 
-func (s *StateCache) Clean() {
+func (s *StateCache) Clean(ctx context.Context) {
 	_ = os.RemoveAll(s.dir)
 	if err := os.MkdirAll(s.dir, 0o755); err != nil {
 		log.ErrorF("Failed to recreate cache directory %s: %v\n", s.dir, err)
@@ -132,14 +133,14 @@ func (s *StateCache) Clean() {
 	}
 }
 
-func (s *StateCache) CleanWithExceptions(excludeKeys ...string) {
+func (s *StateCache) CleanWithExceptions(ctx context.Context, excludeKeys ...string) {
 	excludeKeysSet := map[string]struct{}{}
 	for _, k := range excludeKeys {
 		excludeKeysSet[k] = struct{}{}
 	}
 
 	keysToRemove := make([]string, 0)
-	err := s.Iterate(func(key string, i []byte) error {
+	err := s.Iterate(ctx, func(key string, i []byte) error {
 		if _, ok := excludeKeysSet[key]; ok {
 			return nil
 		}
@@ -158,13 +159,13 @@ func (s *StateCache) CleanWithExceptions(excludeKeys ...string) {
 	}
 
 	for _, key := range keysToRemove {
-		s.Delete(key)
+		s.Delete(ctx, key)
 	}
 }
 
-func (s *StateCache) Delete(name string) {
+func (s *StateCache) Delete(ctx context.Context, name string) {
 	path := s.GetPath(name)
-	ok, _ := s.InCache(name)
+	ok, _ := s.InCache(ctx, name)
 	if ok {
 		if err := os.Remove(path); err != nil {
 			log.ErrorF("Failed to delete cache file %s: %v\n", path, err)
@@ -172,13 +173,13 @@ func (s *StateCache) Delete(name string) {
 	}
 }
 
-func (s *StateCache) Load(name string) ([]byte, error) {
+func (s *StateCache) Load(ctx context.Context, name string) ([]byte, error) {
 	return os.ReadFile(s.GetPath(name))
 }
 
 // LoadStruct loads go struct from the cache
-func (s *StateCache) LoadStruct(name string, v interface{}) error {
-	d, err := s.Load(name)
+func (s *StateCache) LoadStruct(ctx context.Context, name string, v interface{}) error {
+	d, err := s.Load(ctx, name)
 	if err != nil {
 		return fmt.Errorf("can't load struct for key %s: %v", name, err)
 	}
@@ -193,7 +194,7 @@ func (s *StateCache) GetPath(name string) string {
 	return filepath.Join(s.dir, name)
 }
 
-func (s *StateCache) Iterate(iterFunc func(string, []byte) error) error {
+func (s *StateCache) Iterate(ctx context.Context, iterFunc func(string, []byte) error) error {
 	walkFunc := func(path string, info os.FileInfo, _ error) error {
 		if info == nil || info.IsDir() {
 			return nil
@@ -226,18 +227,18 @@ func (s *StateCache) Dir() string {
 // DummyCache is a cache implementation which saves nothing and nowhere
 type DummyCache struct{}
 
-func (d *DummyCache) Save(n string, c []byte) error            { return nil }
-func (d *DummyCache) InCache(n string) (bool, error)           { return false, nil }
-func (d *DummyCache) Clean()                                   {}
-func (d *DummyCache) CleanWithExceptions(e ...string)          {}
-func (d *DummyCache) Delete(n string)                          {}
-func (d *DummyCache) Load(n string) ([]byte, error)            { return nil, nil }
-func (d *DummyCache) LoadStruct(n string, v interface{}) error { return nil }
-func (d *DummyCache) SaveStruct(n string, v interface{}) error { return nil }
-func (d *DummyCache) GetPath(n string) string                  { return "" }
-func (d *DummyCache) Iterate(func(string, []byte) error) error { return nil }
-func (d *DummyCache) NeedIntermediateSave() bool               { return false }
-func (d *DummyCache) Dir() string                              { return "" }
+func (d *DummyCache) Save(ctx context.Context, n string, c []byte) error            { return nil }
+func (d *DummyCache) SaveStruct(ctx context.Context, n string, v interface{}) error { return nil }
+func (d *DummyCache) InCache(ctx context.Context, n string) (bool, error)           { return false, nil }
+func (d *DummyCache) Clean(ctx context.Context)                                     {}
+func (d *DummyCache) CleanWithExceptions(ctx context.Context, e ...string)          {}
+func (d *DummyCache) Delete(ctx context.Context, n string)                          {}
+func (d *DummyCache) Load(ctx context.Context, n string) ([]byte, error)            { return nil, nil }
+func (d *DummyCache) LoadStruct(ctx context.Context, n string, v interface{}) error { return nil }
+func (d *DummyCache) GetPath(n string) string                                       { return "" }
+func (d *DummyCache) Iterate(context.Context, func(string, []byte) error) error     { return nil }
+func (d *DummyCache) NeedIntermediateSave() bool                                    { return false }
+func (d *DummyCache) Dir() string                                                   { return "" }
 
 type TestCache struct {
 	Store map[string][]byte
@@ -249,21 +250,21 @@ func NewTestCache() *TestCache {
 	}
 }
 
-func (d *TestCache) Save(n string, c []byte) error {
+func (d *TestCache) Save(ctx context.Context, n string, c []byte) error {
 	d.Store[n] = c
 	return nil
 }
 
-func (d *TestCache) InCache(n string) (bool, error) {
+func (d *TestCache) InCache(ctx context.Context, n string) (bool, error) {
 	_, ok := d.Store[n]
 	return ok, nil
 }
 
-func (d *TestCache) Clean() {
+func (d *TestCache) Clean(ctx context.Context) {
 	d.Store = make(map[string][]byte)
 }
 
-func (d *TestCache) CleanWithExceptions(e ...string) {
+func (d *TestCache) CleanWithExceptions(ctx context.Context, e ...string) {
 	n := make(map[string][]byte, 0)
 
 	for _, v := range e {
@@ -273,16 +274,16 @@ func (d *TestCache) CleanWithExceptions(e ...string) {
 	d.Store = n
 }
 
-func (d *TestCache) Delete(n string) {
+func (d *TestCache) Delete(ctx context.Context, n string) {
 	delete(d.Store, n)
 }
 
-func (d *TestCache) Load(n string) ([]byte, error) {
+func (d *TestCache) Load(ctx context.Context, n string) ([]byte, error) {
 	return d.Store[n], nil
 }
 
-func (d *TestCache) LoadStruct(n string, v interface{}) error {
-	data, err := d.Load(n)
+func (d *TestCache) LoadStruct(ctx context.Context, n string, v interface{}) error {
+	data, err := d.Load(ctx, n)
 	if err != nil {
 		return fmt.Errorf("can't load struct for key %s: %v", n, err)
 	}
@@ -290,21 +291,21 @@ func (d *TestCache) LoadStruct(n string, v interface{}) error {
 	return gob.NewDecoder(bytes.NewBuffer(data)).Decode(v)
 }
 
-func (d *TestCache) SaveStruct(n string, v interface{}) error {
+func (d *TestCache) SaveStruct(ctx context.Context, n string, v interface{}) error {
 	b := new(bytes.Buffer)
 	err := gob.NewEncoder(b).Encode(v)
 	if err != nil {
 		return err
 	}
 
-	return d.Save(n, b.Bytes())
+	return d.Save(ctx, n, b.Bytes())
 }
 
 func (d *TestCache) GetPath(n string) string {
 	return n
 }
 
-func (d *TestCache) Iterate(action func(string, []byte) error) error {
+func (d *TestCache) Iterate(ctx context.Context, action func(string, []byte) error) error {
 	for k, v := range d.Store {
 		err := action(k, v)
 		if err != nil {

--- a/dhctl/pkg/util/cache/cache_test.go
+++ b/dhctl/pkg/util/cache/cache_test.go
@@ -46,7 +46,7 @@ func TestNewTempStateCache(t *testing.T) {
 
 		tests.RunStateCacheTests(t, stateCache)
 
-		ok, err := stateCache.InCache(".tombstone")
+		ok, err := stateCache.InCache(t.Context(), ".tombstone")
 
 		require.NoError(t, err)
 		require.True(t, ok)

--- a/dhctl/pkg/util/retry/retry.go
+++ b/dhctl/pkg/util/retry/retry.go
@@ -287,7 +287,7 @@ func (l *Loop) run(ctx context.Context, task func() error) error {
 		return fmt.Errorf("Attempts quantity must be greater than zero for loop '%s'", l.name)
 	}
 
-	loopBody := func() error {
+	loopBody := func(ctx context.Context) error {
 		var err error
 		for i := 1; i <= l.attemptsQuantity; i++ {
 			// Check if process is interrupted.
@@ -327,5 +327,5 @@ func (l *Loop) run(ctx context.Context, task func() error) error {
 		return fmt.Errorf("Timeout while %q: last error: %w", l.name, err)
 	}
 
-	return l.logger.LogProcess("default", l.name, loopBody)
+	return l.logger.LogProcessCtx(ctx, "default", l.name, loopBody)
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add default root application context, which propogated to all parts of dhctl from the beginning. 

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Before we started add more observability to dhctl, we need ensure, that all parts of it containing context, propogated to all parts.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: add root context propagation, starting from dhctl kingping
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
