### PR TITLE
[metallb] Add RBACv1 roles for MetalLoadBalancerClass

### DIFF
--- a/ee/se/modules/380-metallb/templates/user-authz-cluster-roles.yaml
+++ b/ee/se/modules/380-metallb/templates/user-authz-cluster-roles.yaml
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: ClusterEditor
+    user-authz.deckhouse.io/access-level: ClusterAdmin
   name: d8:user-authz:{{ .Chart.Name }}:cluster-editor
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:

--- a/ee/se/modules/380-metallb/templates/user-authz-cluster-roles.yaml
+++ b/ee/se/modules/380-metallb/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:{{ .Chart.Name }}:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - network.deckhouse.io
+  resources:
+  - metalloadbalancerclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterEditor
+  name: d8:user-authz:{{ .Chart.Name }}:cluster-editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - network.deckhouse.io
+  resources:
+  - metalloadbalancerclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/ee/se/modules/380-metallb/templates/user-authz-cluster-roles.yaml
+++ b/ee/se/modules/380-metallb/templates/user-authz-cluster-roles.yaml
@@ -21,7 +21,7 @@ kind: ClusterRole
 metadata:
   annotations:
     user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:{{ .Chart.Name }}:cluster-editor
+  name: d8:user-authz:{{ .Chart.Name }}:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:


### PR DESCRIPTION
## Description

This PR adds RBACv1 cluster roles for the `MetalLoadBalancerClass` resource. It integrates the resource with the `user-authz` module's high-level authorization model by adding annotations for `User` and `ClusterAdmin` access levels.

## Why do we need it, and what problem does it solve?

Previously, the `MetalLoadBalancerClass` resource was not covered by the standard Deckhouse authorization roles. Users with the `User` role could not view available load balancer classes for their services, and cluster administrators could not manage them using high-level roles. This change provides necessary visibility for users and management capabilities for cluster operators.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: metallb
type: feature
summary: Added RBACv1 roles (User and ClusterAdmin) for MetalLoadBalancerClass resource.
impact_level: default
```