### PR TITLE
[docs] Update installer channel version endpoint

### DIFF
--- a/docs/site/.helm/templates/10-cm.yaml
+++ b/docs/site/.helm/templates/10-cm.yaml
@@ -55,7 +55,7 @@ data:
         --retry-connrefused \
         --connect-timeout 10 \
         --max-time 30 \
-        "https://deckhouse.ru/downloads/deckhouse-installer-trdl/targets/channels/0/ea")
+        "https://deckhouse.ru/downloads/deckhouse-installer-trdl/targets/channels/1/ea")
 
     if [ -z "$VERSION" ]; then
       echo "Failed to retrieve version."


### PR DESCRIPTION
## Description
Update installer major version in autoupdate script on the site:
- Bump trdl targets channel index from 0 to 1 in the installer version retrieval URL to align with the updated remote channel schema.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update installer major version in autoupdate script on the site.
impact_level: low
```
