### PR TITLE
[cni-simple-bridge] Update base image reference (1.73)

### DIFF
--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -6,7 +6,7 @@ import:
   add: /relocate
   to: /
   before: setup
-- from: {{ index $.Images "base/python" }}
+- image: base/python
   add: /
   to: /
   includePaths:


### PR DESCRIPTION
## Description

Update the base image reference for the `cni-simple-bridge` module.

## Why do we need it, and what problem does it solve?

This update addresses the issue where the old version of Werf does not support the current import format for the base image, preventing successful builds.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-simple-bridge
type: fix
summary: Updated base image reference to support new Werf import format.
impact_level: low
```