### PR TITLE
fix D8UpmeterProbeGarbagePodsFromDeployments alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3595,11 +3595,9 @@ alerts:
       module: upmeter
       edition: ce
       description: |
-        The average number of probe Pods per `upmeter-agent` Pod is {{ $value }}.
+        Pods from the `control-plane/controller-manager` probe have been present in the `d8-upmeter` namespace at every check over the last 10 minutes.
 
-        `upmeter-agent` is expected to clean Deployments created by the `control-plane/controller-manager` probe,
-        and `kube-controller-manager` should remove the associated Pods.
-        There should not be more of these Pods than there are master nodes (since `upmeter-agent` runs as a DaemonSet with a master `nodeSelector`), and the Pods should be deleted within seconds.
+        `upmeter-agent` is expected to clean Deployments created by the `control-plane/controller-manager` probe, and `kube-controller-manager` should remove the associated Pods within seconds.
 
         This may indicate:
 

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3595,7 +3595,7 @@ alerts:
       module: upmeter
       edition: ce
       description: |
-        Pods from the `control-plane/controller-manager` probe have been present in the `d8-upmeter` namespace at every check over the last 10 minutes.
+        A Pod from the `control-plane/controller-manager` probe was created more than 5 minutes ago.
 
         `upmeter-agent` is expected to clean Deployments created by the `control-plane/controller-manager` probe, and `kube-controller-manager` should remove the associated Pods within seconds.
 

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -303,8 +303,8 @@
               namespace="d8-upmeter",
               label_heritage="upmeter",
               label_upmeter_probe="controller-manager"
-            }[30s]
-          )[10m:30s]
+            }[__SCRAPE_INTERVAL__]
+          )[10m:__SCRAPE_INTERVAL__]
         ) == 1
       labels:
         severity_level: "9"

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -303,8 +303,8 @@
               namespace="d8-upmeter",
               label_heritage="upmeter",
               label_upmeter_probe="controller-manager"
-            }[__SCRAPE_INTERVAL__]
-          )[10m:__SCRAPE_INTERVAL__]
+            }[30s]
+          )[10m:30s]
         ) == 1
       labels:
         severity_level: "9"

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -300,21 +300,27 @@
         absent_over_time(
           (
             (
-              count(last_over_time(kube_pod_labels{
-                namespace="d8-upmeter",
-                label_heritage="upmeter",
-                label_upmeter_probe="controller-manager"
-              }[__SCRAPE_INTERVAL__]))
-              /
-              clamp_min(
+              (
                 count(last_over_time(kube_pod_labels{
                   namespace="d8-upmeter",
-                  label_app="upmeter-agent"
-                }[__SCRAPE_INTERVAL__])),
+                  label_heritage="upmeter",
+                  label_upmeter_probe="controller-manager"
+                }[30s]))
+                or on() vector(0)
+              )
+              /
+              clamp_min(
+                (
+                  count(last_over_time(kube_pod_labels{
+                    namespace="d8-upmeter",
+                    label_app="upmeter-agent"
+                  }[30s]))
+                  or on() vector(0)
+                ),
                 1
               )
             ) < 1
-          )[10m:__SCRAPE_INTERVAL__]
+          )[10m:30s]
         ) == 1
       labels:
         severity_level: "9"

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -298,15 +298,12 @@
     - alert: D8UpmeterProbeGarbagePodsFromDeployments
       expr: |
         absent_over_time(
-          (
-            (
-              count(last_over_time(kube_pod_labels{
-                namespace="d8-upmeter",
-                label_heritage="upmeter",
-                label_upmeter_probe="controller-manager"
-              }[30s]))
-              or vector(0)
-            ) == 0
+          absent_over_time(
+            kube_pod_labels{
+              namespace="d8-upmeter",
+              label_heritage="upmeter",
+              label_upmeter_probe="controller-manager"
+            }[30s]
           )[10m:30s]
         ) == 1
       labels:

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -300,26 +300,13 @@
         absent_over_time(
           (
             (
-              (
-                count(last_over_time(kube_pod_labels{
-                  namespace="d8-upmeter",
-                  label_heritage="upmeter",
-                  label_upmeter_probe="controller-manager"
-                }[30s]))
-                or on() vector(0)
-              )
-              /
-              clamp_min(
-                (
-                  count(last_over_time(kube_pod_labels{
-                    namespace="d8-upmeter",
-                    label_app="upmeter-agent"
-                  }[30s]))
-                  or on() vector(0)
-                ),
-                1
-              )
-            ) < 1
+              count(last_over_time(kube_pod_labels{
+                namespace="d8-upmeter",
+                label_heritage="upmeter",
+                label_upmeter_probe="controller-manager"
+              }[30s]))
+              or vector(0)
+            ) == 0
           )[10m:30s]
         ) == 1
       labels:
@@ -335,11 +322,9 @@
         plk_labels_as_annotations: "pod"
         summary: Garbage Pods from the controller-manager probe are not being cleaned up.
         description: |
-          The average number of probe Pods per `upmeter-agent` Pod is {{ $value }}.
+          Pods from the `control-plane/controller-manager` probe have been present in the `d8-upmeter` namespace at every check over the last 10 minutes.
 
-          `upmeter-agent` is expected to clean Deployments created by the `control-plane/controller-manager` probe,
-          and `kube-controller-manager` should remove the associated Pods.
-          There should not be more of these Pods than there are master nodes (since `upmeter-agent` runs as a DaemonSet with a master `nodeSelector`), and the Pods should be deleted within seconds.
+          `upmeter-agent` is expected to clean Deployments created by the `control-plane/controller-manager` probe, and `kube-controller-manager` should remove the associated Pods within seconds.
 
           This may indicate:
 
@@ -354,9 +339,16 @@
              d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
              ```
 
-          2. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`.
+          2. List the stuck Pods and inspect them — pay attention to the status, finalizers, and how long they have been alive:
 
-          3. Delete stale Pods manually:
+             ```shell
+             d8 k -n d8-upmeter get pods -l upmeter-probe=controller-manager -o wide
+             d8 k -n d8-upmeter get pods -l upmeter-probe=controller-manager -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.metadata.deletionTimestamp}{"\t"}{.metadata.finalizers}{"\n"}{end}'
+             ```
+
+          3. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`, `kube-apiserver`, `etcd`, and `kubelet` on the master nodes.
+
+          4. Delete stale Pods manually (use `--force --grace-period=0` if a Pod is stuck in `Terminating`):
 
              ```shell
              d8 k -n d8-upmeter delete pods -l upmeter-probe=controller-manager

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -339,16 +339,9 @@
              d8 k -n d8-upmeter logs -l app=upmeter-agent --tail=-1 | jq -rR 'fromjson? | select(.group=="control-plane" and .probe == "controller-manager") | [.time, .level, .msg] | @tsv'
              ```
 
-          2. List the stuck Pods and inspect them — pay attention to the status, finalizers, and how long they have been alive:
+          2. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`.
 
-             ```shell
-             d8 k -n d8-upmeter get pods -l upmeter-probe=controller-manager -o wide
-             d8 k -n d8-upmeter get pods -l upmeter-probe=controller-manager -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.metadata.deletionTimestamp}{"\t"}{.metadata.finalizers}{"\n"}{end}'
-             ```
-
-          3. Ensure the control plane is operating normally. Pay close attention to `kube-controller-manager`, `kube-apiserver`, `etcd`, and `kubelet` on the master nodes.
-
-          4. Delete stale Pods manually (use `--force --grace-period=0` if a Pod is stuck in `Terminating`):
+          3. Delete stale Pods manually:
 
              ```shell
              d8 k -n d8-upmeter delete pods -l upmeter-probe=controller-manager

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -297,15 +297,9 @@
 
     - alert: D8UpmeterProbeGarbagePodsFromDeployments
       expr: |
-        absent_over_time(
-          absent_over_time(
-            kube_pod_labels{
-              namespace="d8-upmeter",
-              label_heritage="upmeter",
-              label_upmeter_probe="controller-manager"
-            }[30s]
-          )[10m:30s]
-        ) == 1
+        (time() - max by (namespace, pod) (kube_pod_created{namespace="d8-upmeter"})) > 300
+        * on (namespace, pod)
+        max by (namespace, pod) (kube_pod_labels{namespace="d8-upmeter", label_heritage="upmeter", label_upmeter_probe="controller-manager"})
       labels:
         severity_level: "9"
         tier: cluster
@@ -319,7 +313,7 @@
         plk_labels_as_annotations: "pod"
         summary: Garbage Pods from the controller-manager probe are not being cleaned up.
         description: |
-          Pods from the `control-plane/controller-manager` probe have been present in the `d8-upmeter` namespace at every check over the last 10 minutes.
+          A Pod from the `control-plane/controller-manager` probe was created more than 5 minutes ago.
 
           `upmeter-agent` is expected to clean Deployments created by the `control-plane/controller-manager` probe, and `kube-controller-manager` should remove the associated Pods within seconds.
 

--- a/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/500-upmeter/monitoring/prometheus-rules/alerting.yaml
@@ -297,13 +297,25 @@
 
     - alert: D8UpmeterProbeGarbagePodsFromDeployments
       expr: |
-        (
-          count (kube_pod_labels{namespace="d8-upmeter", label_heritage="upmeter",
-                                                         label_upmeter_probe="controller-manager"})
-          /
-          count (kube_pod_labels{namespace="d8-upmeter", label_app="upmeter-agent"})
-        ) >= 1
-      for: 10m
+        absent_over_time(
+          (
+            (
+              count(last_over_time(kube_pod_labels{
+                namespace="d8-upmeter",
+                label_heritage="upmeter",
+                label_upmeter_probe="controller-manager"
+              }[__SCRAPE_INTERVAL__]))
+              /
+              clamp_min(
+                count(last_over_time(kube_pod_labels{
+                  namespace="d8-upmeter",
+                  label_app="upmeter-agent"
+                }[__SCRAPE_INTERVAL__])),
+                1
+              )
+            ) < 1
+          )[10m:__SCRAPE_INTERVAL__]
+        ) == 1
       labels:
         severity_level: "9"
         tier: cluster


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Reworks the D8UpmeterProbeGarbagePodsFromDeployments alert to eliminate false positives caused by Prometheus' lookback delta.
The expression now uses a nested absent_over_time(absent_over_time(kube_pod_labels{...}[30s])[10m:30s]) == 1: the inner absent_over_time(...[30s]) limits series visibility to one scrape interval, while the outer absent_over_time(...[10m:30s]) fires only when probe Pods were never observed absent over a 10-minute window.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes flapping D8UpmeterProbeGarbagePodsFromDeployments alerts on healthy clusters 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
No need

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed the `D8UpmeterProbeGarbagePodsFromDeployments` alert to eliminate false positives.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
