### PR TITLE
[cloud-provider-vcd] Migrate from Terraform to OpenTofu

### DIFF
--- a/candi/terraform_versions.yml
+++ b/candi/terraform_versions.yml
@@ -106,17 +106,7 @@ vcd:
   artifactBinary: terraform-provider-vcd
   destinationBinary: terraform-provider-vcd
   vmResourceType: vcd_vapp_vm
-  # Attention! For migrate to opentofu we need some manual actions.
-  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
-  # But we need enable automigrator and terraform state metrics hook. We can add global hook
-  # for autodiscovery terraform versions file, but we think that this attention will be enough.
-  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
-  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
-  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
-  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
-  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
-  # after migration, please remove this comment
-  useOpentofu: false
+  useOpentofu: true
 yandex:
   namespace: yandex-cloud
   cloudName: Yandex

--- a/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider_test.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider_test.go
@@ -35,7 +35,6 @@ var terraformProviders = []string{
 	"aws",
 	gcp.ProviderName,
 	"azure",
-	vcd.ProviderName,
 }
 
 var tofuProviders = []string{
@@ -46,6 +45,7 @@ var tofuProviders = []string{
 	"vsphere",
 	"huaweicloud",
 	"openstack",
+	vcd.ProviderName,
 }
 
 func TestAllProviderPresentInStore(t *testing.T) {

--- a/ee/modules/030-cloud-provider-vcd/candi/terraform_versions.yml
+++ b/ee/modules/030-cloud-provider-vcd/candi/terraform_versions.yml
@@ -1,4 +1,4 @@
-terraform: 0.14.8
+opentofu: 1.9.4
 vcd:
   namespace: vmware
   cloudName: VCD
@@ -10,14 +10,4 @@ vcd:
   artifactBinary: terraform-provider-vcd
   destinationBinary: terraform-provider-vcd
   vmResourceType: vcd_vapp_vm
-  # Attention! For migrate to opentofu we need some manual actions.
-  # Unfortunately useOpentofu variable available only in werf and discovered inside dhctl
-  # But we need enable automigrator and terraform state metrics hook. We can add global hook
-  # for autodiscovery terraform versions file, but we think that this attention will be enough.
-  # So, for switch to opentofu existing provider with terraform we need to do two additional actions:
-  # 1. in the cloud provider module you should add hook go_lib/hooks/to_tofu_migrate_metric, see example
-  #    modules/030-cloud-provider-yandex/hooks/to_tofu_migrate_metric.go
-  # 2. Enable state migrator here https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml#L61
-  #    to enable migrator please add provider name from this list https://github.com/deckhouse/deckhouse/blob/b6fdb7ce4f084d0d56f839ceef683710c24c3b8e/candi/openapi/cluster_configuration.yaml#L63
-  # after migration, please remove this comment
-  useOpentofu: false
+  useOpentofu: true

--- a/ee/modules/030-cloud-provider-vcd/candi/terraform_versions.yml
+++ b/ee/modules/030-cloud-provider-vcd/candi/terraform_versions.yml
@@ -1,4 +1,4 @@
-opentofu: 1.9.4
+opentofu: 1.12.0
 vcd:
   namespace: vmware
   cloudName: VCD

--- a/ee/modules/030-cloud-provider-vcd/hooks/to_tofu_migrate_metric.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/to_tofu_migrate_metric.go
@@ -1,0 +1,12 @@
+/*
+Copyright 2024 Flant JSC
+Licensed under the Deckhouse Platform Enterprise Edition (EE) license. See https://github.com/deckhouse/deckhouse/blob/main/ee/LICENSE
+*/
+
+package hooks
+
+import (
+	metric "github.com/deckhouse/deckhouse/go_lib/hooks/to_tofu_migrate_metric"
+)
+
+var _ = metric.RegisterHook()

--- a/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
+++ b/modules/040-terraform-manager/templates/terraform-auto-converger/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       - name: deckhouse-registry
       automountServiceAccountToken: true
       serviceAccountName: terraform-auto-converger
-      {{- if has .Values.global.clusterConfiguration.cloud.provider (list "Yandex" "Zvirt" "vSphere" "Huaweicloud" "OpenStack") }}
+      {{- if has .Values.global.clusterConfiguration.cloud.provider (list "Yandex" "Zvirt" "vSphere" "Huaweicloud" "OpenStack" "VCD") }}
       initContainers:
       - name: to-tofu-migrator
         {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" (dict "ro" true) | nindent 8 }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Migrating a VCD provider from Terraform to OpenTofu

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

OpenTofu is needed to keep using an open-source, community-driven infrastructure-as-code tool after Terraform changed its license, reducing legal and vendor-lock risks. It solves the problem of depending on a less predictable proprietary ecosystem while preserving a largely compatible workflow and syntax for existing Terraform users.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vcd
type: feature
summary: Migrated from Terraform to OpenTofu.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
