### PR TITLE
[deckhouse] Add permissions for applications

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
@@ -39,7 +39,7 @@ const (
 	PackageRepositoryOperationReasonPackageRepositoryNotFound    = "PackageRepositoryNotFound"
 	PackageRepositoryOperationReasonRegistryClientCreationFailed = "RegistryClientCreationFailed"
 	PackageRepositoryOperationReasonPackageListingFailed         = "PackageListingFailed"
-	PackageRepositoryOperationReasonPackageListingSuccess        = "PackageListingSuccess"
+	PackageRepositoryOperationReasonPackageScanSuccess           = "PackageScanSuccess"
 
 	// PackagesRepositoryOperationLabelRepository is the label used to identify PackageRepositoryOperations
 	// that belong to a specific PackageRepository

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
@@ -39,7 +39,7 @@ const (
 	PackageRepositoryOperationReasonPackageRepositoryNotFound    = "PackageRepositoryNotFound"
 	PackageRepositoryOperationReasonRegistryClientCreationFailed = "RegistryClientCreationFailed"
 	PackageRepositoryOperationReasonPackageListingFailed         = "PackageListingFailed"
-	PackageRepositoryOperationReasonPackageScanSuccess           = "PackageScanSuccess"
+	PackageRepositoryOperationReasonSuccessfulScan               = "SuccessfulScan"
 
 	// PackagesRepositoryOperationLabelRepository is the label used to identify PackageRepositoryOperations
 	// that belong to a specific PackageRepository

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
@@ -39,6 +39,7 @@ const (
 	PackageRepositoryOperationReasonPackageRepositoryNotFound    = "PackageRepositoryNotFound"
 	PackageRepositoryOperationReasonRegistryClientCreationFailed = "RegistryClientCreationFailed"
 	PackageRepositoryOperationReasonPackageListingFailed         = "PackageListingFailed"
+	PackageRepositoryOperationReasonPackageListingSuccess        = "PackageListingSuccess"
 
 	// PackagesRepositoryOperationLabelRepository is the label used to identify PackageRepositoryOperations
 	// that belong to a specific PackageRepository

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
@@ -441,7 +441,7 @@ func (r *reconciler) handleProcessingState(ctx context.Context, operation *v1alp
 		}
 
 		successMessage := fmt.Sprintf("Successfully scanned repository, found %d package(s)", operation.Status.Packages.Total)
-		if updateErr := r.updatePackageRepositoryCondition(ctx, operation.Spec.PackageRepositoryName, true, "", successMessage); updateErr != nil {
+		if updateErr := r.updatePackageRepositoryCondition(ctx, operation.Spec.PackageRepositoryName, true, v1alpha1.PackageRepositoryOperationReasonPackageListingSuccess, successMessage); updateErr != nil {
 			logger.Warn("failed to update package repository condition", log.Err(updateErr))
 		}
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
@@ -441,7 +441,7 @@ func (r *reconciler) handleProcessingState(ctx context.Context, operation *v1alp
 		}
 
 		successMessage := fmt.Sprintf("Successfully scanned repository, found %d package(s)", operation.Status.Packages.Total)
-		if updateErr := r.updatePackageRepositoryCondition(ctx, operation.Spec.PackageRepositoryName, true, v1alpha1.PackageRepositoryOperationReasonPackageScanSuccess, successMessage); updateErr != nil {
+		if updateErr := r.updatePackageRepositoryCondition(ctx, operation.Spec.PackageRepositoryName, true, v1alpha1.PackageRepositoryOperationReasonSuccessfulScan, successMessage); updateErr != nil {
 			logger.Warn("failed to update package repository condition", log.Err(updateErr))
 		}
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
@@ -441,7 +441,7 @@ func (r *reconciler) handleProcessingState(ctx context.Context, operation *v1alp
 		}
 
 		successMessage := fmt.Sprintf("Successfully scanned repository, found %d package(s)", operation.Status.Packages.Total)
-		if updateErr := r.updatePackageRepositoryCondition(ctx, operation.Spec.PackageRepositoryName, true, v1alpha1.PackageRepositoryOperationReasonPackageListingSuccess, successMessage); updateErr != nil {
+		if updateErr := r.updatePackageRepositoryCondition(ctx, operation.Spec.PackageRepositoryName, true, v1alpha1.PackageRepositoryOperationReasonPackageScanSuccess, successMessage); updateErr != nil {
 			logger.Warn("failed to update package repository condition", log.Err(updateErr))
 		}
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/bundle-image-has-arrived-for-failed-package-version.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/bundle-image-has-arrived-for-failed-package-version.yaml
@@ -69,7 +69,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/bundle-image-has-arrived-for-failed-package-version.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/bundle-image-has-arrived-for-failed-package-version.yaml
@@ -69,7 +69,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-module-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-module-versions.yaml
@@ -101,7 +101,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-module-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-module-versions.yaml
@@ -101,7 +101,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-versions.yaml
@@ -83,7 +83,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/failed-versions.yaml
@@ -83,7 +83,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-module-scan.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-module-scan.yaml
@@ -110,7 +110,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-module-scan.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-module-scan.yaml
@@ -110,7 +110,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/invalid-package-type.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/invalid-package-type.yaml
@@ -54,7 +54,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/invalid-package-type.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/invalid-package-type.yaml
@@ -54,7 +54,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module-old-registry.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module-old-registry.yaml
@@ -93,7 +93,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module-old-registry.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module-old-registry.yaml
@@ -93,7 +93,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module.yaml
@@ -54,7 +54,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/legacy-module.yaml
@@ -54,7 +54,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/no-bundle-image.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/no-bundle-image.yaml
@@ -68,7 +68,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/no-bundle-image.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/no-bundle-image.yaml
@@ -68,7 +68,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/old-image-no-metadata.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/old-image-no-metadata.yaml
@@ -54,7 +54,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/old-image-no-metadata.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/old-image-no-metadata.yaml
@@ -54,7 +54,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-completion.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-completion.yaml
@@ -74,7 +74,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-completion.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-completion.yaml
@@ -74,7 +74,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-discovery.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-discovery.yaml
@@ -49,7 +49,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-discovery.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-discovery.yaml
@@ -49,7 +49,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   phase: Active

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-module-completion.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-module-completion.yaml
@@ -92,7 +92,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: ""
+    reason: PackageScanSuccess
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-module-completion.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/successful-module-completion.yaml
@@ -92,7 +92,7 @@ status:
   conditions:
   - lastTransitionTime: "2019-10-17T15:33:00Z"
     message: Successfully scanned repository, found 1 package(s)
-    reason: PackageScanSuccess
+    reason: SuccessfulScan
     status: "True"
     type: LastOperationScanFinished
   packages:

--- a/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
@@ -14,18 +14,6 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
-  - deckhousereleases
-  - moduleconfigs
-  - moduledocumentations
-  - modulepulloverrides
-  - modulereleases
-  - modules
-  - modulesources
-  - moduleupdatepolicies
-  - packagerepositories
-  - packagerepositoryoperations
-  - applicationpackageversions
-  - applicationpackages
   - applications
   verbs:
   - create

--- a/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
@@ -22,6 +22,10 @@ rules:
   - modules
   - modulesources
   - moduleupdatepolicies
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
   verbs:
   - create
   - update

--- a/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
@@ -14,7 +14,18 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
-  - applications
+  - deckhousereleases
+  - moduleconfigs
+  - moduledocumentations
+  - modulepulloverrides
+  - modulereleases
+  - modules
+  - modulesources
+  - moduleupdatepolicies
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
   verbs:
   - create
   - update

--- a/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/edit.yaml
@@ -26,6 +26,7 @@ rules:
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages
+  - applications
   verbs:
   - create
   - update

--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -26,7 +26,6 @@ rules:
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages
-  - applications
   verbs:
   - get
   - list

--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -22,6 +22,10 @@ rules:
   - modules
   - modulesources
   - moduleupdatepolicies
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
   verbs:
   - get
   - list

--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -26,6 +26,7 @@ rules:
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages
+  - applications
   verbs:
   - get
   - list

--- a/modules/002-deckhouse/templates/rbacv2/use/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/use/edit.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: deckhouse
+    rbac.deckhouse.io/aggregate-to-kubernetes-as: manager
+    rbac.deckhouse.io/kind: use
+  name: d8:use:capability:module:deckhouse:edit
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection

--- a/modules/002-deckhouse/templates/rbacv2/use/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/use/edit.yaml
@@ -12,6 +12,18 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
+  - deckhousereleases
+  - moduleconfigs
+  - moduledocumentations
+  - modulepulloverrides
+  - modulereleases
+  - modules
+  - modulesources
+  - moduleupdatepolicies
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
   - applications
   verbs:
   - create

--- a/modules/002-deckhouse/templates/rbacv2/use/edit.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/use/edit.yaml
@@ -12,18 +12,6 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
-  - deckhousereleases
-  - moduleconfigs
-  - moduledocumentations
-  - modulepulloverrides
-  - modulereleases
-  - modules
-  - modulesources
-  - moduleupdatepolicies
-  - packagerepositories
-  - packagerepositoryoperations
-  - applicationpackageversions
-  - applicationpackages
   - applications
   verbs:
   - create

--- a/modules/002-deckhouse/templates/rbacv2/use/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/use/view.yaml
@@ -12,18 +12,7 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
-  - deckhousereleases
-  - moduleconfigs
-  - moduledocumentations
-  - modulepulloverrides
-  - modulereleases
-  - modules
-  - modulesources
-  - moduleupdatepolicies
-  - packagerepositories
-  - packagerepositoryoperations
-  - applicationpackageversions
-  - applicationpackages
+  - applications
   verbs:
   - get
   - list

--- a/modules/002-deckhouse/templates/rbacv2/use/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/use/view.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    module: deckhouse
+    rbac.deckhouse.io/aggregate-to-kubernetes-as: viewer
+    rbac.deckhouse.io/kind: use
+  name: d8:use:capability:module:deckhouse:view
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - applications
+  verbs:
+  - get
+  - list
+  - watch

--- a/modules/002-deckhouse/templates/rbacv2/use/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/use/view.yaml
@@ -12,6 +12,18 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
+  - deckhousereleases
+  - moduleconfigs
+  - moduledocumentations
+  - modulepulloverrides
+  - modulereleases
+  - modules
+  - modulesources
+  - moduleupdatepolicies
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
   - applications
   verbs:
   - get

--- a/modules/002-deckhouse/templates/rbacv2/use/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/use/view.yaml
@@ -24,7 +24,6 @@ rules:
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages
-  - applications
   verbs:
   - get
   - list

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -1,5 +1,4 @@
 ---
-# Only view
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,41 +16,13 @@ rules:
   - modulepulloverrides
   - modulereleases
   - modules
-  - moduleupdatepolicies
-  - packagerepositoryoperations
-  - applicationpackageversions
-  - applicationpackages
-  - applications
-  verbs:
-  - get
-  - list
-  - watch
----
-# View with secrets (modulesources and packagerepositories)
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: PrivilegedUser
-  name: d8:user-authz:deckhouse:privileged-user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - deckhousereleases
-  - moduleconfigs
-  - moduledocumentations
-  - modulepulloverrides
-  - modulereleases
-  - modules
-  - moduleupdatepolicies
-  - packagerepositoryoperations
-  - applicationpackageversions
-  - applicationpackages
-  - applications
   - modulesources
+  - moduleupdatepolicies
   - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
+  - applications
   verbs:
   - get
   - list
@@ -61,8 +32,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: Editor
-  name: d8:user-authz:deckhouse:editor
+    user-authz.deckhouse.io/access-level: Admin
+  name: d8:user-authz:deckhouse:admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:deckhouse:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - deckhousereleases
+  - moduleconfigs
+  - moduledocumentations
+  - modulepulloverrides
+  - modulereleases
+  - modules
+  - modulesources
+  - moduleupdatepolicies
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
+  - applications
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Admin
+  name: d8:user-authz:deckhouse:admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - deckhousereleases
+  - moduleconfigs
+  - moduledocumentations
+  - modulepulloverrides
+  - modulereleases
+  - modules
+  - modulesources
+  - moduleupdatepolicies
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
+  - applications
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -1,4 +1,5 @@
 ---
+# Only view
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -16,9 +17,7 @@ rules:
   - modulepulloverrides
   - modulereleases
   - modules
-  - modulesources
   - moduleupdatepolicies
-  - packagerepositories
   - packagerepositoryoperations
   - applicationpackageversions
   - applicationpackages
@@ -28,12 +27,42 @@ rules:
   - list
   - watch
 ---
+# View with secrets (modulesources and packagerepositories)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: Admin
-  name: d8:user-authz:deckhouse:admin
+    user-authz.deckhouse.io/access-level: PrivilegedUser
+  name: d8:user-authz:deckhouse:privileged-user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - deckhousereleases
+  - moduleconfigs
+  - moduledocumentations
+  - modulepulloverrides
+  - modulereleases
+  - modules
+  - moduleupdatepolicies
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
+  - applications
+  - modulesources
+  - packagerepositories
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Editor
+  name: d8:user-authz:deckhouse:editor
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:

--- a/modules/040-control-plane-manager/templates/rbac-for-us.yaml
+++ b/modules/040-control-plane-manager/templates/rbac-for-us.yaml
@@ -105,6 +105,11 @@ rules:
   - modulesources
   - moduleupdatepolicies
   - modulepulloverrides
+  - packagerepositories
+  - packagerepositoryoperations
+  - applicationpackageversions
+  - applicationpackages
+  - applications
   - nodegroups
   - nodeusers
   - staticinstances


### PR DESCRIPTION
## Description
This PR fixes the permissions to manage resources of packages system. 
And also fixes the `PackageRepository.deckhouse.io is invalid` error, where according to metav1 contract we must always use the reason field in conditions.

Before:
```bash
kubectl logs deployments/deckhouse
{"level":"warn","logger":"deckhouse-controller.package-repository-operation-controller","msg":"failed to update package repository condition","source":"deckhouse/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go:445","error":"update package repository status: PackageRepository.deckhouse.io \"deckhouse\" is invalid: status.conditions[0].reason: Invalid value: \"\": conditions[0].reason in body should be at least 1 chars long","name":"deckhouse-scan-1777018537","time":"2026-04-24T08:15:38Z"}

kubectl create -f app.yaml   
Error from server (Forbidden): error when creating "app.yaml": applications.deckhouse.io is forbidden: User "kubernetes-admin" cannot create resource "applications" in API group "deckhouse.io" in the namespace "default"
```

After:
```bash
kubectl logs deployments/deckhouse
# no permission or update errors 

kubectl create -f app.yaml   
application.deckhouse.io/myapp created
```

## Why do we need it, and what problem does it solve?
Users must have rights to manage some resources of `packages system`

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Granted RBAC permissions for applications to Deckhouse.
impact_level: default
```