### PR TITLE
[cloud-provider-vsphere] Wrong device path from tf

### DIFF
--- a/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
@@ -40,31 +40,6 @@ function get_data_device_secret() {
   fi
 }
 
-function normalize_disk_path_case() {
-  local path="$1"
-  local dir base candidate
-
-  if [ -b "$path" ]; then
-    printf '%s\n' "$path"
-    return 0
-  fi
-
-  dir="$(dirname "$path")"
-  base="$(basename "$path")"
-
-  if ! [ -d "$dir" ]; then
-    return 1
-  fi
-
-  candidate="$(find "$dir" -maxdepth 1 -type l -iname "$base" -print -quit 2>/dev/null)"
-  if [ -n "$candidate" ] && [ -b "$candidate" ]; then
-    printf '%s\n' "$candidate"
-    return 0
-  fi
-
-  return 1
-}
-
 if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]]; then
   exit 0
 fi
@@ -81,11 +56,6 @@ else
     >&2 echo "failed to get data device path"
     exit 1
   fi
-fi
-
-NORMALIZED_DATA_DEVICE="$(normalize_disk_path_case "$DATA_DEVICE")" || true
-if [ -n "$NORMALIZED_DATA_DEVICE" ]; then
-  DATA_DEVICE="$NORMALIZED_DATA_DEVICE"
 fi
 
 {{- /*

--- a/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
@@ -40,6 +40,31 @@ function get_data_device_secret() {
   fi
 }
 
+function normalize_disk_path_case() {
+  local path="$1"
+  local dir base candidate
+
+  if [ -b "$path" ]; then
+    printf '%s\n' "$path"
+    return 0
+  fi
+
+  dir="$(dirname "$path")"
+  base="$(basename "$path")"
+
+  if ! [ -d "$dir" ]; then
+    return 1
+  fi
+
+  candidate="$(find "$dir" -maxdepth 1 -type l -iname "$base" -print -quit 2>/dev/null)"
+  if [ -n "$candidate" ] && [ -b "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
 if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]]; then
   exit 0
 fi
@@ -56,6 +81,11 @@ else
     >&2 echo "failed to get data device path"
     exit 1
   fi
+fi
+
+NORMALIZED_DATA_DEVICE="$(normalize_disk_path_case "$DATA_DEVICE")" || true
+if [ -n "$NORMALIZED_DATA_DEVICE" ]; then
+  DATA_DEVICE="$NORMALIZED_DATA_DEVICE"
 fi
 
 {{- /*

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/candi/terraform-modules/master-node/outputs.tf
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/candi/terraform-modules/master-node/outputs.tf
@@ -5,7 +5,7 @@ locals {
     for disk in vsphere_virtual_machine.master.disk :
     disk.uuid if disk.label == "disk1"
   ]
-  kubernetes_data_device_uuid = replace(length(local.kubernetes_data_device_uuid_list) > 0 ? local.kubernetes_data_device_uuid_list[0] : "", "-", "")
+  kubernetes_data_device_uuid = lower(replace(length(local.kubernetes_data_device_uuid_list) > 0 ? local.kubernetes_data_device_uuid_list[0] : "", "-", ""))
   kubernetes_data_device_path = local.kubernetes_data_device_uuid != "" ? "/dev/disk/by-id/wwn-0x${local.kubernetes_data_device_uuid}" : "/dev/sdb"
 }
 
@@ -20,4 +20,3 @@ output "node_internal_ip_address" {
 output "kubernetes_data_device_path" {
   value = local.kubernetes_data_device_path
 }
-


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The change normalizes new paths and makes bashible resolve existing paths case-insensitively.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Without this fix, converge can fail on master nodes because bashible cannot find the Kubernetes data disk even though the device is present on the host. This breaks bootstrap/update flows for vSphere clusters after the disk mapping change introduced in #17859.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
This should go into a patch release because it is a regression that affects existing vSphere installations and can block converge of control-plane nodes.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-vsphere
type: fix
summary: normalizes new paths and makes bashible resolve existing paths case-insensitively
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
