### PR TITLE
[istio] Tweak default ztunnel resources

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -849,7 +849,7 @@ properties:
                       max:
                         description: |
                           The maximum value that the VPA can set for the CPU requests.
-                        default: 2
+                        default: 1
                         oneOf:
                         - type: string
                           pattern: "^[0-9]+m?$"
@@ -857,7 +857,7 @@ properties:
                       min:
                         description: |
                           The minimum value that the VPA can set for the CPU requests.
-                        default: '50m'
+                        default: '25m'
                         oneOf:
                         - type: string
                           pattern: "^[0-9]+m?$"
@@ -888,7 +888,7 @@ properties:
                       min:
                         description: |
                           The minimum memory requests the VPA can set.
-                        default: '256Mi'
+                        default: '64Mi'
                         oneOf:
                         - type: string
                           pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'


### PR DESCRIPTION
## Description

Adjusted default resource settings for the ztunnel component in the Istio module to be more conservative and better aligned with actual resource consumption.

Changes to `dataPlane.ztunnel.resourcesManagement.vpa` defaults:
- CPU max: reduced from `2` to `1`
- CPU min: reduced from `50m` to `25m`
- Memory min: reduced from `256Mi` to `64Mi`

These changes apply to the VPA mode configuration for ztunnel pods in ambient mesh mode.

## Why do we need it, and what problem does it solve?

The previous default resource settings for ztunnel were over-provisioned. This change optimizes resource allocation by:

- Reducing the default CPU maximum from 2 cores to 1 core - ztunnel typically consumes far less CPU in practice
- Lowering the minimum CPU request from 50m to 25m - better reflects the baseline resource needs
- Decreasing the minimum memory request from 256Mi to 64Mi - ztunnel has a smaller memory footprint than initially estimated

This ensures more efficient cluster resource utilization while still allowing VPA to scale up as needed based on actual usage.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: istio
type: chore
summary: Reduced default ztunnel resource requests/limits.
impact_level: low
```