### PR TITLE
[ci] Switch dev build to pull_request trigger

### DIFF
--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -16,6 +16,7 @@ WERF_FINAL_IMAGES_ONLY: true
 WERF_LOG_TERMINAL_WIDTH: "200"
 WERF_LOG_TIME: true
 WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+WERF_VIRTUAL_MERGE: "0"
 GOPROXY: "${{vars.GOPROXY}}"
 # </template: werf_envs>
 {!{- end -}!}

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{!{- $pullRequestContext := coll.Dict "pullRequestRefField" "needs.pull_request_info.outputs.ref" -}!}
+{!{- $pullRequestContext := coll.Dict "pullRequestRefField" "github.event.pull_request.head.sha" -}!}
 {!{- $ctx := coll.Merge $pullRequestContext . }!}
 
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  pull_request_target:
+  pull_request:
      types:
       - opened
       - synchronize

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -19,7 +19,7 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  pull_request_target:
+  pull_request:
      types:
       - opened
       - synchronize
@@ -43,6 +43,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 
@@ -433,7 +434,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -731,7 +732,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -1028,7 +1029,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -1325,7 +1326,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -1622,7 +1623,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -1919,7 +1920,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -2216,7 +2217,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -2522,7 +2523,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2608,7 +2609,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2689,7 +2690,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2787,7 +2788,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2899,7 +2900,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       - name: Run python webhook tests
         run: |
@@ -2929,7 +2930,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       - name: DMT lint
         env:
@@ -2964,7 +2965,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -3085,7 +3086,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -3207,7 +3208,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -3328,7 +3329,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -3449,7 +3450,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -43,6 +43,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -43,6 +43,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -57,6 +57,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: alpha

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -57,6 +57,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: beta

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -57,6 +57,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: early-access

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -57,6 +57,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -57,6 +57,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: stable

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test10.yml
+++ b/.github/workflows/deploy-web-test10.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test2.yml
+++ b/.github/workflows/deploy-web-test2.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test3.yml
+++ b/.github/workflows/deploy-web-test3.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test4.yml
+++ b/.github/workflows/deploy-web-test4.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test5.yml
+++ b/.github/workflows/deploy-web-test5.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test6.yml
+++ b/.github/workflows/deploy-web-test6.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test7.yml
+++ b/.github/workflows/deploy-web-test7.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test8.yml
+++ b/.github/workflows/deploy-web-test8.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test9.yml
+++ b/.github/workflows/deploy-web-test9.yml
@@ -62,6 +62,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-dvp.yml
+++ b/.github/workflows/e2e-abort-dvp.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-zvirt.yml
+++ b/.github/workflows/e2e-abort-zvirt.yml
@@ -56,6 +56,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -41,6 +41,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-dvp.yml
+++ b/.github/workflows/e2e-dvp.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-zvirt.yml
+++ b/.github/workflows/e2e-zvirt.yml
@@ -73,6 +73,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/promote_image.yml
+++ b/.github/workflows/promote_image.yml
@@ -53,6 +53,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -41,6 +41,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: alpha

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: beta

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: early-access

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: stable

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -46,6 +46,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 


### PR DESCRIPTION
## Description
Switch dev build to pull_request trigger.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Switch dev build to pull_request trigger.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
