### PR TITLE
[cloud-provider-azure] migrate to lib-helm templates

### DIFF
--- a/modules/030-cloud-provider-azure/template_tests/module_test.go
+++ b/modules/030-cloud-provider-azure/template_tests/module_test.go
@@ -61,7 +61,7 @@ const globalValues = `
     podSubnetCIDR: 10.111.0.0/16
     podSubnetNodeCIDRPrefix: "24"
     serviceSubnetCIDR: 10.222.0.0/16
-  enabledModules: ["vertical-pod-autoscaler"]
+  enabledModules: ["vertical-pod-autoscaler", "vertical-pod-autoscaler-crd"]
   modules:
     placement: {}
   discovery:
@@ -333,7 +333,7 @@ var _ = Describe("Module :: cloud-provider-azure :: helm template ::", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", globalValues)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
-			f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler"]`)
+			f.ValuesSetFromYaml("global.enabledModules", `["vertical-pod-autoscaler", "vertical-pod-autoscaler-crd"]`)
 			f.ValuesSetFromYaml("cloudProviderAzure", moduleValues)
 			f.HelmRender()
 		})

--- a/modules/030-cloud-provider-azure/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-controller-manager/deployment.yaml
@@ -1,142 +1,51 @@
-{{- define "azure_cloud_controller_manager_resources" }}
-cpu: 25m
-memory: 50Mi
-{{- end }}
+{{- define "azure_ccm_args" -}}
+- --v=2
+- --cloud-provider=azure
+- --allocate-node-cidrs=true
+- --cloud-config=/etc/cloud-contoller-manager-config/cloud-config
+- --cluster-cidr={{ .Values.global.discovery.podSubnet }}
+- --configure-cloud-routes=true
+- --route-reconciliation-period=10s
+{{- end -}}
+
+{{- define "azure_ccm_pod_annotations" -}}
+checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
+{{- end -}}
+
+{{- define "azure_ccm_volume_mounts" -}}
+- mountPath: /etc/kubernetes
+  name: etc-kubernetes
+  readOnly: true
+- mountPath: /etc/cloud-contoller-manager-config
+  name: config
+  readOnly: true
+{{- end -}}
+
+{{- define "azure_ccm_volumes" -}}
+- hostPath:
+    path: /etc/kubernetes
+    type: DirectoryOrCreate
+  name: etc-kubernetes
+- name: config
+  secret:
+    secretName: cloud-controller-manager
+{{- end -}}
 
 {{- $kubernetesSemVer := semver .Values.global.discovery.kubernetesVersion }}
 {{- $ccmImageName := join "" (list "cloudControllerManager" $kubernetesSemVer.Major $kubernetesSemVer.Minor ) }}
 {{- $ccmImage := include "helm_lib_module_image_no_fail" (list . $ccmImageName) }}
 {{- if $ccmImage }}
-  {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: cloud-controller-manager
-  namespace: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: cloud-controller-manager
-  updatePolicy:
-    updateMode: "InPlaceOrRecreate"
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "azure-cloud-controller-manager"
-      minAllowed:
-        {{- include "azure_cloud_controller_manager_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 50m
-        memory: 50Mi
-  {{- end }}
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cloud-controller-manager
-  namespace: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: cloud-controller-manager
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cloud-controller-manager
-  namespace: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-controller-manager")) | nindent 2 }}
-spec:
-  {{- include "helm_lib_deployment_on_master_strategy_and_replicas_for_ha" . | nindent 2 }}
-  revisionHistoryLimit: 2
-  selector:
-    matchLabels:
-      app: cloud-controller-manager
-  template:
-    metadata:
-      labels:
-        app: cloud-controller-manager
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manager/secret.yaml") . | sha256sum }}
-    spec:
-      imagePullSecrets:
-      - name: deckhouse-registry
-      {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
-      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "cloud-controller-manager")) | nindent 6 }}
-      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
-      automountServiceAccountToken: true
-      hostNetwork: true
-      dnsPolicy: Default
-      serviceAccountName: cloud-controller-manager
-      containers:
-        - name: azure-cloud-controller-manager
-          {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 10 }}
-          image: {{ $ccmImage }}
-          command:
-          - /usr/local/bin/azure-cloud-controller-manager
-          - --v=2
-          - --cloud-provider=azure
-          - --allocate-node-cidrs=true
-          - --cloud-config=/etc/cloud-contoller-manager-config/cloud-config
-          - --cluster-cidr={{ .Values.global.discovery.podSubnet }}
-          - --leader-elect=true
-          - --configure-cloud-routes=true
-          - --route-reconciliation-period=10s
-          - --bind-address=127.0.0.1
-          - --secure-port=10471
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 10471
-              host: 127.0.0.1
-              scheme: HTTPS
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 10471
-              host: 127.0.0.1
-              scheme: HTTPS
-          env:
-      # KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are needed on the bootstrap phase to make CCM work without kube-proxy
-      {{- if not .Values.global.clusterIsBootstrapped }}
-          - name: KUBERNETES_SERVICE_HOST
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: status.hostIP
-          - name: KUBERNETES_SERVICE_PORT
-            value: "6443"
-      {{- end }}
-          - name: HOST_IP
-            valueFrom:
-              fieldRef:
-                fieldPath: status.hostIP
-          {{- include "helm_lib_envs_for_proxy" . | nindent 10 }}
-          volumeMounts:
-            - mountPath: /etc/kubernetes
-              name: etc-kubernetes
-              readOnly: true
-            - mountPath: /etc/cloud-contoller-manager-config
-              name: config
-              readOnly: true
-          resources:
-            requests:
-              {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 14 }}
-  {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-              {{- include "azure_cloud_controller_manager_resources" . | nindent 14 }}
-  {{- end }}
-      volumes:
-      - hostPath:
-          path: /etc/kubernetes
-          type: DirectoryOrCreate
-        name: etc-kubernetes
-      - name: config
-        secret:
-          secretName: cloud-controller-manager
+{{- $ccmConfig := dict -}}
+{{- $_ := set $ccmConfig "fullname" "cloud-controller-manager" -}}
+{{- $_ := set $ccmConfig "image" $ccmImage -}}
+{{- $_ := set $ccmConfig "containerName" "azure-cloud-controller-manager" -}}
+{{- $_ := set $ccmConfig "command" (list "/usr/local/bin/azure-cloud-controller-manager") -}}
+{{- $_ := set $ccmConfig "additionalArgs" (include "azure_ccm_args" . | fromYamlArray) -}}
+{{- $_ := set $ccmConfig "additionalPodAnnotations" (include "azure_ccm_pod_annotations" . | fromYaml) -}}
+{{- $_ := set $ccmConfig "additionalVolumeMounts" (include "azure_ccm_volume_mounts" . | fromYamlArray) -}}
+{{- $_ := set $ccmConfig "additionalVolumes" (include "azure_ccm_volumes" . | fromYamlArray) -}}
+{{- $_ := set $ccmConfig "vpaEnabled" true -}}
+{{- $_ := set $ccmConfig "securityPolicyExceptionEnabled" true -}}
+
+{{- include "helm_lib_cloud_controller_manager_manifests" (list . $ccmConfig) }}
 {{- end }}

--- a/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/deployment.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/deployment.yaml
@@ -1,180 +1,54 @@
-{{- define "azure_cloud_data_discoverer_resources" }}
-cpu: 25m
-memory: 50Mi
-{{- end }}
+{{- define "azure_cdd_pod_annotations" -}}
+checksum/config: {{ include (print $.Template.BasePath "/cloud-data-discoverer/secret.yaml") . | sha256sum }}
+{{- end -}}
 
-{{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: cloud-data-discoverer
-  namespace: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  targetRef:
-    apiVersion: "apps/v1"
-    kind: Deployment
-    name: cloud-data-discoverer
-  updatePolicy:
-    updateMode: "Initial"
-  resourcePolicy:
-    containerPolicies:
-    - containerName: "cloud-data-discoverer"
-      minAllowed:
-        {{- include "azure_cloud_data_discoverer_resources" . | nindent 8 }}
-      maxAllowed:
-        cpu: 50m
-        memory: 50Mi
-    {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}
-{{- end }}
----
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: cloud-data-discoverer
-  namespace: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: cloud-data-discoverer
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: cloud-data-discoverer
-  namespace: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  replicas: 1
-  revisionHistoryLimit: 2
-  strategy:
-    type: Recreate
-  selector:
-    matchLabels:
-      app: cloud-data-discoverer
-  template:
-    metadata:
-      labels:
-        app: cloud-data-discoverer
-      annotations:
-        kubectl.kubernetes.io/default-exec-container: cloud-data-discoverer
-        kubectl.kubernetes.io/default-logs-container: cloud-data-discoverer
-        checksum/config: {{ include (print $.Template.BasePath "/cloud-data-discoverer/secret.yaml") . | sha256sum }}
-    spec:
-      imagePullSecrets:
-      - name: deckhouse-registry
-      {{- include "helm_lib_priority_class" (tuple . "cluster-low") | nindent 6 }}
-      {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "any-node" "with-uninitialized") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
-      dnsPolicy: {{ include "helm_lib_dns_policy_bootstraping_state" (list . "Default" "ClusterFirstWithHostNet") }}
-      automountServiceAccountToken: true
-      serviceAccountName: cloud-data-discoverer
-      containers:
-      - name: cloud-data-discoverer
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
-        image: {{ include "helm_lib_module_image" (list . "cloudDataDiscoverer") }}
-        args:
-        - --discovery-period=1h
-        - --listen-address=127.0.0.1:8081
-        env:
-        - name: AZURE_LOCATION
-          valueFrom:
-            secretKeyRef:
-              key: location
-              name: cloud-data-discoverer
-        - name: AZURE_SUBSCRIPTION_ID
-          valueFrom:
-            secretKeyRef:
-              key: subscriptionID
-              name: cloud-data-discoverer
-        - name: AZURE_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              key: clientID
-              name: cloud-data-discoverer
-        - name: AZURE_TENANT_ID
-          valueFrom:
-            secretKeyRef:
-              key: tenantID
-              name: cloud-data-discoverer
-        - name: AZURE_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              key: clientSecret
-              name: cloud-data-discoverer
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-        volumeMounts:
-          - mountPath: /etc/config
-            name: config
-            readOnly: true
-        resources:
-          requests:
-            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-          {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "azure_cloud_data_discoverer_resources" . | nindent 12 }}
-          {{- end }}
-      - name: kube-rbac-proxy
-        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
-        image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
-        args:
-          - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8080"
-          - "--v=2"
-          - "--logtostderr=true"
-          - "--stale-cache-interval=1h30m"
-          - "--livez-path=/livez"
-        ports:
-          - containerPort: 8080
-            name: https-metrics
-        env:
-          - name: KUBE_RBAC_PROXY_LISTEN_ADDRESS
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
-          - name: KUBE_RBAC_PROXY_CONFIG
-            value: |
-              excludePaths:
-              - /healthz
-              upstreams:
-              - upstream: http://127.0.0.1:8081/
-                path: /
-                authorization:
-                  resourceAttributes:
-                    namespace: d8-cloud-provider-azure
-                    apiGroup: apps
-                    apiVersion: v1
-                    resource: deployments
-                    subresource: prometheus-metrics
-                    name: cloud-data-discoverer
-        livenessProbe:
-          httpGet:
-            path: /livez
-            port: 8080
-            scheme: HTTPS
-        readinessProbe:
-          httpGet:
-            path: /livez
-            port: 8080
-            scheme: HTTPS
-        resources:
-          requests:
-            {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
-          {{- if not ( .Values.global.enabledModules | has "vertical-pod-autoscaler") }}
-            {{- include "helm_lib_container_kube_rbac_proxy_resources" . | nindent 12 }}
-          {{- end }}
-      volumes:
-      - name: config
-        secret:
-          secretName: cloud-data-discoverer
+{{- define "azure_cdd_envs" -}}
+- name: AZURE_LOCATION
+  valueFrom:
+    secretKeyRef:
+      key: location
+      name: cloud-data-discoverer
+- name: AZURE_SUBSCRIPTION_ID
+  valueFrom:
+    secretKeyRef:
+      key: subscriptionID
+      name: cloud-data-discoverer
+- name: AZURE_CLIENT_ID
+  valueFrom:
+    secretKeyRef:
+      key: clientID
+      name: cloud-data-discoverer
+- name: AZURE_TENANT_ID
+  valueFrom:
+    secretKeyRef:
+      key: tenantID
+      name: cloud-data-discoverer
+- name: AZURE_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      key: clientSecret
+      name: cloud-data-discoverer
+{{- end -}}
+
+{{- define "azure_cdd_volume_mounts" -}}
+- mountPath: /etc/config
+  name: config
+  readOnly: true
+{{- end -}}
+
+{{- define "azure_cdd_volumes" -}}
+- name: config
+  secret:
+    secretName: cloud-data-discoverer
+{{- end -}}
+
+{{- $cddConfig := dict -}}
+{{- $_ := set $cddConfig "fullname" "cloud-data-discoverer" -}}
+{{- $_ := set $cddConfig "image" (include "helm_lib_module_image" (list . "cloudDataDiscoverer")) -}}
+{{- $_ := set $cddConfig "additionalEnv" (include "azure_cdd_envs" . | fromYamlArray) -}}
+{{- $_ := set $cddConfig "additionalPodAnnotations" (include "azure_cdd_pod_annotations" . | fromYaml) -}}
+{{- $_ := set $cddConfig "additionalVolumeMounts" (include "azure_cdd_volume_mounts" . | fromYamlArray) -}}
+{{- $_ := set $cddConfig "additionalVolumes" (include "azure_cdd_volumes" . | fromYamlArray) -}}
+{{- $_ := set $cddConfig "vpaEnabled" true -}}
+
+{{- include "helm_lib_cloud_data_discoverer_manifests" (list . $cddConfig) }}

--- a/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/pod-monitor.yaml
+++ b/modules/030-cloud-provider-azure/templates/cloud-data-discoverer/pod-monitor.yaml
@@ -1,40 +1,4 @@
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
----
-apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: cloud-data-discoverer-metrics
-  namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main" "app" "cloud-data-discoverer")) | nindent 2 }}
-spec:
-  jobLabel: app
-  podMetricsEndpoints:
-    - port: https-metrics
-      path: /metrics
-      scheme: https
-      bearerTokenSecret:
-        name: "prometheus-token"
-        key: "token"
-      tlsConfig:
-        insecureSkipVerify: true
-      honorLabels: true
-      scrapeTimeout: {{ include "helm_lib_prometheus_target_scrape_timeout_seconds" (list . 25) }}
-      relabelings:
-      - regex: endpoint|pod|container
-        action: labeldrop
-      - targetLabel: job
-        replacement: cloud-data-discoverer
-      - sourceLabels: [__meta_kubernetes_pod_node_name]
-        targetLabel: node
-      - targetLabel: tier
-        replacement: cluster
-      - sourceLabels: [__meta_kubernetes_pod_ready]
-        regex: "true"
-        action: keep
-  selector:
-    matchLabels:
-      app: cloud-data-discoverer
-  namespaceSelector:
-    matchNames:
-      - d8-cloud-provider-azure
-{{- end }}
+{{- $podMonitorConfig := dict -}}
+{{- $_ := set $podMonitorConfig "targetNamespace" "d8-cloud-provider-azure" -}}
+
+{{- include "helm_lib_cloud_data_discoverer_pod_monitor" (list . $podMonitorConfig) }}

--- a/modules/030-cloud-provider-azure/templates/csi/controller.yaml
+++ b/modules/030-cloud-provider-azure/templates/csi/controller.yaml
@@ -37,6 +37,7 @@
 
   {{- $csiControllerConfig := dict }}
   {{- $_ := set $csiControllerConfig "controllerImage" $csiControllerImage }}
+  {{- $_ := set $csiControllerConfig "securityPolicyExceptionEnabled" true }}
   {{- $_ := set $csiControllerConfig "additionalControllerArgs" (include "csi_controller_args" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerEnvs" (include "csi_controller_envs" . | fromYamlArray) }}
   {{- $_ := set $csiControllerConfig "additionalControllerVolumes" (include "csi_controller_volumes" . | fromYamlArray) }}
@@ -48,6 +49,7 @@
   {{- $csiNodeConfig := dict }}
   {{- $_ := set $csiNodeConfig "nodeImage" $csiControllerImage }}
   {{- $_ := set $csiNodeConfig "driverFQDN" "disk.csi.azure.com" }}
+  {{- $_ := set $csiNodeConfig "securityPolicyExceptionEnabled" true }}
   {{- $_ := set $csiNodeConfig "additionalNodeArgs" (include "csi_node_args" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "additionalNodeEnvs" (include "csi_node_envs" . | fromYamlArray) }}
   {{- $_ := set $csiNodeConfig "additionalNodeVolumes" (include "csi_node_volumes" . | fromYamlArray) }}

--- a/modules/030-cloud-provider-azure/templates/namespace.yaml
+++ b/modules/030-cloud-provider-azure/templates/namespace.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "security.deckhouse.io/pod-policy" "restricted")) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-azure") }}

--- a/modules/030-cloud-provider-azure/templates/namespace.yaml
+++ b/modules/030-cloud-provider-azure/templates/namespace.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-cloud-provider-azure
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "security.deckhouse.io/pod-policy" "restricted")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "extended-monitoring.deckhouse.io/enabled" ""
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+    "security.deckhouse.io/enable-security-policy-check" "true"
+    )) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-cloud-provider-azure") }}


### PR DESCRIPTION
## Description
Migrate the Azure cloud provider module to shared `lib-helm` templates and align security policy exception handling with the common approach.
Changes:
- Migrate CCM deployment to `helm_lib_cloud_controller_manager_manifests`
- Migrate CDD deployment to `helm_lib_cloud_data_discoverer_manifests`
- Migrate pod monitor to `helm_lib_cloud_data_discoverer_pod_monitor`
- Update tests to include `vertical-pod-autoscaler-crd` in `enabledModules`
- Remove duplicated template code by using shared `lib-helm` defines

## Why do we need it, and what problem does it solve?
This migration reduces code duplication in the Azure cloud provider module by utilizing shared lib-helm templates. 
This change reduces code duplication in the Azure cloud provider module and brings it in line with the shared cloud-provider rendering approach.
It also clarifies the purpose of security policy exceptions for cloud control plane components: host networking is required so they can continue functioning even when CNI is unavailable.  
Using the common `lib-helm` path keeps this behavior explicit and consistent across providers.
Benefits:
- Easier maintenance (fix once in `lib-helm`, reuse in providers)
- Consistent cloud provider behavior
- Lower risk of configuration drift
- Cleaner and more maintainable templates

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-azure
type: feature
summary: Migrated Azure CCM and CDD deployments to shared lib-helm templates.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
