### PR TITLE
[deckhouse] sync maintenance label from ModuleConfig to Module

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/module.go
@@ -93,6 +93,10 @@ const (
 
 	ExperimentalModuleStage = "Experimental"
 	DeprecatedModuleStage   = "Deprecated"
+
+	// ModuleLabelMaintenance is set on a Module when the corresponding
+	// ModuleConfig has spec.maintenance set to a non-empty value.
+	ModuleLabelMaintenance = "module.deckhouse.io/maintenance"
 )
 
 var (

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -582,21 +582,27 @@ func (r *reconciler) enableModule(ctx context.Context, module *v1alpha1.Module) 
 func (r *reconciler) syncMaintenanceLabel(ctx context.Context, module *v1alpha1.Module, maintenance string) error {
 	labels := module.GetLabels()
 	current, hasLabel := labels[v1alpha1.ModuleLabelMaintenance]
-	if maintenance == "" && !hasLabel || maintenance != "" && current == maintenance {
+
+	if maintenance == "" {
+		if !hasLabel {
+			return nil
+		}
+
+		patch := client.MergeFrom(module.DeepCopy())
+		delete(labels, v1alpha1.ModuleLabelMaintenance)
+		module.SetLabels(labels)
+		return r.client.Patch(ctx, module, patch)
+	}
+
+	if current == maintenance {
 		return nil
 	}
 
 	patch := client.MergeFrom(module.DeepCopy())
-	if labels == nil && maintenance != "" {
+	if labels == nil {
 		labels = make(map[string]string)
 	}
-
-	if maintenance != "" {
-		labels[v1alpha1.ModuleLabelMaintenance] = maintenance
-	} else {
-		delete(labels, v1alpha1.ModuleLabelMaintenance)
-	}
-
+	labels[v1alpha1.ModuleLabelMaintenance] = maintenance
 	module.SetLabels(labels)
 	return r.client.Patch(ctx, module, patch)
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -251,6 +251,12 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.ModuleConfig, module *v1alpha1.Module) (ctrl.Result, error) {
 	defer r.logger.Debug("module config reconciled", slog.String("name", moduleConfig.Name))
 
+	// sync maintenance label from ModuleConfig to Module
+	if err := r.syncMaintenanceLabel(ctx, module, moduleConfig.Spec.Maintenance); err != nil {
+		r.logger.Error("failed to sync maintenance label", slog.String("module", module.Name), log.Err(err))
+		return ctrl.Result{}, err
+	}
+
 	// clear conflict metrics
 	metricGroup := fmt.Sprintf(metrics.ModuleConflictMetricGroupTemplate, module.Name)
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricGroup)
@@ -439,6 +445,12 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 		return ctrl.Result{}, err
 	}
 
+	// clear the maintenance label when ModuleConfig is deleted
+	if err := r.syncMaintenanceLabel(ctx, module, ""); err != nil {
+		r.logger.Error("failed to clear maintenance label", slog.String("module", module.Name), log.Err(err))
+		return ctrl.Result{}, err
+	}
+
 	// skip system modules
 	if module.Name == moduleDeckhouse || module.Name == moduleGlobal {
 		r.logger.Debug("skip system module", slog.String("name", module.Name))
@@ -563,5 +575,30 @@ func (r *reconciler) enableModule(ctx context.Context, module *v1alpha1.Module) 
 		module.SetConditionTrue(v1alpha1.ModuleConditionEnabledByModuleConfig)
 
 		return true
+	})
+}
+
+func (r *reconciler) syncMaintenanceLabel(ctx context.Context, module *v1alpha1.Module, maintenance string) error {
+	return utils.Update[*v1alpha1.Module](ctx, r.client, module, func(m *v1alpha1.Module) bool {
+		labels := m.GetLabels()
+		if maintenance != "" {
+			if labels == nil {
+				labels = make(map[string]string)
+			}
+			if labels[v1alpha1.ModuleLabelMaintenance] != maintenance {
+				labels[v1alpha1.ModuleLabelMaintenance] = maintenance
+				m.SetLabels(labels)
+				return true
+			}
+		} else {
+			if labels != nil {
+				if _, ok := labels[v1alpha1.ModuleLabelMaintenance]; ok {
+					delete(labels, v1alpha1.ModuleLabelMaintenance)
+					m.SetLabels(labels)
+					return true
+				}
+			}
+		}
+		return false
 	})
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -251,6 +251,11 @@ func (r *reconciler) handleModuleConfig(ctx context.Context, moduleConfig *v1alp
 func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.ModuleConfig, module *v1alpha1.Module) (ctrl.Result, error) {
 	defer r.logger.Debug("module config reconciled", slog.String("name", moduleConfig.Name))
 
+	if err := r.addFinalizer(ctx, moduleConfig); err != nil {
+		r.logger.Error("failed to add finalizer", slog.String("module", module.Name), log.Err(err))
+		return ctrl.Result{}, err
+	}
+
 	// sync maintenance label from ModuleConfig to Module
 	if err := r.syncMaintenanceLabel(ctx, module, moduleConfig.Spec.Maintenance); err != nil {
 		r.logger.Error("failed to sync maintenance label", slog.String("module", module.Name), log.Err(err))
@@ -260,11 +265,6 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 	// clear conflict metrics
 	metricGroup := fmt.Sprintf(metrics.ModuleConflictMetricGroupTemplate, module.Name)
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricGroup)
-
-	if err := r.addFinalizer(ctx, moduleConfig); err != nil {
-		r.logger.Error("failed to add finalizer", slog.String("module", module.Name), log.Err(err))
-		return ctrl.Result{}, err
-	}
 
 	if !moduleConfig.IsEnabled() {
 		// delete all pending releases for EnabledByModuleConfig disabled modules

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -578,27 +578,25 @@ func (r *reconciler) enableModule(ctx context.Context, module *v1alpha1.Module) 
 	})
 }
 
+// syncMaintenanceLabel patches only the Module maintenance label used by UI.
 func (r *reconciler) syncMaintenanceLabel(ctx context.Context, module *v1alpha1.Module, maintenance string) error {
-	return utils.Update[*v1alpha1.Module](ctx, r.client, module, func(m *v1alpha1.Module) bool {
-		labels := m.GetLabels()
-		if maintenance != "" {
-			if labels == nil {
-				labels = make(map[string]string)
-			}
-			if labels[v1alpha1.ModuleLabelMaintenance] != maintenance {
-				labels[v1alpha1.ModuleLabelMaintenance] = maintenance
-				m.SetLabels(labels)
-				return true
-			}
-		} else {
-			if labels != nil {
-				if _, ok := labels[v1alpha1.ModuleLabelMaintenance]; ok {
-					delete(labels, v1alpha1.ModuleLabelMaintenance)
-					m.SetLabels(labels)
-					return true
-				}
-			}
-		}
-		return false
-	})
+	labels := module.GetLabels()
+	current, hasLabel := labels[v1alpha1.ModuleLabelMaintenance]
+	if maintenance == "" && !hasLabel || maintenance != "" && current == maintenance {
+		return nil
+	}
+
+	patch := client.MergeFrom(module.DeepCopy())
+	if labels == nil && maintenance != "" {
+		labels = make(map[string]string)
+	}
+
+	if maintenance != "" {
+		labels[v1alpha1.ModuleLabelMaintenance] = maintenance
+	} else {
+		delete(labels, v1alpha1.ModuleLabelMaintenance)
+	}
+
+	module.SetLabels(labels)
+	return r.client.Patch(ctx, module, patch)
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
@@ -277,26 +277,29 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 		_, err := suite.r.handleModuleConfig(context.TODO(), suite.moduleConfig("test-module"))
 		require.NoError(suite.T(), err)
 	})
+
+	suite.Run("set maintenance label", func() {
+		suite.setupTestController(string(suite.parseTestdata("set-maintenance-label.yaml")))
+		_, err := suite.r.handleModuleConfig(context.TODO(), suite.moduleConfig("test-module"))
+		require.NoError(suite.T(), err)
+	})
+
+	suite.Run("clear maintenance label", func() {
+		suite.setupTestController(string(suite.parseTestdata("clear-maintenance-label.yaml")))
+		_, err := suite.r.handleModuleConfig(context.TODO(), suite.moduleConfig("test-module"))
+		require.NoError(suite.T(), err)
+	})
 }
 
 func (suite *ControllerTestSuite) TestDeleteReconcile() {
-	suite.Run("simple delete test", func() {
-		m := `
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: test-module
-  finalizers:
-  - modules.deckhouse.io/module-registered
-  deletionTimestamp: "2024-01-01T00:00:00Z"
-spec:
-  enabled: true
-`
-		suite.setupTestController(m)
+	suite.Run("delete clears maintenance label", func() {
+		suite.setupTestController(string(suite.parseTestdata("delete-maintenance-label.yaml")))
 
-		config := suite.moduleConfig("test-module")
-		assert.NotNil(suite.T(), config.DeletionTimestamp)
-		assert.Len(suite.T(), config.Finalizers, 1)
+		_, err := suite.r.deleteModuleConfig(context.TODO(), suite.moduleConfig("test-module"))
+		require.NoError(suite.T(), err)
+
+		module := suite.module("test-module")
+		assert.NotContains(suite.T(), module.Labels, v1alpha1.ModuleLabelMaintenance)
 	})
 }
 
@@ -316,6 +319,14 @@ func (suite *ControllerTestSuite) moduleConfig(name string) *v1alpha1.ModuleConf
 	require.NoError(suite.T(), err)
 
 	return config
+}
+
+func (suite *ControllerTestSuite) module(name string) *v1alpha1.Module {
+	module := new(v1alpha1.Module)
+	err := suite.client.Get(context.TODO(), types.NamespacedName{Name: name}, module)
+	require.NoError(suite.T(), err)
+
+	return module
 }
 
 // Mock implementations

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller_test.go
@@ -292,6 +292,25 @@ func (suite *ControllerTestSuite) TestCreateReconcile() {
 }
 
 func (suite *ControllerTestSuite) TestDeleteReconcile() {
+	suite.Run("simple delete test", func() {
+		m := `
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module
+  finalizers:
+  - modules.deckhouse.io/module-registered
+  deletionTimestamp: "2024-01-01T00:00:00Z"
+spec:
+  enabled: true
+`
+		suite.setupTestController(m)
+
+		config := suite.moduleConfig("test-module")
+		assert.NotNil(suite.T(), config.DeletionTimestamp)
+		assert.Len(suite.T(), config.Finalizers, 1)
+	})
+
 	suite.Run("delete clears maintenance label", func() {
 		suite.setupTestController(string(suite.parseTestdata("delete-maintenance-label.yaml")))
 

--- a/deckhouse-controller/pkg/controller/module-controllers/config/testdata/clear-maintenance-label.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/testdata/clear-maintenance-label.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module
+spec:
+  enabled: true
+  updatePolicy: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module
+  labels:
+    module.deckhouse.io/maintenance: NoResourceReconciliation
+properties:
+  availableSources:
+    - test-source
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "False"

--- a/deckhouse-controller/pkg/controller/module-controllers/config/testdata/delete-maintenance-label.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/testdata/delete-maintenance-label.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module
+  finalizers:
+    - modules.deckhouse.io/module-registered
+  deletionTimestamp: "2024-01-01T00:00:00Z"
+spec:
+  enabled: true
+  maintenance: NoResourceReconciliation
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module
+  labels:
+    module.deckhouse.io/maintenance: NoResourceReconciliation
+status:
+  phase: Available

--- a/deckhouse-controller/pkg/controller/module-controllers/config/testdata/golden/clear-maintenance-label.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/testdata/golden/clear-maintenance-label.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/module-registered
+  name: test-module
+  resourceVersion: "1001"
+spec:
+  enabled: true
+  updatePolicy: Auto
+status:
+  message: ""
+  version: "1"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  creationTimestamp: null
+  name: test-module
+  resourceVersion: "1002"
+properties:
+  availableSources:
+  - test-source
+  source: test-source
+  updatePolicy: Auto
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleConfig
+  phase: Available

--- a/deckhouse-controller/pkg/controller/module-controllers/config/testdata/golden/set-maintenance-label.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/testdata/golden/set-maintenance-label.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - modules.deckhouse.io/module-registered
+  name: test-module
+  resourceVersion: "1001"
+spec:
+  enabled: true
+  maintenance: NoResourceReconciliation
+  updatePolicy: Auto
+status:
+  message: ""
+  version: "1"
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  creationTimestamp: null
+  labels:
+    module.deckhouse.io/maintenance: NoResourceReconciliation
+  name: test-module
+  resourceVersion: "1002"
+properties:
+  availableSources:
+  - test-source
+  source: test-source
+  updatePolicy: Auto
+status:
+  conditions:
+  - lastProbeTime: null
+    lastTransitionTime: null
+    status: "True"
+    type: EnabledByModuleConfig
+  phase: Available

--- a/deckhouse-controller/pkg/controller/module-controllers/config/testdata/set-maintenance-label.yaml
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/testdata/set-maintenance-label.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: test-module
+spec:
+  enabled: true
+  maintenance: NoResourceReconciliation
+  updatePolicy: Auto
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: Module
+metadata:
+  name: test-module
+properties:
+  availableSources:
+    - test-source
+status:
+  phase: Available
+  conditions:
+    - type: EnabledByModuleConfig
+      status: "False"


### PR DESCRIPTION
## Description

When ModuleConfig.spec.maintenance is set, the config controller now syncs a corresponding label to the Module resource.

## Why do we need it, and what problem does it solve?

The UI currently has no way to know whether a module is in maintenance mode without scraping metrics. By adding a `module.deckhouse.io/maintenance` label on the Module CR, the UI can simply read the label to render the maintenance state.

## Example

**Set maintenance mode:**

```console
$ kubectl patch moduleconfig commander-agent --type=merge \
    -p '{"spec":{"maintenance":"NoResourceReconciliation"}}'
```
```
moduleconfig.deckhouse.io/commander-agent patched
```

**Check the label on Module:**

```console
$ kubectl get module commander-agent -o yaml | grep -B1 -A3 "labels:"
```
```
metadata:
  labels:
    module.deckhouse.io/maintenance: NoResourceReconciliation
  name: commander-agent
```

**Clear maintenance mode:**

```console
$ kubectl patch moduleconfig commander-agent --type=merge \
    -p '{"spec":{"maintenance":null}}'
```
```
moduleconfig.deckhouse.io/commander-agent patched
```

**Verify the label is gone:**

```console
$ kubectl get module commander-agent -o yaml | grep "labels:"
```
```
(no output — labels field removed)
```

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: >
  Sync ModuleConfig.spec.maintenance as a `module.deckhouse.io/maintenance` label on the Module CR for UI consumption.
```