### PR TITLE
[istio] Added HTTPRoutes for multiclusters.

### DIFF
--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/httproute.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/httproute.yaml
@@ -1,0 +1,35 @@
+{{- $moduleGateway := dict }}
+{{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
+{{- if and (or .Values.istio.federation.enabled .Values.istio.multicluster.enabled) $moduleGateway .Values.global.modules.publicDomainTemplate (include "helm_lib_kind_exists" (list . "HTTPRoute")) (include "helm_lib_kind_exists" (list . "ListenerSet")) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: metadata-exporter
+  namespace: d8-{{ $.Chart.Name }}
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+  annotations:
+    alb.network.deckhouse.io/response-headers-to-add: '{"Strict-Transport-Security":"max-age=31536000; includeSubDomains"}'
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "metadata-exporter")) | nindent 2 }}
+spec:
+  hostnames:
+  - {{ include "helm_lib_module_public_domain" (list . "istio") }}
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: istio
+    namespace: d8-{{ $.Chart.Name }}
+    sectionName: istio
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: metadata-exporter
+      port: 8080
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /metadata/
+{{- end }}

--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/httproute.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/httproute.yaml
@@ -1,6 +1,9 @@
 {{- $moduleGateway := dict }}
 {{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
 {{- if and (or .Values.istio.federation.enabled .Values.istio.multicluster.enabled) $moduleGateway .Values.global.modules.publicDomainTemplate (include "helm_lib_kind_exists" (list . "HTTPRoute")) (include "helm_lib_kind_exists" (list . "ListenerSet")) }}
+  {{- if eq (include "helm_lib_module_https_mode" .) "Disabled" }}
+    {{- fail "HTTPS is mandatory for spiffe endpoint" }}
+  {{- end }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/ee/modules/110-istio/templates/alliance/metadata-exporter/httproute.yaml
+++ b/ee/modules/110-istio/templates/alliance/metadata-exporter/httproute.yaml
@@ -35,4 +35,35 @@ spec:
     - path:
         type: PathPrefix
         value: /metadata/
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: istio-metadata-exporter
+  namespace: d8-{{ $.Chart.Name }}
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+  annotations:
+    alb.network.deckhouse.io/response-headers-to-add: '{"Strict-Transport-Security":"max-age=31536000; includeSubDomains"}'
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "metadata-exporter")) | nindent 2 }}
+spec:
+  hostnames:
+  - {{ include "helm_lib_module_public_domain" (list . "istio-metadata") }}
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: istio
+    namespace: d8-{{ $.Chart.Name }}
+    sectionName: istio-metadata
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: metadata-exporter
+      port: 8080
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /metadata/
 {{- end }}

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/httproute.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/httproute.yaml
@@ -1,6 +1,9 @@
 {{- $moduleGateway := dict }}
 {{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
 {{- if and .Values.istio.multicluster.enabled $moduleGateway .Values.global.modules.publicDomainTemplate (include "helm_lib_kind_exists" (list . "HTTPRoute")) (include "helm_lib_kind_exists" (list . "ListenerSet")) }}
+  {{- if eq (include "helm_lib_module_https_mode" .) "Disabled" }}
+    {{- fail "HTTPS is mandatory for api proxy." }}
+  {{- end }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/ee/modules/110-istio/templates/multicluster/api-proxy/httproute.yaml
+++ b/ee/modules/110-istio/templates/multicluster/api-proxy/httproute.yaml
@@ -1,0 +1,64 @@
+{{- $moduleGateway := dict }}
+{{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
+{{- if and .Values.istio.multicluster.enabled $moduleGateway .Values.global.modules.publicDomainTemplate (include "helm_lib_kind_exists" (list . "HTTPRoute")) (include "helm_lib_kind_exists" (list . "ListenerSet")) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-proxy
+  namespace: d8-{{ $.Chart.Name }}
+  annotations:
+    alb.network.deckhouse.io/backend-tls-settings: '{"mode": "MUTUAL", "caCertificates": "/etc/kube-rbac-proxy-client-ssl/ca.crt", "clientCertificate": "/etc/kube-rbac-proxy-client-ssl/client.crt", "privateKey": "/etc/kube-rbac-proxy-client-ssl/client.key", "insecureSkipVerify": true}'
+  {{- if or (eq (include "helm_lib_module_https_mode" .) "CertManager") (eq (include "helm_lib_module_https_mode" .) "CustomCertificate") }}
+    alb.network.deckhouse.io/response-headers-to-add: '{"Strict-Transport-Security":"max-age=31536000; includeSubDomains"}'
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
+spec:
+  hostnames:
+  - {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: istio
+    namespace: d8-{{ $.Chart.Name }}
+    sectionName: api-proxy
+  rules:
+  - backendRefs:
+    - group: ""
+      kind: Service
+      name: api-proxy
+      port: 4443
+      weight: 1
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+{{- if (include "helm_lib_module_https_route_tls_enabled" .) }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-proxy-redirect
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
+spec:
+  hostnames:
+  - {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: ListenerSet
+    name: istio
+    namespace: d8-{{ $.Chart.Name }}
+    sectionName: api-proxy-redirect
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 301
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+{{- end }}
+{{- end }}

--- a/modules/110-istio/templates/certificate.yaml
+++ b/modules/110-istio/templates/certificate.yaml
@@ -43,4 +43,25 @@ spec:
   issuerRef:
     name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
     kind: ClusterIssuer
+  {{- if .Values.istio.multicluster.enabled }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-proxy-httproute
+  namespace: d8-{{ $.Chart.Name }}
+  annotations:
+    werf.io/fail-mode: IgnoreAndContinueDeployProcess
+    werf.io/track-termination-mode: NonBlocking
+  {{- include "helm_lib_module_labels" (list . (dict "app" "api-proxy")) | nindent 2 }}
+spec:
+  certificateOwnerRef: false
+  secretName: {{ include "helm_lib_module_https_secret_name" (list . "api-proxy-httproute-tls") }}
+  {{ include "helm_lib_module_generate_common_name" (list . "istio-api-proxy") | nindent 2 }}
+  dnsNames:
+  - {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
+  issuerRef:
+    name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
+    kind: ClusterIssuer
+  {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/certificate.yaml
+++ b/modules/110-istio/templates/certificate.yaml
@@ -8,7 +8,7 @@ metadata:
   name: istio
   namespace: d8-{{ $.Chart.Name }}
   annotations:
-    # Don't work readyness probe with NELM
+    # Don't work readiness probe with NELM
     werf.io/fail-mode: IgnoreAndContinueDeployProcess
     werf.io/track-termination-mode: NonBlocking
   {{- include "helm_lib_module_labels" (list . (dict "app" "istio")) | nindent 2 }}
@@ -40,6 +40,7 @@ spec:
   {{ include "helm_lib_module_generate_common_name" (list . "istio") | nindent 2 }}
   dnsNames:
   - {{ include "helm_lib_module_public_domain" (list . "istio") }}
+  - {{ include "helm_lib_module_public_domain" (list . "istio-metadata") }}
   issuerRef:
     name: {{ printf "letsencrypt-gateway-%s" $moduleGateway.name }}
     kind: ClusterIssuer

--- a/modules/110-istio/templates/custom-certificate.yaml
+++ b/modules/110-istio/templates/custom-certificate.yaml
@@ -3,5 +3,8 @@
 {{ include "helm_lib_module_gateway" (list . $moduleGateway) }}
 {{ if $moduleGateway }}
 {{ include "helm_lib_module_https_copy_custom_certificate" (list . "d8-istio" "istio-httproute-tls") }}
+{{ if .Values.istio.multicluster.enabled }}
+{{ include "helm_lib_module_https_copy_custom_certificate" (list . "d8-istio" "api-proxy-httproute-tls") }}
+{{ end }}
 {{ end }}
 {{ include "helm_lib_module_https_copy_custom_certificate" (list . "d8-istio" "api-proxy-ingress-tls") }}

--- a/modules/110-istio/templates/kiali/httproute.yaml
+++ b/modules/110-istio/templates/kiali/httproute.yaml
@@ -45,6 +45,20 @@ spec:
   - allowedRoutes:
       namespaces:
         from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "istio-metadata") }}
+    name: istio-metadata
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: {{ include "helm_lib_module_https_secret_name" (list . "istio-httproute-tls") }}
+        namespace: d8-{{ $.Chart.Name }}
+      mode: Terminate
+  - allowedRoutes:
+      namespaces:
+        from: Same
     hostname: {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
     name: api-proxy
     port: 443

--- a/modules/110-istio/templates/kiali/httproute.yaml
+++ b/modules/110-istio/templates/kiali/httproute.yaml
@@ -36,7 +36,7 @@ spec:
       certificateRefs:
       - group: ""
         kind: Secret
-        name: {{ include "helm_lib_module_https_secret_name" (list . "api-proxy-ingress-tls") }}
+        name: {{ include "helm_lib_module_https_secret_name" (list . "api-proxy-httproute-tls") }}
         namespace: d8-{{ $.Chart.Name }}
       mode: Terminate
   {{- end }}

--- a/modules/110-istio/templates/kiali/httproute.yaml
+++ b/modules/110-istio/templates/kiali/httproute.yaml
@@ -31,7 +31,17 @@ spec:
     name: istio-redirect
     port: 80
     protocol: HTTP
-  {{- if .Values.istio.multicluster.enabled }}
+{{- else }}
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "istio") }}
+    name: istio
+    port: 80
+    protocol: HTTP
+{{- end }}
+{{- if .Values.istio.multicluster.enabled }}
+  {{- if (include "helm_lib_module_https_route_tls_enabled" .) }}
   - allowedRoutes:
       namespaces:
         from: Same
@@ -53,16 +63,7 @@ spec:
     name: api-proxy-redirect
     port: 80
     protocol: HTTP
-  {{- end }}
-{{- else }}
-  - allowedRoutes:
-      namespaces:
-        from: Same
-    hostname: {{ include "helm_lib_module_public_domain" (list . "istio") }}
-    name: istio
-    port: 80
-    protocol: HTTP
-  {{- if .Values.istio.multicluster.enabled }}
+  {{- else }}
   - allowedRoutes:
       namespaces:
         from: Same

--- a/modules/110-istio/templates/kiali/httproute.yaml
+++ b/modules/110-istio/templates/kiali/httproute.yaml
@@ -24,6 +24,22 @@ spec:
         name: {{ include "helm_lib_module_https_secret_name" (list . "istio-httproute-tls") }}
         namespace: d8-{{ $.Chart.Name }}
       mode: Terminate
+  {{- if .Values.istio.multicluster.enabled }}
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
+    name: api-proxy
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: {{ include "helm_lib_module_https_secret_name" (list . "api-proxy-ingress-tls") }}
+        namespace: d8-{{ $.Chart.Name }}
+      mode: Terminate
+  {{- end }}
   - allowedRoutes:
       namespaces:
         from: Same
@@ -31,6 +47,15 @@ spec:
     name: istio-redirect
     port: 80
     protocol: HTTP
+  {{- if .Values.istio.multicluster.enabled }}
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
+    name: api-proxy-redirect
+    port: 80
+    protocol: HTTP
+  {{- end }}
 {{- else }}
   - allowedRoutes:
       namespaces:
@@ -39,6 +64,15 @@ spec:
     name: istio
     port: 80
     protocol: HTTP
+  {{- if .Values.istio.multicluster.enabled }}
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "istio-api-proxy") }}
+    name: api-proxy
+    port: 80
+    protocol: HTTP
+  {{- end }}
 {{- end }}
   parentRef:
     group: gateway.networking.k8s.io

--- a/modules/110-istio/templates/kiali/httproute.yaml
+++ b/modules/110-istio/templates/kiali/httproute.yaml
@@ -24,6 +24,13 @@ spec:
         name: {{ include "helm_lib_module_https_secret_name" (list . "istio-httproute-tls") }}
         namespace: d8-{{ $.Chart.Name }}
       mode: Terminate
+  - allowedRoutes:
+      namespaces:
+        from: Same
+    hostname: {{ include "helm_lib_module_public_domain" (list . "istio") }}
+    name: istio-redirect
+    port: 80
+    protocol: HTTP
   {{- if .Values.istio.multicluster.enabled }}
   - allowedRoutes:
       namespaces:
@@ -39,15 +46,6 @@ spec:
         name: {{ include "helm_lib_module_https_secret_name" (list . "api-proxy-httproute-tls") }}
         namespace: d8-{{ $.Chart.Name }}
       mode: Terminate
-  {{- end }}
-  - allowedRoutes:
-      namespaces:
-        from: Same
-    hostname: {{ include "helm_lib_module_public_domain" (list . "istio") }}
-    name: istio-redirect
-    port: 80
-    protocol: HTTP
-  {{- if .Values.istio.multicluster.enabled }}
   - allowedRoutes:
       namespaces:
         from: Same


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

As part of the migration to GatewayAPI, HTTPRoutes were added for metadata-exporter and api-proxy.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In new versions of dmt linter, we will check the module for the presence of an HTTPRoute similar to the existing Ingress for seamless migration to the Gateway API.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Added HTTPRoute for multiclusters.
impact: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
