### PR TITLE
feat(cert-manager): add Gateway API ListenerSet feature toggles

### DIFF
--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -146,6 +146,7 @@ properties:
     x-examples: [true, false]
     description: |
       Enable ListenerSet support in cert-manager Gateway API integration.
+      This flag is considered only when Gateway API integration is enabled.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -146,6 +146,7 @@ properties:
     x-examples: [true, false]
     description: |
       Enable ListenerSet support in cert-manager by turning on the `ListenerSets` feature gate.
+
       Additionally, when Gateway API integration is enabled, this flag also enables ListenerSet integration for Gateway API.
 
   ingressClassHttp01:

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -148,7 +148,6 @@ properties:
       Enable ListenerSet support in cert-manager by turning on the `ListenerSets` feature gate.
 
       Additionally, when Gateway API integration is enabled, this flag also enables ListenerSet integration for Gateway API.
-
   ingressClassHttp01:
     type: string
     x-examples: ["nginx"]

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -1,8 +1,5 @@
 type: object
 description: The module does not have any mandatory parameters.
-x-kubernetes-validations:
-  - rule: "self.enableGatewayAPIListenerSet == false || self.enableGatewayAPI == true"
-    message: "enableGatewayAPI must be enabled when enableGatewayAPIListenerSet is set to true"
 properties:
   nodeSelector:
     type: object
@@ -143,31 +140,12 @@ properties:
       Enable CAInjector. It only needs to inject CA certs into `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`, `CustomResourceDefinition` and `APIService`.
       Deckhouse does not use CAInjector, so you have to enable it only if you use custom CA injections in your services.
 
-  enableGatewayAPI:
+  enableListenerSet:
     type: boolean
     default: false
     x-examples: [true, false]
     description: |
-      Enable support for Gateway API in cert-manager.
-
-  enableGatewayAPIListenerSet:
-    type: boolean
-    default: false
-    x-examples: [true, false]
-    description: |
-      Enable support for ListenerSet in cert-manager Gateway API integration.
-      Requires `enableGatewayAPI: true`.
-
-  featureGates:
-    type: object
-    default: {}
-    properties:
-      ListenerSets:
-        type: boolean
-        default: false
-        x-examples: [true, false]
-        description: |
-          Enable cert-manager `ListenerSets` feature gate.
+      Enable ListenerSet support in cert-manager Gateway API integration.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -1,5 +1,8 @@
 type: object
 description: The module does not have any mandatory parameters.
+x-kubernetes-validations:
+  - rule: "self.enableGatewayAPIListenerSet == false || self.enableGatewayAPI == true"
+    message: "enableGatewayAPI must be enabled when enableGatewayAPIListenerSet is set to true"
 properties:
   nodeSelector:
     type: object
@@ -139,6 +142,32 @@ properties:
     description: |
       Enable CAInjector. It only needs to inject CA certs into `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`, `CustomResourceDefinition` and `APIService`.
       Deckhouse does not use CAInjector, so you have to enable it only if you use custom CA injections in your services.
+
+  enableGatewayAPI:
+    type: boolean
+    default: false
+    x-examples: [true, false]
+    description: |
+      Enable support for Gateway API in cert-manager.
+
+  enableGatewayAPIListenerSet:
+    type: boolean
+    default: false
+    x-examples: [true, false]
+    description: |
+      Enable support for ListenerSet in cert-manager Gateway API integration.
+      Requires `enableGatewayAPI: true`.
+
+  featureGates:
+    type: object
+    default: {}
+    properties:
+      ListenerSets:
+        type: boolean
+        default: false
+        x-examples: [true, false]
+        description: |
+          Enable cert-manager `ListenerSets` feature gate.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/openapi/config-values.yaml
+++ b/modules/101-cert-manager/openapi/config-values.yaml
@@ -145,8 +145,8 @@ properties:
     default: false
     x-examples: [true, false]
     description: |
-      Enable ListenerSet support in cert-manager Gateway API integration.
-      This flag is considered only when Gateway API integration is enabled.
+      Enable ListenerSet support in cert-manager by turning on the `ListenerSets` feature gate.
+      Additionally, when Gateway API integration is enabled, this flag also enables ListenerSet integration for Gateway API.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -62,22 +62,9 @@ properties:
       Включить CAInjector. Он необходим только для инъекции CA-сертификатов в `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`, `CustomResourceDefinition` и `APIService`.
       Deckhouse не использует CAInjector, поэтому включать нужно только в том случае, если вы используете в своих сервисах пользовательские инъекции CA.
 
-  enableGatewayAPI:
-    description: |
-      Включить поддержку Gateway API в cert-manager.
-
-  enableGatewayAPIListenerSet:
+  enableListenerSet:
     description: |
       Включить поддержку ListenerSet в интеграции cert-manager с Gateway API.
-      Требует `enableGatewayAPI: true`.
-
-  featureGates:
-    description: |
-      Набор feature gate для cert-manager.
-    properties:
-      ListenerSets:
-        description: |
-          Включить feature gate `ListenerSets` в cert-manager.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -65,7 +65,8 @@ properties:
   enableListenerSet:
     description: |
       Включить поддержку ListenerSet в cert-manager через feature gate `ListenerSets`.
-      Дополнительно, если включена интеграция Gateway API, этот флаг включает интеграцию ListenerSet для Gateway API.
+
+      Также включает интеграцию ListenerSet для Gateway API, если включена интеграция Gateway API.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -67,7 +67,6 @@ properties:
       Включить поддержку ListenerSet в cert-manager через feature gate `ListenerSets`.
 
       Также включает интеграцию ListenerSet для Gateway API, если включена интеграция Gateway API.
-
   ingressClassHttp01:
     type: string
     x-examples: ["nginx"]

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -62,6 +62,23 @@ properties:
       Включить CAInjector. Он необходим только для инъекции CA-сертификатов в `ValidatingWebhookConfiguration`, `MutatingWebhookConfiguration`, `CustomResourceDefinition` и `APIService`.
       Deckhouse не использует CAInjector, поэтому включать нужно только в том случае, если вы используете в своих сервисах пользовательские инъекции CA.
 
+  enableGatewayAPI:
+    description: |
+      Включить поддержку Gateway API в cert-manager.
+
+  enableGatewayAPIListenerSet:
+    description: |
+      Включить поддержку ListenerSet в интеграции cert-manager с Gateway API.
+      Требует `enableGatewayAPI: true`.
+
+  featureGates:
+    description: |
+      Набор feature gate для cert-manager.
+    properties:
+      ListenerSets:
+        description: |
+          Включить feature gate `ListenerSets` в cert-manager.
+
   ingressClassHttp01:
     type: string
     x-examples: ["nginx"]

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -65,6 +65,7 @@ properties:
   enableListenerSet:
     description: |
       Включить поддержку ListenerSet в интеграции cert-manager с Gateway API.
+      Флаг учитывается только при включенной интеграции Gateway API.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/101-cert-manager/openapi/doc-ru-config-values.yaml
@@ -64,8 +64,8 @@ properties:
 
   enableListenerSet:
     description: |
-      Включить поддержку ListenerSet в интеграции cert-manager с Gateway API.
-      Флаг учитывается только при включенной интеграции Gateway API.
+      Включить поддержку ListenerSet в cert-manager через feature gate `ListenerSets`.
+      Дополнительно, если включена интеграция Gateway API, этот флаг включает интеграцию ListenerSet для Gateway API.
 
   ingressClassHttp01:
     type: string

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -581,4 +581,25 @@ namespace: d8-ingress-gateway
 			Expect(args).To(ContainSubstring("--enable-gateway-api-listenerset=true"))
 		})
 	})
+
+	Context("<ListenerSet feature gate without Gateway API>", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValuesManagedHa)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("certManager", certManager+certManagerGatewayAPI)
+			f.HelmRender()
+		})
+
+		It("should enable ListenerSets feature gate only", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			certManagerDeployment := f.KubernetesResource("Deployment", "d8-cert-manager", "cert-manager")
+			Expect(certManagerDeployment.Exists()).To(BeTrue())
+
+			args := certManagerDeployment.Field("spec.template.spec.containers.0.args").String()
+			Expect(args).To(ContainSubstring("--feature-gates=ACMEHTTP01IngressPathTypeExact=false,ListenerSets=true"))
+			Expect(args).NotTo(ContainSubstring("--enable-gateway-api=true"))
+			Expect(args).NotTo(ContainSubstring("--enable-gateway-api-listenerset=true"))
+		})
+	})
 })

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -102,6 +102,13 @@ internal:
     crt: string
 `
 
+const certManagerGatewayAPI = `
+enableGatewayAPI: true
+enableGatewayAPIListenerSet: true
+featureGates:
+  ListenerSets: true
+`
+
 const cloudDNS = `
 cloudDNSServiceAccount: ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsCiAgInByb2plY3RfaWQiOiAicHJvamVjdC0yMDkzMTciLAogICJwcml2YXRlX2tleV9pZCI6ICJwcml2YXRlX2lkIiwKICAicHJpdmF0ZV9rZXkiOiAicHJpdmF0ZV9rZXkiLAogICJjbGllbnRfZW1haWwiOiAiZG5zMDEtc29sdmVyQHByb2plY3QtMjA5MzE3LmlhbS5nc2VydmljZWFjY291bnQuY29tIiwKICAiY2xpZW50X2lkIjogIjExNzM1MzAzMzgzOTQ2NTUzNjY3MiIsCiAgImF1dGhfdXJpIjogImh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi9hdXRoIiwKICAidG9rZW5fdXJpIjogImh0dHBzOi8vb2F1dGgyLmdvb2dsZWFwaXMuY29tL3Rva2VuIiwKICAiYXV0aF9wcm92aWRlcl94NTA5X2NlcnRfdXJsIjogImh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL29hdXRoMi92MS9jZXJ0cyIsCiAgImNsaWVudF94NTA5X2NlcnRfdXJsIjogImh0dHBzOi8vd3d3Lmdvb2dsZWFwaXMuY29tL3JvYm90L3YxL21ldGFkYXRhL3g1MDkvZG5zMDEtc29sdmVyJXByb2plY3QtMjA5MzE3LmlhbS5nc2VydmljZWFjY291bnQuY29tIgp9Cg==
 `
@@ -550,5 +557,31 @@ podAntiAffinity:
 
 		})
 
+	})
+
+	Context("<Gateway API and ListenerSet flags>", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValuesManagedHa)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("global.discovery.gatewayAPIDefaultGateway", `
+name: shared-gateway
+namespace: d8-ingress-gateway
+`)
+			f.ValuesSetFromYaml("global.discovery.apiVersions", `["gateway.networking.k8s.io/v1/Gateway","gateway.networking.k8s.io/v1/HTTPRoute"]`)
+			f.ValuesSetFromYaml("certManager", certManager+certManagerGatewayAPI)
+			f.HelmRender()
+		})
+
+		It("should render gateway and listenerset arguments", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			certManagerDeployment := f.KubernetesResource("Deployment", "d8-cert-manager", "cert-manager")
+			Expect(certManagerDeployment.Exists()).To(BeTrue())
+
+			args := certManagerDeployment.Field("spec.template.spec.containers.0.args").String()
+			Expect(args).To(ContainSubstring("--feature-gates=ACMEHTTP01IngressPathTypeExact=false,ListenerSets=true"))
+			Expect(args).To(ContainSubstring("--enable-gateway-api=true"))
+			Expect(args).To(ContainSubstring("--enable-gateway-api-listenerset=true"))
+		})
 	})
 })

--- a/modules/101-cert-manager/template_tests/module_test.go
+++ b/modules/101-cert-manager/template_tests/module_test.go
@@ -103,10 +103,7 @@ internal:
 `
 
 const certManagerGatewayAPI = `
-enableGatewayAPI: true
-enableGatewayAPIListenerSet: true
-featureGates:
-  ListenerSets: true
+enableListenerSet: true
 `
 
 const cloudDNS = `

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -1,5 +1,9 @@
 {{- $moduleGateway := dict }}
 {{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
+{{- $featureGates := list "ACMEHTTP01IngressPathTypeExact=false" }}
+{{- if and .Values.certManager.featureGates .Values.certManager.featureGates.ListenerSets }}
+  {{- $featureGates = append $featureGates "ListenerSets=true" }}
+{{- end }}
 {{- define "cert_manager_resources" }}
 cpu: 10m
 memory: 25Mi
@@ -65,7 +69,7 @@ spec:
           - --v=1
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)
-          - --feature-gates=ACMEHTTP01IngressPathTypeExact=false # TODO: Remove after update ingress-nginx up to v1.13.2+ and v1.12.6+
+          - --feature-gates={{ join "," $featureGates }} # TODO: Remove ACMEHTTP01IngressPathTypeExact after update ingress-nginx up to v1.13.2+ and v1.12.6+
           - "--acme-http01-solver-image={{ include "helm_lib_module_image" (list . "certManagerAcmeSolver") }}"
           {{- if $.Values.certManager.maxConcurrentChallenges }}
           - --max-concurrent-challenges={{ $.Values.certManager.maxConcurrentChallenges }}
@@ -87,8 +91,11 @@ spec:
           {{- end }}
 {{- end }}
 {{- end }}
-{{- if and $moduleGateway (include "helm_lib_kind_exists" (list . "Gateway")) (include "helm_lib_kind_exists" (list . "HTTPRoute")) }}
+{{- if and $.Values.certManager.enableGatewayAPI $moduleGateway }}
           - --enable-gateway-api=true
+{{- end }}
+{{- if and $.Values.certManager.enableGatewayAPIListenerSet $.Values.certManager.enableGatewayAPI $moduleGateway }}
+          - --enable-gateway-api-listenerset=true
 {{- end }}
           ports:
             - containerPort: 9402

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -4,7 +4,7 @@
 {{- $httpRouteKindExists := or (include "helm_lib_kind_exists" (list . "HTTPRoute")) ((.Values.global.discovery.apiVersions | default list) | has "gateway.networking.k8s.io/v1/HTTPRoute") }}
 {{- $gatewayAPIEnabled := and $moduleGateway $gatewayKindExists $httpRouteKindExists }}
 {{- $featureGates := list "ACMEHTTP01IngressPathTypeExact=false" }}
-{{- if and .Values.certManager.enableListenerSet $gatewayAPIEnabled }}
+{{- if .Values.certManager.enableListenerSet }}
   {{- $featureGates = append $featureGates "ListenerSets=true" }}
 {{- end }}
 {{- define "cert_manager_resources" }}

--- a/modules/101-cert-manager/templates/cert-manager/deployment.yaml
+++ b/modules/101-cert-manager/templates/cert-manager/deployment.yaml
@@ -1,7 +1,10 @@
 {{- $moduleGateway := dict }}
 {{- include "helm_lib_module_gateway" (list . $moduleGateway) }}
+{{- $gatewayKindExists := or (include "helm_lib_kind_exists" (list . "Gateway")) ((.Values.global.discovery.apiVersions | default list) | has "gateway.networking.k8s.io/v1/Gateway") }}
+{{- $httpRouteKindExists := or (include "helm_lib_kind_exists" (list . "HTTPRoute")) ((.Values.global.discovery.apiVersions | default list) | has "gateway.networking.k8s.io/v1/HTTPRoute") }}
+{{- $gatewayAPIEnabled := and $moduleGateway $gatewayKindExists $httpRouteKindExists }}
 {{- $featureGates := list "ACMEHTTP01IngressPathTypeExact=false" }}
-{{- if and .Values.certManager.featureGates .Values.certManager.featureGates.ListenerSets }}
+{{- if and .Values.certManager.enableListenerSet $gatewayAPIEnabled }}
   {{- $featureGates = append $featureGates "ListenerSets=true" }}
 {{- end }}
 {{- define "cert_manager_resources" }}
@@ -91,10 +94,10 @@ spec:
           {{- end }}
 {{- end }}
 {{- end }}
-{{- if and $.Values.certManager.enableGatewayAPI $moduleGateway }}
+{{- if $gatewayAPIEnabled }}
           - --enable-gateway-api=true
 {{- end }}
-{{- if and $.Values.certManager.enableGatewayAPIListenerSet $.Values.certManager.enableGatewayAPI $moduleGateway }}
+{{- if and $.Values.certManager.enableListenerSet $gatewayAPIEnabled }}
           - --enable-gateway-api-listenerset=true
 {{- end }}
           ports:


### PR DESCRIPTION
## Description

This PR adds explicit configuration switches to the `cert-manager` module to control Gateway API and ListenerSet-related behavior:

- `settings.enableGatewayAPI`
- `settings.enableGatewayAPIListenerSet`
- `settings.featureGates.ListenerSets`

These settings are wired to cert-manager controller arguments and covered by template tests.

> Note: Changing these settings affects cert-manager Deployment args and may trigger a cert-manager pod restart.

## Why do we need it, and what problem does it solve?

Some users need ListenerSet-based workflows with Gateway API (e.g., app teams should be able to request certificates without direct edits of infrastructure-owned Gateway resources).

Before this change:
- Gateway API behavior was not fully controlled via module settings.
- ListenerSet feature gate could not be explicitly toggled from module config.

After this change:
- Operators can explicitly enable Gateway API integration in cert-manager.
- Operators can explicitly enable ListenerSet support and corresponding feature gate.
- Configuration becomes predictable and suitable for partner/customer scenarios that require ListenerSets.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cert-manager
type: feature
summary: Added cert-manager module settings to control Gateway API, Gateway API ListenerSet mode, and ListenerSets feature gate.
impact: Cert-manager Deployment args become configurable via module settings; changing these settings may restart cert-manager pods.
impact_level: default