### PR TITLE
[deckhouse] preserve PackageRepository.status.packages on incremental rescan

### DIFF
--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -365,7 +366,12 @@ func setupFakeController(t *testing.T, filename string) (*reconciler, client.Cli
 				var apv v1alpha1.ApplicationPackageVersion
 				err := yaml.Unmarshal([]byte(manifest), &apv)
 				require.NoError(t, err)
+				savedStatus := apv.Status
 				require.NoError(t, kubeClient.Create(context.TODO(), &apv))
+				if !reflect.DeepEqual(savedStatus, v1alpha1.ApplicationPackageVersionStatus{}) {
+					apv.Status = savedStatus
+					require.NoError(t, kubeClient.Status().Update(context.TODO(), &apv))
+				}
 			case "PackageRepository":
 				var repo v1alpha1.PackageRepository
 				err := yaml.Unmarshal([]byte(manifest), &repo)
@@ -605,6 +611,33 @@ func (suite *ControllerTestSuite) TestReconcile() {
 		psm := createFakePSM(newInternalClient(reg))
 
 		suite.setupController("incremental-module-scan.yaml", withPackageServiceManager(psm))
+		operation := suite.getPackageRepositoryOperation("deckhouse-scan-1571326380")
+
+		err := repeat(func() error {
+			_, err := suite.ctr.Reconcile(ctx, ctrl.Request{
+				NamespacedName: k8stypes.NamespacedName{Name: operation.Name},
+			})
+
+			return err
+		})
+
+		require.NoError(suite.T(), err)
+	})
+
+	suite.Run("incremental scan with no new versions keeps package in repository status", func() {
+		// Regression: pre-existing ApplicationPackageVersion v1.0.0 already processed
+		// (Status.PackageMetadata set). Registry still has only v1.0.0, so the incremental
+		// scan finds no new tags and goes through the empty-foundTags branch in
+		// ProcessPackageVersions. Without inferPackageTypeFromExisting, the package would
+		// be appended to op.Status.Packages.Processed with Type="" and dropped by
+		// UpdateRepositoryStatus, silently truncating PackageRepository.status.packages.
+		reg := fakeRegistry.NewRegistry(registryHost)
+		reg.MustAddImage("", "test-package", fakeRegistry.NewImageBuilder().MustBuild())
+		reg.MustAddImage("test-package/version", "v1.0.0", applicationVersionImage().MustBuild())
+
+		psm := createFakePSM(newInternalClient(reg))
+
+		suite.setupController("incremental-no-new-versions.yaml", withPackageServiceManager(psm))
 		operation := suite.getPackageRepositoryOperation("deckhouse-scan-1571326380")
 
 		err := repeat(func() error {

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller_test.go
@@ -376,7 +376,12 @@ func setupFakeController(t *testing.T, filename string) (*reconciler, client.Cli
 				var repo v1alpha1.PackageRepository
 				err := yaml.Unmarshal([]byte(manifest), &repo)
 				require.NoError(t, err)
+				savedStatus := repo.Status
 				require.NoError(t, kubeClient.Create(context.TODO(), &repo))
+				if !reflect.DeepEqual(savedStatus, v1alpha1.PackageRepositoryStatus{}) {
+					repo.Status = savedStatus
+					require.NoError(t, kubeClient.Status().Update(context.TODO(), &repo))
+				}
 			case "ModulePackageVersion":
 				var mpv v1alpha1.ModulePackageVersion
 				err := yaml.Unmarshal([]byte(manifest), &mpv)

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
@@ -150,16 +150,10 @@ func (s *OperationService) DiscoverPackage(ctx context.Context) (*DiscoverResult
 }
 
 // UpdateRepositoryStatus updates the PackageRepository status with the processed packages.
-//
-// Package type (Application/Module) is a stable property — it lives in the
-// version image labels and never changes between scans. The previous
-// status.Packages therefore acts as a cache of already-resolved types: when an
-// incremental scan finds no new tags for a package it returns an empty Type,
-// and we recover it from the existing entry instead of dropping the package.
-// First-ever scan with no resolvable type is still skipped by the safety guard.
 func (s *OperationService) UpdateRepositoryStatus(ctx context.Context, packages []v1alpha1.PackageRepositoryOperationStatusPackage) error {
 	original := s.repo.DeepCopy()
 
+	// Type is stable per package; recover it from the previous status when an incremental scan returned empty.
 	cachedTypes := make(map[string]string, len(s.repo.Status.Packages))
 	for _, p := range s.repo.Status.Packages {
 		cachedTypes[p.Name] = p.Type
@@ -173,7 +167,6 @@ func (s *OperationService) UpdateRepositoryStatus(ctx context.Context, packages 
 			pkgType = cachedTypes[pkg.Name]
 		}
 		if pkgType == "" {
-			// Safety guard: first scan ever, type is still unknown.
 			continue
 		}
 		s.repo.Status.Packages = append(s.repo.Status.Packages, v1alpha1.PackageRepositoryStatusPackage{

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
@@ -149,16 +149,31 @@ func (s *OperationService) DiscoverPackage(ctx context.Context) (*DiscoverResult
 	return res, nil
 }
 
-// UpdateRepositoryStatus updates the PackageRepository status with the processed packages
+// UpdateRepositoryStatus updates the PackageRepository status with the processed packages.
+//
+// Package type (Application/Module) is a stable property — it lives in the
+// version image labels and never changes between scans. The previous
+// status.Packages therefore acts as a cache of already-resolved types: when an
+// incremental scan finds no new tags for a package it returns an empty Type,
+// and we recover it from the existing entry instead of dropping the package.
+// First-ever scan with no resolvable type is still skipped by the safety guard.
 func (s *OperationService) UpdateRepositoryStatus(ctx context.Context, packages []v1alpha1.PackageRepositoryOperationStatusPackage) error {
 	original := s.repo.DeepCopy()
+
+	cachedTypes := make(map[string]string, len(s.repo.Status.Packages))
+	for _, p := range s.repo.Status.Packages {
+		cachedTypes[p.Name] = p.Type
+	}
 
 	s.repo.Status.Packages = make([]v1alpha1.PackageRepositoryStatusPackage, 0, len(packages))
 
 	for _, pkg := range packages {
 		pkgType := pkg.Type
 		if pkgType == "" {
-			// Skip packages without a resolved type (safety guard)
+			pkgType = cachedTypes[pkg.Name]
+		}
+		if pkgType == "" {
+			// Safety guard: first scan ever, type is still unknown.
 			continue
 		}
 		s.repo.Status.Packages = append(s.repo.Status.Packages, v1alpha1.PackageRepositoryStatusPackage{
@@ -304,35 +319,6 @@ func (s *OperationService) getLastProcessedVersion(ctx context.Context, packageN
 	return latestVersionString(versions)
 }
 
-// inferPackageTypeFromExisting derives the package type from already-existing
-// APV/MPV resources for this (repository, package). Used when an incremental
-// scan finds no new tags — without it, the package would be appended to
-// op.Status.Packages.Processed with an empty Type and dropped by
-// UpdateRepositoryStatus, so the repository's status.packages would silently
-// shrink on every quiet rescan.
-func (s *OperationService) inferPackageTypeFromExisting(ctx context.Context, packageName string) packageType {
-	matchLabels := client.MatchingLabels{
-		v1alpha1.ApplicationPackageVersionLabelRepository: s.repo.Name,
-		v1alpha1.ApplicationPackageVersionLabelPackage:    packageName,
-	}
-
-	appList := &v1alpha1.ApplicationPackageVersionList{}
-	if err := s.client.List(ctx, appList, matchLabels); err != nil {
-		s.logger.Warn("failed to list application package versions for type inference", slog.String("package", packageName), log.Err(err))
-	} else if len(appList.Items) > 0 {
-		return packageTypeApplication
-	}
-
-	modList := &v1alpha1.ModulePackageVersionList{}
-	if err := s.client.List(ctx, modList, matchLabels); err != nil {
-		s.logger.Warn("failed to list module package versions for type inference", slog.String("package", packageName), log.Err(err))
-	} else if len(modList.Items) > 0 {
-		return packageTypeModule
-	}
-
-	return ""
-}
-
 func parseProcessedVersion(tag string, hasMetadata bool) *semver.Version {
 	if !hasMetadata {
 		return nil
@@ -378,15 +364,7 @@ func (s *OperationService) ProcessPackageVersions(ctx context.Context, packageNa
 			)
 		}
 
-		// On an incremental rescan with no new versions we still need a
-		// PackageType so the package survives the rebuild of
-		// PackageRepository.status.packages — derive it from already-existing
-		// APV/MPV resources. Empty result is still possible (very first scan
-		// on an empty registry) and is handled by the safety guard in
-		// UpdateRepositoryStatus.
-		return &PackageProcessResult{
-			PackageType: s.inferPackageTypeFromExisting(ctx, packageName),
-		}, nil
+		return &PackageProcessResult{}, nil
 	}
 
 	// Sort tags to pick the latest version for label check (older versions may have outdated/missing labels)

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go
@@ -304,6 +304,35 @@ func (s *OperationService) getLastProcessedVersion(ctx context.Context, packageN
 	return latestVersionString(versions)
 }
 
+// inferPackageTypeFromExisting derives the package type from already-existing
+// APV/MPV resources for this (repository, package). Used when an incremental
+// scan finds no new tags — without it, the package would be appended to
+// op.Status.Packages.Processed with an empty Type and dropped by
+// UpdateRepositoryStatus, so the repository's status.packages would silently
+// shrink on every quiet rescan.
+func (s *OperationService) inferPackageTypeFromExisting(ctx context.Context, packageName string) packageType {
+	matchLabels := client.MatchingLabels{
+		v1alpha1.ApplicationPackageVersionLabelRepository: s.repo.Name,
+		v1alpha1.ApplicationPackageVersionLabelPackage:    packageName,
+	}
+
+	appList := &v1alpha1.ApplicationPackageVersionList{}
+	if err := s.client.List(ctx, appList, matchLabels); err != nil {
+		s.logger.Warn("failed to list application package versions for type inference", slog.String("package", packageName), log.Err(err))
+	} else if len(appList.Items) > 0 {
+		return packageTypeApplication
+	}
+
+	modList := &v1alpha1.ModulePackageVersionList{}
+	if err := s.client.List(ctx, modList, matchLabels); err != nil {
+		s.logger.Warn("failed to list module package versions for type inference", slog.String("package", packageName), log.Err(err))
+	} else if len(modList.Items) > 0 {
+		return packageTypeModule
+	}
+
+	return ""
+}
+
 func parseProcessedVersion(tag string, hasMetadata bool) *semver.Version {
 	if !hasMetadata {
 		return nil
@@ -349,7 +378,15 @@ func (s *OperationService) ProcessPackageVersions(ctx context.Context, packageNa
 			)
 		}
 
-		return &PackageProcessResult{}, nil
+		// On an incremental rescan with no new versions we still need a
+		// PackageType so the package survives the rebuild of
+		// PackageRepository.status.packages — derive it from already-existing
+		// APV/MPV resources. Empty result is still possible (very first scan
+		// on an empty registry) and is handled by the safety guard in
+		// UpdateRepositoryStatus.
+		return &PackageProcessResult{
+			PackageType: s.inferPackageTypeFromExisting(ctx, packageName),
+		}, nil
 	}
 
 	// Sort tags to pick the latest version for label check (older versions may have outdated/missing labels)

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-no-new-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-no-new-versions.yaml
@@ -31,7 +31,6 @@ status:
   packages:
     processed:
     - name: test-package
-      type: Application
     processedOverall: 1
     total: 1
   startTime: "2025-10-31T12:00:00Z"
@@ -60,7 +59,7 @@ kind: PackageRepository
 metadata:
   creationTimestamp: null
   name: deckhouse
-  resourceVersion: "3"
+  resourceVersion: "4"
 spec:
   registry:
     repo: registry.example.com/test

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-no-new-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/golden/incremental-no-new-versions.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: PackageRepositoryOperation
+metadata:
+  creationTimestamp: null
+  labels:
+    packages.deckhouse.io/operation-trigger: manual
+    packages.deckhouse.io/operation-type: Update
+    packages.deckhouse.io/repository: deckhouse
+  name: deckhouse-scan-1571326380
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: PackageRepository
+    name: deckhouse
+    uid: ""
+  resourceVersion: "6"
+spec:
+  packageRepositoryName: deckhouse
+  type: Update
+  update:
+    timeout: 5m
+status:
+  completionTime: "2025-10-31T12:00:00Z"
+  conditions:
+  - lastTransitionTime: "2019-10-17T15:33:00Z"
+    message: ""
+    reason: ScanSucceeded
+    status: "True"
+    type: Completed
+  packages:
+    processed:
+    - name: test-package
+      type: Application
+    processedOverall: 1
+    total: 1
+  startTime: "2025-10-31T12:00:00Z"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ApplicationPackageVersion
+metadata:
+  creationTimestamp: null
+  labels:
+    heritage: deckhouse
+    packages.deckhouse.io/draft: "true"
+    packages.deckhouse.io/package: test-package
+    packages.deckhouse.io/repository: deckhouse
+  name: deckhouse-test-package-v1.0.0
+  resourceVersion: "2"
+spec:
+  packageName: test-package
+  packageRepositoryName: deckhouse
+  packageVersion: v1.0.0
+status:
+  packageMetadata:
+    stage: stable
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: PackageRepository
+metadata:
+  creationTimestamp: null
+  name: deckhouse
+  resourceVersion: "3"
+spec:
+  registry:
+    repo: registry.example.com/test
+status:
+  conditions:
+  - lastTransitionTime: "2019-10-17T15:33:00Z"
+    message: ""
+    reason: ScanSucceeded
+    status: "True"
+    type: LastScanSucceeded
+  packages:
+  - name: test-package
+    type: Application
+  packagesCount: 1
+  phase: Active
+  syncTime: "2025-10-31T12:00:00Z"

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/incremental-no-new-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/incremental-no-new-versions.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: PackageRepositoryOperation
+metadata:
+  creationTimestamp: null
+  labels:
+    packages.deckhouse.io/repository: deckhouse
+  name: deckhouse-scan-1571326380
+  ownerReferences:
+  - apiVersion: deckhouse.io/v1alpha1
+    controller: true
+    kind: PackageRepository
+    name: deckhouse
+    uid: ""
+spec:
+  packageRepositoryName: deckhouse
+  type: Update
+  update:
+    timeout: 5m
+status: {}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: PackageRepository
+metadata:
+  name: deckhouse
+spec:
+  registry:
+    repo: registry.example.com/test
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ApplicationPackageVersion
+metadata:
+  name: deckhouse-test-package-v1.0.0
+  labels:
+    heritage: deckhouse
+    packages.deckhouse.io/draft: "true"
+    packages.deckhouse.io/package: test-package
+    packages.deckhouse.io/repository: deckhouse
+spec:
+  packageName: test-package
+  packageRepositoryName: deckhouse
+  packageVersion: v1.0.0
+status:
+  packageMetadata:
+    stage: stable

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/incremental-no-new-versions.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/testdata/incremental-no-new-versions.yaml
@@ -26,6 +26,12 @@ metadata:
 spec:
   registry:
     repo: registry.example.com/test
+status:
+  packages:
+  - name: test-package
+    type: Application
+  packagesCount: 1
+  phase: Active
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: ApplicationPackageVersion


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Use the previous PackageRepository.status.packages as a type cache in UpdateRepositoryStatus. Package type (Application/Module) is a stable property baked into the version image, so when an incremental scan returns an entry with empty Type, recover it from the existing status entry instead of dropping the package.

Changes:

- deckhouse-controller/pkg/controller/packages/package-repository-operation/operation-service.go — UpdateRepositoryStatus now reads previous types into a map and falls back to it for entries with empty Type.
- Regression test incremental scan with no new versions keeps package in repository status + fixtures.
- Test harness: setupFakeController persists Status for PackageRepository and ApplicationPackageVersion fixtures (parallel to existing ModulePackageVersion handling), guarded on non-zero status.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

PackageRepository.status.packages is fully rebuilt every scan from PackageRepositoryOperation.status.packages.processed. Each entry must have a non-empty type (CRD requirement), so empty-type entries are dropped as a safety guard.

When an incremental scan finds no new semver tags for a package, the controller skips image type detection (no version image to pull) and returns an empty PackageType. The guard then dropped the package from status.packages — every quiet rescan silently truncated the repository status to packages whose type was resolved by a different path (e.g. legacy modules via /release, where the type is hardcoded).
```
status:
  conditions:
  - lastTransitionTime: "2026-04-27T11:08:52Z"
    message: ""
    observedGeneration: 1
    reason: ScanSucceeded
    status: "True"
    type: LastScanSucceeded
  packages:
  - name: 1c
    type: Application
  - name: artem-test
    type: Application
  - name: jellyfin
    type: Application
  - name: m-s-test
    type: Application
  - name: minecraft
    type: Application
  - name: mytestapp
    type: Application
  - name: parca
    type: Module
  - name: pgadmin
    type: Application
  - name: roma-test
    type: Application
  - name: s-p-test
    type: Application
  - name: test
    type: Application
  packagesCount: 11
  phase: Active
  syncTime: "2026-05-03T21:59:10Z"
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Preserve PackageRepository.status.packages on incremental rescan.
impact_level: low
```
