### PR TITLE
[node-manager] Refactor RBAC for user-authz to node-manager

### DIFF
--- a/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
@@ -39,6 +39,22 @@ rules:
   - machines
   - machinesets
   - machinedeployments
+  - machinepools
+  - machinehealthchecks
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vcdmachinetemplates
+  - huaweicloudmachinetemplates
+  - dynamixmachinetemplates
+  - zvirtmachinetemplates
+  - deckhousemachinetemplates
+  - staticmachinetemplates
   verbs:
   - get
   - list
@@ -60,6 +76,11 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -69,6 +90,16 @@ metadata:
   name: d8:user-authz:node-manager:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - nodegroups
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - machine.sapcloud.io
   resources:
@@ -86,12 +117,43 @@ rules:
   verbs:
   - patch
   - update
+  - delete
+  - deletecollection
+- apiGroups:
+  - machine.sapcloud.io
+  resources:
+  - machinedeployments/scale
+  verbs:
+  - patch
+  - update
 - apiGroups:
   - cluster.x-k8s.io
   resources:
   - machines
   - machinesets
   - machinedeployments
+  - machinepools
+  - machinehealthchecks
+  - clusters
+  - machinedeployments/scale
   verbs:
-  - patch
+  - create
   - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vcdmachinetemplates
+  - huaweicloudmachinetemplates
+  - dynamixmachinetemplates
+  - zvirtmachinetemplates
+  - deckhousemachinetemplates
+  - staticmachinetemplates
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection


### PR DESCRIPTION
## Description
Extend the node-manager user-authz ClusterRoles (User, ClusterEditor, ClusterAdmin access levels) so that operators can manage cluster-autoscaler and fencing-agent configuration without escalating to super-admin.


<details>
  <summary>Changes in user-authz-cluster-roles.yaml:</summary>

- **`d8:user-authz:node-manager:user`** (annotation `User`) — additional read access:
  - `cluster.x-k8s.io`: `machinepools`, `machinehealthchecks`, `clusters` (in addition to the existing `machines`/`machinesets`/`machinedeployments`).
  - `infrastructure.cluster.x-k8s.io`: `vcdmachinetemplates`, `huaweicloudmachinetemplates`, `dynamixmachinetemplates`, `zvirtmachinetemplates`, `deckhousemachinetemplates`, `staticmachinetemplates`.

  This lets operators observe the state of ClusterAPI providers (vCD, Huawei Cloud, Dynamix, zVirt, DVP, static) that `cluster-autoscaler` operates on in `clusterapi` mode (see `modules/040-node-manager/templates/cluster-autoscaler/deployment.yaml`).

- **`d8:user-authz:node-manager:cluster-editor`** (annotation `ClusterEditor`) — write access to `deckhouse.io/nodegroups` (`create`, `update`, `patch`, `delete`, `deletecollection`). This single change unblocks both target scenarios:
  - `cluster-autoscaler`: editing `spec.cloudInstances.{minPerZone, maxPerZone, zones}` of a `NodeGroup`.
  - `fencing-agent`: toggling `spec.fencing.mode` (`Watchdog`/`Notify`).

- **`d8:user-authz:node-manager:cluster-admin`** (annotation `ClusterAdmin`) — additional write access:
  - `deckhouse.io/nodegroups`: `create`, `update`, `patch`, `delete`, `deletecollection`.
  - `machine.sapcloud.io/{openstack,aws,azure,vsphere,gcp,alicloud,yandex,packet}machineclasses`, `machines`, `machinesets`, `machinedeployments`: added `delete` and `deletecollection` to the existing `patch`/`update`, so that `MachineClass` objects can be retired without `super-admin`.
  - `machine.sapcloud.io/machinedeployments/scale`: `patch`, `update` — the subresource `cluster-autoscaler` uses to scale node groups.
  - `cluster.x-k8s.io/{machines,machinesets,machinedeployments,machinepools,machinehealthchecks,clusters,machinedeployments/scale}`: `create`, `update`, `patch`, `delete`, `deletecollection` (previously only `patch`/`update` on the first three).
  - `infrastructure.cluster.x-k8s.io/{vcd,huaweicloud,dynamix,zvirt,deckhouse,static}machinetemplates`: `create`, `update`, `patch`, `delete`, `deletecollection`.

No critical components are restarted by this change; it only updates static `ClusterRole` manifests rendered by the `node-manager` Helm chart.
</details>

## Why do we need it, and what problem does it solve?
Currently cluster-autoscaler and fencing-agent cannot be operated by anyone below super-admin:

ClusterEditor has only read access to NodeGroup, so adjusting autoscaler limits (minPerZone/maxPerZone/zones) or enabling/disabling fencing is impossible without elevating privileges.

ClusterAdmin cannot scale machine deployments through the machinedeployments/scale subresource, cannot delete obsolete MachineClass objects, and has no access to ClusterAPI provider templates (*MachineTemplate) at all — even though these are exactly the resources cluster-autoscaler reconciles in clusterapi mode.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: feature
summary: Allow `ClusterEditor` to manage `NodeGroup` and extend `ClusterAdmin`/`User` RBAC for ClusterAPI and MCM resources used by `cluster-autoscaler` and `fencing-agent`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
