### PR TITLE
[istio] Fix ztunnel daemonset ephemeral storage key dublicate in istio-proxy container

### DIFF
--- a/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -71,8 +71,7 @@ spec:
           name: ztunnel-stats
           protocol: TCP
         resources:
-          {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
-          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
+          {{- include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
         imagePullPolicy: IfNotPresent
         securityContext:
           # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true

--- a/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -71,7 +71,8 @@ spec:
           name: ztunnel-stats
           protocol: TCP
         resources:
-          {{- include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
+          {{ include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
+          {{- include "helm_lib_module_ephemeral_storage_only_logs" . | nindent 12 }}
         imagePullPolicy: IfNotPresent
         securityContext:
           # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true


### PR DESCRIPTION
## Description
Fixed ztunnel daemonset ephemeral storage key dublicate in istio-proxy container

## Why do we need it, and what problem does it solve?

Sometimes fire `Tests DMT lint` fails. May have long term consequences.

## Why do we need it in the patch release (if we do)?

Sometimes fire `Tests DMT lint` fails

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: fixed ztunnel deployment ephemeral storage key dublicate↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
