### PR TITLE
[istio] CNI-node readonly root filesystem enable

### DIFF
--- a/modules/110-istio/.dmtlint.yaml
+++ b/modules/110-istio/.dmtlint.yaml
@@ -5,9 +5,6 @@ linters-settings:
         - kind: Deployment
           name: kiali
       read-only-root-filesystem:
-        - kind: DaemonSet
-          name: istio-cni-node
-          container: install-cni
         - kind: Deployment
           name: kiali
         - kind: DaemonSet

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -74,9 +74,13 @@ spec:
           command:
             - install-cni
           {{- if not $.Values.istio.internal.enableAmbientMode }}
-          {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 10 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
           {{- else }}
-          {{- include "helm_lib_module_container_security_context_privileged" . | nindent 10 }}
+          {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 10 }}
           {{- end }}
           env:
             {{- if ($.Values.istio.internal.enableAmbientMode) }}
@@ -151,6 +155,8 @@ spec:
               name: cni-net-dir
             - mountPath: /var/run/istio-cni
               name: cni-log-dir
+            - mountPath: /tmp
+              name: install-cni-tmp
             {{- if ($.Values.istio.internal.enableAmbientMode) }}
             - mountPath: /host/proc
               name: cni-host-procfs
@@ -247,6 +253,8 @@ spec:
             path: /var/run/istio-cni
             type: ""
           name: cni-log-dir
+        - name: install-cni-tmp
+          emptyDir: {}
         {{- if ($.Values.istio.internal.enableAmbientMode) }}
         - name: cni-host-procfs
           hostPath:


### PR DESCRIPTION
## Description
There is a startup problem in istio-cni-node pods in a closed environment. In the current solution, the istio-cni-node substages will be reloaded.

## Why do we need it, and what problem does it solve?
An error occurs when istio-cni-node is enabled:
```
Warning  Failed     5s (x3 over 16s)  kubelet            spec.containers{hpa-scaler}: Error: failed to verify container image "sha256:307e5121840cb661b716566542fe0fd4d5ece0a014462a7253e6d3a1ce65bdeb": container should be run with readonly rootfs
```
To fix this error, the security policies are changed to enable readonly root fs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: CNI-node readonly root filesystem enable
impact_level: default
```
