### PR TITLE
[deckhouse] implement values schema storage

### DIFF
--- a/deckhouse-controller/internal/packages/apps/app.go
+++ b/deckhouse-controller/internal/packages/apps/app.go
@@ -289,20 +289,20 @@ func (a *Application) GetValuesChecksum() string {
 // GetSettingsChecksum returns a checksum of the current config values.
 // Used to detect if settings changed.
 func (a *Application) GetSettingsChecksum() string {
-	return a.values.GetConfigChecksum()
+	return a.values.GetSettingsChecksum()
 }
 
 // ValidateSettings validates settings against openAPI and call setting check if exists
 func (a *Application) ValidateSettings(ctx context.Context, settings addonutils.Values) (settingscheck.Result, error) {
-	if err := a.values.ValidateConfigValues(settings); err != nil {
+	if err := a.values.ValidateSettings(settings); err != nil {
 		return settingscheck.Result{}, err
 	}
 
 	// apply defaults from config values spec
-	settings = a.values.ApplyDefaultsConfigValues(settings)
+	settings = a.values.ApplySettingsDefaults(settings)
 
 	// no need to call the settings check if nothing changed
-	if a.values.GetConfigChecksum() == settings.Checksum() {
+	if a.values.GetSettingsChecksum() == settings.Checksum() {
 		return settingscheck.Result{Valid: true}, nil
 	}
 
@@ -322,7 +322,7 @@ func (a *Application) GetValues() addonutils.Values {
 
 // ApplySettings applies settings values to application
 func (a *Application) ApplySettings(settings addonutils.Values) error {
-	return a.values.ApplyConfigValues(settings)
+	return a.values.ApplySettings(settings)
 }
 
 // GetSettings returns the effective settings: user config merged with

--- a/deckhouse-controller/internal/packages/modules/global/module.go
+++ b/deckhouse-controller/internal/packages/modules/global/module.go
@@ -148,7 +148,7 @@ func (m *Module) GetValuesChecksum() string {
 // GetSettingsChecksum returns a checksum of the current config values.
 // Used to detect if settings changed.
 func (m *Module) GetSettingsChecksum() string {
-	return m.values.GetConfigChecksum()
+	return m.values.GetSettingsChecksum()
 }
 
 // GetValues returns values for rendering
@@ -158,15 +158,15 @@ func (m *Module) GetValues() addonutils.Values {
 
 // ValidateSettings validates settings against openAPI
 func (m *Module) ValidateSettings(_ context.Context, settings addonutils.Values) (settingscheck.Result, error) {
-	if err := m.values.ValidateConfigValues(settings); err != nil {
+	if err := m.values.ValidateSettings(settings); err != nil {
 		return settingscheck.Result{}, err
 	}
 
 	// apply defaults from config values spec
-	settings = m.values.ApplyDefaultsConfigValues(settings)
+	settings = m.values.ApplySettingsDefaults(settings)
 
 	// no need to call the settings check if nothing changed
-	if m.values.GetConfigChecksum() == settings.Checksum() {
+	if m.values.GetSettingsChecksum() == settings.Checksum() {
 		return settingscheck.Result{Valid: true}, nil
 	}
 
@@ -177,7 +177,7 @@ func (m *Module) ValidateSettings(_ context.Context, settings addonutils.Values)
 
 // ApplySettings apply settings values
 func (m *Module) ApplySettings(settings addonutils.Values) error {
-	return m.values.ApplyConfigValues(settings)
+	return m.values.ApplySettings(settings)
 }
 
 // InitializeHooks initializes hook controllers and bind them to Kubernetes events and schedules

--- a/deckhouse-controller/internal/packages/modules/module.go
+++ b/deckhouse-controller/internal/packages/modules/module.go
@@ -264,20 +264,20 @@ func (m *Module) GetValuesChecksum() string {
 // GetSettingsChecksum returns a checksum of the current config values.
 // Used to detect if settings changed.
 func (m *Module) GetSettingsChecksum() string {
-	return m.values.GetConfigChecksum()
+	return m.values.GetSettingsChecksum()
 }
 
 // ValidateSettings validates settings against openAPI and call setting check if exists
 func (m *Module) ValidateSettings(ctx context.Context, settings addonutils.Values) (settingscheck.Result, error) {
-	if err := m.values.ValidateConfigValues(settings); err != nil {
+	if err := m.values.ValidateSettings(settings); err != nil {
 		return settingscheck.Result{}, err
 	}
 
 	// apply defaults from config values spec
-	settings = m.values.ApplyDefaultsConfigValues(settings)
+	settings = m.values.ApplySettingsDefaults(settings)
 
 	// no need to call the settings check if nothing changed
-	if m.values.GetConfigChecksum() == settings.Checksum() {
+	if m.values.GetSettingsChecksum() == settings.Checksum() {
 		return settingscheck.Result{Valid: true}, nil
 	}
 
@@ -300,7 +300,7 @@ func (m *Module) GetValues() addonutils.Values {
 
 // ApplySettings applies settings values
 func (m *Module) ApplySettings(settings addonutils.Values) error {
-	return m.values.ApplyConfigValues(settings)
+	return m.values.ApplySettings(settings)
 }
 
 // GetSettings returns the effective settings: user config merged with

--- a/deckhouse-controller/internal/packages/values/schema/cel/cel.go
+++ b/deckhouse-controller/internal/packages/values/schema/cel/cel.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cel
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/go-openapi/spec"
+	"github.com/google/cel-go/cel"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// ruleKey is the OpenAPI extension key that carries CEL validation rules for Deckhouse schemas.
+const ruleKey = "x-deckhouse-validations"
+
+// rule is a single CEL validation entry in an x-deckhouse-validations extension list.
+// Expression is a CEL expression over "self"; Message is returned when the expression is false.
+type rule struct {
+	Expression string `json:"expression" yaml:"expression"`
+	Message    string `json:"message" yaml:"message"`
+}
+
+// Validate evaluates all x-deckhouse-validations CEL rules attached to schema and its
+// nested properties recursively. It returns validation errors for every rule that
+// evaluated to false, and a non-nil error for configuration or evaluation failures.
+func Validate(schema *spec.Schema, values any) ([]error, error) {
+	var validationErrs []error
+	// First we validate only object nested properties
+	if m, ok := values.(map[string]any); ok {
+		for propName, propSchema := range schema.Properties {
+			if propValue, ok := m[propName]; ok {
+				subErrs, err := Validate(&propSchema, propValue)
+				if err != nil {
+					return nil, err
+				}
+				validationErrs = append(validationErrs, subErrs...)
+			}
+		}
+	}
+
+	raw, found := schema.Extensions[ruleKey]
+	if !found {
+		if len(validationErrs) > 0 {
+			return validationErrs, nil
+		}
+		return nil, nil
+	}
+
+	var rules []rule
+	switch v := raw.(type) {
+	case []any:
+		for _, entry := range v {
+			mapEntry, ok := entry.(map[string]any)
+			if !ok || len(mapEntry) == 0 {
+				return nil, fmt.Errorf("x-deckhouse-validations invalid")
+			}
+
+			if val, ok := mapEntry["expression"]; !ok || len(val.(string)) == 0 {
+				return nil, fmt.Errorf("x-deckhouse-validations invalid: missing expression")
+			}
+			if val, ok := mapEntry["message"]; !ok || len(val.(string)) == 0 {
+				return nil, fmt.Errorf("x-deckhouse-validations invalid: missing message")
+			}
+
+			rules = append(rules, rule{
+				Expression: mapEntry["expression"].(string),
+				Message:    mapEntry["message"].(string),
+			})
+		}
+	default:
+		return nil, fmt.Errorf("x-deckhouse-validations invalid")
+	}
+
+	celSelfType, celSelfValue, err := buildCELValueAndType(values)
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := cel.NewEnv(cel.Variable("self", celSelfType))
+	if err != nil {
+		return nil, fmt.Errorf("create CEL env: %w", err)
+	}
+	for _, r := range rules {
+		ast, issues := env.Compile(r.Expression)
+		if issues.Err() != nil {
+			return nil, fmt.Errorf("compile the '%s' rule: %w", r.Expression, issues.Err())
+		}
+
+		prg, err := env.Program(ast)
+		if err != nil {
+			return nil, fmt.Errorf("create program for the '%s' rule: %w", r.Expression, err)
+		}
+
+		out, _, err := prg.Eval(map[string]any{"self": celSelfValue})
+		if err != nil {
+			if strings.Contains(err.Error(), "no such key:") {
+				continue
+			}
+			return nil, fmt.Errorf("evaluate the '%s' rule: %w", r.Expression, err)
+		}
+
+		pass, ok := out.Value().(bool)
+		if !ok {
+			return nil, errors.New("rule should return boolean")
+		}
+		if !pass {
+			validationErrs = append(validationErrs, errors.New(r.Message))
+		}
+	}
+
+	return validationErrs, nil
+}
+
+// buildCELValueAndType converts a Go value to the CEL type descriptor and
+// protobuf-compatible value required by cel.Program.Eval.
+func buildCELValueAndType(value any) (*cel.Type, any, error) {
+	switch v := value.(type) {
+	case map[string]any:
+		obj, err := structpb.NewStruct(v)
+		if err != nil {
+			return nil, nil, fmt.Errorf("convert values to struct: %w", err)
+		}
+		return cel.MapType(cel.StringType, cel.DynType), obj, nil
+	case []any:
+		list, err := structpb.NewList(v)
+		if err != nil {
+			return nil, nil, fmt.Errorf("convert array to list: %w", err)
+		}
+		return cel.ListType(cel.DynType), list, nil
+	default:
+		val, err := structpb.NewValue(v)
+		if err != nil {
+			return nil, nil, fmt.Errorf("convert dyn to value: %w", err)
+		}
+		return cel.DynType, val, nil
+	}
+}

--- a/deckhouse-controller/internal/packages/values/schema/defaults/defaults.go
+++ b/deckhouse-controller/internal/packages/values/schema/defaults/defaults.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package defaults
+
+import (
+	"github.com/flant/addon-operator/pkg/utils"
+	"github.com/go-openapi/spec"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// Apply traverses an object and apply default values from OpenAPI schema.
+// It returns true if obj is changed.
+//
+// See https://github.com/kubernetes/kubernetes/blob/cea1d4e20b4a7886d8ff65f34c6d4f95efcb4742/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting/algorithm.go
+//
+// Note: check only Properties for object type and List validation for array type.
+func Apply(obj interface{}, s *spec.Schema) bool {
+	if s == nil {
+		return false
+	}
+
+	res := false
+
+	// Support utils.Values
+	switch vals := obj.(type) {
+	case utils.Values:
+		obj = map[string]interface{}(vals)
+	case *utils.Values:
+		// rare case
+		obj = map[string]interface{}(*vals)
+	}
+
+	switch obj := obj.(type) {
+	case map[string]interface{}:
+		// Apply defaults to properties
+		for k, prop := range s.Properties {
+			if prop.Default == nil {
+				continue
+			}
+			if _, found := obj[k]; !found {
+				obj[k] = runtime.DeepCopyJSONValue(prop.Default)
+				res = true
+			}
+		}
+		// Apply to deeper levels.
+		for k, v := range obj {
+			if prop, found := s.Properties[k]; found {
+				deepRes := Apply(v, &prop)
+				res = res || deepRes
+			}
+		}
+	case []interface{}:
+		// If the 'items' section is not specified in the schema, addon-operator will panic here.
+		// The schema itself should be validated earlier before applying defaults,
+		// but having a panic in runtime is much bigger problem.
+		if s.Items == nil {
+			return res
+		}
+
+		// Only List validation is supported.
+		// See https://json-schema.org/understanding-json-schema/reference/array.html#list-validation
+		for _, v := range obj {
+			deepRes := Apply(v, s.Items.Schema)
+			res = res || deepRes
+		}
+	default:
+		// scalars, no action
+	}
+
+	return res
+}

--- a/deckhouse-controller/internal/packages/values/schema/storage.go
+++ b/deckhouse-controller/internal/packages/values/schema/storage.go
@@ -142,8 +142,8 @@ func prepareSchemas(settings, values []byte) (map[Type]*spec.Schema, error) {
 }
 
 // loadSchemaFromBytes returns spec.Schema object loaded from YAML bytes.
-func loadSchemaFromBytes(openApiContent []byte) (*spec.Schema, error) {
-	jsonDoc, err := yamlBytesToJSONDoc(openApiContent)
+func loadSchemaFromBytes(openAPIContent []byte) (*spec.Schema, error) {
+	jsonDoc, err := yamlBytesToJSONDoc(openAPIContent)
 	if err != nil {
 		return nil, err
 	}

--- a/deckhouse-controller/internal/packages/values/schema/storage.go
+++ b/deckhouse-controller/internal/packages/values/schema/storage.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/flant/addon-operator/pkg/utils"
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/swag/loading"
+	"github.com/go-openapi/validate"
+	"github.com/hashicorp/go-multierror"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema/cel"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema/transformers"
+)
+
+// Type identifies which schema variant is used for a given validation context.
+type Type string
+
+const (
+	// TypeSettings is the schema for user-supplied configuration values (config.yaml).
+	TypeSettings Type = "config"
+	// TypeValues is the schema for the full set of internal module values.
+	TypeValues Type = "values"
+	// TypeHelm is derived from TypeValues with x-required-for-helm fields promoted to
+	// required, making those fields mandatory during Helm chart rendering.
+	TypeHelm Type = "helm"
+)
+
+func init() {
+	// Add loader to override swag.BytesToYAML marshaling into yaml.MapSlice.
+	// This type doesn't support map merging feature of YAML anchors. So additional
+	// loader is required to unmarshal into ordinary interface{} before converting to JSON.
+	loads.AddLoader(swag.YAMLMatcher, YAMLDocLoader)
+}
+
+// YAMLDocLoader loads a yaml document from either http or a file and converts it to json.
+func YAMLDocLoader(path string, opts ...loading.Option) (json.RawMessage, error) {
+	data, err := loading.LoadFromFileOrHTTP(path, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return yamlBytesToJSONDoc(data)
+}
+
+// yamlBytesToJSONDoc is a replacement of swag.YAMLData and YAMLDoc to Unmarshal into interface{}.
+// swag.BytesToYAML uses yaml.MapSlice to unmarshal YAML. This type doesn't support map merge of YAML anchors.
+func yamlBytesToJSONDoc(data []byte) (json.RawMessage, error) {
+	var yamlObj interface{}
+	if err := yaml.Unmarshal(data, &yamlObj); err != nil {
+		return nil, fmt.Errorf("yaml unmarshal: %v", err)
+	}
+
+	doc, err := swag.YAMLToJSON(yamlObj)
+	if err != nil {
+		return nil, fmt.Errorf("yaml to json: %v", err)
+	}
+
+	return doc, nil
+}
+
+// Storage holds compiled OpenAPI schemas for a package, keyed by Type.
+// All schemas are pre-processed and ready for repeated validation calls.
+type Storage struct {
+	schemas map[Type]*spec.Schema
+}
+
+// NewStorage parses settings and values YAML schema documents, applies the
+// required transformations, and returns a Storage ready for use.
+func NewStorage(settings, values []byte) (*Storage, error) {
+	schemas, err := prepareSchemas(settings, values)
+	if err != nil {
+		return nil, fmt.Errorf("prepare schemas: %w", err)
+	}
+
+	return &Storage{schemas: schemas}, err
+}
+
+// GetSchema returns schema by Type
+func (s *Storage) GetSchema(schemaType Type) *spec.Schema {
+	return s.schemas[schemaType]
+}
+
+// prepareSchemas loads schemas for config values, values and helm values.
+func prepareSchemas(settings, values []byte) (map[Type]*spec.Schema, error) {
+	res := make(map[Type]*spec.Schema)
+	if len(settings) > 0 {
+		schemaObj, err := loadSchemaFromBytes(settings)
+		if err != nil {
+			return nil, fmt.Errorf("load '%s' schema: %w", TypeSettings, err)
+		}
+
+		res[TypeSettings] = transformers.Transform(
+			schemaObj,
+			&transformers.AdditionalProperties{},
+		)
+	}
+
+	if len(values) > 0 {
+		schemaObj, err := loadSchemaFromBytes(values)
+		if err != nil {
+			return nil, fmt.Errorf("load '%s' schema: %w", TypeValues, err)
+		}
+
+		res[TypeValues] = transformers.Transform(
+			schemaObj,
+			&transformers.Extend{Parent: res[TypeValues]},
+			&transformers.AdditionalProperties{},
+		)
+
+		res[TypeHelm] = transformers.Transform(
+			schemaObj,
+			// Copy schema object.
+			&transformers.Copy{},
+			// Transform x-required-for-helm
+			&transformers.RequiredForHelm{},
+		)
+	}
+
+	return res, nil
+}
+
+// loadSchemaFromBytes returns spec.Schema object loaded from YAML bytes.
+func loadSchemaFromBytes(openApiContent []byte) (*spec.Schema, error) {
+	jsonDoc, err := yamlBytesToJSONDoc(openApiContent)
+	if err != nil {
+		return nil, err
+	}
+
+	s := new(spec.Schema)
+	if err = json.Unmarshal(jsonDoc, s); err != nil {
+		return nil, fmt.Errorf("json unmarshal: %v", err)
+	}
+
+	if err = spec.ExpandSchema(s, s, nil /*new(noopResCache)*/); err != nil {
+		return nil, fmt.Errorf("expand schema: %v", err)
+	}
+
+	return s, nil
+}
+
+// Validate validates values against the schema registered for valuesType.
+// It extracts the value under root and runs both CEL rule checks and JSON-Schema
+// validation. Returns nil if no schema is registered for valuesType.
+func (s *Storage) Validate(valuesType Type, root string, values utils.Values) error {
+	scheme := s.schemas[valuesType]
+	if scheme == nil {
+		return nil
+	}
+
+	obj, ok := values[root]
+	if !ok {
+		return fmt.Errorf("root key '%s' not found in values", root)
+	}
+
+	return validateObject(obj, scheme, root)
+}
+
+// validateObject runs CEL rule checks and JSON-Schema validation on dataObj
+// using schema s, attributing errors to rootName in messages.
+// dataObj must be utils.Values or map[string]interface{}.
+// See https://github.com/kubernetes/apiextensions-apiserver/blob/1bb376f70aa2c6f2dec9a8c7f05384adbfac7fbb/pkg/apiserver/validation/validation.go#L47
+func validateObject(dataObj interface{}, s *spec.Schema, rootName string) error {
+	validator := validate.NewSchemaValidator(s, nil, rootName, strfmt.Default) // , validate.DisableObjectArrayTypeCheck(true)
+
+	switch v := dataObj.(type) {
+	case utils.Values:
+		dataObj = map[string]interface{}(v)
+
+	case map[string]interface{}:
+	// pass
+
+	default:
+		return fmt.Errorf("validated data object have to be utils.Values or map[string]interface{}, got %v instead", reflect.TypeOf(v))
+	}
+
+	// Validate values against x-deckhouse-validation rules.
+	if values, ok := dataObj.(map[string]interface{}); ok {
+		validationErrs, err := cel.Validate(s, values)
+		if err != nil {
+			return err
+		}
+		if len(validationErrs) > 0 {
+			return errors.Join(validationErrs...)
+		}
+	}
+
+	result := validator.Validate(dataObj)
+	if result.IsValid() {
+		return nil
+	}
+
+	var allErrs *multierror.Error
+	for _, err := range result.Errors {
+		allErrs = multierror.Append(allErrs, err)
+	}
+	// NOTE: no validation errors, but config is not valid!
+	if allErrs == nil || allErrs.Len() == 0 {
+		allErrs = multierror.Append(allErrs, fmt.Errorf("configuration is not valid"))
+	}
+
+	return allErrs.ErrorOrNil()
+}

--- a/deckhouse-controller/internal/packages/values/schema/transformers/additional.go
+++ b/deckhouse-controller/internal/packages/values/schema/transformers/additional.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transformers
+
+import "github.com/go-openapi/spec"
+
+// AdditionalProperties is a Transformer that sets AdditionalProperties to false on
+// every object schema node that does not already define it. This prevents values
+// documents from containing undeclared keys that would otherwise pass validation silently.
+type AdditionalProperties struct {
+	Parent *spec.Schema
+}
+
+// Transform sets AdditionalProperties to false on s and recursively on every
+// nested property and array item schema that has not already constrained it.
+func (t *AdditionalProperties) Transform(s *spec.Schema) *spec.Schema {
+	if s.AdditionalProperties == nil {
+		s.AdditionalProperties = &spec.SchemaOrBool{
+			Allows: false,
+		}
+	}
+
+	for k, prop := range s.Properties {
+		if prop.AdditionalProperties == nil {
+			prop.AdditionalProperties = &spec.SchemaOrBool{
+				Allows: false,
+			}
+			ts := prop
+			s.Properties[k] = *t.Transform(&ts)
+		}
+	}
+
+	if s.Items != nil {
+		if s.Items.Schema != nil {
+			s.Items.Schema = t.Transform(s.Items.Schema)
+		}
+		for i, item := range s.Items.Schemas {
+			ts := item
+			s.Items.Schemas[i] = *t.Transform(&ts)
+		}
+	}
+
+	return s
+}

--- a/deckhouse-controller/internal/packages/values/schema/transformers/copy.go
+++ b/deckhouse-controller/internal/packages/values/schema/transformers/copy.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transformers
+
+import "github.com/go-openapi/spec"
+
+// Copy is a Transformer that produces a deep clone of a schema via a
+// JSON marshal/unmarshal round-trip. Used before mutations that must not
+// affect the original schema object (e.g. before RequiredForHelm).
+type Copy struct{}
+
+// Transform returns a deep copy of s, leaving the original unmodified.
+func (t *Copy) Transform(s *spec.Schema) *spec.Schema {
+	tmpBytes, _ := s.MarshalJSON()
+	res := new(spec.Schema)
+	_ = res.UnmarshalJSON(tmpBytes)
+	return res
+}

--- a/deckhouse-controller/internal/packages/values/schema/transformers/extend.go
+++ b/deckhouse-controller/internal/packages/values/schema/transformers/extend.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transformers
+
+import (
+	"encoding/json"
+
+	"github.com/go-openapi/spec"
+)
+
+// XExtendKey is the OpenAPI extension key that signals schema inheritance.
+// When present, the child schema is merged with the parent provided to Extend.
+const XExtendKey = "x-extend"
+
+// ExtendSettings holds the parsed contents of an x-extend extension block.
+// Schema names the parent schema document to inherit from (reserved for future
+// multi-parent support; currently the parent is passed directly to Extend).
+type ExtendSettings struct {
+	Schema *string `json:"schema,omitempty"`
+}
+
+// Extend is a Transformer that merges a parent schema into the child schema
+// when the child carries an x-extend extension. The child's own values take
+// precedence over the parent's for all merged fields.
+type Extend struct {
+	Parent *spec.Schema
+}
+
+// Transform merges the parent schema's definitions, extensions, required fields,
+// properties, pattern properties, title, and description into s.
+// A no-op when Parent is nil or x-extend is absent from s.
+func (t *Extend) Transform(s *spec.Schema) *spec.Schema {
+	if t.Parent == nil {
+		return s
+	}
+
+	extendSettings := extractExtendSettings(s)
+
+	if extendSettings == nil || extendSettings.Schema == nil {
+		return s
+	}
+
+	// TODO check extendSettings.Schema. No need to do it for now.
+
+	s.Definitions = mergeDefinitions(s, t.Parent)
+	s.Extensions = mergeExtensions(s, t.Parent)
+	s.Required = mergeRequired(s, t.Parent)
+	s.Properties = mergeProperties(s, t.Parent)
+	s.PatternProperties = mergePatternProperties(s, t.Parent)
+	s.Title = mergeTitle(s, t.Parent)
+	s.Description = mergeDescription(s, t.Parent)
+
+	return s
+}
+
+// extractExtendSettings parses the x-extend extension value from s into an
+// ExtendSettings struct. Returns nil if x-extend is absent or empty.
+func extractExtendSettings(s *spec.Schema) *ExtendSettings {
+	if s == nil {
+		return nil
+	}
+
+	extendSettingsObj, ok := s.Extensions[XExtendKey]
+	if !ok {
+		return nil
+	}
+
+	if extendSettingsObj == nil {
+		return nil
+	}
+
+	tmpBytes, _ := json.Marshal(extendSettingsObj)
+
+	res := new(ExtendSettings)
+
+	_ = json.Unmarshal(tmpBytes, res)
+	return res
+}
+
+// mergeRequired returns a deduplicated union of parent.Required and s.Required,
+// with parent entries listed first so parent constraints are preserved.
+func mergeRequired(s *spec.Schema, parent *spec.Schema) []string {
+	res := make([]string, 0)
+	resIdx := make(map[string]struct{})
+
+	for _, name := range parent.Required {
+		res = append(res, name)
+		resIdx[name] = struct{}{}
+	}
+
+	for _, name := range s.Required {
+		if _, ok := resIdx[name]; !ok {
+			res = append(res, name)
+		}
+	}
+
+	return res
+}
+
+// mergeProperties returns a merged property map. Child entries override parent entries
+// for the same key, so child-specific schema changes survive the merge.
+func mergeProperties(s *spec.Schema, parent *spec.Schema) map[string]spec.Schema {
+	res := make(map[string]spec.Schema)
+
+	for k, v := range parent.Properties {
+		res[k] = v
+	}
+	for k, v := range s.Properties {
+		res[k] = v
+	}
+
+	return res
+}
+
+// mergePatternProperties returns a merged patternProperties map. Child entries override
+// parent entries for the same pattern key.
+func mergePatternProperties(s *spec.Schema, parent *spec.Schema) map[string]spec.Schema {
+	res := make(map[string]spec.Schema)
+
+	for k, v := range parent.PatternProperties {
+		res[k] = v
+	}
+	for k, v := range s.PatternProperties {
+		res[k] = v
+	}
+
+	return res
+}
+
+// mergeDefinitions returns a merged definitions map. Child entries override parent
+// entries, allowing the child schema to redefine shared $ref targets.
+func mergeDefinitions(s *spec.Schema, parent *spec.Schema) spec.Definitions {
+	res := make(spec.Definitions)
+
+	for k, v := range parent.Definitions {
+		res[k] = v
+	}
+	for k, v := range s.Definitions {
+		res[k] = v
+	}
+
+	return res
+}
+
+// mergeExtensions returns a merged extensions map. Child entries override parent entries.
+func mergeExtensions(s *spec.Schema, parent *spec.Schema) spec.Extensions {
+	ext := make(spec.Extensions)
+
+	for k, v := range parent.Extensions {
+		ext.Add(k, v)
+	}
+	for k, v := range s.Extensions {
+		ext.Add(k, v)
+	}
+
+	return ext
+}
+
+// mergeTitle returns s.Title if non-empty, falling back to parent.Title.
+func mergeTitle(s *spec.Schema, parent *spec.Schema) string {
+	if s.Title != "" {
+		return s.Title
+	}
+	return parent.Title
+}
+
+// mergeDescription returns s.Description if non-empty, falling back to parent.Description.
+func mergeDescription(s *spec.Schema, parent *spec.Schema) string {
+	if s.Description != "" {
+		return s.Description
+	}
+	return parent.Description
+}

--- a/deckhouse-controller/internal/packages/values/schema/transformers/helm.go
+++ b/deckhouse-controller/internal/packages/values/schema/transformers/helm.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transformers
+
+import (
+	"github.com/go-openapi/spec"
+)
+
+// RequiredForHelm is a Transformer that promotes field names listed in the
+// x-required-for-helm extension into the standard required array. This makes
+// those fields mandatory at Helm rendering time even if they are optional in the
+// regular values schema (e.g. fields that Helm templates always dereference).
+type RequiredForHelm struct{}
+
+// XRequiredForHelm is the OpenAPI extension key whose value is a field name or
+// list of field names that must be present in the Helm values document.
+const XRequiredForHelm = "x-required-for-helm"
+
+// Transform promotes x-required-for-helm values into required for the root schema
+// and recursively for all nested object properties.
+func (t *RequiredForHelm) Transform(s *spec.Schema) *spec.Schema {
+	s.Required = mergeRequiredFields(s.Extensions, s.Required)
+
+	// Deep transform.
+	transformRequired(s.Properties)
+	return s
+}
+
+// transformRequired recursively promotes x-required-for-helm into required
+// for all nested property schemas.
+func transformRequired(props map[string]spec.Schema) {
+	for k, prop := range props {
+		prop.Required = mergeRequiredFields(prop.Extensions, prop.Required)
+		props[k] = prop
+		transformRequired(props[k].Properties)
+	}
+}
+
+// mergeArrays returns a deduplicated union of ar1 and ar2, preserving ar1 order
+// and appending unique ar2 elements at the end.
+func mergeArrays(ar1 []string, ar2 []string) []string {
+	res := make([]string, 0)
+	m := make(map[string]struct{})
+	for _, item := range ar1 {
+		res = append(res, item)
+		m[item] = struct{}{}
+	}
+	for _, item := range ar2 {
+		if _, ok := m[item]; !ok {
+			res = append(res, item)
+		}
+	}
+	return res
+}
+
+// mergeRequiredFields merges field names declared in x-required-for-helm with the
+// existing required slice. Supports both a single string and a []string value for
+// the extension. Returns required unchanged if the extension is absent.
+func mergeRequiredFields(ext spec.Extensions, required []string) []string {
+	var xReqFields []string
+	_, hasField := ext[XRequiredForHelm]
+	if !hasField {
+		return required
+	}
+	field, ok := ext.GetString(XRequiredForHelm)
+	if ok {
+		xReqFields = []string{field}
+	} else {
+		xReqFields, _ = ext.GetStringSlice(XRequiredForHelm)
+	}
+
+	// Merge x-required with required
+	return mergeArrays(required, xReqFields)
+}

--- a/deckhouse-controller/internal/packages/values/schema/transformers/transform.go
+++ b/deckhouse-controller/internal/packages/values/schema/transformers/transform.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transformers
+
+import "github.com/go-openapi/spec"
+
+// Transformer mutates or replaces an OpenAPI spec.Schema, returning the result.
+type Transformer interface {
+	Transform(s *spec.Schema) *spec.Schema
+}
+
+// Transform applies each Transformer in order to s, returning the final schema.
+// Returns nil if s is nil.
+func Transform(s *spec.Schema, transformers ...Transformer) *spec.Schema {
+	if s == nil {
+		return nil
+	}
+
+	for _, transformer := range transformers {
+		s = transformer.Transform(s)
+	}
+
+	return s
+}

--- a/deckhouse-controller/internal/packages/values/storage.go
+++ b/deckhouse-controller/internal/packages/values/storage.go
@@ -20,7 +20,8 @@ import (
 	"sync"
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
-	"github.com/flant/addon-operator/pkg/values/validation"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema"
 )
 
 // Storage manages package values with layering, patching, and schema validation.
@@ -32,7 +33,7 @@ type Storage struct {
 
 	valuesPatches []addonutils.ValuesPatch
 
-	schemaStorage *validation.SchemaStorage
+	schemaStorage *schema.Storage
 
 	mu sync.Mutex
 
@@ -41,9 +42,9 @@ type Storage struct {
 	//   /packages/001-package/values.yaml
 	staticValues addonutils.Values
 
-	// configValues are user-defined values from package settings
+	// settings are user-defined values from package settings
 	// These are stored separately before merging with static and openapi values
-	configValues addonutils.Values
+	settings addonutils.Values
 
 	// resultValues is the final merged result of all value sources
 	// This is what hooks and templates see
@@ -56,12 +57,12 @@ type Storage struct {
 // Parameters:
 //   - name: Package name (will be converted to values key format)
 //   - staticValues: Pre-loaded static values from values.yaml
-//   - configBytes: OpenAPI config schema (YAML bytes)
+//   - settingsBytes: OpenAPI config schema (YAML bytes)
 //   - valuesBytes: OpenAPI values schema (YAML bytes)
 //
 // Returns error if schema initialization or initial value calculation fails.
-func NewStorage(name string, staticValues addonutils.Values, configBytes, valuesBytes []byte) (*Storage, error) {
-	schemaStorage, err := validation.NewSchemaStorage(configBytes, valuesBytes)
+func NewStorage(name string, staticValues addonutils.Values, settingsBytes, valuesBytes []byte) (*Storage, error) {
+	schemaStorage, err := schema.NewStorage(settingsBytes, valuesBytes)
 	if err != nil {
 		return nil, fmt.Errorf("new schema storage: %w", err)
 	}
@@ -88,13 +89,13 @@ func (s *Storage) GetValuesChecksum() string {
 	return s.resultValues.Checksum()
 }
 
-// GetConfigChecksum returns a checksum of only the user-defined config values.
+// GetSettingsChecksum returns a checksum of only the user-defined config values.
 // Unlike GetValuesChecksum, this excludes static values, schema defaults, and patches.
-func (s *Storage) GetConfigChecksum() string {
+func (s *Storage) GetSettingsChecksum() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.configValues.Checksum()
+	return s.settings.Checksum()
 }
 
 // GetValues returns the final merged values that hooks and templates see.
@@ -112,17 +113,17 @@ func (s *Storage) GetSettings() addonutils.Values {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	settings := s.configValues
+	settings := s.settings
 	if len(settings) == 0 {
 		settings = addonutils.Values{}
 	}
 
-	return s.openapiDefaultsTransformer(validation.ConfigValuesSchema).Transform(settings)
+	return s.openapiDefaultsTransformer(schema.TypeSettings).Transform(settings)
 }
 
-// ApplyDefaultsConfigValues returns a copy of the provided values with defaults
+// ApplySettingsDefaults returns a copy of the provided values with defaults
 // from the config OpenAPI schema applied. Does not modify stored values.
-func (s *Storage) ApplyDefaultsConfigValues(settings addonutils.Values) addonutils.Values {
+func (s *Storage) ApplySettingsDefaults(settings addonutils.Values) addonutils.Values {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -130,12 +131,12 @@ func (s *Storage) ApplyDefaultsConfigValues(settings addonutils.Values) addonuti
 		settings = addonutils.Values{}
 	}
 
-	return s.openapiDefaultsTransformer(validation.ConfigValuesSchema).Transform(settings)
+	return s.openapiDefaultsTransformer(schema.TypeSettings).Transform(settings)
 }
 
-// ValidateConfigValues validates values against the config OpenAPI schema.
-// Does not modify the stored values - use ApplyConfigValues to persist.
-func (s *Storage) ValidateConfigValues(settings addonutils.Values) error {
+// ValidateSettings validates values against the config OpenAPI schema.
+// Does not modify the stored values - use ApplySettings to persist.
+func (s *Storage) ValidateSettings(settings addonutils.Values) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -143,16 +144,16 @@ func (s *Storage) ValidateConfigValues(settings addonutils.Values) error {
 		settings = addonutils.Values{}
 	}
 
-	if err := s.validateConfigValues(settings); err != nil {
+	if err := s.validateSettings(settings); err != nil {
 		return fmt.Errorf("validate config values: %w", err)
 	}
 
 	return nil
 }
 
-// ApplyConfigValues validates and saves user-defined config values.
+// ApplySettings validates and saves user-defined config values.
 // After saving, recalculates the result values with all layers merged.
-func (s *Storage) ApplyConfigValues(settings addonutils.Values) error {
+func (s *Storage) ApplySettings(settings addonutils.Values) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -160,11 +161,11 @@ func (s *Storage) ApplyConfigValues(settings addonutils.Values) error {
 		settings = addonutils.Values{}
 	}
 
-	if err := s.validateConfigValues(settings); err != nil {
+	if err := s.validateSettings(settings); err != nil {
 		return fmt.Errorf("validate config values: %w", err)
 	}
 
-	s.configValues = settings
+	s.settings = settings
 
 	return s.calculateResultValues()
 }
@@ -204,13 +205,13 @@ func (s *Storage) calculateResultValues() error {
 		s.staticValues,
 
 		// from openapi config spec
-		s.openapiDefaultsTransformer(validation.ConfigValuesSchema),
+		s.openapiDefaultsTransformer(schema.TypeSettings),
 
 		// from package settings
-		s.configValues,
+		s.settings,
 
 		// from openapi values spec
-		s.openapiDefaultsTransformer(validation.ValuesSchema),
+		s.openapiDefaultsTransformer(schema.TypeValues),
 	)
 
 	// from patches
@@ -233,10 +234,9 @@ func (s *Storage) calculateResultValues() error {
 }
 
 // openapiDefaultsTransformer creates a transformer that applies defaults from an OpenAPI schema.
-func (s *Storage) openapiDefaultsTransformer(schemaType validation.SchemaType) transformer {
+func (s *Storage) openapiDefaultsTransformer(schemaType schema.Type) transformer {
 	return &applyDefaults{
-		SchemaType: schemaType,
-		Schemas:    s.schemaStorage.Schemas,
+		schema: s.schemaStorage.GetSchema(schemaType),
 	}
 }
 
@@ -244,17 +244,17 @@ func (s *Storage) openapiDefaultsTransformer(schemaType validation.SchemaType) t
 func (s *Storage) validateValues(values addonutils.Values) error {
 	validatableValues := addonutils.Values{s.name: values}
 
-	return s.schemaStorage.ValidateValues(s.name, validatableValues)
+	return s.schemaStorage.Validate(schema.TypeValues, s.name, validatableValues)
 }
 
 // validateConfigValues validates values against the config OpenAPI schema.
 // Returns error if values are provided but no config schema is defined.
-func (s *Storage) validateConfigValues(values addonutils.Values) error {
+func (s *Storage) validateSettings(values addonutils.Values) error {
 	validatableValues := addonutils.Values{s.name: values}
 
-	if s.schemaStorage.Schemas[validation.ConfigValuesSchema] == nil && len(values) > 0 {
+	if s.schemaStorage.GetSchema(schema.TypeSettings) == nil && len(values) > 0 {
 		return errors.New("config schema is not defined but config values were provided")
 	}
 
-	return s.schemaStorage.ValidateConfigValues(s.name, validatableValues)
+	return s.schemaStorage.Validate(schema.TypeSettings, s.name, validatableValues)
 }

--- a/deckhouse-controller/internal/packages/values/transformers.go
+++ b/deckhouse-controller/internal/packages/values/transformers.go
@@ -16,8 +16,9 @@ package values
 
 import (
 	addonvalues "github.com/flant/addon-operator/pkg/utils"
-	"github.com/flant/addon-operator/pkg/values/validation"
 	"github.com/go-openapi/spec"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/values/schema/defaults"
 )
 
 // transformer interface for applying transformations to values.
@@ -30,11 +31,10 @@ type transformer interface {
 // It reads default values from an OpenAPI schema and merges them into the values.
 //
 // Used in the values layering process to apply:
-//   - Config schema defaults (after static values, before user config)
+//   - Settings schema defaults (after static values, before user config)
 //   - Values schema defaults (after user config)
 type applyDefaults struct {
-	SchemaType validation.SchemaType                  // Which schema to use (config or values)
-	Schemas    map[validation.SchemaType]*spec.Schema // Available OpenAPI schemas
+	schema *spec.Schema // Available OpenAPI schemas
 }
 
 // Transform applies default values from the OpenAPI schema to the provided values.
@@ -49,13 +49,7 @@ type applyDefaults struct {
 // Returns a new values object with defaults applied (original values are not modified).
 func (a *applyDefaults) Transform(values addonvalues.Values) addonvalues.Values {
 	// Return unchanged if no schemas loaded
-	if a.Schemas == nil {
-		return values
-	}
-
-	// Get the schema for our type (config or values)
-	schema := a.Schemas[a.SchemaType]
-	if schema == nil {
+	if a.schema == nil {
 		return values
 	}
 
@@ -63,7 +57,7 @@ func (a *applyDefaults) Transform(values addonvalues.Values) addonvalues.Values 
 	res := values.Copy()
 
 	// Apply default values from the schema
-	validation.ApplyDefaults(res, schema)
+	defaults.Apply(res, a.schema)
 
 	return res
 }


### PR DESCRIPTION
## Description
It reimplements values schema storage [from addon-operator](https://github.com/flant/addon-operator/tree/main/pkg/values/validation)

## Why do we need it, and what problem does it solve?
Get rid of another addon-operator dependency and help to maintain the codebase.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Implement values schema storage.
impact_level: low
```

