### PR TITLE
Fix/certmanager expired upmeter

### DIFF
--- a/modules/101-cert-manager/monitoring/prometheus-rules/propagated-certificate.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/propagated-certificate.yaml
@@ -22,7 +22,7 @@
 
   - alert: CertmanagerCertificateExpired
     expr: |
-      max by (name, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 0)
+      max by (name, exported_namespace) ((certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 0) and certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} > 0)
     for: 1h
     labels:
       severity_level: "4"

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -91,6 +91,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/resources.yaml
@@ -88,6 +88,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
@@ -205,6 +205,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/default_case/template.yaml
@@ -201,6 +201,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
@@ -61,6 +61,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/resources.yaml
@@ -58,6 +58,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
@@ -243,6 +243,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_case/template.yaml
@@ -239,6 +239,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -94,6 +94,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/resources.yaml
@@ -91,6 +91,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
@@ -293,6 +293,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/secure_with_dedicated_node_case/template.yaml
@@ -289,6 +289,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
@@ -92,6 +92,9 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: d8-service-with-healthchecks
+      podSelector:
+        matchLabels:
+          app: agent
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/resources.yaml
@@ -89,6 +89,9 @@ spec:
       podSelector:
         matchLabels:
           app: controller
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: d8-service-with-healthchecks
   podSelector:
     matchLabels: {}
   policyTypes:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
@@ -196,6 +196,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/internal/helm/testdata/without_ns_case/template.yaml
@@ -192,6 +192,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
@@ -206,6 +206,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/default.yaml
@@ -202,6 +202,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         - to:
           # Traffic within the project is allowed.

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
@@ -294,6 +294,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure-with-dedicated-nodes.yaml
@@ -290,6 +290,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
@@ -243,6 +243,9 @@ spec:
             - namespaceSelector:
                 matchLabels:
                   kubernetes.io/metadata.name: "d8-service-with-healthchecks"
+              podSelector:
+                matchLabels:
+                  app: agent
       egress:
         # Traffic within the project is allowed.
         - to:

--- a/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
+++ b/modules/160-multitenancy-manager/images/multitenancy-manager/src/templates/secure.yaml
@@ -239,6 +239,10 @@ spec:
               podSelector:
                 matchLabels:
                   app: controller
+            # ServiceWithHealthChecks agents traffic.
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: "d8-service-with-healthchecks"
       egress:
         # Traffic within the project is allowed.
         - to:


### PR DESCRIPTION
## Description
Update `CertmanagerCertificateExpired` alert expression to ignore zero expiration timestamps.
The alert now treats certificates as expired only when:
- expiration timestamp is in the past, and
- expiration timestamp is greater than zero.
This prevents false positives for temporary/not-yet-issued certificates (notably from upmeter cert-manager probe lifecycle).
## Why do we need it, and what problem does it solve?
`certmanager_certificate_expiration_timestamp_seconds` may be `0` while a certificate is not yet issued.
Current expression interprets `0 - time() < 0` as expired, which produces false `CertmanagerCertificateExpired` alerts.
This is especially visible with upmeter probe certificates that are created/deleted frequently and can hit scrape/lookback windows during API/cert-manager delays.
Issue/card: #62744440
## Why do we need it in the patch release (if we do)?
Yes, this should be backported to patch releases, because it reduces noisy false-positive alerts in production and lowers on-call load without changing behavior for genuinely expired certificates.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: cert-manager
type: fix
summary: Prevent false positive CertmanagerCertificateExpired alerts by excluding zero expiration timestamps.
impact_level: default