### PR TITLE
[deckhouse] Add Age column print column for operations

### DIFF
--- a/deckhouse-controller/crds/packagerepositoryoperation.yaml
+++ b/deckhouse-controller/crds/packagerepositoryoperation.yaml
@@ -23,11 +23,14 @@ spec:
     - jsonPath: .status.conditions[?(@.type=='Completed')].status
       name: Completed
       type: string
+    - jsonPath: .status.completionTime
+      name: CompletionTime
+      type: date
     - jsonPath: .status.conditions[?(@.type=='Completed')].message
       name: MSG
       type: string
-    - jsonPath: .status.completionTime
-      name: CompletionTime
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
       type: date
     name: v1alpha1
     schema:

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
@@ -75,8 +75,9 @@ var _ runtime.Object = (*PackageRepositoryOperation)(nil)
 // +kubebuilder:resource:scope=Cluster,shortName=pro
 // +kubebuilder:printcolumn:name=Count,type=integer,JSONPath=.status.packages.total
 // +kubebuilder:printcolumn:name=Completed,type=string,JSONPath=.status.conditions[?(@.type=='Completed')].status
-// +kubebuilder:printcolumn:name=MSG,type=string,JSONPath=.status.conditions[?(@.type=='Completed')].message
 // +kubebuilder:printcolumn:name=CompletionTime,type=date,JSONPath=.status.completionTime
+// +kubebuilder:printcolumn:name=MSG,type=string,JSONPath=.status.conditions[?(@.type=='Completed')].message
+// +kubebuilder:printcolumn:name=Age,type=date,JSONPath=.status.completionTime
 
 // PackageRepositoryOperation represents an operation to scan/update a package repository.
 type PackageRepositoryOperation struct {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository_operation.go
@@ -77,7 +77,7 @@ var _ runtime.Object = (*PackageRepositoryOperation)(nil)
 // +kubebuilder:printcolumn:name=Completed,type=string,JSONPath=.status.conditions[?(@.type=='Completed')].status
 // +kubebuilder:printcolumn:name=CompletionTime,type=date,JSONPath=.status.completionTime
 // +kubebuilder:printcolumn:name=MSG,type=string,JSONPath=.status.conditions[?(@.type=='Completed')].message
-// +kubebuilder:printcolumn:name=Age,type=date,JSONPath=.status.completionTime
+// +kubebuilder:printcolumn:name=Age,type=date,JSONPath=.metadata.creationTimestamp
 
 // PackageRepositoryOperation represents an operation to scan/update a package repository.
 type PackageRepositoryOperation struct {


### PR DESCRIPTION
## Description
Add `Age` print column to PackageRepositoryOperation CRD.

<img width="541" height="184" alt="image" src="https://github.com/user-attachments/assets/aa712245-55c8-4aa4-a8ab-edc3856a52d5" />

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Currently, `kubectl get packagerepositoryoperations` does not expose an `Age` column, making it hard to quickly assess how long an operation has been pending or running. Users had to describe individual objects or calculate age manually from `metadata.creationTimestamp`.
This PR adds an Age column (sourced from `.metadata.creationTimestamp`) to the PackageRepositoryOperation CRD printer columns, so the resource age is visible at a glance.

`skip/documentation-validation`: change is printcolumn-only (CRD display metadata), no new schema fields added - nothing to translate in doc-ru-*.yaml.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: feature
summary: Add Age print column to PackageRepositoryOperation for kubectl get output.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
