### PR TITLE
Add podMetadata support for DexAuthenticator pods

### DIFF
--- a/modules/150-user-authn/crds/dex-authenticator.yaml
+++ b/modules/150-user-authn/crds/dex-authenticator.yaml
@@ -163,6 +163,23 @@ spec:
                   items:
                     type: string
                     pattern: '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$'
+                podMetadata:
+                  type: object
+                  description: |-
+                    Additional labels and annotations for `dex-authenticator` pods.
+                  properties:
+                    labels:
+                      type: object
+                      description: |-
+                        Additional labels for `dex-authenticator` pods.
+                      additionalProperties:
+                        type: string
+                    annotations:
+                      type: object
+                      description: |-
+                        Additional annotations for `dex-authenticator` pods.
+                      additionalProperties:
+                        type: string
                 nodeSelector:
                   additionalProperties:
                     type: string
@@ -433,6 +450,23 @@ spec:
                   x-doc-default: 'All groups are allowed.'
                   items:
                     type: string
+                podMetadata:
+                  type: object
+                  description: |-
+                    Additional labels and annotations for `dex-authenticator` pods.
+                  properties:
+                    labels:
+                      type: object
+                      description: |-
+                        Additional labels for `dex-authenticator` pods.
+                      additionalProperties:
+                        type: string
+                    annotations:
+                      type: object
+                      description: |-
+                        Additional annotations for `dex-authenticator` pods.
+                      additionalProperties:
+                        type: string
                 nodeSelector:
                   additionalProperties:
                     type: string

--- a/modules/150-user-authn/crds/doc-ru-dex-authenticator.yaml
+++ b/modules/150-user-authn/crds/doc-ru-dex-authenticator.yaml
@@ -72,6 +72,16 @@ spec:
                 whitelistSourceRanges:
                   description: |
                     Список адресов в формате CIDR, которым разрешено проходить аутентификацию. Если параметр не указан, аутентификацию разрешено проходить без ограничения по IP-адресу.
+                podMetadata:
+                  description: |-
+                    Дополнительные лейблы и аннотации для подов `dex-authenticator`.
+                  properties:
+                    labels:
+                      description: |-
+                        Дополнительные лейблы для подов `dex-authenticator`.
+                    annotations:
+                      description: |-
+                        Дополнительные аннотации для подов `dex-authenticator`.
                 nodeSelector:
                   description: |-
                     Определяет `nodeSelector` для подов `dex-authenticator`.
@@ -204,6 +214,16 @@ spec:
 
                     **По умолчанию** разрешено всем группам.
                   x-doc-default: Разрешены все группы.
+                podMetadata:
+                  description: |-
+                    Дополнительные лейблы и аннотации для подов `dex-authenticator`.
+                  properties:
+                    labels:
+                      description: |-
+                        Дополнительные лейблы для подов `dex-authenticator`.
+                    annotations:
+                      description: |-
+                        Дополнительные аннотации для подов `dex-authenticator`.
                 resources:
                   description: |-
                     Ресурсы контейнеров (CPU/память) — requests/limits.

--- a/modules/150-user-authn/docs/CONFIGURATION.md
+++ b/modules/150-user-authn/docs/CONFIGURATION.md
@@ -11,3 +11,21 @@ The creation of the [`DexAuthenticator`](cr.html#dexauthenticator) Custom Resour
 **Caution!** When this module is enabled, authentication in all web interfaces will be switched from HTTP Basic Auth to Dex (the latter, in turn, will use the external providers that you have defined). To configure kubectl, go to `https://kubeconfig.<modules.publicDomainTemplate>/`, log in to your external provider's account and copy the shell commands to your console.
 
 **Caution!** The API server requires [additional configuration](faq.html#configuring-kube-apiserver) to use authentication for dashboard and kubectl. The [control-plane-manager](/modules/control-plane-manager/) module (enabled by default) automates this process.
+
+To set custom labels and annotations for `dex-authenticator` pods, use `spec.podMetadata`.
+
+Example (disable Istio sidecar injection):
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: DexAuthenticator
+metadata:
+  name: app-name
+  namespace: app-namespace
+spec:
+  applicationDomain: app-name.kube.my-domain.com
+  applicationIngressClassName: nginx
+  podMetadata:
+    annotations:
+      sidecar.istio.io/inject: "false"
+```

--- a/modules/150-user-authn/docs/CONFIGURATION_RU.md
+++ b/modules/150-user-authn/docs/CONFIGURATION_RU.md
@@ -12,3 +12,21 @@ title: "Модуль user-authn: настройки"
 Для настройки kubectl необходимо перейти по адресу `https://kubeconfig.<modules.publicDomainTemplate>/`, авторизоваться в настроенном внешнем провайдере и скопировать shell-команды к себе в консоль.
 
 **Важно!** Для работы аутентификации в dashboard и kubectl требуется [донастройка API-сервера](faq.html#настройка-kube-apiserver). Для автоматизации этого процесса реализован модуль [control-plane-manager](/modules/control-plane-manager/), который включен по умолчанию.
+
+Чтобы задать дополнительные лейблы и аннотации для подов `dex-authenticator`, используйте поле `spec.podMetadata`.
+
+Пример (отключение инъекции Istio sidecar):
+
+```yaml
+apiVersion: deckhouse.io/v1
+kind: DexAuthenticator
+metadata:
+  name: app-name
+  namespace: app-namespace
+spec:
+  applicationDomain: app-name.kube.my-domain.com
+  applicationIngressClassName: nginx
+  podMetadata:
+    annotations:
+      sidecar.istio.io/inject: "false"
+```

--- a/modules/150-user-authn/template_tests/authenticator_test.go
+++ b/modules/150-user-authn/template_tests/authenticator_test.go
@@ -74,6 +74,13 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
     - key: foo
       operator: Equal
       value: bar
+    podMetadata:
+      labels:
+        custom-label: custom-value
+        app: overridden
+      annotations:
+        sidecar.istio.io/inject: "false"
+        checksum/config: overridden
 - name: test-2
   encodedName: justForTest2
   namespace: d8-test
@@ -209,6 +216,11 @@ var _ = Describe("Module :: user-authn :: helm template :: dex authenticator", f
   operator: Equal
   value: "bar"
 `))
+			Expect(deploymentTest.Field("spec.template.metadata.labels.custom-label").String()).To(Equal("custom-value"))
+			Expect(deploymentTest.Field("spec.template.metadata.labels.app").String()).To(Equal("dex-authenticator"))
+			Expect(deploymentTest.Field("spec.template.metadata.annotations.sidecar\\.istio\\.io/inject").String()).To(Equal("false"))
+			Expect(deploymentTest.Field("spec.template.metadata.annotations.checksum/config").Exists()).To(BeTrue())
+			Expect(deploymentTest.Field("spec.template.metadata.annotations.checksum/config").String()).ToNot(Equal("overridden"))
 
 			var oauth2proxyArgTest []string
 			for _, result := range deploymentTest.Field("spec.template.spec.containers.0.args").Array() {

--- a/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
+++ b/modules/150-user-authn/templates/dex-authenticator/deployment.yaml
@@ -99,9 +99,19 @@ spec:
   template:
     metadata:
       labels:
+        {{- with $crd.spec.podMetadata }}
+          {{- with .labels }}
+{{ toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
         app: dex-authenticator
         name: {{ $crd.name | quote}}
       annotations:
+        {{- with $crd.spec.podMetadata }}
+          {{- with .annotations }}
+{{ toYaml . | nindent 8 }}
+          {{- end }}
+        {{- end }}
         checksum/config: {{ $crd.credentials | toJson | b64enc | sha256sum }}
     spec:
 {{- if $crd.spec.nodeSelector }}


### PR DESCRIPTION
## Description
This PR adds support for passing custom Pod metadata from `DexAuthenticator` into the generated Deployment Pod template via a new field: `spec.podMetadata`.
What was changed:
- Added `spec.podMetadata.labels` and `spec.podMetadata.annotations` to DexAuthenticator CRD schemas.
- Updated DexAuthenticator Deployment template to propagate these values to Pod metadata.
- Added template tests for metadata propagation and precedence rules.
- Updated EN/RU documentation with an example for disabling Istio sidecar injection.
Impact on critical cluster components:
- This change does **not** directly restart or modify critical cluster components such as control-plane, ingress-controllers, or Prometheus.
- It affects only Pods managed by `DexAuthenticator` resources when `podMetadata` is configured or updated.
## Why do we need it, and what problem does it solve?
In clusters with Istio auto-injection, each DexAuthenticator Pod may get an extra `istio-proxy` sidecar.  
For many DexAuthenticator use cases, this sidecar is unnecessary (DA mainly handles auth checks/redirects in front of ingress-nginx), which leads to avoidable CPU/memory overhead at scale.
This PR solves that by allowing users to pass Pod-level annotations/labels, including:
- `sidecar.istio.io/inject: "false"` to disable sidecar injection for DA Pods,
- other Istio annotations for sidecar tuning when sidecar usage is still required.
The implementation also keeps system keys (`app`, `name`, `checksum/config`) authoritative to prevent accidental selector/rollout breakage.
## Why do we need it in the patch release (if we do)?
Not necessarily.
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: user-authn
type: feature
summary: Added `DexAuthenticator.spec.podMetadata` to pass custom Pod labels/annotations, including Istio sidecar control annotations.
impact_level: default