### PR TITLE
[docs] Extend alb module edition availability

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -16,6 +16,10 @@
   },
   "alb": {
     "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
       "ee"
     ],
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -1,6 +1,10 @@
 {
   "alb": {
     "editions": [
+      "ce",
+      "be",
+      "se",
+      "se-plus",
       "ee"
     ],
     "tags": [


### PR DESCRIPTION
## Description
Add ce, be, se, and se-plus editions to the alb module edition list across documentation data sources.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add ce, be, se, and se-plus editions to the alb module edition list across documentation data sources.
impact_level: low
```
