### PR TITLE
[cloud-provider-vcd] Fix CAPCD SPE

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/deployment.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/deployment.yaml
@@ -88,6 +88,6 @@ periodSeconds: 10
 {{- $_ := set $capiConfig "livenessProbe" (include "capcd_controller_manager_liveness_probe" . | fromYaml) -}}
 {{- $_ := set $capiConfig "readinessProbe" (include "capcd_controller_manager_readiness_probe" . | fromYaml) -}}
 {{- $_ := set $capiConfig "vpaEnabled" true -}}
-{{- $_ := set $capiConfig "securityPolicyExceptionEnabled" true -}}
+{{- $_ := set $capiConfig "securityPolicyExceptionEnabled" false -}}
 
 {{- include "helm_lib_capi_controller_manager_manifests" (list . $capiConfig) }}

--- a/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/security-policy-exception.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/capcd-controller-manager/security-policy-exception.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: capcd-controller-manager
+  namespace: d8-cloud-provider-vcd
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          Allow host network access for CAPI infrastructure controller manager.
+          The CAPI infrastructure controller manager requires host network access to continue infrastructure reconciliation even if the CNI or pod network is unavailable.
+    hostPorts:
+      - port: 4201
+        protocol: TCP
+        metadata:
+          description: |
+            Allow binding TCP port 4201 for the CAPCD webhook server.
+            This port is used by capcd-controller-manager to serve admission webhooks via capcd-controller-manager-webhook-service.
+{{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix SecurityPolicyException for capcd-controller-manager. Add exception for host port 4201

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Without exceptions for host port 4201 (webhook port), capcd-controller-manager pods can be blocked by the admission policy engine.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: fix
summary: Fixed the SecurityPolicyException in CAPCD.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
