### PR TITLE
[docs] Add documentation about du in astra linux

### DIFF
--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING.md
@@ -68,5 +68,5 @@ At migration process the folder `/var/lib/containerd` will be cleared, causing a
 {% endalert %}
 
 {% alert level="warning" %}
-On Astra Linux, when using EROFS images, the `du` command may show an inflated size for the `/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/` directory due to double-counting of mounted layers. To get the correct size, use the `-x` flag: `du -shx /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/`.
+On Astra Linux, when using EROFS images, the `du` command may show an inflated size for the `/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/` directory due to double-counting of layers (as files and as mounted filesystems within the `fs/` subdirectory). To get the correct size, use the `-x` flag: `du -shx /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/`.
 {% endalert %}

--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING.md
@@ -66,3 +66,7 @@ When migrating to containerd v2 Deckhouse Kubernetes Platform will begin sequent
 {% alert level="info" %}
 At migration process the folder `/var/lib/containerd` will be cleared, causing all pod images to be re-downloaded, and the node will reboot.
 {% endalert %}
+
+{% alert level="warning" %}
+On Astra Linux, when using EROFS images, the `du` command may show an inflated size for the `/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/` directory due to double-counting of mounted layers. To get the correct size, use the `-x` flag: `du -shx /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/`.
+{% endalert %}

--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING_RU.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING_RU.md
@@ -68,3 +68,7 @@ ls -l /etc/containerd/conf.d
 {% alert level="info" %}
 В процессе миграции директория `/var/lib/containerd` будет очищена, что приведет к повторному скачиванию образов всех подов, и узел перезагрузится.
 {% endalert %}
+
+{% alert level="warning" %}
+На Astra Linux при использовании EROFS-образов команда `du` может показывать завышенный размер директории `/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/` из-за двойного учета смонтированных слоев. Для корректного расчета используйте флаг `-x`: `du -shx /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/`.
+{% endalert %}

--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING_RU.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/MIGRATING_RU.md
@@ -70,5 +70,5 @@ ls -l /etc/containerd/conf.d
 {% endalert %}
 
 {% alert level="warning" %}
-На Astra Linux при использовании EROFS-образов команда `du` может показывать завышенный размер директории `/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/` из-за двойного учета смонтированных слоев. Для корректного расчета используйте флаг `-x`: `du -shx /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/`.
+На Astra Linux при использовании EROFS-образов команда `du` может показывать завышенный размер директории `/var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/` из-за двойного учета слоев (как файлов и как смонтированных файловых систем внутри поддиректории `fs/`). Для корректного расчета используйте флаг `-x`: `du -shx /var/lib/containerd/io.containerd.snapshotter.v1.erofs/snapshots/`.
 {% endalert %}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adds documentation warning about incorrect disk usage reporting for EROFS snapshots on Astra Linux when using `du`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
`du` may overestimate directory size due to double-counting mounted layers in EROFS snapshots. This clarification prevents misinterpretation of disk usage and provides the correct command.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: clarify du overestimation for EROFS snapshots on Astra Linux
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
