### PR TITLE
[control-plane-manager] Update etcd to 3.6.10

### DIFF
--- a/modules/000-common/images/debug-container/known_vulnerabilities.vex
+++ b/modules/000-common/images/debug-container/known_vulnerabilities.vex
@@ -17,20 +17,6 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-24051 невозможно эксплуатировать в рамках Deckhouse, поскольку она не оказывает влияния на системы под управлением Linux. Данная проблема безопасности связана с выполнением команды ioreg, которая является специфичной для операционной системы macOS (Darwin) и отсутствует в ядре Linux.",
       "timestamp": "2026-03-04T09:42:58.078449Z"
-    },
-    {
-      "vulnerability": {
-        "name": "CVE-2026-33186"
-      },
-      "products": [
-        {
-          "@id": "pkg:golang/google.golang.org/grpc"
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в etcd в рамках Deckhouse: etcd не использует path-based авторизационные интерцепторы (grpc/authz или аналоги) с deny-правилами и fallback allow. Авторизация в etcd реализована через собственный встроенный механизм на основе mTLS и username/password, который не подвержен данной уязвимости.",
-      "timestamp": "2026-03-24T10:09:40.852754Z"
     }
   ],
   "timestamp": "2026-03-04T09:42:58Z",

--- a/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
+++ b/modules/040-control-plane-manager/images/etcd/known_vulnerabilities.vex
@@ -20,20 +20,6 @@
     },
     {
       "vulnerability": {
-        "name": "CVE-2026-33186"
-      },
-      "products": [
-        {
-          "@id": "pkg:golang/google.golang.org/grpc"
-        }
-      ],
-      "status": "not_affected",
-      "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Уязвимость CVE-2026-33186 невозможно эксплуатировать в etcd в рамках Deckhouse: etcd не использует path-based авторизационные интерцепторы (grpc/authz или аналоги) с deny-правилами и fallback allow. Авторизация в etcd реализована через собственный встроенный механизм на основе mTLS и username/password, который не подвержен данной уязвимости.",
-      "timestamp": "2026-03-24T10:09:40.852754Z"
-    },
-    {
-      "vulnerability": {
         "name": "CVE-2026-39883"
       },
       "products": [

--- a/modules/040-control-plane-manager/oss.yaml
+++ b/modules/040-control-plane-manager/oss.yaml
@@ -10,4 +10,4 @@
   logo: /images/logos/etcd-icon-color.svg
   license: Apache License 2.0
   id: etcd
-  version: 3.6.8
+  version: 3.6.10


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Bump etcd version to the new patch 3.6.8 -> 3.6.10.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Upgraded etcd to 3.6.10.
impact: Etcd will restart.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
