### PR TITLE
[service-with-healthchecks] provide correct rbacv2

### DIFF
--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/edit.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/edit.yaml
@@ -1,13 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    heritage: deckhouse
-    module: service-with-healthchecks
-    rbac.deckhouse.io/aggregate-to-security-as: manager
-    rbac.deckhouse.io/kind: manage
-    rbac.deckhouse.io/level: module
-    rbac.deckhouse.io/namespace: d8-service-with-healthchecks
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-networking-as" "manager" "rbac.deckhouse.io/kind" "manage" "rbac.deckhouse.io/level" "module" "rbac.deckhouse.io/namespace" "d8-service-with-healthchecks")) | nindent 2 }}
   name: d8:manage:permission:module:service-with-healthchecks:edit
 rules:
 - apiGroups:

--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/edit.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/edit.yaml
@@ -1,12 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     heritage: deckhouse
     module: service-with-healthchecks
+    rbac.deckhouse.io/aggregate-to-security-as: manager
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-service-with-healthchecks
   name: d8:manage:permission:module:service-with-healthchecks:edit
 rules:
 - apiGroups:

--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/view.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/view.yaml
@@ -1,13 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    heritage: deckhouse
-    module: service-with-healthchecks
-    rbac.deckhouse.io/aggregate-to-security-as: viewer
-    rbac.deckhouse.io/kind: manage
-    rbac.deckhouse.io/level: module
-    rbac.deckhouse.io/namespace: d8-service-with-healthchecks
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-networking-as" "viewer" "rbac.deckhouse.io/kind" "manage" "rbac.deckhouse.io/level" "module" "rbac.deckhouse.io/namespace" "d8-service-with-healthchecks")) | nindent 2 }}
   name: d8:manage:permission:module:service-with-healthchecks:view
 rules:
 - apiGroups:

--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/view.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/manage/view.yaml
@@ -1,12 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
     heritage: deckhouse
     module: service-with-healthchecks
+    rbac.deckhouse.io/aggregate-to-security-as: viewer
     rbac.deckhouse.io/kind: manage
     rbac.deckhouse.io/level: module
+    rbac.deckhouse.io/namespace: d8-service-with-healthchecks
   name: d8:manage:permission:module:service-with-healthchecks:view
 rules:
 - apiGroups:

--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/edit.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/edit.yaml
@@ -1,11 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    heritage: deckhouse
-    module: service-with-healthchecks
-    rbac.deckhouse.io/aggregate-to-kubernetes-as: manager
-    rbac.deckhouse.io/kind: use
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-kubernetes-as" "manager" "rbac.deckhouse.io/aggregate-to-networking-as" "manager" "rbac.deckhouse.io/kind" "use")) | nindent 2 }}
   name: d8:use:capability:module:service-with-healthchecks:edit
 rules:
 - apiGroups:

--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/edit.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/edit.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    heritage: deckhouse
+    module: service-with-healthchecks
+    rbac.deckhouse.io/aggregate-to-kubernetes-as: manager
+    rbac.deckhouse.io/kind: use
+  name: d8:use:capability:module:service-with-healthchecks:edit
+rules:
+- apiGroups:
+  - network.deckhouse.io
+  resources:
+  - servicewithhealthchecks
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection

--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/view.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/view.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    heritage: deckhouse
+    module: service-with-healthchecks
+    rbac.deckhouse.io/aggregate-to-kubernetes-as: viewer
+    rbac.deckhouse.io/kind: use
+  name: d8:use:capability:module:service-with-healthchecks:view
+rules:
+- apiGroups:
+  - network.deckhouse.io
+  resources:
+  - servicewithhealthchecks
+  verbs:
+  - get
+  - list
+  - watch

--- a/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/view.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/rbacv2/use/view.yaml
@@ -1,11 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    heritage: deckhouse
-    module: service-with-healthchecks
-    rbac.deckhouse.io/aggregate-to-kubernetes-as: viewer
-    rbac.deckhouse.io/kind: use
+  {{- include "helm_lib_module_labels" (list . (dict "rbac.deckhouse.io/aggregate-to-kubernetes-as" "viewer" "rbac.deckhouse.io/aggregate-to-networking-as" "viewer" "rbac.deckhouse.io/kind" "use")) | nindent 2 }}
   name: d8:use:capability:module:service-with-healthchecks:view
 rules:
 - apiGroups:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixes Deckhouse RBACv2 manifests.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

To fix RBACv2 model of the module.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

It fixes the module's RBACv2 model and doesn't incur any disruptions.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: service-with-healthchecks
type: fix
summary: Correct RBACv2 is provided.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
