### PR TITLE
[istio] Change API-proxy VPA update mode to fix an interruption in work

### DIFF
--- a/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
@@ -1,6 +1,6 @@
 {{- define "api_proxy_resources" }}
-cpu: 10m
-memory: 25Mi
+cpu: 15m
+memory: 32Mi
 {{- end }}
 
 {{- if .Values.istio.multicluster.enabled }}
@@ -25,8 +25,8 @@ spec:
       minAllowed:
         {{- include "api_proxy_resources" . | nindent 8 }}
       maxAllowed:
-        cpu: 20m
-        memory: 50Mi
+        cpu: 40m
+        memory: 64Mi
   {{- end }}
 ---
 apiVersion: apps/v1

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     kind: Deployment
     name: api-proxy
   updatePolicy:
-    updateMode: "InPlaceOrRecreate"
+    updateMode: "Initial"
   resourcePolicy:
     containerPolicies:
     - containerName: api-proxy


### PR DESCRIPTION
## Description
Updated the VerticalPodAutoscaler for Istio multicluster api-proxy: `spec.updatePolicy.updateMode` is now `Initial` instead of `InPlaceOrRecreate`.

With `Initial`, VPA applies recommended CPU/memory only when a new pod is created; it does not update or evict running pods when recommendations change.

Impact on cluster components: no direct impact on control plane, ingress controllers, or Prometheus. It affects only the istio api-proxy Deployment when the vertical-pod-autoscaler module is enabled and multicluster is on.
User-visible effect is fewer unplanned api-proxy restarts driven by VPA (and thus fewer brief multicluster connectivity drops tied to that path).

## Why do we need it, and what problem does it solve?
Multicluster traffic goes through api-proxy. Under `InPlaceOrRecreate`, VPA can trigger in-place resource updates or pod recreation when recommendations change. If in-place is unsupported or fails, the pod may be recreated, which interrupts cross-cluster connectivity for that window—especially painful with a single replica or long-lived connections.

`Initial` mode keeps recommendations useful for pod startup (Admission Controller still applies them on create) but stops VPA from changing resources for already running pods, so VPA no longer causes mid-flight restarts and the multicluster link is not torn down for that reason.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Changed the API-proxy VPA update mode to avoid work interruption.
impact_level: default
```