### PR TITLE
[deckhouse] add VEX entries for CVEs 

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 16,
+  "version": 17,
   "statements": [
     {
       "vulnerability": {
@@ -245,6 +245,30 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Зависимость github.com/docker/docker является транзитивной, поступающей через цепочку werf (delivery-kit-sdk), go-containerregistry и addon-operator. Уязвимый функционал Docker Engine API не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов компонента deckhouse-controller. Обновление зависимости невозможно без синхронного обновления всей цепочки werf/delivery-kit.",
       "timestamp": "2026-04-17T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-35469"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/moby/spdystream@v0.2.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/moby/spdystream версии 0.2.0 является транзитивной, поступающей через встроенные бинари (kubectl, k8s.io/* пакеты). В корневом go.mod уже используется фикс-версия v0.5.1. Уязвимый функционал spdystream-протокола не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов компонента deckhouse-controller.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-3219"
+      },
+      "products": [
+        {"@id": "pkg:pypi/pip@25.3"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Функционал обработки TAR/ZIP polyglot-архивов pip версии 25.3 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Python-зависимости не обновляются, чтобы не нарушить совместимость с shell-operator.",
+      "timestamp": "2026-04-22T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",

--- a/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
+++ b/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 14,
+  "version": 16,
   "statements": [
     {
       "vulnerability": {
@@ -59,8 +59,68 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Функционал, связанный с шифрованием и криптографическими операциями pypi/cryptography версии 44.0.1, не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Все криптографические операции выполняются через промежуточные компоненты, не предоставляющие доступа к уязвимому коду.",
       "timestamp": "2026-04-09T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-35469"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/moby/spdystream@v0.4.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/moby/spdystream версии 0.4.0 является транзитивной, поступающей через встроенный бинарь. В корневом go.mod уже используется фикс-версия v0.5.1. Уязвимый функционал spdystream-протокола не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов компонента webhook-handler.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-3219"
+      },
+      "products": [
+        {"@id": "pkg:pypi/pip@25.3"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Функционал обработки TAR/ZIP polyglot-архивов pip версии 25.3 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Python-зависимости не обновляются, чтобы не нарушить совместимость с shell-operator.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33186"
+      },
+      "products": [
+        {"@id": "pkg:golang/google.golang.org/grpc@v1.66.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость google.golang.org/grpc версии 1.66.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus (модуль 300-prometheus, Prometheus v2.55.1). Бинарь promtool в webhook-handler используется только для валидации правил Prometheus и не обрабатывает входящие gRPC-запросы — уязвимый код CWE-285 не входит в исполняемый путь. Бамп требует обновления Prometheus в модуле 300-prometheus.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-34040"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker версии v28.0.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus (модуль 300-prometheus, Prometheus v2.55.1). Уязвимый функционал Docker Engine API не используется в рамках работы webhook-handler — promtool применяется только для валидации правил. Бамп требует обновления Prometheus в модуле 300-prometheus.",
+      "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33997"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/docker/docker@v28.0.0+incompatible"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/docker/docker версии v28.0.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus (модуль 300-prometheus, Prometheus v2.55.1). Уязвимый функционал Docker Engine API не используется в рамках работы webhook-handler — promtool применяется только для валидации правил. Бамп требует обновления Prometheus в модуле 300-prometheus.",
+      "timestamp": "2026-04-22T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-04T12:00:00Z",
-  "last_updated": "2026-03-04T12:00:00Z"
+  "last_updated": "2026-04-22T12:00:00Z"
 }

--- a/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
+++ b/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 16,
+  "version": 15,
   "statements": [
     {
       "vulnerability": {


### PR DESCRIPTION

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add VEX entries for CVEs in `webhook-handler` and `deckhouse-controller` images.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Mark unexploitable CVEs as `not_affected` per CVE handling rules (no bumps for promtool/Prometheus, kubectl, werf/delivery-kit chain, Python):

- CVE-2026-33186, CVE-2026-34040, CVE-2026-33997 — from promtool (Prometheus v2.55.1)
- CVE-2026-35469 — moby/spdystream from kubectl/k8s
- CVE-2026-3219 — pip 25.3

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Add VEX entries for CVEs.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
