### PR TITLE
[docs] Remove the beta label from the graphical installer

### DIFF
--- a/docs/documentation/pages/installing/README.md
+++ b/docs/documentation/pages/installing/README.md
@@ -20,6 +20,8 @@ relatedLinks:
 
 {% alert %}
 Step-by-step installation instructions are available in the {% if site.mode == 'module' %}[Getting started]({{ site.urls[page.lang] }}/products/kubernetes-platform/gs/){% else %}[Getting started](/products/kubernetes-platform/gs/){% endif %} section.
+
+You can also try the [Deckhouse Kubernetes Platform graphical installer]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/products/kubernetes-platform/gs/#gui-install).
 {% endalert %}
 
 This page provides an overview of installing Deckhouse Kubernetes Platform (DKP).

--- a/docs/documentation/pages/installing/README.md
+++ b/docs/documentation/pages/installing/README.md
@@ -20,8 +20,6 @@ relatedLinks:
 
 {% alert %}
 Step-by-step installation instructions are available in the {% if site.mode == 'module' %}[Getting started]({{ site.urls[page.lang] }}/products/kubernetes-platform/gs/){% else %}[Getting started](/products/kubernetes-platform/gs/){% endif %} section.
-
-You can also try the [Deckhouse Kubernetes Platform graphical installer]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/products/kubernetes-platform/gs/#gui-install).
 {% endalert %}
 
 This page provides an overview of installing Deckhouse Kubernetes Platform (DKP).

--- a/docs/documentation/pages/installing/README_RU.md
+++ b/docs/documentation/pages/installing/README_RU.md
@@ -22,7 +22,7 @@ relatedLinks:
 {% alert %}
 В разделе {% if site.mode == 'module' %}[«Быстрый старт»]({{ site.urls[page.lang] }}/products/kubernetes-platform/gs/){% else %}[Быстрый старт](/products/kubernetes-platform/gs/){% endif %} доступны пошаговые инструкции по установке Deckhouse Kubernetes Platform.
 
-Попробуйте также [графический установщик Deckhouse Kubernetes Platform]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/products/kubernetes-platform/gs/#gui-install)! <span class="beta-badge">Beta</span>
+Попробуйте также [графический установщик Deckhouse Kubernetes Platform]({% if site.mode == 'module' %}{{ site.urls[page.lang] }}{% endif %}/products/kubernetes-platform/gs/#gui-install).
 {% endalert %}
 
 На этой странице представлена обзорная информация по установке Deckhouse Kubernetes Platform (DKP).


### PR DESCRIPTION
## Description

Remove the beta label from the graphical installer.

## Why do we need it, and what problem does it solve?

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Remove the beta label from the graphical installer.

```changes
section: docs
type: chore
summary: Remove the beta label from the graphical installer.
impact_level: low
```