### PR TITLE
[ingress-nginx] fix vpa default spec

### DIFF
--- a/modules/402-ingress-nginx/crds/ingress-nginx.yaml
+++ b/modules/402-ingress-nginx/crds/ingress-nginx.yaml
@@ -716,7 +716,7 @@ spec:
                           type: string
                           description: |
                             VPA operating mode.
-                          enum: ['Initial', 'Auto']
+                          enum: ['Initial', 'InPlaceOrRecreate']
                           default: 'Initial'
                         cpu:
                           type: object
@@ -1677,7 +1677,7 @@ spec:
                           type: string
                           description: |
                             VPA usage mode.
-                          enum: ['Initial', 'Auto']
+                          enum: ['Initial', 'InPlaceOrRecreate']
                           default: 'Initial'
                         cpu:
                           type: object

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
@@ -123,6 +123,14 @@ func applyControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 	setDefaultEmptyObject("cpu", vpa)
 	setDefaultEmptyObject("memory", vpa)
 
+	vpamode, _, err := unstructured.NestedString(vpa, "mode")
+	if vpamode == "" {
+		err := unstructured.SetNestedField(vpa, "Init", "mode")
+		if err != nil {
+			return nil, fmt.Errorf("cannot set resourcesManagement.vpa.mode from ingress controller spec: %v", err)
+		}
+	}
+
 	err = unstructured.SetNestedMap(resourcesManagement, vpa, "vpa")
 	if err != nil {
 		return nil, fmt.Errorf("cannot set resourcesManagement.vpa from ingress controller spec: %v", err)

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
@@ -124,6 +124,10 @@ func applyControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 	setDefaultEmptyObject("memory", vpa)
 
 	vpamode, _, err := unstructured.NestedString(vpa, "mode")
+	if err != nil {
+		return nil, fmt.Errorf("cannot get resourcesManagement.vpa.mode from ingress controller spec: %v", err)
+	}
+
 	if vpamode == "" {
 		err := unstructured.SetNestedField(vpa, "Initial", "mode")
 		if err != nil {

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers.go
@@ -125,7 +125,7 @@ func applyControllerFilter(obj *unstructured.Unstructured) (go_hook.FilterResult
 
 	vpamode, _, err := unstructured.NestedString(vpa, "mode")
 	if vpamode == "" {
-		err := unstructured.SetNestedField(vpa, "Init", "mode")
+		err := unstructured.SetNestedField(vpa, "Initial", "mode")
 		if err != nil {
 			return nil, fmt.Errorf("cannot set resourcesManagement.vpa.mode from ingress controller spec: %v", err)
 		}

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
@@ -98,7 +98,8 @@ spec:
     },
     "vpa": {
       "cpu": {},
-      "memory": {}
+      "memory": {},
+      "mode": "Init"
     }
   },
   "underscoresInHeaders": false,
@@ -219,7 +220,8 @@ spec:
   },
   "vpa": {
     "cpu": {},
-    "memory": {}
+    "memory": {},
+    "mode": "Init"
   }
 },
 "underscoresInHeaders": false,
@@ -259,6 +261,7 @@ spec:
     "requests": {}
   },
   "vpa": {
+    "mode": "InPlaceOrRecreate",
     "cpu": {
       "limitRatio": 1.5,
       "max": "100m",
@@ -305,7 +308,8 @@ spec:
   },
   "vpa": {
     "cpu": {},
-    "memory": {}
+    "memory": {},
+    "mode": "Init"
   }
 },
 "underscoresInHeaders": false,

--- a/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
+++ b/modules/402-ingress-nginx/hooks/get_ingress_controllers_test.go
@@ -99,7 +99,7 @@ spec:
     "vpa": {
       "cpu": {},
       "memory": {},
-      "mode": "Init"
+      "mode": "Initial"
     }
   },
   "underscoresInHeaders": false,
@@ -221,7 +221,7 @@ spec:
   "vpa": {
     "cpu": {},
     "memory": {},
-    "mode": "Init"
+    "mode": "Initial"
   }
 },
 "underscoresInHeaders": false,
@@ -309,7 +309,7 @@ spec:
   "vpa": {
     "cpu": {},
     "memory": {},
-    "mode": "Init"
+    "mode": "Initial"
   }
 },
 "underscoresInHeaders": false,


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Updates default vpa mode in resourcesManagement configuration.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Fixes the 
```
 3. ModuleRun:main:ingress-nginx:Kubernetes-Change-ModuleValues:failures 7:run helm install: install nelm release "ingress-nginx": failed release "ingress-nginx" (namespace: "d8-system"): execute release install plan: wait for operations completion: execute operation: create resource: server-side apply resource "VerticalPodAutoscaler/controller-third (namespace=d8-ingress-nginx)": admission webhook "vpa.k8s.io" denied the request: updateMode is required if UpdatePolicy is used
```
error.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed the VPA default mode specification.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
