### PR TITLE
[docs] Add info about SWHC to product documentation

### DIFF
--- a/docs/documentation/pages/user/network/INTRA_CLUSTER.md
+++ b/docs/documentation/pages/user/network/INTRA_CLUSTER.md
@@ -115,7 +115,7 @@ spec:
 
 ## Advanced load balancer
 
-The advanced load balancer is implemented using the ServiceWithHealthcheck resources from the [service-with-healthchecks](/modules/service-with-healthchecks/) module.
+The advanced load balancer is implemented using the ServiceWithHealthcheck resources from the [`service-with-healthchecks`](/modules/service-with-healthchecks/) module.
 
 Unlike the standard load balancer where readiness probes are tied to container states,
 the ServiceWithHealthcheck–based load balancer allows you to configure active probes for individual TCP ports.
@@ -150,12 +150,12 @@ to route traffic to workloads in the cluster in the usual way (via `kube-proxy` 
 ### Configuring the load balancer
 
 {% alert level="warning" %}
-To use advanced load balancers, you must:
+To use advanced load balancers:
 
 - Configure the network policies for the project where ServiceWithHealthchecks load balancers will be used.
 - If necessary, manually switch to using ServiceWithHealthchecks instead of standard load balancers (replace the existing Service objects with ServiceWithHealthchecks).
 
-For more details, see the [service-with-healthchecks](/modules/service-with-healthchecks/configuration.html) module documentation.
+For more details, see the [`service-with-healthchecks`](/modules/service-with-healthchecks/configuration.html) module documentation.
 {% endalert %}
 
 You can configure this type of load balancing

--- a/docs/documentation/pages/user/network/INTRA_CLUSTER.md
+++ b/docs/documentation/pages/user/network/INTRA_CLUSTER.md
@@ -115,6 +115,8 @@ spec:
 
 ## Advanced load balancer
 
+The advanced load balancer is implemented using the ServiceWithHealthcheck resources from the [service-with-healthchecks](/modules/service-with-healthchecks/) module.
+
 Unlike the standard load balancer where readiness probes are tied to container states,
 the ServiceWithHealthcheck–based load balancer allows you to configure active probes for individual TCP ports.
 This way, each load balancer serving the same Pod can operate independently from the others.
@@ -146,6 +148,15 @@ During the resource lifecycle, a Service with the same name is created in the sa
 to route traffic to workloads in the cluster in the usual way (via `kube-proxy` or CNI).
 
 ### Configuring the load balancer
+
+{% alert level="warning" %}
+To use advanced load balancers, you must:
+
+- Configure the network policies for the project where ServiceWithHealthchecks load balancers will be used.
+- If necessary, manually switch to using ServiceWithHealthchecks instead of standard load balancers (replace the existing Service objects with ServiceWithHealthchecks).
+
+For more details, see the [service-with-healthchecks](/modules/service-with-healthchecks/configuration.html) module documentation.
+{% endalert %}
 
 You can configure this type of load balancing
 using the [ServiceWithHealthchecks](/modules/service-with-healthchecks/cr.html#servicewithhealthchecks) resource:

--- a/docs/documentation/pages/user/network/INTRA_CLUSTER_RU.md
+++ b/docs/documentation/pages/user/network/INTRA_CLUSTER_RU.md
@@ -110,6 +110,8 @@ spec:
 
 ## Расширенный балансировщик
 
+Расширенный балансировщик реализуется с помощью ресурсов ServiceWithHealthcheck модуля [service-with-healthchecks](/modules/service-with-healthchecks/).
+
 В отличие от стандартного балансировщика, где readiness-пробы привязаны к состоянию контейнеров, ресурс ServiceWithHealthcheck, который используется в балансировщике, позволяет настраивать активные пробы на отдельные TCP-порты. Таким образом, каждый балансировщик, обслуживающий один и тот же под, может работать независимо от других.
 
 ### Внутреннее устройство балансировщика
@@ -128,6 +130,15 @@ spec:
 Миграция с Service на ресурс ServiceWithHealthchecks, например в рамках CI/CD, не должна вызвать затруднений. Спецификация ServiceWithHealthchecks в основе своей повторяет спецификацию Service, но содержит дополнительный раздел `healthcheck`. Во время жизненного цикла ресурса ServiceWithHealthchecks создается одноименный сервис в том же пространстве имён, чтобы привычным способом (`kube-proxy` или cni) направить трафик на рабочие нагрузки в кластере.
 
 ### Настройка балансировщика
+
+{% alert level="warning" %}
+Для использования расширенных балансировщиков необходимо:
+
+- Настроить сетевые политики проекта, где будут использоваться балансировщики ServiceWithHealthchecks.
+- Если есть необходимость, перейти вручную на использование ServiceWithHealthchecks вместо стандартных балансировщиков (заменить используемые объекты Service на ServiceWithHealthchecks).
+
+Подробнее — в документации модуля [service-with-healthchecks](/modules/service-with-healthchecks/configuration.html).
+{% endalert %}
 
 Настроить данный способ балансировки можно при помощи ресурса [ServiceWithHealthchecks](/modules/service-with-healthchecks/cr.html#servicewithhealthchecks):
 

--- a/docs/documentation/pages/user/network/INTRA_CLUSTER_RU.md
+++ b/docs/documentation/pages/user/network/INTRA_CLUSTER_RU.md
@@ -110,7 +110,7 @@ spec:
 
 ## Расширенный балансировщик
 
-Расширенный балансировщик реализуется с помощью ресурсов ServiceWithHealthcheck модуля [service-with-healthchecks](/modules/service-with-healthchecks/).
+Расширенный балансировщик реализуется с помощью ресурсов ServiceWithHealthcheck модуля [`service-with-healthchecks`](/modules/service-with-healthchecks/).
 
 В отличие от стандартного балансировщика, где readiness-пробы привязаны к состоянию контейнеров, ресурс ServiceWithHealthcheck, который используется в балансировщике, позволяет настраивать активные пробы на отдельные TCP-порты. Таким образом, каждый балансировщик, обслуживающий один и тот же под, может работать независимо от других.
 
@@ -132,12 +132,12 @@ spec:
 ### Настройка балансировщика
 
 {% alert level="warning" %}
-Для использования расширенных балансировщиков необходимо:
+Для использования расширенных балансировщиков:
 
-- Настроить сетевые политики проекта, где будут использоваться балансировщики ServiceWithHealthchecks.
-- Если есть необходимость, перейти вручную на использование ServiceWithHealthchecks вместо стандартных балансировщиков (заменить используемые объекты Service на ServiceWithHealthchecks).
+- настройте сетевые политики проекта, где будут использоваться балансировщики ServiceWithHealthchecks;
+- если есть необходимость, перейдите вручную на использование ServiceWithHealthchecks вместо стандартных балансировщиков (замените используемые объекты Service на ServiceWithHealthchecks).
 
-Подробнее — в документации модуля [service-with-healthchecks](/modules/service-with-healthchecks/configuration.html).
+Подробнее — в документации модуля [`service-with-healthchecks`](/modules/service-with-healthchecks/configuration.html).
 {% endalert %}
 
 Настроить данный способ балансировки можно при помощи ресурса [ServiceWithHealthchecks](/modules/service-with-healthchecks/cr.html#servicewithhealthchecks):


### PR DESCRIPTION
## Description

Add info about SWHC from module documentation to product documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Info about SWHC from module documentation to product documentation has been added.
impact_level: low
```
