### PR TITLE
[user-authz] add rbacv1 for Gateway API resources.

### DIFF
--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -148,6 +148,15 @@ read:
     - extensions/ingresses
     - extensions/replicasets
     - extensions/replicationcontrollers
+    - gateway.networking.k8s.io/backendtlspolicies
+    - gateway.networking.k8s.io/gatewayclasses
+    - gateway.networking.k8s.io/gateways
+    - gateway.networking.k8s.io/grpcroutes
+    - gateway.networking.k8s.io/httproutes
+    - gateway.networking.k8s.io/listenersets
+    - gateway.networking.k8s.io/referencegrants
+    - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/tlsroutes
     - limitranges
     - metrics.k8s.io/nodes
     - metrics.k8s.io/pods
@@ -198,6 +207,14 @@ read-write:
     - endpoints
     - extensions/deployments
     - extensions/ingresses
+    - gateway.networking.k8s.io/backendtlspolicies
+    - gateway.networking.k8s.io/gateways
+    - gateway.networking.k8s.io/grpcroutes
+    - gateway.networking.k8s.io/httproutes
+    - gateway.networking.k8s.io/listenersets
+    - gateway.networking.k8s.io/referencegrants
+    - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/tlsroutes
     - networking.k8s.io/ingresses
     - persistentvolumeclaims
     - policy/poddisruptionbudgets
@@ -231,6 +248,7 @@ write:
     - apiextensions.k8s.io/customresourcedefinitions
     - apps/daemonsets
     - extensions/daemonsets
+    - gateway.networking.k8s.io/gatewayclasses
     - storage.k8s.io/storageclasses
 ```
 

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -156,8 +156,8 @@ read:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
-    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
+    - gateway.networking.k8s.io/udproutes
     - limitranges
     - metrics.k8s.io/nodes
     - metrics.k8s.io/pods
@@ -215,8 +215,8 @@ read-write:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
-    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
+    - gateway.networking.k8s.io/udproutes
     - networking.k8s.io/ingresses
     - persistentvolumeclaims
     - policy/poddisruptionbudgets

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -156,6 +156,7 @@ read:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
     - limitranges
     - metrics.k8s.io/nodes
@@ -214,6 +215,7 @@ read-write:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
     - networking.k8s.io/ingresses
     - persistentvolumeclaims

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -165,6 +165,7 @@ read:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
     - limitranges
     - metrics.k8s.io/nodes
@@ -223,6 +224,7 @@ read-write:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
     - networking.k8s.io/ingresses
     - persistentvolumeclaims

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -157,6 +157,15 @@ read:
     - extensions/ingresses
     - extensions/replicasets
     - extensions/replicationcontrollers
+    - gateway.networking.k8s.io/backendtlspolicies
+    - gateway.networking.k8s.io/gatewayclasses
+    - gateway.networking.k8s.io/gateways
+    - gateway.networking.k8s.io/grpcroutes
+    - gateway.networking.k8s.io/httproutes
+    - gateway.networking.k8s.io/listenersets
+    - gateway.networking.k8s.io/referencegrants
+    - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/tlsroutes
     - limitranges
     - metrics.k8s.io/nodes
     - metrics.k8s.io/pods
@@ -207,6 +216,14 @@ read-write:
     - endpoints
     - extensions/deployments
     - extensions/ingresses
+    - gateway.networking.k8s.io/backendtlspolicies
+    - gateway.networking.k8s.io/gateways
+    - gateway.networking.k8s.io/grpcroutes
+    - gateway.networking.k8s.io/httproutes
+    - gateway.networking.k8s.io/listenersets
+    - gateway.networking.k8s.io/referencegrants
+    - gateway.networking.k8s.io/tcproutes
+    - gateway.networking.k8s.io/tlsroutes
     - networking.k8s.io/ingresses
     - persistentvolumeclaims
     - policy/poddisruptionbudgets
@@ -240,6 +257,7 @@ write:
     - apiextensions.k8s.io/customresourcedefinitions
     - apps/daemonsets
     - extensions/daemonsets
+    - gateway.networking.k8s.io/gatewayclasses
     - storage.k8s.io/storageclasses
 ```
 

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -165,8 +165,8 @@ read:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
-    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
+    - gateway.networking.k8s.io/udproutes
     - limitranges
     - metrics.k8s.io/nodes
     - metrics.k8s.io/pods
@@ -224,8 +224,8 @@ read-write:
     - gateway.networking.k8s.io/listenersets
     - gateway.networking.k8s.io/referencegrants
     - gateway.networking.k8s.io/tcproutes
-    - gateway.networking.k8s.io/udproutes
     - gateway.networking.k8s.io/tlsroutes
+    - gateway.networking.k8s.io/udproutes
     - networking.k8s.io/ingresses
     - persistentvolumeclaims
     - policy/poddisruptionbudgets

--- a/modules/140-user-authz/templates/cluster-roles.yaml
+++ b/modules/140-user-authz/templates/cluster-roles.yaml
@@ -140,6 +140,7 @@
   - listenersets
   - referencegrants
   - tcproutes
+  - udproutes
   - tlsroutes
   verbs:
   {{- include "user_authz_verbs" $mode }}

--- a/modules/140-user-authz/templates/cluster-roles.yaml
+++ b/modules/140-user-authz/templates/cluster-roles.yaml
@@ -131,6 +131,25 @@
   verbs:
   {{- include "user_authz_verbs" $mode }}
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - backendtlspolicies
+  - gateways
+  - grpcroutes
+  - httproutes
+  - listenersets
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  verbs:
+  {{- include "user_authz_verbs" $mode }}
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  {{- include "user_authz_verbs" "r" }}
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies
@@ -297,6 +316,12 @@
   - customresourcedefinitions
   verbs:
 {{- include "user_authz_verbs" "w" }}
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+{{- include "user_authz_verbs" "w" }}
 {{- end -}}
 
 {{- define "user_authz_cluster_admin_rules" }}
@@ -425,4 +450,3 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 {{- include "user_authz_super_admin_rules" . }}
-


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR adds RBACv1 cluster roles for standard Gateway API resources such as HTTPRoute and Gateway. These resources are generic Kubernetes networking objects, similar to Ingress, and are not specific to a single ALB instance. Therefore, access to them should be granted through global user-authz roles rather than restricted within the ALB module.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Standard Gateway API resources were not covered by the default Deckhouse authorization roles. As a result, users could not view or manage resources such as `HTTPRoute`, `Gateway`, and `ListenerSet` for their applications.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: chore
summary: Added RBACv1 for Gateway API resources.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
