### PR TITLE
[docs] Update version name to v1.73.1 on LTS channel

### DIFF
--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -19,7 +19,7 @@ github_repo_path: /deckhouse/deckhouse
 d8Revision: EE
 LTSChannel:
   version: v1.73-cse
-  versionName: v1.73 (CSE)
+  versionName: v1.73.1 (CSE)
 excerpt_separator: ""
 
 metrics:


### PR DESCRIPTION
## Description

Update version name to v1.73.1 for DKP CSE on LTS channel.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Update version name to v1.73.1 on LTS channel.
impact_level: low
```
