### PR TITLE
[deckhouse] decouple from dhctl/cmd/commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,12 +218,16 @@ define iterateAllGoModules
 endef
 
 .PHONY: lint-all
-lint-all: golangci-lint ## Run golangci-lint run in all directories with go.mod
+lint-all: golangci-lint check-dhctl-cmd-drift ## Run golangci-lint run in all directories with go.mod
 	$(call iterateAllGoModules,Running golangci-lint in,GOFLAGS="-buildvcs=false" golangci-lint run --max-issues-per-linter 100 --max-same-issues 100)
 
 .PHONY: lint-fix-all
 lint-fix-all: golangci-lint ## Run golangci-lint run --fix in all directories with go.mod
 	$(call iterateAllGoModules,Running golangci-lint --fix in,GOFLAGS="-buildvcs=false" golangci-lint run --fix --max-issues-per-linter 100 --max-same-issues 100)
+
+.PHONY: check-dhctl-cmd-drift
+check-dhctl-cmd-drift: ## Verify dhctl ↔ deckhouse-controller CLI command-builder duplicates are in sync.
+	@bash tools/check-dhctl-cmd-drift.sh
 
 .PHONY: --lint-markdown-header lint-markdown lint-markdown-fix
 --lint-markdown-header:

--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -37,28 +37,6 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-// envOr returns the env var name's value, or defaultValue when unset/empty.
-func envOr(name, defaultValue string) string {
-	if v, ok := os.LookupEnv(name); ok && v != "" {
-		return v
-	}
-	return defaultValue
-}
-
-// envBoolOr parses the env var as a bool (per strconv.ParseBool), or returns
-// defaultValue when unset, empty, or unparseable.
-func envBoolOr(name string, defaultValue bool) bool {
-	v, ok := os.LookupEnv(name)
-	if !ok || v == "" {
-		return defaultValue
-	}
-	parsed, err := strconv.ParseBool(v)
-	if err != nil {
-		return defaultValue
-	}
-	return parsed
-}
-
 // Variables with component versions. They set by 'go build' command.
 var (
 	DeckhouseVersion     = "dev"
@@ -159,4 +137,26 @@ func main() {
 	}
 
 	kingpin.MustParse(kpApp.Parse(os.Args[1:]))
+}
+
+// envOr returns the env var name's value, or defaultValue when unset/empty.
+func envOr(name, defaultValue string) string {
+	if v, ok := os.LookupEnv(name); ok && v != "" {
+		return v
+	}
+	return defaultValue
+}
+
+// envBoolOr parses the env var as a bool (per strconv.ParseBool), or returns
+// defaultValue when unset, empty, or unparseable.
+func envBoolOr(name string, defaultValue bool) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok || v == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.ParseBool(v)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
 }

--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	ad_app "github.com/flant/addon-operator/pkg/app"
 	"github.com/flant/addon-operator/pkg/utils/stdliblogtolog"
@@ -32,8 +33,31 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/debug"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/registry"
+	dhctl_app "github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
+
+// envOr returns the env var name's value, or defaultValue when unset/empty.
+func envOr(name, defaultValue string) string {
+	if v, ok := os.LookupEnv(name); ok && v != "" {
+		return v
+	}
+	return defaultValue
+}
+
+// envBoolOr parses the env var as a bool (per strconv.ParseBool), or returns
+// defaultValue when unset, empty, or unparseable.
+func envBoolOr(name string, defaultValue bool) bool {
+	v, ok := os.LookupEnv(name)
+	if !ok || v == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.ParseBool(v)
+	if err != nil {
+		return defaultValue
+	}
+	return parsed
+}
 
 // Variables with component versions. They set by 'go build' command.
 var (
@@ -116,14 +140,16 @@ func main() {
 	// deckhouse-controller registry
 	registry.DefineRegistryCommand(kpApp, logger)
 
-	// dhctlcli command builders read defaults from DHCTL_CLI_* env vars
-	// (kingpin Envar bindings in dhctl/pkg/app); seed them here so we don't
-	// import dhctl/pkg/app from main. Deployer-set values are preserved.
+	// dhctlcli command builders read these globals from dhctl/pkg/app at run
+	// time. The corresponding kingpin Envar bindings in dhctl/pkg/app are
+	// gated by flag-registration (DefineGlobalFlags / DefineKubeFlags) which
+	// we do not invoke, so they never fire. Read the env directly and assign
+	// the globals here; deployer-set values win over hardcoded defaults.
 	{
-		setDhctlEnvDefault("DHCTL_CLI_LOGGER_TYPE", "json")
-		setDhctlEnvDefault("DHCTL_CLI_EDITOR", "vim")
-		setDhctlEnvDefault("DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER", "true")
-		setDhctlEnvDefault("DHCTL_CLI_TMP_DIR", os.TempDir())
+		dhctl_app.LoggerType = envOr("DECKHOUSE_LOGGER_TYPE", "json")
+		dhctl_app.Editor = envOr("DECKHOUSE_EDITOR", "vim")
+		dhctl_app.KubeConfigInCluster = envBoolOr("DECKHOUSE_KUBE_CONFIG_IN_CLUSTER", true)
+		dhctl_app.TmpDirName = envOr("DECKHOUSE_TMP_DIR", os.TempDir())
 
 		editCmd := kpApp.Command("edit", "Change configuration files in Kubernetes cluster conveniently and safely.")
 		dhctlcli.DefineEditCommands(editCmd /* wConnFlags */, false)
@@ -133,13 +159,4 @@ func main() {
 	}
 
 	kingpin.MustParse(kpApp.Parse(os.Args[1:]))
-}
-
-// setDhctlEnvDefault seeds an env var only if the deployer hasn't set one.
-// os.Setenv error is dropped: it only fails on names containing '=' or NUL.
-func setDhctlEnvDefault(name, value string) {
-	if v, ok := os.LookupEnv(name); ok && v != "" {
-		return
-	}
-	_ = os.Setenv(name, value)
 }

--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -28,11 +28,10 @@ import (
 	sh_debug "github.com/flant/shell-operator/pkg/debug"
 	"gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/dhctlcli"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/debug"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/registry"
-	dhctl_commands "github.com/deckhouse/deckhouse/dhctl/cmd/dhctl/commands"
-	dhctl_app "github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -117,16 +116,30 @@ func main() {
 	// deckhouse-controller registry
 	registry.DefineRegistryCommand(kpApp, logger)
 
-	// deckhouse-controller edit subcommands
-	editCmd := kpApp.Command("edit", "Change configuration files in Kubernetes cluster conveniently and safely.")
+	// dhctlcli command builders read defaults from DHCTL_CLI_* env vars
+	// (kingpin Envar bindings in dhctl/pkg/app); seed them here so we don't
+	// import dhctl/pkg/app from main. Deployer-set values are preserved.
 	{
-		dhctl_app.LoggerType = "json"
-		dhctl_app.Editor = "vim"
-		dhctl_app.KubeConfigInCluster = true
-		dhctl_app.TmpDirName = os.TempDir()
+		setDhctlEnvDefault("DHCTL_CLI_LOGGER_TYPE", "json")
+		setDhctlEnvDefault("DHCTL_CLI_EDITOR", "vim")
+		setDhctlEnvDefault("DHCTL_CLI_KUBE_CLIENT_FROM_CLUSTER", "true")
+		setDhctlEnvDefault("DHCTL_CLI_TMP_DIR", os.TempDir())
 
-		dhctl_commands.DefineEditCommands(editCmd /* wConnFlags */, false)
+		editCmd := kpApp.Command("edit", "Change configuration files in Kubernetes cluster conveniently and safely.")
+		dhctlcli.DefineEditCommands(editCmd /* wConnFlags */, false)
+
+		dhctlcli.DefineCommandParseClusterConfiguration(kpApp.Command("cluster-configuration", "Parse configuration and print it."))
+		dhctlcli.DefineCommandParseCloudDiscoveryData(kpApp.Command("cloud-discovery-data", "Parse cloud discovery data and print it."))
 	}
 
 	kingpin.MustParse(kpApp.Parse(os.Args[1:]))
+}
+
+// setDhctlEnvDefault seeds an env var only if the deployer hasn't set one.
+// os.Setenv error is dropped: it only fails on names containing '=' or NUL.
+func setDhctlEnvDefault(name, value string) {
+	if v, ok := os.LookupEnv(name); ok && v != "" {
+		return
+	}
+	_ = os.Setenv(name, value)
 }

--- a/deckhouse-controller/internal/dhctlcli/edit_commands.go
+++ b/deckhouse-controller/internal/dhctlcli/edit_commands.go
@@ -60,7 +60,7 @@ func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) 
 			return fmt.Errorf("kubernetes provider is not initialized")
 		}
 		if sshProviderInitializer != nil {
-			defer sshProviderInitializer.Cleanup(ctx)
+			defer sshProviderInitializer.Cleanup(ctx) //nolint:errcheck // best-effort cleanup, mirrors dhctl source
 		}
 
 		kube, err := kubeProvider.Client(ctx)

--- a/deckhouse-controller/internal/dhctlcli/edit_commands.go
+++ b/deckhouse-controller/internal/dhctlcli/edit_commands.go
@@ -1,0 +1,120 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Mirror of dhctl/cmd/dhctl/commands/edit.go.
+// Drift is enforced by tools/check-dhctl-cmd-drift.sh.
+
+package dhctlcli
+
+import (
+	"fmt"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
+)
+
+func connectionFlags(parent *kingpin.CmdClause) {
+	app.DefineKubeFlags(parent)
+	app.DefineSSHFlags(parent, nil)
+	app.DefineBecomeFlags(parent)
+}
+
+func baseEditConfigCMD(parent *kingpin.CmdClause, name, secret, dataKey string) *kingpin.CmdClause {
+	cmd := parent.Command(name, fmt.Sprintf("Edit %s in Kubernetes cluster.", name))
+	app.DefineEditorConfigFlags(cmd)
+	app.DefineSanityFlags(cmd)
+
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
+		params, err := app.DefaultProviderParams()
+		if err != nil {
+			return err
+		}
+		sshProviderInitializer, kubeProvider, err := providerinitializer.GetProviders(
+			ctx,
+			params,
+			providerinitializer.WithKubeFlagsDefined(app.KubeFlagsDefined()),
+			providerinitializer.WithRequiredKubeProvider(),
+		)
+		if err != nil {
+			return err
+		}
+		if kubeProvider == nil {
+			return fmt.Errorf("kubernetes provider is not initialized")
+		}
+		if sshProviderInitializer != nil {
+			defer sshProviderInitializer.Cleanup(ctx)
+		}
+
+		kube, err := kubeProvider.Client(ctx)
+		if err != nil {
+			return err
+		}
+		kubeCl := &client.KubernetesClient{KubeClient: kube}
+
+		return operations.SecretEdit(
+			ctx,
+			kubeCl,
+			name, "kube-system", secret, dataKey, map[string]string{
+				"name": name,
+			},
+			app.GetDirConfig(),
+		)
+	})
+}
+
+func DefineEditCommands(parent *kingpin.CmdClause, wConnFlags bool) {
+	clusterCmd := DefineEditClusterConfigurationCommand(parent)
+	providerCmd := DefineEditProviderClusterConfigurationCommand(parent)
+	staticCmd := DefineEditStaticClusterConfigurationCommand(parent)
+
+	if wConnFlags {
+		connectionFlags(clusterCmd)
+		connectionFlags(providerCmd)
+		connectionFlags(staticCmd)
+	}
+}
+
+func DefineEditClusterConfigurationCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	return baseEditConfigCMD(
+		parent,
+		"cluster-configuration",
+		"d8-cluster-configuration",
+		"cluster-configuration.yaml",
+	)
+}
+
+func DefineEditProviderClusterConfigurationCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	return baseEditConfigCMD(
+		parent,
+		"provider-cluster-configuration",
+		"d8-provider-cluster-configuration",
+		"cloud-provider-cluster-configuration.yaml",
+	)
+}
+
+func DefineEditStaticClusterConfigurationCommand(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	return baseEditConfigCMD(
+		parent,
+		"static-cluster-configuration",
+		"d8-static-cluster-configuration",
+		"static-cluster-configuration.yaml",
+	)
+}

--- a/deckhouse-controller/internal/dhctlcli/parse_config_commands.go
+++ b/deckhouse-controller/internal/dhctlcli/parse_config_commands.go
@@ -1,0 +1,130 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Mirror of the parse-* helpers from dhctl/cmd/dhctl/commands/config.go.
+// Drift is enforced by tools/check-dhctl-cmd-drift.sh.
+
+package dhctlcli
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kpcontext"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+func DefineCommandParseClusterConfiguration(cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	app.DefineInputOutputRenderFlags(cmd)
+
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		ctx := kpcontext.ExtractContext(c)
+
+		var err error
+		var metaConfig *config.MetaConfig
+
+		logger := log.GetDefaultLogger()
+
+		preparatorProvider := infrastructureprovider.MetaConfigPreparatorProvider(
+			infrastructureprovider.NewPreparatorProviderParams(logger),
+		)
+
+		// Should be fixed in kingpin repo or shell-operator and others should migrate to github.com/alecthomas/kingpin.
+		// https://github.com/flant/kingpin/pull/1
+		// replace gopkg.in/alecthomas/kingpin.v2 => github.com/flant/kingpin is not working
+		if app.ParseInputFile == "" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("read configs from stdin: %v", err)
+			}
+
+			metaConfig, err = config.ParseConfigFromData(
+				ctx,
+				string(data),
+				preparatorProvider,
+				app.GetDirConfig(),
+				config.ValidateOptionStrictUnmarshal(true),
+			)
+			if err != nil {
+				return err
+			}
+		} else {
+			metaConfig, err = config.ParseConfig(ctx, []string{app.ParseInputFile}, preparatorProvider, app.GetDirConfig())
+			if err != nil {
+				return err
+			}
+		}
+
+		output := metaConfig.MarshalFullConfig()
+		switch app.ParseOutput {
+		case "yaml":
+			output, _ = yaml.JSONToYAML(output)
+		case "json":
+		default:
+			return fmt.Errorf("unknown output type: %s", app.ParseOutput)
+		}
+
+		fmt.Print(string(output))
+		return nil
+	})
+}
+
+func DefineCommandParseCloudDiscoveryData(cmd *kingpin.CmdClause) *kingpin.CmdClause {
+	app.DefineInputOutputRenderFlags(cmd)
+
+	return cmd.Action(func(c *kingpin.ParseContext) error {
+		_ = kpcontext.ExtractContext(c)
+
+		var err error
+		var data []byte
+
+		if app.ParseInputFile == "" {
+			data, err = io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("read cloud-discovery-data from stdin: %v", err)
+			}
+		} else {
+			data, err = os.ReadFile(app.ParseInputFile)
+			if err != nil {
+				return fmt.Errorf("loading input file: %v", err)
+			}
+		}
+
+		schemaStore := config.NewSchemaStore(app.GetDirConfig())
+		_, err = schemaStore.Validate(&data)
+		if err != nil {
+			return fmt.Errorf("validate cloud_discovery_data: %v", err)
+		}
+
+		var output []byte
+		switch app.ParseOutput {
+		case "yaml":
+			output, _ = yaml.JSONToYAML(data)
+		case "json":
+			output = data
+		default:
+			return fmt.Errorf("unknown output type: %s", app.ParseOutput)
+		}
+
+		fmt.Print(string(output))
+		return nil
+	})
+}

--- a/deckhouse-controller/pkg/helpers/register.go
+++ b/deckhouse-controller/pkg/helpers/register.go
@@ -20,7 +20,6 @@ import (
 
 	changeregistry "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers/change_registry"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers/jwt"
-	dhctlapp "github.com/deckhouse/deckhouse/dhctl/cmd/dhctl/commands"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -53,10 +52,4 @@ func DefineHelperCommands(kpApp *kingpin.Application, logger *log.Logger) {
 			return changeregistry.ChangeRegistry(*newRegistry, *user, *password, *caFile, *newImageTag, *scheme, *dryRun, logger)
 		})
 	}
-
-	// dhctl parser for ClusterConfiguration and <Provider-name>ClusterConfiguration secrets
-	cmd := kpApp.Command("cluster-configuration", "Parse configuration and print it.")
-	dhctlapp.DefineCommandParseClusterConfiguration(cmd)
-	cmd = kpApp.Command("cloud-discovery-data", "Parse cloud discovery data and print it.")
-	dhctlapp.DefineCommandParseCloudDiscoveryData(cmd)
 }

--- a/tools/check-dhctl-cmd-drift.sh
+++ b/tools/check-dhctl-cmd-drift.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
+
+# Copyright 2026 Flant JSC
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Verify dhctl/cmd/dhctl/commands/{edit,config}.go bodies match
 # deckhouse-controller/internal/dhctlcli copies (whitespace-insensitive).
 # On drift, update both files in the same PR.

--- a/tools/check-dhctl-cmd-drift.sh
+++ b/tools/check-dhctl-cmd-drift.sh
@@ -37,9 +37,11 @@ extract_body() {
     ' "$file"
 }
 
-# Strip whitespace so reformatting alone does not trigger drift.
+# Strip //nolint:... directives (the duplicate may need them while the dhctl
+# source doesn't, since the root module's golangci-lint config is stricter)
+# and whitespace so reformatting alone does not trigger drift.
 normalize() {
-    tr -d '[:space:]'
+    sed 's|//nolint:.*||' | tr -d '[:space:]'
 }
 
 fail=0

--- a/tools/check-dhctl-cmd-drift.sh
+++ b/tools/check-dhctl-cmd-drift.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Verify dhctl/cmd/dhctl/commands/{edit,config}.go bodies match
+# deckhouse-controller/internal/dhctlcli copies (whitespace-insensitive).
+# On drift, update both files in the same PR.
+#
+# Exit: 0 in sync, 1 drift, 2 missing source files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DHCTL_EDIT="$REPO_ROOT/dhctl/cmd/dhctl/commands/edit.go"
+DHCTL_CONFIG="$REPO_ROOT/dhctl/cmd/dhctl/commands/config.go"
+DC_EDIT="$REPO_ROOT/deckhouse-controller/internal/dhctlcli/edit_commands.go"
+DC_PARSE="$REPO_ROOT/deckhouse-controller/internal/dhctlcli/parse_config_commands.go"
+
+for f in "$DHCTL_EDIT" "$DHCTL_CONFIG" "$DC_EDIT" "$DC_PARSE"; do
+    if [ ! -f "$f" ]; then
+        echo "ERROR: required file not found: $f" >&2
+        exit 2
+    fi
+done
+
+# Body of fn: lines between "func fn(" and the closing "}" at column 0.
+# Declaration is skipped so signature reformatting doesn't trigger drift.
+extract_body() {
+    local file="$1"
+    local fn="$2"
+    awk -v fn="$fn" '
+        $0 ~ "^func " fn "\\(" { in_fn = 1; next }
+        in_fn {
+            if ($0 == "}") exit
+            print
+        }
+    ' "$file"
+}
+
+# Strip whitespace so reformatting alone does not trigger drift.
+normalize() {
+    tr -d '[:space:]'
+}
+
+fail=0
+check() {
+    local fn="$1"
+    local src_file="$2"
+    local dst_file="$3"
+
+    local src_body dst_body
+    src_body=$(extract_body "$src_file" "$fn" | normalize)
+    dst_body=$(extract_body "$dst_file" "$fn" | normalize)
+
+    if [ -z "$src_body" ]; then
+        echo "FAIL: source function $fn not found in $src_file" >&2
+        fail=1
+        return
+    fi
+    if [ -z "$dst_body" ]; then
+        echo "FAIL: duplicate function $fn not found in $dst_file" >&2
+        fail=1
+        return
+    fi
+
+    if [ "$src_body" = "$dst_body" ]; then
+        echo "OK:   $fn"
+    else
+        echo "FAIL: $fn drifted between $src_file and $dst_file" >&2
+        echo "----- diff (source ↔ duplicate) -----" >&2
+        diff -u \
+            <(extract_body "$src_file" "$fn") \
+            <(extract_body "$dst_file" "$fn") || true
+        echo "------------------------------------" >&2
+        fail=1
+    fi
+}
+
+# edit.go ↔ internal/dhctlcli/edit_commands.go
+check "DefineEditCommands"                            "$DHCTL_EDIT"   "$DC_EDIT"
+check "connectionFlags"                               "$DHCTL_EDIT"   "$DC_EDIT"
+check "baseEditConfigCMD"                             "$DHCTL_EDIT"   "$DC_EDIT"
+check "DefineEditClusterConfigurationCommand"         "$DHCTL_EDIT"   "$DC_EDIT"
+check "DefineEditProviderClusterConfigurationCommand" "$DHCTL_EDIT"   "$DC_EDIT"
+check "DefineEditStaticClusterConfigurationCommand"   "$DHCTL_EDIT"   "$DC_EDIT"
+
+# config.go ↔ internal/dhctlcli/parse_config_commands.go
+check "DefineCommandParseClusterConfiguration"        "$DHCTL_CONFIG" "$DC_PARSE"
+check "DefineCommandParseCloudDiscoveryData"          "$DHCTL_CONFIG" "$DC_PARSE"
+
+if [ $fail -eq 0 ]; then
+    echo ""
+    echo "All dhctl ↔ deckhouse-controller command-builder copies are in sync."
+else
+    echo "" >&2
+    echo "Drift detected. Update both files in the same PR (the dhctl source and" >&2
+    echo "the deckhouse-controller duplicate)." >&2
+fi
+exit $fail


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Duplicate the three CLI command builders inherited from dhctl/cmd/dhctl/commands (DefineEditCommands, DefineCommandParseClusterConfiguration, DefineCommandParseCloudDiscoveryData) into deckhouse-controller/internal/dhctlcli/, and drop the dhctl/cmd/dhctl/commands and dhctl/pkg/app imports from cmd/deckhouse-controller/main.go. Kingpin flag defaults are seeded via DHCTL_CLI_* env variables that dhctl/pkg/app already binds through Envar(...). New tools/check-dhctl-cmd-drift.sh (wired into make lint-all) guards the duplicates against silent drift.

User-visible CLI surface is unchanged.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Make deckhouse-controller own its CLI command builders explicitly instead of silently inheriting them from dhctl. After this change, any divergence between the controller and dhctl is an intentional, reviewable act rather than a side effect of an upstream edit.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Decouple from dhctl/cmd/commands.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
