### PR TITLE
[cni-cilium] Reducing CPU usage by the cilium-agent with hubble enabled.

### DIFF
--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -348,7 +348,7 @@ spec:
         command:
         - cilium-dbg
         - build-config
-        - --allow-config-keys=debug,single-cluster-route,mtu,bpf-map-dynamic-size-ratio,monitor-aggregation
+        - --allow-config-keys=debug,single-cluster-route,mtu,bpf-map-dynamic-size-ratio,monitor-aggregation,monitor-aggregation-flags,monitor-aggregation-interval
         env:
         - name: K8S_NODE_NAME
           valueFrom:

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -348,7 +348,7 @@ spec:
         command:
         - cilium-dbg
         - build-config
-        - --allow-config-keys=debug,single-cluster-route,mtu,bpf-map-dynamic-size-ratio
+        - --allow-config-keys=debug,single-cluster-route,mtu,bpf-map-dynamic-size-ratio,monitor-aggregation
         env:
         - name: K8S_NODE_NAME
           valueFrom:

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -153,6 +153,11 @@ data:
   bpf-map-dynamic-size-ratio: "0.005"
   bpf-policy-map-max: "65536"
 
+  # Aggregate datapath monitor events to keep cilium-agent CPU bounded under high flow rate.
+  # Matches the upstream Cilium Helm chart default. Can be overridden
+  # per-node via CiliumNodeConfig (key: monitor-aggregation).
+  monitor-aggregation: "medium"
+
   # Local hubble sever section
   {{- if or (has "cilium-hubble" .Values.global.enabledModules) .Values.cniCilium.internal.hubble.settings.extendedMetrics.enabled .Values.cniCilium.internal.hubble.settings.flowLogs.enabled }}
   enable-hubble: "true"

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -154,9 +154,13 @@ data:
   bpf-policy-map-max: "65536"
 
   # Aggregate datapath monitor events to keep cilium-agent CPU bounded under high flow rate.
-  # Matches the upstream Cilium Helm chart default. Can be overridden
-  # per-node via CiliumNodeConfig (key: monitor-aggregation).
+  # `monitor-aggregation: medium` matches the upstream Cilium Helm chart default; combined
+  # with `monitor-aggregation-flags: all` it still emits a notification on the first
+  # occurrence of each TCP flag bit per connection (SYN/ACK/PSH/FIN/RST/...), preserving
+  # connection-lifecycle visibility. All three keys can be overridden per-node via
+  # CiliumNodeConfig (monitor-aggregation, monitor-aggregation-flags, monitor-aggregation-interval).
   monitor-aggregation: "medium"
+  monitor-aggregation-flags: "all"
 
   # Local hubble sever section
   {{- if or (has "cilium-hubble" .Values.global.enabledModules) .Values.cniCilium.internal.hubble.settings.extendedMetrics.enabled .Values.cniCilium.internal.hubble.settings.flowLogs.enabled }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR sets the default level of BPF trace-event aggregation for the `cilium-agent` in the `cni-cilium` module to `medium` and adds `monitor-aggregation`, `monitor-aggregation-flags` and `monitor-aggregation-interval` to the list of keys that can be overridden per-node via `CiliumNodeConfig` for debug purpose.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
By default, the cilium-agent binary falls back to `monitor-aggregation: "None"`, which is a developer/testing setting. The upstream Cilium Helm chart explicitly overrides this to `medium` for production, but the Deckhouse `cni-cilium` module did not, so all clusters built from this module run without aggregation.
Without aggregation, the BPF datapath emits a per-packet trace event for every observed flow. On busy nodes (KubeVirt VMs, large pod counts, heavy east-west traffic) this generates millions of trace events per second. The cilium-agent's Hubble parser converts each event into a chain of small Go objects (label models, endpoint info, identity lookups), producing extreme allocation churn that forces the Go garbage collector into the majority of cilium-agent CPU.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: feature
summary: Reduced the CPU load in cilium-agent with hubble enabled.
```
