### PR TITLE
[dhctl] Fix StaticInstance preflight check for fails when SSHCredentials has no private key.

### DIFF
--- a/dhctl/pkg/preflight/checks/static_instances_ssh_credentials.go
+++ b/dhctl/pkg/preflight/checks/static_instances_ssh_credentials.go
@@ -260,12 +260,14 @@ func testSSHConnection(ctx context.Context, sshProviderInitializer *providerinit
 	n := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	privateKeyPath := fmt.Sprintf("%s.%d", privateKeyPrefixPathWithoutSuffix, n)
 
-	err = os.WriteFile(privateKeyPath, []byte(cred.PrivateSSHKey), 0o600)
-	if err != nil {
-		return fmt.Errorf("Failed to write private key: %w", err)
-	}
+	if cred.PrivateSSHKey != "" {
+		err = os.WriteFile(privateKeyPath, []byte(cred.PrivateSSHKey), 0o600)
+		if err != nil {
+			return fmt.Errorf("Failed to write private key: %w", err)
+		}
 
-	pkeys = append(pkeys, session.AgentPrivateKey{Key: privateKeyPath})
+		pkeys = append(pkeys, session.AgentPrivateKey{Key: privateKeyPath})
+	}
 	client, err := sshProvider.NewStandaloneClient(ctx, config, pkeys)
 	if err != nil {
 		return fmt.Errorf("Cannot create SSH client: %w", err)

--- a/dhctl/pkg/preflight/checks/static_instances_ssh_credentials.go
+++ b/dhctl/pkg/preflight/checks/static_instances_ssh_credentials.go
@@ -222,15 +222,10 @@ func testSSHConnection(ctx context.Context, sshProviderInitializer *providerinit
 		pkeys = sshClient.PrivateKeys()
 	}
 
-	becomePass, err := base64.StdEncoding.DecodeString(cred.SudoPasswordEncoded)
-	if err != nil {
-		return err
-	}
-
 	config := session.NewSession(session.Input{
 		User:       cred.User,
 		Port:       strconv.Itoa(cred.SSHPort),
-		BecomePass: string(becomePass),
+		BecomePass: cred.SudoPasswordEncoded,
 	})
 	config.AddAvailableHosts(session.Host{Host: address})
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Skip writing empty private key file and fix double base64 decoding of sudoPassword in StaticInstance SSH credentials preflight check.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When SSHCredentials contain only sudoPasswordEncoded without privateSSHKey, the check always wrote an empty file and tried to parse it as a private key, causing "ssh: no key found" error. Also          sudoPasswordEncoded was decoded twice — once in parseSSHCredentials() and again before passing to the session — producing garbage.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed the StaticInstance preflight check failing when SSHCredentials has no private key.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
