### PR TITLE
[vertical-pod-autoscaler] Add RBAC for user-authz to vpa

### DIFF
--- a/modules/302-vertical-pod-autoscaler/templates/user-authz-cluster-roles.yaml
+++ b/modules/302-vertical-pod-autoscaler/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:vertical-pod-autoscaler:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalercheckpoints
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:vertical-pod-autoscaler:cluster-admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - autoscaling.k8s.io
+  resources:
+  - verticalpodautoscalercheckpoints
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Admin
+  name: d8:user-authz:vertical-pod-autoscaler:admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection


### PR DESCRIPTION
## Description

Adds module-scoped RBAC v1 extension for `vertical-pod-autoscaler`. Creates two new
`ClusterRole`s annotated with `user-authz.deckhouse.io/access-level`, which the
`user-authz` hook automatically aggregates into the standard
`user-authz:{user,privileged-user,editor,admin,cluster-editor,cluster-admin}` roles
via `ClusterAuthorizationRule`:

- `d8:user-authz:vertical-pod-autoscaler:user` (level `User`) — `get`, `list`,
  `watch` on `autoscaling.k8s.io/verticalpodautoscalercheckpoints`.
- `d8:user-authz:vertical-pod-autoscaler:cluster-admin` (level `ClusterAdmin`) —
  `create`, `update`, `patch`, `delete`, `deletecollection` on the same resource.

No changes to module workload RBAC (`templates/{recommender,updater,admission-controller}/rbac-for-us.yaml`)
and no changes to common rules in `modules/140-user-authz/templates/cluster-roles.yaml`.
RBAC v2 (`use`/`manage`) is unaffected — it already covers VPA resources via
the global `view_resources`/`manage_resources` capabilities.

No restarts of critical components (control-plane, ingress-controllers,
Prometheus, VPA recommender/updater/admission-controller) are required.

## Why do we need it, and what problem does it solve?

`VerticalPodAutoscalerCheckpoint` is a namespaced CRD written by the VPA
recommender that stores the historical aggregate state used to produce
recommendations. It is essential for debugging cases when a `VerticalPodAutoscaler`
does not produce a `target` (no checkpoint, stale checkpoint, etc.).

Before this change, RBAC v1 had a gap:

- `verticalpodautoscalers` were already covered for all roles in
  `user_authz_common_rules` (`modules/140-user-authz/templates/cluster-roles.yaml`),
- but `verticalpodautoscalercheckpoints` were not present in any role except
  `super-admin`.

This forced platform users to escalate to `super-admin` just to read recommender
state, which is both unsafe and inconvenient.

The fix follows the "module extends roles" pattern (variant Б from the audit):
the extension lives inside the `vertical-pod-autoscaler` module, leaving common
rules untouched and minimizing blast radius.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: vertical-pod-autoscaler
type: feature
summary: Allow `User`/`PrivilegedUser`/`Editor`/`Admin`/`ClusterEditor` roles to read `VerticalPodAutoscalerCheckpoint` and `ClusterAdmin` to manage it.
impact_level: low