### PR TITLE
[webhook-handler] Handle shell-operator exit state in main loop

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -269,15 +269,19 @@ func main() {
 		}
 	}
 
+	processExited := make(chan struct{}, 1)
+
 	// go-routine that checks if shell-operator is exited
 	go func() {
-		for range time.Tick(reloadInterval + 1*time.Second) {
-			// Do not wait if Process already been waited
-			if cmd.ProcessState == nil {
-				err := cmd.Wait()
-				if err != nil {
-					log.Error("wait shell-operator: %w", err)
-				}
+		for {
+			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+				continue
+			}
+			// wait blocks this goroutine until shell-operator is exited
+			err := cmd.Wait()
+			processExited <- struct{}{}
+			if err != nil {
+				log.Error("wait shell-operator: %w", err)
 			}
 			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 				isReloadShellNeed.Store(true)
@@ -290,7 +294,6 @@ func main() {
 		for range time.Tick(reloadInterval) {
 			if isReloadShellNeed.Load() {
 				logger.Debug("restarting shell-operator")
-				isReloadShellNeed.Store(false)
 
 				// TODO: what if SIGTERM don't killed shell-operator?
 				err := cmd.Process.Signal(syscall.SIGTERM)
@@ -298,13 +301,8 @@ func main() {
 					logger.Error("sigterm shell-operator: %w", slog.Any("error", err.Error()))
 				}
 
-				// Do not wait if Process already been waited
-				if cmd.ProcessState == nil {
-					err = cmd.Wait()
-					if err != nil {
-						log.Error("wait shell-operator: %w", err)
-					}
-				}
+				<-processExited // wait for shell-operator to exit
+				isReloadShellNeed.Store(false)
 				logger.Info("killed shell-operator",
 					slog.Int("pid", cmd.Process.Pid),
 				)

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"crypto/tls"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -261,48 +262,49 @@ func main() {
 	var isReloadShellNeed atomic.Bool
 	isReloadShellNeed.Store(false)
 
-	// go-routine that reloads shell-operator periodically when new hooks are registered
-	go func() {
-		reloadInterval := DefaultShellOperatorReloadInterval
-		if envInterval := os.Getenv("SHELL_OPERATOR_RELOAD_INTERVAL_SECONDS"); envInterval != "" {
-			if seconds, err := strconv.Atoi(envInterval); err == nil && seconds > 0 {
-				reloadInterval = time.Duration(seconds) * time.Second
-				logger.Info("using custom shell-operator reload interval", slog.Duration("interval", reloadInterval))
-			}
+	reloadInterval := DefaultShellOperatorReloadInterval
+	if envInterval := os.Getenv("SHELL_OPERATOR_RELOAD_INTERVAL_SECONDS"); envInterval != "" {
+		if seconds, err := strconv.Atoi(envInterval); err == nil && seconds > 0 {
+			reloadInterval = time.Duration(seconds) * time.Second
+			logger.Info("using custom shell-operator reload interval", slog.Duration("interval", reloadInterval))
 		}
-		ticker := time.NewTicker(reloadInterval)
+	}
 
-		for range ticker.C {
-			// if shell-operator is exited
-			if cmd.ProcessState != nil {
-
-				logger.Error("shell-operator exited", slog.Int("exitcode", cmd.ProcessState.ExitCode()))
+	// go-routine that checks if shell-operator is exited
+	go func() {
+		for range time.Tick(reloadInterval + 1*time.Second) {
+			// Do not wait if Process already been waited
+			if cmd.ProcessState == nil {
+				cmd.Wait()
+			}
+			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 				isReloadShellNeed.Store(true)
 			}
+		}
+	}()
 
+	// go-routine that reloads shell-operator periodically when new hooks are registered
+	go func() {
+		for range time.Tick(reloadInterval) {
 			if isReloadShellNeed.Load() {
-				logger.Info("restarting shell-operator")
+				logger.Debug("restarting shell-operator")
 				isReloadShellNeed.Store(false)
 
+				// TODO: what if SIGTERM don't killed shell-operator?
 				err := cmd.Process.Signal(syscall.SIGTERM)
-				if err != nil {
-					log.Error("sigterm shell-operator: %w", err)
+				if err != nil && !errors.Is(err, os.ErrProcessDone) {
+					logger.Error("sigterm shell-operator: %w", slog.Any("error", err.Error()))
 				}
 
-				// TODO: what if SIGTERM don't killed shell-operator?
-				// err = cmd.Process.Kill()
-				// if err != nil {
-				// 	log.Error("kill shell-operator: %w", err)
-				// }
-
-				err = cmd.Wait()
-				if err != nil {
-					log.Error("wait shell-operator: %w", err)
+				// Do not wait if Process already been waited
+				if cmd.ProcessState == nil {
+					err = cmd.Wait()
+					if err != nil {
+						log.Error("wait shell-operator: %w", err)
+					}
 				}
 				logger.Info("killed shell-operator",
 					slog.Int("pid", cmd.Process.Pid),
-					slog.Bool("exited", cmd.ProcessState.Exited()),
-					slog.Int("exitcode", cmd.ProcessState.ExitCode()),
 				)
 
 				// start new shell-operator

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -244,19 +244,6 @@ func main() {
 		log.WithLevel(log.LogLevelFromStr(os.Getenv("LOG_LEVEL")).Level()),
 		log.WithHandlerType(log.TextHandlerType))
 
-	setupLog.Info("starting shell-operator")
-	// synchronous run
-	cmd := exec.Command("./shell-operator")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Start()
-	if err != nil {
-		setupLog.Error(err, "unable to start shell-operator")
-		os.Exit(1)
-	}
-	logger.Info("new shell-operator PID",
-		slog.Int("pid", cmd.Process.Pid),
-	)
 	// non-blocking sync variable to know that we need to reload shell-operator
 	var isReloadShellNeed atomic.Bool
 	isReloadShellNeed.Store(false)
@@ -269,23 +256,28 @@ func main() {
 		}
 	}
 
-	processExited := make(chan struct{}, 1)
+	var cmd *exec.Cmd
+	processExited := make(chan struct{})
 
-	// go-routine that checks if shell-operator is exited
+	// go-routine that runs shell-operator and signals when it exited
 	go func() {
 		for {
-			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-				continue
-			}
-			// wait blocks this goroutine until shell-operator is exited
-			err := cmd.Wait()
-			processExited <- struct{}{}
+			logger.Debug("running shell-operator")
+			cmd = exec.Command("./shell-operator")
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+
+			err := cmd.Run()
 			if err != nil {
-				log.Error("wait shell-operator: %w", err)
+				logger.Info("shell-operator exited", slog.String("error", err.Error()))
 			}
+
+			// if exited not by signal
 			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 				isReloadShellNeed.Store(true)
 			}
+
+			processExited <- struct{}{}
 		}
 	}()
 
@@ -293,32 +285,16 @@ func main() {
 	go func() {
 		for range time.Tick(reloadInterval) {
 			if isReloadShellNeed.Load() {
-				logger.Debug("restarting shell-operator")
+				logger.Info("restarting shell-operator")
 
 				// TODO: what if SIGTERM don't killed shell-operator?
 				err := cmd.Process.Signal(syscall.SIGTERM)
 				if err != nil && !errors.Is(err, os.ErrProcessDone) {
-					logger.Error("sigterm shell-operator: %w", slog.Any("error", err.Error()))
+					logger.Error("sigterm shell-operator", slog.String("error", err.Error()), slog.Int("pid", cmd.Process.Pid))
 				}
 
 				<-processExited // wait for shell-operator to exit
 				isReloadShellNeed.Store(false)
-				logger.Info("killed shell-operator",
-					slog.Int("pid", cmd.Process.Pid),
-				)
-
-				// start new shell-operator
-				cmd = exec.Command("./shell-operator")
-				cmd.Stdout = os.Stdout
-				cmd.Stderr = os.Stderr
-				err = cmd.Start()
-				if err != nil {
-					log.Error("start shell-operator: %w", err)
-					isAlive = false
-				}
-				logger.Info("new shell-operator PID",
-					slog.Int("pid", cmd.Process.Pid),
-				)
 			}
 		}
 	}()

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -275,7 +275,10 @@ func main() {
 		for range time.Tick(reloadInterval + 1*time.Second) {
 			// Do not wait if Process already been waited
 			if cmd.ProcessState == nil {
-				cmd.Wait()
+				err := cmd.Wait()
+				if err != nil {
+					log.Error("wait shell-operator: %w", err)
+				}
 			}
 			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
 				isReloadShellNeed.Store(true)

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -273,6 +273,13 @@ func main() {
 		ticker := time.NewTicker(reloadInterval)
 
 		for range ticker.C {
+			// if shell-operator is exited
+			if cmd.ProcessState != nil {
+
+				logger.Error("shell-operator exited", slog.Int("exitcode", cmd.ProcessState.ExitCode()))
+				isReloadShellNeed.Store(true)
+			}
+
 			if isReloadShellNeed.Load() {
 				logger.Info("restarting shell-operator")
 				isReloadShellNeed.Store(false)

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -56,7 +55,7 @@ const (
 	// This value should be low enough to minimize the delay between webhook registration
 	// and shell-operator becoming aware of the new hook, but high enough to avoid
 	// unnecessary restarts when multiple webhooks are created in quick succession.
-	// Can be overridden via SHELL_OPERATOR_RELOAD_INTERVAL_SECONDS environment variable.
+	// Can be overridden via SHELL_OPERATOR_RELOAD_INTERVAL environment variable.
 	DefaultShellOperatorReloadInterval = 5 * time.Second
 )
 
@@ -263,9 +262,9 @@ func main() {
 	isReloadShellNeed.Store(false)
 
 	reloadInterval := DefaultShellOperatorReloadInterval
-	if envInterval := os.Getenv("SHELL_OPERATOR_RELOAD_INTERVAL_SECONDS"); envInterval != "" {
-		if seconds, err := strconv.Atoi(envInterval); err == nil && seconds > 0 {
-			reloadInterval = time.Duration(seconds) * time.Second
+	if envInterval := os.Getenv("SHELL_OPERATOR_RELOAD_INTERVAL"); envInterval != "" {
+		if parsedInterval, err := time.ParseDuration(envInterval); err == nil && parsedInterval > 0 {
+			reloadInterval = parsedInterval
 			logger.Info("using custom shell-operator reload interval", slog.Duration("interval", reloadInterval))
 		}
 	}


### PR DESCRIPTION
## Description
If the `shell-operator` stops on its own  (for example, when the cluster API is briefly unavailable) the webhook-handler operator now detects that and starts it again, instead of leaving the pod in a broken state until someone restarts it.


**Before:** We only restarted the hook runner when webhooks were added or removed. If it exited because of a startup or connectivity failure, nothing brought it back.
```
shell-operator: error: init failed: initialize ValidatingWebhookManager fail: ValidatingWebhookManager start: register validating webhook: list ValidatingWebhookConfiguration: Get "https://10.222.0.1:443/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations?fieldSelector=metadata.name%3Dd8-deckhouse-validating-webhook-handler-hooks": dial tcp 10.222.0.1:443: connect: connection refused, try --help
{"level":"fatal","logger":"shell-operator","msg":"essemble shell operator","error":"initialize ValidatingWebhookManager fail: ValidatingWebhookManager start: register validating webhook: list ValidatingWebhookConfiguration: Get \"https://10.222.0.1:443/apis/admissionregistration.k8s.io/v1/validatingwebhookconfigurations?fieldSelector=metadata.name%3Dd8-deckhouse-validating-webhook-handler-hooks\": dial tcp 10.222.0.1:443: connect: connection refused","time":"2026-04-29T07:25:47Z"}
# then nothing happening
```

**After:** We also react when the hook runner has stopped, so it can come back without a manual pod restart.
```bash
{"level":"fatal","logger":"shell-operator","msg":"essemble shell operator","source":"src/pkg/shell-operator/bootstrap.go:101","error":"initialize ValidatingWebhookManager fail: ValidatingWebhookManager start: start webhook server: load TLS certs: open /certs/tls.crt.bak: no such file or directory","time":"2026-05-05T11:00:56Z"}
shell-operator: error: init failed: initialize ValidatingWebhookManager fail: ValidatingWebhookManager start: start webhook server: load TLS certs: open /certs/tls.crt.bak: no such file or directory, try --help
2026-05-05T11:00:59Z DEBUG msg='restarting shell-operator' source=perator/cmd/main.go:290 
2026-05-05T11:00:59Z INFO msg='killed shell-operator' source=perator/cmd/main.go:306 pid='1296' 
2026-05-05T11:00:59Z INFO msg='new shell-operator PID' source=perator/cmd/main.go:319 pid='1379' 
```

## Why do we need it, and what problem does it solve?
This reduces cases where `webhook-handler` stays broken after `shell-operator` dies at startup (including when the Kubernetes API is briefly unavailable during validating webhook registration) and does not recover until the pod is restarted manually. The change reuses the existing restart mechanism and triggers it when the `shell-operator` process is detected as finished.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Webhook-handler will reload exited shell-operator now.
impact_level: default 
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
