### PR TITLE
[deckhouse] packages cleanup

### DIFF
--- a/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
@@ -75,24 +75,24 @@ func (d *Deployer) Deploy(ctx context.Context, repo registry.Remote, packageName
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	downloaded := d.downloadedPath(repo.Name, packageName)
-	if err := d.download(ctx, repo, downloaded, packageName, version); err != nil {
+	packageDir := filepath.Join(d.workingDir, repo.Name, packageName)
+	if err := d.download(ctx, repo, packageDir, packageName, version); err != nil {
 		return err
 	}
 
-	return d.mount(ctx, downloaded, d.deployedPath(deployedName), deployedName, version)
+	return d.mount(ctx, packageDir, d.deployedPath(deployedName), deployedName, version)
 }
 
-// Cleanup unmounts deployed packages and removes downloaded images not listed in preserve.
+// Cleanup unmounts deployed packages and removes package images not listed in preserve.
 func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePackage) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Cleanup")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("downloaded", d.workingDir))
+	span.SetAttributes(attribute.String("workingDir", d.workingDir))
 	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
 
 	logger := d.logger.With(
-		slog.String("downloaded", d.workingDir),
+		slog.String("workingDir", d.workingDir),
 		slog.String("deployed", d.deployedRoot()))
 
 	logger.Debug("cleanup packages")
@@ -106,17 +106,12 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 		return fmt.Errorf("cleanup deployed: %w", err)
 	}
 
-	if err := cleanupDownloaded(ctx, d.workingDir, keep, logger); err != nil {
+	if err := cleanupPackageDirs(ctx, d.workingDir, keep, logger); err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		return fmt.Errorf("cleanup downloaded: %w", err)
+		return fmt.Errorf("cleanup package dirs: %w", err)
 	}
 
 	return nil
-}
-
-// downloadedPath returns a package download directory under the deployer root.
-func (d *Deployer) downloadedPath(repository, packageName string) string {
-	return filepath.Join(d.workingDir, repository, packageName)
 }
 
 // deployedRoot returns the directory containing deployed package mount points.
@@ -144,7 +139,7 @@ func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanup
 	}
 
 	for _, item := range preserve {
-		packageDir := d.cleanupPackageDir(item)
+		packageDir := filepath.Join(d.workingDir, item.Repository, item.Name)
 		imagePath := packageImagePath(packageDir, item.Version)
 
 		keep.images[normalizePath(imagePath)] = struct{}{}
@@ -153,11 +148,6 @@ func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanup
 	}
 
 	return keep
-}
-
-// cleanupPackageDir returns the workingDir package directory for a preserved package.
-func (d *Deployer) cleanupPackageDir(item deployer.PreservePackage) string {
-	return filepath.Join(d.workingDir, item.Repository, item.Name)
 }
 
 // cleanupDeployed unmounts deployed packages whose backing images are not preserved.
@@ -201,10 +191,10 @@ func cleanupDeployed(ctx context.Context, deployed string, keepImages map[string
 	return nil
 }
 
-// cleanupDownloaded removes package images and empty parent directories not preserved.
+// cleanupPackageDirs removes package images and empty parent directories not preserved.
 // The deployed subdirectory is skipped here — it is handled by cleanupDeployed.
-func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep, logger *log.Logger) error {
-	entries, err := os.ReadDir(downloaded)
+func cleanupPackageDirs(ctx context.Context, packageDir string, keep cleanupKeep, logger *log.Logger) error {
+	entries, err := os.ReadDir(packageDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -222,7 +212,7 @@ func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep,
 			continue
 		}
 
-		path := filepath.Join(downloaded, entry.Name())
+		path := filepath.Join(packageDir, entry.Name())
 
 		if _, ok := keep.repos[normalizePath(path)]; ok {
 			if err = cleanupRepoDir(ctx, path, keep, logger); err != nil {
@@ -232,7 +222,7 @@ func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep,
 			continue
 		}
 
-		logger.Info("delete downloaded dir", slog.String("path", path))
+		logger.Info("delete package dir", slog.String("path", path))
 		if err = os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -266,7 +256,7 @@ func cleanupRepoDir(ctx context.Context, repo string, keep cleanupKeep, logger *
 			continue
 		}
 
-		logger.Info("delete downloaded package dir", slog.String("path", path))
+		logger.Info("delete package dir", slog.String("path", path))
 		if err = os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -275,7 +265,7 @@ func cleanupRepoDir(ctx context.Context, repo string, keep cleanupKeep, logger *
 	return removeEmptyDir(repo)
 }
 
-// cleanupPackageImages removes downloaded image files not listed in keepImages.
+// cleanupPackageImages removes package image files not listed in keepImages.
 func cleanupPackageImages(ctx context.Context, packageDir string, keepImages map[string]struct{}, logger *log.Logger) error {
 	entries, err := os.ReadDir(packageDir)
 	if err != nil {
@@ -296,7 +286,7 @@ func cleanupPackageImages(ctx context.Context, packageDir string, keepImages map
 			continue
 		}
 
-		logger.Info("delete downloaded image", slog.String("path", path))
+		logger.Info("delete package image", slog.String("path", path))
 		if err = os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -320,20 +310,20 @@ func removeEmptyDir(path string) error {
 
 // download fetches a package image from the registry and creates an erofs image.
 // If the image already exists and passes verification, download is skipped.
-func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloaded, name, version string) error {
+func (d *Deployer) download(ctx context.Context, repo registry.Remote, packageDir, name, version string) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Download")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("name", name))
 	span.SetAttributes(attribute.String("version", version))
-	span.SetAttributes(attribute.String("downloaded", downloaded))
+	span.SetAttributes(attribute.String("packageDir", packageDir))
 	span.SetAttributes(attribute.String("repository", repo.Name))
 	span.SetAttributes(attribute.String("registry", repo.Repository))
 
 	logger := d.logger.With(
 		slog.String("name", name),
 		slog.String("version", version),
-		slog.String("downloaded", downloaded),
+		slog.String("packageDir", packageDir),
 		slog.String("repository", repo.Name),
 		slog.String("registry", repo.Repository))
 
@@ -346,8 +336,8 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloade
 	default:
 	}
 
-	imagePath := packageImagePath(downloaded, version)
-	if err := os.MkdirAll(downloaded, 0755); err != nil {
+	imagePath := packageImagePath(packageDir, version)
+	if err := os.MkdirAll(packageDir, 0755); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return newCreatePackageDirErr(err)
 	}
@@ -369,12 +359,12 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloade
 	// verification failed - fetch fresh image from registry
 	logger.Warn("verify package image failed", log.Err(err))
 
-	if err = cleanupTempImageFiles(downloaded, version); err != nil {
+	if err = cleanupTempImageFiles(packageDir, version); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return newImageByTarErr(err)
 	}
 
-	tempImagePath, err := createTempImagePath(downloaded, version)
+	tempImagePath, err := createTempImagePath(packageDir, version)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return newCreatePackageDirErr(err)
@@ -419,8 +409,8 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloade
 }
 
 // packageImagePath returns the final erofs image path for a package version.
-func packageImagePath(downloaded, version string) string {
-	return filepath.Join(downloaded, fmt.Sprintf("%s.erofs", version))
+func packageImagePath(packageDir, version string) string {
+	return filepath.Join(packageDir, fmt.Sprintf("%s.erofs", version))
 }
 
 // verityPath returns the dm-verity hash tree path for an erofs image path.
@@ -429,8 +419,8 @@ func verityPath(imagePath string) string {
 }
 
 // cleanupTempImageFiles removes stale temporary erofs images for a package version.
-func cleanupTempImageFiles(downloaded, version string) error {
-	entries, err := os.ReadDir(downloaded)
+func cleanupTempImageFiles(packageDir, version string) error {
+	entries, err := os.ReadDir(packageDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -445,7 +435,7 @@ func cleanupTempImageFiles(downloaded, version string) error {
 			continue
 		}
 
-		if err = os.Remove(filepath.Join(downloaded, entry.Name())); err != nil && !os.IsNotExist(err) {
+		if err = os.Remove(filepath.Join(packageDir, entry.Name())); err != nil && !os.IsNotExist(err) {
 			return err
 		}
 	}
@@ -454,8 +444,8 @@ func cleanupTempImageFiles(downloaded, version string) error {
 }
 
 // createTempImagePath reserves and returns a same-directory temporary erofs image path.
-func createTempImagePath(downloaded, version string) (string, error) {
-	file, err := os.CreateTemp(downloaded, tempImagePrefix(version))
+func createTempImagePath(packageDir, version string) (string, error) {
+	file, err := os.CreateTemp(packageDir, tempImagePrefix(version))
 	if err != nil {
 		return "", err
 	}
@@ -480,17 +470,17 @@ func tempImagePrefix(version string) string {
 
 // mount mounts an erofs image using dm-verity for integrity verification.
 // Flow: compute hash → unmount old → close mapper → create mapper → mount new.
-func (d *Deployer) mount(ctx context.Context, downloaded, deployed, name, version string) error {
+func (d *Deployer) mount(ctx context.Context, packageDir, deployed, name, version string) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Deploy")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("downloaded", downloaded))
+	span.SetAttributes(attribute.String("packageDir", packageDir))
 	span.SetAttributes(attribute.String("deployed", deployed))
 	span.SetAttributes(attribute.String("name", name))
 	span.SetAttributes(attribute.String("version", version))
 
 	logger := d.logger.With(
-		slog.String("downloaded", downloaded),
+		slog.String("packageDir", packageDir),
 		slog.String("deployed", deployed),
 		slog.String("name", name),
 		slog.String("version", version))
@@ -504,8 +494,8 @@ func (d *Deployer) mount(ctx context.Context, downloaded, deployed, name, versio
 	default:
 	}
 
-	// <downloaded>/<version>.erofs
-	imagePath := packageImagePath(downloaded, version)
+	// <packageDir>/<version>.erofs
+	imagePath := packageImagePath(packageDir, version)
 
 	// Compute the new image hash before unmounting the currently deployed package.
 	logger.Debug("compute erofs image hash", slog.String("path", imagePath))
@@ -545,7 +535,7 @@ func (d *Deployer) mount(ctx context.Context, downloaded, deployed, name, versio
 }
 
 // Undeploy unmounts the erofs image and closes the dm-verity mapper.
-// If keep=false, the downloaded image files are also deleted.
+// If keep=false, the package directory is also deleted.
 func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Undeploy")
 	defer span.End()
@@ -571,7 +561,7 @@ func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool)
 	defer d.mu.Unlock()
 
 	// Resolve the backing image before tearing down the mapper, so the
-	// deferred package-dir cleanup can target the actual download path
+	// deferred package-dir cleanup can target the actual package directory
 	// (the parent of <package>/<version>.erofs) regardless of layout.
 	var packageDir string
 	if !keep {
@@ -590,7 +580,7 @@ func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool)
 
 		logger.Info("delete package dir", slog.String("path", packageDir))
 		if err := os.RemoveAll(packageDir); err != nil {
-			logger.Warn("failed to remove downloaded images", slog.String("path", packageDir), log.Err(err))
+			logger.Warn("failed to remove package dir", slog.String("path", packageDir), log.Err(err))
 		}
 	}()
 

--- a/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
@@ -51,7 +51,7 @@ const (
 // Operations are serialized via mutex to prevent concurrent mount/unmount conflicts.
 type Deployer struct {
 	mu         sync.Mutex
-	downloaded string
+	workingDir string
 	registry   registryService
 	logger     *log.Logger
 }
@@ -62,10 +62,10 @@ type registryService interface {
 }
 
 // NewDeployer creates a Deployer for packages.
-func NewDeployer(registry registryService, downloaded string, logger *log.Logger) *Deployer {
+func NewDeployer(registry registryService, workingDir string, logger *log.Logger) *Deployer {
 	return &Deployer{
 		registry:   registry,
-		downloaded: downloaded,
+		workingDir: workingDir,
 		logger:     logger.Named(loggerName),
 	}
 }
@@ -88,11 +88,11 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Cleanup")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("downloaded", d.downloaded))
+	span.SetAttributes(attribute.String("downloaded", d.workingDir))
 	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
 
 	logger := d.logger.With(
-		slog.String("downloaded", d.downloaded),
+		slog.String("downloaded", d.workingDir),
 		slog.String("deployed", d.deployedRoot()))
 
 	logger.Debug("cleanup packages")
@@ -106,7 +106,7 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 		return fmt.Errorf("cleanup deployed: %w", err)
 	}
 
-	if err := cleanupDownloaded(ctx, d.downloaded, keep, logger); err != nil {
+	if err := cleanupDownloaded(ctx, d.workingDir, keep, logger); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("cleanup downloaded: %w", err)
 	}
@@ -116,12 +116,12 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 
 // downloadedPath returns a package download directory under the deployer root.
 func (d *Deployer) downloadedPath(repository, packageName string) string {
-	return filepath.Join(d.downloaded, repository, packageName)
+	return filepath.Join(d.workingDir, repository, packageName)
 }
 
 // deployedRoot returns the directory containing deployed package mount points.
 func (d *Deployer) deployedRoot() string {
-	return filepath.Join(d.downloaded, deployedDir)
+	return filepath.Join(d.workingDir, deployedDir)
 }
 
 // deployedPath returns a package deployed path under the deployer root.
@@ -149,15 +149,15 @@ func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanup
 
 		keep.images[normalizePath(imagePath)] = struct{}{}
 		keep.packages[normalizePath(packageDir)] = struct{}{}
-		keep.repos[normalizePath(filepath.Join(d.downloaded, item.Repository))] = struct{}{}
+		keep.repos[normalizePath(filepath.Join(d.workingDir, item.Repository))] = struct{}{}
 	}
 
 	return keep
 }
 
-// cleanupPackageDir returns the downloaded package directory for a preserved package.
+// cleanupPackageDir returns the workingDir package directory for a preserved package.
 func (d *Deployer) cleanupPackageDir(item deployer.PreservePackage) string {
-	return filepath.Join(d.downloaded, item.Repository, item.Name)
+	return filepath.Join(d.workingDir, item.Repository, item.Name)
 }
 
 // cleanupDeployed unmounts deployed packages whose backing images are not preserved.

--- a/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
@@ -18,6 +18,7 @@ package erofs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -25,24 +26,34 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/tools/verity"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-const tracerName = "deployer"
+const (
+	// tracerName is the OpenTelemetry tracer name for deployer operations.
+	tracerName = "deployer"
+	// deployedDir is the deployed packages directory name.
+	deployedDir = "deployed"
+	// loggerName is the logger scope for erofs deployment.
+	loggerName = "erofs-deployer"
+)
 
 // Deployer handles package lifecycle using erofs images with dm-verity integrity.
 // Operations are serialized via mutex to prevent concurrent mount/unmount conflicts.
 type Deployer struct {
-	mu       sync.Mutex
-	registry registryService
-	logger   *log.Logger
+	mu         sync.Mutex
+	downloaded string
+	registry   registryService
+	logger     *log.Logger
 }
 
 type registryService interface {
@@ -50,24 +61,261 @@ type registryService interface {
 	GetImageReader(ctx context.Context, cred registry.Remote, packageName, tag string) (io.ReadCloser, error)
 }
 
-// NewDeployer creates a Deployer with the given registry service.
-func NewDeployer(registry registryService, logger *log.Logger) *Deployer {
+// NewDeployer creates a Deployer for packages.
+func NewDeployer(registry registryService, downloaded string, logger *log.Logger) *Deployer {
 	return &Deployer{
-		registry: registry,
-		logger:   logger.Named("erofs-deployer"),
+		registry:   registry,
+		downloaded: downloaded,
+		logger:     logger.Named(loggerName),
 	}
 }
 
 // Deploy fetches a package image from the registry and mounts it at the deployed path.
-func (d *Deployer) Deploy(ctx context.Context, repo registry.Remote, downloaded, deployed, packageName, name, version string) error {
+func (d *Deployer) Deploy(ctx context.Context, repo registry.Remote, packageName, deployedName, version string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	downloaded := d.downloadedPath(repo.Name, packageName)
 	if err := d.download(ctx, repo, downloaded, packageName, version); err != nil {
 		return err
 	}
 
-	return d.mount(ctx, downloaded, deployed, name, version)
+	return d.mount(ctx, downloaded, d.deployedPath(deployedName), deployedName, version)
+}
+
+// Cleanup unmounts deployed packages and removes downloaded images not listed in preserve.
+func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePackage) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "Cleanup")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("downloaded", d.downloaded))
+	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
+
+	logger := d.logger.With(
+		slog.String("downloaded", d.downloaded),
+		slog.String("deployed", d.deployedRoot()))
+
+	logger.Debug("cleanup packages")
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	keep := d.buildCleanupKeep(preserve)
+	if err := cleanupDeployed(ctx, d.deployedRoot(), keep.images, logger); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("cleanup deployed: %w", err)
+	}
+
+	if err := cleanupDownloaded(ctx, d.downloaded, keep, logger); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("cleanup downloaded: %w", err)
+	}
+
+	return nil
+}
+
+// downloadedPath returns a package download directory under the deployer root.
+func (d *Deployer) downloadedPath(repository, packageName string) string {
+	return filepath.Join(d.downloaded, repository, packageName)
+}
+
+// deployedRoot returns the directory containing deployed package mount points.
+func (d *Deployer) deployedRoot() string {
+	return filepath.Join(d.downloaded, deployedDir)
+}
+
+// deployedPath returns a package deployed path under the deployer root.
+func (d *Deployer) deployedPath(deployedName string) string {
+	return filepath.Join(d.deployedRoot(), deployedName)
+}
+
+type cleanupKeep struct {
+	images   map[string]struct{}
+	packages map[string]struct{}
+	repos    map[string]struct{}
+}
+
+// buildCleanupKeep returns normalized paths that must survive cleanup.
+func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanupKeep {
+	keep := cleanupKeep{
+		images:   make(map[string]struct{}, len(preserve)),
+		packages: make(map[string]struct{}, len(preserve)),
+		repos:    make(map[string]struct{}),
+	}
+
+	for _, item := range preserve {
+		packageDir := d.cleanupPackageDir(item)
+		imagePath := packageImagePath(packageDir, item.Version)
+
+		keep.images[normalizePath(imagePath)] = struct{}{}
+		keep.packages[normalizePath(packageDir)] = struct{}{}
+		keep.repos[normalizePath(filepath.Join(d.downloaded, item.Repository))] = struct{}{}
+	}
+
+	return keep
+}
+
+// cleanupPackageDir returns the downloaded package directory for a preserved package.
+func (d *Deployer) cleanupPackageDir(item deployer.PreservePackage) string {
+	return filepath.Join(d.downloaded, item.Repository, item.Name)
+}
+
+// cleanupDeployed unmounts deployed packages whose backing images are not preserved.
+func cleanupDeployed(ctx context.Context, deployed string, keepImages map[string]struct{}, logger *log.Logger) error {
+	entries, err := os.ReadDir(deployed)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		path := filepath.Join(deployed, entry.Name())
+		imagePath, imageErr := verity.GetImagePathByDevice(ctx, entry.Name())
+		if imageErr != nil {
+			// Best-effort: a single missing/transient mapper must not block the rest of cleanup.
+			logger.Warn("get erofs image path", slog.String("name", entry.Name()), log.Err(imageErr))
+			continue
+		}
+
+		if _, ok := keepImages[normalizePath(imagePath)]; ok {
+			continue
+		}
+
+		logger.Info("delete deployed mount", slog.String("path", path))
+		if err = verity.Unmount(ctx, path); err != nil {
+			return err
+		}
+
+		if err = verity.CloseMapper(ctx, entry.Name()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanupDownloaded removes package images and empty parent directories not preserved.
+// The deployed subdirectory is skipped here — it is handled by cleanupDeployed.
+func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep, logger *log.Logger) error {
+	entries, err := os.ReadDir(downloaded)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		if entry.Name() == deployedDir {
+			continue
+		}
+
+		path := filepath.Join(downloaded, entry.Name())
+
+		if _, ok := keep.repos[normalizePath(path)]; ok {
+			if err = cleanupRepoDir(ctx, path, keep, logger); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		logger.Info("delete downloaded dir", slog.String("path", path))
+		if err = os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanupRepoDir removes package directories not preserved under a repository.
+func cleanupRepoDir(ctx context.Context, repo string, keep cleanupKeep, logger *log.Logger) error {
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		path := filepath.Join(repo, entry.Name())
+		if _, ok := keep.packages[normalizePath(path)]; ok {
+			if err = cleanupPackageImages(ctx, path, keep.images, logger); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		logger.Info("delete downloaded package dir", slog.String("path", path))
+		if err = os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
+	return removeEmptyDir(repo)
+}
+
+// cleanupPackageImages removes downloaded image files not listed in keepImages.
+func cleanupPackageImages(ctx context.Context, packageDir string, keepImages map[string]struct{}, logger *log.Logger) error {
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		path := filepath.Join(packageDir, entry.Name())
+		if _, ok := keepImages[normalizePath(path)]; ok {
+			continue
+		}
+
+		logger.Info("delete downloaded image", slog.String("path", path))
+		if err = os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
+	return removeEmptyDir(packageDir)
+}
+
+// removeEmptyDir removes path only when it has no entries.
+func removeEmptyDir(path string) error {
+	err := os.Remove(path)
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
+		return nil
+	}
+
+	return err
 }
 
 // download fetches a package image from the registry and creates an erofs image.
@@ -298,13 +546,14 @@ func (d *Deployer) mount(ctx context.Context, downloaded, deployed, name, versio
 
 // Undeploy unmounts the erofs image and closes the dm-verity mapper.
 // If keep=false, the downloaded image files are also deleted.
-func (d *Deployer) Undeploy(ctx context.Context, downloaded, deployed, name string, keep bool) error {
+func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Undeploy")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("name", name))
+	span.SetAttributes(attribute.String("name", deployedName))
 
-	logger := d.logger.With(slog.String("name", name))
+	deployed := d.deployedPath(deployedName)
+	logger := d.logger.With(slog.String("name", deployedName))
 
 	logger.Debug("undeploy package")
 
@@ -317,15 +566,27 @@ func (d *Deployer) Undeploy(ctx context.Context, downloaded, deployed, name stri
 		return fmt.Errorf("check mount path '%s': %w", deployed, err)
 	}
 
-	// clear package dir
+	// Resolve the backing image before tearing down the mapper, so the
+	// deferred package-dir cleanup can target the actual download path
+	// (the parent of <package>/<version>.erofs) regardless of layout.
+	var packageDir string
+	if !keep {
+		imagePath, err := verity.GetImagePathByDevice(ctx, deployedName)
+		if err != nil {
+			logger.Warn("resolve image path for cleanup", log.Err(err))
+		} else {
+			packageDir = filepath.Dir(imagePath)
+		}
+	}
+
 	defer func() {
-		if keep {
+		if keep || packageDir == "" {
 			return
 		}
 
-		logger.Info("delete package dir", slog.String("path", downloaded))
-		if err := os.RemoveAll(downloaded); err != nil {
-			logger.Warn("failed to remove downloaded images", slog.String("path", downloaded))
+		logger.Info("delete package dir", slog.String("path", packageDir))
+		if err := os.RemoveAll(packageDir); err != nil {
+			logger.Warn("failed to remove downloaded images", slog.String("path", packageDir), log.Err(err))
 		}
 	}()
 
@@ -340,7 +601,7 @@ func (d *Deployer) Undeploy(ctx context.Context, downloaded, deployed, name stri
 	}
 
 	logger.Debug("close device mapper")
-	if err := verity.CloseMapper(ctx, name); err != nil {
+	if err := verity.CloseMapper(ctx, deployedName); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("close device mapper: %w", err)
 	}
@@ -348,6 +609,16 @@ func (d *Deployer) Undeploy(ctx context.Context, downloaded, deployed, name stri
 	logger.Debug("package undeployed")
 
 	return nil
+}
+
+// normalizePath returns a comparable absolute clean path when possible.
+func normalizePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+
+	return filepath.Clean(abs)
 }
 
 // verifyImage checks that the image exists and matches rootHash when one is provided.

--- a/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/erofs/deployer.go
@@ -566,6 +566,10 @@ func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool)
 		return fmt.Errorf("check mount path '%s': %w", deployed, err)
 	}
 
+	// mounts should not be executed simultaneously
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
 	// Resolve the backing image before tearing down the mapper, so the
 	// deferred package-dir cleanup can target the actual download path
 	// (the parent of <package>/<version>.erofs) regardless of layout.
@@ -589,10 +593,6 @@ func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool)
 			logger.Warn("failed to remove downloaded images", slog.String("path", packageDir), log.Err(err))
 		}
 	}()
-
-	// mounts should not be executed simultaneously
-	d.mu.Lock()
-	defer d.mu.Unlock()
 
 	logger.Debug("unmount erofs image", slog.String("path", deployed))
 	if err := verity.Unmount(ctx, deployed); err != nil {

--- a/deckhouse-controller/internal/packages/deployer/preserve.go
+++ b/deckhouse-controller/internal/packages/deployer/preserve.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deployer
+
+// PreservePackage identifies one downloaded package version to preserve during cleanup.
+type PreservePackage struct {
+	// Name is the downloaded package directory name.
+	Name string
+	// Version is the downloaded package version name.
+	Version string
+	// Repository is the downloaded repository directory name.
+	Repository string
+}

--- a/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
@@ -69,29 +69,28 @@ func NewDeployer(reg registryService, workingDir string, logger *log.Logger) *De
 
 // Deploy fetches a package image from the registry and exposes it at the deployed path.
 func (d *Deployer) Deploy(ctx context.Context, repo registry.Remote, packageName, deployedName, version string) error {
-	// one package can be downloaded by different apps in the same time
-	// so lock it to prevent downloading same package
+	// the same package may be deployed by multiple apps concurrently; serialize to avoid duplicate work
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	downloaded := d.downloadedPath(repo.Name, packageName)
-	if err := d.download(ctx, repo, downloaded, packageName, version); err != nil {
+	packageDir := filepath.Join(d.workingDir, repo.Name, packageName)
+	if err := d.download(ctx, repo, packageDir, packageName, version); err != nil {
 		return err
 	}
 
-	return d.symlink(ctx, downloaded, d.deployedPath(deployedName), deployedName, version)
+	return d.symlink(ctx, packageDir, d.deployedPath(deployedName), deployedName, version)
 }
 
-// Cleanup removes deployed symlinks and downloaded package versions not listed in preserve.
+// Cleanup removes deployed symlinks and package versions not listed in preserve.
 func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePackage) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Cleanup")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("downloaded", d.workingDir))
+	span.SetAttributes(attribute.String("workingDir", d.workingDir))
 	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
 
 	logger := d.logger.With(
-		slog.String("downloaded", d.workingDir),
+		slog.String("workingDir", d.workingDir),
 		slog.String("deployed", d.deployedRoot()))
 
 	logger.Debug("cleanup packages")
@@ -105,17 +104,12 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 		return fmt.Errorf("cleanup deployed: %w", err)
 	}
 
-	if err := cleanupDownloaded(ctx, d.workingDir, keep, logger); err != nil {
+	if err := cleanupPackageDirs(ctx, d.workingDir, keep, logger); err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		return fmt.Errorf("cleanup downloaded: %w", err)
+		return fmt.Errorf("cleanup package dirs: %w", err)
 	}
 
 	return nil
-}
-
-// downloadedPath returns a package download directory under the deployer root.
-func (d *Deployer) downloadedPath(repository, packageName string) string {
-	return filepath.Join(d.workingDir, repository, packageName)
 }
 
 // deployedRoot returns the directory containing deployed package symlinks.
@@ -143,7 +137,7 @@ func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanup
 	}
 
 	for _, item := range preserve {
-		packageDir := d.cleanupPackageDir(item)
+		packageDir := filepath.Join(d.workingDir, item.Repository, item.Name)
 		versionDir := filepath.Join(packageDir, item.Version)
 
 		keep.versions[normalizePath(versionDir)] = struct{}{}
@@ -154,12 +148,7 @@ func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanup
 	return keep
 }
 
-// cleanupPackageDir returns the workingDir package directory for a preserved package.
-func (d *Deployer) cleanupPackageDir(item deployer.PreservePackage) string {
-	return filepath.Join(d.workingDir, item.Repository, item.Name)
-}
-
-// cleanupDeployed removes symlinks whose targets are not preserved downloaded versions.
+// cleanupDeployed removes symlinks whose targets are not preserved package versions.
 func cleanupDeployed(ctx context.Context, deployed string, keepVersions map[string]struct{}, logger *log.Logger) error {
 	entries, err := os.ReadDir(deployed)
 	if err != nil {
@@ -211,10 +200,10 @@ func cleanupDeployed(ctx context.Context, deployed string, keepVersions map[stri
 	return nil
 }
 
-// cleanupDownloaded removes package versions and empty parent directories not preserved.
+// cleanupPackageDirs removes package versions and empty parent directories not preserved.
 // The deployed subdirectory is skipped here — it is handled by cleanupDeployed.
-func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep, logger *log.Logger) error {
-	entries, err := os.ReadDir(downloaded)
+func cleanupPackageDirs(ctx context.Context, packageDir string, keep cleanupKeep, logger *log.Logger) error {
+	entries, err := os.ReadDir(packageDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -232,7 +221,7 @@ func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep,
 			continue
 		}
 
-		path := filepath.Join(downloaded, entry.Name())
+		path := filepath.Join(packageDir, entry.Name())
 
 		if _, ok := keep.repos[normalizePath(path)]; ok {
 			if err = cleanupRepoDir(ctx, path, keep, logger); err != nil {
@@ -242,7 +231,7 @@ func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep,
 			continue
 		}
 
-		logger.Info("delete downloaded dir", slog.String("path", path))
+		logger.Info("delete package dir", slog.String("path", path))
 		if err = os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -276,7 +265,7 @@ func cleanupRepoDir(ctx context.Context, repo string, keep cleanupKeep, logger *
 			continue
 		}
 
-		logger.Info("delete downloaded package dir", slog.String("path", path))
+		logger.Info("delete package dir", slog.String("path", path))
 		if err = os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -285,7 +274,7 @@ func cleanupRepoDir(ctx context.Context, repo string, keep cleanupKeep, logger *
 	return removeEmptyDir(repo)
 }
 
-// cleanupPackageVersions removes downloaded versions not listed in keepVersions.
+// cleanupPackageVersions removes package versions not listed in keepVersions.
 func cleanupPackageVersions(ctx context.Context, packageDir string, keepVersions map[string]struct{}, logger *log.Logger) error {
 	entries, err := os.ReadDir(packageDir)
 	if err != nil {
@@ -306,7 +295,7 @@ func cleanupPackageVersions(ctx context.Context, packageDir string, keepVersions
 			continue
 		}
 
-		logger.Info("delete downloaded version dir", slog.String("path", path))
+		logger.Info("delete package version dir", slog.String("path", path))
 		if err = os.RemoveAll(path); err != nil {
 			return err
 		}
@@ -339,20 +328,20 @@ func normalizePath(path string) string {
 }
 
 // download fetches a package image into a versioned directory via an atomic temporary directory rename.
-func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloaded, name, version string) error {
+func (d *Deployer) download(ctx context.Context, repo registry.Remote, packageDir, name, version string) error {
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "download")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("name", name))
 	span.SetAttributes(attribute.String("version", version))
-	span.SetAttributes(attribute.String("downloaded", downloaded))
+	span.SetAttributes(attribute.String("packageDir", packageDir))
 	span.SetAttributes(attribute.String("repository", repo.Name))
 	span.SetAttributes(attribute.String("registry", repo.Repository))
 
 	logger := d.logger.With(
 		slog.String("name", name),
 		slog.String("version", version),
-		slog.String("downloaded", downloaded),
+		slog.String("packageDir", packageDir),
 		slog.String("repository", repo.Name),
 		slog.String("registry", repo.Repository))
 
@@ -365,23 +354,23 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloade
 	default:
 	}
 
-	versionPath := filepath.Join(downloaded, version)
+	versionPath := filepath.Join(packageDir, version)
 	if _, err := os.Stat(versionPath); err == nil {
 		return nil
 	} else if !os.IsNotExist(err) {
 		return newCheckVersionErr(err)
 	}
 
-	if err := os.MkdirAll(downloaded, 0755); err != nil {
+	if err := os.MkdirAll(packageDir, 0755); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return newCreatePackageDirErr(err)
 	}
 
-	if err := cleanupTempDownloadDirs(downloaded, version); err != nil {
+	if err := cleanupTempDownloadDirs(packageDir, version); err != nil {
 		return newDownloadErr(err)
 	}
 
-	tempDir, err := os.MkdirTemp(downloaded, tempDownloadPrefix(version))
+	tempDir, err := os.MkdirTemp(packageDir, tempDownloadPrefix(version))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return newCreatePackageDirErr(err)
@@ -394,7 +383,7 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloade
 		}
 	}()
 
-	// download/extract into a temporary directory, then atomically publish it as <downloaded>/<version>
+	// download/extract into a temporary directory, then atomically publish it as <packageDir>/<version>
 	if err = d.registry.Download(ctx, repo, tempDir, name, version); err != nil {
 		return newDownloadErr(err)
 	}
@@ -408,8 +397,8 @@ func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloade
 }
 
 // cleanupTempDownloadDirs removes stale temporary download directories for a package version.
-func cleanupTempDownloadDirs(downloaded, version string) error {
-	entries, err := os.ReadDir(downloaded)
+func cleanupTempDownloadDirs(packageDir, version string) error {
+	entries, err := os.ReadDir(packageDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -424,7 +413,7 @@ func cleanupTempDownloadDirs(downloaded, version string) error {
 			continue
 		}
 
-		if err = os.RemoveAll(filepath.Join(downloaded, entry.Name())); err != nil {
+		if err = os.RemoveAll(filepath.Join(packageDir, entry.Name())); err != nil {
 			return err
 		}
 	}
@@ -439,17 +428,17 @@ func tempDownloadPrefix(version string) string {
 
 // symlink creates a symlink from deployed path to the workingDir version directory.
 // Removes any existing symlink for atomic version switching.
-func (d *Deployer) symlink(ctx context.Context, downloaded, deployed, name, version string) error {
+func (d *Deployer) symlink(ctx context.Context, packageDir, deployed, name, version string) error {
 	_, span := otel.Tracer(tracerName).Start(ctx, "symlink")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("downloaded", downloaded))
+	span.SetAttributes(attribute.String("packageDir", packageDir))
 	span.SetAttributes(attribute.String("deployed", deployed))
 	span.SetAttributes(attribute.String("name", name))
 	span.SetAttributes(attribute.String("version", version))
 
 	logger := d.logger.With(
-		slog.String("downloaded", downloaded),
+		slog.String("packageDir", packageDir),
 		slog.String("deployed", deployed),
 		slog.String("name", name),
 		slog.String("version", version))
@@ -477,8 +466,8 @@ func (d *Deployer) symlink(ctx context.Context, downloaded, deployed, name, vers
 		return newCreatePackageDirErr(err)
 	}
 
-	// <downloaded>/<version>
-	versionPath := filepath.Join(downloaded, version)
+	// <packageDir>/<version>
+	versionPath := filepath.Join(packageDir, version)
 	if _, err := os.Stat(versionPath); err != nil {
 		return newCheckVersionErr(err)
 	}
@@ -492,7 +481,7 @@ func (d *Deployer) symlink(ctx context.Context, downloaded, deployed, name, vers
 	return nil
 }
 
-// Undeploy removes the symlink. If keep=false, also deletes downloaded files.
+// Undeploy removes the symlink. If keep=false, also deletes the package directory.
 func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool) error {
 	_, span := otel.Tracer(tracerName).Start(ctx, "Undeploy")
 	defer span.End()
@@ -527,10 +516,10 @@ func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool)
 			target = filepath.Join(filepath.Dir(deployed), target)
 		}
 
-		downloaded := filepath.Dir(target)
-		logger.Info("delete package dir", slog.String("path", downloaded))
-		if err := os.RemoveAll(downloaded); err != nil {
-			logger.Warn("failed to remove downloaded images", slog.String("path", downloaded))
+		packageDir := filepath.Dir(target)
+		logger.Info("delete package dir", slog.String("path", packageDir))
+		if err := os.RemoveAll(packageDir); err != nil {
+			logger.Warn("failed to remove package dir", slog.String("path", packageDir))
 		}
 	}()
 

--- a/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
@@ -18,61 +18,329 @@ package symlink
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 const (
+	// tracerName is the OpenTelemetry tracer name for deployer operations.
 	tracerName = "deployer"
+	// deployedDir is the deployed packages directory name.
+	deployedDir = "deployed"
+	// loggerName is the logger scope for symlink deployment.
+	loggerName = "symlink-deployer"
 )
 
 // Deployer handles package lifecycle using symlinks instead of dm-verity mounts.
 // Simpler alternative for environments where dm-verity is unavailable.
 type Deployer struct {
-	mu       sync.Mutex
-	registry registryService
-	logger   *log.Logger
+	mu         sync.Mutex
+	downloaded string
+	registry   registryService
+	logger     *log.Logger
 }
 
 type registryService interface {
 	Download(ctx context.Context, cred registry.Remote, out, packageName, tag string) error
 }
 
-// NewDeployer creates a Deployer with the given registry service.
-func NewDeployer(reg registryService, logger *log.Logger) *Deployer {
+// NewDeployer creates a Deployer for packages.
+func NewDeployer(reg registryService, downloaded string, logger *log.Logger) *Deployer {
 	return &Deployer{
-		registry: reg,
-		logger:   logger.Named("symlink-deployer"),
+		registry:   reg,
+		downloaded: downloaded,
+		logger:     logger.Named(loggerName),
 	}
 }
 
 // Deploy fetches a package image from the registry and exposes it at the deployed path.
-func (d *Deployer) Deploy(ctx context.Context, repo registry.Remote, downloaded, deployed, packageName, name, version string) error {
+func (d *Deployer) Deploy(ctx context.Context, repo registry.Remote, packageName, deployedName, version string) error {
 	// one package can be downloaded by different apps in the same time
 	// so lock it to prevent downloading same package
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	downloaded := d.downloadedPath(repo.Name, packageName)
 	if err := d.download(ctx, repo, downloaded, packageName, version); err != nil {
 		return err
 	}
 
-	return d.symlink(ctx, downloaded, deployed, name, version)
+	return d.symlink(ctx, downloaded, d.deployedPath(deployedName), deployedName, version)
+}
+
+// Cleanup removes deployed symlinks and downloaded package versions not listed in preserve.
+func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePackage) error {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "Cleanup")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("downloaded", d.downloaded))
+	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
+
+	logger := d.logger.With(
+		slog.String("downloaded", d.downloaded),
+		slog.String("deployed", d.deployedRoot()))
+
+	logger.Debug("cleanup packages")
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	keep := d.buildCleanupKeep(preserve)
+	if err := cleanupDeployed(ctx, d.deployedRoot(), keep.versions, logger); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("cleanup deployed: %w", err)
+	}
+
+	if err := cleanupDownloaded(ctx, d.downloaded, keep, logger); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return fmt.Errorf("cleanup downloaded: %w", err)
+	}
+
+	return nil
+}
+
+// downloadedPath returns a package download directory under the deployer root.
+func (d *Deployer) downloadedPath(repository, packageName string) string {
+	return filepath.Join(d.downloaded, repository, packageName)
+}
+
+// deployedRoot returns the directory containing deployed package symlinks.
+func (d *Deployer) deployedRoot() string {
+	return filepath.Join(d.downloaded, deployedDir)
+}
+
+// deployedPath returns a package deployed path under the deployer root.
+func (d *Deployer) deployedPath(deployedName string) string {
+	return filepath.Join(d.deployedRoot(), deployedName)
+}
+
+type cleanupKeep struct {
+	versions map[string]struct{}
+	packages map[string]struct{}
+	repos    map[string]struct{}
+}
+
+// buildCleanupKeep returns normalized paths that must survive cleanup.
+func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanupKeep {
+	keep := cleanupKeep{
+		versions: make(map[string]struct{}, len(preserve)),
+		packages: make(map[string]struct{}, len(preserve)),
+		repos:    make(map[string]struct{}),
+	}
+
+	for _, item := range preserve {
+		packageDir := d.cleanupPackageDir(item)
+		versionDir := filepath.Join(packageDir, item.Version)
+
+		keep.versions[normalizePath(versionDir)] = struct{}{}
+		keep.packages[normalizePath(packageDir)] = struct{}{}
+		keep.repos[normalizePath(filepath.Join(d.downloaded, item.Repository))] = struct{}{}
+	}
+
+	return keep
+}
+
+// cleanupPackageDir returns the downloaded package directory for a preserved package.
+func (d *Deployer) cleanupPackageDir(item deployer.PreservePackage) string {
+	return filepath.Join(d.downloaded, item.Repository, item.Name)
+}
+
+// cleanupDeployed removes symlinks whose targets are not preserved downloaded versions.
+func cleanupDeployed(ctx context.Context, deployed string, keepVersions map[string]struct{}, logger *log.Logger) error {
+	entries, err := os.ReadDir(deployed)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		path := filepath.Join(deployed, entry.Name())
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				continue
+			}
+
+			return statErr
+		}
+
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+
+		target, readErr := os.Readlink(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(deployed, target)
+		}
+
+		if _, ok := keepVersions[normalizePath(target)]; ok {
+			continue
+		}
+
+		logger.Info("delete deployed symlink", slog.String("path", path))
+		if err = os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanupDownloaded removes package versions and empty parent directories not preserved.
+// The deployed subdirectory is skipped here — it is handled by cleanupDeployed.
+func cleanupDownloaded(ctx context.Context, downloaded string, keep cleanupKeep, logger *log.Logger) error {
+	entries, err := os.ReadDir(downloaded)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		if entry.Name() == deployedDir {
+			continue
+		}
+
+		path := filepath.Join(downloaded, entry.Name())
+
+		if _, ok := keep.repos[normalizePath(path)]; ok {
+			if err = cleanupRepoDir(ctx, path, keep, logger); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		logger.Info("delete downloaded dir", slog.String("path", path))
+		if err = os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanupRepoDir removes package directories not preserved under an application repository.
+func cleanupRepoDir(ctx context.Context, repo string, keep cleanupKeep, logger *log.Logger) error {
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		path := filepath.Join(repo, entry.Name())
+		if _, ok := keep.packages[normalizePath(path)]; ok {
+			if err = cleanupPackageVersions(ctx, path, keep.versions, logger); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		logger.Info("delete downloaded package dir", slog.String("path", path))
+		if err = os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
+	return removeEmptyDir(repo)
+}
+
+// cleanupPackageVersions removes downloaded versions not listed in keepVersions.
+func cleanupPackageVersions(ctx context.Context, packageDir string, keepVersions map[string]struct{}, logger *log.Logger) error {
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		path := filepath.Join(packageDir, entry.Name())
+		if _, ok := keepVersions[normalizePath(path)]; ok {
+			continue
+		}
+
+		logger.Info("delete downloaded version dir", slog.String("path", path))
+		if err = os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
+	return removeEmptyDir(packageDir)
+}
+
+// removeEmptyDir removes path only when it has no entries.
+func removeEmptyDir(path string) error {
+	err := os.Remove(path)
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
+		return nil
+	}
+
+	return err
+}
+
+// normalizePath returns a comparable absolute clean path when possible.
+func normalizePath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+
+	return filepath.Clean(abs)
 }
 
 // download fetches a package image into a versioned directory via an atomic temporary directory rename.
 func (d *Deployer) download(ctx context.Context, repo registry.Remote, downloaded, name, version string) error {
-	ctx, span := otel.Tracer(tracerName).Start(ctx, "Download")
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "download")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("name", name))
@@ -172,7 +440,7 @@ func tempDownloadPrefix(version string) string {
 // symlink creates a symlink from deployed path to the downloaded version directory.
 // Removes any existing symlink for atomic version switching.
 func (d *Deployer) symlink(ctx context.Context, downloaded, deployed, name, version string) error {
-	_, span := otel.Tracer(tracerName).Start(ctx, "Deploy")
+	_, span := otel.Tracer(tracerName).Start(ctx, "symlink")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("downloaded", downloaded))
@@ -225,17 +493,19 @@ func (d *Deployer) symlink(ctx context.Context, downloaded, deployed, name, vers
 }
 
 // Undeploy removes the symlink. If keep=false, also deletes downloaded files.
-func (d *Deployer) Undeploy(ctx context.Context, downloaded, deployed, name string, keep bool) error {
+func (d *Deployer) Undeploy(ctx context.Context, deployedName string, keep bool) error {
 	_, span := otel.Tracer(tracerName).Start(ctx, "Undeploy")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("name", name))
+	span.SetAttributes(attribute.String("name", deployedName))
 
-	logger := d.logger.With(slog.String("name", name))
+	deployed := d.deployedPath(deployedName)
+	logger := d.logger.With(slog.String("name", deployedName))
 
 	logger.Debug("undeploy package")
 
-	if _, err := os.Lstat(deployed); err != nil {
+	target, err := os.Readlink(deployed)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
@@ -253,6 +523,11 @@ func (d *Deployer) Undeploy(ctx context.Context, downloaded, deployed, name stri
 			return
 		}
 
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(deployed), target)
+		}
+
+		downloaded := filepath.Dir(target)
 		logger.Info("delete package dir", slog.String("path", downloaded))
 		if err := os.RemoveAll(downloaded); err != nil {
 			logger.Warn("failed to remove downloaded images", slog.String("path", downloaded))

--- a/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
+++ b/deckhouse-controller/internal/packages/deployer/symlink/deployer.go
@@ -49,7 +49,7 @@ const (
 // Simpler alternative for environments where dm-verity is unavailable.
 type Deployer struct {
 	mu         sync.Mutex
-	downloaded string
+	workingDir string
 	registry   registryService
 	logger     *log.Logger
 }
@@ -59,10 +59,10 @@ type registryService interface {
 }
 
 // NewDeployer creates a Deployer for packages.
-func NewDeployer(reg registryService, downloaded string, logger *log.Logger) *Deployer {
+func NewDeployer(reg registryService, workingDir string, logger *log.Logger) *Deployer {
 	return &Deployer{
 		registry:   reg,
-		downloaded: downloaded,
+		workingDir: workingDir,
 		logger:     logger.Named(loggerName),
 	}
 }
@@ -87,11 +87,11 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "Cleanup")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("downloaded", d.downloaded))
+	span.SetAttributes(attribute.String("downloaded", d.workingDir))
 	span.SetAttributes(attribute.String("deployed", d.deployedRoot()))
 
 	logger := d.logger.With(
-		slog.String("downloaded", d.downloaded),
+		slog.String("downloaded", d.workingDir),
 		slog.String("deployed", d.deployedRoot()))
 
 	logger.Debug("cleanup packages")
@@ -105,7 +105,7 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 		return fmt.Errorf("cleanup deployed: %w", err)
 	}
 
-	if err := cleanupDownloaded(ctx, d.downloaded, keep, logger); err != nil {
+	if err := cleanupDownloaded(ctx, d.workingDir, keep, logger); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return fmt.Errorf("cleanup downloaded: %w", err)
 	}
@@ -115,12 +115,12 @@ func (d *Deployer) Cleanup(ctx context.Context, preserve []deployer.PreservePack
 
 // downloadedPath returns a package download directory under the deployer root.
 func (d *Deployer) downloadedPath(repository, packageName string) string {
-	return filepath.Join(d.downloaded, repository, packageName)
+	return filepath.Join(d.workingDir, repository, packageName)
 }
 
 // deployedRoot returns the directory containing deployed package symlinks.
 func (d *Deployer) deployedRoot() string {
-	return filepath.Join(d.downloaded, deployedDir)
+	return filepath.Join(d.workingDir, deployedDir)
 }
 
 // deployedPath returns a package deployed path under the deployer root.
@@ -148,15 +148,15 @@ func (d *Deployer) buildCleanupKeep(preserve []deployer.PreservePackage) cleanup
 
 		keep.versions[normalizePath(versionDir)] = struct{}{}
 		keep.packages[normalizePath(packageDir)] = struct{}{}
-		keep.repos[normalizePath(filepath.Join(d.downloaded, item.Repository))] = struct{}{}
+		keep.repos[normalizePath(filepath.Join(d.workingDir, item.Repository))] = struct{}{}
 	}
 
 	return keep
 }
 
-// cleanupPackageDir returns the downloaded package directory for a preserved package.
+// cleanupPackageDir returns the workingDir package directory for a preserved package.
 func (d *Deployer) cleanupPackageDir(item deployer.PreservePackage) string {
-	return filepath.Join(d.downloaded, item.Repository, item.Name)
+	return filepath.Join(d.workingDir, item.Repository, item.Name)
 }
 
 // cleanupDeployed removes symlinks whose targets are not preserved downloaded versions.
@@ -437,7 +437,7 @@ func tempDownloadPrefix(version string) string {
 	return "." + strings.NewReplacer("/", "_", string(os.PathSeparator), "_").Replace(version) + ".tmp-"
 }
 
-// symlink creates a symlink from deployed path to the downloaded version directory.
+// symlink creates a symlink from deployed path to the workingDir version directory.
 // Removes any existing symlink for atomic version switching.
 func (d *Deployer) symlink(ctx context.Context, downloaded, deployed, name, version string) error {
 	_, span := otel.Tracer(tracerName).Start(ctx, "symlink")

--- a/deckhouse-controller/internal/packages/deployer/symlink/deployer_test.go
+++ b/deckhouse-controller/internal/packages/deployer/symlink/deployer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer/symlink"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
@@ -79,6 +80,15 @@ func setupSymlink(t *testing.T, deployed, target string) {
 	require.NoError(t, os.Symlink(target, deployed))
 }
 
+// setupDeployer creates a test deployer and returns package-specific paths.
+func setupDeployer(tmpDir string, downloader *mockDownloader) (*symlink.Deployer, string, string) {
+	downloadedRoot := filepath.Join(tmpDir, "downloaded")
+	downloaded := filepath.Join(downloadedRoot, "apps", "test-repo", "my-package")
+	deployed := filepath.Join(downloadedRoot, "apps", "deployed", "my-package")
+
+	return symlink.NewDeployer(downloader, filepath.Join(downloadedRoot, "apps"), log.NewNop()), downloaded, deployed
+}
+
 // TestDeployDownloadsPackage verifies that Deploy downloads package contents and exposes the version path.
 func TestDeployDownloadsPackage(t *testing.T) {
 	tests := []struct {
@@ -115,10 +125,8 @@ func TestDeployDownloadsPackage(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			downloaded := filepath.Join(tmpDir, "downloaded", "my-package")
-			deployed := filepath.Join(tmpDir, "deployed", "my-package")
+			deployer, downloaded, deployed := setupDeployer(tmpDir, &mockDownloader{downloadErr: tc.downloadErr})
 
-			deployer := symlink.NewDeployer(&mockDownloader{downloadErr: tc.downloadErr}, log.NewNop())
 			repo := registry.Remote{Name: "test-repo", Repository: "registry.example.com"}
 
 			ctx := context.Background()
@@ -128,7 +136,7 @@ func TestDeployDownloadsPackage(t *testing.T) {
 				cancel()
 			}
 
-			err := deployer.Deploy(ctx, repo, downloaded, deployed, "my-package", "my-package", "1.0.0")
+			err := deployer.Deploy(ctx, repo, "my-package", "my-package", "1.0.0")
 
 			if tc.wantErrIs != nil {
 				require.Error(t, err)
@@ -154,14 +162,12 @@ func TestDeployDownloadsPackage(t *testing.T) {
 // TestDeployRemovesPartialDownload verifies that failed downloads do not publish reusable version directories.
 func TestDeployRemovesPartialDownload(t *testing.T) {
 	tmpDir := t.TempDir()
-	downloaded := filepath.Join(tmpDir, "downloaded", "my-package")
-	deployed := filepath.Join(tmpDir, "deployed", "my-package")
 	repo := registry.Remote{Name: "test-repo", Repository: "registry.example.com"}
 
 	failingDownloader := &mockDownloader{partialBeforeErr: true}
-	deployer := symlink.NewDeployer(failingDownloader, log.NewNop())
+	deployer, downloaded, deployed := setupDeployer(tmpDir, failingDownloader)
 
-	err := deployer.Deploy(context.Background(), repo, downloaded, deployed, "my-package", "my-package", "1.0.0")
+	err := deployer.Deploy(context.Background(), repo, "my-package", "my-package", "1.0.0")
 	require.Error(t, err)
 
 	_, statErr := os.Stat(filepath.Join(downloaded, "1.0.0"))
@@ -170,9 +176,9 @@ func TestDeployRemovesPartialDownload(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "failed deploy should not create deployed symlink")
 
 	successfulDownloader := &mockDownloader{}
-	deployer = symlink.NewDeployer(successfulDownloader, log.NewNop())
+	deployer, _, _ = setupDeployer(tmpDir, successfulDownloader)
 
-	err = deployer.Deploy(context.Background(), repo, downloaded, deployed, "my-package", "my-package", "1.0.0")
+	err = deployer.Deploy(context.Background(), repo, "my-package", "my-package", "1.0.0")
 	require.NoError(t, err)
 	require.Equal(t, 1, successfulDownloader.calls)
 
@@ -184,17 +190,15 @@ func TestDeployRemovesPartialDownload(t *testing.T) {
 // TestDeployReusesCompletedVersion verifies that an existing completed version is reused without registry access.
 func TestDeployReusesCompletedVersion(t *testing.T) {
 	tmpDir := t.TempDir()
-	downloaded := filepath.Join(tmpDir, "downloaded", "my-package")
-	deployed := filepath.Join(tmpDir, "deployed", "my-package")
+	downloader := &mockDownloader{}
+	deployer, downloaded, deployed := setupDeployer(tmpDir, downloader)
 	versionPath := filepath.Join(downloaded, "1.0.0")
 	require.NoError(t, os.MkdirAll(versionPath, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(versionPath, "package.yaml"), []byte("name: my-package\nversion: cached"), 0644))
 
-	downloader := &mockDownloader{}
-	deployer := symlink.NewDeployer(downloader, log.NewNop())
 	repo := registry.Remote{Name: "test-repo", Repository: "registry.example.com"}
 
-	err := deployer.Deploy(context.Background(), repo, downloaded, deployed, "my-package", "my-package", "1.0.0")
+	err := deployer.Deploy(context.Background(), repo, "my-package", "my-package", "1.0.0")
 	require.NoError(t, err)
 	require.Zero(t, downloader.calls)
 
@@ -270,14 +274,11 @@ func TestDeploy(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			downloaded := filepath.Join(tmpDir, "downloaded", "my-package")
-			deployed := filepath.Join(tmpDir, "deployed", "my-package")
+			deployer, downloaded, deployed := setupDeployer(tmpDir, new(mockDownloader))
 
 			if tc.setup != nil {
 				tc.setup(t, downloaded, deployed)
 			}
-
-			deployer := symlink.NewDeployer(new(mockDownloader), log.NewNop())
 
 			ctx := context.Background()
 			if tc.cancelCtx {
@@ -287,7 +288,7 @@ func TestDeploy(t *testing.T) {
 			}
 
 			repo := registry.Remote{Name: "test-repo", Repository: "registry.example.com"}
-			err := deployer.Deploy(ctx, repo, downloaded, deployed, "my-package", "my-package", tc.version)
+			err := deployer.Deploy(ctx, repo, "my-package", "my-package", tc.version)
 
 			if tc.wantErrIs != nil {
 				require.Error(t, err)
@@ -369,21 +370,242 @@ func TestUndeploy(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			downloaded := filepath.Join(tmpDir, "downloaded", "my-package")
-			deployed := filepath.Join(tmpDir, "deployed", "my-package")
+			deployer, downloaded, deployed := setupDeployer(tmpDir, new(mockDownloader))
 
 			if tc.setup != nil {
 				tc.setup(t, downloaded, deployed)
 			}
 
-			deployer := symlink.NewDeployer(new(mockDownloader), log.NewNop())
-
-			err := deployer.Undeploy(context.Background(), downloaded, deployed, "my-package", tc.keep)
+			err := deployer.Undeploy(context.Background(), "my-package", tc.keep)
 			require.NoError(t, err)
 
 			if tc.checkResult != nil {
 				tc.checkResult(t, downloaded, deployed)
 			}
+		})
+	}
+}
+
+// newCleanupDeployer creates a fresh deployer rooted at a tempdir-relative apps/ directory.
+// Returns the deployer and the apps root that was passed to NewDeployer.
+func newCleanupDeployer(t *testing.T) (*symlink.Deployer, string) {
+	t.Helper()
+	appsRoot := filepath.Join(t.TempDir(), "downloaded", "apps")
+	require.NoError(t, os.MkdirAll(appsRoot, 0755))
+	return symlink.NewDeployer(new(mockDownloader), appsRoot, log.NewNop()), appsRoot
+}
+
+// makePackageVersion lays out <appsRoot>/<repo>/<pkg>/<version>/version and returns the version dir.
+func makePackageVersion(t *testing.T, appsRoot, repo, pkg, version string) string {
+	t.Helper()
+	return setupVersionDir(t, filepath.Join(appsRoot, repo, pkg), version, version)
+}
+
+// makeDeployedSymlink creates <appsRoot>/deployed/<name> -> target and returns the symlink path.
+func makeDeployedSymlink(t *testing.T, appsRoot, name, target string) string {
+	t.Helper()
+	deployed := filepath.Join(appsRoot, "deployed", name)
+	setupSymlink(t, deployed, target)
+	return deployed
+}
+
+// preserved is a shorthand for building a PreservePackage triple in test tables.
+func preserved(repo, pkg, version string) deployer.PreservePackage {
+	return deployer.PreservePackage{Repository: repo, Name: pkg, Version: version}
+}
+
+// TestCleanup verifies that Cleanup removes only the downloaded versions and deployed
+// symlinks that are not listed in the preserve set, and that empty parent directories
+// collapse afterwards.
+func TestCleanup(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, appsRoot string) []deployer.PreservePackage
+		cancelCtx bool
+		wantErrIs error
+		check     func(t *testing.T, appsRoot string)
+	}{
+		{
+			name: "empty_preserve_removes_all_packages",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				makePackageVersion(t, appsRoot, "repo-a", "pkg-2", "2.0.0")
+				makePackageVersion(t, appsRoot, "repo-b", "pkg-3", "3.0.0")
+				return nil
+			},
+			check: func(t *testing.T, appsRoot string) {
+				for _, repo := range []string{"repo-a", "repo-b"} {
+					_, err := os.Stat(filepath.Join(appsRoot, repo))
+					assert.True(t, os.IsNotExist(err), "%s should be removed", repo)
+				}
+			},
+		},
+		{
+			name: "preserve_one_version_removes_other_versions",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "2.0.0")
+				return []deployer.PreservePackage{preserved("repo-a", "pkg-1", "1.0.0")}
+			},
+			check: func(t *testing.T, appsRoot string) {
+				assert.DirExists(t, filepath.Join(appsRoot, "repo-a", "pkg-1", "1.0.0"))
+				_, err := os.Stat(filepath.Join(appsRoot, "repo-a", "pkg-1", "2.0.0"))
+				assert.True(t, os.IsNotExist(err), "non-preserved version should be removed")
+			},
+		},
+		{
+			name: "preserve_one_package_removes_siblings_in_same_repo",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				makePackageVersion(t, appsRoot, "repo-a", "kept", "1.0.0")
+				makePackageVersion(t, appsRoot, "repo-a", "dropped", "1.0.0")
+				return []deployer.PreservePackage{preserved("repo-a", "kept", "1.0.0")}
+			},
+			check: func(t *testing.T, appsRoot string) {
+				assert.DirExists(t, filepath.Join(appsRoot, "repo-a", "kept", "1.0.0"))
+				_, err := os.Stat(filepath.Join(appsRoot, "repo-a", "dropped"))
+				assert.True(t, os.IsNotExist(err), "sibling package should be removed")
+			},
+		},
+		{
+			name: "preserve_one_repo_removes_other_repos",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				makePackageVersion(t, appsRoot, "repo-b", "pkg-1", "1.0.0")
+				return []deployer.PreservePackage{preserved("repo-a", "pkg-1", "1.0.0")}
+			},
+			check: func(t *testing.T, appsRoot string) {
+				assert.DirExists(t, filepath.Join(appsRoot, "repo-a", "pkg-1", "1.0.0"))
+				_, err := os.Stat(filepath.Join(appsRoot, "repo-b"))
+				assert.True(t, os.IsNotExist(err), "non-preserved repo should be removed")
+			},
+		},
+		{
+			name: "deployed_symlink_to_preserved_version_kept",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				v := makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				makeDeployedSymlink(t, appsRoot, "alias", v)
+				return []deployer.PreservePackage{preserved("repo-a", "pkg-1", "1.0.0")}
+			},
+			check: func(t *testing.T, appsRoot string) {
+				link := filepath.Join(appsRoot, "deployed", "alias")
+				info, err := os.Lstat(link)
+				require.NoError(t, err, "symlink should still exist")
+				assert.NotZero(t, info.Mode()&os.ModeSymlink, "alias should still be a symlink")
+				assert.DirExists(t, filepath.Join(appsRoot, "repo-a", "pkg-1", "1.0.0"))
+			},
+		},
+		{
+			name: "deployed_symlink_to_unpreserved_version_removed",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				v1 := makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "2.0.0")
+				makeDeployedSymlink(t, appsRoot, "alias", v1)
+				return []deployer.PreservePackage{preserved("repo-a", "pkg-1", "2.0.0")}
+			},
+			check: func(t *testing.T, appsRoot string) {
+				_, err := os.Lstat(filepath.Join(appsRoot, "deployed", "alias"))
+				assert.True(t, os.IsNotExist(err), "stale symlink should be removed")
+				_, err = os.Stat(filepath.Join(appsRoot, "repo-a", "pkg-1", "1.0.0"))
+				assert.True(t, os.IsNotExist(err), "stale version should be removed")
+				assert.DirExists(t, filepath.Join(appsRoot, "repo-a", "pkg-1", "2.0.0"))
+			},
+		},
+		{
+			name: "relative_symlink_target_matches_preserve",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				v := makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				deployedRoot := filepath.Join(appsRoot, "deployed")
+				require.NoError(t, os.MkdirAll(deployedRoot, 0755))
+				rel, err := filepath.Rel(deployedRoot, v)
+				require.NoError(t, err)
+				require.NoError(t, os.Symlink(rel, filepath.Join(deployedRoot, "alias")))
+				return []deployer.PreservePackage{preserved("repo-a", "pkg-1", "1.0.0")}
+			},
+			check: func(t *testing.T, appsRoot string) {
+				_, err := os.Lstat(filepath.Join(appsRoot, "deployed", "alias"))
+				require.NoError(t, err, "relative symlink should be kept when target is preserved")
+			},
+		},
+		{
+			name: "non_symlink_entry_in_deployed_left_alone",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				deployedRoot := filepath.Join(appsRoot, "deployed")
+				require.NoError(t, os.MkdirAll(deployedRoot, 0755))
+				require.NoError(t, os.WriteFile(filepath.Join(deployedRoot, "stray.txt"), []byte("x"), 0644))
+				return nil
+			},
+			check: func(t *testing.T, appsRoot string) {
+				_, err := os.Stat(filepath.Join(appsRoot, "deployed", "stray.txt"))
+				require.NoError(t, err, "non-symlink entry should be left alone")
+			},
+		},
+		{
+			name: "deployed_dir_skipped_during_downloaded_walk",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				v := makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				makeDeployedSymlink(t, appsRoot, "alias", v)
+				return nil
+			},
+			check: func(t *testing.T, appsRoot string) {
+				assert.DirExists(t, filepath.Join(appsRoot, "deployed"), "deployed root should not be removed")
+				_, err := os.Lstat(filepath.Join(appsRoot, "deployed", "alias"))
+				assert.True(t, os.IsNotExist(err), "stale symlink should be removed")
+				_, err = os.Stat(filepath.Join(appsRoot, "repo-a"))
+				assert.True(t, os.IsNotExist(err), "non-preserved repo should be removed")
+			},
+		},
+		{
+			name: "preserve_with_missing_version_collapses_empty_dirs",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				require.NoError(t, os.MkdirAll(filepath.Join(appsRoot, "repo-a", "pkg-1"), 0755))
+				return []deployer.PreservePackage{preserved("repo-a", "pkg-1", "1.0.0")}
+			},
+			check: func(t *testing.T, appsRoot string) {
+				_, err := os.Stat(filepath.Join(appsRoot, "repo-a"))
+				assert.True(t, os.IsNotExist(err), "empty preserved repo should collapse")
+			},
+		},
+		{
+			name:  "idempotent_on_missing_tree",
+			setup: func(_ *testing.T, _ string) []deployer.PreservePackage { return nil },
+			check: func(*testing.T, string) {},
+		},
+		{
+			name: "context_canceled_aborts_cleanup",
+			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
+				makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
+				return nil
+			},
+			cancelCtx: true,
+			wantErrIs: context.Canceled,
+			check: func(t *testing.T, appsRoot string) {
+				assert.DirExists(t, filepath.Join(appsRoot, "repo-a", "pkg-1", "1.0.0"), "tree should remain when ctx canceled")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, appsRoot := newCleanupDeployer(t)
+
+			preserve := tc.setup(t, appsRoot)
+
+			ctx := context.Background()
+			if tc.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			err := d.Cleanup(ctx, preserve)
+			if tc.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErrIs)
+			} else {
+				require.NoError(t, err)
+			}
+
+			tc.check(t, appsRoot)
 		})
 	}
 }
@@ -420,19 +642,17 @@ func TestLifecycle(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			downloaded := filepath.Join(tmpDir, "downloaded", "my-package")
-			deployed := filepath.Join(tmpDir, "deployed", "my-package")
+			deployer, downloaded, deployed := setupDeployer(tmpDir, new(mockDownloader))
 
 			// Create parent directory for deployed symlink
 			require.NoError(t, os.MkdirAll(filepath.Dir(deployed), 0755))
 
-			deployer := symlink.NewDeployer(new(mockDownloader), log.NewNop())
 			repo := registry.Remote{Name: "test-repo", Repository: "registry.example.com"}
 			ctx := context.Background()
 
 			// Download and deploy each version.
 			for _, version := range tc.versions {
-				err := deployer.Deploy(ctx, repo, downloaded, deployed, "my-package", "my-package", version)
+				err := deployer.Deploy(ctx, repo, "my-package", "my-package", version)
 				require.NoError(t, err, "deploy %s", version)
 
 				// Verify correct version is deployed
@@ -447,7 +667,7 @@ func TestLifecycle(t *testing.T) {
 			}
 
 			// Undeploy
-			err := deployer.Undeploy(ctx, downloaded, deployed, "my-package", !tc.cleanup)
+			err := deployer.Undeploy(ctx, "my-package", !tc.cleanup)
 			require.NoError(t, err)
 
 			// Verify symlink removed

--- a/deckhouse-controller/internal/packages/deployer/symlink/deployer_test.go
+++ b/deckhouse-controller/internal/packages/deployer/symlink/deployer_test.go
@@ -82,11 +82,11 @@ func setupSymlink(t *testing.T, deployed, target string) {
 
 // setupDeployer creates a test deployer and returns package-specific paths.
 func setupDeployer(tmpDir string, downloader *mockDownloader) (*symlink.Deployer, string, string) {
-	downloadedRoot := filepath.Join(tmpDir, "downloaded")
-	downloaded := filepath.Join(downloadedRoot, "apps", "test-repo", "my-package")
-	deployed := filepath.Join(downloadedRoot, "apps", "deployed", "my-package")
+	root := filepath.Join(tmpDir, "root")
+	packageDir := filepath.Join(root, "apps", "test-repo", "my-package")
+	deployed := filepath.Join(root, "apps", "deployed", "my-package")
 
-	return symlink.NewDeployer(downloader, filepath.Join(downloadedRoot, "apps"), log.NewNop()), downloaded, deployed
+	return symlink.NewDeployer(downloader, filepath.Join(root, "apps"), log.NewNop()), packageDir, deployed
 }
 
 // TestDeployDownloadsPackage verifies that Deploy downloads package contents and exposes the version path.
@@ -96,12 +96,12 @@ func TestDeployDownloadsPackage(t *testing.T) {
 		downloadErr error
 		cancelCtx   bool
 		wantErrIs   error // nil = success, errAny = any error, specific = errors.Is check
-		checkResult func(t *testing.T, downloaded, deployed string)
+		checkResult func(t *testing.T, packageDir, deployed string)
 	}{
 		{
 			name: "success",
-			checkResult: func(t *testing.T, downloaded, deployed string) {
-				versionPath := filepath.Join(downloaded, "1.0.0")
+			checkResult: func(t *testing.T, packageDir, deployed string) {
+				versionPath := filepath.Join(packageDir, "1.0.0")
 				assert.DirExists(t, versionPath)
 				assert.FileExists(t, filepath.Join(versionPath, "package.yaml"))
 
@@ -125,7 +125,7 @@ func TestDeployDownloadsPackage(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			deployer, downloaded, deployed := setupDeployer(tmpDir, &mockDownloader{downloadErr: tc.downloadErr})
+			deployer, packageDir, deployed := setupDeployer(tmpDir, &mockDownloader{downloadErr: tc.downloadErr})
 
 			repo := registry.Remote{Name: "test-repo", Repository: "registry.example.com"}
 
@@ -153,7 +153,7 @@ func TestDeployDownloadsPackage(t *testing.T) {
 
 			require.NoError(t, err)
 			if tc.checkResult != nil {
-				tc.checkResult(t, downloaded, deployed)
+				tc.checkResult(t, packageDir, deployed)
 			}
 		})
 	}
@@ -165,12 +165,12 @@ func TestDeployRemovesPartialDownload(t *testing.T) {
 	repo := registry.Remote{Name: "test-repo", Repository: "registry.example.com"}
 
 	failingDownloader := &mockDownloader{partialBeforeErr: true}
-	deployer, downloaded, deployed := setupDeployer(tmpDir, failingDownloader)
+	deployer, packageDir, deployed := setupDeployer(tmpDir, failingDownloader)
 
 	err := deployer.Deploy(context.Background(), repo, "my-package", "my-package", "1.0.0")
 	require.Error(t, err)
 
-	_, statErr := os.Stat(filepath.Join(downloaded, "1.0.0"))
+	_, statErr := os.Stat(filepath.Join(packageDir, "1.0.0"))
 	require.True(t, os.IsNotExist(statErr), "partial version dir should not be published")
 	_, statErr = os.Lstat(deployed)
 	require.True(t, os.IsNotExist(statErr), "failed deploy should not create deployed symlink")
@@ -191,8 +191,8 @@ func TestDeployRemovesPartialDownload(t *testing.T) {
 func TestDeployReusesCompletedVersion(t *testing.T) {
 	tmpDir := t.TempDir()
 	downloader := &mockDownloader{}
-	deployer, downloaded, deployed := setupDeployer(tmpDir, downloader)
-	versionPath := filepath.Join(downloaded, "1.0.0")
+	deployer, packageDir, deployed := setupDeployer(tmpDir, downloader)
+	versionPath := filepath.Join(packageDir, "1.0.0")
 	require.NoError(t, os.MkdirAll(versionPath, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(versionPath, "package.yaml"), []byte("name: my-package\nversion: cached"), 0644))
 
@@ -212,20 +212,20 @@ func TestDeploy(t *testing.T) {
 	tests := []struct {
 		name        string
 		version     string
-		setup       func(t *testing.T, downloaded, deployed string)
+		setup       func(t *testing.T, packageDir, deployed string)
 		cancelCtx   bool
 		wantErrIs   error
-		checkResult func(t *testing.T, downloaded, deployed string)
+		checkResult func(t *testing.T, packageDir, deployed string)
 	}{
 		{
 			name:    "creates_symlink",
 			version: "1.0.0",
-			setup: func(t *testing.T, downloaded, deployed string) {
-				setupVersionDir(t, downloaded, "1.0.0", "1.0.0")
+			setup: func(t *testing.T, packageDir, deployed string) {
+				setupVersionDir(t, packageDir, "1.0.0", "1.0.0")
 				require.NoError(t, os.MkdirAll(filepath.Dir(deployed), 0755))
 			},
-			checkResult: func(t *testing.T, downloaded, deployed string) {
-				versionPath := filepath.Join(downloaded, "1.0.0")
+			checkResult: func(t *testing.T, packageDir, deployed string) {
+				versionPath := filepath.Join(packageDir, "1.0.0")
 				linkTarget, err := os.Readlink(deployed)
 				require.NoError(t, err)
 				assert.Equal(t, versionPath, linkTarget)
@@ -238,9 +238,9 @@ func TestDeploy(t *testing.T) {
 		{
 			name:    "replaces_existing_symlink",
 			version: "2.0.0",
-			setup: func(t *testing.T, downloaded, deployed string) {
-				v1 := setupVersionDir(t, downloaded, "1.0.0", "1.0.0")
-				setupVersionDir(t, downloaded, "2.0.0", "2.0.0")
+			setup: func(t *testing.T, packageDir, deployed string) {
+				v1 := setupVersionDir(t, packageDir, "1.0.0", "1.0.0")
+				setupVersionDir(t, packageDir, "2.0.0", "2.0.0")
 				setupSymlink(t, deployed, v1)
 			},
 			checkResult: func(t *testing.T, _, deployed string) {
@@ -258,9 +258,9 @@ func TestDeploy(t *testing.T) {
 		{
 			name:    "downgrade_version",
 			version: "1.0.0",
-			setup: func(t *testing.T, downloaded, deployed string) {
-				setupVersionDir(t, downloaded, "1.0.0", "1.0.0")
-				v2 := setupVersionDir(t, downloaded, "2.0.0", "2.0.0")
+			setup: func(t *testing.T, packageDir, deployed string) {
+				setupVersionDir(t, packageDir, "1.0.0", "1.0.0")
+				v2 := setupVersionDir(t, packageDir, "2.0.0", "2.0.0")
 				setupSymlink(t, deployed, v2)
 			},
 			checkResult: func(t *testing.T, _, deployed string) {
@@ -274,10 +274,10 @@ func TestDeploy(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			deployer, downloaded, deployed := setupDeployer(tmpDir, new(mockDownloader))
+			deployer, packageDir, deployed := setupDeployer(tmpDir, new(mockDownloader))
 
 			if tc.setup != nil {
-				tc.setup(t, downloaded, deployed)
+				tc.setup(t, packageDir, deployed)
 			}
 
 			ctx := context.Background()
@@ -300,45 +300,45 @@ func TestDeploy(t *testing.T) {
 
 			require.NoError(t, err)
 			if tc.checkResult != nil {
-				tc.checkResult(t, downloaded, deployed)
+				tc.checkResult(t, packageDir, deployed)
 			}
 		})
 	}
 }
 
-// TestUndeploy verifies symlink removal and downloaded file cleanup behavior.
+// TestUndeploy verifies symlink removal and package directory cleanup behavior.
 func TestUndeploy(t *testing.T) {
 	tests := []struct {
 		name        string
-		setup       func(t *testing.T, downloaded, deployed string)
+		setup       func(t *testing.T, packageDir, deployed string)
 		keep        bool
-		checkResult func(t *testing.T, downloaded, deployed string)
+		checkResult func(t *testing.T, packageDir, deployed string)
 	}{
 		{
 			name: "removes_symlink_keeps_files",
-			setup: func(t *testing.T, downloaded, deployed string) {
-				versionPath := setupVersionDir(t, downloaded, "1.0.0", "1.0.0")
+			setup: func(t *testing.T, packageDir, deployed string) {
+				versionPath := setupVersionDir(t, packageDir, "1.0.0", "1.0.0")
 				setupSymlink(t, deployed, versionPath)
 			},
 			keep: true,
-			checkResult: func(t *testing.T, downloaded, deployed string) {
+			checkResult: func(t *testing.T, packageDir, deployed string) {
 				_, err := os.Lstat(deployed)
 				assert.True(t, os.IsNotExist(err), "symlink should be removed")
-				assert.DirExists(t, filepath.Join(downloaded, "1.0.0"), "version dir should be kept")
+				assert.DirExists(t, filepath.Join(packageDir, "1.0.0"), "version dir should be kept")
 			},
 		},
 		{
 			name: "removes_symlink_deletes_files",
-			setup: func(t *testing.T, downloaded, deployed string) {
-				versionPath := setupVersionDir(t, downloaded, "1.0.0", "1.0.0")
+			setup: func(t *testing.T, packageDir, deployed string) {
+				versionPath := setupVersionDir(t, packageDir, "1.0.0", "1.0.0")
 				setupSymlink(t, deployed, versionPath)
 			},
 			keep: false,
-			checkResult: func(t *testing.T, downloaded, deployed string) {
+			checkResult: func(t *testing.T, packageDir, deployed string) {
 				_, err := os.Lstat(deployed)
 				assert.True(t, os.IsNotExist(err), "symlink should be removed")
-				_, err = os.Stat(downloaded)
-				assert.True(t, os.IsNotExist(err), "downloaded dir should be removed")
+				_, err = os.Stat(packageDir)
+				assert.True(t, os.IsNotExist(err), "package dir should be removed")
 			},
 		},
 		{
@@ -352,17 +352,17 @@ func TestUndeploy(t *testing.T) {
 		},
 		{
 			name: "keeps_multiple_versions",
-			setup: func(t *testing.T, downloaded, deployed string) {
-				setupVersionDir(t, downloaded, "1.0.0", "1.0.0")
-				versionPath := setupVersionDir(t, downloaded, "2.0.0", "2.0.0")
+			setup: func(t *testing.T, packageDir, deployed string) {
+				setupVersionDir(t, packageDir, "1.0.0", "1.0.0")
+				versionPath := setupVersionDir(t, packageDir, "2.0.0", "2.0.0")
 				setupSymlink(t, deployed, versionPath)
 			},
 			keep: true,
-			checkResult: func(t *testing.T, downloaded, deployed string) {
+			checkResult: func(t *testing.T, packageDir, deployed string) {
 				_, err := os.Lstat(deployed)
 				assert.True(t, os.IsNotExist(err), "symlink should be removed")
-				assert.DirExists(t, filepath.Join(downloaded, "1.0.0"), "v1 should be kept")
-				assert.DirExists(t, filepath.Join(downloaded, "2.0.0"), "v2 should be kept")
+				assert.DirExists(t, filepath.Join(packageDir, "1.0.0"), "v1 should be kept")
+				assert.DirExists(t, filepath.Join(packageDir, "2.0.0"), "v2 should be kept")
 			},
 		},
 	}
@@ -370,17 +370,17 @@ func TestUndeploy(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			deployer, downloaded, deployed := setupDeployer(tmpDir, new(mockDownloader))
+			deployer, packageDir, deployed := setupDeployer(tmpDir, new(mockDownloader))
 
 			if tc.setup != nil {
-				tc.setup(t, downloaded, deployed)
+				tc.setup(t, packageDir, deployed)
 			}
 
 			err := deployer.Undeploy(context.Background(), "my-package", tc.keep)
 			require.NoError(t, err)
 
 			if tc.checkResult != nil {
-				tc.checkResult(t, downloaded, deployed)
+				tc.checkResult(t, packageDir, deployed)
 			}
 		})
 	}
@@ -390,7 +390,7 @@ func TestUndeploy(t *testing.T) {
 // Returns the deployer and the apps root that was passed to NewDeployer.
 func newCleanupDeployer(t *testing.T) (*symlink.Deployer, string) {
 	t.Helper()
-	appsRoot := filepath.Join(t.TempDir(), "downloaded", "apps")
+	appsRoot := filepath.Join(t.TempDir(), "root", "apps")
 	require.NoError(t, os.MkdirAll(appsRoot, 0755))
 	return symlink.NewDeployer(new(mockDownloader), appsRoot, log.NewNop()), appsRoot
 }
@@ -414,7 +414,7 @@ func preserved(repo, pkg, version string) deployer.PreservePackage {
 	return deployer.PreservePackage{Repository: repo, Name: pkg, Version: version}
 }
 
-// TestCleanup verifies that Cleanup removes only the downloaded versions and deployed
+// TestCleanup verifies that Cleanup removes only the package versions and deployed
 // symlinks that are not listed in the preserve set, and that empty parent directories
 // collapse afterwards.
 func TestCleanup(t *testing.T) {
@@ -540,7 +540,7 @@ func TestCleanup(t *testing.T) {
 			},
 		},
 		{
-			name: "deployed_dir_skipped_during_downloaded_walk",
+			name: "deployed_dir_skipped_during_package_walk",
 			setup: func(t *testing.T, appsRoot string) []deployer.PreservePackage {
 				v := makePackageVersion(t, appsRoot, "repo-a", "pkg-1", "1.0.0")
 				makeDeployedSymlink(t, appsRoot, "alias", v)
@@ -642,7 +642,7 @@ func TestLifecycle(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			deployer, downloaded, deployed := setupDeployer(tmpDir, new(mockDownloader))
+			deployer, packageDir, deployed := setupDeployer(tmpDir, new(mockDownloader))
 
 			// Create parent directory for deployed symlink
 			require.NoError(t, os.MkdirAll(filepath.Dir(deployed), 0755))
@@ -663,7 +663,7 @@ func TestLifecycle(t *testing.T) {
 
 			// All version directories should exist before undeploy.
 			for _, version := range tc.versions {
-				assert.DirExists(t, filepath.Join(downloaded, version))
+				assert.DirExists(t, filepath.Join(packageDir, version))
 			}
 
 			// Undeploy
@@ -675,11 +675,11 @@ func TestLifecycle(t *testing.T) {
 			assert.True(t, os.IsNotExist(err), "symlink should be removed")
 
 			// Verify cleanup behavior
-			_, err = os.Stat(downloaded)
+			_, err = os.Stat(packageDir)
 			if tc.cleanup {
-				assert.True(t, os.IsNotExist(err), "downloaded dir should be removed")
+				assert.True(t, os.IsNotExist(err), "package dir should be removed")
 			} else {
-				assert.NoError(t, err, "downloaded dir should be kept")
+				assert.NoError(t, err, "package dir should be kept")
 			}
 		})
 	}

--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -107,7 +107,7 @@ func (r *Runtime) UpdateApp(repo registry.Remote, app App) {
 	r.status.ClearRuntimeConditions(name)
 
 	tasks := []queue.Task{
-		taskdeploy.NewAppTask(name, packageName, version, repo, r.deployer, r.status, r.logger),
+		taskdeploy.NewAppTask(name, packageName, version, repo, r.appDeployer, r.status, r.logger),
 		taskload.NewAppTask(name, repo, r.loadApp, r.status, r.logger),
 	}
 
@@ -194,5 +194,5 @@ func (r *Runtime) RemoveApp(namespace, instance string) {
 		}()
 	})
 
-	r.queueService.Enqueue(ctx, name, taskundeploy.NewAppTask(name, r.deployer, r.logger), cleanup)
+	r.queueService.Enqueue(ctx, name, taskundeploy.NewAppTask(name, r.appDeployer, r.logger), cleanup)
 }

--- a/deckhouse-controller/internal/packages/runtime/hookevent/handler.go
+++ b/deckhouse-controller/internal/packages/runtime/hookevent/handler.go
@@ -118,7 +118,7 @@ func NewHandler(conf Config, logger *log.Logger) *Handler {
 //   - One of the event channels closes (abnormal termination)
 //
 // To stop the handler, call Stop() which waits for goroutine completion.
-func (h *Handler) Start() *Handler {
+func (h *Handler) Start() {
 	h.once.Do(func() {
 		h.logger.Info("start loop")
 
@@ -162,8 +162,6 @@ func (h *Handler) Start() *Handler {
 			}
 		}()
 	})
-
-	return h
 }
 
 // Stop gracefully shuts down the event handler.

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -77,7 +77,7 @@ func (r *Runtime) UpdateModule(repo registry.Remote, module Module) {
 	r.status.ClearRuntimeConditions(name)
 
 	tasks := []queue.Task{
-		taskdeploy.NewModuleTask(name, version, repo, r.deployer, r.status, r.logger),
+		taskdeploy.NewModuleTask(name, version, repo, r.moduleDeployer, r.status, r.logger),
 		taskload.NewModuleTask(name, repo, r.loadModule, r.status, r.logger),
 	}
 
@@ -159,5 +159,5 @@ func (r *Runtime) RemoveModule(name string) {
 		}()
 	})
 
-	r.queueService.Enqueue(ctx, name, taskundeploy.NewModuleTask(name, r.deployer, r.logger), cleanup)
+	r.queueService.Enqueue(ctx, name, taskundeploy.NewModuleTask(name, r.moduleDeployer, r.logger), cleanup)
 }

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/cron"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/apps"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer"
 	erofsdeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer/erofs"
 	symlinkdeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer/symlink"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
@@ -55,6 +57,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/tools/verity"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	"github.com/deckhouse/deckhouse/go_lib/d8env"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
@@ -83,7 +86,8 @@ type Runtime struct {
 	hookEventHandler *hookevent.Handler // Routes Kube/schedule events into hook tasks
 	queueService     *queue.Service     // Per-package task queues with retry
 	nelmService      *nelm.Service      // Helm release management and drift monitoring
-	deployer         deployerI          // Deploys and undeploys package images
+	appDeployer      deployerI          // Deploys and undeploys application package images
+	moduleDeployer   deployerI          // Deploys and undeploys module package images
 
 	status      *status.Service     // Tracks per-package condition chain
 	scheduler   *schedule.Scheduler // Evaluates enable/disable based on version constraints
@@ -105,8 +109,9 @@ type Runtime struct {
 
 // deployerI abstracts package image deployment to and removal from the filesystem.
 type deployerI interface {
-	Deploy(ctx context.Context, repo registry.Remote, downloaded, deployed, packageName, name, version string) error
-	Undeploy(ctx context.Context, downloaded, deployed, name string, keep bool) error
+	Deploy(ctx context.Context, repo registry.Remote, packageName, deployedName, version string) error
+	Undeploy(ctx context.Context, deployedName string, keep bool) error
+	Cleanup(ctx context.Context, preserve []deployer.PreservePackage) error
 }
 
 // moduleManagerI provides access to global values for version getters and bootstrap checks.
@@ -132,14 +137,20 @@ func New(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Contain
 	r.status = status.NewService()
 
 	reg := registry.NewService(dc, logger)
+	downloadedDir := d8env.GetDownloadedModulesDir()
+
+	downloadedAppsDir := filepath.Join(downloadedDir, "apps")
+	downloadedModulesDir := filepath.Join(downloadedDir, "modules")
 
 	// Default to symlink backend (works everywhere, including MacOS)
-	r.deployer = symlinkdeploy.NewDeployer(reg, logger)
+	r.appDeployer = symlinkdeploy.NewDeployer(reg, downloadedAppsDir, logger)
+	r.moduleDeployer = symlinkdeploy.NewDeployer(reg, downloadedModulesDir, logger)
 
 	// Prefer erofs backend when dm-verity is supported (better integrity guarantees)
 	if verity.IsSupported() {
 		logger.Info("erofs supported")
-		r.deployer = erofsdeploy.NewDeployer(reg, logger)
+		r.appDeployer = erofsdeploy.NewDeployer(reg, downloadedAppsDir, logger)
+		r.moduleDeployer = erofsdeploy.NewDeployer(reg, downloadedModulesDir, logger)
 	}
 
 	// Initialize scheduler with enabling/disabling callbacks
@@ -165,7 +176,7 @@ func New(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Contain
 		ScheduleManager:   r.scheduleManager,
 		TaskBuilder:       r,
 		QueueService:      r.queueService,
-	}, r.logger).Start()
+	}, r.logger)
 
 	if err := r.registerDebugServer("/tmp/deckhouse-debug.socket"); err != nil {
 		return nil, fmt.Errorf("register debug server: %w", err)
@@ -477,6 +488,8 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 // schedule and disable events from the scheduler and dispatches them to the
 // appropriate handler, driving the enable/disable lifecycle for all packages.
 func (r *Runtime) Run() {
+	r.hookEventHandler.Start()
+
 	go func() {
 		for event := range r.scheduler.Ch() {
 			switch event.Kind {
@@ -586,14 +599,49 @@ func (r *Runtime) Stop() {
 	r.scheduler.Stop()
 }
 
+// PreservePackage identifies one downloaded package version to preserve during cleanup.
+type PreservePackage struct {
+	// Name is the downloaded package directory name.
+	Name string
+	// Version is the downloaded package version name.
+	Version string
+	// Repository is the downloaded repository directory name.
+	Repository string
+}
+
+// Cleanup removes deployed packages that are not listed in preserve from both app and module deployers.
+func (r *Runtime) Cleanup(ctx context.Context, preserve []PreservePackage) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	converted := make([]deployer.PreservePackage, 0, len(preserve))
+	for _, packageVersion := range preserve {
+		converted = append(converted, deployer.PreservePackage{
+			Name:       packageVersion.Name,
+			Repository: packageVersion.Repository,
+			Version:    packageVersion.Version,
+		})
+	}
+
+	if err := r.appDeployer.Cleanup(ctx, converted); err != nil {
+		r.logger.Warn("cleanup apps failed", log.Err(err))
+		return
+	}
+}
+
 // Status returns package status service for external access
 func (r *Runtime) Status() *status.Service {
 	return r.status
 }
 
-// Scheduler returns package scheduler for external access
-func (r *Runtime) Scheduler() *schedule.Scheduler {
-	return r.scheduler
+// PauseScheduler suspends the scheduler so it stops firing enable/disable callbacks.
+func (r *Runtime) PauseScheduler() {
+	r.scheduler.Pause()
+}
+
+// ResumeScheduler resumes the scheduler after a previous pause.
+func (r *Runtime) ResumeScheduler() {
+	r.scheduler.Resume()
 }
 
 // CheckConstraints checks constraints in scheduler

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -139,18 +139,18 @@ func New(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Contain
 	reg := registry.NewService(dc, logger)
 	downloadedDir := d8env.GetDownloadedModulesDir()
 
-	downloadedAppsDir := filepath.Join(downloadedDir, "apps")
-	downloadedModulesDir := filepath.Join(downloadedDir, "modules")
+	appsDir := filepath.Join(downloadedDir, "apps")
+	modulesDir := filepath.Join(downloadedDir, "modules")
 
 	// Default to symlink backend (works everywhere, including MacOS)
-	r.appDeployer = symlinkdeploy.NewDeployer(reg, downloadedAppsDir, logger)
-	r.moduleDeployer = symlinkdeploy.NewDeployer(reg, downloadedModulesDir, logger)
+	r.appDeployer = symlinkdeploy.NewDeployer(reg, appsDir, logger)
+	r.moduleDeployer = symlinkdeploy.NewDeployer(reg, modulesDir, logger)
 
 	// Prefer erofs backend when dm-verity is supported (better integrity guarantees)
 	if verity.IsSupported() {
 		logger.Info("erofs supported")
-		r.appDeployer = erofsdeploy.NewDeployer(reg, downloadedAppsDir, logger)
-		r.moduleDeployer = erofsdeploy.NewDeployer(reg, downloadedModulesDir, logger)
+		r.appDeployer = erofsdeploy.NewDeployer(reg, appsDir, logger)
+		r.moduleDeployer = erofsdeploy.NewDeployer(reg, modulesDir, logger)
 	}
 
 	// Initialize scheduler with enabling/disabling callbacks

--- a/deckhouse-controller/internal/packages/runtime/tasks/deploy/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/deploy/task.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path/filepath"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
-	"github.com/deckhouse/deckhouse/go_lib/d8env"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -31,15 +29,8 @@ const (
 	taskTracer = "package-deploy"
 )
 
-var (
-	modulesDownloadedDir = d8env.GetDownloadedModulesDir()
-	modulesDeployedDir   = filepath.Join(modulesDownloadedDir, "modules")
-	appsDownloadedDir    = filepath.Join(d8env.GetDownloadedModulesDir(), "apps")
-	appsDeployedDir      = filepath.Join(appsDownloadedDir, "deployed")
-)
-
 type deployerI interface {
-	Deploy(ctx context.Context, repo registry.Remote, downloaded, deployed, packageName, name, version string) error
+	Deploy(ctx context.Context, repo registry.Remote, packageName, deployedName, version string) error
 }
 
 type statusService interface {
@@ -51,8 +42,6 @@ type task struct {
 	name        string
 	packageName string
 	version     string
-	downloaded  string
-	deployed    string
 
 	repository registry.Remote
 
@@ -63,14 +52,11 @@ type task struct {
 }
 
 // NewModuleTask creates a Deploy task for a Module package.
-// The package is cached under downloaded/{name} and exposed at downloaded/modules/{name}.
 func NewModuleTask(name, version string, repo registry.Remote, deployer deployerI, status statusService, logger *log.Logger) queue.Task {
 	return &task{
 		name:        name,
 		packageName: name,
 		version:     version,
-		downloaded:  filepath.Join(modulesDownloadedDir, name),
-		deployed:    filepath.Join(modulesDeployedDir, name),
 		repository:  repo,
 		deployer:    deployer,
 		status:      status,
@@ -79,14 +65,11 @@ func NewModuleTask(name, version string, repo registry.Remote, deployer deployer
 }
 
 // NewAppTask creates a Deploy task for an Application package.
-// The package is cached under apps/{repo}/{package} and exposed at apps/deployed/{instance}.
 func NewAppTask(instance, name, version string, repo registry.Remote, deployer deployerI, status statusService, logger *log.Logger) queue.Task {
 	return &task{
 		name:        instance,
 		packageName: name,
 		version:     version,
-		downloaded:  filepath.Join(appsDownloadedDir, repo.Name, name),
-		deployed:    filepath.Join(appsDeployedDir, instance),
 		repository:  repo,
 		deployer:    deployer,
 		status:      status,
@@ -101,13 +84,13 @@ func (t *task) String() string {
 func (t *task) Execute(ctx context.Context) error {
 	logger := t.logger.With(
 		slog.String("name", t.name),
-		slog.String("downloaded", t.downloaded),
 		slog.String("repository", t.repository.Name),
+		slog.String("package", t.packageName),
 		slog.String("version", t.version))
 
 	// Cache package content locally and expose it at the path consumed by the load task.
 	logger.Debug("deploy package")
-	if err := t.deployer.Deploy(ctx, t.repository, t.downloaded, t.deployed, t.packageName, t.name, t.version); err != nil {
+	if err := t.deployer.Deploy(ctx, t.repository, t.packageName, t.name, t.version); err != nil {
 		t.status.HandleError(t.name, err)
 		return fmt.Errorf("deploy package: %w", err)
 	}

--- a/deckhouse-controller/internal/packages/runtime/tasks/load/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/load/task.go
@@ -34,11 +34,15 @@ const (
 )
 
 var (
-	embeddedDeployedDir  = "modules"
-	modulesDownloadedDir = d8env.GetDownloadedModulesDir()
-	modulesDeployedDir   = filepath.Join(modulesDownloadedDir, "modules")
-	appsDownloadedDir    = filepath.Join(d8env.GetDownloadedModulesDir(), "apps")
-	appsDeployedDir      = filepath.Join(appsDownloadedDir, "deployed")
+	embeddedDeployedDir = "modules"
+
+	downloadedDir = d8env.GetDownloadedModulesDir()
+
+	modulesDownloadedDir = filepath.Join(downloadedDir, "modules")
+	modulesDeployedDir   = filepath.Join(modulesDownloadedDir, "deployed")
+
+	appsDownloadedDir = filepath.Join(downloadedDir, "apps")
+	appsDeployedDir   = filepath.Join(appsDownloadedDir, "deployed")
 )
 
 type loader func(ctx context.Context, repo registry.Remote, path string) (string, error)

--- a/deckhouse-controller/internal/packages/runtime/tasks/undeploy/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/undeploy/task.go
@@ -17,10 +17,8 @@ package undeploy
 import (
 	"context"
 	"log/slog"
-	"path/filepath"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/queue"
-	"github.com/deckhouse/deckhouse/go_lib/d8env"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -28,22 +26,13 @@ const (
 	taskTracer = "package-undeploy"
 )
 
-var (
-	modulesDownloadedDir = d8env.GetDownloadedModulesDir()
-	modulesDeployedDir   = filepath.Join(modulesDownloadedDir, "modules")
-	appsDownloadedDir    = filepath.Join(d8env.GetDownloadedModulesDir(), "apps")
-	appsDeployedDir      = filepath.Join(appsDownloadedDir, "deployed")
-)
-
 type deployerI interface {
-	Undeploy(ctx context.Context, downloaded, deployed, name string, keep bool) error
+	Undeploy(ctx context.Context, deployedName string, keep bool) error
 }
 
 type task struct {
-	name       string
-	downloaded string
-	deployed   string
-	keep       bool
+	name string
+	keep bool
 
 	deployer deployerI
 
@@ -55,7 +44,6 @@ type task struct {
 func NewAppTask(name string, deployer deployerI, logger *log.Logger) queue.Task {
 	return &task{
 		name:     name,
-		deployed: filepath.Join(appsDeployedDir, name),
 		keep:     true,
 		deployer: deployer,
 		logger:   logger.Named(taskTracer),
@@ -66,12 +54,10 @@ func NewAppTask(name string, deployer deployerI, logger *log.Logger) queue.Task 
 // Sets keep=false to remove both deployed and downloaded directories.
 func NewModuleTask(name string, deployer deployerI, logger *log.Logger) queue.Task {
 	return &task{
-		name:       name,
-		downloaded: filepath.Join(modulesDownloadedDir, name),
-		deployed:   filepath.Join(modulesDeployedDir, name),
-		keep:       false,
-		deployer:   deployer,
-		logger:     logger.Named(taskTracer),
+		name:     name,
+		keep:     false,
+		deployer: deployer,
+		logger:   logger.Named(taskTracer),
 	}
 }
 
@@ -82,5 +68,5 @@ func (t *task) String() string {
 func (t *task) Execute(ctx context.Context) error {
 	t.logger.Debug("undeploy package", slog.String("name", t.name))
 
-	return t.deployer.Undeploy(ctx, t.downloaded, t.deployed, t.name, t.keep)
+	return t.deployer.Undeploy(ctx, t.name, t.keep)
 }

--- a/deckhouse-controller/internal/tools/verity/dmverity.go
+++ b/deckhouse-controller/internal/tools/verity/dmverity.go
@@ -260,7 +260,19 @@ func extractRootHash(output string) string {
 // Equivalent shell command:
 // veritysetup status <name>
 func GetVersionByDevice(ctx context.Context, name string) (string, error) {
-	ctx, span := otel.Tracer(tracerName).Start(ctx, "GetVersionByDevice")
+	imagePath, err := GetImagePathByDevice(ctx, name)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSuffix(filepath.Base(imagePath), filepath.Ext(imagePath)), nil
+}
+
+// GetImagePathByDevice retrieves the backing image path from an active dm-verity device.
+// Equivalent shell command:
+// veritysetup status <name>
+func GetImagePathByDevice(ctx context.Context, name string) (string, error) {
+	ctx, span := otel.Tracer(tracerName).Start(ctx, "GetImagePathByDevice")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("name", name))
@@ -278,16 +290,15 @@ func GetVersionByDevice(ctx context.Context, name string) (string, error) {
 		return "", fmt.Errorf("veritysetup status: %w (output: %s)", err, string(output))
 	}
 
-	if version := parseImageVersion(string(output)); version != "" {
-		return version, nil
+	if imagePath := parseImagePath(string(output)); imagePath != "" {
+		return imagePath, nil
 	}
 
 	return "", ErrVersionNotFound
 }
 
-// parseImageVersion extracts version from veritysetup status output.
-// Parses "data loop: /path/to/v0.6.22.erofs" and returns "v0.6.22".
-func parseImageVersion(output string) string {
+// parseImagePath extracts the backing image path from veritysetup status output.
+func parseImagePath(output string) string {
 	_, after, found := strings.Cut(output, "data loop:")
 	if !found {
 		return ""
@@ -299,5 +310,5 @@ func parseImageVersion(output string) string {
 		return ""
 	}
 
-	return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	return path
 }

--- a/deckhouse-controller/pkg/controller/controller.go
+++ b/deckhouse-controller/pkg/controller/controller.go
@@ -49,7 +49,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/metrics"
-	packageoperator "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime"
+	packageruntime "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/validation"
@@ -345,7 +345,7 @@ func NewDeckhouseController(
 		return nil, fmt.Errorf("register objectkeeper controller: %w", err)
 	}
 
-	packageOperator, err := packageoperator.New(runtimeManager.GetClient(), operator.ModuleManager, dc, logger)
+	pkgRuntime, err := packageruntime.New(runtimeManager.GetClient(), operator.ModuleManager, dc, logger)
 	if err != nil {
 		return nil, fmt.Errorf("create package operator: %w", err)
 	}
@@ -353,19 +353,19 @@ func NewDeckhouseController(
 	// package should not run before converge done
 	operator.ConvergeState.SetOnConvergeStart(func() {
 		logger.Debug("start converge")
-		packageOperator.Scheduler().Pause()
+		pkgRuntime.PauseScheduler()
 	})
 
 	operator.ConvergeState.SetOnConvergeFinish(func() {
 		logger.Debug("finish converge")
-		packageOperator.Scheduler().Resume()
+		pkgRuntime.ResumeScheduler()
 	})
 
 	// Package system controllers (feature flag)
 	if os.Getenv(envEnablePackageSystem) == "true" {
 		logger.Info("Package system controllers are enabled")
 
-		packageOperator.Run()
+		pkgRuntime.Run()
 
 		err = packagerepository.RegisterController(runtimeManager, dc, logger.Named("package-repository-controller"))
 		if err != nil {
@@ -382,7 +382,7 @@ func NewDeckhouseController(
 			return nil, fmt.Errorf("register application package version controller: %w", err)
 		}
 
-		err = application.RegisterController(runtimeManager, packageOperator, operator.ModuleManager, dc, logger.Named("application-controller"))
+		err = application.RegisterController(runtimeManager, pkgRuntime, operator.ModuleManager, dc, logger.Named("application-controller"))
 		if err != nil {
 			return nil, fmt.Errorf("register application controller: %w", err)
 		}
@@ -412,7 +412,7 @@ func NewDeckhouseController(
 		operator.AdmissionServer,
 		runtimeManager.GetClient(),
 		operator.ModuleManager,
-		packageOperator,
+		pkgRuntime,
 		configtools.NewValidator(operator.ModuleManager, conversionsStore),
 		loader,
 		operator.MetricStorage,

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/apps"
-	packageoperator "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime"
+	packageruntime "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime"
 	packagestatus "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
@@ -54,10 +54,10 @@ const (
 )
 
 type reconciler struct {
-	init     *sync.WaitGroup
-	client   client.Client
-	operator packageOperator
-	status   *status.Service
+	init    *sync.WaitGroup
+	client  client.Client
+	runtime packageRuntime
+	status  *status.Service
 
 	moduleManager moduleManager
 	dc            dependency.Container
@@ -68,15 +68,16 @@ type moduleManager interface {
 	AreModulesInited() bool
 }
 
-type packageOperator interface {
-	UpdateApp(repo registry.Remote, inst packageoperator.App)
+type packageRuntime interface {
+	UpdateApp(repo registry.Remote, inst packageruntime.App)
 	RemoveApp(namespace, name string)
 	Status() *packagestatus.Service
+	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
 }
 
 func RegisterController(
 	runtimeManager manager.Manager,
-	operator packageOperator,
+	packageRuntime packageRuntime,
 	moduleManager moduleManager,
 	dc dependency.Container,
 	logger *log.Logger,
@@ -84,7 +85,7 @@ func RegisterController(
 	r := &reconciler{
 		init:          new(sync.WaitGroup),
 		client:        runtimeManager.GetClient(),
-		operator:      operator,
+		runtime:       packageRuntime,
 		moduleManager: moduleManager,
 		dc:            dc,
 		logger:        logger,
@@ -97,8 +98,8 @@ func RegisterController(
 		return fmt.Errorf("add preflight: %w", err)
 	}
 
-	r.status = status.NewService(r.client, operator.Status().GetStatus, r.logger)
-	r.status.Start(context.Background(), operator.Status().GetCh())
+	r.status = status.NewService(r.client, packageRuntime.Status().GetStatus, r.logger)
+	r.status.Start(context.Background(), packageRuntime.Status().GetCh())
 
 	applicationController, err := controller.New(controllerName, runtimeManager, controller.Options{
 		MaxConcurrentReconciles: maxConcurrentReconciles,
@@ -124,6 +125,22 @@ func (r *reconciler) preflight(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("init module manager: %w", err)
 	}
+
+	appsList := new(v1alpha1.ApplicationList)
+	if err := r.client.List(ctx, appsList); err != nil {
+		return fmt.Errorf("list applications: %w", err)
+	}
+
+	var preserve []packageruntime.PreservePackage
+	for _, app := range appsList.Items {
+		preserve = append(preserve, packageruntime.PreservePackage{
+			Name:       app.Spec.PackageName,
+			Version:    app.Spec.PackageVersion,
+			Repository: app.Spec.PackageRepositoryName,
+		})
+	}
+
+	r.runtime.Cleanup(ctx, preserve)
 
 	r.logger.Debug("controller is ready")
 
@@ -301,7 +318,7 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, app *v1alpha1.App
 		return fmt.Errorf("get package repository '%s': %w", app.Spec.PackageRepositoryName, err)
 	}
 
-	r.operator.UpdateApp(registry.BuildRemote(repo), packageoperator.App{
+	r.runtime.UpdateApp(registry.BuildRemote(repo), packageruntime.App{
 		Name:      app.Name,
 		Namespace: app.Namespace,
 		Definition: apps.Definition{
@@ -382,7 +399,7 @@ func (r *reconciler) handleDelete(ctx context.Context, app *v1alpha1.Application
 	logger.Debug("delete application")
 
 	// call PackageOperator method (PackageRemover interface)
-	r.operator.RemoveApp(app.Namespace, app.Name)
+	r.runtime.RemoveApp(app.Namespace, app.Name)
 
 	patch := client.MergeFrom(app.DeepCopy())
 

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -198,7 +198,7 @@ func setupFakeController(t *testing.T, filename string) (*reconciler, client.Cli
 		init:          new(sync.WaitGroup),
 		client:        kubeClient,
 		logger:        log.NewNop(),
-		operator:      &operatorStub{},
+		runtime:       &operatorStub{},
 		moduleManager: &moduleManagerStub{},
 		dc:            dependency.NewMockedContainer(),
 	}
@@ -448,3 +448,5 @@ func (o *operatorStub) RemoveApp(_, _ string) {
 func (o *operatorStub) Status() *packagestatus.Service {
 	return packagestatus.NewService()
 }
+
+func (o *operatorStub) Cleanup(_ context.Context, _ []packageoperator.PreservePackage) {}


### PR DESCRIPTION
## Description
Adds a `Cleanup(preserve)` API to both deployer backends (symlink and erofs) and
wires it from the application controller's preflight, so disk state is reconciled
to the cluster's `Application` set on every controller start.

Also changes the apps download layout from per-instance to per-package, lets
multiple Application instances share a single download, and splits the runtime's
single deployer into separate `appDeployer` / `moduleDeployer` instances rooted
at `apps/` and `modules/` respectively.

### What changed

**Layout**
- `apps/<repo>/<package>/<version>` (was `apps/<repo>/<instance>/<version>`).
  Multiple `Application` objects pointing at the same package now share its
  download.
- Two deployer instances replace the single one in `runtime.Runtime`.

**Deployer API**
- New `Cleanup(ctx, []deployer.PreservePackage)` on each backend. Removes
  deployed mounts/symlinks not in `preserve`, then prunes the download tree
  (versions → packages → repos), collapsing empty parents.
- New `runtime.Runtime.Cleanup(ctx, preserve)` fans out to both backends under
  `r.mu`.
- Shared `deployer.PreservePackage{Name, Version, Repository}` type.
- Deploy/Undeploy signatures slimmed: `Deploy(ctx, repo, packageName,
  deployedName, version)`, `Undeploy(ctx, deployedName, keep)`. Caller no
  longer plumbs `downloaded`/`deployed` paths.

**Bug fixes inside the deployers**
- Erofs `Undeploy` now derives the package dir from the active dm-verity device
  (`verity.GetImagePathByDevice`), mirroring the symlink backend's `readlink`
  pattern. Removes the latent app/module mismatch in
  `removeDownloadedPackageDirs(deployedName)`.
- Erofs `cleanupDeployed` is best-effort: a single failed mapper status query
  no longer aborts the whole pass.

**Trigger**
- `application.controller.preflight` lists all `Application` objects, builds a
  `preserve` set from their `(PackageName, PackageVersion, PackageRepositoryName)`,
  and calls `runtime.Cleanup` before reconciling. Stale on-disk state from
  prior runs is cleaned up at controller startup.

**Plumbing tightening**
- `Runtime.Scheduler()` replaced with explicit `PauseScheduler()` /
  `ResumeScheduler()`.
- `hookevent.Handler.Start()` moved from `runtime.New` to `runtime.Run` so
  startup order matches the lifecycle.
- `verity.GetImagePathByDevice` added (the existing `GetVersionByDevice` now
  delegates to it).
- Renames: `packageOperator` → `packageRuntime` in controller wiring.

## Why do we need it, and what problem does it solve?
We need to cleanup stale packages from fs.  

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Add packages cleanup.
impact_level: low
```
