### PR TITLE
[cni-cilium] Add RBACv1 roles for HubbleMonitoringConfig

### DIFF
--- a/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
+++ b/modules/021-cni-cilium/templates/user-authz-cluster-roles.yaml
@@ -26,6 +26,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - deckhouse.io
+  resources:
+  - hubblemonitoringconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
@@ -67,6 +75,16 @@ rules:
   resources:
   - egressgateways
   - egressgatewaypolicies
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - hubblemonitoringconfigs
   verbs:
   - create
   - delete


### PR DESCRIPTION
## Description

This PR adds RBACv1 cluster roles for the `HubbleMonitoringConfig` resource within the `cni-cilium` module. It integrates the resource with the `user-authz` high-level authorization model by adding necessary permissions to the `User` (read-only) and `ClusterEditor` (read-write) access levels.

```bash
kubectl get clusterrole d8:user-authz:cni-cilium:user d8:user-authz:cni-cilium:cluster-editor
NAME                                      CREATED AT
d8:user-authz:cni-cilium:user             2026-03-18T08:00:19Z
d8:user-authz:cni-cilium:cluster-editor   2026-04-16T12:21:59Z
```

## Why do we need it, and what problem does it solve?

Previously, the `HubbleMonitoringConfig` resource was not covered by the standard Deckhouse authorization roles. This meant that users with the `User` role could not view the Hubble monitoring configuration, and cluster administrators could not manage it using standard high-level roles. This update provides better observability for users and standard management capabilities for cluster operators.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: feature
summary: Added RBACv1 roles (User and ClusterEditor) for HubbleMonitoringConfig resource.
impact_level: default
```