### PR TITLE
[service-with-healthchecks] Add RBACv1 roles for ServiceWithHealthchecks

### DIFF
--- a/ee/modules/610-service-with-healthchecks/templates/user-authz-cluster-roles.yaml
+++ b/ee/modules/610-service-with-healthchecks/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:{{ .Chart.Name }}:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - network.deckhouse.io
+  resources:
+  - servicewithhealthchecks
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Editor
+  name: d8:user-authz:{{ .Chart.Name }}:editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - network.deckhouse.io
+  resources:
+  - servicewithhealthchecks
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update


### PR DESCRIPTION
## Description

This PR adds RBACv1 cluster roles for the `ServiceWithHealthchecks` resource. It enables integration with the `user-authz` module's high-level authorization model by adding annotations for `User` and `Editor` access levels.

```bash
kubectl get clusterrole d8:user-authz:service-with-healthchecks:user d8:user-authz:service-with-healthchecks:editor
NAME                                             CREATED AT
d8:user-authz:service-with-healthchecks:user     2026-05-06T12:10:41Z
d8:user-authz:service-with-healthchecks:editor   2026-05-06T12:10:41Z
```

## Why do we need it, and what problem does it solve?

Previously, the `ServiceWithHealthchecks` resource was not covered by the standard Deckhouse authorization roles. Users with the `User` role could not view these resources for diagnostics, and users with the `Editor` role could not manage them in their namespaces. This change aligns the resource access with the standard `Service` resource permissions.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: service-with-healthchecks
type: feature
summary: Added RBACv1 roles (User and Editor) for ServiceWithHealthchecks resource.
impact_level: default
```