### PR TITLE
Fix/user authn remove expired user from groups v2

### DIFF
--- a/modules/150-user-authn/hooks/expire_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/expire_dex_user_crds.go
@@ -76,6 +76,14 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 			ExecuteHookOnSynchronization: ptr.To(false),
 			FilterFunc:                   applyDexUserExpireFilter,
 		},
+		{
+			Name:                         "groups",
+			ApiVersion:                   "deckhouse.io/v1alpha1",
+			Kind:                         "Group",
+			ExecuteHookOnEvents:          ptr.To(false),
+			ExecuteHookOnSynchronization: ptr.To(false),
+			FilterFunc:                   applyDexGroupFilter,
+		},
 	},
 }, expireDexUsers)
 
@@ -89,7 +97,70 @@ func expireDexUsers(_ context.Context, input *go_hook.HookInput) error {
 
 		if dexUserExpire.CheckExpire && dexUserExpire.ExpireAt.Before(now) {
 			input.PatchCollector.Delete("deckhouse.io/v1", "User", "", dexUserExpire.Name)
+
+			for group, err := range sdkobjectpatch.SnapshotIter[DexGroup](input.Snapshots.Get("groups")) {
+				if err != nil {
+					return fmt.Errorf("cannot convert group: cannot iterate over 'groups' snapshot: %v", err)
+				}
+
+				if !groupContainsUser(group, dexUserExpire.Name) {
+					continue
+				}
+
+				expiredUserName := dexUserExpire.Name
+				input.PatchCollector.PatchWithMutatingFunc(func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+					_, err := removeUserFromGroupMembers(obj, expiredUserName)
+					if err != nil {
+						return nil, err
+					}
+					return obj, nil
+				}, "deckhouse.io/v1alpha1", "Group", "", group.Name)
+			}
 		}
 	}
 	return nil
+}
+
+func groupContainsUser(group DexGroup, username string) bool {
+	for _, member := range group.Spec.Members {
+		if member.Kind == "User" && member.Name == username {
+			return true
+		}
+	}
+	return false
+}
+
+func removeUserFromGroupMembers(groupObj *unstructured.Unstructured, username string) (bool, error) {
+	members, found, err := unstructured.NestedSlice(groupObj.Object, "spec", "members")
+	if err != nil || !found {
+		return false, err
+	}
+
+	newMembers := make([]interface{}, 0, len(members))
+	changed := false
+	for _, member := range members {
+		memberMap, ok := member.(map[string]interface{})
+		if !ok {
+			newMembers = append(newMembers, member)
+			continue
+		}
+
+		kind, _ := memberMap["kind"].(string)
+		name, _ := memberMap["name"].(string)
+		if kind == "User" && name == username {
+			changed = true
+			continue
+		}
+
+		newMembers = append(newMembers, member)
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	if err := unstructured.SetNestedSlice(groupObj.Object, newMembers, "spec", "members"); err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/modules/150-user-authn/hooks/expire_dex_user_crds.go
+++ b/modules/150-user-authn/hooks/expire_dex_user_crds.go
@@ -107,13 +107,15 @@ func expireDexUsers(_ context.Context, input *go_hook.HookInput) error {
 					continue
 				}
 
-				expiredUserName := dexUserExpire.Name
-				input.PatchCollector.PatchWithMutatingFunc(func(obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-					_, err := removeUserFromGroupMembers(obj, expiredUserName)
-					if err != nil {
-						return nil, err
-					}
-					return obj, nil
+				members, changed := removeUserFromGroupMembers(group.Spec.Members, dexUserExpire.Name)
+				if !changed {
+					continue
+				}
+
+				input.PatchCollector.PatchWithMerge(map[string]any{
+					"spec": map[string]any{
+						"members": members,
+					},
 				}, "deckhouse.io/v1alpha1", "Group", "", group.Name)
 			}
 		}
@@ -130,24 +132,11 @@ func groupContainsUser(group DexGroup, username string) bool {
 	return false
 }
 
-func removeUserFromGroupMembers(groupObj *unstructured.Unstructured, username string) (bool, error) {
-	members, found, err := unstructured.NestedSlice(groupObj.Object, "spec", "members")
-	if err != nil || !found {
-		return false, err
-	}
-
-	newMembers := make([]interface{}, 0, len(members))
+func removeUserFromGroupMembers(members []DexGroupMember, username string) ([]DexGroupMember, bool) {
+	newMembers := make([]DexGroupMember, 0, len(members))
 	changed := false
 	for _, member := range members {
-		memberMap, ok := member.(map[string]interface{})
-		if !ok {
-			newMembers = append(newMembers, member)
-			continue
-		}
-
-		kind, _ := memberMap["kind"].(string)
-		name, _ := memberMap["name"].(string)
-		if kind == "User" && name == username {
+		if member.Kind == "User" && member.Name == username {
 			changed = true
 			continue
 		}
@@ -155,12 +144,5 @@ func removeUserFromGroupMembers(groupObj *unstructured.Unstructured, username st
 		newMembers = append(newMembers, member)
 	}
 
-	if !changed {
-		return false, nil
-	}
-
-	if err := unstructured.SetNestedSlice(groupObj.Object, newMembers, "spec", "members"); err != nil {
-		return false, err
-	}
-	return true, nil
+	return newMembers, changed
 }

--- a/modules/150-user-authn/hooks/expire_dex_user_crds_test.go
+++ b/modules/150-user-authn/hooks/expire_dex_user_crds_test.go
@@ -26,6 +26,7 @@ import (
 var _ = Describe("User Authn hooks :: get dex user crds ::", func() {
 	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
 	f.RegisterCRD("deckhouse.io", "v1", "User", false)
+	f.RegisterCRD("deckhouse.io", "v1alpha1", "Group", false)
 
 	Context("User expiration schedule", func() {
 		BeforeEach(func() {
@@ -68,15 +69,47 @@ spec:
   - Admins
   - Everyone
   password: password
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Group
+metadata:
+  name: admins
+spec:
+  name: Admins
+  members:
+  - kind: User
+    name: admin
+  - kind: User
+    name: future
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Group
+metadata:
+  name: everyone
+spec:
+  name: Everyone
+  members:
+  - kind: User
+    name: admin
+  - kind: Group
+    name: admins
 `)
 			f.BindingContexts.Set(f.GenerateScheduleContext("*/5 * * * *"))
 			f.RunHook()
 		})
 
 		When("User expired (.status.expireAt < time.Now())", func() {
-			It("Should delete user CR", func() {
+			It("Should delete user CR and remove user from groups", func() {
 				Expect(f).To(ExecuteSuccessfully())
 				Expect(f.KubernetesGlobalResource("User", "admin").Exists()).Should(BeFalse())
+				Expect(f.KubernetesGlobalResource("Group", "admins").Field("spec.members").String()).To(MatchJSON(`
+[
+  {"kind":"User","name":"future"}
+]`))
+				Expect(f.KubernetesGlobalResource("Group", "everyone").Field("spec.members").String()).To(MatchJSON(`
+[
+  {"kind":"Group","name":"admins"}
+]`))
 			})
 		})
 


### PR DESCRIPTION
## Description
Fix local user TTL expiration flow in `user-authn`: when an expired `User` is deleted, the hook now also removes this user from all `Group.spec.members` entries.
## Why do we need it, and what problem does it solve?
Previously, after TTL expiration, a local user was removed but stale `User` references remained in groups.
This produced inconsistent authn data and “dead” group members.
The fix keeps group membership state consistent by cleaning up expired users from groups during the same expiration cycle.
## Why do we need it in the patch release (if we do)?
This is a user-visible bug fix in existing behavior.
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: user-authn
type: fix
summary: Remove expired local users from Group members during TTL cleanup.
impact: Group membership no longer keeps stale references to deleted local users after TTL expiration.
impact_level: default