### PR TITLE
[node-managet] mcm annotaion len fix

### DIFF
--- a/modules/040-node-manager/hooks/trim_machine_set_revision_history.go
+++ b/modules/040-node-manager/hooks/trim_machine_set_revision_history.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+const (
+	mcmMachineSetAPIVersion               = "machine.sapcloud.io/v1alpha1"
+	mcmMachineSetRevisionHistoryKey       = "deployment.kubernetes.io/revision-history"
+	mcmMachineSetRevisionHistoryMaxLength = 16
+)
+
+type mcmMachineSetRevisionHistory struct {
+	Name            string
+	Namespace       string
+	RevisionHistory string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/trim_machine_set_revision_history",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                   "mcm_machinesets",
+			ApiVersion:             mcmMachineSetAPIVersion,
+			Kind:                   "MachineSet",
+			WaitForSynchronization: ptr.To(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-cloud-instance-manager"},
+				},
+			},
+			FilterFunc: mcmMachineSetRevisionHistoryFilter,
+		},
+	},
+}, handleTrimMachineSetRevisionHistory)
+
+func mcmMachineSetRevisionHistoryFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	annotations := obj.GetAnnotations()
+
+	return mcmMachineSetRevisionHistory{
+		Name:            obj.GetName(),
+		Namespace:       obj.GetNamespace(),
+		RevisionHistory: annotations[mcmMachineSetRevisionHistoryKey],
+	}, nil
+}
+
+func handleTrimMachineSetRevisionHistory(_ context.Context, input *go_hook.HookInput) error {
+	snaps := input.Snapshots.Get("mcm_machinesets")
+
+	for ms, err := range sdkobjectpatch.SnapshotIter[mcmMachineSetRevisionHistory](snaps) {
+		if err != nil {
+			return fmt.Errorf("iterate MachineSet snapshots: %w", err)
+		}
+
+		if len(ms.RevisionHistory) <= mcmMachineSetRevisionHistoryMaxLength {
+			continue
+		}
+
+		revisionHistory := trimMachineSetRevisionHistory(ms.RevisionHistory)
+		if revisionHistory == ms.RevisionHistory {
+			continue
+		}
+
+		patch := map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]string{
+					mcmMachineSetRevisionHistoryKey: revisionHistory,
+				},
+			},
+		}
+
+		input.PatchCollector.PatchWithMerge(patch, mcmMachineSetAPIVersion, "MachineSet", ms.Namespace, ms.Name)
+	}
+
+	return nil
+}
+
+func trimMachineSetRevisionHistory(revisionHistory string) string {
+	firstRevision, _, _ := strings.Cut(revisionHistory, ",")
+
+	return firstRevision
+}

--- a/modules/040-node-manager/hooks/trim_machine_set_revision_history_test.go
+++ b/modules/040-node-manager/hooks/trim_machine_set_revision_history_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node-manager :: hooks :: trim_machine_set_revision_history ::", func() {
+	const machineSets = `
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: long-revision-history
+  namespace: d8-cloud-instance-manager
+  annotations:
+    deployment.kubernetes.io/revision-history: "1,2,3,4,5,6,7,8,9"
+    other-annotation: value
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: short-revision-history
+  namespace: d8-cloud-instance-manager
+  annotations:
+    deployment.kubernetes.io/revision-history: "1,2,3"
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: boundary-revision-history
+  namespace: d8-cloud-instance-manager
+  annotations:
+    deployment.kubernetes.io/revision-history: "1,2,3,4,5,6,7,8"
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: long-revision-history-without-comma
+  namespace: d8-cloud-instance-manager
+  annotations:
+    deployment.kubernetes.io/revision-history: "12345678901234567"
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: empty-revision-history
+  namespace: d8-cloud-instance-manager
+  annotations:
+    deployment.kubernetes.io/revision-history: ""
+---
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineSet
+metadata:
+  name: absent-revision-history
+  namespace: d8-cloud-instance-manager
+`
+
+	f := HookExecutionConfigInit(`{"nodeManager":{"internal":{}}}`, `{}`)
+	f.RegisterCRD("machine.sapcloud.io", "v1alpha1", "MachineSet", true)
+
+	Context("Cluster with MachineSets", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(machineSets))
+			f.RunHook()
+		})
+
+		It("trims long revision history and keeps short or absent values unchanged", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			longMachineSet := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "long-revision-history")
+			Expect(longMachineSet.Field(`metadata.annotations.deployment\.kubernetes\.io\/revision-history`).String()).To(Equal("1"))
+			Expect(longMachineSet.Field(`metadata.annotations.other-annotation`).String()).To(Equal("value"))
+
+			shortMachineSet := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "short-revision-history")
+			Expect(shortMachineSet.Field(`metadata.annotations.deployment\.kubernetes\.io\/revision-history`).String()).To(Equal("1,2,3"))
+
+			boundaryMachineSet := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "boundary-revision-history")
+			Expect(boundaryMachineSet.Field(`metadata.annotations.deployment\.kubernetes\.io\/revision-history`).String()).To(Equal("1,2,3,4,5,6,7,8"))
+
+			longWithoutCommaMachineSet := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "long-revision-history-without-comma")
+			Expect(longWithoutCommaMachineSet.Field(`metadata.annotations.deployment\.kubernetes\.io\/revision-history`).String()).To(Equal("12345678901234567"))
+
+			emptyMachineSet := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "empty-revision-history")
+			Expect(emptyMachineSet.Field(`metadata.annotations.deployment\.kubernetes\.io\/revision-history`).String()).To(Equal(""))
+
+			absentMachineSet := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "absent-revision-history")
+			Expect(absentMachineSet.Field(`metadata.annotations.deployment\.kubernetes\.io\/revision-history`).Exists()).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
## Description

Added a node-manager hook that watches MCM `MachineSet` resources and trims too long `deployment.kubernetes.io/revision-history` annotation.

## Why do we need it, and what problem does it solve?

In some cases MCM `MachineSet` stores a very large list of revisions in the `deployment.kubernetes.io/revision-history` annotation. This can make the object too large and block normal controller work.
The new hook keeps this annotation small by leaving only the first revision when the value becomes too long.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary:  Added cleanup for oversized MCM MachineSet revision history annotation
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
