### PR TITLE
[cloud-provider-dvp] Add missing fields in provider cluster configuration hook

### DIFF
--- a/go_lib/hooks/cluster_configuration/hook.go
+++ b/go_lib/hooks/cluster_configuration/hook.go
@@ -95,6 +95,7 @@ func clusterConfiguration(ctx context.Context, input *go_hook.HookInput, handler
 		// We are forced to keep such a variable as a workaround in order to pass the tests during the build stage
 		// This variable (and this package) will be removed after the cloud provider modules are externalized
 		additionalOpenAPISchemasPaths := []string{
+			"/deckhouse/modules/030-cloud-provider-dvp/candi/openapi",
 			"/deckhouse/modules/030-cloud-provider-yandex/candi/openapi",
 			"/deckhouse/modules/030-cloud-provider-gcp/candi/openapi",
 			"/deckhouse/modules/030-cloud-provider-azure/candi/openapi",

--- a/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
@@ -1,6 +1,17 @@
 /*
-Copyright 2023 Flant JSC
-Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 package hooks

--- a/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/dvp_cluster_configuration_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2023 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: cloud-provider-dvp :: hooks :: dvp_cluster_configuration ::", func() {
+	const (
+		emptyValues = `
+global:
+  discovery: {}
+cloudProviderDvp:
+  internal: {}
+`
+	)
+	var (
+		stateACloudDiscoveryData = `
+{
+   "apiVersion": "deckhouse.io/v1",
+   "kind": "DVPCloudDiscoveryData",
+   "zones": ["default"]
+}
+`
+		stateAClusterConfiguration1 = `
+apiVersion: deckhouse.io/v1
+kind: DVPClusterConfiguration
+layout: Standard
+masterNodeGroup:
+  instanceClass:
+    etcdDisk:
+      size: 15Gi
+      storageClass: ceph-pool-r2-csi-rbd-immediate
+    rootDisk:
+      image:
+        kind: ClusterVirtualImage
+        name: ubuntu-2204
+      size: 50Gi
+      storageClass: ceph-pool-r2-csi-rbd-immediate
+    virtualMachine:
+      virtualMachineClassName: superbe-class
+      bootloader: EFI
+      cpu:
+        coreFraction: 100%
+        cores: 4
+      liveMigrationPolicy: PreferForced
+      runPolicy: AlwaysOnUnlessStoppedManually
+      ipAddresses:
+        - Auto
+      memory:
+        size: 8Gi
+  replicas: 3
+provider:
+  kubeconfigDataBase64: YXBpVmV=
+  namespace: cloud-provider01
+sshPublicKey: ssh-rsa AAAAB3N
+region: ru-msk-1
+zones:
+- default
+`
+	)
+
+	notEmptyProviderClusterConfigurationState := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(stateAClusterConfiguration1)), base64.StdEncoding.EncodeToString([]byte(stateACloudDiscoveryData)))
+
+	a := HookExecutionConfigInit(emptyValues, `{}`)
+	Context("Cluster without module configuration", func() {
+		BeforeEach(func() {
+			a.BindingContexts.Set(a.KubeStateSet(notEmptyProviderClusterConfigurationState))
+			a.RunHook()
+		})
+
+		It("Should fill values from secret", func() {
+			Expect(a).To(ExecuteSuccessfully())
+			Expect(a.ValuesGet("cloudProviderDvp.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfiguration1))
+			Expect(a.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData").String()).To(MatchJSON(stateACloudDiscoveryData))
+		})
+	})
+})

--- a/modules/030-cloud-provider-dvp/hooks/internal/v1/provider_cluster_configuration.go
+++ b/modules/030-cloud-provider-dvp/hooks/internal/v1/provider_cluster_configuration.go
@@ -17,11 +17,15 @@ limitations under the License.
 package v1
 
 type DvpProviderClusterConfiguration struct {
-	APIVersion   *string      `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
-	Kind         *string      `json:"kind,omitempty" yaml:"kind,omitempty"`
-	Provider     *DvpProvider `json:"provider,omitempty" yaml:"provider,omitempty"`
-	SSHPublicKey *string      `json:"sshPublicKey,omitempty" yaml:"sshPublicKey,omitempty"`
-	Zones        *[]string    `json:"zones,omitempty" yaml:"zones,omitempty"`
+	APIVersion      *string      `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind            *string      `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Provider        *DvpProvider `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Layout          *string      `json:"layout,omitempty" yaml:"layout,omitempty"`
+	MasterNodeGroup any          `json:"masterNodeGroup,omitempty" yaml:"masterNodeGroup,omitempty"`
+	NodeGroups      []any        `json:"nodeGroups,omitempty" yaml:"nodeGroups,omitempty"`
+	SSHPublicKey    *string      `json:"sshPublicKey,omitempty" yaml:"sshPublicKey,omitempty"`
+	Region          *string      `json:"region,omitempty" yaml:"region,omitempty"`
+	Zones           *[]string    `json:"zones,omitempty" yaml:"zones,omitempty"`
 }
 
 type DvpProvider struct {

--- a/modules/030-cloud-provider-dvp/hooks/internal/v1/provider_cluster_configuration.go
+++ b/modules/030-cloud-provider-dvp/hooks/internal/v1/provider_cluster_configuration.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1
 
 type DvpProviderClusterConfiguration struct {
-	APIVersion *string      `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
-	Kind       *string      `json:"kind,omitempty" yaml:"kind,omitempty"`
-	Provider   *DvpProvider `json:"provider,omitempty" yaml:"provider,omitempty"`
-	Zones      *[]string    `json:"zones,omitempty" yaml:"zones,omitempty"`
+	APIVersion   *string      `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind         *string      `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Provider     *DvpProvider `json:"provider,omitempty" yaml:"provider,omitempty"`
+	SSHPublicKey *string      `json:"sshPublicKey,omitempty" yaml:"sshPublicKey,omitempty"`
+	Zones        *[]string    `json:"zones,omitempty" yaml:"zones,omitempty"`
 }
 
 type DvpProvider struct {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Missing fields have been added to the `DvpProviderClusterConfiguration` type so they don’t get lost when moving data into internal values.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When `ProviderClusterConfiguration` is copied into values in the `dvp_provider_cluster_configuration.go` hook, some data gets lost, which can lead, for example, to an incorrect setup of ephemeral nodes.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

We don't

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Fixed missing SSH public keys for ephemeral nodes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
