### PR TITLE
[candi] add CRDSensitiveData if secretEncryptionKey exist

### DIFF
--- a/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
+++ b/candi/control-plane-kubeadm/v1beta4/config.yaml.tpl
@@ -30,6 +30,9 @@ https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
 {{- $apiserverFeatureGates := $baseFeatureGates -}}
 {{- $controllerManagerFeatureGates := $baseFeatureGates -}}
 {{- $schedulerFeatureGates := $baseFeatureGates -}}
+{{- if .apiserver.secretEncryptionKey }}
+  {{- $apiserverFeatureGates = append $apiserverFeatureGates "CRDSensitiveData=true" -}}
+{{- end }}
 {{- if hasKey . "allowedFeatureGates" -}}
   {{- range .allowedFeatureGates.apiserver -}}
     {{- $apiserverFeatureGates = append $apiserverFeatureGates (printf "%s=true" .) -}}

--- a/candi/feature_gates_map.yml
+++ b/candi/feature_gates_map.yml
@@ -34,7 +34,6 @@
     - RelaxedEnvironmentVariableValidation
     - StrictCostEnforcementForVAP
     - StrictCostEnforcementForWebhooks
-    - CRDSensitiveData
   kubeControllerManager:
     - ConcurrentWatchObjectDecode
     - CrossNamespaceVolumeDataSource
@@ -85,7 +84,6 @@
     - OrderedNamespaceDeletion
     - PodLifecycleSleepActionAllowZero
     - RelaxedDNSSearchValidation
-    - CRDSensitiveData
   kubeControllerManager:
     - ComponentFlagz
     - ComponentStatusz
@@ -148,7 +146,6 @@
     - SELinuxMount
     - StrictIPCIDRValidation
     - DisableAllocatorDualWrite
-    - CRDSensitiveData
   kubeControllerManager:
     - AllowParsingUserUIDFromCertAuth
     - ComponentFlagz
@@ -204,7 +201,6 @@
     - ResourceHealthStatus
     - SELinuxMount
     - StrictIPCIDRValidation
-    - CRDSensitiveData
   kubeControllerManager:
     - ComponentFlagz
     - ComponentStatusz
@@ -258,7 +254,6 @@
     - SELinuxMount
     - StrictIPCIDRValidation
     - TaintTolerationComparisonOperators
-    - CRDSensitiveData
   kubeControllerManager:
     - ComponentFlagz
     - ComponentStatusz

--- a/modules/040-control-plane-manager/hooks/feature_gates_generated.go
+++ b/modules/040-control-plane-manager/hooks/feature_gates_generated.go
@@ -121,7 +121,6 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"RelaxedEnvironmentVariableValidation",
 			"StrictCostEnforcementForVAP",
 			"StrictCostEnforcementForWebhooks",
-			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ConcurrentWatchObjectDecode",
@@ -177,7 +176,6 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"OrderedNamespaceDeletion",
 			"PodLifecycleSleepActionAllowZero",
 			"RelaxedDNSSearchValidation",
-			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ComponentFlagz",
@@ -245,7 +243,6 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"SELinuxMount",
 			"StrictIPCIDRValidation",
 			"DisableAllocatorDualWrite",
-			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"AllowParsingUserUIDFromCertAuth",
@@ -304,7 +301,6 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"ResourceHealthStatus",
 			"SELinuxMount",
 			"StrictIPCIDRValidation",
-			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ComponentFlagz",
@@ -363,7 +359,6 @@ var FeatureGatesMap = map[string]ComponentFeatures{
 			"SELinuxMount",
 			"StrictIPCIDRValidation",
 			"TaintTolerationComparisonOperators",
-			"CRDSensitiveData",
 		},
 		KubeControllerManager: []string{
 			"ComponentFlagz",

--- a/modules/040-control-plane-manager/webhooks/validating/feature_gates_generated.py
+++ b/modules/040-control-plane-manager/webhooks/validating/feature_gates_generated.py
@@ -39,7 +39,6 @@ versions = {
             "RelaxedEnvironmentVariableValidation",
             "StrictCostEnforcementForVAP",
             "StrictCostEnforcementForWebhooks",
-            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ConcurrentWatchObjectDecode",
@@ -95,7 +94,6 @@ versions = {
             "OrderedNamespaceDeletion",
             "PodLifecycleSleepActionAllowZero",
             "RelaxedDNSSearchValidation",
-            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ComponentFlagz",
@@ -163,7 +161,6 @@ versions = {
             "SELinuxMount",
             "StrictIPCIDRValidation",
             "DisableAllocatorDualWrite",
-            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "AllowParsingUserUIDFromCertAuth",
@@ -222,7 +219,6 @@ versions = {
             "ResourceHealthStatus",
             "SELinuxMount",
             "StrictIPCIDRValidation",
-            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ComponentFlagz",
@@ -281,7 +277,6 @@ versions = {
             "SELinuxMount",
             "StrictIPCIDRValidation",
             "TaintTolerationComparisonOperators",
-            "CRDSensitiveData",
         ],
         "kubeControllerManager": [
             "ComponentFlagz",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Automatically enable the `CRDSensitiveData` feature gate only when `secretEncryptionKey` is configured.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The `CRDSensitiveData` feature gate should be enabled only when secret encryption is actually used (i.e., when `secretEncryptionKey` is set).  This change ensures that the feature gate is automatically turned on when needed. It simplifies configuration and avoids potential issues in clusters that do not use secret encryption.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Automatically enable the `CRDSensitiveData` feature gate only when `secretEncryptionKey` is configured.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
