### PR TITLE
[cloud-provider-huaweicloud] separate VM lookup flow for create and delete

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1551,6 +1551,31 @@ alerts:
         The ModuleConfig annotation for allowing module disabling is set.
       severity: "4"
       markupFormat: markdown
+    - name: D8HuaweiCloudMachineStuckInDeleting
+      sourceFile: ee/modules/030-cloud-provider-huaweicloud/monitoring/prometheus-rules/caphc-controller-manager.tpl
+      moduleUrl: 030-cloud-provider-huaweicloud
+      module: cloud-provider-huaweicloud
+      edition: ee
+      description: |
+        The HuaweiCloudMachine `{{ $labels.name }}` in namespace `{{ $labels.namespace }}` has been stuck in Deleting state for more than 24 hours.
+
+        This usually means the deletion job in HuaweiCloud is failing or the API is unavailable.
+
+        To inspect the machine status, run:
+
+        ```shell
+        d8 k get huaweicloudmachine -n {{ $labels.namespace }} {{ $labels.name }} -o yaml
+        ```
+
+        Check the controller logs for errors:
+
+        ```shell
+        d8 k logs -n d8-cloud-provider-huaweicloud -l app=caphc-controller-manager
+        ```
+      summary: |
+        HuaweiCloudMachine {{ $labels.name }} is stuck in Deleting for more than 24h.
+      severity: "6"
+      markupFormat: markdown
     - name: D8ImageAvailabilityExporterMalfunctioning
       sourceFile: modules/340-extended-monitoring/monitoring/prometheus-rules/image-availability/image-availability-exporter-health.yaml
       moduleUrl: 340-extended-monitoring
@@ -7281,6 +7306,7 @@ modules-having-alerts:
     - admission-policy-engine
     - cert-manager
     - chrony
+    - cloud-provider-huaweicloud
     - cloud-provider-yandex
     - cni-cilium
     - control-plane-manager

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -15,7 +15,6 @@ imageSpec:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
 fromImage: common/src-artifact
-fromCacheVersion: "2026-04-30"
 secrets:
 - id: CLOUD_PROVIDERS_SOURCE_REPO
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "v0.6.1" }}
+{{- $version := "fix/caphc-machine-delete-flow-and-stuck-deleting-alert" }}
 {{- $version_common := "v0.8.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -15,6 +15,7 @@ imageSpec:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
 fromImage: common/src-artifact
+fromCacheVersion: "2026-04-27"
 secrets:
 - id: CLOUD_PROVIDERS_SOURCE_REPO
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -15,7 +15,7 @@ imageSpec:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
 fromImage: common/src-artifact
-fromCacheVersion: "2026-04-27"
+fromCacheVersion: "2026-04-30"
 secrets:
 - id: CLOUD_PROVIDERS_SOURCE_REPO
   value: {{ .CLOUD_PROVIDERS_SOURCE_REPO }}

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $version := "fix/caphc-machine-delete-flow-and-stuck-deleting-alert" }}
+{{- $version := "v0.6.2" }}
 {{- $version_common := "v0.8.0" }}
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/ee/modules/030-cloud-provider-huaweicloud/monitoring/prometheus-rules/caphc-controller-manager.tpl
+++ b/ee/modules/030-cloud-provider-huaweicloud/monitoring/prometheus-rules/caphc-controller-manager.tpl
@@ -1,0 +1,31 @@
+- name: d8.cloud-provider-huaweicloud.capi
+  rules:
+  - alert: D8HuaweiCloudMachineStuckInDeleting
+    expr: caphc_machine_deleting_stuck > 0
+    for: 0m
+    labels:
+      severity_level: "6"
+      tier: cluster
+      d8_module: cloud-provider-huaweicloud
+      d8_component: caphc-controller-manager
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_labels_as_annotations: "name,namespace"
+      summary: HuaweiCloudMachine {{`{{ $labels.name }}`}} is stuck in Deleting for more than 24h.
+      description: |
+        The HuaweiCloudMachine `{{`{{ $labels.name }}`}}` in namespace `{{`{{ $labels.namespace }}`}}` has been stuck in Deleting state for more than 24 hours.
+
+        This usually means the deletion job in HuaweiCloud is failing or the API is unavailable.
+
+        To inspect the machine status, run:
+
+        ```shell
+        d8 k get huaweicloudmachine -n {{`{{ $labels.namespace }}`}} {{`{{ $labels.name }}`}} -o yaml
+        ```
+
+        Check the controller logs for errors:
+
+        ```shell
+        d8 k logs -n d8-cloud-provider-huaweicloud -l app=caphc-controller-manager
+        ```

--- a/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
@@ -266,7 +266,9 @@ var _ = Describe("Module :: cloud-provider-huaweicloud :: helm template ::", fun
 			Expect(caphcDeployment.Exists()).To(BeTrue())
 			Expect(caphcDeployment.Field("spec.template.spec.containers.0.name").String()).To(Equal("caphc-controller-manager"))
 			Expect(caphcDeployment.Field("spec.template.spec.containers.0.args").String()).To(MatchYAML(`
-- --leader-elect`))
+- --leader-elect
+- --metrics-bind-address=:8080
+- --metrics-secure=false`))
 			Expect(caphcDeployment.Field("spec.template.spec.containers.0.env").String()).To(MatchYAML(`
 - name: HUAWEICLOUD_CLOUD
   valueFrom:

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/deployment.yaml
@@ -40,6 +40,8 @@
 {{- $_ := set $capiConfig "image" (include "helm_lib_module_image" (list . "caphcControllerManager")) }}
 {{- $_ := set $capiConfig "capiProviderName" "infrastructure-huaweicloud" }}
 {{- $_ := set $capiConfig "additionalEnv" (include "caphc_envs" . | fromYamlArray) }}
+{{- $_ := set $capiConfig "additionalArgs" (list "--metrics-bind-address=:8080" "--metrics-secure=false") }}
+{{- $_ := set $capiConfig "additionalPorts" (list (dict "containerPort" 8080 "name" "metrics" "protocol" "TCP")) }}
 {{- $_ := set $capiConfig "vpaEnabled" true }}
 
 {{- include "helm_lib_capi_controller_manager_manifests" (list . $capiConfig) }}

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/pod-monitor.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/caphc-controller-manager/pod-monitor.yaml
@@ -1,0 +1,29 @@
+{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: caphc-controller-manager
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "prometheus" "main" "app" "caphc-controller-manager")) | nindent 2 }}
+spec:
+  jobLabel: app
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      scheme: http
+      honorLabels: true
+      relabelings:
+        - regex: endpoint|pod|container
+          action: labeldrop
+        - targetLabel: job
+          replacement: caphc-controller-manager
+        - targetLabel: tier
+          replacement: cluster
+  selector:
+    matchLabels:
+      app: caphc-controller-manager
+  namespaceSelector:
+    matchNames:
+      - d8-cloud-provider-huaweicloud
+{{- end }}

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/monitoring.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/monitoring.yaml
@@ -1,0 +1,1 @@
+{{- include "helm_lib_prometheus_rules" (list . "d8-cloud-provider-huaweicloud") }}


### PR DESCRIPTION
## Description
Split VM lookup logic in caphc-controller-manager for create and delete flows.

During machine deletion, the controller no longer depends on instance-creation-job-id status checks (which are relevant only for VM creation).
Also, HuaweiCloudMachine objects stuck in Deleting for more than 24 hours are explicitly marked with failure status/condition (VMDeletingStuck) to improve visibility and troubleshooting.

Critical components impact: caphc-controller-manager behavior changes for machine deletion reconciliation; no control-plane restarts required by logic itself.


## Why do we need it, and what problem does it solve?
Huawei Cloud VM creation is asynchronous and uses instance-creation-job-id.
Previously, findVMForMachine used creation-job checks for both creation and deletion paths. As a result, deletion could fail/requeue incorrectly when creation job status was unavailable or irrelevant at delete time.

This fix separates create/delete lookup behavior, making deletion flow robust and preventing false failures during machine cleanup.
Additionally, stuck deletions (>1d) are surfaced directly in HuaweiCloudMachine status/conditions.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-huaweicloud
type: fix
summary: Separated HuaweiCloudMachine VM lookup logic for create/delete and marked machines stuck in Deleting for more than 24h.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
