### PR TITLE
[istio] Fixed RBAC for kubernetes-admin

### DIFF
--- a/modules/110-istio/templates/rbac-for-us.yaml
+++ b/modules/110-istio/templates/rbac-for-us.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - istiofederations
+  - istiomulticlusters
+  - ingressistiocontrollers
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  - envoyfilters
+  - serviceentries
+  - sidecars
+  - gateways
+  - workloadentries
+  - workloadgroups
+  - virtualservices
+  - proxyconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - security.istio.io
+  resources:
+  - peerauthentications
+  - authorizationpolicies
+  - requestauthentications
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups: 
+  - telemetry.istio.io
+  resources:
+  - telemetries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: 
+  - install.istio.io
+  resources: 
+  - istiooperators
+  verbs: 
+  - get
+  - list
+  - watch
+- apiGroups: 
+  - sailoperator.io
+  resources: 
+  - istiocnis
+  - ztunnels
+  - istiorevisions
+  - istiorevisiontags
+  - istios
+  verbs: 
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.istio.io
+  resources:
+  - wasmplugins
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: kubeadm:cluster-admins

--- a/modules/110-istio/templates/rbac-for-us.yaml
+++ b/modules/110-istio/templates/rbac-for-us.yaml
@@ -24,14 +24,12 @@ rules:
   - networking.istio.io
   resources:
   - destinationrules
-  - envoyfilters
   - serviceentries
   - sidecars
   - gateways
   - workloadentries
   - workloadgroups
   - virtualservices
-  - proxyconfigs
   verbs:
   - get
   - list
@@ -64,6 +62,11 @@ rules:
   - get
   - list
   - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 - apiGroups: 
   - install.istio.io
   resources: 
@@ -72,6 +75,11 @@ rules:
   - get
   - list
   - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 - apiGroups: 
   - sailoperator.io
   resources: 
@@ -84,6 +92,11 @@ rules:
   - get
   - list
   - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 - apiGroups:
   - extensions.istio.io
   resources:
@@ -92,6 +105,11 @@ rules:
   - get
   - list
   - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description
Binded access rights (full CRUD) over module CRs to kubeadm:cluster-admins group.

## Why do we need it, and what problem does it solve?
It allows to work with module resources for kubeadm:cluster-admins group by default.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: binded access rights of module CRs to kubeadm:cluster-admins group
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
