### PR TITLE
[kubernetes] Make flag encryption-provider-config-automatic-reload auto enabled when secretEncryptionKey is true

### DIFF
--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -203,6 +203,8 @@ apiServer:
     {{- if .apiserver.secretEncryptionKey }}
     - name: encryption-provider-config
       value: /etc/kubernetes/deckhouse/extra-files/secret-encryption-config.yaml
+    - name: encryption-provider-config-automatic-reload
+      value: "true"
     {{- end }}
     - name: profiling
       value: "false"

--- a/candi/feature_gates_map.yml
+++ b/candi/feature_gates_map.yml
@@ -34,6 +34,7 @@
     - RelaxedEnvironmentVariableValidation
     - StrictCostEnforcementForVAP
     - StrictCostEnforcementForWebhooks
+    - CRDSensitiveData
   kubeControllerManager:
     - ConcurrentWatchObjectDecode
     - CrossNamespaceVolumeDataSource
@@ -84,6 +85,7 @@
     - OrderedNamespaceDeletion
     - PodLifecycleSleepActionAllowZero
     - RelaxedDNSSearchValidation
+    - CRDSensitiveData
   kubeControllerManager:
     - ComponentFlagz
     - ComponentStatusz
@@ -146,6 +148,7 @@
     - SELinuxMount
     - StrictIPCIDRValidation
     - DisableAllocatorDualWrite
+    - CRDSensitiveData
   kubeControllerManager:
     - AllowParsingUserUIDFromCertAuth
     - ComponentFlagz
@@ -201,6 +204,7 @@
     - ResourceHealthStatus
     - SELinuxMount
     - StrictIPCIDRValidation
+    - CRDSensitiveData
   kubeControllerManager:
     - ComponentFlagz
     - ComponentStatusz
@@ -254,6 +258,7 @@
     - SELinuxMount
     - StrictIPCIDRValidation
     - TaintTolerationComparisonOperators
+    - CRDSensitiveData
   kubeControllerManager:
     - ComponentFlagz
     - ComponentStatusz

--- a/modules/040-control-plane-manager/hooks/feature_gates_generated.go
+++ b/modules/040-control-plane-manager/hooks/feature_gates_generated.go
@@ -121,6 +121,7 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"RelaxedEnvironmentVariableValidation",
 			"StrictCostEnforcementForVAP",
 			"StrictCostEnforcementForWebhooks",
+			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ConcurrentWatchObjectDecode",
@@ -176,6 +177,7 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"OrderedNamespaceDeletion",
 			"PodLifecycleSleepActionAllowZero",
 			"RelaxedDNSSearchValidation",
+			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ComponentFlagz",
@@ -243,6 +245,7 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"SELinuxMount",
 			"StrictIPCIDRValidation",
 			"DisableAllocatorDualWrite",
+			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"AllowParsingUserUIDFromCertAuth",
@@ -301,6 +304,7 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"ResourceHealthStatus",
 			"SELinuxMount",
 			"StrictIPCIDRValidation",
+			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ComponentFlagz",
@@ -359,6 +363,7 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"SELinuxMount",
 			"StrictIPCIDRValidation",
 			"TaintTolerationComparisonOperators",
+			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ComponentFlagz",

--- a/modules/040-control-plane-manager/webhooks/validating/feature_gates_generated.py
+++ b/modules/040-control-plane-manager/webhooks/validating/feature_gates_generated.py
@@ -39,6 +39,7 @@ versions = {
             "RelaxedEnvironmentVariableValidation",
             "StrictCostEnforcementForVAP",
             "StrictCostEnforcementForWebhooks",
+            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ConcurrentWatchObjectDecode",
@@ -94,6 +95,7 @@ versions = {
             "OrderedNamespaceDeletion",
             "PodLifecycleSleepActionAllowZero",
             "RelaxedDNSSearchValidation",
+            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ComponentFlagz",
@@ -161,6 +163,7 @@ versions = {
             "SELinuxMount",
             "StrictIPCIDRValidation",
             "DisableAllocatorDualWrite",
+            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "AllowParsingUserUIDFromCertAuth",
@@ -219,6 +222,7 @@ versions = {
             "ResourceHealthStatus",
             "SELinuxMount",
             "StrictIPCIDRValidation",
+            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ComponentFlagz",
@@ -277,6 +281,7 @@ versions = {
             "SELinuxMount",
             "StrictIPCIDRValidation",
             "TaintTolerationComparisonOperators",
+            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ComponentFlagz",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
In continuation of this [#18241](https://github.com/deckhouse/deckhouse/pull/18241).
Make flag `encryption-provider-config-automatic-reload` auto enabled when `secretEncryptionKey` is true. Enable `CRDSensitiveData` feature gate for apiserver.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Make flag encryption-provider-config-automatic-reload auto enabled when secretEncryptionKey is true
impact: Apiserver will restart if secretEncryptionKey is true
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
