### PR TITLE
[extended-monitoring] fix CVEs in image-availability-exporter and events-exporter

### DIFF
--- a/modules/340-extended-monitoring/images/events-exporter/patches/001-go-mod-logrus.patch
+++ b/modules/340-extended-monitoring/images/events-exporter/patches/001-go-mod-logrus.patch
@@ -1,0 +1,9 @@
+diff --git a/go.mod b/go.mod
+--- a/go.mod
++++ b/go.mod
+@@ -60,3 +60,5 @@ require (
+ 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+ 	sigs.k8s.io/yaml v1.2.0 // indirect
+ )
++
++replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.9.3

--- a/modules/340-extended-monitoring/images/events-exporter/patches/README.md
+++ b/modules/340-extended-monitoring/images/events-exporter/patches/README.md
@@ -1,0 +1,3 @@
+### 001-go-mod-logrus.patch
+
+Force `github.com/sirupsen/logrus` to v1.9.3 via a `replace` directive in `go.mod` to fix CVE-2025-65637.

--- a/modules/340-extended-monitoring/images/events-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/events-exporter/werf.inc.yaml
@@ -14,12 +14,20 @@ imageSpec:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
+git:
+- add: /{{ $.ModulePath }}modules/340-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
+  to: /patches
+  stageDependencies:
+    setup:
+      - '**/*'
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
 shell:
   setup:
   - git clone --depth 1 --branch v0.0.5 $(cat /run/secrets/SOURCE_REPO)/deckhouse/events_exporter.git /src
+  - cd /src
+  - git apply /patches/*.patch --verbose
   - rm -rf /src/.git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
@@ -43,6 +51,7 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - cd /src
+    - go mod tidy
     - make build
     - mv bin/events_exporter /events_exporter
     - chown 64535:64535 /events_exporter

--- a/modules/340-extended-monitoring/images/image-availability-exporter/known_vulnerabilities.vex
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-image-availability-exporter-cve-2025-15558",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-15558"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/cli"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Docker CLI local privilege escalation on Windows - Уязвимость касается только Docker CLI под Windows (повышение привилегий через путь поиска плагинов в C:\\ProgramData\\Docker\\cli-plugins). Deckhouse нигде не использует Windows, все компоненты работают под Linux; уязвимый код не выполняется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы.",
+      "timestamp": "2026-03-11T00:00:00Z"
+    }
+  ],
+  "timestamp": "2026-03-11T00:00:00Z"
+}


### PR DESCRIPTION
## Description

Fix two CVEs in the `340-extended-monitoring` module:

1. `image-availability-exporter` — add a VEX statement for CVE-2025-15558 (`github.com/docker/cli`) marking it `not_affected` with justification `vulnerable_code_not_in_execute_path`.
2. `events-exporter` — add a build-time `replace` patch that forces `github.com/sirupsen/logrus` to v1.9.3 to fix CVE-2025-65637, and runs `go mod tidy` before `make build` so go.sum is rebuilt against the pinned version.


## Why do we need it, and what problem does it solve?

- CVE-2025-15558 describes a local privilege escalation in Docker CLI on Windows (plugin lookup path `C:\ProgramData\Docker\cli-plugins`). Deckhouse runs only on Linux, so the vulnerable code path is never executed; the VEX statement suppresses the false-positive finding.
- CVE-2025-65637 affects `github.com/sirupsen/logrus` < 1.8.3, used as a transitive dependency in `events_exporter`. The `replace` directive pins it to v1.9.3 (fixed version) and `go mod tidy` removes the stale `v1.6.0/go.mod` entry that Trivy was picking up.


## Why do we need it in the patch release (if we do)?


We need to backport it to 1.73 cse.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: chore
summary: Fixed CVE-2025-15558 (docker/cli) in image-availability-exporter and CVE-2025-65637 (sirupsen/logrus) in events-exporter.
impact_level: low
```
