### PR TITLE
[cloud-provider-dvp] retry on conflict when updating ServiceWithHealthchecks

### DIFF
--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/cloud.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/src/pkg/cloudprovider/dvp/cloud.go
@@ -19,6 +19,7 @@ package dvp
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log"
 	"time"
@@ -28,8 +29,11 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	discv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	cloudprovider "k8s.io/cloud-provider"
@@ -45,6 +49,7 @@ const (
 type Cloud struct {
 	dvpService *api.DVPCloudAPI
 	config     config.CloudConfig
+	kubeClient kubernetes.Interface
 }
 
 func init() {
@@ -79,6 +84,7 @@ func (c *Cloud) Initialize(
 	stop <-chan struct{},
 ) {
 	clientSet := clientBuilder.ClientOrDie("cloud-controller-manager")
+	c.kubeClient = clientSet
 
 	informerFactory := informers.NewSharedInformerFactory(clientSet, time.Second*30)
 	serviceInformer := informerFactory.Core().V1().Services()
@@ -199,7 +205,33 @@ func (c *Cloud) onEndpointSliceEvent(
 	klog.V(3).InfoS("onEndpointSliceEvent: triggering ensureLB",
 		"namespace", svc.Namespace, "service", svc.Name, "slice", es.Name)
 
-	if _, err = c.ensureLB(context.Background(), svc, nodes); err != nil {
+	lbStatus, err := c.ensureLB(context.Background(), svc, nodes)
+	if err != nil {
 		klog.ErrorS(err, "ensureLB failed", "namespace", svc.Namespace, "service", svc.Name)
+		return
 	}
+	if lbStatus != nil && len(lbStatus.Ingress) > 0 {
+		if err := c.patchServiceStatus(context.Background(), svc, lbStatus); err != nil {
+			klog.ErrorS(err, "failed to patch service status", "namespace", svc.Namespace, "service", svc.Name)
+		}
+	}
+}
+
+func (c *Cloud) patchServiceStatus(
+	ctx context.Context,
+	svc *corev1.Service,
+	status *corev1.LoadBalancerStatus,
+) error {
+	if len(status.Ingress) == 0 {
+		return nil
+	}
+
+	patch := fmt.Sprintf(
+		`{"status":{"loadBalancer":{"ingress":[{"ip":%q}]}}}`,
+		status.Ingress[0].IP,
+	)
+
+	_, err := c.kubeClient.CoreV1().Services(svc.Namespace).
+		Patch(ctx, svc.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{}, "status")
+	return err
 }

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/loadbalancer_reconcile.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/loadbalancer_reconcile.go
@@ -50,13 +50,7 @@ func (lb *LoadBalancerService) CreateOrUpdateLoadBalancer(
 	}
 	if svc != nil {
 		if isOwnedBySWHC(svc) {
-			u, err := lb.getServiceWithHealthchecksByName(ctx, loadBalancer.Name)
-			if err != nil {
-				return nil, err
-			}
-			if u != nil {
-				return lb.updateServiceWithHealthchecks(ctx, u, loadBalancer)
-			}
+			return lb.updateServiceWithHealthchecks(ctx, loadBalancer)
 		}
 		return lb.updateLoadBalancerService(ctx, svc, loadBalancer)
 	}

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/servicewithhealthchecks.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/servicewithhealthchecks.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 )
 
@@ -40,7 +41,7 @@ func (lb *LoadBalancerService) CreateOrUpdateServiceWithHealthchecks(
 		return nil, err
 	}
 	if u != nil {
-		return lb.updateServiceWithHealthchecks(ctx, u, loadBalancer)
+		return lb.updateServiceWithHealthchecks(ctx, loadBalancer)
 	}
 	return lb.createServiceWithHealthchecks(ctx, loadBalancer)
 }
@@ -75,7 +76,6 @@ func (lb *LoadBalancerService) getServiceWithHealthchecksByName(ctx context.Cont
 
 func (lb *LoadBalancerService) updateServiceWithHealthchecks(
 	ctx context.Context,
-	u *unstructured.Unstructured,
 	loadBalancer LoadBalancer,
 ) (*corev1.Service, error) {
 	name := loadBalancer.Name
@@ -97,22 +97,29 @@ func (lb *LoadBalancerService) updateServiceWithHealthchecks(
 
 	ports := lb.CreateLoadBalancerPorts(service)
 
-	u.SetAnnotations(service.Annotations)
-	u.SetLabels(serviceLabels)
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		u, err := lb.getServiceWithHealthchecksByName(ctx, name)
+		if err != nil {
+			return err
+		}
 
-	if err := setServiceWithHealthchecksSpec(
-		u,
-		ports,
-		service.Spec.ExternalTrafficPolicy,
-		map[string]string{lbKey: "loadbalancer"},
-		service.Spec.ExternalIPs,
-		service.Spec.LoadBalancerClass,
-		service.Spec.LoadBalancerIP,
-	); err != nil {
-		return nil, err
-	}
+		u.SetAnnotations(service.Annotations)
+		u.SetLabels(serviceLabels)
 
-	if err := lb.client.Update(ctx, u); err != nil {
+		if err := setServiceWithHealthchecksSpec(
+			u,
+			ports,
+			service.Spec.ExternalTrafficPolicy,
+			map[string]string{lbKey: "loadbalancer"},
+			service.Spec.ExternalIPs,
+			service.Spec.LoadBalancerClass,
+			service.Spec.LoadBalancerIP,
+		); err != nil {
+			return err
+		}
+
+		return lb.client.Update(ctx, u)
+	}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description
Two fixes for DVP cloud-controller-manager that caused LoadBalancer services to stay in <pending> state indefinitely.

Fix 1 — retry on conflict when updating ServiceWithHealthchecks
When updating a ServiceWithHealthchecks object in the parent cluster, the CCM performs a GET followed by an Update. If another actor (kubelet node heartbeat, safe-agent-updater, etc.) modifies the same object between GET and Update, the API server returns a 409 Conflict (the object has been modified; please apply your changes to the latest version). Without a retry the CCM logs the error and waits for the next 30-second reconcile tick — which also conflicts. The result is that LoadBalancer services stay in <pending> state indefinitely and the LoadBalancerServiceWithoutExternalIP alert fires.

The fix moves the GET inside a retry.RetryOnConflict loop so on conflict the object is re-fetched with the latest resourceVersion before retrying the Update.

Fix 2 — patch child-cluster service status with LB IP after ensureLB
DVP CCM has a custom onEndpointSliceEvent handler that re-reconciles load balancers when endpoints change (needed for ExternalTrafficPolicy: Local services). This handler called ensureLB but discarded the returned LoadBalancerStatus. As a result, even after the ServiceWithHealthchecks in the parent cluster received an external IP, the child-cluster Service.Status.LoadBalancer was never updated — so the service stayed in <pending> state.

The fix captures the LoadBalancerStatus returned by ensureLB and calls patchServiceStatus to write the IP back to the child-cluster service via the Kubernetes status subresource.

## Why do we need it, and what problem does it solve?
LoadBalancer services (e.g. nginx-load-balancer for ingress-nginx) on DVP clusters stay in <pending> indefinitely. The LoadBalancerServiceWithoutExternalIP alert fires. Both fixes are required together:

The GET → Update pattern without conflict retry caused every reconcile attempt to fail with 409 when any other actor touched the SWHC object — which happens frequently because the SWHC controller actively modifies these objects.
The onEndpointSliceEvent handler races with the standard EnsureLoadBalancer path during bootstrap: if it creates the SWHC first, subsequent EnsureLoadBalancer calls hit 409 and never propagate the IP back. Even when ensureLB succeeded through onEndpointSliceEvent, the result was discarded.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Fixed LoadBalancer stuck in pending by retrying on conflict when updating ServiceWithHealthchecks and propagating IP to the child cluster service status.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->