### PR TITLE
[dhctl] Fix SSH preflight check for StaticInstances with password-only auth.

### DIFF
--- a/dhctl/pkg/preflight/check_staticinstances_with_sshcredentials.go
+++ b/dhctl/pkg/preflight/check_staticinstances_with_sshcredentials.go
@@ -198,12 +198,20 @@ func testSSHConnection(ctx context.Context, nodeInterface node.Interface, addres
 		config.BastionHost = sess.BastionHost
 		config.BastionPort = sess.BastionPort
 		config.BastionUser = sess.BastionUser
-		config.BastionPassword = sess.BastionPassword
+		bastionPassword := sess.BastionPassword
+		if bastionPassword == "" {
+			bastionPassword = app.SSHBastionPass
+		}
+		config.BastionPassword = bastionPassword
 	} else {
 		config.BastionHost = sess.AvailableHosts()[0].Host
 		config.BastionPort = sess.Port
 		config.BastionUser = sess.User
-		config.BastionPassword = sess.BecomePass
+		bastionPassword := sess.BecomePass
+		if bastionPassword == "" {
+			bastionPassword = app.BecomePass
+		}
+		config.BastionPassword = bastionPassword
 	}
 
 	client, err := sshclient.NewClientFromConfig(ctx, address, config)

--- a/dhctl/pkg/system/node/gossh/client.go
+++ b/dhctl/pkg/system/node/gossh/client.go
@@ -137,7 +137,7 @@ func (s *Client) Start() error {
 		var bastionPass string
 
 		if s.Settings.BastionPassword != "" {
-			bastionPass = s.Settings.BecomePass
+			bastionPass = s.Settings.BastionPassword
 		} else {
 			bastionPass = app.SSHBastionPass
 		}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Preflight check for StaticInstance SSH credentials fails with "No credentials present to connect to bastion   host" when SSHConfig uses password authentication without private keys.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
The password from SSHConfig (sudoPassword) was not being passed through to the preflight check that verifies connectivity to StaticInstances. Also fixed a bug where bastion and target node passwords could be mixed up when they   differ.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: fix SSH preflight check for StaticInstances with password-only auth.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
