### PR TITLE
[CI] Fixing the definition of WERF repositories in workflow build_and_test_release

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -173,9 +173,30 @@ steps:
       REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
 
     {!{- if eq $buildType "release" }!}
+      declare -A WERF_SECONDARY_REPOS=(
+        ["ce"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ce"
+        ["ee"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ee"
+        ["fe"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/fe"
+        [se]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se"
+        [se-plus]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se-plus"
+        [be]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/be"
+      )
+    
       STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
       export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
       export WERF_REPO="${STAGE_REGISTRY_PATH}"
+
+      # Set up WERF_SECONDARY_REPO_1, WERF_SECONDARY_REPO_2, etc. Because werf needs cache from other editions.
+      # Exclude current edition from the list.
+      repo_number=0
+      for edition in "${!WERF_SECONDARY_REPOS[@]}"; do
+        if [ "${REGISTRY_SUFFIX}" == "${edition}" ]; then
+          continue
+        else
+          repo_number=$((repo_number+1))
+          export WERF_SECONDARY_REPO_${repo_number}="${WERF_SECONDARY_REPOS[${edition}]}"
+        fi
+      done
     {!{- else }!}
       DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
       export REGISTRY_PATH="${DEV_REGISTRY_PATH}"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -483,9 +483,30 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          declare -A WERF_SECONDARY_REPOS=(
+            ["ce"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ce"
+            ["ee"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ee"
+            ["fe"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/fe"
+            [se]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se"
+            [se-plus]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se-plus"
+            [be]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/be"
+          )
+
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
+
+          # Set up WERF_SECONDARY_REPO_1, WERF_SECONDARY_REPO_2, etc. Because werf needs cache from other editions.
+          # Exclude current edition from the list.
+          repo_number=0
+          for edition in "${!WERF_SECONDARY_REPOS[@]}"; do
+            if [ "${REGISTRY_SUFFIX}" == "${edition}" ]; then
+              continue
+            else
+              repo_number=$((repo_number+1))
+              export WERF_SECONDARY_REPO_${repo_number}="${WERF_SECONDARY_REPOS[${edition}]}"
+            fi
+          done
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -808,9 +829,30 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          declare -A WERF_SECONDARY_REPOS=(
+            ["ce"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ce"
+            ["ee"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ee"
+            ["fe"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/fe"
+            [se]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se"
+            [se-plus]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se-plus"
+            [be]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/be"
+          )
+
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
+
+          # Set up WERF_SECONDARY_REPO_1, WERF_SECONDARY_REPO_2, etc. Because werf needs cache from other editions.
+          # Exclude current edition from the list.
+          repo_number=0
+          for edition in "${!WERF_SECONDARY_REPOS[@]}"; do
+            if [ "${REGISTRY_SUFFIX}" == "${edition}" ]; then
+              continue
+            else
+              repo_number=$((repo_number+1))
+              export WERF_SECONDARY_REPO_${repo_number}="${WERF_SECONDARY_REPOS[${edition}]}"
+            fi
+          done
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -1133,9 +1175,30 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          declare -A WERF_SECONDARY_REPOS=(
+            ["ce"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ce"
+            ["ee"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ee"
+            ["fe"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/fe"
+            [se]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se"
+            [se-plus]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se-plus"
+            [be]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/be"
+          )
+
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
+
+          # Set up WERF_SECONDARY_REPO_1, WERF_SECONDARY_REPO_2, etc. Because werf needs cache from other editions.
+          # Exclude current edition from the list.
+          repo_number=0
+          for edition in "${!WERF_SECONDARY_REPOS[@]}"; do
+            if [ "${REGISTRY_SUFFIX}" == "${edition}" ]; then
+              continue
+            else
+              repo_number=$((repo_number+1))
+              export WERF_SECONDARY_REPO_${repo_number}="${WERF_SECONDARY_REPOS[${edition}]}"
+            fi
+          done
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -1446,9 +1509,30 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          declare -A WERF_SECONDARY_REPOS=(
+            ["ce"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ce"
+            ["ee"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ee"
+            ["fe"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/fe"
+            [se]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se"
+            [se-plus]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se-plus"
+            [be]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/be"
+          )
+
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
+
+          # Set up WERF_SECONDARY_REPO_1, WERF_SECONDARY_REPO_2, etc. Because werf needs cache from other editions.
+          # Exclude current edition from the list.
+          repo_number=0
+          for edition in "${!WERF_SECONDARY_REPOS[@]}"; do
+            if [ "${REGISTRY_SUFFIX}" == "${edition}" ]; then
+              continue
+            else
+              repo_number=$((repo_number+1))
+              export WERF_SECONDARY_REPO_${repo_number}="${WERF_SECONDARY_REPOS[${edition}]}"
+            fi
+          done
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -1759,9 +1843,30 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          declare -A WERF_SECONDARY_REPOS=(
+            ["ce"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ce"
+            ["ee"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ee"
+            ["fe"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/fe"
+            [se]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se"
+            [se-plus]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se-plus"
+            [be]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/be"
+          )
+
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
+
+          # Set up WERF_SECONDARY_REPO_1, WERF_SECONDARY_REPO_2, etc. Because werf needs cache from other editions.
+          # Exclude current edition from the list.
+          repo_number=0
+          for edition in "${!WERF_SECONDARY_REPOS[@]}"; do
+            if [ "${REGISTRY_SUFFIX}" == "${edition}" ]; then
+              continue
+            else
+              repo_number=$((repo_number+1))
+              export WERF_SECONDARY_REPO_${repo_number}="${WERF_SECONDARY_REPOS[${edition}]}"
+            fi
+          done
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -2072,9 +2177,30 @@ jobs:
 
           # CE/EE/FE -> ce/ee/fe
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
+          declare -A WERF_SECONDARY_REPOS=(
+            ["ce"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ce"
+            ["ee"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/ee"
+            ["fe"]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/fe"
+            [se]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se"
+            [se-plus]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/se-plus"
+            [be]="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/be"
+          )
+
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
           export WERF_REPO="${STAGE_REGISTRY_PATH}"
+
+          # Set up WERF_SECONDARY_REPO_1, WERF_SECONDARY_REPO_2, etc. Because werf needs cache from other editions.
+          # Exclude current edition from the list.
+          repo_number=0
+          for edition in "${!WERF_SECONDARY_REPOS[@]}"; do
+            if [ "${REGISTRY_SUFFIX}" == "${edition}" ]; then
+              continue
+            else
+              repo_number=$((repo_number+1))
+              export WERF_SECONDARY_REPO_${repo_number}="${WERF_SECONDARY_REPOS[${edition}]}"
+            fi
+          done
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fixing the definition of WERF repositories in workflow build_and_test_release
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
