### PR TITLE
[istio] Added ClusterRoles (RBAC v1) over module CRs

### DIFF
--- a/modules/110-istio/templates/user-authz-cluster-roles.yaml
+++ b/modules/110-istio/templates/user-authz-cluster-roles.yaml
@@ -14,6 +14,9 @@ rules:
   - virtualservices
   - serviceentries
   - gateways
+  - sidecars
+  - workloadentries
+  - workloadgroups
   verbs:
   - get
   - list
@@ -23,6 +26,23 @@ rules:
   resources:
   - peerauthentications
   - authorizationpolicies
+  - requestauthentications
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: 
+  - telemetry.istio.io
+  resources:
+  - telemetries
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.istio.io
+  resources:
+  - wasmplugins
   verbs:
   - get
   - list
@@ -43,6 +63,9 @@ rules:
   - virtualservices
   - serviceentries
   - gateways
+  - sidecars
+  - workloadentries
+  - workloadgroups
   verbs:
   - create
   - delete
@@ -54,6 +77,120 @@ rules:
   resources:
   - peerauthentications
   - authorizationpolicies
+  - requestauthentications
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Admin
+  name: d8:user-authz:{{ .Chart.Name }}:admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups: 
+  - telemetry.istio.io
+  resources:
+  - telemetries
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - extensions.istio.io
+  resources:
+  - wasmplugins
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterEditor
+  name: d8:user-authz:{{ .Chart.Name }}:cluster-editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - istiofederations
+  - istiomulticlusters
+  - ingressistiocontrollers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: 
+  - install.istio.io
+  resources: 
+  - istiooperators
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: 
+  - sailoperator.io
+  resources: 
+  - istiocnis
+  - ztunnels
+  - istiorevisions
+  - istiorevisiontags
+  - istios
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:{{ .Chart.Name }}:cluster-admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - istiofederations
+  - istiomulticlusters
+  - ingressistiocontrollers
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups: 
+  - install.istio.io
+  resources: 
+  - istiooperators
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups: 
+  - sailoperator.io
+  resources: 
+  - istiocnis
+  - ztunnels
+  - istiorevisions
+  - istiorevisiontags
+  - istios
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Description
Added ClusterRoles for module CustomResources:

- d8:user-authz:istio:admin
- d8:user-authz:istio:cluster-editor
- d8:user-authz:istio:cluster-admin

Changed ClusterRoles to cover more namespaced resources:

- d8:user-authz:istio:user
- d8:user-authz:istio:editor

## Why do we need it, and what problem does it solve?
It allows to grant access to module resources using pre-defined ClusterRoles.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Added ClusterRoles (RBAC v1) over Istio module CustomResources.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
