### PR TITLE
[docs] Add a plugin for tabbed content

### DIFF
--- a/docs/documentation/_plugins/tabs.rb
+++ b/docs/documentation/_plugins/tabs.rb
@@ -11,11 +11,10 @@ module Jekyll
         markup = markup.strip
         raise SyntaxError, "#{tag_name}: group name is required. Usage: {% tabs group_name %}" if markup.empty?
 
-        m = markup.match(/^(\S+)(?:\s+store_key="([^"]*)")?/)
-        raise SyntaxError, "#{tag_name}: invalid syntax. Usage: {% tabs group_name [store_key=\"key\"] %}" unless m
+        m = markup.match(/^(\S+)/)
+        raise SyntaxError, "#{tag_name}: invalid syntax. Usage: {% tabs group_name %}" unless m
 
         @group = m[1]
-        @store_key = m[2]
       end
 
       def render(context)
@@ -31,10 +30,10 @@ module Jekyll
         cont_class  = "tabs__content_#{@group}"
 
         buttons = tabs.each_with_index.map do |tab, i|
-          block_id   = "block_#{@group}_#{slugify(tab[:label])}"
-          active     = i == 0 ? " active" : ""
-          store_args = @store_key && tab[:store_val] ? ", '#{@store_key}', '#{tab[:store_val]}'" : ""
-          %Q(<a href="javascript:void(0)" class="tabs__btn #{btn_class}#{active}" onclick="openTabAndSaveStatus(event, '#{btn_class}', '#{cont_class}', '#{block_id}'#{store_args});">#{tab[:label]}</a>)
+          block_id  = "block_#{@group}_#{slugify(tab[:label])}"
+          store_val = slugify(tab[:label])
+          active    = i == 0 ? " active" : ""
+          %Q(<a href="javascript:void(0)" class="tabs__btn #{btn_class}#{active}" data-store-key="#{@group}" data-store-val="#{store_val}" onclick="openTabAndSaveStatus(event, '#{btn_class}', '#{cont_class}', '#{block_id}', '#{@group}', '#{store_val}');">#{tab[:label]}</a>)
         end
 
         panels = tabs.each_with_index.map do |tab, i|
@@ -59,11 +58,10 @@ module Jekyll
       def initialize(tag_name, markup, tokens)
         super
 
-        m = markup.strip.match(/^"([^"]+)"(?:\s+store_val="([^"]*)")?/)
-        raise SyntaxError, "#{tag_name}: tab label is required. Usage: {% tab \"Label\" [store_val=\"val\"] %}" unless m
+        m = markup.strip.match(/^"([^"]+)"/)
+        raise SyntaxError, "#{tag_name}: tab label is required. Usage: {% tab \"Label\" %}" unless m
 
-        @label     = m[1]
-        @store_val = m[2]
+        @label = m[1]
       end
 
       def render(context)
@@ -75,7 +73,7 @@ module Jekyll
         converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
         html = converter.convert(content).gsub(/\n/, '')
 
-        context.registers[:tabs_stack].last << { label: @label, html: html, store_val: @store_val }
+        context.registers[:tabs_stack].last << { label: @label, html: html }
 
         ""
       end

--- a/docs/documentation/_plugins/tabs.rb
+++ b/docs/documentation/_plugins/tabs.rb
@@ -1,0 +1,87 @@
+require_relative "utils"
+
+module Jekyll
+  module Tabs
+    class TabsTag < Liquid::Block
+      include JekyllLiquidBlockUtils
+
+      def initialize(tag_name, markup, tokens)
+        super
+
+        markup = markup.strip
+        raise SyntaxError, "#{tag_name}: group name is required. Usage: {% tabs group_name %}" if markup.empty?
+
+        m = markup.match(/^(\S+)(?:\s+store_key="([^"]*)")?/)
+        raise SyntaxError, "#{tag_name}: invalid syntax. Usage: {% tabs group_name [store_key=\"key\"] %}" unless m
+
+        @group = m[1]
+        @store_key = m[2]
+      end
+
+      def render(context)
+        context.registers[:tabs_stack] ||= []
+        context.registers[:tabs_stack].push([])
+
+        super
+
+        tabs = context.registers[:tabs_stack].pop
+        return "" if tabs.empty?
+
+        btn_class   = "tabs__btn_#{@group}"
+        cont_class  = "tabs__content_#{@group}"
+
+        buttons = tabs.each_with_index.map do |tab, i|
+          block_id   = "block_#{@group}_#{slugify(tab[:label])}"
+          active     = i == 0 ? " active" : ""
+          store_args = @store_key && tab[:store_val] ? ", '#{@store_key}', '#{tab[:store_val]}'" : ""
+          %Q(<a href="javascript:void(0)" class="tabs__btn #{btn_class}#{active}" onclick="openTabAndSaveStatus(event, '#{btn_class}', '#{cont_class}', '#{block_id}'#{store_args});">#{tab[:label]}</a>)
+        end
+
+        panels = tabs.each_with_index.map do |tab, i|
+          block_id = "block_#{@group}_#{slugify(tab[:label])}"
+          active   = i == 0 ? " active" : ""
+          %Q(<div id="#{block_id}" class="tabs__content #{cont_class}#{active}" markdown="0">#{tab[:html]}</div>)
+        end
+
+        %Q(<div markdown="0"><div class="tabs">#{buttons.join}</div>#{panels.join}</div>)
+      end
+
+      private
+
+      def slugify(text)
+        text.downcase.strip.gsub(/[^a-z0-9\s_-]/, '').gsub(/[\s-]+/, '_')
+      end
+    end
+
+    class TabTag < Liquid::Block
+      include JekyllLiquidBlockUtils
+
+      def initialize(tag_name, markup, tokens)
+        super
+
+        m = markup.strip.match(/^"([^"]+)"(?:\s+store_val="([^"]*)")?/)
+        raise SyntaxError, "#{tag_name}: tab label is required. Usage: {% tab \"Label\" [store_val=\"val\"] %}" unless m
+
+        @label     = m[1]
+        @store_val = m[2]
+      end
+
+      def render(context)
+        raise SyntaxError, "{% tab %} must be used inside {% tabs %}" unless context.registers[:tabs_stack]&.last
+
+        content = dedent(super)
+
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        html = converter.convert(content).gsub(/\n/, '')
+
+        context.registers[:tabs_stack].last << { label: @label, html: html, store_val: @store_val }
+
+        ""
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('tabs', Jekyll::Tabs::TabsTag)
+Liquid::Template.register_tag('tab', Jekyll::Tabs::TabTag)

--- a/docs/documentation/werf-documentation-static.inc.yaml
+++ b/docs/documentation/werf-documentation-static.inc.yaml
@@ -36,7 +36,7 @@ shell:
 
 {{ if ne .ModuleName "website-docs" }}
         # Syncing file from the documentation to the main site...
-        cp /srv/jekyll-data/documentation/_plugins/{alert.rb,codeblock_unknown_lang_fallback.rb,jekyll_asset_pipeline.rb,custom_filters.rb,utils.rb,breadcrumbs_generator.rb,sidebar_custom.rb,offtopic.rb,navigation_helper.rb} /srv/jekyll-data/site/_plugins/
+        cp /srv/jekyll-data/documentation/_plugins/{alert.rb,codeblock_unknown_lang_fallback.rb,jekyll_asset_pipeline.rb,custom_filters.rb,utils.rb,breadcrumbs_generator.rb,sidebar_custom.rb,offtopic.rb,navigation_helper.rb,tabs.rb} /srv/jekyll-data/site/_plugins/
         cp /srv/jekyll-data/documentation/_assets/js/search.js /srv/jekyll-data/site/_assets/
 
         # "Converting public documentation links to internal relative..."

--- a/docs/site/assets/js/tab.js
+++ b/docs/site/assets/js/tab.js
@@ -1,7 +1,7 @@
 function openTabAndSaveStatus(evt, linksClass, contentClass, contentId, storeKey = null, storeVal = null) {
     openTab(evt, linksClass, contentClass, contentId);
     if (storeKey && storeVal) {
-        sessionStorage.setItem(storeKey, storeVal );
+        sessionStorage.setItem(storeKey, storeVal);
     }
 }
 
@@ -21,3 +21,75 @@ function openTab(evt, linksClass, contentClass, contentId) {
   document.getElementById(contentId).style.display = "block";
   evt.currentTarget.className += " active";
 }
+
+// Activate a tab button without a real click event and without writing to sessionStorage.
+function activateTabBtn(btn) {
+  var linksClass, contentClass, block, onclickStr, match;
+
+  // Derive classes and target block id from the onclick attribute.
+  onclickStr = btn.getAttribute("onclick") || "";
+  match = onclickStr.match(/openTab\w*\(event,\s*'([^']+)',\s*'([^']+)',\s*'([^']+)'/);
+  if (!match) return;
+
+  linksClass  = match[1];
+  contentClass = match[2];
+  var blockId = match[3];
+
+  var tabcontent = document.getElementsByClassName(contentClass);
+  for (var i = 0; i < tabcontent.length; i++) {
+    tabcontent[i].style.display = "none";
+  }
+
+  var tablinks = document.getElementsByClassName(linksClass);
+  for (var i = 0; i < tablinks.length; i++) {
+    tablinks[i].className = tablinks[i].className.replace(" active", "");
+  }
+
+  block = document.getElementById(blockId);
+  if (block) block.style.display = "block";
+  btn.className += " active";
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  // 1. Restore tab state from sessionStorage.
+  // Process in DOM order so outer tabs restore before inner tabs.
+  var buttons = document.querySelectorAll("a[data-store-key]");
+  buttons.forEach(function (btn) {
+    var key = btn.dataset.storeKey;
+    var val = btn.dataset.storeVal;
+    if (key && val && sessionStorage.getItem(key) === val) {
+      activateTabBtn(btn);
+    }
+  });
+
+  // 2. Activate tabs for URL hash anchor (overrides sessionStorage restore).
+  var hash = window.location.hash;
+  if (hash) {
+    try {
+      var target = document.querySelector(hash);
+      if (target) {
+        // Walk up the DOM, collecting every .tabs__content ancestor.
+        var panels = [];
+        var node = target.parentElement;
+        while (node) {
+          if (node.classList && node.classList.contains("tabs__content")) {
+            panels.unshift(node); // prepend so outermost comes first
+          }
+          node = node.parentElement;
+        }
+
+        // Activate outermost → innermost so nested tabs open correctly.
+        panels.forEach(function (panel) {
+          var panelId = panel.id;
+          if (!panelId) return;
+          var btn = document.querySelector("a[onclick*=\"'" + panelId + "'\"]");
+          if (btn) activateTabBtn(btn);
+        });
+
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    } catch (e) {
+      // Invalid selector (e.g. hash with special chars) — ignore.
+    }
+  }
+});

--- a/docs/site/werf-web-frontend.inc.yaml
+++ b/docs/site/werf-web-frontend.inc.yaml
@@ -81,6 +81,7 @@ git:
   - _includes/rbac/
   - _includes/related_links.liquid
   - _plugins/alert.rb
+  - _plugins/tabs.rb
   - _plugins/jekyll_asset_pipeline.rb
   - _plugins/codeblock_unknown_lang_fallback.rb
   - _plugins/custom_filters.rb


### PR DESCRIPTION
## Description

This pull request introduces a new custom Jekyll plugin for tabbed content in documentation, integrates it into the documentation build and deployment process, and updates the frontend JavaScript to support tab state persistence and anchor navigation. The main changes are grouped as follows:

**New tabbed content support in documentation:**

* Added a new Jekyll plugin `tabs.rb` that provides `{% tabs group_name %}` and `{% tab "Label" %}` Liquid tags for rendering tabbed content in documentation pages. This includes logic for grouping, labeling, and rendering tabbed blocks with HTML and CSS classes, as well as Markdown support within tab panels.

**Build and deployment integration:**

* Updated the documentation build process to copy the new `tabs.rb` plugin to the site plugins directory, ensuring it is available during site generation.
* Registered the new `tabs.rb` plugin in the frontend's plugin list for deployment.

**Frontend JavaScript enhancements for tabs:**

* Extended `tab.js` to support restoring the last selected tab using `sessionStorage`, and to automatically activate the correct tab(s) when navigating via URL hash anchors (including support for nested tabs). Added the `activateTabBtn` helper function to activate tabs programmatically.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Examples

1. Simple

```
{% tabs os %}
{% tab "Linux" %}
Run the following command:

{% endtab %}
{% tab "macOS" %}
Run the following command:

{% endtab %}
{% tab "Windows" %}
Download the installer from the website and run it as Administrator.
{% endtab %}
{% endtabs %}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: feature
summary: Add a Jekyll plugin for tabbed content in the documentation.
impact_level: low
```
