### PR TITLE
[admission-policy-engine] tolerate csi-not-bootstrapped on gatekeeper pods

### DIFF
--- a/modules/015-admission-policy-engine/templates/audit-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/audit-deployment.yaml
@@ -58,7 +58,7 @@ spec:
         gatekeeper.sh/operation: audit
     spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "system" "with-no-csi") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
       automountServiceAccountToken: true

--- a/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
+++ b/modules/015-admission-policy-engine/templates/gatekeeper-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         gatekeeper.sh/operation: webhook
     spec:
       {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
-      {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "system" "with-no-csi") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "system-cluster-critical") | nindent 6 }}
       {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict "app" "gatekeeper" "control-plane" "controller-manager")) | nindent 6 }}
       {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}


### PR DESCRIPTION
## Description
Add with-no-csi toleration to gatekeeper deployments to fix a deadlock during worker node replacement.

PR #16738 enabled enable-security-policy-check for system namespaces, placing them under the security-policy-exception webhook with failurePolicy=Fail. Unlike other system components (kube-dns, registry-packages-proxy) that already tolerate csi-not-bootstrapped, gatekeeper-controller-manager and gatekeeper-audit were missing this toleration. When a worker node is replaced, both gatekeeper pods fail to schedule on the new node → webhook becomes unavailable → requests are rejected with failurePolicy=Fail → deadlock.

The fix adds with-no-csi toleration to both gatekeeper deployments, following the same pattern as other system components that don't depend on CSI.

## Why do we need it, and what problem does it solve?
During worker node replacement, gatekeeper pods couldn't schedule on the new node due to csi-not-bootstrapped taint. This made the security-policy-exception webhook unavailable, causing a deadlock for any operation subject to that webhook.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: admission-policy-engine
type: fix
summary: Made Gatekeeper pods tolerate the csi-not-bootstrapped taint to prevent webhook deadlock during worker node replacement.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
