### PR TITLE
[istio] Fix lag-bug of internal.operatorVersionsToInstall not follow internal.versionsToInstall

### DIFF
--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -84,7 +84,7 @@ func applyIstioFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue:        lib.Queue("discovery"),
+	Queue: lib.Queue("discovery"),
 	// Relies on hook discovery_versions_to_install.go (Order: 5) and must run before hooks deprecated_versions_monitoring.go and compatibility_version_istio_k8s_monitoring.go (Order: 10)
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9},
 	Kubernetes: []go_hook.KubernetesConfig{

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -85,6 +85,7 @@ func applyIstioFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, err
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue:        lib.Queue("discovery"),
+	// Relies on hook discovery_versions_to_install.go (Order: 5) and must run before hooks deprecated_versions_monitoring.go and compatibility_version_istio_k8s_monitoring.go (Order: 10)
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -25,10 +25,14 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 
+	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/requirements"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/crd"
@@ -37,7 +41,14 @@ import (
 
 const (
 	minVersionValuesKey = "istio:minimalVersion"
+	istioNamespace      = "d8-istio"
 )
+
+var sailIstioGVR = schema.GroupVersionResource{
+	Group:    "sailoperator.io",
+	Version:  "v1",
+	Resource: "istios",
+}
 
 type IstioOperatorCrdInfo struct {
 	Name     string
@@ -58,8 +69,23 @@ func applyIstioOperatorFilter(obj *unstructured.Unstructured) (go_hook.FilterRes
 	}, nil
 }
 
+func applyIstioFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	var istio crd.Istio
+
+	err := sdk.FromUnstructured(obj, &istio)
+	if err != nil {
+		return nil, err
+	}
+
+	return IstioOperatorCrdInfo{
+		Name:     istio.GetName(),
+		Revision: istio.Spec.Revision,
+	}, nil
+}
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
-	Queue: lib.Queue("discovery"),
+	Queue:        lib.Queue("discovery"),
+	OnBeforeHelm: &go_hook.OrderedConfig{Order: 9},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:              "istiooperators",
@@ -69,9 +95,9 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			NamespaceSelector: lib.NsSelector(),
 		},
 	},
-}, operatorRevisionsToInstallDiscovery)
+}, dependency.WithExternalDependencies(operatorRevisionsToInstallDiscovery))
 
-func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookInput) error {
+func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookInput, dc dependency.Container) error {
 	var operatorVersionsToInstall = make([]string, 0)
 	var unsupportedRevisions = make([]string, 0)
 
@@ -94,6 +120,39 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 		}
 		if !lib.Contains(operatorVersionsToInstall, iopVer) {
 			operatorVersionsToInstall = append(operatorVersionsToInstall, iopVer)
+		}
+	}
+
+	k8sClient, err := dc.GetK8sClient()
+	if err != nil {
+		return err
+	}
+
+	istios, err := k8sClient.Dynamic().Resource(sailIstioGVR).Namespace(istioNamespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		// The CRD can be absent on old control planes; this is expected.
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		for _, istio := range istios.Items {
+			infoAny, err := applyIstioFilter(&istio)
+			if err != nil {
+				return fmt.Errorf("cannot parse Istio %q: %w", istio.GetName(), err)
+			}
+			istioInfo, ok := infoAny.(IstioOperatorCrdInfo)
+			if !ok {
+				return fmt.Errorf("unexpected Istio filter result type for %q", istio.GetName())
+			}
+
+			istioVer := versionMap.GetVersionByRevision(istioInfo.Revision)
+			if !versionMap.IsRevisionSupported(istioInfo.Revision) {
+				unsupportedRevisions = append(unsupportedRevisions, istioInfo.Revision)
+				continue
+			}
+			if !lib.Contains(operatorVersionsToInstall, istioVer) {
+				operatorVersionsToInstall = append(operatorVersionsToInstall, istioVer)
+			}
 		}
 	}
 

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
@@ -27,6 +27,7 @@ import (
 var _ = Describe("Istio hooks :: discovery_operator_versions_to_install ::", func() {
 	f := HookExecutionConfigInit(`{"istio":{}}`, "")
 	f.RegisterCRD("install.istio.io", "v1alpha1", "IstioOperator", true)
+	f.RegisterCRD("sailoperator.io", "v1", "Istio", true)
 
 	Context("Empty cluster and minimal settings", func() {
 		BeforeEach(func() {
@@ -97,6 +98,55 @@ spec:
 			f.RunHook()
 		})
 		It("Should count all namespaces and revisions properly", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(Equal([]string{"1.2", "1.3", "1.4", "1.8"}))
+
+			value, exists := requirements.GetValue(minVersionValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("1.2"))
+		})
+	})
+
+	Context("There are supported Istio resources in cluster", func() {
+		BeforeEach(func() {
+			values := `
+internal:
+  versionMap:
+    "1.1":
+        revision: "v1x1"
+    "1.8":
+        revision: "v1x8"
+    "1.2":
+        revision: "v1x2"
+    "1.3":
+        revision: "v1x3"
+    "1.4":
+        revision: "v1x4"
+  versionsToInstall: ["1.3", "1.4"]
+`
+			f.ValuesSetFromYaml("istio", []byte(values))
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: v1x8
+  namespace: d8-istio
+spec:
+  revision: v1x8
+---
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: v1x2
+  namespace: d8-istio
+spec:
+  revision: v1x2
+`))
+
+			f.RunHook()
+		})
+		It("Should include versions from Istio resources", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(Equal([]string{"1.2", "1.3", "1.4", "1.8"}))
 


### PR DESCRIPTION
## Description
Fixed bug when adding `spec.settings.additionalVersions` for version `1.25` in MC Istio wont work.

## Why do we need it, and what problem does it solve?
Now it's possible to migrate from version 1.21 to 1.25 seamlessly.

## Why do we need it in the patch release (if we do)?
Now it's possible to migrate from version 1.21 to 1.25 seamlessly.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fixed the discovery_operator_versions_to_install hook to migrate from Istio 1.21 to 1.25.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
