### PR TITLE
[dhctl] Improve preflight check for deckhouse user.

### DIFF
--- a/candi/bashible/preflight/check_deckhouse_user.sh.tpl
+++ b/candi/bashible/preflight/check_deckhouse_user.sh.tpl
@@ -15,10 +15,32 @@
 # limitations under the License.
 */}}
     
+EXPECTED_ID="64535"
+
+fail() {
+    echo "ERROR: $1"
+    echo ""
+    echo "To resolve this issue:"
+    echo "  - If the node was previously part of a Deckhouse cluster, run the cleanup script:"
+    echo "      chmod +x /var/lib/bashible/cleanup_static_node.sh"
+    echo "      sudo bash /var/lib/bashible/cleanup_static_node.sh --yes-i-am-sane-and-i-understand-what-i-am-doing"
+    echo "  - Otherwise, remove the conflicting account manually:"
+    echo "      sudo userdel deckhouse"
+    echo "      sudo groupdel deckhouse"
+    exit 1
+}
+
 uid="$(id -u deckhouse 2>/dev/null || true)"
 gid="$(getent group deckhouse | cut -d: -f3 || true)"
 
-if [ -n "$uid" ] || [ -n "$gid" ]; then
-    echo "deckhouse user or group already exists with id: uid=${uid}, gid=${gid}"
-    exit 1
+if [ -z "$uid" ] && [ -z "$gid" ]; then
+    exit 0
+fi
+
+if [ "$uid" != "$EXPECTED_ID" ] || [ "$gid" != "$EXPECTED_ID" ]; then
+    fail "deckhouse user or group exists with unexpected id: uid=${uid}, gid=${gid} (expected ${EXPECTED_ID})"
+fi
+
+if sudo -l -U deckhouse 2>/dev/null | grep -q "(ALL"; then
+    fail "deckhouse user has sudo privileges — this is a security risk"
 fi

--- a/dhctl/pkg/preflight/checks/deckhouse_user.go
+++ b/dhctl/pkg/preflight/checks/deckhouse_user.go
@@ -33,7 +33,7 @@ type DeckhouseUserCheck struct {
 const DeckhouseUserCheckName preflight.CheckName = "deckhouse-user"
 
 func (DeckhouseUserCheck) Description() string {
-	return "deckhouse user and group aren't present on node"
+	return "no conflicting deckhouse user or group on the node"
 }
 
 func (DeckhouseUserCheck) Phase() preflight.Phase {
@@ -53,14 +53,17 @@ func (c DeckhouseUserCheck) Run(ctx context.Context) error {
 	cmd := c.Node.UploadScript(file)
 	out, err := cmd.Execute(ctx)
 	if err != nil {
+		outMsg := strings.TrimSpace(string(out))
+		if outMsg != "" {
+			return fmt.Errorf("Deckhouse user check failed: %s", outMsg)
+		}
 		var ee *exec.ExitError
 		if errors.As(err, &ee) {
-			return fmt.Errorf("Deckhouse user existence check failed: %w, %s", err, string(ee.Stderr))
+			return fmt.Errorf("Deckhouse user check failed: %w, %s", err, string(ee.Stderr))
 		}
 		return fmt.Errorf("Could not execute a script to check deckhouse user and group aren't present on the node: %w", err)
 	}
 
-	_ = strings.TrimSpace(string(out))
 	return nil
 }
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Enhance the deckhouse user preflight check to allow idempotent bootstrap when the user already exists with the correct UID/GID (64535), and add a sudo privileges check to prevent privilege escalation risks.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Previously, the preflight check rejected any existing deckhouse user, breaking re-bootstrap scenarios. It also didn't detect cases where the user had sudo privileges or mismatched UID/GID, which could lead to security issues since nginx registry-proxy runs as this user on the node.
## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature 
summary: Improved the preflight check for the deckhouse user.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
