### PR TITLE
[common] Fix golangci-lint for image check-kernel-version

### DIFF
--- a/modules/000-common/images/check-kernel-version/src/check-kernel-version.go
+++ b/modules/000-common/images/check-kernel-version/src/check-kernel-version.go
@@ -17,12 +17,12 @@ limitations under the License.
 package main
 
 import (
-	"bytes"
-	"github.com/Masterminds/semver/v3"
-	"golang.org/x/sys/unix"
 	"log"
 	"os"
 	"strconv"
+
+	"github.com/Masterminds/semver/v3"
+	"golang.org/x/sys/unix"
 )
 
 func main() {
@@ -64,25 +64,23 @@ func toSemver(version string) string {
 
 	var mmp [3]int
 	c := 0
+
+loop:
 	for _, b := range version {
-		if b >= '0' && b <= '9' {
+		switch {
+		case b >= '0' && b <= '9':
 			mmp[c] = 10*mmp[c] + int(b-'0')
-		} else if b == '.' {
+
+		case b == '.':
 			c++
 			if c > 2 {
-				break
+				break loop
 			}
-		} else {
-			break
+
+		default:
+			break loop
 		}
 	}
 
-	var buffer bytes.Buffer
-	buffer.WriteString(strconv.Itoa(mmp[0]))
-	buffer.WriteString(".")
-	buffer.WriteString(strconv.Itoa(mmp[1]))
-	buffer.WriteString(".")
-	buffer.WriteString(strconv.Itoa(mmp[2]))
-
-	return buffer.String()
+	return strconv.Itoa(mmp[0]) + "." + strconv.Itoa(mmp[1]) + "." + strconv.Itoa(mmp[2])
 }


### PR DESCRIPTION
## Description
This PR fixed `golangci-lint` for image `check-kernel-version`

## Why do we need it, and what problem does it solve?
Since [PR 19329](https://github.com/deckhouse/deckhouse/pull/19329) was created from a fork, the `golangci-lint` linter was not executed, which caused code style warnings to be missed

```
============================================================
Running golangci-lint in in ./modules/000-common/images/check-kernel-version/src
============================================================

modules/000-common/images/check-kernel-version/src/check-kernel-version.go:21:1: File is not properly formatted (gci)
    "github.com/Masterminds/semver/v3"
^
modules/000-common/images/check-kernel-version/src/check-kernel-version.go:68:3: ifElseChain: rewrite if-else to switch statement (gocritic)
        if b >= '0' && b <= '9' {
        ^
2 issues:
* gci: 1
* gocritic: 1
```

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: common
type: fix
summary: Fix golangci-lint for image check-kernel-version
impact_level: low
```