### PR TITLE
[upmeter] fix panic in shutdown

### DIFF
--- a/modules/500-upmeter/images/upmeter/src/pkg/server/server.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/server/server.go
@@ -139,12 +139,18 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 func (s *Server) Stop() error {
-	err := s.server.Shutdown(context.Background())
-	if err != nil && err != http.ErrServerClosed {
-		return err
+	if s.server != nil {
+		err := s.server.Shutdown(context.Background())
+		if err != nil && err != http.ErrServerClosed {
+			return err
+		}
 	}
-	s.remoteWriteController.Stop()
-	s.downtimeMonitor.Stop()
+	if s.remoteWriteController != nil {
+		s.remoteWriteController.Stop()
+	}
+	if s.downtimeMonitor != nil {
+		s.downtimeMonitor.Stop()
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add nil-checks to prevent panic when the server is shut down during incomplete initialization.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

When upmeter lacks RBAC permissions to list `downtimes.deckhouse.io` (e.g. because the Deckhouse queue is stuck and ClusterRole manifests haven't been applied yet), `Server.Start()` blocks on cache sync. If a shutdown signal arrives at this point, `Server.Stop()` is called while `s.server`, `s.remoteWriteController`, or `s.downtimeMonitor` are still nil, causing a nil pointer dereference panic.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
No need

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix 
summary: Fixed a nil pointer panic in `upmeter` on shutdown when server initialization is incomplete.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
