### PR TITLE
[network-gateway] Fix werf import syntax for compatibility (1.74)

### DIFF
--- a/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/snat/werf.inc.yaml
@@ -18,7 +18,7 @@ import:
   add: /relocate
   to: /
   before: setup
-- from: {{ index $.Images "base/python" }}
+- image: base/python
   add: /
   to: /
   before: install


### PR DESCRIPTION
## Description

This PR reverts the image import syntax in the `snat` image configuration. The `image:` keyword is not supported by the older version of werf used in this release branch.

## Why do we need it, and what problem does it solve?

A recent backport introduced a modern werf import syntax (`image:`) which is incompatible with the werf version in this branch. This caused image build failures. Reverting to the `from:` syntax restores compatibility and fixes the build.

## Why do we need it in the patch release (if we do)?

It is required to fix a broken build in the patch release caused by an incorrect backport.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: network-gateway
type: fix
summary: Fixed werf import syntax for compatibility with older werf versions.
```