### PR TITLE
[deckhouse] overwrite currentReleaseImageName on mismatch

### DIFF
--- a/modules/002-deckhouse/hooks/set_module_image_value.go
+++ b/modules/002-deckhouse/hooks/set_module_image_value.go
@@ -84,13 +84,19 @@ func parseDeckhouseImage(_ context.Context, input *go_hook.HookInput) error {
 	}
 	tag := imageRepoTag.TagStr()
 
-	// Set deckhouse image only if it was not set before, e.g. by stabilize_release_channel hook
-	if input.Values.Get(deckhouseImagePath).String() == "" {
-		if !input.Values.Get(deckhouseBasePath).Exists() {
-			return fmt.Errorf("registry base path doesn't exist yet")
-		}
-		base := input.Values.Get(deckhouseBasePath).String()
-		input.Values.Set(deckhouseImagePath, fmt.Sprintf("%s:%s", base, tag))
+	if !input.Values.Get(deckhouseBasePath).Exists() {
+		return fmt.Errorf("registry base path doesn't exist yet")
+	}
+	base := input.Values.Get(deckhouseBasePath).String()
+	desired := fmt.Sprintf("%s:%s", base, tag)
+
+	// Overwrite when values-level image diverges from the Deployment image.
+	// Guards against a race with bumpDeckhouseDeployment: if the hook re-runs
+	// on the old leader pod between the Deployment bump and the leader handover,
+	// a stale cached value would make Helm re-render the previous image and
+	// roll the Deployment back.
+	if input.Values.Get(deckhouseImagePath).String() != desired {
+		input.Values.Set(deckhouseImagePath, desired)
 	}
 
 	return nil

--- a/modules/002-deckhouse/hooks/set_module_image_value.go
+++ b/modules/002-deckhouse/hooks/set_module_image_value.go
@@ -90,11 +90,9 @@ func parseDeckhouseImage(_ context.Context, input *go_hook.HookInput) error {
 	base := input.Values.Get(deckhouseBasePath).String()
 	desired := fmt.Sprintf("%s:%s", base, tag)
 
-	// Overwrite when values-level image diverges from the Deployment image.
-	// Guards against a race with bumpDeckhouseDeployment: if the hook re-runs
-	// on the old leader pod between the Deployment bump and the leader handover,
-	// a stale cached value would make Helm re-render the previous image and
-	// roll the Deployment back.
+	// Guards a race with bumpDeckhouseDeployment: if the hook re-runs on the
+	// old leader between the Deployment bump and leader handover, a stale
+	// values entry would make Helm roll the Deployment back.
 	if input.Values.Get(deckhouseImagePath).String() != desired {
 		input.Values.Set(deckhouseImagePath, desired)
 	}

--- a/modules/002-deckhouse/hooks/set_module_image_value_test.go
+++ b/modules/002-deckhouse/hooks/set_module_image_value_test.go
@@ -97,7 +97,7 @@ spec:
 			})
 		})
 
-		Context("when image in present values", func() {
+		Context("when values and Deployment images differ — values are overwritten", func() {
 			BeforeEach(func() {
 				f.ValuesSet("deckhouse.internal.currentReleaseImageName", "registry.deckhouse.io/deckhouse/ce/initial:test")
 				f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
@@ -116,7 +116,7 @@ spec:
     spec:
       containers:
       - name: deckhouse
-        image: registry.deckhouse.io/deckhouse/ce/different:test
+        image: registry.deckhouse.io/deckhouse/ce/different:newtag
 `, 1))
 				f.RunHook()
 			})
@@ -125,7 +125,7 @@ spec:
 				Expect(f).To(ExecuteSuccessfully())
 				deployment := f.KubernetesResource("Deployment", "d8-system", "deckhouse")
 				Expect(deployment.Exists()).To(BeTrue())
-				Expect(f.ValuesGet("deckhouse.internal.currentReleaseImageName").String()).To(Equal("registry.deckhouse.io/deckhouse/ce/initial:test"))
+				Expect(f.ValuesGet("deckhouse.internal.currentReleaseImageName").String()).To(Equal("registry.deckhouse.io/deckhouse/fe:newtag"))
 			})
 		})
 	})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The set_module_image_value OnBeforeHelm hook now compares deckhouse.internal.currentReleaseImageName with the image from the d8-system/deckhouse Deployment snapshot and overwrites the value on mismatch (previously it only wrote when the value was empty).

Affects only the 002-deckhouse module — restarts the deckhouse Deployment at most once during a release, which already happens.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Fixes a race during Deckhouse release updates where the Deployment image rolled back to the previous version.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Overwrite currentReleaseImageName on mismatch.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
