### PR TITLE
[istio] Add ambient waypoint support

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -765,6 +765,288 @@ properties:
                 ```
               > **Warning!** Disabling this timeout (setting the value to `0s`) is very likely to result in leaky connections due to TCP FIN packet loss, etc.
               > **Warning!** After changing this setting, a restart of the client pods is required.
+      waypoint:
+        type: object
+        description: |
+          Waypoint proxy specific settings.
+        default: {}
+        x-doc-skip: true
+        x-experimental: true
+        oneOf:
+        - properties:
+            replicasManagement:
+              properties:
+                mode:
+                  enum: ['Standard', 'Static']
+            resourcesManagement:
+              properties:
+                mode:
+                  enum: ['Static', 'VPA']
+        - properties:
+            replicasManagement:
+              properties:
+                mode:
+                  enum: ['HPA']
+            resourcesManagement:
+              properties:
+                mode:
+                  enum: ['Static']
+        properties:
+          enabled:
+            type: boolean
+            default: false
+            description: |
+              Enable shared waypoint proxy deployment to `d8-istio` namespace.
+            x-experimental: true
+            x-examples: [true]
+          replicasManagement:
+            description: |
+              Replication management settings and scaling of waypoint proxy.
+            type: object
+            default: {}
+            x-examples:
+            - mode: Standard
+            - mode: Static
+              static:
+                replicas: 3
+            x-doc-examples:
+            - mode: Standard
+            - mode: Static
+              static:
+                replicas: 3
+            - mode: HPA
+              hpa:
+                minReplicas: 2
+                maxReplicas: 5
+                metrics:
+                - type: CPU
+                  targetAverageUtilization: 80
+            properties:
+              mode:
+                type: string
+                description: |
+                  Replicas management mode:
+                  - `Standard` — replicas management and scaling mode according to the global fault tolerance mode (the [highAvailability](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-highavailability) parameter);
+                  - `Static` — the mode, where the number of replicas is specified explicitly (the [static.replicas](#parameters-dataplane-waypoint-replicasmanagement-static-replicas) parameter);
+                  - `HPA` — the mode, where the number of replicas is calculated automatically using [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) based on CPU usage. You can configure this mode by modifying parameters in the [hpa](#parameters-dataplane-waypoint-replicasmanagement-hpa) parameter section.
+                enum: ['Standard', 'Static', 'HPA']
+                default: 'Standard'
+              static:
+                type: object
+                description: |
+                  Options for replicas management for the `Static` mode.
+                required: ["replicas"]
+                properties:
+                  replicas:
+                    type: number
+                    minimum: 1
+                    description: |
+                      Desired number of replicas.
+              hpa:
+                type: object
+                description: |
+                  Options for replicas management for the `HPA` mode.
+                required: ["minReplicas", "maxReplicas", "metrics"]
+                properties:
+                  minReplicas:
+                    type: number
+                    minimum: 1
+                    description: |
+                      The lower limit for the number of replicas to which the HPA can scale down.
+                  maxReplicas:
+                    type: number
+                    minimum: 1
+                    description: |
+                      The upper limit for the number of replicas to which the HPA can scale up. It cannot be less that `minReplicas`.
+                  metrics:
+                    type: array
+                    description: |
+                      The HPA will use these metrics to decide whether to increase or decrease the number of replicates.
+                    minItems: 1
+                    items:
+                      type: object
+                      required: ["type","targetAverageUtilization"]
+                      properties:
+                        type:
+                          type: string
+                          description: |
+                            Metric type.
+                          enum: ['CPU']
+                        targetAverageUtilization:
+                          type: number
+                          description: |
+                            The target value of the average of the resource metric across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
+                          minimum: 1
+                          maximum: 100
+          resourcesManagement:
+            description: |
+              Settings for CPU and memory requests and limits by waypoint proxy pods.
+            type: object
+            default: {}
+            x-examples:
+            - mode: VPA
+              vpa:
+                mode: InPlaceOrRecreate
+                cpu:
+                  min: "50m"
+                  max: 2
+                  limitRatio: 1.5
+                memory:
+                  min: "256Mi"
+                  max: "2Gi"
+                  limitRatio: 1.5
+            - mode: Static
+              static:
+                requests:
+                  cpu: "55m"
+                  memory: "256Mi"
+                limits:
+                  cpu: "2"
+                  memory: "2Gi"
+            - mode: VPA
+              vpa:
+                mode: Auto
+                cpu:
+                  min: "50m"
+                  max: 2
+                  limitRatio: 1.5
+                memory:
+                  min: "256Mi"
+                  max: "2Gi"
+                  limitRatio: 1.5
+            properties:
+              mode:
+                type: string
+                description: |
+                  Resource management mode:
+                  - `Static` — allows you to specify requests/limits. The parameters of this mode are defined in the [static](#parameters-dataplane-waypoint-resourcesmanagement-static) parameter section;
+                  - `VPA` — uses [VPA](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md). You can configure this mode by modifying parameters in the [vpa](#parameters-dataplane-waypoint-resourcesmanagement-vpa) parameter section.
+                enum: ['VPA', 'Static']
+                default: 'VPA'
+              vpa:
+                type: object
+                default: {}
+                description: |
+                  Resource management options for the `VPA` mode.
+                properties:
+                  mode:
+                    type: string
+                    description: |
+                      VPA operating mode.
+
+                      - `Initial` — VPA sets initial values for pod resource requests and limits at pod creation time.
+                        Resource values are not changed automatically afterwards.
+
+                      - `InPlaceOrRecreate` — VPA attempts to update pod resources in place when supported by the cluster.
+                        If in-place updates are not possible, the pod will be recreated.
+
+                      - `Auto` — VPA automatically recreates pods to apply updated resource values.
+
+                        > Starting from Deckhouse version 1.75, this mode is considered legacy.
+                        > It is recommended to use `InPlaceOrRecreate` instead.
+                    enum: ['Initial', 'InPlaceOrRecreate', 'Auto']
+                    default: 'InPlaceOrRecreate'
+                  cpu:
+                    type: object
+                    default: {}
+                    description: |
+                      CPU-related VPA settings.
+                    properties:
+                      max:
+                        description: |
+                          The maximum value that the VPA can set for the CPU requests.
+                        default: 1
+                        oneOf:
+                        - type: string
+                          pattern: "^[0-9]+m?$"
+                        - type: number
+                      min:
+                        description: |
+                          The minimum value that the VPA can set for the CPU requests.
+                        default: '25m'
+                        oneOf:
+                        - type: string
+                          pattern: "^[0-9]+m?$"
+                        - type: number
+                      limitRatio:
+                        type: number
+                        examples: [1.5]
+                        description: |
+                          The CPU limits/requests ratio.
+
+                          This ratio is used for calculating the initial CPU limits for a pod.
+
+                          If this parameter is set, the VPA will recalculate the CPU limits while maintaining the specified limits/requests ratio.
+                  memory:
+                    type: object
+                    default: {}
+                    description: |
+                      Memory-related VPA settings.
+                    properties:
+                      max:
+                        description: |
+                          The maximum memory requests the VPA can set.
+                        default: '2Gi'
+                        oneOf:
+                        - type: string
+                          pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                        - type: number
+                      min:
+                        description: |
+                          The minimum memory requests the VPA can set.
+                        default: '64Mi'
+                        oneOf:
+                        - type: string
+                          pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                        - type: number
+                      limitRatio:
+                        type: number
+                        examples: [1.5]
+                        description: |
+                          The memory limits/requests ratio.
+
+                          This ratio is used for calculating the initial memory limits for a pod.
+
+                          If this parameter is set, the VPA will recalculate the memory limits while maintaining the specified limits/requests ratio.
+              static:
+                type: object
+                description: |
+                  Resource management options for the `Static` mode.
+                properties:
+                  requests:
+                    type: object
+                    description: |
+                      Resource requests settings for pods.
+                    properties:
+                      cpu:
+                        type: string
+                        pattern: "^[0-9]+m?$"
+                        description: |
+                          Configuring CPU requests.
+                      memory:
+                        oneOf:
+                        - type: string
+                          pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                        - type: number
+                        description: |
+                          Configuring memory requests.
+                  limits:
+                    type: object
+                    description: |
+                      Configuring CPU and memory limits.
+                    properties:
+                      cpu:
+                        type: string
+                        pattern: "^[0-9]+m?$"
+                        description: |
+                          Configuring CPU limits.
+                      memory:
+                        oneOf:
+                        - type: string
+                          pattern: '^[0-9]+(\.[0-9]+)?(E|P|T|G|M|k|Ei|Pi|Ti|Gi|Mi|Ki)?$'
+                        - type: number
+                        description: |
+                          Configuring memory limits.
       ztunnel:
         type: object
         description: |

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -352,6 +352,135 @@ properties:
                 ```
               > **Внимание.** Отключение этого таймаута (значение `0s`) с большой вероятностью может привести к утечке соединений из-за потери пакетов TCP FIN и т.п.
               > **Внимание.** После изменения настройки необходим рестарт клиентских подов.
+      waypoint:
+        description: |
+          Настройки для waypoint-прокси.
+        properties:
+          enabled:
+            description: |
+              Включить развёртывание общего waypoint-прокси в namespace `d8-istio`.
+          replicasManagement:
+            description: |
+              Настройки управления репликами и горизонтальным масштабированием waypoint-прокси.
+            properties:
+              mode:
+                description: |
+                  Режим работы с репликами:
+                  - `Standard` — режим управления репликами и масштабированием в соответствии с глобальным режимом отказоустойчивости (параметр [highAvailability](/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-highavailability));
+                  - `Static` — режим, где количество реплик указывается явно (параметр [static.replicas](#parameters-dataplane-waypoint-replicasmanagement-static-replicas));
+                  - `HPA` — режим, где количество реплик рассчитывается автоматически с помощью [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) на основе загрузки CPU. Настраивается в секции параметров [hpa](#parameters-dataplane-waypoint-replicasmanagement-hpa).
+              static:
+                description: |
+                  Параметры управления репликами и масштабированием в режиме Static.
+                properties:
+                  replicas:
+                    description: |
+                      Желаемое количество реплик.
+              hpa:
+                description: |
+                  Параметры управления репликами и масштабированием в режиме HPA.
+                properties:
+                  minReplicas:
+                    description: |
+                      Минимальное количество реплик, которое может быть установлено HPA.
+                  maxReplicas:
+                    description: |
+                      Максимальное количество реплик, которое может быть установлено HPA. Не может быть меньше `minReplicas`.
+                  metrics:
+                    description: |
+                      HPA будет основываться на этих метриках при принятии решения об увеличении или уменьшении количества реплик.
+                    items:
+                      properties:
+                        type:
+                          description: |
+                            Тип метрики.
+                        targetAverageUtilization:
+                          description: |
+                            Целевое значение средней загрузки CPU во всех репликах. Задается в процентах от `Requests CPU`.
+          resourcesManagement:
+            description: |
+              Настройки запросов (requests) и ограничений (limits) использования CPU и памяти подами waypoint-прокси.
+            properties:
+              mode:
+                description: |
+                  Режим управления ресурсами:
+                  - `Static` — с помощью прямого указания запросов/ограничений (requests/limits). Настраивается в секции параметров [static](#parameters-dataplane-waypoint-resourcesmanagement-static);
+                  - `VPA` — с помощью [VPA](https://github.com/kubernetes/design-proposals-archive/blob/main/autoscaling/vertical-pod-autoscaler.md). Настраивается в секции параметров [vpa](#parameters-dataplane-waypoint-resourcesmanagement-vpa).
+              vpa:
+                description: |
+                  Параметры управления ресурсами в режиме VPA.
+                properties:
+                  mode:
+                    description: |
+                      Режим работы VPA.
+                      - `Initial` — VPA устанавливает начальные значения requests/limits при создании пода.
+                        В дальнейшем значения ресурсов не изменяются автоматически.
+
+                      - `InPlaceOrRecreate` — VPA пытается изменить ресурсы пода «на месте» (in-place),
+                        если это поддерживается кластером. Если in-place обновление невозможно,
+                        под будет пересоздан.
+
+                      - `Auto` — VPA автоматически пересоздаёт поды для применения новых значений ресурсов.
+                        Начиная с версии Deckhouse 1.75 данный режим считается устаревшим.
+                        Рекомендуется использовать `InPlaceOrRecreate`.
+                  cpu:
+                    description: |
+                      Настройки VPA при работе с CPU.
+                    properties:
+                      min:
+                        description: |
+                          Минимальное значение, которое может выставить VPA для запроса CPU (CPU requests).
+                      max:
+                        description: |
+                          Максимальное значение, которое может выставить VPA для запроса CPU (CPU requests).
+                      limitRatio:
+                        description: |
+                          Коэффициент расчета ограничений использования CPU относительно запросов (limits/requests).
+
+                          Применяется для расчета начальных ограничений использования CPU для пода (CPU limits).
+
+                          Если параметр указан, то VPA, при пересчете запросов CPU (CPU requests) будет пересчитывать ограничения использования CPU (CPU limits) сохраняя указанное соотношение ограничений к запросам (limits/requests).
+                  memory:
+                    description: |
+                      Настройки VPA при работе с памятью.
+                    properties:
+                      min:
+                        description: |
+                          Минимальное значение, которое может выставить VPA для запроса к памяти (memory requests).
+                      max:
+                        description: |
+                          Максимальное значение, которое может выставить VPA для запроса к памяти (memory requests).
+                      limitRatio:
+                        description: |
+                          Коэффициент расчета ограничений использования памяти относительно запросов (limits/requests).
+
+                          Применяется для расчета начальных ограничений использования памяти для пода (memory limits).
+
+                          Если параметр указан, то VPA, при пересчете запросов памяти (memory requests) будет пересчитывать ограничения использования памяти (memory limits) сохраняя указанное соотношение ограничений к запросам (limits/requests).
+              static:
+                description: |
+                  Настройка управления ресурсами в режиме `Static`.
+                properties:
+                  requests:
+                    description: |
+                      Настройки запросов ресурсов (requests) подов.
+                    properties:
+                      cpu:
+                        description: |
+                          Настройка запроса CPU (CPU requests).
+                      memory:
+                        description: |
+                          Настройка запроса памяти (memory requests).
+                  limits:
+                    description: |
+                      Настройка ограничений (limits) использования CPU и памяти.
+                    properties:
+                      cpu:
+                        description: |
+                          Настройка ограничений использования CPU (CPU limits).
+                      memory:
+                        description: |
+                          Настройка ограничений использования памяти (memory limits).
       ztunnel:
         description: |
           Настройки для компонента ztunnel.

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -132,8 +132,31 @@ const istioValues = `
       accessLog:
         type: "Text"
         textFormat: '[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% "%UPSTREAM_TRANSPORT_FAILURE_REASON%" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%" %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%'
+      waypoint:
+        enabled: false
+        replicasManagement:
+          mode: Standard
+        resourcesManagement:
+          mode: VPA
+          vpa:
+            mode: InPlaceOrRecreate
+            cpu:
+              max: "2"
+              min: "50m"
+            memory:
+              max: "2Gi"
+              min: "256Mi"
       ztunnel:
-        resourcesManagement: {}
+        resourcesManagement:
+          mode: VPA
+          vpa:
+            mode: InPlaceOrRecreate
+            cpu:
+              max: "1"
+              min: "25m"
+            memory:
+              max: "2Gi"
+              min: "64Mi"
     ambient:
       enabled: false
 `

--- a/modules/110-istio/template_tests/waypoint_test.go
+++ b/modules/110-istio/template_tests/waypoint_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: istio :: helm template :: waypoint", func() {
+	f := SetupHelmConfig(``)
+
+	Context("Ambient mode enabled, waypoint enabled, global version 1.25.2 (supports ambient)", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
+			f.ValuesSet("istio.ambient.enabled", true)
+			f.ValuesSet("istio.dataPlane.waypoint.enabled", true)
+			f.HelmRender()
+		})
+
+		It("waypoint resources should be created", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			waypointDeploy := f.KubernetesResource("Deployment", "d8-istio", "waypoint")
+			Expect(waypointDeploy.Exists()).To(BeTrue())
+			Expect(waypointDeploy.Field("spec.template.spec.serviceAccountName").String()).To(Equal("waypoint"))
+
+			waypointSa := f.KubernetesResource("ServiceAccount", "d8-istio", "waypoint")
+			Expect(waypointSa.Exists()).To(BeTrue())
+
+			waypointSvc := f.KubernetesResource("Service", "d8-istio", "waypoint")
+			Expect(waypointSvc.Exists()).To(BeTrue())
+			Expect(waypointSvc.Field("spec.type").String()).To(Equal("ClusterIP"))
+
+			waypointGateway := f.KubernetesResource("Gateway", "d8-istio", "waypoint")
+			Expect(waypointGateway.Exists()).To(BeTrue())
+			Expect(waypointGateway.Field("spec.gatewayClassName").String()).To(Equal("istio-waypoint"))
+
+			waypointVpa := f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "waypoint")
+			Expect(waypointVpa.Exists()).To(BeTrue())
+			Expect(waypointVpa.Field("spec.targetRef.name").String()).To(Equal("waypoint"))
+			Expect(waypointVpa.Field("spec.targetRef.kind").String()).To(Equal("Deployment"))
+
+			waypointPodMonitor := f.KubernetesResource("PodMonitor", "d8-monitoring", "istio-waypoint")
+			Expect(waypointPodMonitor.Exists()).To(BeTrue())
+
+			waypointHpa := f.KubernetesResource("HorizontalPodAutoscaler", "d8-istio", "waypoint")
+			Expect(waypointHpa.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Ambient mode enabled, waypoint enabled, global version 1.21.6 (does not support ambient)", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSet("istio.internal.globalVersion", "1.21.6")
+			f.ValuesSet("istio.ambient.enabled", true)
+			f.ValuesSet("istio.dataPlane.waypoint.enabled", true)
+			f.HelmRender()
+		})
+
+		It("waypoint resources should NOT be created", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Service", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Gateway", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("HorizontalPodAutoscaler", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "istio-waypoint").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Ambient mode disabled, waypoint enabled, global version 1.25.2", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
+			f.ValuesSet("istio.ambient.enabled", false)
+			f.ValuesSet("istio.dataPlane.waypoint.enabled", true)
+			f.HelmRender()
+		})
+
+		It("waypoint resources should NOT be created", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Service", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Gateway", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("HorizontalPodAutoscaler", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "istio-waypoint").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Ambient mode enabled, waypoint disabled, global version 1.25.2", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
+			f.ValuesSet("istio.ambient.enabled", true)
+			f.ValuesSet("istio.dataPlane.waypoint.enabled", false)
+			f.HelmRender()
+		})
+
+		It("waypoint resources should NOT be created", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			Expect(f.KubernetesResource("Deployment", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("ServiceAccount", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Service", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Gateway", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("HorizontalPodAutoscaler", "d8-istio", "waypoint").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("PodMonitor", "d8-monitoring", "istio-waypoint").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Waypoint with HPA replicasManagement mode", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSet("istio.internal.globalVersion", "1.25.2")
+			f.ValuesSet("istio.ambient.enabled", true)
+			f.ValuesSetFromYaml("istio.dataPlane.waypoint", `
+enabled: true
+replicasManagement:
+  mode: HPA
+  hpa:
+    minReplicas: 2
+    maxReplicas: 5
+    metrics:
+    - type: CPU
+      targetAverageUtilization: 80
+resourcesManagement:
+  mode: Static
+  static:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+`)
+			f.HelmRender()
+		})
+
+		It("HPA should be created and deployment should not have replicas set", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			waypointHpa := f.KubernetesResource("HorizontalPodAutoscaler", "d8-istio", "waypoint")
+			Expect(waypointHpa.Exists()).To(BeTrue())
+			Expect(waypointHpa.Field("spec.minReplicas").Int()).To(Equal(int64(2)))
+			Expect(waypointHpa.Field("spec.maxReplicas").Int()).To(Equal(int64(5)))
+			Expect(waypointHpa.Field("spec.scaleTargetRef.name").String()).To(Equal("waypoint"))
+			Expect(waypointHpa.Field("spec.scaleTargetRef.kind").String()).To(Equal("Deployment"))
+
+			waypointDeploy := f.KubernetesResource("Deployment", "d8-istio", "waypoint")
+			Expect(waypointDeploy.Exists()).To(BeTrue())
+			Expect(waypointDeploy.Field("spec.replicas").Exists()).To(BeFalse())
+
+			waypointVpa := f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "waypoint")
+			Expect(waypointVpa.Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/110-istio/templates/_helpers.tpl
+++ b/modules/110-istio/templates/_helpers.tpl
@@ -1,8 +1,40 @@
+{{- define "istioCloudPlatform" -}}
+{{- $supportedProviders := list "aws" "gcp" "azure" -}}
+{{- if and (.Values.global.clusterConfiguration) (hasKey .Values.global.clusterConfiguration "cloud") -}}
+{{- $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower -}}
+{{- if has $currentProvider $supportedProviders -}}
+{{- $currentProvider -}}
+{{- else -}}
+{{- "none" -}}
+{{- end -}}
+{{- else -}}
+{{- "none" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "istioGlobalRevision" -}}
+{{- $version := $.Values.istio.internal.globalVersion -}}
+{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+{{- get $versionInfo "revision" -}}
+{{- end -}}
+
+{{- define "istioImageSuffix" -}}
+{{- $version := $.Values.istio.internal.globalVersion -}}
+{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+{{- get $versionInfo "imageSuffix" -}}
+{{- end -}}
+
 {{- define "istioJWTPolicy" -}}
-    third-party-jwt
-{{- end }}
+third-party-jwt
+{{- end -}}
 
 {{- define "istioNetworkName" -}}
-  {{- $context := . -}}
-  network-{{ $context.Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
-{{- end }}
+network-{{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+{{- end -}}
+
+{{- define "istioSupportsAmbient" -}}
+{{- $version := $.Values.istio.internal.globalVersion -}}
+{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+{{- if get $versionInfo "supportsAmbient" -}}true{{- end -}}
+{{- end -}}
+

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
@@ -5,10 +5,11 @@
   - deployments
   verbs:
   - get
-  - list
   - watch
+  - list
   - update
   - patch
+  - create
   - delete
 - apiGroups:
   - ""
@@ -186,15 +187,6 @@
   verbs:
   - create
 - apiGroups:
-  - gateway.networking.k8s.io
-  resources:
-  - gatewayclasses
-  verbs:
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ""
   resources:
   - secrets
@@ -239,12 +231,7 @@
   - list
 - apiGroups:
   - gateway.networking.k8s.io
-  resources:
-  - gateways
-  - httproutes
-  - grpcroutes
-  - gatewayclasses
-  - referencegrants
+  resources: ["*"]
   verbs:
   - get
   - watch
@@ -253,6 +240,23 @@
   - gateway.networking.k8s.io
   resources:
   - gatewayclasses/status
+  - gateways/status
+  - grpcroutes/status
+  - httproutes/status
+  - referencegrants/status
+  - tcproutes/status
+  - tlsroutes/status
+  - udproutes/status
   verbs:
   - update
+  - patch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
 {{- end -}}

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
@@ -231,7 +231,15 @@
   - list
 - apiGroups:
   - gateway.networking.k8s.io
-  resources: ["*"]
+  resources:
+  - gatewayclasses
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  - updroutes
   verbs:
   - get
   - watch

--- a/modules/110-istio/templates/waypoint/deployment.yaml
+++ b/modules/110-istio/templates/waypoint/deployment.yaml
@@ -1,0 +1,247 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.istio.dataPlane.waypoint.enabled)
+}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: waypoint
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "app" "waypoint"
+    "istio.io/rev" (include "istioGlobalRevision" .)
+    "istio.io/waypoint-for" "all"
+    "gateway.networking.k8s.io/gateway-name" "waypoint"
+    "gateway.istio.io/managed" "istio.io-mesh-controller"
+  )) | nindent 2 }}
+spec:
+  {{- if eq .Values.istio.dataPlane.waypoint.replicasManagement.mode "Standard" }}
+  {{- include "helm_lib_deployment_strategy_and_replicas_for_ha" . | nindent 2 }}
+  {{- else if eq .Values.istio.dataPlane.waypoint.replicasManagement.mode "Static" }}
+  replicas: {{ .Values.istio.dataPlane.waypoint.replicasManagement.static.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: waypoint
+      gateway.networking.k8s.io/gateway-name: waypoint
+  template:
+    metadata:
+      annotations:
+        istio.io/rev: {{ include "istioGlobalRevision" . }}
+        prometheus.io/path: "/stats/prometheus"
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+      {{- include "helm_lib_module_labels" (list . (dict
+        "app" "waypoint"
+        "gateway.istio.io/managed" "istio.io-mesh-controller"
+        "gateway.networking.k8s.io/gateway-name" "waypoint"
+        "istio.io/dataplane-mode" "none"
+        "istio.io/rev" (include "istioGlobalRevision" .)
+        "istio.io/waypoint-for" "all"
+        "service.istio.io/canonical-name" "waypoint"
+        "service.istio.io/canonical-revision" "latest"
+        "sidecar.istio.io/inject" "false"
+        "topology.istio.io/network" (include "istioNetworkName" .)
+      )) | nindent 6 }}
+    spec:
+      {{- include "helm_lib_pod_anti_affinity_for_ha" (list . (dict
+        "app" "waypoint"
+        "gateway.networking.k8s.io/gateway-name" "waypoint"
+      )) | nindent 6 }}
+      {{- include "helm_lib_node_selector" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_tolerations" (tuple . "system") | nindent 6 }}
+      {{- include "helm_lib_module_pod_security_context_run_as_user_nobody" . | nindent 6 }}
+      containers:
+      - args:
+        - proxy
+        - waypoint
+        - --domain
+        - $(POD_NAMESPACE).svc.{{ .Values.global.discovery.clusterDomain }}
+        - --serviceCluster
+        - waypoint.$(POD_NAMESPACE)
+        - --log_as_json
+        - --log_output_level=default:info
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        env:
+        - name: ISTIO_META_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: ISTIO_META_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod-{{ include "istioGlobalRevision" . }}.d8-istio.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_CPU_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: PROXY_CONFIG
+          value: |
+            {
+              "discoveryAddress": "istiod-{{ include "istioGlobalRevision" . }}.d8-istio.svc:15012",
+              "proxyMetadata": {
+                "CLOUD_PLATFORM": {{ include "istioCloudPlatform" . | quote }},
+                "ISTIO_META_DNS_AUTO_ALLOCATE": "true",
+                "ISTIO_META_DNS_CAPTURE": "true",
+                "ISTIO_META_IDLE_TIMEOUT": "1h",
+                "PROXY_CONFIG_XDS_AGENT": "true"
+              },
+              "meshId": "d8-istio-mesh",
+              "holdApplicationUntilProxyStarts": false
+            }
+        - name: CLOUD_PLATFORM
+          value: {{ include "istioCloudPlatform" . | quote }}
+        - name: ISTIO_META_DNS_AUTO_ALLOCATE
+          value: "true"
+        - name: ISTIO_META_DNS_CAPTURE
+          value: "true"
+        - name: ISTIO_META_IDLE_TIMEOUT
+          value: 1h
+        - name: PROXY_CONFIG_XDS_AGENT
+          value: "true"
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: ISTIO_META_CLUSTER_ID
+          value: {{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum .Values.global.discovery.clusterUUID }}
+        - name: ISTIO_META_NETWORK
+          value: {{ include "istioNetworkName" . | quote }}
+        - name: ISTIO_META_INTERCEPTION_MODE
+          value: REDIRECT
+        - name: ISTIO_META_WORKLOAD_NAME
+          value: waypoint
+        - name: ISTIO_META_OWNER
+          value: kubernetes://apis/apps/v1/namespaces/d8-{{ .Chart.Name }}/deployments/waypoint
+        - name: ISTIO_META_MESH_ID
+          value: d8-istio-mesh
+        - name: TRUST_DOMAIN
+          value: {{ .Values.global.discovery.clusterDomain | quote }}
+        image: {{ include "helm_lib_module_image" (list . (printf "proxyv2%s" (include "istioImageSuffix" .))) }}
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15020
+          name: metrics
+          protocol: TCP
+        - containerPort: 15021
+          name: status-port
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          {{- include "helm_lib_resources_management_pod_resources" (list .Values.istio.dataPlane.waypoint.resourcesManagement) | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsGroup: 1337
+          runAsNonRoot: true
+          runAsUser: 1337
+        startupProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/workload-spiffe-uds
+          name: workload-socket
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /var/lib/istio/data
+          name: istio-data
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio/pod
+          name: istio-podinfo
+      imagePullSecrets:
+      - name: d8-istio-sidecar-registry
+      serviceAccountName: waypoint
+      terminationGracePeriodSeconds: 2
+      volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+      - emptyDir:
+          medium: Memory
+        name: go-proxy-envoy
+      - emptyDir: {}
+        name: istio-data
+      - emptyDir: {}
+        name: go-proxy-data
+      - downwardAPI:
+          defaultMode: 420
+          items:
+          - fieldRef:
+              fieldPath: metadata.labels
+            path: labels
+          - fieldRef:
+              fieldPath: metadata.annotations
+            path: annotations
+        name: istio-podinfo
+      - name: istio-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      - configMap:
+          defaultMode: 420
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+{{- end }}

--- a/modules/110-istio/templates/waypoint/gateway.yaml
+++ b/modules/110-istio/templates/waypoint/gateway.yaml
@@ -1,0 +1,30 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.istio.dataPlane.waypoint.enabled)
+}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "app" "waypoint"
+    "istio.io/rev" (include "istioGlobalRevision" .)
+    "istio.io/waypoint-for" "all"
+    "gateway.networking.k8s.io/gateway-name" "waypoint"
+  )) | nindent 2 }}
+spec:
+  addresses:
+  - value: waypoint.d8-{{ .Chart.Name }}.svc.{{ .Values.global.discovery.clusterDomain }}
+    type: Hostname
+  gatewayClassName: istio-waypoint
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    name: mesh
+    port: 15008
+    protocol: HBONE
+{{- end }}

--- a/modules/110-istio/templates/waypoint/hpa.yaml
+++ b/modules/110-istio/templates/waypoint/hpa.yaml
@@ -1,0 +1,39 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.istio.dataPlane.waypoint.enabled)
+  (eq .Values.istio.dataPlane.waypoint.replicasManagement.mode "HPA")
+}}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: waypoint
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "app" "waypoint"
+    "gateway.istio.io/managed" "istio.io-mesh-controller"
+    "gateway.networking.k8s.io/gateway-name" "waypoint"
+    "istio.io/rev" (include "istioGlobalRevision" .)
+    "istio.io/waypoint-for" "all"
+    "topology.istio.io/network" (include "istioNetworkName" .)
+  )) | nindent 2 }}
+spec:
+  maxReplicas: {{ .Values.istio.dataPlane.waypoint.replicasManagement.hpa.maxReplicas }}
+  metrics:
+  {{- range $metric := .Values.istio.dataPlane.waypoint.replicasManagement.hpa.metrics }}
+  {{- if eq $metric.type "CPU" }}
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ $metric.targetAverageUtilization }}
+  {{- end }}
+  {{- end }}
+  minReplicas: {{ .Values.istio.dataPlane.waypoint.replicasManagement.hpa.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: waypoint
+{{- end }}

--- a/modules/110-istio/templates/waypoint/podmonitor.yaml
+++ b/modules/110-istio/templates/waypoint/podmonitor.yaml
@@ -1,0 +1,49 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.istio.dataPlane.waypoint.enabled)
+  (.Values.global.enabledModules | has "operator-prometheus")
+}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-waypoint
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict
+    "app" "waypoint"
+    "prometheus" "main"
+  )) | nindent 2 }}
+spec:
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - d8-{{ .Chart.Name }}
+  podMetricsEndpoints:
+  - path: /stats/prometheus
+    port: metrics
+    relabelings:
+    - action: replace
+      replacement: cluster
+      targetLabel: tier
+    - action: replace
+      replacement: istio-waypoint
+      targetLabel: job
+    - action: replace
+      sourceLabels: [__meta_kubernetes_namespace]
+      targetLabel: namespace
+    - action: replace
+      sourceLabels: [__meta_kubernetes_pod_name]
+      targetLabel: pod
+    - action: keep
+      regex: istio-proxy
+      sourceLabels: [__meta_kubernetes_pod_container_name]
+    - action: labeldrop
+      regex: endpoint
+    scheme: http
+  selector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values: ["waypoint"]
+{{- end }}

--- a/modules/110-istio/templates/waypoint/service.yaml
+++ b/modules/110-istio/templates/waypoint/service.yaml
@@ -1,0 +1,38 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.istio.dataPlane.waypoint.enabled)
+}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: waypoint
+  namespace: d8-{{ .Chart.Name }}
+  annotations:
+    networking.istio.io/traffic-distribution: PreferClose
+  {{- include "helm_lib_module_labels" (list . (dict
+    "app" "waypoint"
+    "gateway.istio.io/managed" "istio.io-mesh-controller"
+    "gateway.networking.k8s.io/gateway-name" "waypoint"
+    "istio.io/rev" (include "istioGlobalRevision" .)
+    "istio.io/waypoint-for" "all"
+    "topology.istio.io/network" (include "istioNetworkName" .)
+  )) | nindent 2 }}
+spec:
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+  - appProtocol: hbone
+    name: mesh
+    port: 15008
+    protocol: TCP
+    targetPort: 15008
+  selector:
+    app: waypoint
+    gateway.networking.k8s.io/gateway-name: waypoint
+  type: ClusterIP
+{{- end }}

--- a/modules/110-istio/templates/waypoint/serviceaccount.yaml
+++ b/modules/110-istio/templates/waypoint/serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.istio.dataPlane.waypoint.enabled)
+}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: waypoint
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "app" "waypoint"
+    "gateway.istio.io/managed" "istio.io-mesh-controller"
+    "gateway.networking.k8s.io/gateway-name" "waypoint"
+    "istio.io/rev" (include "istioGlobalRevision" .)
+    "istio.io/waypoint-for" "all"
+    "topology.istio.io/network" (include "istioNetworkName" .)
+  )) | nindent 2 }}
+{{- end }}

--- a/modules/110-istio/templates/waypoint/vpa.yaml
+++ b/modules/110-istio/templates/waypoint/vpa.yaml
@@ -1,0 +1,30 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.istio.dataPlane.waypoint.enabled)
+  (eq .Values.istio.dataPlane.waypoint.resourcesManagement.mode "VPA")
+  (.Values.global.enabledModules | has "vertical-pod-autoscaler")
+}}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: waypoint
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
+    "app" "waypoint"
+    "gateway.istio.io/managed" "istio.io-mesh-controller"
+    "gateway.networking.k8s.io/gateway-name" "waypoint"
+    "istio.io/rev" (include "istioGlobalRevision" .)
+    "istio.io/waypoint-for" "all"
+    "topology.istio.io/network" (include "istioNetworkName" .)
+  )) | nindent 2 }}
+spec:
+{{- include "helm_lib_resources_management_vpa_spec" (list
+  "apps/v1"
+  "Deployment"
+  "waypoint"
+  "istio-proxy"
+  .Values.istio.dataPlane.waypoint.resourcesManagement
+) | nindent 2 }}
+{{- end }}

--- a/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -1,28 +1,14 @@
-{{- $version := $.Values.istio.internal.globalVersion }}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version }}
-{{- $imageSuffix := get $versionInfo "imageSuffix" }}
-{{- $revision := get $versionInfo "revision" }}
-{{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-
-{{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
-{{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: ztunnel
-  namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list $ (dict "app" "ztunnel")) | nindent 2 }}
-spec:
-{{ include "helm_lib_resources_management_vpa_spec" (list "apps/v1" "DaemonSet" "ztunnel" "istio-proxy" $.Values.istio.dataPlane.ztunnel.resourcesManagement ) | nindent 2 }}
-{{- end }}
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+}}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ztunnel
-  namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list $ (dict 
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
       "app" "ztunnel"
   )) | nindent 2 }}
 spec:
@@ -35,14 +21,14 @@ spec:
       app: ztunnel
   template:
     metadata:
-      {{- include "helm_lib_module_labels" (list $ (dict 
+      {{- include "helm_lib_module_labels" (list . (dict
           "app" "ztunnel"
           "sidecar.istio.io/inject" "false"
           "istio.io/dataplane-mode" "none"
       )) | nindent 6 }}
       annotations:
         sidecar.istio.io/inject: "false"
-        istio.io/rev: {{ $revision }}
+        istio.io/rev: {{ include "istioGlobalRevision" . }}
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
     spec:
@@ -56,13 +42,13 @@ spec:
           operator: Exists
       containers:
       - name: istio-proxy
-        image: {{ include "helm_lib_module_image" (list $ (printf "ztunnel%s" $imageSuffix)) }}
+        image: {{ include "helm_lib_module_image" (list . (printf "ztunnel%s" (include "istioImageSuffix" .))) }}
         ports:
         - containerPort: 15020
           name: ztunnel-stats
           protocol: TCP
         resources:
-          {{- include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
+          {{- include "helm_lib_resources_management_pod_resources" (list .Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
         imagePullPolicy: IfNotPresent
         securityContext:
           # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
@@ -90,15 +76,15 @@ spec:
         - ztunnel
         env:
         - name: CA_ADDRESS
-          value: istiod-{{ $revision }}.d8-istio.svc:15012
+          value: istiod-{{ include "istioGlobalRevision" . }}.d8-istio.svc:15012
         - name: XDS_ADDRESS
-          value: istiod-{{ $revision }}.d8-istio.svc:15012
+          value: istiod-{{ include "istioGlobalRevision" . }}.d8-istio.svc:15012
         - name: RUST_LOG
           value: info
         - name: RUST_BACKTRACE
           value: "1"
         - name: ISTIO_META_CLUSTER_ID
-          value: {{ $.Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+          value: {{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum .Values.global.discovery.clusterUUID }}
         - name: INPOD_ENABLED
           value: "true"
         - name: TERMINATION_GRACE_PERIOD_SECONDS

--- a/modules/110-istio/templates/ztunnel/podmonitor.yaml
+++ b/modules/110-istio/templates/ztunnel/podmonitor.yaml
@@ -1,16 +1,15 @@
-{{- $version := $.Values.istio.internal.globalVersion }}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version }}
-{{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
-{{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.global.enabledModules | has "operator-prometheus")
+}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: ztunnel
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list $ (dict "app" "ztunnel" "prometheus" "main")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "ztunnel" "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
   podMetricsEndpoints:
@@ -21,15 +20,16 @@ spec:
       key: "token"
     honorLabels: true
     relabelings:
-    - targetLabel: tier
+    - action: replace
       replacement: cluster
-    - targetLabel: job
-      replacement: "ztunnel"
+      targetLabel: tier
+    - action: replace
+      replacement: ztunnel
+      targetLabel: job
   selector:
     matchLabels:
       app: ztunnel
   namespaceSelector:
     matchNames:
       - d8-{{ .Chart.Name }}
-{{- end }}
 {{- end }}

--- a/modules/110-istio/templates/ztunnel/rbac-for-us.yaml
+++ b/modules/110-istio/templates/ztunnel/rbac-for-us.yaml
@@ -1,15 +1,14 @@
-{{- $version := $.Values.istio.internal.globalVersion }}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version }}
-{{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-
-{{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+}}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ztunnel
-  namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list $ (dict 
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
       "app" "ztunnel"
   )) | nindent 2 }}
 ---

--- a/modules/110-istio/templates/ztunnel/vpa.yaml
+++ b/modules/110-istio/templates/ztunnel/vpa.yaml
@@ -1,0 +1,22 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (eq .Values.istio.dataPlane.ztunnel.resourcesManagement.mode "VPA")
+  (.Values.global.enabledModules | has "vertical-pod-autoscaler")
+}}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: ztunnel
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "ztunnel")) | nindent 2 }}
+spec:
+{{- include "helm_lib_resources_management_vpa_spec" (list
+  "apps/v1"
+  "DaemonSet"
+  "ztunnel"
+  "istio-proxy"
+  .Values.istio.dataPlane.ztunnel.resourcesManagement
+) | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
## Description

Add waypoint proxy support for Istio ambient mode. Introduce a full set of Helm templates (Deployment, Service, ServiceAccount, Gateway, VPA, HPA, PodMonitor) for the waypoint proxy component, along with OpenAPI configuration schema for all new parameters. This enables users to deploy a shared waypoint proxy in the `d8-istio` namespace with full resource management (VPA/Static), replicas management (Standard/Static/HPA), and monitoring out of the box.

Additionally, refactors ztunnel templates to use shared helper functions (`istioSupportsAmbient`, `istioGlobalRevision`, `istioImageSuffix`, `istioCloudPlatform`) defined in `_helpers.tpl`, reducing code duplication. Updates istiod RBAC rules for Gateway API v1.25 compatibility (broader resource access for `gateway.networking.k8s.io`).

## Why do we need it, and what problem does it solve?

Waypoint proxies are a core component of Istio's ambient mesh architecture. They handle L7 traffic processing (authorization policies, traffic management, observability) for workloads enrolled in ambient mode. Without a waypoint proxy, ambient mesh can only provide L4 mTLS via ztunnel — no L7 policies can be enforced.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Add waypoint proxy support for ambient mesh mode with configurable resource and replica management.
impact_level: default
```