### PR TITLE
[docs][ci][testing] Add .vex and module.yaml to exception in linter

### DIFF
--- a/tools/validation/no_cyrillic.go
+++ b/tools/validation/no_cyrillic.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-var skipDocRe = regexp.MustCompile(`doc-ru-.+\.y[a]?ml$|_RU\.md$|\.ru\.md$|_ru\.html$|docs/site/_.+|docs/documentation/_.+|tools/docs/spelling/.+`)
+var skipDocRe = regexp.MustCompile(`doc-ru-.+\.y[a]?ml$|_RU\.md$|\.ru\.md$|_ru\.html$|docs/site/_.+|docs/documentation/_.+|tools/docs/spelling/.+|\.vex$|module\.yaml$`)
 var skipI18NRe = regexp.MustCompile(`/i18n/`)
 var skipSelfRe = regexp.MustCompile(`no_cyrillic(_test)?.go$`)
 


### PR DESCRIPTION
## Description

This pull request updates the regular expression used for skipping files in the Cyrillic validation tool. The main change is to expand the list of file patterns to be skipped, ensuring that certain additional file types are excluded from validation.

**File skipping improvements:**

* Updated the `skipDocRe` regular expression in `tools/validation/no_cyrillic.go` to also skip files ending with `.vex` and `module.yaml`, in addition to the existing patterns.

Add .vex and module.yaml to exception.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Add .vex and module.yaml to exception in CI linter.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
