### PR TITLE
[ci] Switch dev build to pull_request trigger (#19466)

### DIFF
--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -14,6 +14,7 @@ WERF_FINAL_IMAGES_ONLY: true
 WERF_LOG_TERMINAL_WIDTH: "200"
 WERF_LOG_TIME: true
 WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+WERF_VIRTUAL_MERGE: "0"
 GOPROXY: "${{vars.GOPROXY}}"
 # </template: werf_envs>
 {!{- end -}!}

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{!{- $pullRequestContext := coll.Dict "pullRequestRefField" "needs.pull_request_info.outputs.ref" -}!}
+{!{- $pullRequestContext := coll.Dict "pullRequestRefField" "github.event.pull_request.head.sha" -}!}
 {!{- $ctx := coll.Merge $pullRequestContext . }!}
 
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  pull_request_target:
+  pull_request:
      types:
       - opened
       - synchronize

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -19,7 +19,7 @@
 # on every push to dev branches
 name: Build and test for dev branches
 on:
-  pull_request_target:
+  pull_request:
      types:
       - opened
       - synchronize
@@ -41,6 +41,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 
@@ -415,7 +416,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -707,7 +708,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -999,7 +1000,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -1291,7 +1292,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -1583,7 +1584,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -1875,7 +1876,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
 
       # <template: login_dev_registry_step>
@@ -2184,7 +2185,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2265,7 +2266,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2341,7 +2342,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2434,7 +2435,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2541,7 +2542,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       - name: Run python webhook tests
         run: |
@@ -2571,7 +2572,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       - name: DMT lint
         env:
@@ -2606,7 +2607,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2722,7 +2723,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2838,7 +2839,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name
@@ -2954,7 +2955,7 @@ jobs:
         uses: actions/checkout@v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       # </template: checkout_full_step>
       # <template: import_secrets>
       - name: Split repository name

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -42,6 +42,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -41,6 +41,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -58,6 +58,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -55,6 +55,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: alpha

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -55,6 +55,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: beta

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -55,6 +55,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: early-access

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -55,6 +55,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -55,6 +55,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: stable

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test2.yml
+++ b/.github/workflows/deploy-web-test2.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test3.yml
+++ b/.github/workflows/deploy-web-test3.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test4.yml
+++ b/.github/workflows/deploy-web-test4.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test5.yml
+++ b/.github/workflows/deploy-web-test5.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test6.yml
+++ b/.github/workflows/deploy-web-test6.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/deploy-web-test7.yml
+++ b/.github/workflows/deploy-web-test7.yml
@@ -60,6 +60,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-dvp.yml
+++ b/.github/workflows/e2e-abort-dvp.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-abort-zvirt.yml
+++ b/.github/workflows/e2e-abort-zvirt.yml
@@ -54,6 +54,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -39,6 +39,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-dvp.yml
+++ b/.github/workflows/e2e-dvp.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/e2e-zvirt.yml
+++ b/.github/workflows/e2e-zvirt.yml
@@ -71,6 +71,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -39,6 +39,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
 

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -52,6 +52,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: alpha

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -52,6 +52,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: beta

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -52,6 +52,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: early-access

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -52,6 +52,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: rock-solid

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -52,6 +52,7 @@ env:
   WERF_LOG_TERMINAL_WIDTH: "200"
   WERF_LOG_TIME: true
   WERF_GIT_WORK_TREE_POOL_LIMIT: "10"
+  WERF_VIRTUAL_MERGE: "0"
   GOPROXY: "${{vars.GOPROXY}}"
   # </template: werf_envs>
   DEPLOY_CHANNEL: stable


### PR DESCRIPTION
## Description
Switch dev build to pull_request trigger.
Backports #19466.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: ci
type: chore
summary: Switch dev build to pull_request trigger.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
