### PR TITLE
[deckhouse] fix exp module auto enabling

### DIFF
--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -320,7 +320,7 @@ func NewDeckhouseController(
 		return nil, fmt.Errorf("register module config controller: %w", err)
 	}
 
-	err = modulesource.RegisterController(runtimeManager, operator.ModuleManager, edition, dc, operator.MetricStorage, embeddedPolicy, logger.Named("module-source-controller"))
+	err = modulesource.RegisterController(runtimeManager, operator.ModuleManager, edition, dc, operator.MetricStorage, embeddedPolicy, settingsContainer, logger.Named("module-source-controller"))
 	if err != nil {
 		return nil, fmt.Errorf("register module source controller: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -80,6 +80,7 @@ func RegisterController(
 	dc dependency.Container,
 	metricStorage metricsstorage.Storage,
 	embeddedPolicy *helpers.ModuleUpdatePolicySpecContainer,
+	deckhouseSettings *helpers.DeckhouseSettingsContainer,
 	logger *log.Logger,
 ) error {
 	r := &reconciler{
@@ -92,6 +93,7 @@ func RegisterController(
 		metricStorage:        metricStorage,
 		downloadedModulesDir: d8env.GetDownloadedModulesDir(),
 		embeddedPolicy:       embeddedPolicy,
+		deckhouseSettings:    deckhouseSettings,
 	}
 
 	r.init.Add(1)
@@ -162,6 +164,7 @@ type reconciler struct {
 	metricStorage metricsstorage.Storage
 
 	embeddedPolicy       *helpers.ModuleUpdatePolicySpecContainer
+	deckhouseSettings    *helpers.DeckhouseSettingsContainer
 	moduleManager        moduleManager
 	edition              *d8edition.Edition
 	downloadedModulesDir string

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller_test.go
@@ -47,9 +47,11 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/controller/module-controllers/utils"
 	d8edition "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/edition"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/helpers"
+	releaseUpdater "github.com/deckhouse/deckhouse/deckhouse-controller/pkg/releaseupdater"
 	"github.com/deckhouse/deckhouse/go_lib/d8env"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
+	"github.com/deckhouse/deckhouse/go_lib/hooks/update"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 )
@@ -110,6 +112,8 @@ func (suite *ControllerTestSuite) setupTestController(raw string, options ...rec
 		WithStatusSubresource(&v1alpha1.Module{}, &v1alpha1.ModuleSource{}, &v1alpha1.ModuleRelease{}).
 		Build()
 
+	metricStorage := metricstorage.NewMetricStorage(metricstorage.WithNewRegistry(), metricstorage.WithLogger(log.NewNop()))
+
 	rec := &reconciler{
 		init:                 new(sync.WaitGroup),
 		client:               suite.client,
@@ -120,8 +124,17 @@ func (suite *ControllerTestSuite) setupTestController(raw string, options ...rec
 			Name:   "fe",
 			Bundle: "Default",
 		},
-		metricStorage: metricstorage.NewMetricStorage(metricstorage.WithNewRegistry(), metricstorage.WithLogger(log.NewNop())),
-
+		metricStorage: metricStorage,
+		deckhouseSettings: helpers.NewDeckhouseSettingsContainer(&helpers.DeckhouseSettings{
+			Update: struct {
+				Mode                   string                            `json:"mode"`
+				DisruptionApprovalMode string                            `json:"disruptionApprovalMode"`
+				Windows                update.Windows                    `json:"windows"`
+				NotificationConfig     releaseUpdater.NotificationConfig `json:"notification"`
+			}{},
+			ReleaseChannel:           "",
+			AllowExperimentalModules: true,
+		}, metricStorage),
 		embeddedPolicy: helpers.NewModuleUpdatePolicySpecContainer(&v1alpha2.ModuleUpdatePolicySpec{
 			Update: v1alpha2.ModuleUpdatePolicySpecUpdate{
 				Mode: "Auto",

--- a/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/helpers.go
@@ -176,6 +176,15 @@ func (r *reconciler) needToEnsureRelease(
 	sourceModule v1alpha1.AvailableModule,
 	meta *downloader.ModuleDownloadResult,
 	releaseExists bool) bool {
+	// skip experimental modules when deckhouse does not allow them
+	if module.IsExperimental() && !r.deckhouseSettings.Get().AllowExperimentalModules {
+		r.logger.Debug("experimental module not allowed, skip release ensure",
+			slog.String("source_name", source.Name),
+			slog.String("name", module.Name))
+
+		return false
+	}
+
 	// check the active source
 	if module.Properties.Source != "" && module.Properties.Source != source.Name {
 		r.logger.Debug("source not active, skip module",


### PR DESCRIPTION
## Description
It fixes exp modules autoenabling. 

## Why do we need it, and what problem does it solve?
Deckhouse has settings that allows us to prohibit exp modules to be enabled, but autoenabling does not respect it.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix exp modules auto enabling.
```