### PR TITLE
[deckhouse-tools] Add VEX for CVE-2026-39882 in otlpmetrichttp

### DIFF
--- a/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
+++ b/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 14,
+  "version": 16,
   "statements": [
     {
       "vulnerability": {
@@ -355,8 +355,116 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость github.com/docker/docker зафиксирована на версии v25.0.6 через replace-директиву в deckhouse-cli для обеспечения совместимости с цепочкой werf. d8 delivery-kit использует docker исключительно как клиентскую библиотеку Docker API, уязвимый функционал Docker Engine не входит в исполняемый путь.",
       "timestamp": "2026-04-17T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39882"
+      },
+      "products": [
+        {"@id": "pkg:golang/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp@v0.44.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Зависимость go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp приходит транзитивно через werf и github.com/docker/buildx/util/metricutil и используется исключительно для экспорта метрик BuildKit-бекенда. d8 delivery-kit по умолчанию использует стандартный Docker backend, путь с BuildKit-метриками не активируется, что исключает возможность эксплуатации данной уязвимости.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32280"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.8"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8 в составе образа deckhouse-tools web: обработка внешних входных данных ограничена администраторскими сценариями, неограниченное потребление ресурсов не достигается. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32281"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.8"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-295 (Improper Certificate Validation) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8 в составе образа deckhouse-tools web: TLS-соединения устанавливаются только к эндпоинтам, доверие к которым (через CA-сертификаты, kubeconfig) устанавливается администратором, что исключает возможность эксплуатации уязвимости валидации сертификатов. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32282"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.8"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-59 (Improper Link Resolution Before File Access, symlink following) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8 в составе образа deckhouse-tools web: d8 не обрабатывает произвольные пути файловой системы от недоверенных пользователей - работает только с путями, указанными администратором. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32283"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.8"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8 в составе образа deckhouse-tools web: входные данные, приводящие к неограниченному потреблению ресурсов, не могут быть предоставлены недоверенной стороной - d8 запускается локально администратором. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32288"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.8"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8 в составе образа deckhouse-tools web: поверхность атаки ограничена локальным запуском администратором, вектор подачи недоверенных данных в уязвимый путь отсутствует. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32289"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.8"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-79 (Cross-site Scripting) в Go stdlib v1.25.8 не эксплуатируема в бинарнике d8 в составе образа deckhouse-tools web: d8 - это CLI-инструмент, не рендерит HTML и не работает как веб-сервер, выводящий контент в браузер. XSS-уязвимости в стандартной библиотеке не достигаются в рамках исполнения d8. Бамп Go toolchain в d8-cli будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-3xc5-wrhm-f963"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость связана с обработкой вредоносных данных Git-репозитория (pack/index файлов), приводящей к некорректному поведению парсера. В типовой модели эксплуатации deckhouse-tools web источники Git-репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности подменить входные данные и исключает достижимость уязвимого кода.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-35469"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/moby/spdystream@v0.5.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость в github.com/moby/spdystream v0.5.0 достигается исключительно через подкоманду d8 backup etcd, где spdystream приходит транзитивно из k8s.io/client-go/transport/spdy. Уязвимый код обрабатывает SPDY-фреймы от kube-apiserver, который в типовой модели эксплуатации является доверенным компонентом под управлением администратора кластера. Возможность подачи вредоносных SPDY-фреймов нарушителем исключена архитектурой взаимодействия d8 с Kubernetes API.",
+      "timestamp": "2026-04-22T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-04-17T12:00:00Z"
+  "last_updated": "2026-04-22T12:00:00Z"
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add VEX for [CVE-2026-39882](https://nvd.nist.gov/vuln/detail/CVE-2026-39882) in `modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Vulnerability in `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp` pulled transitively through the werf dependency chain into `d8-cli`. The vulnerable path is only reachable via the BuildKit backend metrics, which is not active in `d8 delivery-kit` (default Docker backend).

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-tools
type: fix
summary: Add vex for CVE-2026-39882
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->