### PR TITLE
[docs] Fix visibility scope for nested details component

### DIFF
--- a/docs/documentation/_plugins/offtopic.rb
+++ b/docs/documentation/_plugins/offtopic.rb
@@ -40,6 +40,13 @@ module Jekyll
         @converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
         rendered_content = collapse_inter_block_newlines(@converter.convert(content))
 
+        rendered_content = rendered_content.gsub(/(<pre\b[^>]*>)(.*?)(<\/pre>)/m) do
+          pre_open = $1
+          pre_body = $2
+          pre_close = $3
+          "#{pre_open}#{pre_body.gsub("\n", '&#10;')}#{pre_close}"
+        end
+
         %Q(<div markdown="0" class="details"><p class="details__lnk"><a href="javascript:void(0)" class="details__summary">#{@config[:title]}</a></p><div class="details__content"><div class="expand">#{rendered_content}</div></div></div>)
       end
     end

--- a/docs/site/assets/css/docs.scss
+++ b/docs/site/assets/css/docs.scss
@@ -1766,11 +1766,11 @@ a.comparison-table__module-proprietaryOkmeter::after {
     transform: rotate(0deg);
 }
 
-.docs .details .details__content {
+.docs .details > .details__content {
     display: none;
 }
 
-.docs .details.active .details__content {
+.docs .details.active > .details__content {
     display: block;
 }
 


### PR DESCRIPTION
## Description

This pull request introduces improvements to the rendering of custom "details" blocks in the documentation and refines CSS selectors to enhance specificity for these expandable sections.

**Rendering improvements:**

* In `docs/documentation/_plugins/offtopic.rb`, the `render` method now replaces newline characters inside `<pre>` blocks with HTML line breaks (`&#10;`) to preserve formatting when displaying code snippets inside expandable "details" blocks.

**CSS selector refinement:**

* In `docs/site/assets/css/docs.scss`, the CSS selectors for `.details__content` are updated to use the child combinator (`>`) for more precise targeting, ensuring that only direct children are affected when toggling visibility of expandable content.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Fix visibility scope for nested details component
impact_level: low
```
