### PR TITLE
[cloud-provider-dvp] Add skip storage class annotation handling

### DIFF
--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
@@ -221,7 +221,7 @@ func mergeStorageDomains(
 
 		for i := range result {
 			if result[i].Name == sc.Name {
-				result[i].isEnabled = isEnabled
+				result[i].IsEnabled = isEnabled
 				result[i].IsDefault = isDefault
 				break
 			}

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
@@ -38,6 +38,7 @@ import (
 const (
 	stableDefaultAnnotation = "storageclass.kubernetes.io/is-default-class"
 	betaDefaultAnnotation   = "storageclass.beta.kubernetes.io/is-default-class"
+	skipSCAnnotation		= "dvp-provider.deckhouse.io/skip-storage-class"
 )
 
 type CloudConfig struct {
@@ -203,7 +204,14 @@ func mergeStorageDomains(
 			betaDefaultAnnotation,
 		}
 
+		isEnabled := true
 		isDefault := false
+
+		if v, ok := annotations[skipSCAnnotation]; ok && strings.ToLower(v) == "true" {
+			isEnabled = false
+			break
+		}
+		
 		for _, annot := range annotToCheck {
 			if v, ok := annotations[annot]; ok && strings.ToLower(v) == "true" {
 				isDefault = true
@@ -211,14 +219,12 @@ func mergeStorageDomains(
 			}
 		}
 
-		if isDefault {
-			for i := range result {
-				if result[i].Name == sc.Name {
-					result[i].IsDefault = true
-					break
-				}
+		for i := range result {
+			if result[i].Name == sc.Name {
+				result[i].isEnabled = isEnabled
+				result[i].IsDefault = isDefault
+				break
 			}
-			break
 		}
 	}
 

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
@@ -38,7 +38,7 @@ import (
 const (
 	stableDefaultAnnotation = "storageclass.kubernetes.io/is-default-class"
 	betaDefaultAnnotation   = "storageclass.beta.kubernetes.io/is-default-class"
-	skipSCAnnotation		= "dvp-provider.deckhouse.io/skip-storage-class"
+	skipSCAnnotation		= "cloud-provider.deckhouse.io/skip-storage-class"
 )
 
 type CloudConfig struct {


### PR DESCRIPTION
## Description
Skip some SC from parent clusters 

## Why do we need it, and what problem does it solve?
Skip some SC from parent clusters, e.g., local disks

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Add skip storage class annotation handling to skip discovery of some storage classes from parent clusters, e.g., local disks.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
