### PR TITLE
[node-manager] add dh version to bashible-apiserver context 

### DIFF
--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
@@ -65,6 +65,7 @@ type BashibleContextData struct {
 	VersionMap map[string]interface{}       `json:"versionMap" yaml:"versionMap"`
 	Registry   map[string]interface{}       `json:"registry" yaml:"registry"`
 	Proxy      map[string]interface{}       `json:"proxy" yaml:"proxy"`
+	Deckhouse  deckhouse                    `json:"deckhouse" yaml:"deckhouse"`
 }
 
 // Map returns context data as map[string]interface{} for proper yaml marshalling
@@ -79,6 +80,7 @@ func (bd BashibleContextData) Map() map[string]interface{} {
 	result["registry"] = bd.Registry
 	result["versionMap"] = bd.VersionMap
 	result["proxy"] = bd.Proxy
+	result["deckhouse"] = bd.Deckhouse
 	if bashibleData, ok := bd.VersionMap["bashible"]; ok {
 		result["bashible"] = bashibleData
 	}
@@ -133,6 +135,7 @@ func (cb *ContextBuilder) Build() (BashibleContextData, map[string][]byte, map[s
 		Images:           cb.imagesDigests,
 		Registry:         cb.registryData,
 		Proxy:            cb.clusterInputData.Proxy,
+		Deckhouse:        cb.clusterInputData.Deckhouse,
 	}
 
 	ngMap := make(map[string][]byte)
@@ -155,6 +158,7 @@ func (cb *ContextBuilder) Build() (BashibleContextData, map[string][]byte, map[s
 		Registry:                   cb.registryData,
 		Images:                     cb.imagesDigests,
 		Proxy:                      cb.clusterInputData.Proxy,
+		Deckhouse:                  cb.clusterInputData.Deckhouse,
 		PackagesProxy:              cb.clusterInputData.PackagesProxy,
 		AllowedKubeletFeatureGates: cb.clusterInputData.AllowedKubeletFeatureGates,
 	}
@@ -205,6 +209,7 @@ func (cb *ContextBuilder) newBashibleContext(checksumCollector hash.Hash, ng nod
 		Images:                     cb.imagesDigests,
 		Registry:                   cb.registryData,
 		Proxy:                      cb.clusterInputData.Proxy,
+		Deckhouse:                  cb.clusterInputData.Deckhouse,
 		CloudProviderType:          cb.getCloudProvider(),
 		PackagesProxy:              cb.clusterInputData.PackagesProxy,
 		AllowedKubeletFeatureGates: cb.clusterInputData.AllowedKubeletFeatureGates,
@@ -379,6 +384,7 @@ type bashibleContext struct {
 	Images                     map[string]map[string]string `json:"images" yaml:"images"`
 	Registry                   map[string]interface{}       `json:"registry" yaml:"registry"`
 	Proxy                      map[string]interface{}       `json:"proxy" yaml:"proxy"`
+	Deckhouse                  deckhouse                    `json:"deckhouse" yaml:"deckhouse"`
 	CloudProviderType          string                       `json:"cloudProviderType" yaml:"cloudProviderType"`
 	PackagesProxy              map[string]interface{}       `json:"packagesProxy" yaml:"packagesProxy"`
 	AllowedKubeletFeatureGates []string                     `json:"allowedKubeletFeatureGates,omitempty" yaml:"allowedKubeletFeatureGates,omitempty"`
@@ -427,6 +433,7 @@ type tplContextCommon struct {
 	Registry map[string]interface{}       `json:"registry" yaml:"registry"`
 
 	Proxy                      map[string]interface{} `json:"proxy,omitempty" yaml:"proxy,omitempty"`
+	Deckhouse                  deckhouse              `json:"deckhouse" yaml:"deckhouse"`
 	PackagesProxy              map[string]interface{} `json:"packagesProxy,omitempty" yaml:"packagesProxy,omitempty"`
 	AllowedKubeletFeatureGates []string               `json:"allowedKubeletFeatureGates,omitempty" yaml:"allowedKubeletFeatureGates,omitempty"`
 }
@@ -455,7 +462,14 @@ type normal struct {
 	ModuleSourcesCA         map[string]string      `json:"moduleSourcesCA" yaml:"moduleSourcesCA"`
 }
 
+type deckhouse struct {
+	Channel string `json:"channel" yaml:"channel"`
+	Version string `json:"version" yaml:"version"`
+	Edition string `json:"edition" yaml:"edition"`
+}
+
 type inputData struct {
+	Deckhouse                  deckhouse              `json:"deckhouse" yaml:"deckhouse"`
 	PodSubnetNodeCIDRPrefix    string                 `json:"podSubnetNodeCIDRPrefix" yaml:"podSubnetNodeCIDRPrefix"`
 	ClusterDomain              string                 `json:"clusterDomain" yaml:"clusterDomain"`
 	ClusterDNSAddress          string                 `json:"clusterDNSAddress" yaml:"clusterDNSAddress"`

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -114,8 +114,9 @@ spec:
 
 
 {{- define "bashible_input_data" }}
+{{- $deckhouseValues := .Values.deckhouse | default dict }}
     deckhouse:
-      channel: {{ .Values.deckhouse.releaseChannel | default "unknown" | quote }}
+      channel: {{ get $deckhouseValues "releaseChannel" | default "unknown" | quote }}
       version: {{ .Values.global.deckhouseVersion | quote }}
       edition: {{ .Values.global.deckhouseEdition | quote }}
     podSubnetNodeCIDRPrefix: {{ $.Values.global.clusterConfiguration.podSubnetNodeCIDRPrefix | quote }}

--- a/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
+++ b/modules/040-node-manager/templates/bashible-apiserver/deployment.yaml
@@ -114,6 +114,10 @@ spec:
 
 
 {{- define "bashible_input_data" }}
+    deckhouse:
+      channel: {{ .Values.deckhouse.releaseChannel | default "unknown" | quote }}
+      version: {{ .Values.global.deckhouseVersion | quote }}
+      edition: {{ .Values.global.deckhouseEdition | quote }}
     podSubnetNodeCIDRPrefix: {{ $.Values.global.clusterConfiguration.podSubnetNodeCIDRPrefix | quote }}
     clusterDomain: {{ $.Values.global.discovery.clusterDomain | toYaml }}
     clusterDNSAddress: {{ $.Values.global.discovery.clusterDNSAddress | toYaml }}


### PR DESCRIPTION
## Description

add Deckhouse version metadata to the bashible-apiserver context.
This exposes additional template variables for use in bashible:

example:

```tpl
echo version "{{ .deckhouse.version }}"
echo edition "{{ .deckhouse.edition }}"
echo channel "{{ .deckhouse.channel }}"
```


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: add dh version to bashible-apiserver context 
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
