### PR TITLE
[istio] Changed DMT lint exclude-rules

### DIFF
--- a/modules/110-istio/.dmtlint.yaml
+++ b/modules/110-istio/.dmtlint.yaml
@@ -16,6 +16,8 @@ linters-settings:
       controller-security-context:
         - kind: Deployment
           name: kiali
+        - kind: DaemonSet
+          name: ztunnel-1x25
       security-context:
         - kind: Deployment
           name: kiali
@@ -24,12 +26,21 @@ linters-settings:
           name: operator-1x21
           container: operator
         - kind: Deployment
+          name: operator-1x25
+          container: operator
+        - kind: Deployment
           name: metadata-exporter
           container: metadata-discovery
       liveness-probe:
         - kind: Deployment
           name: operator-1x21
           container: operator
+        - kind: Deployment
+          name: operator-1x25
+          container: operator
+        - kind: DaemonSet
+          name: ztunnel-1x25
+          container: istio-proxy
         - kind: Deployment
           name: metadata-exporter
           container: metadata-discovery
@@ -54,9 +65,15 @@ linters-settings:
         - kind: Deployment
           name: operator-1x21
           container: operator
+        - kind: Deployment
+          name: operator-1x25
+          container: operator
         - kind: DaemonSet
           name: istio-cni-node
           container: kube-rbac-proxy
+      vpa:
+        - kind: DaemonSet
+          name: ztunnel-1x25
   module:
     conversions:
       disable: true

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -10,7 +10,7 @@ properties:
         type: object
         default: {}
         x-examples:
-          - {"1.25": { "fullVersion": "1.25.2", "revision": "v1x25", "imageSuffix": "V1x25x2", "isReady": false } } # must be real
+          - {"1.25": { "fullVersion": "1.25.2", "revision": "1x25", "imageSuffix": "V1x25x2", "isReady": false } } # must be real
         additionalProperties:
           type: object
           properties:


### PR DESCRIPTION
## Description
Added excludes for DMT lint

## Why do we need it, and what problem does it solve?
After setting up version 1.25 as default globalVersion added some excludes for DMT lint to prevent errors while build.

## Why do we need it in the patch release (if we do)?
After setting up version 1.25 as default globalVersion added some excludes for DMT lint to prevent errors while build.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: added excludes for DMT lint
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
