### PR TITLE
[container-base] Implement package manager to cloud-provider-aws

### DIFF
--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,5 +1,5 @@
 # version=v1.0.18
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/golang: "sha256:d001db9dce89bfb37d53a1d7fc8c95ff01d4495c1372fbcad096936c082582fc" # from: base/distroless
-minget: "sha256:ab4378d754527faf0b0346c356c9bb22356dc6fa0ecdcaa5b9a7d52cba4e9e8e" # from: builder/scratch
-builder/distroless: "sha256:65eae2c55ffca108888904526c18d3007f6bd1cc4f4ca175b5da11faad09cc78" # from: builder/scratch
+builder/distroless: "sha256:142b7977f9ff4fc3a02402a4f13b22a5d536d65cf24af4bd3642039b107c37ed" # from: builder/scratch
+builder/golang: "sha256:955568d7a4ee047d9db681d86ed58f95b5185d6cfdb8ded4aa2e844c9d5bdde4" # from: base/distroless
+minget: "sha256:71467545ce0c913df0341abb09e2e762f3ad3b96e36147b65e1c3065f3db028a" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,5 +1,5 @@
-# version=v1.0.18
+# version=v1.0.19
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:142b7977f9ff4fc3a02402a4f13b22a5d536d65cf24af4bd3642039b107c37ed" # from: builder/scratch
-builder/golang: "sha256:955568d7a4ee047d9db681d86ed58f95b5185d6cfdb8ded4aa2e844c9d5bdde4" # from: base/distroless
+base/distroless: "sha256:66740e683b5986bb01ac2bb8119f2ee981478d2b14b8e15eec796a9a31d59d81" # from: builder/scratch
+builder/golang: "sha256:4b3f3b82cd286e4e5e8db0dfb32767f367fb4ad5484f233adec5bc0d6e77ad8c" # from: base/distroless
 minget: "sha256:71467545ce0c913df0341abb09e2e762f3ad3b96e36147b65e1c3065f3db028a" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,7 +1,5 @@
-# version=v1.0.17
-# REGISTRY_PATH is a special key which is concatenated with other base images
+# version=v1.0.18
 REGISTRY_PATH: registry.deckhouse.io/container-factory
 builder/golang: "sha256:d001db9dce89bfb37d53a1d7fc8c95ff01d4495c1372fbcad096936c082582fc" # from: base/distroless
-builder/golang-1.26: "sha256:d001db9dce89bfb37d53a1d7fc8c95ff01d4495c1372fbcad096936c082582fc" # from: base/distroless
-minget-0.1: "sha256:71467545ce0c913df0341abb09e2e762f3ad3b96e36147b65e1c3065f3db028a" # from: builder/scratch
-minget: "sha256:71467545ce0c913df0341abb09e2e762f3ad3b96e36147b65e1c3065f3db028a" # from: builder/scratch
+minget: "sha256:ab4378d754527faf0b0346c356c9bb22356dc6fa0ecdcaa5b9a7d52cba4e9e8e" # from: builder/scratch
+builder/distroless: "sha256:65eae2c55ffca108888904526c18d3007f6bd1cc4f4ca175b5da11faad09cc78" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,5 +1,5 @@
-# version=v1.0.19
+# version=v1.0.20
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-base/distroless: "sha256:66740e683b5986bb01ac2bb8119f2ee981478d2b14b8e15eec796a9a31d59d81" # from: builder/scratch
-builder/golang: "sha256:4b3f3b82cd286e4e5e8db0dfb32767f367fb4ad5484f233adec5bc0d6e77ad8c" # from: base/distroless
+base/distroless: "sha256:86d87712dec2781115bea04a3a269d2c61ba9c5e9c75d20db467b0aa066f3a6c" # from: builder/scratch
+builder/golang: "sha256:dd8cc64d1b082a996a89279514a620b12c6928b6824cec68e59cd438d333263e" # from: base/distroless
 minget: "sha256:71467545ce0c913df0341abb09e2e762f3ad3b96e36147b65e1c3065f3db028a" # from: builder/scratch

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
@@ -46,7 +46,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/distroless" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
     add: /src
@@ -58,8 +58,6 @@ secrets:
 - id: GOPROXY
   value: {{ $.GOPROXY }}
 shell:
-  beforeInstall:
-  - pm install golang coreutils
   install:
   - cd /src
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download

--- a/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-controller-manager/werf.inc.yaml
@@ -46,7 +46,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/distroless" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
     add: /src
@@ -58,6 +58,8 @@ secrets:
 - id: GOPROXY
   value: {{ $.GOPROXY }}
 shell:
+  beforeInstall:
+  - pm install golang coreutils
   install:
   - cd /src
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download

--- a/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/cloud-data-discoverer/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/modules/030-cloud-provider-aws/images/ebs-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/ebs-csi-plugin/werf.inc.yaml
@@ -51,7 +51,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
     add: /src

--- a/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/node-termination-handler/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/modules/030-cloud-provider-aws/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-aws/images/terraform-manager/werf.inc.yaml
@@ -40,7 +40,7 @@ shell:
 ---
 image: terraform-provider-aws
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -52,8 +52,6 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 shell:
-  beforeInstall:
-  - apk add --no-cache make bash
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src


### PR DESCRIPTION
## Description
Migrate to a unified golang builder with integrated Container Base package manager and Go GOST compilation toolchain.

## Why do we need it, and what problem does it solve?
Standardizes the build process, implement Go GOST 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: feature
summary: Migrated cloud-provider-aws builds to the unified builder with package manager and Go toolchain.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
