### PR TITLE
[dhctl] chore(dhctl-for-commander): handle ctx done in CreateResourcesLoop

### DIFF
--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -357,6 +357,8 @@ func CreateResourcesLoop(ctx context.Context, kubeCl *client.KubernetesClient, r
 		}
 
 		select {
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-endChannel:
 			if len(resources) > 0 {
 				_ = log.ProcessCtx(ctx, "Create Resources", "Failed to create", func(ctx context.Context) error {


### PR DESCRIPTION
## Description
Fixed `CreateResourcesLoop` to exit immediately on context cancellation, which is required for Deckhouse Commander where operations can be cancelled by the user via UI button, causing the gRPC stream context to be cancelled.

**Before**: user clicks Cancel → times out with error after 30m.
<details>
<summary>Before</summary>
<img width="1211" height="680" alt="Screenshot 2026-05-05 at 14 49 01" src="https://github.com/user-attachments/assets/dda16fee-32b6-4a91-9fa0-1663796c5f07" />
</details>

**After**: user clicks Cancel → operation stops.
<details>
<summary>After</summary>
<img width="1211" height="680" alt="Screenshot 2026-05-05 at 15 54 05" src="https://github.com/user-attachments/assets/a2ee1211-fa8a-4388-824a-79a49c2b9ca0" />
</details>

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Fixed `CreateResourcesLoop` to exit immediately on context cancellation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
