### PR TITLE
[user-authn] Access grant to usops adn some dex crds for ClusterAdmin

### DIFF
--- a/modules/150-user-authn/templates/rbacv2/manage/edit.yaml
+++ b/modules/150-user-authn/templates/rbacv2/manage/edit.yaml
@@ -23,6 +23,14 @@ rules:
   - patch
   - delete
   - deletecollection
+# UserOperations are write-only action objects (force-logout, reset 2FA, etc.). Manager creates
+# them on demand; existing operations are immutable, so create-only is enough.
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - useroperations
+  verbs:
+  - create
 - apiGroups:
   - deckhouse.io
   resourceNames:

--- a/modules/150-user-authn/templates/rbacv2/manage/view.yaml
+++ b/modules/150-user-authn/templates/rbacv2/manage/view.yaml
@@ -31,3 +31,14 @@ rules:
   - get
   - list
   - watch
+# Read-only audit access to internal Dex storage CRDs (incident response: enumerate active
+# sessions, see which users have stored passwords). list-only — `get` on a single object
+# would expose bcrypt hashes / refresh tokens.
+# NOTE: plural is `offlinesessionses` (matches Dex CRD name).
+- apiGroups:
+  - dex.coreos.com
+  resources:
+  - passwords
+  - offlinesessionses
+  verbs:
+  - list

--- a/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
+++ b/modules/150-user-authn/templates/user-authz-cluster-roles.yaml
@@ -50,6 +50,8 @@ rules:
   resources:
   - users
   - groups
+  - dexproviders
+  - useroperations
   verbs:
   - get
   - list
@@ -59,3 +61,15 @@ rules:
   - deletecollection
   - patch
   - update
+# Read-only audit access to internal Dex storage CRDs. Deliberately list-only:
+# `passwords` contain bcrypt-hashed credentials, `offlinesessionses` carry refresh tokens —
+# `get` on a single object would return the same secret material, so we keep ClusterAdmin
+# at the listing level only (enough to enumerate sessions for incident response).
+# NOTE: plural is `offlinesessionses` (matches Dex CRD name in crds/external/offlinesessionses.yaml).
+- apiGroups:
+  - dex.coreos.com
+  resources:
+  - passwords
+  - offlinesessionses
+  verbs:
+  - list


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This pr add access grant: useroperations and some dex CRDs for ClusterAdmin
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
add access grant: useroperations and some dex CRDs for ClusterAdmin
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: chore
summary: Add access grant useroperations and some dex CRDs for ClusterAdmin
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
