### PR TITLE
feat(prometheus): add keep_firing_for support to CustomPrometheusRules

### DIFF
--- a/modules/300-prometheus/crds/customprometheusrules.yaml
+++ b/modules/300-prometheus/crds/customprometheusrules.yaml
@@ -72,6 +72,8 @@ spec:
                               x-kubernetes-int-or-string: true
                             for:
                               type: string
+                            keep_firing_for:
+                              type: string
                             labels:
                               additionalProperties:
                                 type: string

--- a/modules/300-prometheus/hooks/custom_rules_test.go
+++ b/modules/300-prometheus/hooks/custom_rules_test.go
@@ -197,4 +197,40 @@ metadata:
 			Expect(f.KubernetesResource("PrometheusRule", "d8-monitoring", "d8-custom-one").Exists()).To(BeFalse())
 		})
 	})
+
+	Context("Cluster with keep_firing_for rule", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSetAndWaitForBindingContexts(`
+---
+apiVersion: deckhouse.io/v1
+kind: CustomPrometheusRules
+metadata:
+  name: with-keep-firing
+spec:
+  groups:
+  - name: gr-keep
+    rules:
+    - alert: RuleWithKeepFiring
+      expr: up == 0
+      for: 5m
+      keep_firing_for: 10m
+`, 1))
+			f.RunHook()
+		})
+
+		It("Should create PrometheusRule and preserve keep_firing_for field", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			prometheusRule := f.KubernetesResource("PrometheusRule", "d8-monitoring", "d8-custom-with-keep-firing")
+			Expect(prometheusRule.Exists()).To(BeTrue())
+			Expect(prometheusRule.Field("spec.groups").String()).To(MatchYAML(`
+- name: gr-keep
+  rules:
+  - alert: RuleWithKeepFiring
+    expr: up == 0
+    for: 5m
+    keep_firing_for: 10m
+`))
+		})
+	})
 })


### PR DESCRIPTION
## Description
Added the `keep_firing_for` field to the `CustomPrometheusRules` CRD schema. The existing hook logic already passes the raw `groups` array to the `PrometheusRule` resource, so no Go code changes were required. Also added a dedicated test case to ensure the field is preserved.

This feature does not influence critical cluster components and does not cause unexpected restarts.

## Why do we need it, and what problem does it solve?
Prometheus 2.42 introduced the `keep_firing_for` field, which allows alerts to remain active for a specified time after the triggering condition has cleared. This is extremely useful for handling flapping alerts or ensuring that temporary recoveries don't prematurely resolve an incident. 

Previously, the Deckhouse CRD wrapper `customprometheusrules.deckhouse.io` did not allow this field in its OpenAPI schema validation, preventing users from utilizing this native Prometheus feature.

## Why do we need it in the patch release (if we do)?
Not necessarily. It's a new feature, not a critical bug fix.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: feature
summary: Add support for the `keep_firing_for` field in the CustomPrometheusRules CRD.
impact_level: default