### PR TITLE
[cloud-provider-vcd] Add support for hybrid clusters

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
@@ -204,7 +204,7 @@ Before you begin, ensure the following conditions are met:
 
 ### Adding automatically created nodes in VCD
 
-1. Create a `cloud-provider-vcd-mc.yaml` file with the following content:
+1. 1. Create a file, for example `cloud-provider-vcd-mc.yaml`, with a ModuleConfig resource:
 
    ```yaml
    apiVersion: deckhouse.io/v1alpha1
@@ -235,10 +235,20 @@ Before you begin, ensure the following conditions are met:
    - `virtualApplicationName` — the name of the vApp where nodes will be created (e.g., `dkp-vcd-app`).
    - `sshPublicKey` — the SSH public key for node access.
    - `provider.server` — the API URL of your VCD instance.
-   - `provider.apiToken` — the access token of a user with administrator privileges in VCD.
    - `provider.username` — the name of the static user that will be used to interact with VCD.
    - `provider.password` — the password of a user with administrator privileges in VCD.
    - `provider.insecure` — set to `true` if VCD uses a self-signed TLS certificate.
+
+   If a token is used for authentication, specify `apiToken` instead of `username` and `password`:
+
+   ```yaml
+   provider:
+     server: <API_URL>
+     apiToken: <API_TOKEN>
+     username: ""
+     password: ""
+     insecure: false
+   ```
 
 1. Apply the ModuleConfig:
 
@@ -247,17 +257,19 @@ Before you begin, ensure the following conditions are met:
    d8 k get mc cloud-provider-vcd
    ```
 
-1. Edit the `d8-cni-configuration` secret so that the `mode` parameter is determined from `mc cni-cilium` (change `.data.cilium` to `.data.necilium` if necessary).
-
-1. Verify that all pods in the `d8-cloud-provider-vcd` namespace are in the `Running` state:
+1. Make sure all pods in the `d8-cloud-provider-vcd` namespace are in the `Running` state:
 
    ```shell
    d8 k get pods -n d8-cloud-provider-vcd
    ```
 
-1. Reboot the master node and wait for initialization to complete.
+1. Make sure StorageClasses for VCD have been created in the cluster:
 
-1. Create instance classes in VCD:
+   ```shell
+   d8 k get sc
+   ```
+
+1. Create a file, for example `vcd-instanceclass-nodegroup.yaml` with the [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass) and [NodeGroup](/modules/node-manager/cr.html#nodegroup) resources:
 
    ```yaml
    apiVersion: deckhouse.io/v1
@@ -269,16 +281,13 @@ Before you begin, ensure the following conditions are met:
      sizingPolicy: <SIZING_POLICY>
      storageProfile: <STORAGE_PROFILE>
      template: <VAPP_TEMPLATE>
-   ```  
-
-1. Create a [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource:
-
-   ```yaml
+   ---
    apiVersion: deckhouse.io/v1
    kind: NodeGroup
    metadata:
      name: worker
    spec:
+     nodeType: CloudEphemeral
      cloudInstances:
        classReference:
          kind: VCDInstanceClass
@@ -288,11 +297,25 @@ Before you begin, ensure the following conditions are met:
      nodeTemplate:
        labels:
          node-role/worker: ""
-     nodeType: CloudEphemeral
    ```
 
-1. Verify that the required number of nodes has appeared in the cluster:
+1. Apply the manifest:
+
+   ```shell
+   d8 k apply -f vcd-instanceclass-nodegroup.yaml
+   ```
+
+   After the manifest is applied, DKP will start creating virtual machines in VCD managed by the `node-manager` module.
+
+1. Make sure the required number of nodes has appeared in the cluster:
 
    ```shell
    d8 k get nodes -o wide
+   ```
+
+1. If VM creation fails, check the Machine and MachineSet objects and the machine-controller-manager logs:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
    ```

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
@@ -245,76 +245,47 @@ Before you begin, ensure the following conditions are met:
 
 ### Setup
 
-1. Create a configuration file `cloud-provider-vcd-token.yml` with the following content:
+1. Create a `cloud-provider-vcd-mc.yaml` file with the following content:
 
    ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: VCDClusterConfiguration
-   layout: Standard
-   mainNetwork: <NETWORK_NAME>
-   internalNetworkCIDR: <NETWORK_CIDR>
-   organization: <ORGANIZATION>
-   virtualApplicationName: <VAPP_NAME>
-   virtualDataCenter: <VDC_NAME>
-   provider:
-     server: <API_URL>
-     apiToken: <PASSWORD>
-     username: <USER_NAME>
-     insecure: false
-   masterNodeGroup:
-     instanceClass:
-       etcdDiskSizeGb: 10
-       mainNetworkIPAddresses:
-       - 192.168.199.2
-       rootDiskSizeGb: 50
-       sizingPolicy: <SIZING_POLICY>
-       storageProfile: <STORAGE_PROFILE>
-       template: <VAPP_TEMPLATE>
-     replicas: 1
-   sshPublicKey: <SSH_PUBLIC_KEY>
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-vcd
+   spec:
+     version: 1
+     enabled: true
+     settings:
+       mainNetwork: <NETWORK_NAME>
+       organization: <ORGANIZATION>
+       virtualDataCenter: <VDC_NAME>
+       virtualApplicationName: <VAPP_NAME>
+       sshPublicKey: <SSH_PUBLIC_KEY>
+       provider:
+         server: <API_URL>
+         username: <USER_NAME>
+         password: <PASSWORD>
+         apiToken: <API_TOKEN>
+         insecure: false
    ```
 
    Where:
    - `mainNetwork` — the name of the network where cloud nodes will be deployed in your VCD cluster.
-   - `internalNetworkCIDR` — the CIDR of the specified network.
    - `organization` — the name of your VCD organization.
-   - `virtualApplicationName` — the name of the vApp where nodes will be created (e.g., `dkp-vcd-app`).
    - `virtualDataCenter` — the name of the virtual data center.
-   - `template` — the VM template used to create nodes.
-   - `sizingPolicy` and `storageProfile` — corresponding policies configured in VCD.
+   - `virtualApplicationName` — the name of the vApp where nodes will be created (e.g., `dkp-vcd-app`).
+   - `sshPublicKey` — the SSH public key for node access.
    - `provider.server` — the API URL of your VCD instance.
-   - `provider.apiToken` — the access token (password) of a user with administrator privileges in VCD.
+   - `provider.apiToken` — the access token of a user with administrator privileges in VCD.
    - `provider.username` — the name of the static user that will be used to interact with VCD.
-   - `mainNetworkIPAddresses` — a list of IP addresses from the specified network that will be assigned to master nodes.
-   - `storageProfile` — the name of the storage profile defining where the VM disks will be placed.
+   - `provider.password` — the password of a user with administrator privileges in VCD.
+   - `provider.insecure` — set to `true` if VCD uses a self-signed TLS certificate.
 
-1. Encode the `cloud-provider-vcd-token.yml` file in Base64:
-
-   ```shell
-   base64 -i $PWD/cloud-provider-vcd-token.yml
-   ```
-
-1. Create a secret with the following content:
-
-   ```yaml
-   apiVersion: v1
-   data:
-     cloud-provider-cluster-configuration.yaml: <BASE64_STRING_OBTAINED_IN_THE_PREVIOUS_STEP>
-     cloud-provider-discovery-data.json: eyJhcGlWZXJzaW9uIjoiZGVja2hvdXNlLmlvL3YxIiwia2luZCI6IlZDRENsb3VkUHJvdmlkZXJEaXNjb3ZlcnlEYXRhIiwiem9uZXMiOlsiZGVmYXVsdCJdfQo=
-   kind: Secret
-     metadata:
-       labels:
-         heritage: deckhouse
-         name: d8-provider-cluster-configuration
-       name: d8-provider-cluster-configuration
-       namespace: kube-system
-   type: Opaque
-   ```
-
-1. Enable the `cloud-provider-vcd` module:
+1. Apply the `ModuleConfig` with `d8 k`:
 
    ```shell
-   d8 system module enable cloud-provider-vcd
+   d8 k apply -f cloud-provider-vcd-mc.yaml
+   d8 k get mc cloud-provider-vcd
    ```
 
 1. Edit the `d8-cni-configuration` secret so that the `mode` parameter is determined from `mc cni-cilium` (change `.data.cilium` to `.data.necilium` if necessary).

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
@@ -14,60 +14,17 @@ The Deckhouse Kubernetes Platform allows to set a prefix for the names of CloudE
 To do this, use the [`instancePrefix`](/modules/node-manager/configuration.html#parameters-instanceprefix) parameter of the `node-manager` module. The prefix specified in the parameter will be added to the name of all CloudEphemeral nodes added to the cluster. It is not possible to set a prefix for a specific NodeGroup.
 {% endalert %}
 
-## Hybrid cluster with OpenStack
-
-Follow these steps:
-
-1. Remove `flannel` from the `kube-system` namespace:
-
-   ```shell
-   kubectl -n kube-system delete ds flannel-ds
-   ```
-
-1. Configure the integration and set the required parameters.
-1. Create one or more [OpenStackInstanceClass](/modules/cloud-provider-openstack/cr.html#openstackinstanceclass) custom resources.
-1. Create one or more [NodeGroup](/modules/node-manager/cr.html#nodegroup) resources to manage the number and provisioning of cloud-based VMs.
-
-{% alert level="warning" %}
-`Cloud-controller-manager` synchronizes state between OpenStack and Kubernetes,
-removing nodes from Kubernetes that are not present in OpenStack.
-In a hybrid cluster, this behavior is not always desirable.
-Therefore, any Kubernetes node not launched with the `--cloud-provider=external` flag will be automatically ignored.
-DKP automatically sets `static://` in the `.spec.providerID` field of such nodes, which `cloud-controller-manager` then ignores.
-{% endalert %}
-
-### Storage integration
-
-If you require PersistentVolumes on nodes connected to the cluster from OpenStack, you must create a StorageClass with the appropriate OpenStack volume type. You can get a list of available types using the following command:
-
-```shell
-openstack volume type list
-```
-
-Example for `ceph-ssd` volume type:
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: ceph-ssd
-provisioner: csi-cinderplugin # Leave this as shown here.
-parameters:
-  type: ceph-ssd
-volumeBindingMode: WaitForFirstConsumer
-```
-
 ## Hybrid cluster with Yandex Cloud
 
-To create a hybrid cluster combining static nodes and nodes in Yandex Cloud, follow these steps.
+The following section describes how to create a hybrid cluster that combines static (bare-metal) nodes and cloud nodes in Yandex Cloud using Deckhouse Kubernetes Platform (DKP).
 
-### Prerequisites
+### Prerequisites for Yandex Cloud
 
 - A working cluster with the parameter `clusterType: Static`.
 - The CNI controller switched to VXLAN mode. For details, refer to the [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode) parameter.
 - Configured network connectivity between the static cluster node network and VCD (either at L2 level, or at L3 level with port access according to the [required network policies for DKP operation](../../configuration/network/policy/configuration.html)).
 
-### Setup steps
+### Adding automatically created nodes in Yandex Cloud
 
 1. Create a Service Account in the required Yandex Cloud folder:
 
@@ -230,6 +187,8 @@ To create a hybrid cluster combining static nodes and nodes in Yandex Cloud, fol
 
 This section describes the process of creating a hybrid cluster that combines static (bare-metal) nodes and cloud nodes in VMware vCloud Director (VCD) using Deckhouse Kubernetes Platform (DKP).
 
+### Prerequisites for VCD
+
 Before you begin, ensure the following conditions are met:
 
 - **Infrastructure**:
@@ -243,7 +202,7 @@ Before you begin, ensure the following conditions are met:
   - The CNI controller is switched to VXLAN mode. More details — [`tunnelMode` configuration](/modules/cni-cilium/configuration.html#parameters-tunnelmode).
   - A [list of required VCD resources](../virtualization/vcd/connection-and-authorization.html) is prepared (VDC, VAPP, templates, policies, etc.).
 
-### Setup
+### Adding automatically created nodes in VCD
 
 1. Create a `cloud-provider-vcd-mc.yaml` file with the following content:
 
@@ -281,7 +240,7 @@ Before you begin, ensure the following conditions are met:
    - `provider.password` — the password of a user with administrator privileges in VCD.
    - `provider.insecure` — set to `true` if VCD uses a self-signed TLS certificate.
 
-1. Apply the `ModuleConfig` with `d8 k`:
+1. Apply the ModuleConfig:
 
    ```shell
    d8 k apply -f cloud-provider-vcd-mc.yaml

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
@@ -13,56 +13,17 @@ Deckhouse Kubernetes Platform (DKP) имеет возможность испол
 Для этого используйте параметр [`instancePrefix`](/modules/node-manager/configuration.html#parameters-instanceprefix) модуля `node-manager`. Префикс, указанный в параметре, будет добавляться к имени всех добавляемых в кластер узлов типа CloudEphemeral. Задать префикс для определенной NodeGroup нельзя.
 {% endalert %}
 
-## Гибридный кластер с OpenStack
-
-Выполните следующие шаги:
-
-1. Удалите `flannel` из `kube-system`:
-
-   ```shell
-   d8 k -n kube-system delete ds flannel-ds
-   ```
-
-2. Настройте интеграцию и пропишите необходимые для работы параметры.
-3. Создайте один или несколько кастомных ресурсов [OpenStackInstanceClass](/modules/cloud-provider-openstack/cr.html#openstackinstanceclass).
-4. Создайте один или несколько кастомных ресурсов [NodeGroup](/modules/node-manager/cr.html#nodegroup) для управления количеством и процессом заказа машин в облаке.
-
-{% alert level="warning" %}
-`Cloud-controller-manager` синхронизирует состояние между OpenStack и Kubernetes, удаляя из Kubernetes те узлы, которых нет в OpenStack. В гибридном кластере такое поведение не всегда соответствует потребности, поэтому, если узел Kubernetes запущен не с параметром `--cloud-provider=external`, он автоматически игнорируется (DKP прописывает `static://` на узлы в `.spec.providerID`, а `cloud-controller-manager` такие узлы игнорирует).
-{% endalert %}
-
-### Подключение storage
-
-Если вам требуются PersistentVolumes на узлах, подключаемых к кластеру из OpenStack, необходимо создать StorageClass с нужным OpenStack volume type. Получить список типов можно с помощью следующей команды:
-
-```shell
-openstack volume type list
-```
-
-Например, для volume type `ceph-ssd`:
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: ceph-ssd
-provisioner: csi-cinderplugin # Обязательно должно быть так.
-parameters:
-  type: ceph-ssd
-volumeBindingMode: WaitForFirstConsumer
-```
-
 ## Гибридный кластер с Yandex Cloud
 
-Для создания гибридного кластера, объединяющего статические узлы и узлы в Yandex Cloud, выполните описанные далее шаги.
+Далее описан процесс создания гибридного кластера, объединяющего статические (bare-metal) узлы и облачные узлы в Yandex Cloud с использованием Deckhouse Kubernetes Platform (DKP).
 
-### Предварительные требования
+### Предварительные требования для Yandex Cloud
 
 - Рабочий кластер с параметром `clusterType: Static`.
 - Контроллер CNI переведён в режим VXLAN. Подробнее — [настройка `tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode).
 - Настроенная сетевая связность между Yandex Cloud и сетью узлов статического кластера согласно [необходимым сетевым политикам для работы DKP](../../configuration/network/policy/configuration.html).
 
-### Шаги по настройке
+### Добавление автоматически создаваемых узлов в Yandex Cloud
 
 1. Создайте Service Account в нужном каталоге Yandex Cloud:
 
@@ -225,7 +186,7 @@ volumeBindingMode: WaitForFirstConsumer
 
 Далее описан процесс создания гибридного кластера, объединяющего статические (bare-metal) узлы и облачные узлы в VMware vCloud Director (VCD) с использованием Deckhouse Kubernetes Platform (DKP).
 
-### Предварительные требования
+### Предварительные требования для VCD
 
 Перед началом убедитесь, что выполнены следующие условия:
 
@@ -240,7 +201,7 @@ volumeBindingMode: WaitForFirstConsumer
   - Контроллер CNI переведён в режим VXLAN. Подробнее — [настройка `tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode).
   - Подготовлен [список необходимых ресурсов VCD](../virtualization/vcd/connection-and-authorization.html) (VDC, VAPP, шаблоны, политики и т.д.).
 
-### Настройка
+### Добавление автоматически создаваемых узлов в VCD
 
 1. Создайте файл `cloud-provider-vcd-mc.yaml` со следующим содержимым:
 
@@ -278,7 +239,7 @@ volumeBindingMode: WaitForFirstConsumer
    - `provider.password` — пароль пользователя с правами администратора в VCD.
    - `provider.insecure` — установите значение `true`, если VCD использует самоподписанный TLS-сертификат.
 
-1. Примените `ModuleConfig` через `d8 k`:
+1. Примените ModuleConfig:
 
    ```shell
    d8 k apply -f cloud-provider-vcd-mc.yaml

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
@@ -225,6 +225,8 @@ volumeBindingMode: WaitForFirstConsumer
 
 Далее описан процесс создания гибридного кластера, объединяющего статические (bare-metal) узлы и облачные узлы в VMware vCloud Director (VCD) с использованием Deckhouse Kubernetes Platform (DKP).
 
+### Предварительные требования
+
 Перед началом убедитесь, что выполнены следующие условия:
 
 - **Инфраструктура**:
@@ -240,76 +242,47 @@ volumeBindingMode: WaitForFirstConsumer
 
 ### Настройка
 
-1. Создайте файл конфигурации `cloud-provider-vcd-token.yml` со следующим содержимым:
+1. Создайте файл `cloud-provider-vcd-mc.yaml` со следующим содержимым:
 
    ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: VCDClusterConfiguration
-   layout: Standard
-   mainNetwork: <NETWORK_NAME>
-   internalNetworkCIDR: <NETWORK_CIDR>
-   organization: <ORGANIZATION>
-   virtualApplicationName: <VAPP_NAME>
-   virtualDataCenter: <VDC_NAME>
-   provider:
-     server: <API_URL>
-     apiToken: <PASSWORD>
-     username: <USER_NAME>
-     insecure: false
-   masterNodeGroup:
-     instanceClass:
-       etcdDiskSizeGb: 10
-       mainNetworkIPAddresses:
-       - 192.168.199.2
-       rootDiskSizeGb: 50
-       sizingPolicy: <SIZING_POLICY>
-       storageProfile: <STORAGE_PROFILE>
-       template: <VAPP_TEMPLATE>
-     replicas: 1
-   sshPublicKey: <SSH_PUBLIC_KEY>
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-vcd
+   spec:
+     version: 1
+     enabled: true
+     settings:
+       mainNetwork: <NETWORK_NAME>
+       organization: <ORGANIZATION>
+       virtualDataCenter: <VDC_NAME>
+       virtualApplicationName: <VAPP_NAME>
+       sshPublicKey: <SSH_PUBLIC_KEY>
+       provider:
+         server: <API_URL>
+         username: <USER_NAME>
+         password: <PASSWORD>
+         apiToken: <API_TOKEN>
+         insecure: false
    ```
 
    Где:
    - `mainNetwork` — имя сети, в которой будут размещаться облачные узлы в кластере VCD.
-   - `internalNetworkCIDR` — CIDR-адресация указанной сети.
    - `organization` — название вашей организации в VCD.
-   - `virtualApplicationName` — имя vApp, где будут создаваться узлы (например, `dkp-vcd-app`).
    - `virtualDataCenter` — имя виртуального датацентра.
-   - `template` — шаблон ВМ для создания узлов.
-   - `sizingPolicy` и `storageProfile` — соответствующие политики в VCD.
+   - `virtualApplicationName` — имя vApp, где будут создаваться узлы (например, `dkp-vcd-app`).
+   - `sshPublicKey` — публичный SSH-ключ для доступа к узлам.
    - `provider.server` — URL-адрес API вашего VCD.
-   - `provider.apiToken` — токен доступа (пароль) пользователя с правами администратора в VCD.
+   - `provider.apiToken` — токен доступа пользователя с правами администратора в VCD.
    - `provider.username` — имя статического пользователя, от имени которого будет происходить взаимодействие с VCD.
-   - `mainNetworkIPAddresses` — список IP-адресов из указанной сети, которые будут выделены для master-узлов.
-   - `storageProfile` — имя storage-профиля, определяющего хранилище для дисков создаваемых ВМ.
+   - `provider.password` — пароль пользователя с правами администратора в VCD.
+   - `provider.insecure` — установите значение `true`, если VCD использует самоподписанный TLS-сертификат.
 
-1. Закодируйте файл `cloud-provider-vcd-token.yml` в Base64:
-
-   ```shell
-   base64 -i $PWD/cloud-provider-vcd-token.yml
-   ```
-
-1. Создайте секрет со следующим содержимым:
-
-   ```yaml
-   apiVersion: v1
-   data:
-     cloud-provider-cluster-configuration.yaml: <BASE64_СТРОКА_ПОЛУЧЕННАЯ_НА_ПРЕДЫДУЩЕМ_ЭТАПЕ> 
-     cloud-provider-discovery-data.json: eyJhcGlWZXJzaW9uIjoiZGVja2hvdXNlLmlvL3YxIiwia2luZCI6IlZDRENsb3VkUHJvdmlkZXJEaXNjb3ZlcnlEYXRhIiwiem9uZXMiOlsiZGVmYXVsdCJdfQo=
-   kind: Secret
-     metadata:
-       labels:
-         heritage: deckhouse
-         name: d8-provider-cluster-configuration
-       name: d8-provider-cluster-configuration
-       namespace: kube-system
-   type: Opaque
-   ```
-
-1. Включите модуль `cloud-provider-vcd`:
+1. Примените `ModuleConfig` через `d8 k`:
 
    ```shell
-   d8 system module enable cloud-provider-vcd
+   d8 k apply -f cloud-provider-vcd-mc.yaml
+   d8 k get mc cloud-provider-vcd
    ```
 
 1. Отредактируйте секрет `d8-cni-configuration`, чтобы значение параметра `mode` определялось из `mc cni-cilium` (измените `.data.cilium` на `.data.necilium` при необходимости).

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
@@ -269,7 +269,7 @@ volumeBindingMode: WaitForFirstConsumer
    Где:
    - `mainNetwork` — имя сети, в которой будут размещаться облачные узлы в кластере VCD.
    - `organization` — название вашей организации в VCD.
-   - `virtualDataCenter` — имя виртуального датацентра.
+   - `virtualDataCenter` — имя виртуального дата-центра.
    - `virtualApplicationName` — имя vApp, где будут создаваться узлы (например, `dkp-vcd-app`).
    - `sshPublicKey` — публичный SSH-ключ для доступа к узлам.
    - `provider.server` — URL-адрес API вашего VCD.

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
@@ -203,7 +203,7 @@ Deckhouse Kubernetes Platform (DKP) имеет возможность испол
 
 ### Добавление автоматически создаваемых узлов в VCD
 
-1. Создайте файл `cloud-provider-vcd-mc.yaml` со следующим содержимым:
+1. Создайте файл, например, `cloud-provider-vcd-mc.yaml` с ресурсом ModuleConfig:
 
    ```yaml
    apiVersion: deckhouse.io/v1alpha1
@@ -223,7 +223,6 @@ Deckhouse Kubernetes Platform (DKP) имеет возможность испол
          server: <API_URL>
          username: <USER_NAME>
          password: <PASSWORD>
-         apiToken: <API_TOKEN>
          insecure: false
    ```
 
@@ -234,10 +233,20 @@ Deckhouse Kubernetes Platform (DKP) имеет возможность испол
    - `virtualApplicationName` — имя vApp, где будут создаваться узлы (например, `dkp-vcd-app`).
    - `sshPublicKey` — публичный SSH-ключ для доступа к узлам.
    - `provider.server` — URL-адрес API вашего VCD.
-   - `provider.apiToken` — токен доступа пользователя с правами администратора в VCD.
    - `provider.username` — имя статического пользователя, от имени которого будет происходить взаимодействие с VCD.
    - `provider.password` — пароль пользователя с правами администратора в VCD.
    - `provider.insecure` — установите значение `true`, если VCD использует самоподписанный TLS-сертификат.
+
+   Если для аутентификации используется токен, вместо `username` и `password` укажите `apiToken`:
+
+   ```yaml
+   provider:
+     server: <API_URL>
+     apiToken: <API_TOKEN>
+     username: ""
+     password: ""
+     insecure: false
+   ```
 
 1. Примените ModuleConfig:
 
@@ -246,17 +255,19 @@ Deckhouse Kubernetes Platform (DKP) имеет возможность испол
    d8 k get mc cloud-provider-vcd
    ```
 
-1. Отредактируйте секрет `d8-cni-configuration`, чтобы значение параметра `mode` определялось из `mc cni-cilium` (измените `.data.cilium` на `.data.necilium` при необходимости).
-
 1. Убедитесь, что все поды в пространстве имён `d8-cloud-provider-vcd` находятся в состоянии `Running`:
 
    ```shell
    d8 k get pods -n d8-cloud-provider-vcd
    ```
 
-1. Перезагрузите master-узел и дождитесь завершения инициализации.
+1. Убедитесь, что в кластере созданы StorageClass для VCD:
 
-1. Создайте классы инстансов в VCD:
+   ```shell
+   d8 k get sc
+   ```
+
+1. Создайте файл, например, `vcd-instanceclass-nodegroup.yaml` с ресурсами [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass) и [NodeGroup](/modules/node-manager/cr.html#nodegroup):
 
    ```yaml
    apiVersion: deckhouse.io/v1
@@ -268,16 +279,13 @@ Deckhouse Kubernetes Platform (DKP) имеет возможность испол
      sizingPolicy: <SIZING_POLICY>
      storageProfile: <STORAGE_PROFILE>
      template: <VAPP_TEMPLATE>
-   ```  
-
-1. Создайте ресурс [NodeGroup](/modules/node-manager/cr.html#nodegroup):
-
-   ```yaml
+   ---
    apiVersion: deckhouse.io/v1
    kind: NodeGroup
    metadata:
      name: worker
    spec:
+     nodeType: CloudEphemeral
      cloudInstances:
        classReference:
          kind: VCDInstanceClass
@@ -287,11 +295,25 @@ Deckhouse Kubernetes Platform (DKP) имеет возможность испол
      nodeTemplate:
        labels:
          node-role/worker: ""
-     nodeType: CloudEphemeral
    ```
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f vcd-instanceclass-nodegroup.yaml
+   ```
+
+   После применения манифеста DKP начнёт создавать виртуальные машины в VCD, управляемые модулем `node-manager`.
 
 1. Убедитесь, что в кластере появилось требуемое количество узлов:
 
    ```shell
    d8 k get nodes -o wide
+   ```
+
+1. При сбоях создания ВМ проверьте объекты Machine, MachineSet и логи machine-controller-manager:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
    ```

--- a/ee/modules/030-cloud-provider-vcd/hooks/discover.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/discover.go
@@ -135,7 +135,7 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 		return fmt.Errorf("failed to unmarshal 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: %v", err)
 	}
 
-	input.Values.Set("cloudProviderVcd.internal.discoveryData", discoveryData)
+	input.Values.Set("cloudProviderVcd.internal.providerDiscoveryData", discoveryData)
 
 	handleDiscoveryDataVolumeTypes(input, discoveryData.StorageProfiles)
 

--- a/ee/modules/030-cloud-provider-vcd/hooks/discover.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/discover.go
@@ -25,7 +25,7 @@ import (
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
-	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
+	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -129,7 +129,7 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 		return fmt.Errorf("failed to validate 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: %v", err)
 	}
 
-	var discoveryData v1alpha1.VCDCloudProviderDiscoveryData
+	var discoveryData cloudDataV1.VCDCloudProviderDiscoveryData
 	err = json.Unmarshal(discoveryDataJSON, &discoveryData)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal 'discovery-data.json' from 'd8-cloud-provider-discovery-data' secret: %v", err)
@@ -142,7 +142,7 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 	return nil
 }
 
-func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, volumeTypes []v1alpha1.VCDStorageProfile) {
+func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, volumeTypes []cloudDataV1.VCDStorageProfile) {
 	volumeTypesMap := make(map[string]string, len(volumeTypes))
 
 	for _, volumeType := range volumeTypes {

--- a/ee/modules/030-cloud-provider-vcd/hooks/internal/v1/module_config.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/internal/v1/module_config.go
@@ -1,0 +1,16 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package v1
+
+type VCDModuleConfig struct {
+	Provider               *VCDProvider      `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Organization           string            `json:"organization,omitempty" yaml:"organization,omitempty"`
+	VirtualDataCenter      string            `json:"virtualDataCenter,omitempty" yaml:"virtualDataCenter,omitempty"`
+	VirtualApplicationName string            `json:"virtualApplicationName,omitempty" yaml:"virtualApplicationName,omitempty"`
+	MainNetwork            string            `json:"mainNetwork,omitempty" yaml:"mainNetwork,omitempty"`
+	SSHPublicKey           string            `json:"sshPublicKey,omitempty" yaml:"sshPublicKey,omitempty"`
+	Metadata               map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}

--- a/ee/modules/030-cloud-provider-vcd/hooks/internal/v1/provider_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/internal/v1/provider_cluster_configuration.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package v1
+
+type VCDProviderClusterConfiguration struct {
+	APIVersion                          *string           `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty"`
+	Kind                                *string           `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Layout                              *string           `json:"layout,omitempty" yaml:"layout,omitempty"`
+	Provider                            *VCDProvider      `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Organization                        *string           `json:"organization,omitempty" yaml:"organization,omitempty"`
+	VirtualDataCenter                   *string           `json:"virtualDataCenter,omitempty" yaml:"virtualDataCenter,omitempty"`
+	VirtualApplicationName              *string           `json:"virtualApplicationName,omitempty" yaml:"virtualApplicationName,omitempty"`
+	Bastion                             any               `json:"bastion,omitempty" yaml:"bastion,omitempty"`
+	MasterNodeGroup                     any               `json:"masterNodeGroup,omitempty" yaml:"masterNodeGroup,omitempty"`
+	NodeGroups                          []any             `json:"nodeGroups,omitempty" yaml:"nodeGroups,omitempty"`
+	EdgeGateway                         any               `json:"edgeGateway,omitempty" yaml:"edgeGateway,omitempty"`
+	CreateDefaultFirewallRules          *bool             `json:"createDefaultFirewallRules,omitempty" yaml:"createDefaultFirewallRules,omitempty"`
+	MainNetwork                         *string           `json:"mainNetwork,omitempty" yaml:"mainNetwork,omitempty"`
+	InternalNetworkCIDR                 *string           `json:"internalNetworkCIDR,omitempty" yaml:"internalNetworkCIDR,omitempty"`
+	InternalNetworkDNSServers           []string          `json:"internalNetworkDNSServers,omitempty" yaml:"internalNetworkDNSServers,omitempty"`
+	InternalNetworkDHCPPoolStartAddress *int              `json:"internalNetworkDHCPPoolStartAddress,omitempty" yaml:"internalNetworkDHCPPoolStartAddress,omitempty"`
+	SSHPublicKey                        *string           `json:"sshPublicKey,omitempty" yaml:"sshPublicKey,omitempty"`
+	LegacyMode                          *bool             `json:"legacyMode,omitempty" yaml:"legacyMode,omitempty"`
+	Metadata                            map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
+type VCDProvider struct {
+	Server   *string `json:"server,omitempty" yaml:"server,omitempty"`
+	Username *string `json:"username,omitempty" yaml:"username,omitempty"`
+	Password *string `json:"password,omitempty" yaml:"password,omitempty"`
+	APIToken *string `json:"apiToken,omitempty" yaml:"apiToken,omitempty"`
+	Insecure *bool   `json:"insecure,omitempty" yaml:"insecure,omitempty"`
+}
+
+func (p VCDProvider) IsEmpty() bool {
+	if p.Server != nil {
+		return false
+	}
+	if p.Username != nil {
+		return false
+	}
+	if p.Password != nil {
+		return false
+	}
+	if p.APIToken != nil {
+		return false
+	}
+	if p.Insecure != nil {
+		return false
+	}
+
+	return true
+}

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
@@ -9,14 +9,15 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud/vcd"
 	v1 "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-vcd/hooks/internal/v1"
 	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/cluster_configuration"
-	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
-	"github.com/flant/addon-operator/sdk"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func preparatorProvider(_ string) config.MetaConfigPreparator {

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
@@ -87,7 +87,7 @@ var _ = cluster_configuration.RegisterHook(
 			discoveryData = mergeDiscoveryData(currentDiscoveryData, discoveryData)
 		}
 
-		discoveryData = setDiscoveryDataDefaults(discoveryData)
+		discoveryData.SetDefaults()
 		input.Values.Set("cloudProviderVcd.internal.providerDiscoveryData", discoveryData)
 
 		return nil
@@ -237,20 +237,3 @@ func mergeDiscoveryData(
 	return result
 }
 
-func setDiscoveryDataDefaults(
-	value cloudDataV1.VCDCloudProviderDiscoveryData,
-) cloudDataV1.VCDCloudProviderDiscoveryData {
-	result := value
-
-	if result.APIVersion == "" {
-		result.APIVersion = "deckhouse.io/v1"
-	}
-	if result.Kind == "" {
-		result.Kind = "VCDCloudProviderDiscoveryData"
-	}
-	if len(result.Zones) == 0 {
-		result.Zones = []string{"default"}
-	}
-
-	return result
-}

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
@@ -6,37 +6,232 @@ Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https
 package hooks
 
 import (
-	"fmt"
+	"encoding/json"
+	"errors"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud/vcd"
+	v1 "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-vcd/hooks/internal/v1"
+	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/cluster_configuration"
 )
 
 func preparatorProvider(_ string) config.MetaConfigPreparator {
-	return vcd.NewMetaConfigPreparatorWithoutLogger(vcd.MetaConfigPreparatorParams{
-		// todo it was bad idea patch metaconfig during installation
-		// we need to prepare meta config in dhctl during installation
-		// for checking vcd version
-		// we do not want to prepare metaconfig here because we already got prepared
-		// after installation during first deckhouse converge and legacy mode will get
-		// in legacy_mode.go hook with order 10, this hook has 20 order index
-		// after first converge we deploy vcd data discoverer and hook legacy_mode.go
-		// directory form data discoverer
-		PrepareMetaConfig: false,
-		// cluster prefix does not provide here
-		ValidateClusterPrefix: false,
-	})
+	return vcd.NewMetaConfigPreparatorWithoutLogger(
+		vcd.MetaConfigPreparatorParams{
+			// todo it was bad idea patch metaconfig during installation
+			// we need to prepare meta config in dhctl during installation
+			// for checking vcd version
+			// we do not want to prepare metaconfig here because we already got prepared
+			// after installation during first deckhouse converge and legacy mode will get
+			// in legacy_mode.go hook with order 10, this hook has 20 order index
+			// after first converge we deploy vcd data discoverer and hook legacy_mode.go
+			// directory form data discoverer
+			PrepareMetaConfig: false,
+			// cluster prefix does not provide here
+			ValidateClusterPrefix: false,
+		},
+	)
 }
 
-var _ = cluster_configuration.RegisterHook(func(input *go_hook.HookInput, metaCfg *config.MetaConfig, providerDiscoveryData *unstructured.Unstructured, secretFound bool) error {
-	if !secretFound {
-		return fmt.Errorf("kube-system/d8-provider-cluster-configuration secret not found")
+var _ = cluster_configuration.RegisterHook(
+	func(
+		input *go_hook.HookInput, metaCfg *config.MetaConfig, providerDiscoveryData *unstructured.Unstructured,
+		_ bool,
+	) error {
+		p := make(map[string]json.RawMessage)
+		if metaCfg != nil {
+			p = metaCfg.ProviderClusterConfig
+		}
+
+		var providerClusterConfiguration v1.VCDProviderClusterConfiguration
+		err := convertJSONRawMessageToStruct(p, &providerClusterConfiguration)
+		if err != nil {
+			return err
+		}
+
+		var moduleConfig v1.VCDModuleConfig
+		err = json.Unmarshal([]byte(input.Values.Get("cloudProviderVcd").String()), &moduleConfig)
+		if err != nil {
+			return err
+		}
+
+		overrideProviderClusterConfig(&providerClusterConfiguration, &moduleConfig)
+
+		err = validateProviderClusterConfig(providerClusterConfiguration)
+		if err != nil {
+			return err
+		}
+		input.Values.Set("cloudProviderVcd.internal.providerClusterConfiguration", providerClusterConfiguration)
+
+		var discoveryData cloudDataV1.VCDCloudProviderDiscoveryData
+		if providerDiscoveryData != nil {
+			err := sdk.FromUnstructured(providerDiscoveryData, &discoveryData)
+			if err != nil {
+				return err
+			}
+		}
+
+		providerDiscoveryDataValuesJSON, ok := input.Values.GetOk("cloudProviderVcd.internal.providerDiscoveryData")
+		if ok && len(providerDiscoveryDataValuesJSON.String()) != 0 {
+			var currentDiscoveryData cloudDataV1.VCDCloudProviderDiscoveryData
+			err = json.Unmarshal([]byte(providerDiscoveryDataValuesJSON.String()), &currentDiscoveryData)
+			if err != nil {
+				return err
+			}
+
+			discoveryData = mergeDiscoveryData(currentDiscoveryData, discoveryData)
+		}
+
+		input.Values.Set("cloudProviderVcd.internal.providerDiscoveryData", discoveryData)
+
+		return nil
+	}, cluster_configuration.NewConfig(preparatorProvider),
+)
+
+func convertJSONRawMessageToStruct(in map[string]json.RawMessage, out interface{}) error {
+	b, err := json.Marshal(in)
+	if err != nil {
+		return err
 	}
-	input.Values.Set("cloudProviderVcd.internal.providerClusterConfiguration", metaCfg.ProviderClusterConfig)
-	input.Values.Set("cloudProviderVcd.internal.providerDiscoveryData", providerDiscoveryData.Object)
+	return json.Unmarshal(b, out)
+}
+
+func overrideProviderClusterConfig(
+	providerClusterConfig *v1.VCDProviderClusterConfiguration,
+	moduleConfig *v1.VCDModuleConfig,
+) {
+	if moduleConfig.Provider != nil && !moduleConfig.Provider.IsEmpty() {
+		if providerClusterConfig.Provider == nil {
+			providerClusterConfig.Provider = &v1.VCDProvider{}
+		}
+		if moduleConfig.Provider.Server != nil {
+			providerClusterConfig.Provider.Server = moduleConfig.Provider.Server
+		}
+		if moduleConfig.Provider.Username != nil {
+			providerClusterConfig.Provider.Username = moduleConfig.Provider.Username
+		}
+		if moduleConfig.Provider.Password != nil {
+			providerClusterConfig.Provider.Password = moduleConfig.Provider.Password
+		}
+		if moduleConfig.Provider.APIToken != nil {
+			providerClusterConfig.Provider.APIToken = moduleConfig.Provider.APIToken
+		}
+		if moduleConfig.Provider.Insecure != nil {
+			providerClusterConfig.Provider.Insecure = moduleConfig.Provider.Insecure
+		}
+	}
+	if len(moduleConfig.Organization) > 0 {
+		providerClusterConfig.Organization = &moduleConfig.Organization
+	}
+	if len(moduleConfig.VirtualDataCenter) > 0 {
+		providerClusterConfig.VirtualDataCenter = &moduleConfig.VirtualDataCenter
+	}
+	if len(moduleConfig.VirtualApplicationName) > 0 {
+		providerClusterConfig.VirtualApplicationName = &moduleConfig.VirtualApplicationName
+	}
+	if len(moduleConfig.MainNetwork) > 0 {
+		providerClusterConfig.MainNetwork = &moduleConfig.MainNetwork
+	}
+	if len(moduleConfig.SSHPublicKey) > 0 {
+		providerClusterConfig.SSHPublicKey = &moduleConfig.SSHPublicKey
+	}
+	if len(moduleConfig.Metadata) > 0 {
+		providerClusterConfig.Metadata = moduleConfig.Metadata
+	}
+
+	if len(providerClusterConfig.Metadata) == 0 {
+		providerClusterConfig.Metadata = make(map[string]string)
+	}
+}
+
+func validateProviderClusterConfig(providerClusterConfig v1.VCDProviderClusterConfiguration) error {
+	if providerClusterConfig.Provider == nil {
+		return errors.New("provider section is required")
+	}
+
+	hasAPIToken := providerClusterConfig.Provider.APIToken != nil && len(*providerClusterConfig.Provider.APIToken) > 0
+	hasUsername := providerClusterConfig.Provider.Username != nil && len(*providerClusterConfig.Provider.Username) > 0
+	hasPassword := providerClusterConfig.Provider.Password != nil && len(*providerClusterConfig.Provider.Password) > 0
+	hasUserPass := hasUsername || hasPassword
+
+	if hasAPIToken && hasUserPass {
+		return errors.New("provider authentication must use either apiToken or username/password")
+	}
+	if !hasAPIToken && !hasUserPass {
+		return errors.New("provider.apiToken or provider.username/provider.password should be set")
+	}
+	if !hasAPIToken && (!hasUsername || !hasPassword) {
+		return errors.New("both provider.username and provider.password should be set")
+	}
+
+	if providerClusterConfig.Provider.Server == nil || len(*providerClusterConfig.Provider.Server) == 0 {
+		return errors.New("provider.server cannot be empty")
+	}
+	if providerClusterConfig.Organization == nil || len(*providerClusterConfig.Organization) == 0 {
+		return errors.New("organization cannot be empty")
+	}
+	if providerClusterConfig.VirtualDataCenter == nil || len(*providerClusterConfig.VirtualDataCenter) == 0 {
+		return errors.New("virtualDataCenter cannot be empty")
+	}
+	if providerClusterConfig.VirtualApplicationName == nil || len(*providerClusterConfig.VirtualApplicationName) == 0 {
+		return errors.New("virtualApplicationName cannot be empty")
+	}
+	if providerClusterConfig.MainNetwork == nil || len(*providerClusterConfig.MainNetwork) == 0 {
+		return errors.New("mainNetwork cannot be empty")
+	}
+
+	cloudManaged := providerClusterConfig.APIVersion != nil || providerClusterConfig.Kind != nil
+	if cloudManaged {
+		if providerClusterConfig.APIVersion == nil || len(*providerClusterConfig.APIVersion) == 0 {
+			return errors.New("apiVersion cannot be empty")
+		}
+		if providerClusterConfig.Kind == nil || len(*providerClusterConfig.Kind) == 0 {
+			return errors.New("kind cannot be empty")
+		}
+	}
+
 	return nil
-}, cluster_configuration.NewConfig(preparatorProvider))
+}
+
+func mergeDiscoveryData(
+	currentValue cloudDataV1.VCDCloudProviderDiscoveryData,
+	newValue cloudDataV1.VCDCloudProviderDiscoveryData,
+) cloudDataV1.VCDCloudProviderDiscoveryData {
+	result := currentValue
+
+	if newValue.APIVersion != "" && currentValue.APIVersion == "" {
+		result.APIVersion = newValue.APIVersion
+	}
+	if newValue.Kind != "" && currentValue.Kind == "" {
+		result.Kind = newValue.Kind
+	}
+	if len(newValue.SizingPolicies) > 0 && len(currentValue.SizingPolicies) == 0 {
+		result.SizingPolicies = newValue.SizingPolicies
+	}
+	if len(newValue.StorageProfiles) > 0 && len(currentValue.StorageProfiles) == 0 {
+		result.StorageProfiles = newValue.StorageProfiles
+	}
+	if len(newValue.InternalNetworks) > 0 && len(currentValue.InternalNetworks) == 0 {
+		result.InternalNetworks = newValue.InternalNetworks
+	}
+	if len(newValue.Zones) > 0 && len(currentValue.Zones) == 0 {
+		result.Zones = newValue.Zones
+	}
+	if newValue.VCDAPIVersion != "" && currentValue.VCDAPIVersion == "" {
+		result.VCDAPIVersion = newValue.VCDAPIVersion
+	}
+	if newValue.VCDInstallationVersion != "" && currentValue.VCDInstallationVersion == "" {
+		result.VCDInstallationVersion = newValue.VCDInstallationVersion
+	}
+	if newValue.LoadBalancer != nil && currentValue.LoadBalancer == nil {
+		result.LoadBalancer = new(cloudDataV1.VCDLoadBalancer)
+		result.LoadBalancer.Enabled = newValue.LoadBalancer.Enabled
+	}
+
+	return result
+}

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
@@ -87,6 +87,7 @@ var _ = cluster_configuration.RegisterHook(
 			discoveryData = mergeDiscoveryData(currentDiscoveryData, discoveryData)
 		}
 
+		discoveryData = setDiscoveryDataDefaults(discoveryData)
 		input.Values.Set("cloudProviderVcd.internal.providerDiscoveryData", discoveryData)
 
 		return nil
@@ -232,6 +233,14 @@ func mergeDiscoveryData(
 		result.LoadBalancer = new(cloudDataV1.VCDLoadBalancer)
 		result.LoadBalancer.Enabled = newValue.LoadBalancer.Enabled
 	}
+
+	return result
+}
+
+func setDiscoveryDataDefaults(
+	value cloudDataV1.VCDCloudProviderDiscoveryData,
+) cloudDataV1.VCDCloudProviderDiscoveryData {
+	result := value
 
 	if result.APIVersion == "" {
 		result.APIVersion = "deckhouse.io/v1"

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
@@ -233,5 +233,15 @@ func mergeDiscoveryData(
 		result.LoadBalancer.Enabled = newValue.LoadBalancer.Enabled
 	}
 
+	if result.APIVersion == "" {
+		result.APIVersion = "deckhouse.io/v1"
+	}
+	if result.Kind == "" {
+		result.Kind = "VCDCloudProviderDiscoveryData"
+	}
+	if len(result.Zones) == 0 {
+		result.Zones = []string{"default"}
+	}
+
 	return result
 }

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration.go
@@ -9,15 +9,14 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
-	"github.com/flant/addon-operator/sdk"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud/vcd"
 	v1 "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-vcd/hooks/internal/v1"
 	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/cluster_configuration"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func preparatorProvider(_ string) config.MetaConfigPreparator {
@@ -236,4 +235,3 @@ func mergeDiscoveryData(
 
 	return result
 }
-

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration_test.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	v1 "github.com/deckhouse/deckhouse/ee/modules/030-cloud-provider-vcd/hooks/internal/v1"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
@@ -24,6 +25,136 @@ global:
 cloudProviderVcd:
   internal: {}
 `
+		hybridValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+    username: module-user
+    password: module-password
+    insecure: false
+  organization: module-org
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  sshPublicKey: module-ssh-key
+  metadata:
+    env: test
+    owner: qa
+  internal:
+    providerDiscoveryData:
+      apiVersion: deckhouse.io/v1
+      kind: VCDCloudProviderDiscoveryData
+      zones:
+      - zone-a
+      - zone-b
+`
+		emptyProviderValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  internal: {}
+  provider: {}
+  metadata:
+    from: module
+`
+		missingProviderServerValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    username: module-user
+    password: module-password
+  organization: module-org
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal: {}
+`
+		missingOrganizationValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+    username: module-user
+    password: module-password
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal: {}
+`
+		missingUsernameValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+    password: module-password
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal: {}
+`
+		missingPasswordValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+    username: module-username
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal: {}
+`
+		missingUserPassAndAPITokenValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal: {}
+`
+		hasUserPassAndAPITokenValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+    username: module-user
+    password: module-password
+    apiToken: module-api-token
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal: {}
+`
+		mergeDiscoveryValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  internal:
+    providerDiscoveryData:
+      zones:
+      - module-zone
+      storageProfiles:
+      - name: module-profile
+        isEnabled: true
+`
+		loadBalancerCurrentValues = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  internal:
+    providerDiscoveryData:
+      loadBalancer:
+        enabled: false
+`
 	)
 	var (
 		stateACloudDiscoveryData = `
@@ -31,6 +162,26 @@ cloudProviderVcd:
    "apiVersion": "deckhouse.io/v1",
    "kind": "VCDCloudProviderDiscoveryData",
    "zones": ["default"]
+}
+`
+		stateBCloudDiscoveryData = `
+{
+   "apiVersion": "deckhouse.io/v1",
+   "kind": "VCDCloudProviderDiscoveryData",
+   "sizingPolicies": ["secret-policy"],
+   "internalNetworks": ["secret-network"],
+   "zones": ["secret-zone"],
+   "storageProfiles": [
+     {
+       "name": "secret-profile",
+       "isEnabled": true
+     }
+   ],
+   "vcdAPIVersion": "37.3",
+   "vcdInstallationVersion": "10.5",
+   "loadBalancer": {
+     "enabled": true
+   }
 }
 `
 		stateAClusterConfiguration1 = `
@@ -78,21 +229,359 @@ data:
   "cloud-provider-discovery-data.json": %s
 `, base64.StdEncoding.EncodeToString([]byte(stateAClusterConfiguration1)), base64.StdEncoding.EncodeToString([]byte(stateACloudDiscoveryData)))
 
+	notEmptyProviderClusterConfigurationStateWithRichDiscovery := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cluster-configuration
+  namespace: kube-system
+data:
+  "cloud-provider-cluster-configuration.yaml": %s
+  "cloud-provider-discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(stateAClusterConfiguration1)), base64.StdEncoding.EncodeToString([]byte(stateBCloudDiscoveryData)))
+
 	// todo(31337Ghost) eliminate the following dirty hack after `ee` subdirectory will be merged to the root
 	// Used to make dhctl config function able to validate `VsphereClusterConfiguration`.
 	_ = os.Setenv("DHCTL_CLI_ADDITIONAL_SCHEMAS_PATHS", "/deckhouse/ee/modules/030-cloud-provider-vcd/candi/openapi")
 
-	a := HookExecutionConfigInit(emptyValues, `{}`)
 	Context("Cluster without module configuration", func() {
+		cfg := HookExecutionConfigInit(emptyValues, `{}`)
 		BeforeEach(func() {
-			a.BindingContexts.Set(a.KubeStateSet(notEmptyProviderClusterConfigurationState))
-			a.RunHook()
+			cfg.BindingContexts.Set(cfg.KubeStateSet(notEmptyProviderClusterConfigurationState))
+			cfg.RunHook()
 		})
 
 		It("Should fill values from secret", func() {
-			Expect(a).To(ExecuteSuccessfully())
-			Expect(a.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfiguration1))
-			Expect(a.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData").String()).To(MatchJSON(stateACloudDiscoveryData))
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration").String()).To(MatchYAML(stateAClusterConfiguration1))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.metadata").String()).To(BeEmpty())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData").String()).To(MatchJSON(stateACloudDiscoveryData))
+		})
+	})
+
+	Context("Cluster without secret and without module configuration", func() {
+		cfg := HookExecutionConfigInit(emptyValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should fail because provider section is required", func() {
+			Expect(cfg).ToNot(ExecuteSuccessfully())
+			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("provider section is required")))
+		})
+	})
+
+	Context("Hybrid cluster with module configuration and without secret", func() {
+		cfg := HookExecutionConfigInit(hybridValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should build provider cluster configuration from module config and preserve inline discovery data", func() {
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.server").String()).To(Equal("https://module.example.com/api"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.username").String()).To(Equal("module-user"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.password").String()).To(Equal("module-password"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.organization").String()).To(Equal("module-org"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.virtualDataCenter").String()).To(Equal("module-vdc"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.virtualApplicationName").String()).To(Equal("module-vapp"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.mainNetwork").String()).To(Equal("module-network"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.sshPublicKey").String()).To(Equal("module-ssh-key"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.metadata").String()).To(MatchYAML(`
+env: test
+owner: qa
+`))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData").String()).To(MatchJSON(`
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "VCDCloudProviderDiscoveryData",
+  "zones": ["zone-a", "zone-b"]
+}
+`))
+		})
+	})
+
+	Context("Hybrid cluster with module configuration and bootstrap secret", func() {
+		cfg := HookExecutionConfigInit(hybridValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(notEmptyProviderClusterConfigurationState))
+			cfg.RunHook()
+		})
+
+		It("Should override secret values with module config and keep non-hybrid fields from secret", func() {
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.layout").String()).To(Equal("Standard"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.masterNodeGroup.replicas").Int()).To(Equal(int64(1)))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.server").String()).To(Equal("https://module.example.com/api"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.username").String()).To(Equal("module-user"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.password").String()).To(Equal("module-password"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.organization").String()).To(Equal("module-org"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.virtualDataCenter").String()).To(Equal("module-vdc"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.virtualApplicationName").String()).To(Equal("module-vapp"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.mainNetwork").String()).To(Equal("module-network"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.sshPublicKey").String()).To(Equal("module-ssh-key"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.metadata").String()).To(MatchYAML(`
+env: test
+owner: qa
+`))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData").String()).To(MatchJSON(`
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "VCDCloudProviderDiscoveryData",
+  "zones": ["zone-a", "zone-b"]
+}
+`))
+		})
+	})
+
+	Context("Cluster with empty provider in module configuration and bootstrap secret", func() {
+		cfg := HookExecutionConfigInit(emptyProviderValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(notEmptyProviderClusterConfigurationState))
+			cfg.RunHook()
+		})
+
+		It("Should keep provider from secret and still patch metadata from module config", func() {
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.server").String()).To(Equal("<SERVER>"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.username").String()).To(Equal("<USERNAME>"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.provider.password").String()).To(Equal("<PASSWORD>"))
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerClusterConfiguration.metadata").String()).To(MatchYAML(`
+from: module
+`))
+		})
+	})
+
+	Context("Cluster with module configuration and provider section without server", func() {
+		cfg := HookExecutionConfigInit(missingProviderServerValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should fail because provider.server is required", func() {
+			Expect(cfg).ToNot(ExecuteSuccessfully())
+			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("provider.server cannot be empty")))
+		})
+	})
+
+	Context("Cluster with module configuration and missing organization", func() {
+		cfg := HookExecutionConfigInit(missingOrganizationValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should fail because organization is required", func() {
+			Expect(cfg).ToNot(ExecuteSuccessfully())
+			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("organization cannot be empty")))
+		})
+	})
+
+	Context("Cluster with module configuration and missing username", func() {
+		cfg := HookExecutionConfigInit(missingUsernameValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should fail because provider.username and provider.password must be set together", func() {
+			Expect(cfg).ToNot(ExecuteSuccessfully())
+			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("both provider.username and provider.password should be set")))
+		})
+	})
+
+	Context("Cluster with module configuration and missing password", func() {
+		cfg := HookExecutionConfigInit(missingPasswordValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should fail because provider.username and provider.password must be set together", func() {
+			Expect(cfg).ToNot(ExecuteSuccessfully())
+			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("both provider.username and provider.password should be set")))
+		})
+	})
+
+	Context("Cluster with module configuration and without user/password and apiToken", func() {
+		cfg := HookExecutionConfigInit(missingUserPassAndAPITokenValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should fail because one auth mode is required", func() {
+			Expect(cfg).ToNot(ExecuteSuccessfully())
+			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("provider.apiToken or provider.username/provider.password should be set")))
+		})
+	})
+
+	Context("Cluster with module configuration and both user/password and apiToken", func() {
+		cfg := HookExecutionConfigInit(hasUserPassAndAPITokenValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should fail because auth modes are mutually exclusive", func() {
+			Expect(cfg).ToNot(ExecuteSuccessfully())
+			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("provider authentication must use either apiToken or username/password")))
+		})
+	})
+
+	Context("Cluster with secret discovery data and partial inline discovery data", func() {
+		cfg := HookExecutionConfigInit(mergeDiscoveryValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(notEmptyProviderClusterConfigurationStateWithRichDiscovery))
+			cfg.RunHook()
+		})
+
+		It("Should merge missing discovery fields from secret and preserve existing inline ones", func() {
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData").String()).To(MatchJSON(`
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "VCDCloudProviderDiscoveryData",
+  "sizingPolicies": ["secret-policy"],
+  "internalNetworks": ["secret-network"],
+  "zones": ["module-zone"],
+  "storageProfiles": [
+    {
+      "name": "module-profile",
+      "isEnabled": true
+    }
+  ],
+  "vcdAPIVersion": "37.3",
+  "vcdInstallationVersion": "10.5",
+  "loadBalancer": {
+    "enabled": true
+  }
+}
+`))
+		})
+	})
+
+	Context("Cluster with inline load balancer discovery data and bootstrap secret", func() {
+		cfg := HookExecutionConfigInit(loadBalancerCurrentValues, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(notEmptyProviderClusterConfigurationStateWithRichDiscovery))
+			cfg.RunHook()
+		})
+
+		It("Should keep current inline load balancer when secret also has one", func() {
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData.loadBalancer").String()).To(MatchJSON(`
+{
+  "enabled": false
+}
+`))
+		})
+	})
+
+	Context("overrideValues validation and provider patching", func() {
+		strPtr := func(v string) *string { return &v }
+
+		getPartialProviderCfg := func() v1.VCDProviderClusterConfiguration {
+			return v1.VCDProviderClusterConfiguration{
+				Provider: &v1.VCDProvider{
+					Server:   strPtr("https://provider.example.com/api"),
+					Username: strPtr("provider-user"),
+					Password: strPtr("provider-password"),
+				},
+				Organization:           strPtr("org"),
+				VirtualDataCenter:      strPtr("vdc"),
+				VirtualApplicationName: strPtr("vapp"),
+				MainNetwork:            strPtr("main-network"),
+			}
+		}
+
+		It("Should return error when virtualDataCenter is missing", func() {
+			cfg := getPartialProviderCfg()
+			cfg.VirtualDataCenter = nil
+
+			overrideProviderClusterConfig(&cfg, &v1.VCDModuleConfig{})
+			err := validateProviderClusterConfig(cfg)
+			Expect(err).To(MatchError("virtualDataCenter cannot be empty"))
+		})
+
+		It("Should return error when virtualApplicationName is missing", func() {
+			cfg := getPartialProviderCfg()
+			cfg.VirtualApplicationName = nil
+
+			overrideProviderClusterConfig(&cfg, &v1.VCDModuleConfig{})
+			err := validateProviderClusterConfig(cfg)
+			Expect(err).To(MatchError("virtualApplicationName cannot be empty"))
+		})
+
+		It("Should return error when mainNetwork is missing", func() {
+			cfg := getPartialProviderCfg()
+			cfg.MainNetwork = nil
+
+			overrideProviderClusterConfig(&cfg, &v1.VCDModuleConfig{})
+			err := validateProviderClusterConfig(cfg)
+			Expect(err).To(MatchError("mainNetwork cannot be empty"))
+		})
+
+		It("Should return error when kind exists but apiVersion is empty", func() {
+			cfg := getPartialProviderCfg()
+			cfg.Kind = strPtr("VCDClusterConfiguration")
+			cfg.APIVersion = strPtr("")
+
+			overrideProviderClusterConfig(&cfg, &v1.VCDModuleConfig{})
+			err := validateProviderClusterConfig(cfg)
+			Expect(err).To(MatchError("apiVersion cannot be empty"))
+		})
+
+		It("Should return error when apiVersion exists but kind is empty", func() {
+			cfg := getPartialProviderCfg()
+			cfg.APIVersion = strPtr("deckhouse.io/v1")
+			cfg.Kind = strPtr("")
+
+			overrideProviderClusterConfig(&cfg, &v1.VCDModuleConfig{})
+			err := validateProviderClusterConfig(cfg)
+			Expect(err).To(MatchError("kind cannot be empty"))
+		})
+
+		It("Should override provider apiToken from module config", func() {
+			cfg := getPartialProviderCfg()
+			cfg.Provider.APIToken = strPtr("secret-token")
+			cfg.Provider.Username = nil
+			cfg.Provider.Password = nil
+
+			moduleCfg := v1.VCDModuleConfig{
+				Provider: &v1.VCDProvider{
+					APIToken: strPtr("module-token"),
+				},
+			}
+
+			overrideProviderClusterConfig(&cfg, &moduleCfg)
+			err := validateProviderClusterConfig(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Provider.APIToken).ToNot(BeNil())
+			Expect(*cfg.Provider.APIToken).To(Equal("module-token"))
+		})
+
+		It("Should override provider username and password from module config", func() {
+			cfg := getPartialProviderCfg()
+
+			moduleCfg := v1.VCDModuleConfig{
+				Provider: &v1.VCDProvider{
+					Username: strPtr("module-user"),
+					Password: strPtr("module-password"),
+				},
+			}
+
+			overrideProviderClusterConfig(&cfg, &moduleCfg)
+			err := validateProviderClusterConfig(cfg)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cfg.Provider.Username).ToNot(BeNil())
+			Expect(cfg.Provider.Password).ToNot(BeNil())
+			Expect(*cfg.Provider.Username).To(Equal("module-user"))
+			Expect(*cfg.Provider.Password).To(Equal("module-password"))
+			Expect(cfg.Provider.APIToken).To(BeNil())
 		})
 	})
 })

--- a/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration_test.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/vcd_cluster_configuration_test.go
@@ -134,6 +134,38 @@ cloudProviderVcd:
   mainNetwork: module-network
   internal: {}
 `
+		hybridValuesWithoutDiscoveryData = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+    username: module-user
+    password: module-password
+  organization: module-org
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal: {}
+`
+		partialInlineDiscoveryValuesWithoutDefaults = `
+global:
+  discovery: {}
+cloudProviderVcd:
+  provider:
+    server: https://module.example.com/api
+    username: module-user
+    password: module-password
+  organization: module-org
+  virtualDataCenter: module-vdc
+  virtualApplicationName: module-vapp
+  mainNetwork: module-network
+  internal:
+    providerDiscoveryData:
+      storageProfiles:
+      - name: module-profile
+        isEnabled: true
+`
 		mergeDiscoveryValues = `
 global:
   discovery: {}
@@ -429,6 +461,50 @@ from: module
 		It("Should fail because auth modes are mutually exclusive", func() {
 			Expect(cfg).ToNot(ExecuteSuccessfully())
 			Expect(cfg.GoHookError).To(MatchError(ContainSubstring("provider authentication must use either apiToken or username/password")))
+		})
+	})
+
+	Context("Hybrid cluster without discovery data in secret and values", func() {
+		cfg := HookExecutionConfigInit(hybridValuesWithoutDiscoveryData, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should set default discovery data values", func() {
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData").String()).To(MatchJSON(`
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "VCDCloudProviderDiscoveryData",
+  "zones": ["default"]
+}
+`))
+		})
+	})
+
+	Context("Hybrid cluster with partial inline discovery data without defaults", func() {
+		cfg := HookExecutionConfigInit(partialInlineDiscoveryValuesWithoutDefaults, `{}`)
+		BeforeEach(func() {
+			cfg.BindingContexts.Set(cfg.KubeStateSet(""))
+			cfg.RunHook()
+		})
+
+		It("Should keep inline fields and apply missing defaults", func() {
+			Expect(cfg).To(ExecuteSuccessfully())
+			Expect(cfg.ValuesGet("cloudProviderVcd.internal.providerDiscoveryData").String()).To(MatchJSON(`
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "VCDCloudProviderDiscoveryData",
+  "zones": ["default"],
+  "storageProfiles": [
+    {
+      "name": "module-profile",
+      "isEnabled": true
+    }
+  ]
+}
+`))
 		})
 	})
 

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
@@ -132,7 +133,7 @@ func (d *Discoverer) CheckCloudConditions(ctx context.Context) ([]v1alpha1.Cloud
 }
 
 func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData []byte) ([]byte, error) {
-	discoveryData := &v1alpha1.VCDCloudProviderDiscoveryData{}
+	discoveryData := &v1.VCDCloudProviderDiscoveryData{}
 	if len(cloudProviderDiscoveryData) > 0 {
 		err := json.Unmarshal(cloudProviderDiscoveryData, &discoveryData)
 		if err != nil {
@@ -180,7 +181,7 @@ func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData
 	networks = removeDuplicatesStrings(networks)
 	discoveryData.InternalNetworks = networks
 
-	storageProfiles := make([]v1alpha1.VCDStorageProfile, 0)
+	storageProfiles := make([]v1.VCDStorageProfile, 0)
 	st, err := d.getStorageProfiles(vcdClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get storage profiles: %v", err)
@@ -213,7 +214,7 @@ func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover loadbalancer: %v", err)
 	}
-	discoveryData.LoadBalancer = &v1alpha1.VCDLoadBalancer{
+	discoveryData.LoadBalancer = &v1.VCDLoadBalancer{
 		Enabled: lbInfo.Enabled,
 	}
 
@@ -266,7 +267,7 @@ func (d *Discoverer) getInternalNetworks(vcdClient *govcd.VCDClient) ([]string, 
 	return networks, nil
 }
 
-func (d *Discoverer) getStorageProfiles(vcdClient *govcd.VCDClient) ([]v1alpha1.VCDStorageProfile, error) {
+func (d *Discoverer) getStorageProfiles(vcdClient *govcd.VCDClient) ([]v1.VCDStorageProfile, error) {
 	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
 		"type": types.QtOrgVdcStorageProfile,
 	})
@@ -278,13 +279,13 @@ func (d *Discoverer) getStorageProfiles(vcdClient *govcd.VCDClient) ([]v1alpha1.
 		return nil, nil
 	}
 
-	profiles := make([]v1alpha1.VCDStorageProfile, 0, len(results.Results.OrgVdcStorageProfileRecord))
+	profiles := make([]v1.VCDStorageProfile, 0, len(results.Results.OrgVdcStorageProfileRecord))
 
 	for _, p := range results.Results.OrgVdcStorageProfileRecord {
 		if p.Name == "" {
 			continue
 		}
-		profiles = append(profiles, v1alpha1.VCDStorageProfile{
+		profiles = append(profiles, v1.VCDStorageProfile{
 			Name:                    p.Name,
 			IsEnabled:               p.IsEnabled,
 			IsDefaultStorageProfile: p.IsDefaultStorageProfile,
@@ -363,12 +364,12 @@ func removeDuplicatesStrings(list []string) []string {
 }
 
 // removeDupluicatesStorageProfiles removes duplicates from slice and sort it
-func removeDuplicatesStorageProfiles(list []v1alpha1.VCDStorageProfile) []v1alpha1.VCDStorageProfile {
+func removeDuplicatesStorageProfiles(list []v1.VCDStorageProfile) []v1.VCDStorageProfile {
 	if len(list) == 0 {
 		return nil
 	}
 
-	uniqueMap := make(map[string]v1alpha1.VCDStorageProfile, len(list))
+	uniqueMap := make(map[string]v1.VCDStorageProfile, len(list))
 	for _, elem := range list {
 		if elem.Name == "" {
 			continue
@@ -376,7 +377,7 @@ func removeDuplicatesStorageProfiles(list []v1alpha1.VCDStorageProfile) []v1alph
 		uniqueMap[elem.Name] = elem
 	}
 
-	uniqueList := make([]v1alpha1.VCDStorageProfile, 0, len(list))
+	uniqueList := make([]v1.VCDStorageProfile, 0, len(list))
 	for _, elem := range uniqueMap {
 		uniqueList = append(uniqueList, elem)
 	}

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
@@ -19,7 +19,7 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
+	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
@@ -133,7 +133,7 @@ func (d *Discoverer) CheckCloudConditions(ctx context.Context) ([]v1alpha1.Cloud
 }
 
 func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData []byte) ([]byte, error) {
-	discoveryData := &v1.VCDCloudProviderDiscoveryData{}
+	discoveryData := &cloudDataV1.VCDCloudProviderDiscoveryData{}
 	if len(cloudProviderDiscoveryData) > 0 {
 		err := json.Unmarshal(cloudProviderDiscoveryData, discoveryData)
 		if err != nil {
@@ -182,7 +182,7 @@ func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData
 	networks = removeDuplicatesStrings(networks)
 	discoveryData.InternalNetworks = networks
 
-	storageProfiles := make([]v1.VCDStorageProfile, 0)
+	storageProfiles := make([]cloudDataV1.VCDStorageProfile, 0)
 	st, err := d.getStorageProfiles(vcdClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get storage profiles: %v", err)
@@ -215,7 +215,7 @@ func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover loadbalancer: %v", err)
 	}
-	discoveryData.LoadBalancer = &v1.VCDLoadBalancer{
+	discoveryData.LoadBalancer = &cloudDataV1.VCDLoadBalancer{
 		Enabled: lbInfo.Enabled,
 	}
 
@@ -268,7 +268,7 @@ func (d *Discoverer) getInternalNetworks(vcdClient *govcd.VCDClient) ([]string, 
 	return networks, nil
 }
 
-func (d *Discoverer) getStorageProfiles(vcdClient *govcd.VCDClient) ([]v1.VCDStorageProfile, error) {
+func (d *Discoverer) getStorageProfiles(vcdClient *govcd.VCDClient) ([]cloudDataV1.VCDStorageProfile, error) {
 	results, err := vcdClient.QueryWithNotEncodedParams(nil, map[string]string{
 		"type": types.QtOrgVdcStorageProfile,
 	})
@@ -280,13 +280,13 @@ func (d *Discoverer) getStorageProfiles(vcdClient *govcd.VCDClient) ([]v1.VCDSto
 		return nil, nil
 	}
 
-	profiles := make([]v1.VCDStorageProfile, 0, len(results.Results.OrgVdcStorageProfileRecord))
+	profiles := make([]cloudDataV1.VCDStorageProfile, 0, len(results.Results.OrgVdcStorageProfileRecord))
 
 	for _, p := range results.Results.OrgVdcStorageProfileRecord {
 		if p.Name == "" {
 			continue
 		}
-		profiles = append(profiles, v1.VCDStorageProfile{
+		profiles = append(profiles, cloudDataV1.VCDStorageProfile{
 			Name:                    p.Name,
 			IsEnabled:               p.IsEnabled,
 			IsDefaultStorageProfile: p.IsDefaultStorageProfile,
@@ -365,12 +365,12 @@ func removeDuplicatesStrings(list []string) []string {
 }
 
 // removeDupluicatesStorageProfiles removes duplicates from slice and sort it
-func removeDuplicatesStorageProfiles(list []v1.VCDStorageProfile) []v1.VCDStorageProfile {
+func removeDuplicatesStorageProfiles(list []cloudDataV1.VCDStorageProfile) []cloudDataV1.VCDStorageProfile {
 	if len(list) == 0 {
 		return nil
 	}
 
-	uniqueMap := make(map[string]v1.VCDStorageProfile, len(list))
+	uniqueMap := make(map[string]cloudDataV1.VCDStorageProfile, len(list))
 	for _, elem := range list {
 		if elem.Name == "" {
 			continue
@@ -378,7 +378,7 @@ func removeDuplicatesStorageProfiles(list []v1.VCDStorageProfile) []v1.VCDStorag
 		uniqueMap[elem.Name] = elem
 	}
 
-	uniqueList := make([]v1.VCDStorageProfile, 0, len(list))
+	uniqueList := make([]cloudDataV1.VCDStorageProfile, 0, len(list))
 	for _, elem := range uniqueMap {
 		uniqueList = append(uniqueList, elem)
 	}

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
@@ -135,7 +135,7 @@ func (d *Discoverer) CheckCloudConditions(ctx context.Context) ([]v1alpha1.Cloud
 func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData []byte) ([]byte, error) {
 	discoveryData := &v1.VCDCloudProviderDiscoveryData{}
 	if len(cloudProviderDiscoveryData) > 0 {
-		err := json.Unmarshal(cloudProviderDiscoveryData, &discoveryData)
+		err := json.Unmarshal(cloudProviderDiscoveryData, discoveryData)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal cloud provider discovery data: %v", err)
 		}

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer.go
@@ -140,6 +140,7 @@ func (d *Discoverer) DiscoveryData(_ context.Context, cloudProviderDiscoveryData
 			return nil, fmt.Errorf("failed to unmarshal cloud provider discovery data: %v", err)
 		}
 	}
+	discoveryData.SetDefaults()
 
 	vcdClient, err := d.config.client()
 	if err != nil {

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer_test.go
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/src/discoverer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
 	"github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1alpha1"
 )
 
@@ -48,11 +49,11 @@ func TestRemoveDuplicatesStrings(t *testing.T) {
 
 func TestRemoveDuplicatesStorageProfiles(t *testing.T) {
 	tests := []struct {
-		args []v1alpha1.VCDStorageProfile
-		want []v1alpha1.VCDStorageProfile
+		args []v1.VCDStorageProfile
+		want []v1.VCDStorageProfile
 	}{
 		{
-			args: []v1alpha1.VCDStorageProfile{
+			args: []v1.VCDStorageProfile{
 				{
 					Name:                    "1",
 					IsEnabled:               true,
@@ -74,7 +75,7 @@ func TestRemoveDuplicatesStorageProfiles(t *testing.T) {
 					IsDefaultStorageProfile: false,
 				},
 			},
-			want: []v1alpha1.VCDStorageProfile{
+			want: []v1.VCDStorageProfile{
 				{
 					Name:                    "1",
 					IsEnabled:               true,

--- a/ee/modules/030-cloud-provider-vcd/openapi/config-values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/config-values.yaml
@@ -30,3 +30,54 @@ properties:
           * the first (in lexicographic order) StorageClass created by the module.
 
           > **Parameter is deprecated.** Instead, use the global parameter [global.defaultClusterStorageClass](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-defaultclusterstorageclass).
+  provider:
+    type: object
+    additionalProperties: false
+    description: Parameters for connecting to the VCD API.
+    properties:
+      server:
+        type: string
+        description: The host or the IP address of the VCD server.
+      username:
+        type: string
+        description: The login ID.
+      password:
+        type: string
+        description: The user's password.
+      apiToken:
+        type: string
+        description: |
+          The token for authentication.
+
+          > **Caution!** When using `apiToken`, leave `username` and `password` empty.
+      insecure:
+        type: boolean
+        description: Set to `true` if VCD has a self-signed certificate.
+        x-doc-default: false
+  organization:
+    type: string
+    description: VMware Cloud Director Organization name.
+  virtualDataCenter:
+    type: string
+    description: VMware Cloud Director Virtual Data Center name (belongs to Organization).
+  virtualApplicationName:
+    type: string
+      # cluster api getting app by VCDCluster name and we should create app with kubernetes resources name restrictions
+    # base on this answer https://stackoverflow.com/a/67387967
+    pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+    description: VMware Cloud Director Virtual Application name (belongs to Virtual Data Center).
+  mainNetwork:
+    type: string
+    description: Path to the network that VirtualMachines' primary NICs will connect to (default gateway).
+    example: internal
+  sshPublicKey:
+    type: string
+    description: A public key for accessing nodes.
+  metadata:
+    type: object
+    description: |
+      Custom metadata entries to be stored in cluster objects such as virtual machines, disks and network.
+
+      > **Caution!** Changing the metadata will cause the recreation of CloudEphemeral nodes.
+    additionalProperties:
+      type: string

--- a/ee/modules/030-cloud-provider-vcd/openapi/config-values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/config-values.yaml
@@ -37,47 +37,45 @@ properties:
     properties:
       server:
         type: string
-        description: The host or the IP address of the VCD server.
+        description: VCD server host or IP address.
       username:
         type: string
-        description: The login ID.
+        description: VCD user name with full permissions for the project.
       password:
         type: string
-        description: The user's password.
+        description: VCD user password.
       apiToken:
         type: string
         description: |
-          The token for authentication.
+          Token for authentication in VCD.
 
-          > **Caution!** When using `apiToken`, leave `username` and `password` empty.
+          > When using the `apiToken` parameter, the `username` and `password` parameters must be empty.
       insecure:
         type: boolean
         description: Set to `true` if VCD has a self-signed certificate.
         x-doc-default: false
   organization:
     type: string
-    description: VMware Cloud Director Organization name.
+    description: Name of the Organization in VCD.
   virtualDataCenter:
     type: string
-    description: VMware Cloud Director Virtual Data Center name (belongs to Organization).
+    description: Name of the Virtual Data Center in VCD that belongs to the specified Organization.
   virtualApplicationName:
     type: string
-      # cluster api getting app by VCDCluster name and we should create app with kubernetes resources name restrictions
-    # base on this answer https://stackoverflow.com/a/67387967
     pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-    description: VMware Cloud Director Virtual Application name (belongs to Virtual Data Center).
+    description: Name of the Virtual Application in VCD that belongs to the specified Virtual Data Center.
   mainNetwork:
     type: string
-    description: Path to the network that VirtualMachines' primary NICs will connect to (default gateway).
+    description: Path to the network to which the primary network interfaces of virtual machines will be connected..
     example: internal
   sshPublicKey:
     type: string
-    description: A public key for accessing nodes.
+    description: Public SSH key for accessing the nodes.
   metadata:
     type: object
     description: |
-      Custom metadata entries to be stored in cluster objects such as virtual machines, disks and network.
+      Custom metadata entries that will be stored in cluster objects, such as virtual machines, disks, and networks.
 
-      > **Caution!** Changing the metadata will cause the recreation of CloudEphemeral nodes.
+      > Changing metadata will cause CloudEphemeral nodes to be recreated.
     additionalProperties:
       type: string

--- a/ee/modules/030-cloud-provider-vcd/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/doc-ru-config-values.yaml
@@ -18,3 +18,34 @@ properties:
           * первый (по алфавиту) StorageClass из тех, что создаются модулем.
 
           > **Параметр устарел**. Вместо этого параметра используйте глобальный параметр [global.defaultClusterStorageClass](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-defaultclusterstorageclass).
+  provider:
+    description: Параметры подключения к VCD.
+    properties:
+      server:
+        description: Хост или IP-адрес сервера VCD-сервера.
+      username:
+        description: Имя пользователя с полными правами на проект.
+      password:
+        description: Пароль пользователя.
+      apiToken:
+        description: |
+          Токен для аутентификации.
+
+          > **Внимание!** При использовании `apiToken` необходимо оставить `username` и `password` пустыми.
+      insecure:
+        description: Установите `true`, если VCD использует самоподписанный сертификат.
+  organization:
+    description: Имя Organization в VMware Cloud Director.
+  virtualDataCenter:
+    description: Имя Virtual Data Center в VMware Cloud Director, принадлежащего указанной Organization.
+  virtualApplicationName:
+    description: Имя Virtual Application в VMware Cloud Director, принадлежащего указанному Virtual Data Center.
+  mainNetwork:
+    description: Путь к сети, к которой будут подключены основные сетевые интерфейсы VirtualMachine.
+  sshPublicKey:
+    description: Публичный ключ для доступа к узлам.
+  metadata:
+    description: |
+      Пользовательские записи metadata, которые будут сохранены в объектах кластера, например в виртуальных машинах, дисках и сетях.
+
+       > **Внимание!** Изменение метаданных приведет к пересозданию CloudEphemeral-узлов.

--- a/ee/modules/030-cloud-provider-vcd/openapi/doc-ru-config-values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/doc-ru-config-values.yaml
@@ -26,26 +26,26 @@ properties:
       username:
         description: Имя пользователя с полными правами на проект.
       password:
-        description: Пароль пользователя.
+        description: Пароль пользователя в VCD.
       apiToken:
         description: |
-          Токен для аутентификации.
+          Токен для аутентификации в VCD.
 
-          > **Внимание!** При использовании `apiToken` необходимо оставить `username` и `password` пустыми.
+          > При использовании параметра `apiToken` параметры `username` и `password` должны быть пустыми.
       insecure:
-        description: Установите `true`, если VCD использует самоподписанный сертификат.
+        description: Установите значение `true`, если VCD использует самоподписанный сертификат.
   organization:
-    description: Имя Organization в VMware Cloud Director.
+    description: Имя Organization в VCD.
   virtualDataCenter:
-    description: Имя Virtual Data Center в VMware Cloud Director, принадлежащего указанной Organization.
+    description: Имя Virtual Data Center в VCD, принадлежащего указанной Organization.
   virtualApplicationName:
-    description: Имя Virtual Application в VMware Cloud Director, принадлежащего указанному Virtual Data Center.
+    description: Имя Virtual Application в VCD, принадлежащего указанному Virtual Data Center.
   mainNetwork:
-    description: Путь к сети, к которой будут подключены основные сетевые интерфейсы VirtualMachine.
+    description: Путь к сети, к которой будут подключены основные сетевые интерфейсы виртуальных машин.
   sshPublicKey:
     description: Публичный ключ для доступа к узлам.
   metadata:
     description: |
-      Пользовательские записи metadata, которые будут сохранены в объектах кластера, например в виртуальных машинах, дисках и сетях.
+      Пользовательские метаданные, которые будут сохранены в объектах кластера, например в виртуальных машинах, дисках и сетях.
 
-       > **Внимание!** Изменение метаданных приведет к пересозданию CloudEphemeral-узлов.
+      > Изменение метаданных приведет к пересозданию CloudEphemeral-узлов.

--- a/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
+++ b/ee/modules/030-cloud-provider-vcd/openapi/values.yaml
@@ -53,7 +53,7 @@ properties:
               username: '<USERNAME>'
               password: '<PASSWORD>'
               insecure: true
-        required: [apiVersion, kind, masterNodeGroup, sshPublicKey, layout, provider, organization, virtualDataCenter, virtualApplicationName, mainNetwork]
+        required: [sshPublicKey, provider, organization, virtualDataCenter, virtualApplicationName, mainNetwork]
         properties:
           apiVersion:
             type: string

--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -64,13 +64,10 @@ const moduleValuesA = `
       providerDiscoveryData:
         kind: VCDCloudProviderDiscoveryData
         apiVersion: deckhouse.io/v1
-        zones:
-        - default
-      discoveryData:
-        kind: VCDCloudProviderDiscoveryData
-        apiVersion: deckhouse.io/v1
         vcdInstallationVersion: "10.4.2"
         vcdAPIVersion: "37.2"
+        zones:
+        - default
       providerClusterConfiguration:
         apiVersion: deckhouse.io/v1
         kind: VCDClusterConfiguration
@@ -126,15 +123,12 @@ const moduleValuesB = `
       providerDiscoveryData:
         kind: VCDCloudProviderDiscoveryData
         apiVersion: deckhouse.io/v1
-        zones:
-        - default
-      discoveryData:
-        kind: VCDCloudProviderDiscoveryData
-        apiVersion: deckhouse.io/v1
         vcdInstallationVersion: "10.4.2"
         vcdAPIVersion: "37.2"
         loadBalancer:
           enabled: false
+        zones:
+        - default
       providerClusterConfiguration:
         apiVersion: deckhouse.io/v1
         kind: VCDClusterConfiguration
@@ -168,15 +162,12 @@ const moduleValuesC = `
       providerDiscoveryData:
         kind: VCDCloudProviderDiscoveryData
         apiVersion: deckhouse.io/v1
-        zones:
-        - default
-      discoveryData:
-        kind: VCDCloudProviderDiscoveryData
-        apiVersion: deckhouse.io/v1
         vcdInstallationVersion: "10.4.2"
         vcdAPIVersion: "37.2"
         loadBalancer:
           enabled: true
+        zones:
+        - default
       providerClusterConfiguration:
         apiVersion: deckhouse.io/v1
         kind: VCDClusterConfiguration

--- a/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/cloud-controller-manager/deployment.yaml
@@ -41,9 +41,9 @@ checksum/config: {{ printf "%s%s" (include (print $.Template.BasePath "/registra
 {{- end -}}
 
 {{- $ccmEnabledControllers := "cloud-node,cloud-node-lifecycle" -}}
-{{- if hasKey .Values.cloudProviderVcd.internal.discoveryData "loadBalancer" -}}
-  {{- if hasKey .Values.cloudProviderVcd.internal.discoveryData.loadBalancer "enabled" -}}
-    {{- if .Values.cloudProviderVcd.internal.discoveryData.loadBalancer.enabled -}}
+{{- if hasKey .Values.cloudProviderVcd.internal.providerDiscoveryData "loadBalancer" -}}
+  {{- if hasKey .Values.cloudProviderVcd.internal.providerDiscoveryData.loadBalancer "enabled" -}}
+    {{- if .Values.cloudProviderVcd.internal.providerDiscoveryData.loadBalancer.enabled -}}
       {{- $ccmEnabledControllers = printf "%s,service" $ccmEnabledControllers -}}
     {{- end -}}
   {{- end -}}

--- a/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/registration.yaml
@@ -2,6 +2,7 @@
 {{- define "registration_values" }}
 {{- $context := index . 0 }}
 {{- $providerClusterConfiguration := $context.Values.cloudProviderVcd.internal.providerClusterConfiguration | required "internal.providerClusterConfiguration is required" }}
+{{- $virtualApplicationName := $context.Values.cloudProviderVcd.internal.providerClusterConfiguration.virtualApplicationName | required "internal.providerClusterConfiguration.virtualApplicationName is required" }}
 type: {{ b64enc "vcd" | quote }}
 # vcloud director does not contain meaning regions and zones
 # but out machinery use them. we use default as region and as one zone
@@ -11,7 +12,7 @@ instanceClassKind: {{ b64enc "VCDInstanceClass" | quote }}
 machineClassKind: {{ b64enc "" | quote }}
 capiClusterKind: {{ b64enc "VCDCluster" | quote }}
 capiClusterAPIVersion: {{ b64enc "infrastructure.cluster.x-k8s.io/v1beta2" | quote }}
-capiClusterName: {{ $providerClusterConfiguration.virtualApplicationName | b64enc | quote }}
+capiClusterName: {{ $virtualApplicationName | b64enc | quote }}
 capiMachineTemplateKind: {{ b64enc "VCDMachineTemplate" | quote }}
 capiMachineTemplateAPIVersion: {{ b64enc "infrastructure.cluster.x-k8s.io/v1beta2" | quote }}
 sshPublicKey: {{ b64enc $providerClusterConfiguration.sshPublicKey | quote }}
@@ -22,7 +23,7 @@ sshPublicKey: {{ b64enc $providerClusterConfiguration.sshPublicKey | quote }}
 {{- $_ := set $vcdValues "organization" $providerClusterConfiguration.organization }}
 {{- $_ := set $vcdValues "virtualDataCenter" $providerClusterConfiguration.virtualDataCenter  }}
 {{- $_ := set $vcdValues "mainNetwork" $providerClusterConfiguration.mainNetwork  }}
-{{- $_ := set $vcdValues "virtualApplicationName" $providerClusterConfiguration.virtualApplicationName }}
+{{- $_ := set $vcdValues "virtualApplicationName" $virtualApplicationName }}
 {{- $_ := set $vcdValues "server" ($providerClusterConfiguration.provider.server | trimSuffix "/") }}
 {{- $_ := set $vcdValues "username" $providerClusterConfiguration.provider.username }}
 {{- $_ := set $vcdValues "password" $providerClusterConfiguration.provider.password }}

--- a/go_lib/cloud-data/apis/v1/vcd_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1/vcd_cloud_provider_discovery_data.go
@@ -36,3 +36,15 @@ type VCDStorageProfile struct {
 type VCDLoadBalancer struct {
 	Enabled bool `json:"enabled"`
 }
+
+func (d *VCDCloudProviderDiscoveryData) SetDefaults() {
+	if d.APIVersion == "" {
+		d.APIVersion = "deckhouse.io/v1"
+	}
+	if d.Kind == "" {
+		d.Kind = "VCDCloudProviderDiscoveryData"
+	}
+	if len(d.Zones) == 0 {
+		d.Zones = []string{"default"}
+	}
+}

--- a/go_lib/cloud-data/apis/v1/vcd_cloud_provider_discovery_data.go
+++ b/go_lib/cloud-data/apis/v1/vcd_cloud_provider_discovery_data.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+type VCDCloudProviderDiscoveryData struct {
+	APIVersion string `json:"apiVersion,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+
+	SizingPolicies         []string            `json:"sizingPolicies,omitempty"`
+	InternalNetworks       []string            `json:"internalNetworks,omitempty"`
+	Zones                  []string            `json:"zones,omitempty"`
+	StorageProfiles        []VCDStorageProfile `json:"storageProfiles,omitempty"`
+	VCDAPIVersion          string              `json:"vcdAPIVersion,omitempty"`
+	VCDInstallationVersion string              `json:"vcdInstallationVersion,omitempty"`
+	LoadBalancer           *VCDLoadBalancer    `json:"loadBalancer,omitempty"`
+}
+
+type VCDStorageProfile struct {
+	Name                    string `json:"name"`
+	IsEnabled               bool   `json:"isEnabled,omitempty"`
+	IsDefaultStorageProfile bool   `json:"isDefaultStorageProfile,omitempty"`
+}
+
+type VCDLoadBalancer struct {
+	Enabled bool `json:"enabled"`
+}


### PR DESCRIPTION
## Description

Adds hybrid cluster support to `cloud-provider-vcd`.   

The module can now create cloud VCD provider settings for hybrid clusters from the module configuration, combine them with the provider cluster configuration and discovery data as needed, and pass the resulting configuration into the registration secret and reconciliation process.    

The PR also adds validation of the required hybrid parameters, applies standard settings for VCD discovery data, and updates OpenAPI/documentation for the new configuration path.   

## Why do we need it and what problem does it solve?   

We need this feature to support hybrid clusters in VMware Cloud Director.   

Prior to these changes, the `cloud-provider-vcd` system relied on the configuration of the provider cluster and did not fully support building the required internal VCD configuration from module values. This made hybrid scenarios incomplete: important fields such as provider credentials, network settings, and discovery data could not be managed uniformly across hybrid clusters, and the user had to manually set these settings in specific secrets.   

This PR adds missing support so that hybrid VCD clusters can be configured through the module, properly validated, and provided with complete discovery data and registration parameters.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-vcd
type: feature
summary: Add support for hybrid clusters in VMware Cloud Director, including module-based provider configuration.
impact_level: default