### PR TITLE
[deckhouse] allow users to update ModuleSource scanInterval 

### DIFF
--- a/modules/002-deckhouse/templates/validation.yaml
+++ b/modules/002-deckhouse/templates/validation.yaml
@@ -74,6 +74,19 @@ spec:
           && "security.deckhouse.io/heritage-bypass" in oldObject.metadata.labels
           && oldObject.metadata.labels["security.deckhouse.io/heritage-bypass"] == "delete"
         )
+    - name: 'exclude-module-source-scan-interval'
+      expression: |
+        !(
+          request.operation == "UPDATE"
+          && has(request.kind) && request.kind.kind == "ModuleSource"
+          && (
+            (!has(oldObject.spec.scanInterval) && has(object.spec.scanInterval))
+            || (has(oldObject.spec.scanInterval) && !has(object.spec.scanInterval))
+            || (has(oldObject.spec.scanInterval) && has(object.spec.scanInterval)
+                && oldObject.spec.scanInterval != object.spec.scanInterval)
+          )
+          && object.spec.registry == oldObject.spec.registry
+        )
   validations:
     - expression: |
         request.userInfo.username.startsWith("system:serviceaccount:d8-")


### PR DESCRIPTION
## Description

This PR adds a new matchCondition to the label-objects.deckhouse.io ValidatingAdmissionPolicy that allows users to update the spec.scanInterval field on the built-in ModuleSource/deckhouse object.

## Why do we need it, and what problem does it solve?

DKP 1.75 introduced the scanInterval parameter on ModuleSource to control how often the container image registry is polled for new modules - addressing registry DoS issues caused by the default 3-minute scan interval. However, the built-in ModuleSource/deckhouse carries the heritage: deckhouse label, which causes the ValidatingAdmissionPolicy to block any manual updates to this object. As a result, users cannot configure scanInterval on the system ModuleSource.

The new matchCondition excludes UPDATE requests from validation when only spec.scanInterval is changed and spec.registry remains untouched, ensuring registry substitution is still blocked.

### Will Deckhouse reconcile overwrite the user's scanInterval?

No. The scanInterval field is absent from the `default-module-source.yaml`
helm template, so nelm (with SSA) never becomes the field owner. During each reconcile cycle, `nelm` applies only the fields it owns (`spec.registry.*`) and does not touch `scanInterval`. This was verified on a live cluster with nelm+SSA: the user-set value survived multiple reconcile cycles and a Deckhouse restart.

## Checklist

 - [ ]  The code is covered by unit tests.
 - [ ]  e2e tests passed.
 - [ ]  Documentation updated according to the changes.
 - [X]  Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Allow updating scanInterval on the deckhouse ModuleSource.
```