### PR TITLE
[cni-cilium] Added support for non-standard Linux release names

### DIFF
--- a/modules/021-cni-cilium/images/check-wg-kernel-compat/src/main.go
+++ b/modules/021-cni-cilium/images/check-wg-kernel-compat/src/main.go
@@ -187,7 +187,7 @@ func getCurrentKernelVersion() (string, error) {
 }
 
 func checkKernelVersionWGCiliumRequirements(kernelVersion, kernelConstraint string) (bool, error) {
-	kernelVersionSM, err := semver.NewVersion(strings.Split(kernelVersion, "-")[0])
+	kernelVersionSM, err := semver.NewVersion(toSemver(kernelVersion))
 	if err != nil {
 		return false, fmt.Errorf("failed to parse kernel version '%s': %w", kernelVersion, err)
 	}
@@ -202,4 +202,53 @@ func checkKernelVersionWGCiliumRequirements(kernelVersion, kernelConstraint stri
 	}
 
 	return true, nil
+}
+
+func toSemver(version string) string {
+	if version == "" {
+		return "0.0.0"
+	}
+
+	start := -1
+	for i, r := range version {
+		if r >= '0' && r <= '9' {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		return "0.0.0"
+	}
+
+	v := version[start:]
+
+	var nums []string
+	cur := ""
+
+	for _, r := range v {
+		if r >= '0' && r <= '9' {
+			cur += string(r)
+		} else {
+			if cur != "" {
+				nums = append(nums, cur)
+				cur = ""
+			}
+			if len(nums) == 3 {
+				break
+			}
+			if r != '.' {
+				break
+			}
+		}
+	}
+
+	if cur != "" {
+		nums = append(nums, cur)
+	}
+
+	for len(nums) < 3 {
+		nums = append(nums, "0")
+	}
+
+	return nums[0] + "." + nums[1] + "." + nums[2]
 }

--- a/modules/021-cni-cilium/images/check-wg-kernel-compat/src/main_test.go
+++ b/modules/021-cni-cilium/images/check-wg-kernel-compat/src/main_test.go
@@ -185,15 +185,9 @@ func TestCheckKernelVersionWGCiliumRequirements(t *testing.T) {
 		},
 		{
 			name:          "Version parsing ok and not met requirements",
-			inVerStr:      "5.15.15",
+			inVerStr:      "5.15.15+deb13+1-cloud-amd64",
 			expectCondMet: false,
 			expectError:   false,
-		},
-		{
-			name:          "Version parsing failed",
-			inVerStr:      "6.8.4.15",
-			expectCondMet: false,
-			expectError:   true,
 		},
 	}
 	for _, test := range testCases {
@@ -224,6 +218,99 @@ func TestCheckKernelVersionWGCiliumRequirements(t *testing.T) {
 				if !isKernelVersionMeet {
 					t.Fatalf("expected true but received false")
 				}
+			}
+		})
+	}
+}
+
+func TestToSemver(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "6.1.0+deb13+1-cloud-amd64",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0-custom-build+abc",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0-38-amd64",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0beta1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0-rc1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0~rc1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6",
+			expected: "6.0.0",
+		},
+		{
+			input:    "6.",
+			expected: "6.0.0",
+		},
+		{
+			input:    ".",
+			expected: "0.0.0",
+		},
+		{
+			input:    "",
+			expected: "0.0.0",
+		},
+		{
+			input:    "unknown",
+			expected: "0.0.0",
+		},
+		{
+			input:    "6.1.0-very-long-suffix-with-many-parts-and-build-metadata-xyz123",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0+20240101+git+sha+dirty",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0_beta",
+			expected: "6.1.0",
+		},
+		{
+			input:    "6.1.0.beta",
+			expected: "6.1.0",
+		},
+		{
+			input:    "v6.1.0",
+			expected: "6.1.0",
+		},
+		{
+			input:    "kernel-6.1.0",
+			expected: "6.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := toSemver(tt.input)
+			if got != tt.expected {
+				t.Fatalf("toSemver(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
This PR extends the `check-wg-kernel-compat` image to support extracting the Linux kernel version from `uname -r` in a semver-compatible way, ignoring distro-specific suffixes (e.g. `+deb13+1-cloud-amd64`).

Example: `6.8.0+deb13+1-cloud-amd64` → `6.8.0`

## Why do we need it, and what problem does it solve?
The previous implementation assumed that the kernel version in `uname -r` is always followed by a dash (`-`). This caused failures when parsing non-standard Linux release formats.

This change improves parsing to correctly extract the SemVer-compatible kernel version, ignoring distro-specific suffixes.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cni-cilium
type: feature
summary: Added support for non-standard Linux release names
impact_level: low
```