### PR TITLE
[cpm] new openapi scheme for clusterConfiguration migrate

### DIFF
--- a/modules/040-control-plane-manager/openapi/config-values.yaml
+++ b/modules/040-control-plane-manager/openapi/config-values.yaml
@@ -6,7 +6,7 @@ x-doc-example:
   metadata:
     name: control-plane-manager
   spec:
-    version: 2
+    version: 3
     enabled: true
     settings:
       apiserver:
@@ -16,6 +16,95 @@ x-doc-example:
           - devs.infra
         loadBalancer: { }
 properties:
+  kubernetesVersion:
+    type: string
+    description: |
+      Kubernetes version (control plane components of the cluster).
+
+      Changing a parameter in a running cluster will [automatically update](https://deckhouse.io/modules/control-plane-manager/#version-control) the cluster's control plane version.
+
+      If `Automatic` is specified, then the control plane version is used, which is considered stable at the moment. If the stable version of control plane is less than the maximum version that has ever been installed in the cluster, more than 1 minor version, then the version of the cluster will not be changed.
+      The version may change when the minor version of the Deckhouse release is changed (see a corresponding release message).
+  encryptionAlgorithm:
+    type: string
+    description: |
+      Starting from version **1.31**, kubeadm use the specified asymmetric encryption algorithm
+      when generating keys and certificates for the following control-plane components:
+
+      - `apiserver`
+      - `apiserver-kubelet-client`
+      - `apiserver-etcd-client`
+      - `front-proxy-client`
+      - `etcd-server`
+      - `etcd-peer`
+      - `etcd-healthcheck-client`
+
+      Certificates for the components listed above will be reissued using the selected algorithm and key length.
+
+      > **Warning.** When reissuing certificates, the root certificate (**CA**) is not rotated. The root certificate is created with the selected algorithm only during the initial cluster bootstrap.
+  resourcesRequests:
+    description: |
+      Amount of resources (CPU and memory) allocated to control plane components on each master node.
+      These settings do not apply if the cluster control plane is managed by a cloud provider (for example, Google Kubernetes Engine or Azure Kubernetes Service).
+
+      [More](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes) about resource units in Kubernetes.
+    x-examples:
+      - cpu: 1000m
+        memory: 500M
+    type: object
+    properties:
+      cpu:
+        description: |
+          The combined CPU requests for control-plane components on each master node.
+        oneOf:
+          - type: string
+            pattern: "^[0-9]+m?$"
+          - type: number
+      memory:
+        description: |
+          The combined memory requests for control-plane components on each master node.
+        type: string
+        pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+  network:
+    type: object
+    properties:
+      podSubnetNodeCIDRPrefix:
+        type: integer
+        description: |
+          The prefix size of the Pod network allocated to each node.
+
+          This parameter determines how many IP addresses are available for Pods on each individual node. For example, if `podSubnetCIDR: 10.111.0.0/16` and `podSubnetNodeCIDRPrefix: "24"`, each node will receive a `/24` subnet (e.g., `10.111.0.0/24`, `10.111.1.0/24`, etc.), providing up to 254 IP addresses per node (253 usable for Pods, accounting for network and broadcast addresses).
+
+          **Calculation examples:**
+          - With `/16` network and `/24` prefix: maximum **256 nodes** (2^(24-16) = 256)
+          - With `/16` network and `/25` prefix: maximum **512 nodes**, but only **126 IPs per node**
+          - Each Pod network IP can support up to 2 Pods (one running + one terminating)
+
+          > **Warning!** Changing this parameter in a running cluster is **extremely dangerous** and can lead to complete cluster failure. The change is blocked by default. To bypass this protection, use `dhctl config edit cluster-configuration --yes-i-am-sane-and-i-understand-what-i-am-doing` command. However, it is **strongly recommended to recreate the cluster** instead of changing this parameter. See [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/#modifying-protected-parameters) for details.
+        default: 24
+      podSubnetCIDR:
+        type: string
+        x-unsafe: true
+        description: |
+          Address space of the cluster's Pods.
+
+          > **Warning!** Changing this parameter in a running cluster is **extremely dangerous** and can lead to complete cluster failure. The change is blocked by default. To bypass this protection, use `dhctl config edit cluster-configuration --yes-i-am-sane-and-i-understand-what-i-am-doing` command. However, it is **strongly recommended to recreate the cluster** instead of changing this parameter. See [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/#modifying-protected-parameters) for details.
+      serviceSubnetCIDR:
+        type: string
+        x-unsafe: true
+        description: |
+          Address space of the cluster's services.
+
+          > **Warning!** Changing this parameter in a running cluster is **extremely dangerous** and can lead to complete cluster failure. The change is blocked by default. To bypass this protection, use `dhctl config edit cluster-configuration --yes-i-am-sane-and-i-understand-what-i-am-doing` command. However, it is **strongly recommended to recreate the cluster** instead of changing this parameter. See [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/#modifying-protected-parameters) for details.
+      clusterDomain:
+        type: string
+        default: "cluster.local"
+        description: |
+          Cluster domain (used for local routing).
+
+          **Please note:** the domain must not match the domain used in the DNS name template in the [publicDomainTemplate](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-publicdomaintemplate) parameter. For example, you cannot set `cluster Domain: cluster.local` and `publicDomainTemplate: %s.cluster.local` at the same time.
+
+          > If you need to change a parameter in a running cluster, it is recommended to use [instructions](/modules/kube-dns/faq.html#how-do-i-replace-the-cluster-domain-with-minimal-downtime)
   apiserver:
     type: object
     default: {}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

```yaml
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata:
  name: control-plane-manager
spec:
  version: 3
  enabled: true
  settings:
    kubernetesVersion: "1.29"
    encryptionAlgorithm: "RSA-2048"
    resourcesRequests:
      cpu: "500m"
      memory: "512Mi"
    network:
      podSubnetNodeCIDRPrefix: 24
      podSubnetCIDR: "10.111.0.0/16"
      serviceSubnetCIDR: "10.222.0.0/16"
      clusterDomain: "cluster.local"
    ...
    apiserver:
      auditPolicyEnabled: true
    failedNodePodEvictionTimeoutSeconds: 29
```

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
