### PR TITLE
[docs] Bump Hugo to v0.159.2 in tools

### DIFF
--- a/docs/site/backends/docs-builder/README.md
+++ b/docs/site/backends/docs-builder/README.md
@@ -174,7 +174,7 @@ When `--highAvailability` is enabled:
 ## Dependencies
 
 ### Core Dependencies
-- **Hugo:** v0.150.1 - Static site generator
+- **Hugo:** v0.159.2 - Static site generator
 - **Kubernetes Client:** v0.28.3 - K8s API integration
 - **Deckhouse Logger:** Custom structured logging
 - **Afero/Fsync:** File system operations

--- a/tools/docs/external-module-docs.sh
+++ b/tools/docs/external-module-docs.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="${OUTPUT_DIR:-${TEMPLATE_DIR}/public}"
 MODULE_PATH="${MODULE_PATH:-}"
 CHANNEL="${CHANNEL:-alpha}"
 MODULE_VERSION="${MODULE_VERSION:-v0.1.0}"
-HUGO_IMAGE="${HUGO_IMAGE:-hugomods/hugo:debian-ci-0.150.1}"
+HUGO_IMAGE="${HUGO_IMAGE:-ghcr.io/gohugoio/hugo:v0.159.2}"
 MODE="${MODE:-build}"
 POLL_INTERVAL="${POLL_INTERVAL:-700ms}"
 

--- a/tools/docs/run_external_modules.sh
+++ b/tools/docs/run_external_modules.sh
@@ -66,7 +66,7 @@ function prepare_channels() {
 }
 
 function run_hugo() {
-    docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src -w /src cibuilds/hugo:0.150.1 hugo server --disableFastRender --environment production
+    docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src -w /src cibuilds/hugo:0.159.2 hugo server --disableFastRender --environment production
 }
 
 if [ "$1" = "clean" ]; then


### PR DESCRIPTION
## Description

Bump Hugo to v0.159.2 in tools
- Upgrade the static site generator from v0.150.1 to v0.159.2 across all documentation build and serve tooling
- Switch the external module docs container image registry from hugomods to the official gohugoio source on ghcr.io
- Update dependency version reference in builder documentation to reflect the new baseline

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Bump Hugo to v0.159.2 in tools.
impact_level: low
```
