### PR TITLE
[istio] ingressGateway advertise FQDN does not create a ServiceEntry due to an error

### DIFF
--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log/slog"
+	"net"
 	"sort"
 	"strings"
 	"time"
@@ -60,10 +61,23 @@ type IstioMulticlusterMergeCrdInfo struct {
 }
 
 type ServiceEntry struct {
-	Name      string                              `json:"name"`
-	Hostname  string                              `json:"hostname"`
-	Ports     []eeCrd.FederationPublicServicePort `json:"ports"`
-	Endpoints []eeCrd.FederationIngressGateway    `json:"endpoints"`
+	Name       string                              `json:"name"`
+	Hostname   string                              `json:"hostname"`
+	Resolution string                              `json:"resolution"`
+	Ports      []eeCrd.FederationPublicServicePort `json:"ports"`
+	Endpoints  []eeCrd.FederationIngressGateway    `json:"endpoints"`
+}
+
+func federationServiceEntryResolution(endpoints []eeCrd.FederationIngressGateway) string {
+	for _, ep := range endpoints {
+		if strings.TrimSpace(ep.Address) == "" {
+			return "DNS"
+		}
+		if net.ParseIP(ep.Address) == nil {
+			return "DNS"
+		}
+	}
+	return "STATIC"
 }
 
 func sortedEndpointsKey(endpoints []eeCrd.FederationIngressGateway) string {
@@ -522,6 +536,7 @@ federationsLoop:
 				return se.Endpoints[i].Port < se.Endpoints[j].Port
 			})
 			se.Name = serviceEntryName(se.Hostname, se.Endpoints)
+			se.Resolution = federationServiceEntryResolution(se.Endpoints)
 			serviceEntries = append(serviceEntries, *se)
 		}
 	}

--- a/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
+++ b/ee/modules/110-istio/hooks/ee/alliance_metadata_merge_test.go
@@ -452,6 +452,7 @@ status:
 				{
 					"name": "bbb-687b4cd97",
 					"hostname": "bbb",
+					"resolution": "DNS",
 					"ports": [
 						{"name": "ppp", "port": 123, "protocol": "TCP"},
 						{"name": "https-xxx", "port": 555, "protocol": "TLS"},
@@ -462,36 +463,42 @@ status:
 				{
 					"name": "ccc-7bbfbb59bd",
 					"hostname": "ccc",
+					"resolution": "DNS",
 					"ports": [{"name": "ppp", "port": 123, "protocol": "TCP"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
 					"name": "ddd-7bbfbb59bd",
 					"hostname": "ddd",
+					"resolution": "DNS",
 					"ports": [{"name": "xxx", "port": 555, "protocol": "TCP"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
 					"name": "eee-7bbfbb59bd",
 					"hostname": "eee",
+					"resolution": "DNS",
 					"ports": [{"name": "http-xxx", "port": 555, "protocol": "HTTP"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
 					"name": "fff-7bbfbb59bd",
 					"hostname": "fff",
+					"resolution": "DNS",
 					"ports": [{"name": "https-xxx", "port": 555, "protocol": "TLS"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
 					"name": "ggg-7bbfbb59bd",
 					"hostname": "ggg",
+					"resolution": "DNS",
 					"ports": [{"name": "grpc-xxx", "port": 555, "protocol": "HTTP2"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				},
 				{
 					"name": "hhh-7bbfbb59bd",
 					"hostname": "hhh",
+					"resolution": "DNS",
 					"ports": [{"name": "tls-xxx", "port": 555, "protocol": "TLS"}],
 					"endpoints": [{"address": "ccc", "port": 222}]
 				}
@@ -622,6 +629,7 @@ status:
 				{
 					"name": "my-svc-my-ns-svc-cluster-local-9c8cbb5bc",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [
 						{
 							"name": "http",
@@ -677,6 +685,7 @@ status:
 				{
 					"name": "dup-svc-ns-svc-cluster-local-6475d67dcb",
 					"hostname": "dup-svc.ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [
 						{"name": "http", "port": 8080, "protocol": "HTTP"},
 						{"name": "grpc", "port": 9090, "protocol": "HTTP2"}
@@ -688,6 +697,7 @@ status:
 				{
 					"name": "unique-svc-ns-svc-cluster-local-6475d67dcb",
 					"hostname": "unique-svc.ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [{"name": "http", "port": 80, "protocol": "HTTP"}],
 					"endpoints": [
 						{"address": "3.3.3.3", "port": 15443}
@@ -752,6 +762,7 @@ status:
 				{
 					"name": "svc-ns-svc-cluster-local-64465b95f6",
 					"hostname": "svc.ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [{"name": "http", "port": 8080, "protocol": "HTTP"}],
 					"endpoints": [
 						{"address": "10.0.0.1", "port": 15443}
@@ -760,6 +771,7 @@ status:
 				{
 					"name": "svc-ns-svc-cluster-local-85bb6b6b89",
 					"hostname": "svc.ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [{"name": "grpc", "port": 9090, "protocol": "HTTP2"}],
 					"endpoints": [
 						{"address": "10.0.0.2", "port": 15443}
@@ -934,6 +946,7 @@ status:
 				{
 					"name": "my-svc-my-ns-svc-cluster-local-55b5c6469d",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [
 						{
 							"name": "websocket",
@@ -955,6 +968,7 @@ status:
 				{
 					"name": "my-svc-my-ns-svc-cluster-local-7f8594896",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [
 						{
 						  "name": "debug",
@@ -976,6 +990,7 @@ status:
 				{
 					"name": "my-svc-my-ns-svc-cluster-local-d797d8d68",
 					"hostname": "my-svc.my-ns.svc.cluster.local",
+					"resolution": "STATIC",
 					"ports": [
 						{
 							"name": "web",

--- a/ee/modules/110-istio/templates/federation/remote-services.yaml
+++ b/ee/modules/110-istio/templates/federation/remote-services.yaml
@@ -17,7 +17,7 @@ spec:
     number: {{ $port.port }}
     protocol: {{ $port.protocol }}
   {{- end }}
-  resolution: STATIC
+  resolution: {{ $svc.resolution | default "STATIC" }}
   endpoints:
   {{- range $endpoint := $svc.endpoints }}
   - address: {{ $endpoint.address | quote }}

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -74,7 +74,7 @@ properties:
         type: array
         default: []
         x-examples:
-        - [{"name": "zzz-xxx-ccc-a1b2c3d4", "hostname": "zzz.xxx.ccc", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "endpoints": [{"address": "1.2.3.4", "port": 15443}]}]
+        - [{"name": "zzz-xxx-ccc-a1b2c3d4", "hostname": "zzz.xxx.ccc", "resolution": "STATIC", "ports": [{"name": "ddd", "port": 2345, "protocol": "TCP"}], "endpoints": [{"address": "1.2.3.4", "port": 15443}]}]
       multiclusters:
         type: array
         default: []


### PR DESCRIPTION
## Description
This change updates Istio federation `ServiceEntry` generation to select `spec.resolution` dynamically based on endpoint addresses instead of always using `STATIC`.

- If all endpoint addresses are valid IPs, resolution is set to STATIC (existing behavior).
- If at least one endpoint address is a hostname/FQDN (or empty), resolution is set to DNS.

No intentional control-plane-wide restarts are introduced by this logic itself; changes affect generated federation ServiceEntry objects.

## Why do we need it, and what problem does it solve?
`alliance.ingressGateway.advertise` already allows hostnames/FQDNs, but generated `ServiceEntry` objects were always rendered with `resolution: STATIC`.
Istio validation requires IP addresses in `endpoints[].address` for `STATIC`, so using FQDNs caused reconciliation failures (for example: `endpoint address "...“ is not a valid IP address`).

This change aligns generated resources with Istio validation rules:
- IP endpoints -> `STATIC`
- FQDN endpoints -> `DNS`

As a result, federation works correctly when advertised ingress addresses are DNS names.

## Why do we need it in the patch release (if we do)?
Without this fix, clusters that configure federation advertise addresses as FQDNs can fail to apply Istio resources and may have broken federation service discovery.
For clusters that use only IP addresses, behavior remains unchanged (`STATIC`)

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Fixed ingressGateway advertise FQDN failing to create a ServiceEntry.
impact_level: default
```
