### PR TITLE
[cloud-provider-openstack] switch terraform manager to OpenTofu with migration hook

### DIFF
--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -75,7 +75,6 @@ openstack:
   destinationBinary: terraform-provider-openstack
   vmResourceType: openstack_blockstorage_volume_v3
   useOpentofu: true
-
 ovirt:
   namespace: terraform-provider-ovirt
   cloudName: Zvirt

--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -74,17 +74,8 @@ openstack:
   artifactBinary: terraform-provider-openstack
   destinationBinary: terraform-provider-openstack
   vmResourceType: openstack_blockstorage_volume_v3
-  # Attention! For migrate to opentofu we need some manual actions.
-  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
-  # But we need enable automigrator and terraform state metrics hook. We can add global hook
-  # for autodiscovery terraform versions file, but we think that this attention will be enough.
-  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
-  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
-  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
-  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
-  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
-  # after migration, please remove this comment
-  useOpentofu: false
+  useOpentofu: true
+
 ovirt:
   namespace: terraform-provider-ovirt
   cloudName: Zvirt

--- a/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider_test.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 var terraformProviders = []string{
-	"openstack",
 	"aws",
 	gcp.ProviderName,
 	"azure",
@@ -47,6 +46,7 @@ var tofuProviders = []string{
 	dvp.ProviderName,
 	"vsphere",
 	"huaweicloud",
+	"openstack",
 }
 
 func TestAllProviderPresentInStore(t *testing.T) {

--- a/ee/modules/030-cloud-provider-openstack/candi/layouts/simple-with-internal-network/master-node/main.tf
+++ b/ee/modules/030-cloud-provider-openstack/candi/layouts/simple-with-internal-network/master-node/main.tf
@@ -32,7 +32,7 @@ module "master" {
   additional_tags = local.additional_tags
   image_name = local.image_name
   keypair_ssh_name = data.openstack_compute_keypair_v2.ssh.name
-  network_port_ids = list(local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id)
+  network_port_ids = tolist([local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id])
   internal_network_cidr = data.openstack_networking_subnet_v2.internal.cidr
   floating_ip_network = local.external_network_floating_ip ? local.external_network_name : ""
   config_drive = !local.external_network_dhcp

--- a/ee/modules/030-cloud-provider-openstack/candi/layouts/simple/master-node/main.tf
+++ b/ee/modules/030-cloud-provider-openstack/candi/layouts/simple/master-node/main.tf
@@ -91,7 +91,7 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   dynamic "block_device" {
-    for_each = local.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v3.master[0])
+    for_each = local.root_disk_size == "" ? [] : tolist([openstack_blockstorage_volume_v3.master[0]])
     content {
       uuid = block_device.value["id"]
       boot_index = 0

--- a/ee/modules/030-cloud-provider-openstack/candi/layouts/standard-with-no-router/master-node/main.tf
+++ b/ee/modules/030-cloud-provider-openstack/candi/layouts/standard-with-no-router/master-node/main.tf
@@ -36,7 +36,7 @@ module "master" {
   additional_tags = local.additional_tags
   image_name = local.image_name
   keypair_ssh_name = data.openstack_compute_keypair_v2.ssh.name
-  network_port_ids = local.network_security ? list(openstack_networking_port_v2.master_external_with_security[0].id, openstack_networking_port_v2.master_internal_with_security[0].id) : list(openstack_networking_port_v2.master_external_without_security[0].id, openstack_networking_port_v2.master_internal_without_security[0].id)
+  network_port_ids = local.network_security ? tolist([openstack_networking_port_v2.master_external_with_security[0].id, openstack_networking_port_v2.master_internal_with_security[0].id]) : tolist([openstack_networking_port_v2.master_external_without_security[0].id, openstack_networking_port_v2.master_internal_without_security[0].id])
   internal_network_cidr = local.internal_network_cidr
   config_drive = !local.external_network_dhcp
   tags = local.tags

--- a/ee/modules/030-cloud-provider-openstack/candi/layouts/standard/master-node/main.tf
+++ b/ee/modules/030-cloud-provider-openstack/candi/layouts/standard/master-node/main.tf
@@ -35,7 +35,7 @@ module "master" {
   additional_tags       = local.additional_tags
   image_name            = local.image_name
   keypair_ssh_name      = data.openstack_compute_keypair_v2.ssh.name
-  network_port_ids      = list(local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id)
+  network_port_ids      = tolist([local.network_security ? openstack_networking_port_v2.master_internal_with_security[0].id : openstack_networking_port_v2.master_internal_without_security[0].id])
   internal_network_cidr = local.internal_network_cidr
   floating_ip_network   = lookup(local.standard, "bastion", {}) == {} ? data.openstack_networking_network_v2.external.name : ""
   tags                  = local.tags

--- a/ee/modules/030-cloud-provider-openstack/candi/terraform-modules/master/main.tf
+++ b/ee/modules/030-cloud-provider-openstack/candi/terraform-modules/master/main.tf
@@ -56,7 +56,7 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   dynamic "block_device" {
-    for_each = var.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v3.master[0])
+    for_each = var.root_disk_size == "" ? [] : tolist([openstack_blockstorage_volume_v3.master[0]])
     content {
       uuid                  = block_device.value["id"]
       boot_index            = 0
@@ -83,9 +83,9 @@ resource "openstack_compute_instance_v2" "master" {
   dynamic "scheduler_hints" {
     for_each = (
       local.server_group_policy == "AntiAffinity" ?
-        list(data.openstack_compute_servergroup_v2.master[0]) :
+        tolist([data.openstack_compute_servergroup_v2.master[0]]) :
       local.server_group_policy == "ManuallyManaged" ?
-        list({"id": lookup(var.server_group.manuallyManaged, "id", "")}) :
+        tolist([{"id": lookup(var.server_group.manuallyManaged, "id", "")}]) :
       []
    )
 

--- a/ee/modules/030-cloud-provider-openstack/candi/terraform-modules/static-node/main.tf
+++ b/ee/modules/030-cloud-provider-openstack/candi/terraform-modules/static-node/main.tf
@@ -10,12 +10,12 @@ locals {
 }
 
 module "security_groups" {
-  source               = "../../../terraform-modules/security-groups"
+  source               = "../security-groups"
   security_group_names = local.security_group_names
 }
 
 module "volume_zone" {
-  source       = "../../../terraform-modules/volume-zone"
+  source       = "../volume-zone"
   compute_zone = element(local.zones, var.nodeIndex)
   region       = var.providerClusterConfiguration.provider.region
 }

--- a/ee/modules/030-cloud-provider-openstack/candi/terraform-modules/static-node/main.tf
+++ b/ee/modules/030-cloud-provider-openstack/candi/terraform-modules/static-node/main.tf
@@ -39,7 +39,7 @@ resource "openstack_networking_port_v2" "port" {
   security_group_ids = try(index(local.networks_with_security_disabled, data.openstack_networking_network_v2.network[count.index].name), -1) == -1 ? module.security_groups.security_group_ids : []
 
   dynamic "allowed_address_pairs" {
-    for_each = local.internal_network_security_enabled && local.networks[count.index] == local.network_with_port_security ? list(local.pod_subnet_cidr) : []
+    for_each = local.internal_network_security_enabled && local.networks[count.index] == local.network_with_port_security ? tolist([local.pod_subnet_cidr]) : []
     content {
       ip_address = allowed_address_pairs.value
     }
@@ -87,7 +87,7 @@ resource "openstack_compute_instance_v2" "node" {
   }
 
   dynamic "block_device" {
-    for_each = local.root_disk_size == "" ? [] : list(openstack_blockstorage_volume_v3.volume[0])
+    for_each = local.root_disk_size == "" ? [] : tolist([openstack_blockstorage_volume_v3.volume[0]])
     content {
       uuid                  = block_device.value["id"]
       boot_index            = 0

--- a/ee/modules/030-cloud-provider-openstack/candi/terraform_versions.yml
+++ b/ee/modules/030-cloud-provider-openstack/candi/terraform_versions.yml
@@ -1,5 +1,4 @@
 opentofu: 1.9.4
-
 openstack:
   namespace: terraform-provider-openstack
   cloudName: OpenStack

--- a/ee/modules/030-cloud-provider-openstack/candi/terraform_versions.yml
+++ b/ee/modules/030-cloud-provider-openstack/candi/terraform_versions.yml
@@ -1,4 +1,5 @@
-terraform: 0.14.8
+opentofu: 1.9.4
+
 openstack:
   namespace: terraform-provider-openstack
   cloudName: OpenStack
@@ -8,14 +9,4 @@ openstack:
   artifactBinary: terraform-provider-openstack
   destinationBinary: terraform-provider-openstack
   vmResourceType: openstack_blockstorage_volume_v3
-  # Attention! For migrate to opentofu we need some manual actions.
-  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
-  # But we need enable automigrator and terraform state metrics hook. We can add global hook
-  # for autodiscovery terraform versions file, but we think that this attention will be enough.
-  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
-  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
-  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
-  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
-  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
-  # after migration, please remove this comment
-  useOpentofu: false
+  useOpentofu: true

--- a/ee/modules/030-cloud-provider-openstack/hooks/to_tofu_migrate_metric.go
+++ b/ee/modules/030-cloud-provider-openstack/hooks/to_tofu_migrate_metric.go
@@ -1,0 +1,12 @@
+/*
+Copyright 2025 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	metric "github.com/deckhouse/deckhouse/go_lib/hooks/to_tofu_migrate_metric"
+)
+
+var _ = metric.RegisterHook()

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       - name: deckhouse-registry
       automountServiceAccountToken: true
       serviceAccountName: terraform-auto-converger
-      {{- if has .Values.global.clusterConfiguration.cloud.provider (list "Yandex" "Zvirt" "vSphere" "Huaweicloud") }}
+      {{- if has .Values.global.clusterConfiguration.cloud.provider (list "Yandex" "Zvirt" "vSphere" "Huaweicloud" "OpenStack") }}
       initContainers:
       - name: to-tofu-migrator
         {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" true) | nindent 8 }}


### PR DESCRIPTION
## Description
Switch OpenStack infrastructure provider from Terraform to OpenTofu by enabling useOpentofu for OpenStack and wiring automatic state migration.
Changes include:

- enabling OpenTofu for OpenStack in provider versions;
- enabling to-tofu-migrator init container for OpenStack in terraform-auto-converger;
- adding the to_tofu_migrate_metric hook in cloud-provider-openstack module to expose migration-need metric;
-  updating HCL syntax in OpenStack terraform configs (master-node, static-node) from deprecated `list()` to `tolist([])` for OpenTofu compatibility;
- fixing static-node module source paths to use relative paths from the real file location, resolving a symlink resolution behavior difference between Terraform 0.14 and OpenTofu.


This affects the terraform-manager flow for OpenStack cloud clusters and may trigger migration logic on module rollout.


## Why do we need it, and what problem does it solve?
OpenStack still used Terraform mode, which prevented unified OpenTofu-based infrastructure management and required manual migration steps.

This change makes OpenStack consistent with providers already migrated to OpenTofu and automates detection/execution prerequisites for Terraform state migration, reducing manual operations and migration risk.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-openstack
type: feature
summary: Switched OpenStack to OpenTofu mode with terraform-state migration in terraform-manager.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
