### PR TITLE
[common] Added support for non-standard Linux release names

### DIFF
--- a/modules/000-common/images/check-kernel-version/src/check-kernel-version.go
+++ b/modules/000-common/images/check-kernel-version/src/check-kernel-version.go
@@ -17,12 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"log"
-	"os"
-	"strings"
-
+	"bytes"
 	"github.com/Masterminds/semver/v3"
 	"golang.org/x/sys/unix"
+	"log"
+	"os"
+	"strconv"
 )
 
 func main() {
@@ -32,23 +32,57 @@ func main() {
 	}
 	c, err := semver.NewConstraint(kernelConstraint)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to parse KERNEL_CONSTRAINT=%q as a semver constraint: %v", kernelConstraint, err)
 	}
 
 	utsname := unix.Utsname{}
-	_ = unix.Uname(&utsname)
-	kernelVersion := string(utsname.Release[:])
+	err = unix.Uname(&utsname)
+	if err != nil {
+		log.Fatalf("failed to read kernel version via uname(2): %v", err)
+	}
+	kernelVersion := unix.ByteSliceToString(utsname.Release[:])
 	/* Kernel version should be splitted to parts because versions `5.15.0-52-generic`
 	parses by semver as prerelease version. Prerelease versions by default come before stable versions
 	in the order of precedence, so in semver terms `5.15.0-52-generic` less than `5.15`.
 	More info - https://github.com/Masterminds/semver#working-with-prerelease-versions */
-	v, err := semver.NewVersion(strings.Split(kernelVersion, "-")[0])
+	semverVersion := toSemver(kernelVersion)
+	v, err := semver.NewVersion(semverVersion)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("failed to parse kernel version %q (normalized to %q) as semver: %v", kernelVersion, semverVersion, err)
 	}
 
 	if !c.Check(v) {
 		log.Fatalf("the kernel %s does not meet the requirements: %s", kernelVersion, kernelConstraint)
 	}
 	log.Printf("the kernel %s meets the requirements: %s", kernelVersion, kernelConstraint)
+}
+
+func toSemver(version string) string {
+	if version == "" {
+		return "0.0.0"
+	}
+
+	var mmp [3]int
+	c := 0
+	for _, b := range version {
+		if b >= '0' && b <= '9' {
+			mmp[c] = 10*mmp[c] + int(b-'0')
+		} else if b == '.' {
+			c++
+			if c > 2 {
+				break
+			}
+		} else {
+			break
+		}
+	}
+
+	var buffer bytes.Buffer
+	buffer.WriteString(strconv.Itoa(mmp[0]))
+	buffer.WriteString(".")
+	buffer.WriteString(strconv.Itoa(mmp[1]))
+	buffer.WriteString(".")
+	buffer.WriteString(strconv.Itoa(mmp[2]))
+
+	return buffer.String()
 }

--- a/modules/000-common/images/check-kernel-version/src/check-kernel-version_test.go
+++ b/modules/000-common/images/check-kernel-version/src/check-kernel-version_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestToSemver(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "6.1.0+deb13+1-cloud-amd64",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0-custom-build+abc",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0-38-amd64",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0beta1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0-rc1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0~rc1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6",
+			expected: "6.0.0",
+		},
+		{
+			input:    "6.",
+			expected: "6.0.0",
+		},
+		{
+			input:    ".",
+			expected: "0.0.0",
+		},
+		{
+			input:    "",
+			expected: "0.0.0",
+		},
+		{
+			input:    "unknown",
+			expected: "0.0.0",
+		},
+		{
+			input:    "6.1.0-very-long-suffix-with-many-parts-and-build-metadata-xyz123",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0+20240101+git+sha+dirty",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0_beta",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0.beta",
+			expected: "6.1.0",
+		},
+		{
+			input:    "1.2.3extra",
+			expected: "1.2.3",
+		},
+		{
+			input:    "01.2.3",
+			expected: "1.2.3",
+		},
+		{
+			input:    "000001.2.3",
+			expected: "1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := toSemver(tt.input)
+			if got != tt.expected {
+				t.Fatalf("toSemver(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/modules/000-common/images/check-kernel-version/src/check-kernel-version_test.go
+++ b/modules/000-common/images/check-kernel-version/src/check-kernel-version_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
This PR extends the `check-kernel-version` image to support extracting the Linux kernel version from `uname -r` in a semver-compatible way, ignoring distro-specific suffixes (e.g. `+deb13+1-cloud-amd64`).

Example: `6.12.74+deb13+1-cloud-amd64` → `6.12.74`

## Why do we need it, and what problem does it solve?
The previous implementation assumed that the kernel version in `uname -r` is always followed by a dash (`-`). This caused failures when parsing non-standard Linux release formats.

This change improves parsing to correctly extract the SemVer-compatible kernel version, ignoring distro-specific suffixes.

---
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: common
type: fix
summary: Normalized the kernel version from uname to semver for non-standard Linux release names.
impact: Nodes with Debian 13 kernels (e.g. 6.12.74+deb13+1-cloud-amd64) previously failed the kernel version check and could not join the cluster.
impact_level: default
```
