### PR TITLE
[cert-manager] Ignore zero expiration timestamps in expired alert

### DIFF
--- a/modules/101-cert-manager/monitoring/prometheus-rules/propagated-certificate.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/propagated-certificate.yaml
@@ -22,7 +22,7 @@
 
   - alert: CertmanagerCertificateExpired
     expr: |
-      max by (name, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 0)
+      max by (name, exported_namespace) ((certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 0) and certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} > 0)
     for: 1h
     labels:
       severity_level: "4"

--- a/modules/101-cert-manager/monitoring/prometheus-rules/propagated-certificate.yaml
+++ b/modules/101-cert-manager/monitoring/prometheus-rules/propagated-certificate.yaml
@@ -22,7 +22,11 @@
 
   - alert: CertmanagerCertificateExpired
     expr: |
-      max by (name, exported_namespace) ((certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 0) and certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} > 0)
+      max by (name, exported_namespace) (
+        (certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"} - time() < 0)
+        and
+        (count_over_time(certmanager_certificate_expiration_timestamp_seconds{job="cert-manager"}[5m]) > 5)
+      )
     for: 1h
     labels:
       severity_level: "4"


### PR DESCRIPTION
## Description
Update `CertmanagerCertificateExpired` alert expression to ignore zero expiration timestamps.
The alert now treats certificates as expired only when:
- expiration timestamp is in the past, and
- expiration timestamp is greater than zero.
This prevents false positives for temporary/not-yet-issued certificates (notably from upmeter cert-manager probe lifecycle).
## Why do we need it, and what problem does it solve?
`certmanager_certificate_expiration_timestamp_seconds` may be `0` while a certificate is not yet issued.
Current expression interprets `0 - time() < 0` as expired, which produces false `CertmanagerCertificateExpired` alerts.
This is especially visible with upmeter probe certificates that are created/deleted frequently and can hit scrape/lookback windows during API/cert-manager delays.
Issue/card: #62744440
## Why do we need it in the patch release (if we do)?
Yes, this should be backported to patch releases, because it reduces noisy false-positive alerts in production and lowers on-call load without changing behavior for genuinely expired certificates.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: cert-manager
type: fix
summary: Prevent false positive CertmanagerCertificateExpired alerts by excluding zero expiration timestamps.
impact_level: default