### PR TITLE
[node-manage] make logs more informative in fencing-agent

### DIFF
--- a/modules/040-node-manager/images/fencing-agent/src/internal/usecase/health_monitor.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/usecase/health_monitor.go
@@ -46,6 +46,8 @@ type NodeWatcher interface {
 
 type Decider interface {
 	ShouldFeed(memberNum int) bool
+	Quorum() int
+	TotalNodes() int
 }
 
 type FallbackDecider interface {
@@ -153,20 +155,25 @@ func (h *HealthMonitor) check(ctx context.Context) {
 
 	numMembers := h.membership.NumMembers()
 
+	quorum := h.decider.Quorum()
+	totalNodes := h.decider.TotalNodes()
+
 	if h.decider.ShouldFeed(numMembers) {
 		if feedErr := h.watchdog.Feed(); feedErr != nil {
 			h.logger.Error("unable to feed watchdog", sl.Err(feedErr))
 		}
-		h.logger.Info("quorum feeding")
+		h.logger.Info("quorum feeding", "members", numMembers, "quorum", quorum, "total_nodes", totalNodes)
 		return
 	}
 	if h.fallback.ShouldFeed(ctx) {
 		if feedErr := h.watchdog.Feed(); feedErr != nil {
 			h.logger.Error("unable to feed watchdog", sl.Err(feedErr))
 		}
-		h.logger.Info("fallback feeding")
+		h.logger.Warn("fallback(k8s api) feeding: quorum lost", "members", numMembers, "quorum", quorum, "total_nodes", totalNodes)
 		return
 	}
+
+	h.logger.Error("watchdog starvation: quorum lost and kubernetes API unreachable", "members", numMembers, "quorum", quorum, "total_nodes", totalNodes)
 }
 
 func (h *HealthMonitor) startWatchdogBackoff(ctx context.Context) error {

--- a/modules/040-node-manager/images/fencing-agent/src/internal/usecase/quorum_decider.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/usecase/quorum_decider.go
@@ -45,6 +45,20 @@ func (qd *QuorumDecider) ShouldFeed(numMembers int) bool {
 	return numMembers >= quorum
 }
 
+func (qd *QuorumDecider) Quorum() int {
+	qd.mtx.RLock()
+	defer qd.mtx.RUnlock()
+
+	return qd.nodesNumber.TotalNodes/2 + 1
+}
+
+func (qd *QuorumDecider) TotalNodes() int {
+	qd.mtx.RLock()
+	defer qd.mtx.RUnlock()
+
+	return qd.nodesNumber.TotalNodes
+}
+
 func (qd *QuorumDecider) SetTotalNodes(nodesNumber domain.NodeGroupState) {
 	qd.mtx.Lock()
 	defer qd.mtx.Unlock()


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Improve health monitor logging in the fencing-agent to provide clear visibility into degraded cluster states.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Improve fencing-agent health monitor logging — warn on fallback feeding, error on watchdog starvation, add diagnostic context to all feeding log messages.
impact: Operators can now detect degraded fencing states (quorum loss, API unreachability) through log levels and diagnostic fields without parsing log messages.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
