### PR TITLE
[common]Add patch for apiserver that fix serviceaccount_stale_tokens_total metrics

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1959,6 +1959,7 @@ alerts:
       module: control-plane-manager
       edition: ce
       description: |-
+        Service account `{{ $labels.token_namespace }}/{{ $labels.token_name }}` is using a stale token.
         This issue may occur if an application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
 
         **Recommended actions:**
@@ -1969,37 +1970,12 @@ alerts:
         Note that currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
         **For further investigation:**
-        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
-
+        You can find the problematic pods using the following command:
         ```bash
-        jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
-        ```
-
-        If you do not see the necessary logs, set `settings.apiserver.auditPolicyEnabled` in control-plane-manager ModuleConfig [according to the documentation](https://deckhouse.io/modules/control-plane-manager/faq.html#how-do-i-configure-additional-audit-policies) and add an additional audit policy to log actions of all service accounts.
-
-        ```yaml
-        - level: Metadata
-          omitStages:
-          - RequestReceived
-          userGroups:
-          - system:serviceaccounts
-        ```
-
-        Example of applying an additional audit policy:
-
-        ```bash
-        d8 k apply -f - <<EOF
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: audit-policy
-          namespace: kube-system
-        data:
-          audit-policy.yaml: YXBpVmVyc2lvbjogYXVkaXQuazhzLmlvL3YxCmtpbmQ6IFBvbGljeQpydWxlczoKLSBsZXZlbDogTWV0YWRhdGEKICBvbWl0U3RhZ2VzOgogIC0gUmVxdWVzdFJlY2VpdmVkCiAgdXNlckdyb3VwczoKICAtIHN5c3RlbTpzZXJ2aWNlYWNjb3VudHM=
-        EOF
+        d8 k get pods -A -o json | jq -r '.items[] | select(.spec.serviceAccountName=="{{ $labels.token_name }}" and .metadata.namespace=="{{ $labels.token_namespace }}") | .metadata.name'
         ```
       summary: |
-        Stale service account tokens detected.
+        Stale service account tokens detected for {{ $labels.token_namespace }}/{{ $labels.token_name }}.
       severity: "8"
       markupFormat: markdown
     - name: D8KubernetesVersionIsDeprecated

--- a/modules/000-common/images/kubernetes/patches/1.31/012-fix-stale-token-metrics.patch
+++ b/modules/000-common/images/kubernetes/patches/1.31/012-fix-stale-token-metrics.patch
@@ -1,0 +1,33 @@
+diff --git a/pkg/serviceaccount/claims.go b/pkg/serviceaccount/claims.go
+index 64feaca7ed3..e3ff0f55889 100644
+--- a/pkg/serviceaccount/claims.go
++++ b/pkg/serviceaccount/claims.go
+@@ -268,7 +268,7 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims,
+ 			secondsAfterWarn := nowTime.Unix() - warnafter.Time().Unix()
+ 			auditInfo := fmt.Sprintf("subject: %s, seconds after warning threshold: %d", public.Subject, secondsAfterWarn)
+ 			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/stale-token", auditInfo)
+-			staleTokensTotal.WithContext(ctx).Inc()
++			staleTokensTotal.WithContext(ctx).WithLabelValues(private.Kubernetes.Namespace, private.Kubernetes.Svcacct.Name).Inc()
+ 		} else {
+ 			validTokensTotal.WithContext(ctx).Inc()
+ 		}
+diff --git a/pkg/serviceaccount/metrics.go b/pkg/serviceaccount/metrics.go
+index 7dc2bf397e7..2a58e6dc9f5 100644
+--- a/pkg/serviceaccount/metrics.go
++++ b/pkg/serviceaccount/metrics.go
+@@ -38,13 +38,14 @@ var (
+ 
+ 	// StaleTokensTotal is the number of stale projected tokens not refreshed on
+ 	// client side.
+-	staleTokensTotal = metrics.NewCounter(
++	staleTokensTotal = metrics.NewCounterVec(
+ 		&metrics.CounterOpts{
+ 			Subsystem:      kubeServiceAccountSubsystem,
+ 			Name:           "stale_tokens_total",
+ 			Help:           "Cumulative stale projected service account tokens used",
+ 			StabilityLevel: metrics.ALPHA,
+ 		},
++		[]string{"token_namespace", "token_name"},
+ 	)
+ 
+ 	// mauallyCreatedTokensTotal is the number of manually created secret-based long lived tokens.

--- a/modules/000-common/images/kubernetes/patches/1.32/011-fix-stale-token-metrics.patch
+++ b/modules/000-common/images/kubernetes/patches/1.32/011-fix-stale-token-metrics.patch
@@ -1,0 +1,33 @@
+diff --git a/pkg/serviceaccount/claims.go b/pkg/serviceaccount/claims.go
+index 1cac8b3b507..ff559f02832 100644
+--- a/pkg/serviceaccount/claims.go
++++ b/pkg/serviceaccount/claims.go
+@@ -269,7 +269,7 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims,
+ 			secondsAfterWarn := nowTime.Unix() - warnafter.Time().Unix()
+ 			auditInfo := fmt.Sprintf("subject: %s, seconds after warning threshold: %d", public.Subject, secondsAfterWarn)
+ 			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/stale-token", auditInfo)
+-			staleTokensTotal.WithContext(ctx).Inc()
++			staleTokensTotal.WithContext(ctx).WithLabelValues(private.Kubernetes.Namespace, private.Kubernetes.Svcacct.Name).Inc()
+ 		} else {
+ 			validTokensTotal.WithContext(ctx).Inc()
+ 		}
+diff --git a/pkg/serviceaccount/metrics.go b/pkg/serviceaccount/metrics.go
+index 7dc2bf397e7..2a58e6dc9f5 100644
+--- a/pkg/serviceaccount/metrics.go
++++ b/pkg/serviceaccount/metrics.go
+@@ -38,13 +38,14 @@ var (
+ 
+ 	// StaleTokensTotal is the number of stale projected tokens not refreshed on
+ 	// client side.
+-	staleTokensTotal = metrics.NewCounter(
++	staleTokensTotal = metrics.NewCounterVec(
+ 		&metrics.CounterOpts{
+ 			Subsystem:      kubeServiceAccountSubsystem,
+ 			Name:           "stale_tokens_total",
+ 			Help:           "Cumulative stale projected service account tokens used",
+ 			StabilityLevel: metrics.ALPHA,
+ 		},
++		[]string{"token_namespace", "token_name"},
+ 	)
+ 
+ 	// mauallyCreatedTokensTotal is the number of manually created secret-based long lived tokens.

--- a/modules/000-common/images/kubernetes/patches/1.33/011-fix-stale-token-metrics.patch
+++ b/modules/000-common/images/kubernetes/patches/1.33/011-fix-stale-token-metrics.patch
@@ -111,7 +111,7 @@ index 2893599cf6c..d9c810922de 100644
  			validTokensTotal.WithContext(ctx).Inc()
  		}
 diff --git a/pkg/serviceaccount/metrics.go b/pkg/serviceaccount/metrics.go
-index 7dc2bf397e7..78996287bea 100644
+index 7dc2bf397e7..2a58e6dc9f5 100644
 --- a/pkg/serviceaccount/metrics.go
 +++ b/pkg/serviceaccount/metrics.go
 @@ -38,13 +38,14 @@ var (
@@ -126,7 +126,7 @@ index 7dc2bf397e7..78996287bea 100644
  			Help:           "Cumulative stale projected service account tokens used",
  			StabilityLevel: metrics.ALPHA,
  		},
-+		[]string{"namespace", "name"},
++		[]string{"token_namespace", "token_name"},
  	)
  
  	// mauallyCreatedTokensTotal is the number of manually created secret-based long lived tokens.

--- a/modules/000-common/images/kubernetes/patches/1.33/011-fix-stale-token-metrics.patch
+++ b/modules/000-common/images/kubernetes/patches/1.33/011-fix-stale-token-metrics.patch
@@ -1,0 +1,132 @@
+diff --git a/go.work.sum b/go.work.sum
+index f64b55f6550..39d9f1d6430 100644
+--- a/go.work.sum
++++ b/go.work.sum
+@@ -25,6 +25,7 @@ cloud.google.com/go/clouddms v1.7.3 h1:xe/wJKz55VO1+L891a1EG9lVUgfHr9Ju/I3xh1nwF
+ cloud.google.com/go/cloudtasks v1.12.4 h1:5xXuFfAjg0Z5Wb81j2GAbB3e0bwroCeSF+5jBn/L650=
+ cloud.google.com/go/compute v1.23.3 h1:6sVlXXBmbd7jNX0Ipq0trII3e4n1/MsADLK6a+aiVlk=
+ cloud.google.com/go/compute/metadata v0.5.0 h1:Zr0eK8JbFv6+Wi4ilXAR8FJ3wyNdpxHKJNPos6LTZOY=
++cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+ cloud.google.com/go/contactcenterinsights v1.12.1 h1:EiGBeejtDDtr3JXt9W7xlhXyZ+REB5k2tBgVPVtmNb0=
+ cloud.google.com/go/container v1.29.0 h1:jIltU529R2zBFvP8rhiG1mgeTcnT27KhU0H/1d6SQRg=
+ cloud.google.com/go/containeranalysis v0.11.3 h1:5rhYLX+3a01drpREqBZVXR9YmWH45RnML++8NsCtuD8=
+@@ -116,6 +117,7 @@ cloud.google.com/go/webrisk v1.9.4 h1:iceR3k0BCRZgf2D/NiKviVMFfuNC9LmeNLtxUFRB/w
+ cloud.google.com/go/websecurityscanner v1.6.4 h1:5Gp7h5j7jywxLUp6NTpjNPkgZb3ngl0tUSw6ICWvtJQ=
+ cloud.google.com/go/workflows v1.12.3 h1:qocsqETmLAl34mSa01hKZjcqAvt699gaoFbooGGMvaM=
+ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
++github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
+ github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
+ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+ github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
+@@ -138,17 +140,28 @@ github.com/cilium/ebpf v0.17.3 h1:FnP4r16PWYSE4ux6zN+//jMcW4nMVRvuTLVTvCjyyjg=
+ github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
+ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
+ github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 h1:QVw89YDxXxEe+l8gU8ETbOasdwEV+avkR75ZzsVV9WI=
++github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
++github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
++github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+ github.com/envoyproxy/go-control-plane v0.13.0 h1:HzkeUz1Knt+3bK+8LG1bxOO/jzWZmdxpwC51i202les=
++github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
++github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
++github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
+ github.com/envoyproxy/protoc-gen-validate v1.1.0 h1:tntQDh69XqOCOZsDz0lVJQez/2L6Uu2PdjCQwWCJ3bM=
++github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=
+ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
+ github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
++github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+ github.com/go-kit/kit v0.9.0 h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=
+ github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80nA=
+ github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
+ github.com/golang/glog v1.2.2 h1:1+mZ9upx1Dh6FmUTFR1naJ77miKiXgALjWOZ3NVFPmY=
++github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
+ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
+ github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
++github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+ github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
++github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
+ github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465 h1:KwWnWVWCNtNq/ewIX7HIKnELmEx2nDP42yskD/pi7QE=
+ github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+@@ -164,18 +177,49 @@ github.com/opencontainers/runc v1.2.5 h1:8KAkq3Wrem8bApgOHyhRI/8IeLXIfmZ6Qaw6DNS
+ github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
+ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
+ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
++github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
++github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
++github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
+ github.com/rogpeppe/fastuuid v1.2.0 h1:Ppwyp6VYCF1nvBTXL3trRso7mXMlRrw9ooo375wvi2s=
+ github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
++github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
+ github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+ github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
+ go.etcd.io/gofail v0.1.0 h1:XItAMIhOojXFQMgrxjnd2EIIHun/d5qL0Pf7FzVTkFg=
++go.opentelemetry.io/contrib/detectors/gcp v1.39.0/go.mod h1:t/OGqzHBa5v6RHZwrDBJ2OirWc+4q/w2fTbLZwAKjTk=
++go.opentelemetry.io/otel v1.39.0/go.mod h1:kLlFTywNWrFyEdH0oj2xK0bFYZtHRYUdv1NklR/tgc8=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.27.0 h1:QY7/0NeRPKlzusf40ZE4t1VlMKbqSNT7cJRYzWuja0s=
++go.opentelemetry.io/otel/metric v1.39.0/go.mod h1:jrZSWL33sD7bBxg1xjrqyDjnuzTUB0x1nBERXd7Ftcs=
++go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
++go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
+ go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
++golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
++golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
++golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
++golang.org/x/sync v0.18.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
++golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
++golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
++golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+ golang.org/x/telemetry v0.0.0-20240521205824-bda55230c457 h1:zf5N6UOrA487eEFacMePxjXAJctxKmyjKUsjA11Uzuk=
++golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
++golang.org/x/text v0.26.0/go.mod h1:QK15LZJUUQVJxhz7wXgxSy/CJaTFjd0G+YLonydOVQA=
++golang.org/x/text v0.27.0/go.mod h1:1D28KMCvyooCX9hBiosv5Tz/+YLxj0j7XhWjpSUF7CU=
++golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
+ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+ google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
++google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822/go.mod h1:h3c4v36UTKzUiuaOKQ6gr3S+0hovBtUrXzTG/i3+XEc=
++google.golang.org/genproto/googleapis/api v0.0.0-20250728155136-f173205681a0/go.mod h1:8ytArBbtOy2xfht+y2fqKd5DRDJRUQhqbyEnQ4bDChs=
++google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
++google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
++google.golang.org/genproto/googleapis/rpc v0.0.0-20251124214823-79d6a2a48846/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
++google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
++google.golang.org/grpc v1.73.0/go.mod h1:50sbHOUqWoCQGI8V2HQLJM0B+LMlIUjNSZmow7EVBQc=
++google.golang.org/grpc v1.74.2/go.mod h1:CtQ+BGjaAIXHs/5YS3i473GqwBBa1zGQNevxdeBEXrM=
++google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
++google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
++google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+ gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
+ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc h1:/hemPrYIhOhy8zYrNj+069zDB68us2sMGsfkFJO0iZs=
+diff --git a/pkg/serviceaccount/claims.go b/pkg/serviceaccount/claims.go
+index 2893599cf6c..d9c810922de 100644
+--- a/pkg/serviceaccount/claims.go
++++ b/pkg/serviceaccount/claims.go
+@@ -269,7 +269,7 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims,
+ 			secondsAfterWarn := nowTime.Unix() - warnafter.Time().Unix()
+ 			auditInfo := fmt.Sprintf("subject: %s, seconds after warning threshold: %d", public.Subject, secondsAfterWarn)
+ 			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/stale-token", auditInfo)
+-			staleTokensTotal.WithContext(ctx).Inc()
++			staleTokensTotal.WithContext(ctx).WithLabelValues(private.Kubernetes.Namespace, private.Kubernetes.Svcacct.Name).Inc()
+ 		} else {
+ 			validTokensTotal.WithContext(ctx).Inc()
+ 		}
+diff --git a/pkg/serviceaccount/metrics.go b/pkg/serviceaccount/metrics.go
+index 7dc2bf397e7..78996287bea 100644
+--- a/pkg/serviceaccount/metrics.go
++++ b/pkg/serviceaccount/metrics.go
+@@ -38,13 +38,14 @@ var (
+ 
+ 	// StaleTokensTotal is the number of stale projected tokens not refreshed on
+ 	// client side.
+-	staleTokensTotal = metrics.NewCounter(
++	staleTokensTotal = metrics.NewCounterVec(
+ 		&metrics.CounterOpts{
+ 			Subsystem:      kubeServiceAccountSubsystem,
+ 			Name:           "stale_tokens_total",
+ 			Help:           "Cumulative stale projected service account tokens used",
+ 			StabilityLevel: metrics.ALPHA,
+ 		},
++		[]string{"namespace", "name"},
+ 	)
+ 
+ 	// mauallyCreatedTokensTotal is the number of manually created secret-based long lived tokens.

--- a/modules/000-common/images/kubernetes/patches/1.34/011-fix-stale-token-metrics.patch
+++ b/modules/000-common/images/kubernetes/patches/1.34/011-fix-stale-token-metrics.patch
@@ -1,0 +1,33 @@
+diff --git a/pkg/serviceaccount/claims.go b/pkg/serviceaccount/claims.go
+index 2893599cf6c..d9c810922de 100644
+--- a/pkg/serviceaccount/claims.go
++++ b/pkg/serviceaccount/claims.go
+@@ -269,7 +269,7 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims,
+ 			secondsAfterWarn := nowTime.Unix() - warnafter.Time().Unix()
+ 			auditInfo := fmt.Sprintf("subject: %s, seconds after warning threshold: %d", public.Subject, secondsAfterWarn)
+ 			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/stale-token", auditInfo)
+-			staleTokensTotal.WithContext(ctx).Inc()
++			staleTokensTotal.WithContext(ctx).WithLabelValues(private.Kubernetes.Namespace, private.Kubernetes.Svcacct.Name).Inc()
+ 		} else {
+ 			validTokensTotal.WithContext(ctx).Inc()
+ 		}
+diff --git a/pkg/serviceaccount/metrics.go b/pkg/serviceaccount/metrics.go
+index 7dc2bf397e7..2a58e6dc9f5 100644
+--- a/pkg/serviceaccount/metrics.go
++++ b/pkg/serviceaccount/metrics.go
+@@ -38,13 +38,14 @@ var (
+ 
+ 	// StaleTokensTotal is the number of stale projected tokens not refreshed on
+ 	// client side.
+-	staleTokensTotal = metrics.NewCounter(
++	staleTokensTotal = metrics.NewCounterVec(
+ 		&metrics.CounterOpts{
+ 			Subsystem:      kubeServiceAccountSubsystem,
+ 			Name:           "stale_tokens_total",
+ 			Help:           "Cumulative stale projected service account tokens used",
+ 			StabilityLevel: metrics.ALPHA,
+ 		},
++		[]string{"token_namespace", "token_name"},
+ 	)
+ 
+ 	// mauallyCreatedTokensTotal is the number of manually created secret-based long lived tokens.

--- a/modules/000-common/images/kubernetes/patches/1.35/011-fix-stale-token-metrics.patch
+++ b/modules/000-common/images/kubernetes/patches/1.35/011-fix-stale-token-metrics.patch
@@ -1,0 +1,33 @@
+diff --git a/pkg/serviceaccount/claims.go b/pkg/serviceaccount/claims.go
+index 2893599cf6c..d9c810922de 100644
+--- a/pkg/serviceaccount/claims.go
++++ b/pkg/serviceaccount/claims.go
+@@ -269,7 +269,7 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims,
+ 			secondsAfterWarn := nowTime.Unix() - warnafter.Time().Unix()
+ 			auditInfo := fmt.Sprintf("subject: %s, seconds after warning threshold: %d", public.Subject, secondsAfterWarn)
+ 			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/stale-token", auditInfo)
+-			staleTokensTotal.WithContext(ctx).Inc()
++			staleTokensTotal.WithContext(ctx).WithLabelValues(private.Kubernetes.Namespace, private.Kubernetes.Svcacct.Name).Inc()
+ 		} else {
+ 			validTokensTotal.WithContext(ctx).Inc()
+ 		}
+diff --git a/pkg/serviceaccount/metrics.go b/pkg/serviceaccount/metrics.go
+index 7dc2bf397e7..2a58e6dc9f5 100644
+--- a/pkg/serviceaccount/metrics.go
++++ b/pkg/serviceaccount/metrics.go
+@@ -38,13 +38,14 @@ var (
+ 
+ 	// StaleTokensTotal is the number of stale projected tokens not refreshed on
+ 	// client side.
+-	staleTokensTotal = metrics.NewCounter(
++	staleTokensTotal = metrics.NewCounterVec(
+ 		&metrics.CounterOpts{
+ 			Subsystem:      kubeServiceAccountSubsystem,
+ 			Name:           "stale_tokens_total",
+ 			Help:           "Cumulative stale projected service account tokens used",
+ 			StabilityLevel: metrics.ALPHA,
+ 		},
++		[]string{"token_namespace", "token_name"},
+ 	)
+ 
+ 	// mauallyCreatedTokensTotal is the number of manually created secret-based long lived tokens.

--- a/modules/000-common/images/kubernetes/patches/README.md
+++ b/modules/000-common/images/kubernetes/patches/README.md
@@ -70,3 +70,10 @@ When set the API server will: encrypt the value at rest in etcd (using the same 
 See our KEP:
 - https://github.com/kubernetes/enhancements/pull/5937
 - https://github.com/kubernetes/enhancements/issues/5933
+
+### 011-fix-stale-token-metrics.patch
+
+Patch enhances the observability of stale ServiceAccount tokens by adding namespace and name labels to the `serviceaccount_stale_tokens_total` metric.
+
+Why it is needed:
+Previously, the `serviceaccount_stale_tokens_total` metric was a simple counter without any labels. While it indicated that some clients were using outdated tokens (past their warnafter threshold), it provided no information about which ServiceAccounts were responsible

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -54,15 +54,16 @@
         Read [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/platform-scaling/control-plane/updating-and-versioning.html) about how to update the Kubernetes version in the cluster.
   - alert: D8KubernetesStaleTokensDetected
     for: 10m
-    expr: sum(rate(serviceaccount_stale_tokens_total[10m])) by (instance) > 0
+    expr: sum(rate(serviceaccount_stale_tokens_total[10m])) by (instance, token_namespace, token_name) > 0
     labels:
       severity_level: "8"
       tier: cluster
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
-      summary: Stale service account tokens detected.
+      summary: Stale service account tokens detected for `{{ $labels.token_namespace }}/{{ $labels.token_name }}`.
       description: |-
+        Service account `{{ $labels.token_namespace }}/{{ $labels.token_name }}` is using a stale token.
         This issue may occur if an application reads the token only at startup and does not reload it periodically. As a result, an outdated token might be used, leading to security breach and authentication failures.
 
         **Recommended actions:**
@@ -73,35 +74,11 @@
         Note that currently these tokens are not blocked because the `--service-account-extend-token-expiration` flag is enabled by default (`Default: true`). With this flag enabled, admission-injected tokens are extended up to 1 year during token generation to facilitate a safe transition from legacy tokens to the bound service account token feature, ignoring the value of `service-account-max-token-expiration`.
 
         **For further investigation:**
-        Log into the server with label `instance={{ $labels.instance }}` and inspect the audit log using the following command:
-
+        You can find the problematic pods using the following command:
         ```bash
-        jq 'select(.annotations["authentication.k8s.io/stale-token"]) | {auditID, stageTimestamp, requestURI, verb, user: .user.username, stale_token: .annotations["authentication.k8s.io/stale-token"]}' /var/log/kube-audit/audit.log
+        d8 k get pods -A -o json | jq -r '.items[] | select(.spec.serviceAccountName=="{{ $labels.token_name }}" and .metadata.namespace=="{{ $labels.token_namespace }}") | .metadata.name'
         ```
 
-        If you do not see the necessary logs, set `settings.apiserver.auditPolicyEnabled` in control-plane-manager ModuleConfig [according to the documentation](https://deckhouse.io/modules/control-plane-manager/faq.html#how-do-i-configure-additional-audit-policies) and add an additional audit policy to log actions of all service accounts.
-
-        ```yaml
-        - level: Metadata
-          omitStages:
-          - RequestReceived
-          userGroups:
-          - system:serviceaccounts
-        ```
-
-        Example of applying an additional audit policy:
-
-        ```bash
-        d8 k apply -f - <<EOF
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: audit-policy
-          namespace: kube-system
-        data:
-          audit-policy.yaml: YXBpVmVyc2lvbjogYXVkaXQuazhzLmlvL3YxCmtpbmQ6IFBvbGljeQpydWxlczoKLSBsZXZlbDogTWV0YWRhdGEKICBvbWl0U3RhZ2VzOgogIC0gUmVxdWVzdFJlY2VpdmVkCiAgdXNlckdyb3VwczoKICAtIHN5c3RlbTpzZXJ2aWNlYWNjb3VudHM=
-        EOF
-        ```
 
   - alert: D8ProblematicFeatureGateInUse
     for: 5m

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
@@ -54,7 +54,7 @@
         Read [documentation](/products/kubernetes-platform/documentation/v1/admin/configuration/platform-scaling/control-plane/updating-and-versioning.html) about how to update the Kubernetes version in the cluster.
   - alert: D8KubernetesStaleTokensDetected
     for: 10m
-    expr: sum(rate(serviceaccount_stale_tokens_total[10m])) by (instance, token_namespace, token_name) > 0
+    expr: sum(rate(serviceaccount_stale_tokens_total[10m])) by (token_namespace, token_name) > 0
     labels:
       severity_level: "8"
       tier: cluster


### PR DESCRIPTION


## Description
This PR enhances the observability of stale ServiceAccount tokens by adding `token_namespace` and `token_name` labels to the `serviceaccount_stale_tokens_total` metric.


## Why do we need it, and what problem does it solve?

Currently, the `serviceaccount_stale_tokens_total` metric is a global counter that only indicates *that* stale tokens are being used, but not *by whom*. 

Identifying the affected ServiceAccounts via audit logs is unreliable because:
1. **Authentication Caching:** The `authentication.k8s.io/stale-token` audit annotation is only added during a cache miss. Subsequent requests using the same cached token increment the metric but do not trigger new audit annotations.
2. **Audit Configuration:** Audit logs can be easily missed due to complex policy rules or high volume.

This PR allows administrators to directly identify ServiceAccounts that need token rotation using a simple Prometheus query, making the transition to newer token versions much more manageable.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: feature
summary: Add token_namespace and token_name labels to serviceaccount_stale_tokens_total kube-apiserver metric
impact_level: default
```