### PR TITLE
[cloud-provider-openstack] Increase interval and timeout for health monitor

### DIFF
--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -328,8 +328,8 @@ ipv6-support-disabled = true
 [LoadBalancer]
 enabled = true
 create-monitor = "true"
-monitor-delay = "2s"
-monitor-timeout = "1s"
+monitor-delay = "5s"
+monitor-timeout = "3s"
 subnet-id = "my-subnet-id"
 floating-network-id = "my-floating-network-id"
 enable-ingress-hostname = %s

--- a/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/cloud-controller-manager/secret.yaml
@@ -36,8 +36,8 @@ ipv6-support-disabled = true
 {{- end }}
 enabled = {{ not $lbDisabled }}
 create-monitor = "true"
-monitor-delay = "2s"
-monitor-timeout = "1s"
+monitor-delay = "5s"
+monitor-timeout = "3s"
   {{- if hasKey $internal "loadBalancer" }}
     {{- if hasKey .Values.cloudProviderOpenstack.internal.loadBalancer "subnetID" }}
 subnet-id = {{ .Values.cloudProviderOpenstack.internal.loadBalancer.subnetID | quote }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Increase interval and timeout for health monitor

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

We have noticed a validation error when creating a Load Balancer:

```bash
Validation failure: The request delay value 2 should be larger than 3 for UDP-CONNECT health monitor type.
```

After studying the [documentation](https://docs.openstack.org/octavia/latest/_modules/octavia/api/v2/controllers/health_monitor.html) and source code, it turned out that validation works only for UPD monitors (so we have not encountered any errors before) and the [default](https://docs.openstack.org/octavia/latest/configuration/configref.html#api_settings.udp_connect_min_interval_health_monitor) interval is 3 seconds.

As a workaround, you can use the service annotation `loadbalancer.openstack.org/health-monitor-delay`. But to minimize manual actions, it is better to increase the `delay` and at the same time the `timeout`

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: fix
summary: Increase interval and timeout for health monitor
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
