### PR TITLE
Backport: [admission-policy-engine] Fix enforcementAction for D8ReplicaLimits, added more template tests

### DIFF
--- a/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/operation_policies_test.go
@@ -51,6 +51,7 @@ admissionPolicyEngine:
       - metadata:
           name: genpolicy
         spec:
+          enforcementAction: Warn
           policies:
             allowedRepos:
               - foo
@@ -105,6 +106,14 @@ admissionPolicyEngine:
             namespaceSelector:
               matchNames:
                 - default
+              excludeNames:
+                - kube-system
+              labelSelector:
+                matchLabels:
+                  operation-policy.deckhouse.io/enabled: "true"
+            labelSelector:
+              matchLabels:
+                operation-policy.deckhouse.io/enabled: "true"
     trackedConstraintResources:
       - apiGroups:
           - ""
@@ -178,6 +187,57 @@ admissionPolicyEngine:
 					}
 					validateYAML(resourceMap, constraintKind)
 				}
+			}
+		})
+
+		It("Operation policy constraints must use values for enforcementAction, match and parameters", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			expectedSelector := constraintSelectorExpectation{
+				namespaces:         mustParseYaml("- default"),
+				excludedNamespaces: mustParseYaml("- kube-system"),
+				namespaceSelector:  mustParseYaml("matchLabels:\n  operation-policy.deckhouse.io/enabled: \"true\""),
+				labelSelector:      mustParseYaml("matchLabels:\n  operation-policy.deckhouse.io/enabled: \"true\""),
+			}
+			expectedAction := "warn"
+
+			expectedParameters := map[string]interface{}{
+				"D8AllowedRepos":          mustParseYaml("repos:\n  - foo"),
+				"D8RequiredResources":     mustParseYaml("limits:\n  - memory\nrequests:\n  - cpu\n  - memory"),
+				"D8DisallowedTags":        mustParseYaml("tags:\n  - latest"),
+				"D8RequiredLabels":        mustParseYaml("labels:\n  - key: foo\n  - key: bar\n    allowedRegex: \"^[a-zA-Z]+.agilebank.demo$\""),
+				"D8RequiredAnnotations":   mustParseYaml("annotations:\n  - key: foo\n  - key: bar\n    allowedRegex: \"^[a-zA-Z]+.myapp.demo$\""),
+				"D8RequiredProbes":        mustParseYaml("probes:\n  - livenessProbe\n  - readinessProbe"),
+				"D8RevisionHistoryLimit":  mustParseYaml("limit: 3"),
+				"D8ImagePullPolicy":       mustParseYaml("policy: \"Always\""),
+				"D8PriorityClass":         mustParseYaml("priorityClassNames:\n  - foo\n  - bar"),
+				"D8IngressClass":          mustParseYaml("ingressClassNames:\n  - ing1\n  - ing2"),
+				"D8StorageClass":          mustParseYaml("storageClassNames:\n  - st1\n  - st2"),
+				"D8ReplicaLimits":         mustParseYaml("ranges:\n  - minReplicas: 1\n    maxReplicas: 10"),
+				"D8DisallowedTolerations": mustParseYaml("tolerations:\n  - key: node-role.kubernetes.io/master\n    operator: Exists\n  - key: node-role.kubernetes.io/control-plane\n    operator: Exists"),
+			}
+
+			constraintsWithoutParameters := []string{
+				"D8DNSPolicy",
+				"D8ContainerDuplicates",
+			}
+
+			for constraintKind, expected := range expectedParameters {
+				constraint := f.KubernetesGlobalResource(constraintKind, testPolicyName)
+				Expect(constraint.Exists()).To(BeTrue())
+				spec := getConstraintSpecMap(constraint)
+				expectConstraintAction(spec, expectedAction)
+				expectConstraintSelector(spec, expectedSelector)
+				expectConstraintParameters(spec, expected)
+			}
+
+			for _, constraintKind := range constraintsWithoutParameters {
+				constraint := f.KubernetesGlobalResource(constraintKind, testPolicyName)
+				Expect(constraint.Exists()).To(BeTrue())
+				spec := getConstraintSpecMap(constraint)
+				expectConstraintAction(spec, expectedAction)
+				expectConstraintSelector(spec, expectedSelector)
+				expectConstraintParameters(spec, nil)
 			}
 		})
 	})

--- a/modules/015-admission-policy-engine/template_tests/policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/policies_test.go
@@ -30,6 +30,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	. "github.com/deckhouse/deckhouse/testing/helm"
+	"github.com/deckhouse/deckhouse/testing/library/object_store"
 )
 
 var _ = Describe("Module :: admissionPolicyEngine :: pod security policies ::", func() {
@@ -458,4 +459,69 @@ func getOperationConstraintNames() []string {
 	}
 
 	return result
+}
+
+// constraintSelectorExpectation describes expected selector fields rendered by constraint_selector helper.
+type constraintSelectorExpectation struct {
+	namespaces         interface{}
+	excludedNamespaces interface{}
+	namespaceSelector  interface{}
+	labelSelector      interface{}
+}
+
+func mustParseYaml(input string) interface{} {
+	var result interface{}
+	err := yaml.Unmarshal([]byte(input), &result)
+	Expect(err).ShouldNot(HaveOccurred())
+	return result
+}
+
+func getConstraintSpecMap(constraint object_store.KubeObject) map[string]interface{} {
+	var resource map[string]interface{}
+	err := yaml.Unmarshal([]byte(constraint.ToYaml()), &resource)
+	Expect(err).ShouldNot(HaveOccurred())
+	spec, ok := resource["spec"].(map[string]interface{})
+	Expect(ok).To(BeTrue())
+	return spec
+}
+
+func expectConstraintAction(spec map[string]interface{}, expectedAction string) {
+	Expect(spec).To(HaveKeyWithValue("enforcementAction", expectedAction))
+}
+
+func expectConstraintSelector(spec map[string]interface{}, expected constraintSelectorExpectation) {
+	match, ok := spec["match"].(map[string]interface{})
+	Expect(ok).To(BeTrue())
+
+	if expected.namespaces != nil {
+		Expect(match).To(HaveKeyWithValue("namespaces", expected.namespaces))
+	} else {
+		Expect(match).ToNot(HaveKey("namespaces"))
+	}
+
+	if expected.excludedNamespaces != nil {
+		Expect(match).To(HaveKeyWithValue("excludedNamespaces", expected.excludedNamespaces))
+	} else {
+		Expect(match).ToNot(HaveKey("excludedNamespaces"))
+	}
+
+	if expected.namespaceSelector != nil {
+		Expect(match).To(HaveKeyWithValue("namespaceSelector", expected.namespaceSelector))
+	} else {
+		Expect(match).ToNot(HaveKey("namespaceSelector"))
+	}
+
+	if expected.labelSelector != nil {
+		Expect(match).To(HaveKeyWithValue("labelSelector", expected.labelSelector))
+	} else {
+		Expect(match).ToNot(HaveKey("labelSelector"))
+	}
+}
+
+func expectConstraintParameters(spec map[string]interface{}, expected interface{}) {
+	if expected == nil {
+		Expect(spec).ToNot(HaveKey("parameters"))
+		return
+	}
+	Expect(spec).To(HaveKeyWithValue("parameters", expected))
 }

--- a/modules/015-admission-policy-engine/template_tests/security_policies_test.go
+++ b/modules/015-admission-policy-engine/template_tests/security_policies_test.go
@@ -44,6 +44,7 @@ admissionPolicyEngine:
       - metadata:
           name: genpolicy
         spec:
+          enforcementAction: Warn
           policies:
             allowHostIPC: true
             allowHostNetwork: false
@@ -65,13 +66,12 @@ admissionPolicyEngine:
               - user/example
             allowedProcMount: default
             allowedVolumes:
-              volumes:
-                - csi
+              - csi
             requiredDropCapabilities:
               - ALL
             allowedAppArmor:
               - unconfined
-            readOnlyRootFilesystem: "true"
+            readOnlyRootFilesystem: true
             automountServiceAccountToken: false
             allowedClusterRoles:
               - "*"
@@ -106,6 +106,14 @@ admissionPolicyEngine:
             namespaceSelector:
               matchNames:
                 - default
+              excludeNames:
+                - kube-system
+              labelSelector:
+                matchLabels:
+                  security-policy.deckhouse.io/enabled: "true"
+            labelSelector:
+              matchLabels:
+                security-policy.deckhouse.io/enabled: "true"
       - metadata:
           name: minpolicy
         spec:
@@ -272,6 +280,61 @@ admissionPolicyEngine:
 					}
 					validateYAML(resourceMap, constraintKind)
 				}
+			}
+		})
+
+		It("Security policy constraints must use values for enforcementAction, match and parameters", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			expectedSelector := constraintSelectorExpectation{
+				namespaces:         mustParseYaml("- default"),
+				excludedNamespaces: mustParseYaml("- kube-system"),
+				namespaceSelector:  mustParseYaml("matchLabels:\n  security-policy.deckhouse.io/enabled: \"true\""),
+				labelSelector:      mustParseYaml("matchLabels:\n  security-policy.deckhouse.io/enabled: \"true\""),
+			}
+			expectedAction := "warn"
+
+			expectedParameters := map[string]interface{}{
+				"D8AllowedCapabilities":    mustParseYaml("requiredDropCapabilities:\n  - ALL"),
+				"D8AllowedFlexVolumes":     mustParseYaml("allowedFlexVolumes:\n  - driver: vmware"),
+				"D8AllowedHostPaths":       mustParseYaml("allowedHostPaths:\n  - pathPrefix: /dev\n    readOnly: true"),
+				"D8AllowedProcMount":       mustParseYaml("allowedProcMount: default"),
+				"D8AllowedSeccompProfiles": mustParseYaml("allowedProfiles:\n  - RuntimeDefault\n  - Localhost\nallowedLocalhostFiles:\n  - \"*\""),
+				"D8AllowedSysctls":         mustParseYaml("allowedSysctls:\n  - \"*\"\nforbiddenSysctls:\n  - user/example"),
+				"D8AllowedUsers":           mustParseYaml("runAsUser:\n  ranges:\n    - min: 300\n      max: 500\n  rule: MustRunAs\nsupplementalGroups:\n  ranges:\n    - min: 500\n      max: 1000\n  rule: MustRunAs"),
+				"D8AllowedVolumeTypes":     mustParseYaml("volumes:\n  - csi"),
+				"D8HostNetwork":            mustParseYaml("allowHostNetwork: false\nranges:\n  - min: 10\n    max: 100"),
+				"D8HostProcesses":          mustParseYaml("allowHostPID: false\nallowHostIPC: true"),
+				"D8AllowedClusterRoles":    mustParseYaml("allowedClusterRoles:\n  - \"*\""),
+				"D8SeLinux":                mustParseYaml("allowedSELinuxOptions:\n  - role: role\n    user: user\n  - level: level\n    type: type"),
+				"D8AppArmor":               mustParseYaml("allowedProfiles:\n  - unconfined"),
+				"D8VerifyImageSignatures":  mustParseYaml("references:\n  - \"^.*$\""),
+			}
+
+			constraintsWithoutParameters := []string{
+				"D8AllowPrivilegeEscalation",
+				"D8PrivilegedContainer",
+				"D8ReadOnlyRootFilesystem",
+				"D8AutomountServiceAccountTokenPod",
+				"D8AllowRbacWildcards",
+			}
+
+			for constraintKind, expected := range expectedParameters {
+				constraint := f.KubernetesGlobalResource(constraintKind, testPolicyName)
+				Expect(constraint.Exists()).To(BeTrue())
+				spec := getConstraintSpecMap(constraint)
+				expectConstraintAction(spec, expectedAction)
+				expectConstraintSelector(spec, expectedSelector)
+				expectConstraintParameters(spec, expected)
+			}
+
+			for _, constraintKind := range constraintsWithoutParameters {
+				constraint := f.KubernetesGlobalResource(constraintKind, testPolicyName)
+				Expect(constraint.Exists()).To(BeTrue())
+				spec := getConstraintSpecMap(constraint)
+				expectConstraintAction(spec, expectedAction)
+				expectConstraintSelector(spec, expectedSelector)
+				expectConstraintParameters(spec, nil)
 			}
 		})
 	})

--- a/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
+++ b/modules/015-admission-policy-engine/templates/policies/operation-policy/constraint.yaml
@@ -346,6 +346,7 @@ metadata:
   name: {{$cr.metadata.name}}
   {{- include "helm_lib_module_labels" (list $context (dict "security.deckhouse.io/operation-policy" "")) | nindent 2 }}
 spec:
+  enforcementAction: {{ $cr.spec.enforcementAction | default "deny" | lower }}
   match:
     kinds:
       - apiGroups: ["apps"]


### PR DESCRIPTION
## Description
It was discovered that the enforcementAction parameter from the populated CR `OperationPolicy` parameters for the `D8ReplicaLimits` constraint was not being correctly processed.


## Why do we need it, and what problem does it solve?
The template for `D8ReplicaLimits` has been corrected, and tests have been written to ensure that all parameters from CR `OperationPolicy` and `SecurityPolicy` are included in the final constraint.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: admission-policy-engine
type: fix
summary: Fixed enforcementAction for D8ReplicaLimits, added more template tests.
impact_level: default 
```
