### PR TITLE
[istio] Fixed vex files in pilot images

### DIFF
--- a/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
@@ -1,23 +1,23 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-istio-pilot-v1x21x6-cve-2026-35206",
+  "@id": "merged-vex-a39d1c37bbf68a4ba0ce2826c7918e0c386f3005378b34e8dd0df13b296d192c",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
   "version": 1,
   "statements": [
     {
       "vulnerability": {
-        "name": "CVE-2026-35206"
+        "name": "CVE-2026-40179"
       },
       "products": [
         {
-          "@id": "pkg:golang/helm.sh/helm/v3@v3.14.2"
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
         }
       ],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "Helm pull с распаковкой chart (флаг --untar) из произвольного URL или имени из репозитория (CVE-2026-35206, GHSA-hr2v-4r36-88hr, CWE-22) в программном продукте helm версии 3.14.2 не используется в рамках эксплуатации pilot-discovery (istiod). Манифесты и chart-артефакты подготавливаются на этапе сборки образа и не подменяются из недоверенных источников во время работы в кластере, что исключает возможность эксплуатации данной уязвимости.",
-      "timestamp": "2026-03-30T10:17:01.000000000Z"
+      "impact_statement": "Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (stored XSS, CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79). Бинарник pilot-discovery не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-04T09:03:17.000000000Z"
     }
   ],
-  "timestamp": "2026-03-30T10:17:00Z"
+  "timestamp": "2026-05-04T09:03:17Z"
 }

--- a/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
@@ -1,6 +1,6 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-istio-pilot-v1x25x2-cve-2026-40179",
+  "@id": "merged-vex-2a4150b46379ac95a55d8eb62cb035f9930831c37db2941aeee7f195e08e9527",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
   "version": 1,
   "statements": [
@@ -16,8 +16,8 @@
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (stored XSS, CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79). Бинарник pilot-discovery не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
-      "timestamp": "2026-03-30T10:18:01.000000000Z"
+      "timestamp": "2026-05-04T09:08:31.000000000Z"
     }
   ],
-  "timestamp": "2026-03-30T10:18:00Z"
+  "timestamp": "2026-05-04T09:08:31Z"
 }


### PR DESCRIPTION
## Description

1. CVE-2026-35206 replaced with CVE-2026-40179 in pilot v1.21 `known_vulnerabilities.vex` file
2. changed IDs in both `known_vulnerabilities.vex` files

## Why do we need it, and what problem does it solve?
Omitted prometheus@v0.48.1 justification.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: changed vex CVE justifications in pilots images
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
