### PR TITLE
[deckhouse] revoke user to view moduleconfig

### DIFF
--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -15,6 +15,7 @@ rules:
   - deckhouse.io
   resources:
   - deckhousereleases
+  - moduleconfigs
   - moduledocumentations
   - modulepulloverrides
   - modulereleases

--- a/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
+++ b/modules/002-deckhouse/templates/rbacv2/manage/view.yaml
@@ -15,7 +15,6 @@ rules:
   - deckhouse.io
   resources:
   - deckhousereleases
-  - moduleconfigs
   - moduledocumentations
   - modulepulloverrides
   - modulereleases

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -11,7 +11,6 @@ rules:
   - deckhouse.io
   resources:
   - deckhousereleases
-  - moduleconfigs
   - moduledocumentations
   - modulepulloverrides
   - modulereleases

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -52,6 +52,9 @@ rules:
   - applicationpackages
   - applications
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
   - deletecollection

--- a/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
+++ b/modules/002-deckhouse/templates/user-authz-cluster-roles.yaml
@@ -52,11 +52,18 @@ rules:
   - applicationpackages
   - applications
   verbs:
-  - get
-  - list
-  - watch
   - create
   - delete
   - deletecollection
   - patch
   - update
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - deckhouse
+  resources:
+  - moduleconfigs
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
## Description
This PR revokes to view moduleconfigs with user account.

How to test:
```
k create sa test
serviceaccount/test created
k create clusterrolebinding test --clusterrole d8:user-authz:deckhouse:user --serviceaccount d8-system:test 
clusterrolebinding.rbac.authorization.k8s.io/test created
```

Before:
```
k auth can-i --as system:serviceaccount:d8-system:test get app
yes

k auth can-i --as system:serviceaccount:d8-system:test get mc 
Warning: resource 'moduleconfigs' is not namespace scoped in group 'deckhouse.io'

yes
```
After:
```
k auth can-i --as system:serviceaccount:d8-system:test get app
yes

k auth can-i --as system:serviceaccount:d8-system:test get mc 
Warning: resource 'moduleconfigs' is not namespace scoped in group 'deckhouse.io'
no
```

## Why do we need it, and what problem does it solve?
The ModuleConfig may contain sensitive information that should not be accessible to low-privilege users.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Revoke permission to use moduleconfig to user.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
