### PR TITLE
[dmt] Change version to 0.1.70

### DIFF
--- a/tools/dmt-lint.sh
+++ b/tools/dmt-lint.sh
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-DMT_VERSION=0.1.67
+DMT_VERSION=0.1.70
 
 function install_dmt() {
   platform_name=$(uname -m)


### PR DESCRIPTION
## Description

- Update dmt version in lint script to `0.1.70`.

## Why do we need it, and what problem does it solve?
Use the latest dmt release in local and CI lint checks.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: fix
summary: Updated the dmt version to 0.1.70.
impact_level: default
```