### PR TITLE
[istio] Use CEL validation for metadataEndpoint

### DIFF
--- a/ee/modules/110-istio/crds/istiofederation.yaml
+++ b/ee/modules/110-istio/crds/istiofederation.yaml
@@ -58,7 +58,17 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^https://[0-9a-zA-Z._/:-]+$'
+                  x-kubernetes-validations:
+                    - rule: "isURL(self)"
+                      message: "must be a valid URL"
+                    - rule: "url(self).getScheme() == 'https'"
+                      message: "must use https"
+                    - rule: "url(self).getHost() != ''"
+                      message: "must include a host"
+                    - rule: "url(self).getQuery().size() == 0"
+                      message: "query parameters are not allowed"
+                    - rule: "!self.contains('#')"
+                      message: "fragments are not allowed"
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object

--- a/ee/modules/110-istio/crds/istiomulticluster.yaml
+++ b/ee/modules/110-istio/crds/istiomulticluster.yaml
@@ -56,7 +56,17 @@ spec:
                     - cse-pro
                   description: |
                     HTTPS endpoint with remote cluster metadata.
-                  pattern: '^https://[0-9a-zA-Z._/:-]+$'
+                  x-kubernetes-validations:
+                    - rule: "isURL(self)"
+                      message: "must be a valid URL"
+                    - rule: "url(self).getScheme() == 'https'"
+                      message: "must use https"
+                    - rule: "url(self).getHost() != ''"
+                      message: "must include a host"
+                    - rule: "url(self).getQuery().size() == 0"
+                      message: "query parameters are not allowed"
+                    - rule: "!self.contains('#')"
+                      message: "fragments are not allowed"
                   x-doc-examples: ['https://istio.k8s.example.com/metadata/']
                 metadata:
                   type: object


### PR DESCRIPTION
## Description

Improve validation of Istio federation and multicluster `metadataEndpoint` fields in CRDs by replacing a permissive regex with CEL-based URL checks.

## Why do we need it, and what problem does it solve?

The previous regex accepted many malformed values and made user configuration errors more likely. This change validates that `metadataEndpoint` is a valid HTTPS URL with a host and rejects query parameters and fragments that are not expected for this field.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Tighten validation of Istio metadata endpoint URLs in federation and multicluster CRDs.
impact_level: low
```