### PR TITLE
[node-manager] capi InfrastructureRef recover hook

### DIFF
--- a/modules/040-node-manager/hooks/set_api_version_on_machine.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine.go
@@ -31,23 +31,23 @@ import (
 )
 
 const (
-	capiMachineAPIVersion = "cluster.x-k8s.io/v1beta2"
+	capiMachineAPIVersion = "cluster.x-k8s.io/v1beta1"
 )
 
-var capiMachineAPIGroups = map[string]string{
-	"DynamixMachine":     capiInfrastructureAPIGroup,
-	"HuaweiCloudMachine": capiInfrastructureAPIGroup,
-	"VCDMachine":         capiInfrastructureAPIGroup,
-	"ZvirtMachine":       capiInfrastructureAPIGroup,
-	"DeckhouseMachine":   capiInfrastructureAPIGroup,
-	"StaticMachine":      capiInfrastructureAPIGroup,
+var capiMachineAPIVersions = map[string]string{
+	"DynamixMachine":     capiInfrastructureAPIVersion,
+	"HuaweiCloudMachine": capiInfrastructureAPIVersion,
+	"VCDMachine":         capiInfrastructureAPIVersion,
+	"ZvirtMachine":       capiInfrastructureAPIVersion,
+	"DeckhouseMachine":   capiInfrastructureAPIVersion,
+	"StaticMachine":      capiInfrastructureAPIVersion,
 }
 
 type machineInfrastructureRef struct {
-	Name      string
-	Namespace string
-	Kind      string
-	APIGroup  string
+	Name       string
+	Namespace  string
+	Kind       string
+	APIVersion string
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -70,13 +70,13 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func capiMachineInfrastructureRefFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "infrastructureRef", "kind")
-	apiGroup, _, _ := unstructured.NestedString(obj.Object, "spec", "infrastructureRef", "apiGroup")
+	apiVersion, _, _ := unstructured.NestedString(obj.Object, "spec", "infrastructureRef", "apiVersion")
 
 	return machineInfrastructureRef{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		Kind:      kind,
-		APIGroup:  apiGroup,
+		Name:       obj.GetName(),
+		Namespace:  obj.GetNamespace(),
+		Kind:       kind,
+		APIVersion: apiVersion,
 	}, nil
 }
 
@@ -88,25 +88,25 @@ func handleSetMachineInfrastructureAPIVersion(_ context.Context, input *go_hook.
 			return fmt.Errorf("failed to iterate over Machine snapshots: %w", err)
 		}
 
-		apiGroup, ok := capiMachineAPIGroups[machine.Kind]
+		apiVersion, ok := capiMachineAPIVersions[machine.Kind]
 		if !ok {
 			input.Logger.Warn("unknown infrastructure machine kind", slog.String("machine", machine.Name), slog.String("kind", machine.Kind))
 			continue
 		}
 
-		if machine.APIGroup == apiGroup {
+		if machine.APIVersion == apiVersion {
 			continue
 		}
 
-		if machine.APIGroup != "" {
-			input.Logger.Debug("infrastructureRef.apiGroup already set", slog.String("machine", machine.Name), slog.String("apiGroup", machine.APIGroup))
+		if machine.APIVersion != "" {
+			input.Logger.Debug("infrastructureRef.apiVersion already set", slog.String("machine", machine.Name), slog.String("apiVersion", machine.APIVersion))
 			continue
 		}
 
 		patch := map[string]interface{}{
 			"spec": map[string]interface{}{
 				"infrastructureRef": map[string]interface{}{
-					"apiGroup": apiGroup,
+					"apiVersion": apiVersion,
 				},
 			},
 		}

--- a/modules/040-node-manager/hooks/set_api_version_on_machine.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+const (
+	capiMachineAPIVersion = "cluster.x-k8s.io/v1beta2"
+)
+
+var capiMachineAPIGroups = map[string]string{
+	"DynamixMachine":     capiInfrastructureAPIGroup,
+	"HuaweiCloudMachine": capiInfrastructureAPIGroup,
+	"VCDMachine":         capiInfrastructureAPIGroup,
+	"ZvirtMachine":       capiInfrastructureAPIGroup,
+	"DeckhouseMachine":   capiInfrastructureAPIGroup,
+	"StaticMachine":      capiInfrastructureAPIGroup,
+}
+
+type machineInfrastructureRef struct {
+	Name      string
+	Namespace string
+	Kind      string
+	APIGroup  string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/set_api_version_on_machine",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                   "capi_machines",
+			ApiVersion:             capiMachineAPIVersion,
+			Kind:                   "Machine",
+			WaitForSynchronization: ptr.To(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-cloud-instance-manager"},
+				},
+			},
+			FilterFunc: capiMachineInfrastructureRefFilter,
+		},
+	},
+}, handleSetMachineInfrastructureAPIVersion)
+
+func capiMachineInfrastructureRefFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "infrastructureRef", "kind")
+	apiGroup, _, _ := unstructured.NestedString(obj.Object, "spec", "infrastructureRef", "apiGroup")
+
+	return machineInfrastructureRef{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Kind:      kind,
+		APIGroup:  apiGroup,
+	}, nil
+}
+
+func handleSetMachineInfrastructureAPIVersion(_ context.Context, input *go_hook.HookInput) error {
+	snaps := input.Snapshots.Get("capi_machines")
+
+	for machine, err := range sdkobjectpatch.SnapshotIter[machineInfrastructureRef](snaps) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over Machine snapshots: %w", err)
+		}
+
+		apiGroup, ok := capiMachineAPIGroups[machine.Kind]
+		if !ok {
+			input.Logger.Warn("unknown infrastructure machine kind", slog.String("machine", machine.Name), slog.String("kind", machine.Kind))
+			continue
+		}
+
+		if machine.APIGroup == apiGroup {
+			continue
+		}
+
+		if machine.APIGroup != "" {
+			input.Logger.Debug("infrastructureRef.apiGroup already set", slog.String("machine", machine.Name), slog.String("apiGroup", machine.APIGroup))
+			continue
+		}
+
+		patch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"infrastructureRef": map[string]interface{}{
+					"apiGroup": apiGroup,
+				},
+			},
+		}
+
+		input.PatchCollector.PatchWithMerge(patch, capiMachineAPIVersion, "Machine", machine.Namespace, machine.Name)
+	}
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_deployment.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_deployment.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+const (
+	capiMachineDeploymentAPIVersion = "cluster.x-k8s.io/v1beta2"
+	capiInfrastructureAPIGroup      = "infrastructure.cluster.x-k8s.io"
+)
+
+var capiMachineTemplateAPIGroups = map[string]string{
+	"DynamixMachineTemplate":     capiInfrastructureAPIGroup,
+	"HuaweiCloudMachineTemplate": capiInfrastructureAPIGroup,
+	"VCDMachineTemplate":         capiInfrastructureAPIGroup,
+	"ZvirtMachineTemplate":       capiInfrastructureAPIGroup,
+	"DeckhouseMachineTemplate":   capiInfrastructureAPIGroup,
+	"StaticMachineTemplate":      capiInfrastructureAPIGroup,
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/set_api_version_on_machine_deployment",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                   "capi_mds",
+			ApiVersion:             capiMachineDeploymentAPIVersion,
+			Kind:                   "MachineDeployment",
+			WaitForSynchronization: ptr.To(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-cloud-instance-manager"},
+				},
+			},
+			FilterFunc: capiInfrastructureRefFilter,
+		},
+	},
+}, handleSetInfrastructureAPIVersion)
+
+type machineDeploymentInfrastructureRef struct {
+	Name      string
+	Namespace string
+	Kind      string
+	APIGroup  string
+}
+
+func capiInfrastructureRefFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "kind")
+	apiGroup, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "apiGroup")
+
+	return machineDeploymentInfrastructureRef{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Kind:      kind,
+		APIGroup:  apiGroup,
+	}, nil
+}
+
+func handleSetInfrastructureAPIVersion(_ context.Context, input *go_hook.HookInput) error {
+	snaps := input.Snapshots.Get("capi_mds")
+
+	for md, err := range sdkobjectpatch.SnapshotIter[machineDeploymentInfrastructureRef](snaps) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over MachineDeployment snapshots: %w", err)
+		}
+
+		apiGroup, ok := capiMachineTemplateAPIGroups[md.Kind]
+		if !ok {
+			input.Logger.Warn("unknown infrastructure template kind", slog.String("machinedeployment", md.Name), slog.String("kind", md.Kind))
+			continue
+		}
+
+		if md.APIGroup == apiGroup {
+			continue
+		}
+
+		if md.APIGroup != "" {
+			input.Logger.Debug("infrastructureRef.apiGroup already set", slog.String("machinedeployment", md.Name), slog.String("apiGroup", md.APIGroup))
+			continue
+		}
+
+		patch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"apiGroup": apiGroup,
+						},
+					},
+				},
+			},
+		}
+
+		input.PatchCollector.PatchWithMerge(patch, capiMachineDeploymentAPIVersion, "MachineDeployment", md.Namespace, md.Name)
+	}
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_deployment.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_deployment.go
@@ -31,17 +31,17 @@ import (
 )
 
 const (
-	capiMachineDeploymentAPIVersion = "cluster.x-k8s.io/v1beta2"
-	capiInfrastructureAPIGroup      = "infrastructure.cluster.x-k8s.io"
+	capiMachineDeploymentAPIVersion = "cluster.x-k8s.io/v1beta1"
+	capiInfrastructureAPIVersion    = "infrastructure.cluster.x-k8s.io/v1alpha1"
 )
 
-var capiMachineTemplateAPIGroups = map[string]string{
-	"DynamixMachineTemplate":     capiInfrastructureAPIGroup,
-	"HuaweiCloudMachineTemplate": capiInfrastructureAPIGroup,
-	"VCDMachineTemplate":         capiInfrastructureAPIGroup,
-	"ZvirtMachineTemplate":       capiInfrastructureAPIGroup,
-	"DeckhouseMachineTemplate":   capiInfrastructureAPIGroup,
-	"StaticMachineTemplate":      capiInfrastructureAPIGroup,
+var capiMachineTemplateAPIVersions = map[string]string{
+	"DynamixMachineTemplate":     capiInfrastructureAPIVersion,
+	"HuaweiCloudMachineTemplate": capiInfrastructureAPIVersion,
+	"VCDMachineTemplate":         capiInfrastructureAPIVersion,
+	"ZvirtMachineTemplate":       capiInfrastructureAPIVersion,
+	"DeckhouseMachineTemplate":   capiInfrastructureAPIVersion,
+	"StaticMachineTemplate":      capiInfrastructureAPIVersion,
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -63,21 +63,21 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 }, handleSetInfrastructureAPIVersion)
 
 type machineDeploymentInfrastructureRef struct {
-	Name      string
-	Namespace string
-	Kind      string
-	APIGroup  string
+	Name       string
+	Namespace  string
+	Kind       string
+	APIVersion string
 }
 
 func capiInfrastructureRefFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "kind")
-	apiGroup, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "apiGroup")
+	apiVersion, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "apiVersion")
 
 	return machineDeploymentInfrastructureRef{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		Kind:      kind,
-		APIGroup:  apiGroup,
+		Name:       obj.GetName(),
+		Namespace:  obj.GetNamespace(),
+		Kind:       kind,
+		APIVersion: apiVersion,
 	}, nil
 }
 
@@ -89,18 +89,18 @@ func handleSetInfrastructureAPIVersion(_ context.Context, input *go_hook.HookInp
 			return fmt.Errorf("failed to iterate over MachineDeployment snapshots: %w", err)
 		}
 
-		apiGroup, ok := capiMachineTemplateAPIGroups[md.Kind]
+		apiVersion, ok := capiMachineTemplateAPIVersions[md.Kind]
 		if !ok {
 			input.Logger.Warn("unknown infrastructure template kind", slog.String("machinedeployment", md.Name), slog.String("kind", md.Kind))
 			continue
 		}
 
-		if md.APIGroup == apiGroup {
+		if md.APIVersion == apiVersion {
 			continue
 		}
 
-		if md.APIGroup != "" {
-			input.Logger.Debug("infrastructureRef.apiGroup already set", slog.String("machinedeployment", md.Name), slog.String("apiGroup", md.APIGroup))
+		if md.APIVersion != "" {
+			input.Logger.Debug("infrastructureRef.apiVersion already set", slog.String("machinedeployment", md.Name), slog.String("apiVersion", md.APIVersion))
 			continue
 		}
 
@@ -109,7 +109,7 @@ func handleSetInfrastructureAPIVersion(_ context.Context, input *go_hook.HookInp
 				"template": map[string]interface{}{
 					"spec": map[string]interface{}{
 						"infrastructureRef": map[string]interface{}{
-							"apiGroup": apiGroup,
+							"apiVersion": apiVersion,
 						},
 					},
 				},

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_deployment_test.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_deployment_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node-manager :: hooks :: set_api_version_on_machine_deployment ::", func() {
+	const (
+		machineDeployments = `
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: empty
+  namespace: d8-cloud-instance-manager
+spec:
+  template:
+    spec:
+      infrastructureRef:
+        kind: HuaweiCloudMachineTemplate
+        name: template-empty
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: ready
+  namespace: d8-cloud-instance-manager
+spec:
+  template:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: HuaweiCloudMachineTemplate
+        name: template-ready
+`
+	)
+
+	f := HookExecutionConfigInit(`{"nodeManager": {"internal": {}}}`, `{}`)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta2", "MachineDeployment", true)
+
+	Context("Cluster with MachineDeployments", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(machineDeployments))
+			f.RunHook()
+		})
+
+		It("fills missing infrastructureRef apiGroup", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			mdEmpty := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "empty")
+			mdReady := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "ready")
+
+			Expect(mdEmpty.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+			Expect(mdReady.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+		})
+	})
+})

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_deployment_test.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_deployment_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Modules :: node-manager :: hooks :: set_api_version_on_machine
 	const (
 		machineDeployments = `
 ---
-apiVersion: cluster.x-k8s.io/v1beta2
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: empty
@@ -39,7 +39,7 @@ spec:
         kind: HuaweiCloudMachineTemplate
         name: template-empty
 ---
-apiVersion: cluster.x-k8s.io/v1beta2
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: ready
@@ -48,14 +48,14 @@ spec:
   template:
     spec:
       infrastructureRef:
-        apiGroup: infrastructure.cluster.x-k8s.io
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: HuaweiCloudMachineTemplate
         name: template-ready
 `
 	)
 
 	f := HookExecutionConfigInit(`{"nodeManager": {"internal": {}}}`, `{}`)
-	f.RegisterCRD("cluster.x-k8s.io", "v1beta2", "MachineDeployment", true)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta1", "MachineDeployment", true)
 
 	Context("Cluster with MachineDeployments", func() {
 		BeforeEach(func() {
@@ -63,13 +63,13 @@ spec:
 			f.RunHook()
 		})
 
-		It("fills missing infrastructureRef apiGroup", func() {
+		It("fills missing infrastructureRef apiVersion", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			mdEmpty := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "empty")
 			mdReady := f.KubernetesResource("MachineDeployment", "d8-cloud-instance-manager", "ready")
 
-			Expect(mdEmpty.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
-			Expect(mdReady.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+			Expect(mdEmpty.Field("spec.template.spec.infrastructureRef.apiVersion").String()).To(Equal("infrastructure.cluster.x-k8s.io/v1alpha1"))
+			Expect(mdReady.Field("spec.template.spec.infrastructureRef.apiVersion").String()).To(Equal("infrastructure.cluster.x-k8s.io/v1alpha1"))
 		})
 	})
 })

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_set.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_set.go
@@ -31,14 +31,14 @@ import (
 )
 
 const (
-	capiMachineSetAPIVersion = "cluster.x-k8s.io/v1beta2"
+	capiMachineSetAPIVersion = "cluster.x-k8s.io/v1beta1"
 )
 
 type machineSetInfrastructureRef struct {
-	Name      string
-	Namespace string
-	Kind      string
-	APIGroup  string
+	Name       string
+	Namespace  string
+	Kind       string
+	APIVersion string
 }
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -61,13 +61,13 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 
 func capiMachineSetInfrastructureRefFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "kind")
-	apiGroup, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "apiGroup")
+	apiVersion, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "apiVersion")
 
 	return machineSetInfrastructureRef{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-		Kind:      kind,
-		APIGroup:  apiGroup,
+		Name:       obj.GetName(),
+		Namespace:  obj.GetNamespace(),
+		Kind:       kind,
+		APIVersion: apiVersion,
 	}, nil
 }
 
@@ -79,18 +79,18 @@ func handleSetMachineSetInfrastructureAPIVersion(_ context.Context, input *go_ho
 			return fmt.Errorf("failed to iterate over MachineSet snapshots: %w", err)
 		}
 
-		apiGroup, ok := capiMachineTemplateAPIGroups[ms.Kind]
+		apiVersion, ok := capiMachineTemplateAPIVersions[ms.Kind]
 		if !ok {
 			input.Logger.Warn("unknown infrastructure template kind", slog.String("machineset", ms.Name), slog.String("kind", ms.Kind))
 			continue
 		}
 
-		if ms.APIGroup == apiGroup {
+		if ms.APIVersion == apiVersion {
 			continue
 		}
 
-		if ms.APIGroup != "" {
-			input.Logger.Debug("infrastructureRef.apiGroup already set", slog.String("machineset", ms.Name), slog.String("apiGroup", ms.APIGroup))
+		if ms.APIVersion != "" {
+			input.Logger.Debug("infrastructureRef.apiVersion already set", slog.String("machineset", ms.Name), slog.String("apiVersion", ms.APIVersion))
 			continue
 		}
 
@@ -99,7 +99,7 @@ func handleSetMachineSetInfrastructureAPIVersion(_ context.Context, input *go_ho
 				"template": map[string]interface{}{
 					"spec": map[string]interface{}{
 						"infrastructureRef": map[string]interface{}{
-							"apiGroup": apiGroup,
+							"apiVersion": apiVersion,
 						},
 					},
 				},

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_set.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_set.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+const (
+	capiMachineSetAPIVersion = "cluster.x-k8s.io/v1beta2"
+)
+
+type machineSetInfrastructureRef struct {
+	Name      string
+	Namespace string
+	Kind      string
+	APIGroup  string
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/set_api_version_on_machine_set",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:                   "capi_machinesets",
+			ApiVersion:             capiMachineSetAPIVersion,
+			Kind:                   "MachineSet",
+			WaitForSynchronization: ptr.To(false),
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{
+					MatchNames: []string{"d8-cloud-instance-manager"},
+				},
+			},
+			FilterFunc: capiMachineSetInfrastructureRefFilter,
+		},
+	},
+}, handleSetMachineSetInfrastructureAPIVersion)
+
+func capiMachineSetInfrastructureRefFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	kind, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "kind")
+	apiGroup, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "spec", "infrastructureRef", "apiGroup")
+
+	return machineSetInfrastructureRef{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+		Kind:      kind,
+		APIGroup:  apiGroup,
+	}, nil
+}
+
+func handleSetMachineSetInfrastructureAPIVersion(_ context.Context, input *go_hook.HookInput) error {
+	snaps := input.Snapshots.Get("capi_machinesets")
+
+	for ms, err := range sdkobjectpatch.SnapshotIter[machineSetInfrastructureRef](snaps) {
+		if err != nil {
+			return fmt.Errorf("failed to iterate over MachineSet snapshots: %w", err)
+		}
+
+		apiGroup, ok := capiMachineTemplateAPIGroups[ms.Kind]
+		if !ok {
+			input.Logger.Warn("unknown infrastructure template kind", slog.String("machineset", ms.Name), slog.String("kind", ms.Kind))
+			continue
+		}
+
+		if ms.APIGroup == apiGroup {
+			continue
+		}
+
+		if ms.APIGroup != "" {
+			input.Logger.Debug("infrastructureRef.apiGroup already set", slog.String("machineset", ms.Name), slog.String("apiGroup", ms.APIGroup))
+			continue
+		}
+
+		patch := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"infrastructureRef": map[string]interface{}{
+							"apiGroup": apiGroup,
+						},
+					},
+				},
+			},
+		}
+
+		input.PatchCollector.PatchWithMerge(patch, capiMachineSetAPIVersion, "MachineSet", ms.Namespace, ms.Name)
+	}
+
+	return nil
+}

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_set_test.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_set_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Modules :: node-manager :: hooks :: set_api_version_on_machine
 	const (
 		machineSets = `
 ---
-apiVersion: cluster.x-k8s.io/v1beta2
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineSet
 metadata:
   name: empty
@@ -39,7 +39,7 @@ spec:
         kind: HuaweiCloudMachineTemplate
         name: template-empty
 ---
-apiVersion: cluster.x-k8s.io/v1beta2
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineSet
 metadata:
   name: ready
@@ -48,14 +48,14 @@ spec:
   template:
     spec:
       infrastructureRef:
-        apiGroup: infrastructure.cluster.x-k8s.io
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: HuaweiCloudMachineTemplate
         name: template-ready
 `
 	)
 
 	f := HookExecutionConfigInit(`{"nodeManager": {"internal": {}}}`, `{}`)
-	f.RegisterCRD("cluster.x-k8s.io", "v1beta2", "MachineSet", true)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta1", "MachineSet", true)
 
 	Context("Cluster with MachineSets", func() {
 		BeforeEach(func() {
@@ -63,13 +63,13 @@ spec:
 			f.RunHook()
 		})
 
-		It("fills missing infrastructureRef apiGroup", func() {
+		It("fills missing infrastructureRef apiVersion", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			msEmpty := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "empty")
 			msReady := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "ready")
 
-			Expect(msEmpty.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
-			Expect(msReady.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+			Expect(msEmpty.Field("spec.template.spec.infrastructureRef.apiVersion").String()).To(Equal("infrastructure.cluster.x-k8s.io/v1alpha1"))
+			Expect(msReady.Field("spec.template.spec.infrastructureRef.apiVersion").String()).To(Equal("infrastructure.cluster.x-k8s.io/v1alpha1"))
 		})
 	})
 })

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_set_test.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_set_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node-manager :: hooks :: set_api_version_on_machine_set ::", func() {
+	const (
+		machineSets = `
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineSet
+metadata:
+  name: empty
+  namespace: d8-cloud-instance-manager
+spec:
+  template:
+    spec:
+      infrastructureRef:
+        kind: HuaweiCloudMachineTemplate
+        name: template-empty
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineSet
+metadata:
+  name: ready
+  namespace: d8-cloud-instance-manager
+spec:
+  template:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: HuaweiCloudMachineTemplate
+        name: template-ready
+`
+	)
+
+	f := HookExecutionConfigInit(`{"nodeManager": {"internal": {}}}`, `{}`)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta2", "MachineSet", true)
+
+	Context("Cluster with MachineSets", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(machineSets))
+			f.RunHook()
+		})
+
+		It("fills missing infrastructureRef apiGroup", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			msEmpty := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "empty")
+			msReady := f.KubernetesResource("MachineSet", "d8-cloud-instance-manager", "ready")
+
+			Expect(msEmpty.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+			Expect(msReady.Field("spec.template.spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+		})
+	})
+})

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_test.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: node-manager :: hooks :: set_api_version_on_machine ::", func() {
+	const (
+		machines = `
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  name: empty
+  namespace: d8-cloud-instance-manager
+spec:
+  infrastructureRef:
+    kind: HuaweiCloudMachine
+    name: template-empty
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Machine
+metadata:
+  name: ready
+  namespace: d8-cloud-instance-manager
+spec:
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: HuaweiCloudMachine
+    name: template-ready
+`
+	)
+
+	f := HookExecutionConfigInit(`{"nodeManager": {"internal": {}}}`, `{}`)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta2", "Machine", true)
+
+	Context("Cluster with Machines", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(machines))
+			f.RunHook()
+		})
+
+		It("fills missing infrastructureRef apiGroup", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			machineEmpty := f.KubernetesResource("Machine", "d8-cloud-instance-manager", "empty")
+			machineReady := f.KubernetesResource("Machine", "d8-cloud-instance-manager", "ready")
+
+			Expect(machineEmpty.Field("spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+			Expect(machineReady.Field("spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+		})
+	})
+})

--- a/modules/040-node-manager/hooks/set_api_version_on_machine_test.go
+++ b/modules/040-node-manager/hooks/set_api_version_on_machine_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Modules :: node-manager :: hooks :: set_api_version_on_machine
 	const (
 		machines = `
 ---
-apiVersion: cluster.x-k8s.io/v1beta2
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Machine
 metadata:
   name: empty
@@ -37,21 +37,21 @@ spec:
     kind: HuaweiCloudMachine
     name: template-empty
 ---
-apiVersion: cluster.x-k8s.io/v1beta2
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Machine
 metadata:
   name: ready
   namespace: d8-cloud-instance-manager
 spec:
   infrastructureRef:
-    apiGroup: infrastructure.cluster.x-k8s.io
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
     kind: HuaweiCloudMachine
     name: template-ready
 `
 	)
 
 	f := HookExecutionConfigInit(`{"nodeManager": {"internal": {}}}`, `{}`)
-	f.RegisterCRD("cluster.x-k8s.io", "v1beta2", "Machine", true)
+	f.RegisterCRD("cluster.x-k8s.io", "v1beta1", "Machine", true)
 
 	Context("Cluster with Machines", func() {
 		BeforeEach(func() {
@@ -59,13 +59,13 @@ spec:
 			f.RunHook()
 		})
 
-		It("fills missing infrastructureRef apiGroup", func() {
+		It("fills missing infrastructureRef apiVersion", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			machineEmpty := f.KubernetesResource("Machine", "d8-cloud-instance-manager", "empty")
 			machineReady := f.KubernetesResource("Machine", "d8-cloud-instance-manager", "ready")
 
-			Expect(machineEmpty.Field("spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
-			Expect(machineReady.Field("spec.infrastructureRef.apiGroup").String()).To(Equal("infrastructure.cluster.x-k8s.io"))
+			Expect(machineEmpty.Field("spec.infrastructureRef.apiVersion").String()).To(Equal("infrastructure.cluster.x-k8s.io/v1alpha1"))
+			Expect(machineReady.Field("spec.infrastructureRef.apiVersion").String()).To(Equal("infrastructure.cluster.x-k8s.io/v1alpha1"))
 		})
 	})
 })


### PR DESCRIPTION
## Description

Added a hook that adds apiVersion to InfrastructureRef object if it is missing

## Why do we need it, and what problem does it solve?

necessary for correct operation of capi

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: CAPI crd served version fix
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
