### PR TITLE
[docs] Add metadata to gpu module

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -69,7 +69,7 @@
       "ee"
     ],
     "tags": [
-      "ai",
+      "ml/ai",
       "core"
     ],
     "external": "true",

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -64,6 +64,17 @@
     "external": "true",
     "path": "/modules/code/stable/"
   },
+  "gpu": {
+    "editions": [
+      "ee"
+    ],
+    "tags": [
+      "ai",
+      "core"
+    ],
+    "external": "true",
+    "path": "/modules/gpu/"
+  },
   "managed-cassandra": {
     "editions": [
       "ee"

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -69,8 +69,7 @@
       "ee"
     ],
     "tags": [
-      "ml/ai",
-      "core"
+      "ml/ai"
     ],
     "external": "true",
     "path": "/modules/gpu/"

--- a/docs/site/assets/js/filter.js
+++ b/docs/site/assets/js/filter.js
@@ -216,8 +216,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const label = document.createElement('label');
     label.htmlFor = tag;
-    label.textContent = tag;
-    label.style.textTransform = 'capitalize';
+    label.textContent = capitalizeWords(tag);
+
 
     filterCheckboxesTags.appendChild(input);
     filterCheckboxesTags.appendChild(label);

--- a/docs/site/assets/js/filter.js
+++ b/docs/site/assets/js/filter.js
@@ -104,8 +104,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
+  const uppercaseAcronyms = { 'ml': 'ML', 'ai': 'AI', 'ci': 'CI', 'cd': 'CD', 'api': 'API' };
+
   function capitalizeWords(value) {
-    return value.trim().split(/\s+/).map(word => (word ? word.charAt(0).toUpperCase() + word.slice(1) : word)).join(' ');
+    return value.trim().split(/(\s+|(?=[/])|(?<=[/]))/).map(part => {
+      const lower = part.toLowerCase();
+      if (uppercaseAcronyms[lower]) return uppercaseAcronyms[lower];
+      return part ? part.charAt(0).toUpperCase() + part.slice(1) : part;
+    }).join('');
   }
 
   function markEmptyCheckboxes() {

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -215,6 +215,17 @@
     "external": "true",
     "path": "/modules/csi-yadro-tatlin-unified/stable/"
   },
+  "gpu": {
+    "editions": [
+      "ee"
+    ],
+    "tags": [
+      "ai",
+      "core"
+    ],
+    "external": "true",
+    "path": "/modules/gpu/"
+  },
   "delivery-kit": {
     "editions": [
       "cse-lite",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -220,7 +220,7 @@
       "ee"
     ],
     "tags": [
-      "ai",
+      "ml/ai",
       "core"
     ],
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -220,8 +220,7 @@
       "ee"
     ],
     "tags": [
-      "ml/ai",
-      "core"
+      "ml/ai"
     ],
     "external": "true",
     "path": "/modules/gpu/"


### PR DESCRIPTION
## Description

Assign gpu-specific tag for module categorisation and discovery within the documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add metadata to gpu module.
impact_level: low
```
