### PR TITLE
[local-path-provisioner] Add wildcard tolerations to helper pod template

### DIFF
--- a/modules/031-local-path-provisioner/templates/configmap.yaml
+++ b/modules/031-local-path-provisioner/templates/configmap.yaml
@@ -27,6 +27,7 @@ data:
     metadata:
       name: helper-pod
     spec:
+{{- include "helm_lib_tolerations" (tuple $context "wildcard") | nindent 6 }}
       securityContext:
         runAsNonRoot: false
         runAsUser: 0


### PR DESCRIPTION
## Description

Add `helm_lib_tolerations` with the `wildcard` strategy to the `helperPod.yaml` embedded in the local-path-provisioner ConfigMap, matching the provisioner Deployment. This restores scheduling of helper pods on nodes with custom taints after rancher/local-path-provisioner v0.0.32+ replaced the permissive default toleration with `node.kubernetes.io/disk-pressure` only.

## Why do we need it, and what problem does it solve?

Upstream [local-path-provisioner](https://github.com/rancher/local-path-provisioner) v0.0.32+ (Deckhouse image v0.0.34) changed default helper-pod tolerations: the previous implicit `operator: Exists` without a key (tolerating any taint) was replaced by a narrow `node.kubernetes.io/disk-pressure` toleration, and default tolerations are applied only when `spec.tolerations` is unset in the helper pod template.

The Deckhouse module already uses wildcard tolerations for the provisioner itself, but the helper pod manifest in the ConfigMap had none. Helper pods then failed the scheduler predicate `TaintToleration` on tainted worker nodes, breaking PVC provisioning.

Aligning helper pods with the same wildcard tolerations as the controller restores the previous effective behaviour for Deckhouse clusters.

## Why do we need it in the patch release (if we do)?

Users on recent module builds who rely on local storage on tainted nodes hit a regression in PVC provisioning; backporting reduces support burden and unblocks clusters without requiring manual ConfigMap edits.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: local-path-provisioner
type: fix
summary: Add wildcard tolerations to the helper pod template so PVC provisioning works on tainted nodes after local-path-provisioner v0.0.32+.
impact_level: default
```
