### PR TITLE
[deckhouse] Don't skip module patches during updates

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -330,11 +330,12 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		require.NoError(suite.T(), err)
 	})
 
-	suite.Run("module source with existing module releases apply last patch without listing tags", func() {
+	suite.Run("module source with existing module releases apply last patch", func() {
 		dc := newMockedContainerWithData(suite.T(),
 			"v1.4.4",
 			[]string{"parca"},
-			[]string{})
+			[]string{"v1.4.1", "v1.4.2", "v1.4.3", "v1.4.4"},
+		)
 		suite.setupTestController(string(suite.parseTestdata("existing-module-releases-without-listing-registry.yaml")), withDependencyContainer(dc))
 		_, err := suite.r.handleModuleSource(context.TODO(), suite.moduleSource(suite.source))
 		require.NoError(suite.T(), err)

--- a/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
@@ -212,17 +212,21 @@ func (f *ModuleReleaseFetcher) fetchModuleReleases(ctx context.Context) error {
 	return nil
 }
 
-// ensureReleases create releases and return metadata of last created release.
-// flow:
-//  1. if no releases in cluster - create from channel
-//  2. if deployed release patch version is lower than channel (with same minor and major) - create from channel
-//  3. if deployed release minor version is lower than channel (with same major) - create from channel
-//  4. if deployed release minor version is lower by 2 or more than channel (with same major) - look at releases in cluster
-//     4.1 if update sequence between deployed release and last release in cluster is broken - get releases from registry between deployed and version from channel, and create releases
-//     4.2 if update sequence between deployed release and last release in cluster not broken - check update sequence between last release in cluster and version in channel
-//     4.2.1 if update sequence between last release in cluster and version in channel is broken - get releases from registry between last release in cluster and version from channel, and create releases
-//     4.2.2 if update sequence between last release in cluster and version in channel not broken - create from channel
-//     4.3 if update sequences not broken - create from channel
+// ensureReleases creates ModuleReleases for all intermediate versions between
+// the deployed release and the version from the channel.
+//
+// Flow:
+//  1. If no releases in cluster - create release from channel
+//  2. If release channel is LTS - create release from channel (no step-by-step)
+//  3. Otherwise - always use step-by-step update:
+//     3.1 Determine starting version:
+//     - Use deployed release, or
+//     - Use last release in sequence if all releases in cluster are sequential
+//     3.2 Get all new versions from registry between starting version and channel version
+//     (includes the highest patch of current minor to avoid skipping migrations)
+//     3.3 If no new versions (actual >= target) - no-op
+//     3.4 Create releases sequentially; if a gap is detected (missing minor version)
+//     and from-to mechanism does not resolve it - record the error and continue
 func (f *ModuleReleaseFetcher) ensureReleases(
 	ctx context.Context,
 	releaseForUpdate *v1alpha1.ModuleRelease,
@@ -273,48 +277,31 @@ func (f *ModuleReleaseFetcher) ensureReleases(
 		return nil
 	}
 
-	// create release if deployed release and new release are in updating sequence
+	// Determine starting version for step-by-step update
 	actual := releaseForUpdate
 	metricLabels[metrics.LabelActualVersion] = "v" + actual.GetVersion().String()
-	if isUpdatingSequence(actual.GetVersion(), newSemver) {
-		logger.Debug("from deployed")
 
-		err := f.ensureModuleRelease(ctx, f.targetReleaseMeta, "from deployed")
-		if err != nil {
-			return fmt.Errorf("create release %s: %w", f.targetReleaseMeta.ModuleVersion, err)
-		}
-
-		return nil
-	}
-
-	isSequence := false
+	isSequenceInCluster := true
 	for i := 1; i < len(releasesInCluster); i++ {
-		isSequence = isUpdatingSequence(releasesInCluster[i-1].GetVersion(), releasesInCluster[i].GetVersion())
-		if !isSequence {
+		if !isUpdatingSequence(releasesInCluster[i-1].GetVersion(), releasesInCluster[i].GetVersion()) {
+			isSequenceInCluster = false
 			break
 		}
 	}
 
-	if isSequence {
-		// check
+	// If all releases are in sequence, use the last one as starting point
+	if isSequenceInCluster {
 		actual = releasesInCluster[len(releasesInCluster)-1]
-
-		// create release if last release and new release are in updating sequence
-		if isUpdatingSequence(actual.GetVersion(), newSemver) {
-			logger.Debug("from deployed")
-
-			err := f.ensureModuleRelease(ctx, f.targetReleaseMeta, "from last release in cluster")
-			if err != nil {
-				return fmt.Errorf("create release %s: %w", f.targetReleaseMeta.ModuleVersion, err)
-			}
-
-			return nil
-		}
 	}
 
 	vers, err := f.getNewVersions(ctx, actual.GetVersion(), newSemver)
 	if err != nil {
 		return fmt.Errorf("get new versions: %w", err)
+	}
+
+	// Empty result means actual >= target, nothing to create
+	if len(vers) == 0 {
+		return nil
 	}
 
 	var ErrModuleIsCorrupted = errors.New("module is corrupted")
@@ -596,20 +583,20 @@ func (f *ModuleReleaseFetcher) ensureModuleRelease(ctx context.Context, meta *do
 	return nil
 }
 
-// getNewVersions - getting all last patches from registry
-// it's ignore last patch of actual minor version, if it has new minor version
+// getNewVersions - getting all last patches from registry for each minor version
+// between actual and target versions (inclusive of actual minor's patches).
 //
 // f.e.
 // in registry:
 // 1.66.3 (deployed)
 // 1.66.5
-// result will be 1.66.5
+// result will be [1.66.5]
 //
-// but if we have a new minor version like:
+// with a new minor version:
 // 1.66.3 (deployed)
 // 1.66.5
 // 1.67.11
-// result will be 1.67.11
+// result will be [1.66.5, 1.67.11]
 //
 // several patches:
 // 1.66.3 (deployed)
@@ -619,7 +606,7 @@ func (f *ModuleReleaseFetcher) ensureModuleRelease(ctx context.Context, meta *do
 // 1.68.1
 // 1.68.3
 // 1.68.5
-// result will be [1.67.11, 1.68.5]
+// result will be [1.66.5, 1.67.11, 1.68.5]
 func (f *ModuleReleaseFetcher) getNewVersions(ctx context.Context, actual, target *semver.Version) ([]*semver.Version, error) {
 	tags, err := f.registryClientTagFetcher.ListTags(ctx)
 	if err != nil {
@@ -667,15 +654,7 @@ func (f *ModuleReleaseFetcher) getNewVersions(ctx context.Context, actual, targe
 		}
 	}
 
-	// Remove highest patch from actual minor version if we have more versions
-	if len(result) > 1 && result[0].Minor() == actual.Minor() {
-		result = result[1:]
-	}
-
-	if len(result) == 0 {
-		return nil, fmt.Errorf("no acceptable for step by step update tags in registry")
-	}
-
+	// Empty result is not an error - it means actual >= target, no new versions needed
 	return result, nil
 }
 
@@ -701,10 +680,24 @@ func (f *ModuleReleaseFetcher) parseAndFilterVersions(tags []string) []*semver.V
 	return versions
 }
 
+// isVersionInRange checks if version 'ver' is within the range between 'actual' and 'target'.
+// Returns true if ver > actual and ver is within target's minor version.
+//
+// Example:
+//
+//	[actual=v1.4.1, ver=v1.4.0, target=v1.5.2] -> false  // ver <= actual
+//	[actual=v1.4.1, ver=v1.4.4, target=v1.5.2] -> true   // patch of current minor
+//	[actual=v1.4.1, ver=v1.5.2, target=v1.5.2] -> true   // target version
+//	[actual=v1.4.1, ver=v1.6.0, target=v1.5.2] -> false  // exceeds target minor
 func isVersionInRange(ver, actual, target *semver.Version) bool {
-	return (ver.Major() > actual.Major() ||
-		(ver.Major() == actual.Major() && ver.Minor() >= actual.Minor())) &&
-		(ver.Major() < target.Major() || (ver.Major() == target.Major() && ver.Minor() <= target.Minor()))
+	// Must be strictly greater than actual
+	if !ver.GreaterThan(actual) {
+		return false
+	}
+
+	// Must be within target minor
+	return ver.Major() < target.Major() ||
+		(ver.Major() == target.Major() && ver.Minor() <= target.Minor())
 }
 
 func isVersionGreaterThanTarget(ver, target *semver.Version) bool {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+func TestIsVersionInRange(t *testing.T) {
+	tests := []struct {
+		name     string
+		ver      string
+		actual   string
+		target   string
+		expected bool
+	}{
+		{"ver is lower patch of current minor", "1.4.0", "1.4.1", "1.5.2", false},
+		{"ver equals actual", "1.4.1", "1.4.1", "1.5.2", false},
+		{"ver is higher patch of current minor", "1.4.4", "1.4.1", "1.5.2", true},
+		{"ver is the target version", "1.5.2", "1.4.1", "1.5.2", true},
+		{"ver is between actual and target", "1.5.0", "1.4.1", "1.6.0", true},
+		{"ver exceeds target minor", "1.6.0", "1.4.1", "1.5.2", false},
+		{"ver is next major but within target", "2.0.1", "1.33.0", "2.1.0", true},
+		{"ver is lower major", "0.9.0", "1.0.0", "1.2.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isVersionInRange(
+				semver.MustParse(tt.ver),
+				semver.MustParse(tt.actual),
+				semver.MustParse(tt.target),
+			)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetNewVersions(t *testing.T) {
+	registryTags := []string{
+		"v1.31.0",
+		"v1.31.1",
+		"v1.32.0",
+		"v1.32.1",
+		"v1.32.2",
+		"v1.32.3",
+		"v1.33.0",
+		"v1.33.1",
+		"v2.0.0",
+		"v2.0.1",
+		"v2.0.5",
+		"v2.1.2",
+		"v2.1.12",
+		"v2.5.1",
+	}
+
+	check := func(name string, actualStr, targetStr string, expected []*semver.Version) {
+		t.Run(name, func(t *testing.T) {
+			mockClient := cr.NewClientMock(t)
+			mockClient.ListTagsMock.Return(registryTags, nil)
+
+			f := &ModuleReleaseFetcher{
+				registryClientTagFetcher: mockClient,
+				logger:                   log.NewNop(),
+			}
+
+			actual, err := semver.NewVersion(actualStr)
+			require.NoError(t, err)
+			target, err := semver.NewVersion(targetStr)
+			require.NoError(t, err)
+
+			got, err := f.getNewVersions(context.Background(), actual, target)
+			require.NoError(t, err)
+
+			if !cmp.Equal(got, expected) {
+				t.Fatalf("got != expected, diff:\n%s", cmp.Diff(got, expected))
+			}
+		})
+	}
+
+	check("patch of current minor", "1.31.0", "1.31.1",
+		[]*semver.Version{semver.MustParse("1.31.1")})
+
+	check("patch of current minor is kept on minor bump", "1.31.0", "1.32.3",
+		[]*semver.Version{
+			semver.MustParse("1.31.1"),
+			semver.MustParse("1.32.3"),
+		})
+
+	check("several minors", "1.31.0", "1.33.1",
+		[]*semver.Version{
+			semver.MustParse("1.31.1"),
+			semver.MustParse("1.32.3"),
+			semver.MustParse("1.33.1"),
+		})
+
+	check("major bump", "1.31.0", "2.0.5",
+		[]*semver.Version{
+			semver.MustParse("1.31.1"),
+			semver.MustParse("1.32.3"),
+			semver.MustParse("1.33.1"),
+			semver.MustParse("2.0.5"),
+		})
+
+	check("across major and minor", "1.31.0", "2.1.12",
+		[]*semver.Version{
+			semver.MustParse("1.31.1"),
+			semver.MustParse("1.32.3"),
+			semver.MustParse("1.33.1"),
+			semver.MustParse("2.0.5"),
+			semver.MustParse("2.1.12"),
+		})
+
+	check("last minor has no patches matching target", "1.31.0", "1.33.0",
+		[]*semver.Version{
+			semver.MustParse("1.31.1"),
+			semver.MustParse("1.32.3"),
+			semver.MustParse("1.33.0"),
+		})
+
+	check("actual equals target returns empty", "1.31.1", "1.31.1",
+		[]*semver.Version{})
+
+	check("actual above target returns empty", "1.33.1", "1.32.3",
+		[]*semver.Version{})
+}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/existing-module-releases-with-listing-registry.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/existing-module-releases-with-listing-registry.yaml
@@ -89,6 +89,38 @@ metadata:
     modules.deckhouse.io/update-policy: ""
     release-checksum: 1beb143dffb1b662137094e7faea1e17
     source: test-source-1
+  name: parca-v1.5.3
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: ModuleSource
+    name: test-source-1
+    uid: ""
+  resourceVersion: "1"
+spec:
+  moduleName: parca
+  requirements:
+    kubernetes: '>= 1.27'
+  version: 1.5.3
+  weight: 900
+status:
+  approved: false
+  message: ""
+  pullDuration: 0s
+  size: 0
+  transitionTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleRelease
+metadata:
+  annotations:
+    modules.deckhouse.io/change-cause: check release (step-by-step)
+  creationTimestamp: null
+  labels:
+    module: parca
+    modules.deckhouse.io/update-policy: ""
+    release-checksum: 1beb143dffb1b662137094e7faea1e17
+    source: test-source-1
   name: parca-v1.6.2
   ownerReferences:
   - apiVersion: deckhouse.io/v1alpha1

--- a/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/existing-module-releases-without-listing-registry.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/testdata/golden/existing-module-releases-without-listing-registry.yaml
@@ -108,7 +108,7 @@ apiVersion: deckhouse.io/v1alpha1
 kind: ModuleRelease
 metadata:
   annotations:
-    modules.deckhouse.io/change-cause: check release (from deployed)
+    modules.deckhouse.io/change-cause: check release (step-by-step)
   creationTimestamp: null
   labels:
     module: parca


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Port the `DeckhouseRelease` step-by-step update fix (#17548) to `ModuleRelease`. 

When a module's channel jumps a minor version, the controller was skipping the highest patch of the current minor, which dropped migrations bundled in those patches.

**Before:** `v1.4.1` deployed, channel targets `v1.5.2`, registry has `v1.4.4`. `isUpdatingSequence(v1.4.1, v1.5.2) == true` triggers the shortcut, controller creates only `v1.5.2` with cause `from deployed`. `v1.4.4` is silently dropped.

**After:** both shortcuts in `ensureReleases` are removed, `getNewVersions` keeps the highest patch of the current minor, and `isVersionInRange` requires a strictly greater version. 

Controller creates `v1.4.4 -> v1.5.2` with cause `step-by-step`.

### Main changes:

- Remove both `isUpdatingSequence` shortcuts in `ensureReleases`; always go through `getNewVersions`
- Stop discarding the highest patch of the current minor in `getNewVersions` - treat an empty result as a no-op instead of an error.
- Switch `isVersionInRange` to strict `GreaterThan` so the deployed release itself cannot land in the candidate set.
- Preserve `from-to` mechanism, `ErrModuleIsCorrupted` handling, and `errors.Join` accumulation inside the per-version loop.
- Add direct unit tests for `isVersionInRange` and `getNewVersions`
- Update golden `existing-module-releases-with-listing-registry.yaml` to include the previously dropped patch `parca-v1.5.3`; adjust `apply last patch` case to exercise the listing path.

#### Before
<img width="733" height="49" alt="2026-04-22 AT 05 12" src="https://github.com/user-attachments/assets/ce1104d8-f91c-41c6-a0a0-e3dcbcd350eb" />


#### After 

<img width="757" height="68" alt="2026-04-22 AT 05 37" src="https://github.com/user-attachments/assets/66f3f30d-e36a-4a05-9467-a0d01b8b2ec9" />


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Module patch releases between the deployed version and the channel target are lost when the channel bumps a minor. 

Any migrations shipped in those patches never run - the cluster jumps straight between minor versions, which can leave broken data or unapplied hooks. 

The impact is especially acute in air-gapped setups where patches accumulate between syncs. 

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Fixed module updates skipping patch releases when updating to a new minor version.
impact_level: default
```