### PR TITLE
[common] Fix Trivy not seeing VEX files in coredns images (#19297, 1.73)

### DIFF
--- a/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
+++ b/ee/be/modules/350-node-local-dns/images/coredns/werf.inc.yaml
@@ -44,3 +44,5 @@ shell:
   - cd /src
   - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags="-s -w" -o /coredns-helper main.go
   - chmod 0700 /coredns-helper
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/modules/000-common/images/coredns/werf.inc.yaml
+++ b/modules/000-common/images/coredns/werf.inc.yaml
@@ -60,3 +60,5 @@ git:
 imageSpec:
   config:
     entrypoint: ["/coredns"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -162,6 +162,7 @@ var DefaultImagesDigests = map[string]interface{}{
 	"common": map[string]interface{}{
 		"checkKernelVersion":             "imageHash-common-checkKernelVersion",
 		"coredns":                        "imageHash-common-coredns",
+		"corednsVexArtifact":             "imageHash-common-corednsVexArtifact",
 		"csiExternalAttacher129":         "imageHash-common-csiExternalAttacher129",
 		"csiExternalAttacher130":         "imageHash-common-csiExternalAttacher130",
 		"csiExternalAttacher131":         "imageHash-common-csiExternalAttacher131",
@@ -395,6 +396,7 @@ var DefaultImagesDigests = map[string]interface{}{
 	},
 	"nodeLocalDns": map[string]interface{}{
 		"coredns":                    "imageHash-nodeLocalDns-coredns",
+		"corednsVexArtifact":         "imageHash-nodeLocalDns-corednsVexArtifact",
 		"iptablesLoop":               "imageHash-nodeLocalDns-iptablesLoop",
 		"iptablesWrapperInit":        "imageHash-nodeLocalDns-iptablesWrapperInit",
 		"staleDnsConnectionsCleaner": "imageHash-nodeLocalDns-staleDnsConnectionsCleaner",


### PR DESCRIPTION
## Description

Add vex mitigation to coredns images (`common` and `node-local-dns` modules). This ensures that Trivy correctly detects and processes VEX files within these images, which helps reduce false positive vulnerability reports.

These changes only affect the build process and the contents of the resulting images. They do not influence critical cluster components and do not trigger any component restarts.

## Why do we need it, and what problem does it solve?

We need this because Trivy was previously unable to see VEX files in coredns images, leading to inaccurate vulnerability scanning results with false positives. By adding the `vex mitigation` step into `werf.inc.yaml`, we properly embed the VEX data directly into the images, solving the problem and providing users with accurate security scan reports.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Fixed an issue where Trivy could not detect VEX files in coredns images.
impact_level: low
```