### PR TITLE
[docs] Fix Jekyll plugins to improve rendering

### DIFF
--- a/docs/documentation/_plugins/offtopic.rb
+++ b/docs/documentation/_plugins/offtopic.rb
@@ -40,13 +40,6 @@ module Jekyll
         @converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
         rendered_content = collapse_inter_block_newlines(@converter.convert(content))
 
-        rendered_content = rendered_content.gsub(/(<pre\b[^>]*>)(.*?)(<\/pre>)/m) do
-          pre_open = $1
-          pre_body = $2
-          pre_close = $3
-          "#{pre_open}#{pre_body.gsub("\n", '&#10;')}#{pre_close}"
-        end
-
         %Q(<div markdown="0" class="details"><p class="details__lnk"><a href="javascript:void(0)" class="details__summary">#{@config[:title]}</a></p><div class="details__content"><div class="expand">#{rendered_content}</div></div></div>)
       end
     end

--- a/docs/documentation/_plugins/tabs.rb
+++ b/docs/documentation/_plugins/tabs.rb
@@ -48,7 +48,7 @@ module Jekyll
       private
 
       def slugify(text)
-        text.downcase.strip.gsub(/[^a-z0-9\s_-]/, '').gsub(/[\s-]+/, '_')
+        text.downcase.strip.gsub('+', '-plus-').gsub(/[^a-z0-9\s_-]/, '').gsub(/[\s-]+/, '_')
       end
     end
 

--- a/docs/documentation/_plugins/tabs.rb
+++ b/docs/documentation/_plugins/tabs.rb
@@ -45,11 +45,6 @@ module Jekyll
         %Q(<div markdown="0"><div class="tabs">#{buttons.join}</div>#{panels.join}</div>)
       end
 
-      private
-
-      def slugify(text)
-        text.downcase.strip.gsub('+', '-plus-').gsub(/[^a-z0-9\s_-]/, '').gsub(/[\s-]+/, '_')
-      end
     end
 
     class TabTag < Liquid::Block

--- a/docs/documentation/_plugins/utils.rb
+++ b/docs/documentation/_plugins/utils.rb
@@ -1,4 +1,21 @@
 module JekyllLiquidBlockUtils
+  CYRILLIC_MAP = {
+    'а' => 'a',  'б' => 'b',  'в' => 'v',  'г' => 'g',  'д' => 'd',
+    'е' => 'e',  'ё' => 'yo', 'ж' => 'zh', 'з' => 'z',  'и' => 'i',
+    'й' => 'j',  'к' => 'k',  'л' => 'l',  'м' => 'm',  'н' => 'n',
+    'о' => 'o',  'п' => 'p',  'р' => 'r',  'с' => 's',  'т' => 't',
+    'у' => 'u',  'ф' => 'f',  'х' => 'kh', 'ц' => 'ts', 'ч' => 'ch',
+    'ш' => 'sh', 'щ' => 'sch','ъ' => '',   'ы' => 'y',  'ь' => '',
+    'э' => 'e',  'ю' => 'yu', 'я' => 'ya',
+  }.freeze
+
+  def slugify(text)
+    s = text.downcase.strip
+    s = s.gsub('+', '-plus-')
+    s = s.chars.map { |c| CYRILLIC_MAP.fetch(c, c) }.join
+    s.gsub(/[^a-z0-9\s_-]/, '').gsub(/[\s-]+/, '_')
+  end
+
   def dedent(text)
     lines = text.split("\n")
     # Exclude HTML lines (already-rendered inner tags) from indent calculation

--- a/docs/documentation/_plugins/utils.rb
+++ b/docs/documentation/_plugins/utils.rb
@@ -11,19 +11,20 @@ module JekyllLiquidBlockUtils
     lines.map { |l| l.length >= min_indent ? l[min_indent..] : l }.join("\n")
   end
 
-  # Collapse all newlines outside <pre> blocks and replace blank lines inside
-  # <pre> blocks with a newline entity. Kramdown's block HTML parser stops at
-  # any newline that introduces a new block element even inside
-  # <div markdown="0">, so the output must be newline-free outside <pre>.
+  # Collapse all newlines outside <pre> blocks and replace all newlines inside
+  # <pre> blocks with &#10; entities. Kramdown's block HTML parser breaks the
+  # HTML structure on any bare newline inside div markdown="0", so the output
+  # must be completely newline-free. &#10; is rendered identically by browsers.
   def collapse_inter_block_newlines(html)
     parts = html.split(/(<pre\b[^>]*>.*?<\/pre>)/m)
     parts.map.with_index do |part, i|
       if i.even?
         part.strip.gsub(/\n+/, ' ')
       else
-        # Replace blank lines inside <pre> with a newline entity so Kramdown
-        # does not see a blank line while browsers still render a blank line.
-        part.gsub(/\n([ \t]*\n)+/, "&#10;\n")
+        # Capture groups from the outer split are stable — no inner gsub here,
+        # so $~ is not clobbered. Replace every newline so the whole plugin
+        # output is a single line and Kramdown cannot break the block.
+        part.gsub("\n", '&#10;')
       end
     end.join
   end


### PR DESCRIPTION
## Description
This pull request refactors the handling of newlines in HTML generated by Jekyll plugins and centralizes utility functions. The main improvements are in how newlines inside and outside `<pre>` blocks are processed, and in the introduction of a more robust `slugify` method with support for Cyrillic transliteration.

**Improvements to newline handling:**

* The logic for replacing newlines inside `<pre>` blocks with `&#10;` entities is now centralized in the `collapse_inter_block_newlines` utility function, ensuring consistent processing and preventing HTML structure issues with Kramdown.
* The manual newline replacement in `offtopic.rb` has been removed in favor of using the improved utility function, reducing code duplication and potential errors.

**Utility function enhancements and code cleanup:**

* A new `slugify` utility function is introduced in `utils.rb`, supporting transliteration of Cyrillic characters and improved normalization for tab identifiers.
* The old `slugify` method in `tabs.rb` is removed, and future code should use the centralized version from `utils.rb`.
## Why do we need it, and what problem does it solve?
Fix rendering (especially for cases like YAML codeblocks) in alerts, offtopics and tabs.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: fix
summary:  Fix Jekyll plugins to improve rendering.
impact_level: low
```
