### PR TITLE
[istio] Set globalVersion 1.25 as default

### DIFF
--- a/modules/110-istio/.dmtlint.yaml
+++ b/modules/110-istio/.dmtlint.yaml
@@ -24,11 +24,17 @@ linters-settings:
           name: operator-1x21
           container: operator
         - kind: Deployment
+          name: operator-1x25
+          container: operator
+        - kind: Deployment
           name: metadata-exporter
           container: metadata-discovery
       liveness-probe:
         - kind: Deployment
           name: operator-1x21
+          container: operator
+        - kind: Deployment
+          name: operator-1x25
           container: operator
         - kind: Deployment
           name: metadata-exporter
@@ -53,6 +59,9 @@ linters-settings:
       pdb:
         - kind: Deployment
           name: operator-1x21
+          container: operator
+        - kind: Deployment
+          name: operator-1x25
           container: operator
         - kind: DaemonSet
           name: istio-cni-node

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -5,14 +5,14 @@ properties:
     type: string
     pattern: '^[0-9]+\.[0-9]+$'
     description: Specific version of Istio control-plane which handles unspecific versions of data plane (namespaces with `istio-injection=enabled` label, not `istio.io/rev=`).
-    examples: ["1.21"]
-    default: "1.21"
+    examples: ["1.25"]
+    default: "1.25"
   additionalVersions:
     type: array
     description: |
       Additional versions of Istio control plane to install. You can use specific namespace labels (`istio.io/rev=`) to switch between installed revisions.
     examples:
-    - ["1.21"]
+    - ["1.25"]
     default: []
     items:
       type: string

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -10,19 +10,19 @@ properties:
         type: object
         default: {}
         x-examples:
-          - {"1.21": { "fullVersion": "1.21.6", "revision": "1x21", "imageSuffix": "V1x21x6", "isReady": false, "supportsAmbient": false } } # must be real
+          - {"1.25": { "fullVersion": "1.25.2", "revision": "1x25", "imageSuffix": "V1x25x2", "isReady": false, "supportsAmbient": false } } # must be real
         additionalProperties:
           type: object
           properties:
             fullVersion:
               type: string
-              x-examples: ["1.21.6"]
+              x-examples: ["1.25.2"]
             revision:
               type: string
-              x-examples: ["v1x21"]
+              x-examples: ["v1x25"]
             imageSuffix:
               type: string
-              x-examples: ["V1x21x6"]
+              x-examples: ["V1x25x2"]
             isReady:
               type: boolean
               x-examples: [false]
@@ -142,7 +142,7 @@ properties:
             alertSeverity: 4
       globalVersion:
         type: string
-        x-examples: ["1.21"] # must be real
+        x-examples: ["1.25"] # must be real
       isGlobalVersionIstiodReady:
         type: boolean
         default: false
@@ -153,14 +153,14 @@ properties:
           type: string
         default: []
         x-examples:
-        - ["1.21"] # must be real
+        - ["1.25"] # must be real
       operatorVersionsToInstall:
         type: array
         items:
           type: string
         default: []
         x-examples:
-        - ["1.21"] # must be real
+        - ["1.25"] # must be real
       applicationNamespaces:
         type: array
         items:


### PR DESCRIPTION
## Description
Istio v1.25 set as default value of globalVersion in istio ModuleConfig.

## Why do we need it, and what problem does it solve?
This is one of the steps to abandon version 1.21

## Why do we need it in patch release?
We had to set default global version to 1.25 in 1.73 CSE, so we also need it in 1.75.
(it is safe for current setups).

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: version 1.25 set as default for globalVersion
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
