### PR TITLE
[fix] add fallback for invalid timestamps

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -543,9 +543,9 @@ alerts:
       description: |
         Deckhouse has detected that CronJob `{{$labels.namespace}}/{{$labels.cronjob}}` failed to schedule on time.
 
-        - Current schedule: `{{ printf "kube_cronjob_info{namespace=\"%s\", cronjob=\"%s\"}" $labels.namespace $labels.cronjob | query | first | label "schedule" }}`
-        - Last scheduled time: `{{ printf "kube_cronjob_status_last_schedule_time{namespace=\"%s\", cronjob=\"%s\"}" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp }}%`
-        - Next projected schedule time: `{{ printf "kube_cronjob_next_schedule_time{namespace=\"%s\", cronjob=\"%s\"}" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp }}%`
+        - Current schedule: `{{ printf "kube_cronjob_info{namespace=\"%s\", cronjob=\"%s\"} or vector(0)" $labels.namespace $labels.cronjob | query | first | label "schedule" | reReplaceAll "^$" "unknown" }}`
+        - Last scheduled time: `{{ printf "clamp(kube_cronjob_status_last_schedule_time{namespace=\"%s\", cronjob=\"%s\"}, 0, 2147483647) or vector(0)" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp | reReplaceAll "^1970.+" "unknown" }}`
+        - Next projected schedule time: `{{ printf "clamp(kube_cronjob_next_schedule_time{namespace=\"%s\", cronjob=\"%s\"}, 0, 2147483647) or vector(0)" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp | reReplaceAll "^1970.+" "unknown" }}`
       summary: |
         CronJob {{$labels.namespace}}/{{$labels.cronjob}} failed to schedule on time.
       severity: "6"

--- a/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/propagated-cronjob.yaml
+++ b/modules/340-extended-monitoring/monitoring/prometheus-rules/extended-monitoring/propagated-cronjob.yaml
@@ -125,6 +125,6 @@
       description: |
         Deckhouse has detected that CronJob `{{$labels.namespace}}/{{$labels.cronjob}}` failed to schedule on time.
 
-        - Current schedule: `{{ printf "kube_cronjob_info{namespace=\"%s\", cronjob=\"%s\"}" $labels.namespace $labels.cronjob | query | first | label "schedule" }}`
-        - Last scheduled time: `{{ printf "kube_cronjob_status_last_schedule_time{namespace=\"%s\", cronjob=\"%s\"}" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp }}%`
-        - Next projected schedule time: `{{ printf "kube_cronjob_next_schedule_time{namespace=\"%s\", cronjob=\"%s\"}" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp }}%`
+        - Current schedule: `{{ printf "kube_cronjob_info{namespace=\"%s\", cronjob=\"%s\"} or vector(0)" $labels.namespace $labels.cronjob | query | first | label "schedule" | reReplaceAll "^$" "unknown" }}`
+        - Last scheduled time: `{{ printf "clamp(kube_cronjob_status_last_schedule_time{namespace=\"%s\", cronjob=\"%s\"}, 0, 2147483647) or vector(0)" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp | reReplaceAll "^1970.+" "unknown" }}`
+        - Next projected schedule time: `{{ printf "clamp(kube_cronjob_next_schedule_time{namespace=\"%s\", cronjob=\"%s\"}, 0, 2147483647) or vector(0)" $labels.namespace $labels.cronjob | query | first | value | humanizeTimestamp | reReplaceAll "^1970.+" "unknown" }}`


### PR DESCRIPTION
## Description

Make the CronJobSchedulingError alert description template fault-tolerant: wrap query | first | value | humanizeTimestamp in with/if, fall back to n/a (no data) when the metric is missing and n/a (invalid timestamp) when the value is outside the safe range (> 0 and < 9.2e9).

## Why do we need it, and what problem does it solve?

kube-state-metrics returns -62135596800 (Go zero time) for CronJobs that were never scheduled. humanizeTimestamp multiplies it by 1e9 and overflows int64, so Prometheus spams:

```
Expanding alert template failed ... -6.21355968e+10 cannot be represented as a nanoseconds timestamp since it overflows int64
```

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Made the `CronJobSchedulingError` alert description fault-tolerant when timestamp data was missing or invalid.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
