### PR TITLE
[dhctl] Wait for stronghold cluster sync before node deletion

### DIFF
--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -78,6 +78,7 @@ func NewHookForUpdatePipeline(
 	}
 
 	checkers = append(checkers, NewManagerReadinessChecker(kubeGetter))
+	checkers = append(checkers, NewStrongholdReadinessChecker(kubeGetter))
 	checker := NewChecker(nodeToHostForChecks, checkers, "", DefaultConfirm)
 
 	return &HookForUpdatePipeline{
@@ -221,6 +222,22 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 	err = waitEtcdHasMember(ctx, kubeClient.KubeClient.(libcon.KubeClient), h.nodeToConverge)
 	if err != nil {
 		return fmt.Errorf("failed to wait for the master node '%s' to be listed as etcd cluster member: %w", h.nodeToConverge, err)
+	}
+
+	err = retry.NewLoop("Check Stronghold readiness after node converge", 45, 10*time.Second).RunContext(ctx, func() error {
+		ready, err := NewStrongholdReadinessChecker(h.kubeGetter).IsReady(ctx, h.nodeToConverge)
+		if err != nil {
+			return fmt.Errorf("failed to check Stronghold readiness: %w", err)
+		}
+
+		if !ready {
+			return hook.ErrNotReady
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return retry.NewLoop(fmt.Sprintf("Check control-plane is ready on node '%s'", h.nodeToConverge), 45, 10*time.Second).RunContext(ctx, func() error {

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/stronghold.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/stronghold.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+const (
+	strongholdNamespace   = "d8-stronghold"
+	strongholdStatefulSet = "stronghold"
+)
+
+type StrongholdReadinessChecker struct {
+	getter kubernetes.KubeClientProviderWithCtx
+}
+
+func NewStrongholdReadinessChecker(getter kubernetes.KubeClientProviderWithCtx) *StrongholdReadinessChecker {
+	return &StrongholdReadinessChecker{
+		getter: getter,
+	}
+}
+
+// IsReady checks that all replicas of the Stronghold StatefulSet are ready.
+// The nodeName parameter is ignored because the check is cluster-wide.
+// Returns true (skip) when the d8-stronghold namespace or the StatefulSet does not exist.
+func (c *StrongholdReadinessChecker) IsReady(ctx context.Context, _ string) (bool, error) {
+	kubeClient, err := c.getter.KubeClientCtx(ctx)
+	if err != nil {
+		return false, fmt.Errorf("could not get kube client: %w", err)
+	}
+
+	_, err = kubeClient.CoreV1().Namespaces().Get(ctx, strongholdNamespace, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.DebugLn("Namespace d8-stronghold not found, skipping Stronghold readiness check")
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to check d8-stronghold namespace: %w", err)
+	}
+
+	sts, err := kubeClient.AppsV1().StatefulSets(strongholdNamespace).Get(ctx, strongholdStatefulSet, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.DebugLn("StatefulSet stronghold not found in d8-stronghold namespace, skipping readiness check")
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to get Stronghold StatefulSet: %w", err)
+	}
+
+	desired := int32(1)
+	if sts.Spec.Replicas != nil {
+		desired = *sts.Spec.Replicas
+	}
+	ready := sts.Status.ReadyReplicas
+
+	if ready < desired {
+		log.InfoF("Stronghold StatefulSet: %d/%d replicas ready\n", ready, desired)
+		return false, nil
+	}
+
+	log.InfoF("Stronghold StatefulSet is ready (%d/%d replicas)\n", ready, desired)
+	return true, nil
+}
+
+func (c *StrongholdReadinessChecker) Name() string {
+	return "Stronghold readiness"
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Wait for stronghold cluster sync before node deletion

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When recreating cluster nodes, the stronghold may not yet be fully synchronized, but the node is already being deleted. This means all data may be lost, as it is stored on the node's disk.
Checking the stronghold cluster status will prevent the node from being deleted along with its data.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Wait for stronghold cluster sync before node deletion
impact_level: default
```
<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
