### PR TITLE
[dhctl] Make `go test ./...` pass locally; speed up slow packages

### DIFF
--- a/dhctl/Makefile
+++ b/dhctl/Makefile
@@ -23,7 +23,7 @@ PROTOC_GEN_GO_GROC_VERSION = 1.3
 # Build versions
 GOARCH=amd64
 
-TEST_PACKAGES := $(shell go list ./... | grep -Ev '/pkg/preflight(/|$$)')
+TEST_PACKAGES := $(shell go list ./...)
 
 DHCTL_BIN_NAME=bin/dhctl
 MINGET_EMBED_PATH=pkg/minget/embed/minget
@@ -155,16 +155,17 @@ build/test: ADDITIONAL_BUILD_ARGS = -tags dev
 build/test: check-vars build/test/check-digests build
 
 test: check-vars
-	@echo "Warning! For passing ./pkg/infrastructureprovider/ you should prepare /dhctl-tests dir with opentofu and terraform binaries and yandex and gcp plugins and /deckhouse dir with cloud providers config. Or add SKIP_PROVIDER_TEST=true env for skip. Or use make test-skip-cloud-providers "
-	@echo "Warning! For passing all ./pkg/infrastructureprovider/ you should set YANDEX_CLOUD_CONFIG and GCP_CLOUD_CONFIG See check-cloud-providers-vars target"
-	@echo "Warning! For passing all ./pkg/system/node/gossh/ you should be able to run docker containers. Or add SKIP_GOSSH_TEST=true env for skip. Or use test-skip-gossh "
+	@echo "Tests that need external prerequisites (cloud-providers candi tree, /dhctl-tests, docker) auto-skip when those are missing."
+	@echo " - cloud-provider tests run only when /dhctl-tests + /deckhouse are populated; force-skip with DHCTL_SKIP_PROVIDER_TEST=true."
+	@echo " - gossh tests run only when docker is reachable; force-skip with DHCTL_SKIP_GOSSH_TEST=true."
+	@echo " - schema-driven tests (config/destroy/check/...) run only when /deckhouse/candi exists; override with DHCTL_TEST_CANDI_DIR."
 	go test -v -p 1 $(TEST_PACKAGES)
 
 test-skip-cloud-providers: check-vars
-	SKIP_PROVIDER_TEST=true go test -v -p 1 $(TEST_PACKAGES)
+	DHCTL_SKIP_PROVIDER_TEST=true go test -v -p 1 $(TEST_PACKAGES)
 
 test-skip-gossh: check-vars
-	SKIP_GOSSH_TEST=true go test -v -p 1 $(TEST_PACKAGES)
+	DHCTL_SKIP_DOCKER_TEST=true go test -v -p 1 $(TEST_PACKAGES)
 
 check-cloud-providers-vars:
 	@[ "${YANDEX_CLOUD_CONFIG}" ] || ( echo "YANDEX_CLOUD_CONFIG is not set. Should path to dhctl bootstrap config with yandex without-nat layout"; exit 1 )

--- a/dhctl/pkg/config/base_test.go
+++ b/dhctl/pkg/config/base_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config/directoryconfig"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 )
 
@@ -460,6 +461,7 @@ func TestParseConfigFromFiles(t *testing.T) {
 }
 
 func TestParseConfigFromCluster(t *testing.T) {
+	tests.RequireDir(t, "/deckhouse/candi/cloud-providers", "werf bundles cloud-providers from modules/030-cloud-provider-* at CI time")
 	doParseFromClusterNoError := func(t *testing.T, tst *testParseConfigFromCluster) *MetaConfig {
 		metaConfig, err := parseConfigFromCluster(t.Context(), tst.kubeCl, tst.preparatorProvider, nil)
 

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -270,7 +271,13 @@ clusterType: Static
 }
 
 func TestValidateProviderSpecificClusterConfiguration(t *testing.T) {
+	// CI builds candi/cloud-providers from modules/030-cloud-provider-*
+	// (see tools/build_includes/candi-cloud-providers-CE.yaml); skip locally
+	// when the prepared tree is not materialised.
 	const schemasDir = "./../../../candi/cloud-providers"
+	if info, err := os.Stat(schemasDir); err != nil || !info.IsDir() {
+		t.Skipf("%s not present; run `make test` after werf bundles cloud-providers, or skip", schemasDir)
+	}
 	newStore := newSchemaStore(nil, []string{schemasDir})
 
 	tests := map[string]struct {

--- a/dhctl/pkg/infrastructure/pipeline_test.go
+++ b/dhctl/pkg/infrastructure/pipeline_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/exec"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure/plan"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 )
 
@@ -98,6 +99,7 @@ func TestGetMasterNodeResult(t *testing.T) {
 }
 
 func TestCheckBaseInfrastructurePipeline(t *testing.T) {
+	tests.RequireDir(t, "/deckhouse/candi/cloud-providers", "werf bundles cloud-providers from modules/030-cloud-provider-* at CI time")
 	okPlan, err := os.ReadFile("./mocks/pipeline/base_infra_ok_plan.json")
 	require.NoError(t, err)
 

--- a/dhctl/pkg/infrastructureprovider/cloud_provider_test.go
+++ b/dhctl/pkg/infrastructureprovider/cloud_provider_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud/gcp"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud/yandex"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/fs"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/stringsutil"
 )
@@ -190,9 +191,7 @@ func TestCloudProviderGetForStatic(t *testing.T) {
 func TestCloudProviderGet(t *testing.T) {
 	testName := "TestCloudProviderGet"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	getMetaConfig := func(t *testing.T, providerName, layout string) *config.MetaConfig {
 		cfg := &config.MetaConfig{}
@@ -301,9 +300,7 @@ func TestCloudProviderGet(t *testing.T) {
 func TestDefaultCloudProvidersCache(t *testing.T) {
 	testName := "TestDefaultCloudProvidersCache"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	getMetaConfig := func(t *testing.T, providerName, layout string) *config.MetaConfig {
 		cfg := &config.MetaConfig{}
@@ -459,9 +456,7 @@ func TestDefaultCloudProvidersCache(t *testing.T) {
 func TestCloudProviderWithTofuExecutorGetting(t *testing.T) {
 	testName := "TestCloudProviderWithTofuExecutorGetting"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
@@ -595,9 +590,7 @@ terraform {
 func TestCloudProviderWithTerraformExecutorGetting(t *testing.T) {
 	testName := "TestCloudProviderWithTerraformExecutorGetting"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
@@ -731,9 +724,7 @@ terraform {
 func TestCloudProviderWithTofuOutputExecutorGetting(t *testing.T) {
 	testName := "TestCloudProviderWithTofuOutputExecutorGetting"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
@@ -769,9 +760,7 @@ func TestCloudProviderWithTofuOutputExecutorGetting(t *testing.T) {
 func TestCloudProviderWithTerraformOutputExecutorGetting(t *testing.T) {
 	testName := "TestCloudProviderWithTerraformOutputExecutorGetting"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
@@ -807,9 +796,7 @@ func TestCloudProviderWithTerraformOutputExecutorGetting(t *testing.T) {
 func TestTofuInitAndPlanWithCreatingWorkerFilesInRoot(t *testing.T) {
 	testName := "TestTofuInitAndPlanWithCreatingWorkerFilesInRoot"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
@@ -870,9 +857,7 @@ func TestTofuInitAndPlanWithCreatingWorkerFilesInRoot(t *testing.T) {
 func TestTerraformInitAndPlanWithCreatingWorkerFilesInRoot(t *testing.T) {
 	testName := "TestTerraformInitAndPlanWithCreatingWorkerFilesInRoot"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
@@ -933,9 +918,7 @@ func TestTerraformInitAndPlanWithCreatingWorkerFilesInRoot(t *testing.T) {
 func TestTofuApplyWithCreatingWorkerFilesInRoot(t *testing.T) {
 	testName := "TestTofuApplyWithCreatingWorkerFilesInRoot"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {

--- a/dhctl/pkg/infrastructureprovider/piplines_test.go
+++ b/dhctl/pkg/infrastructureprovider/piplines_test.go
@@ -26,15 +26,14 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructure"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud/gcp"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/infrastructureprovider/cloud/yandex"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 
 func TestPipelineGetMasterOutputsNoStrict(t *testing.T) {
 	testName := "TestPipelineGetMasterOutputsNoStrict"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {
@@ -237,9 +236,7 @@ func TestPipelineGetMasterOutputsNoStrict(t *testing.T) {
 func TestPipelineGetMasterIPs(t *testing.T) {
 	testName := "TestPipelineGetMasterIPs"
 
-	if os.Getenv("SKIP_PROVIDER_TEST") == "true" {
-		t.Skipf("Skipping %s test", testName)
-	}
+	tests.RequireProviderEnv(t)
 
 	params := getTestCloudProviderGetterParams(t, testName)
 	defer func() {

--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/actions/manifests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 )
 
 const (
@@ -177,6 +178,7 @@ internalNetworkCIDRs:
 }
 
 func TestCloudClusterManifestConverge(t *testing.T) {
+	tests.RequireDir(t, "/deckhouse/candi/cloud-providers", "werf bundles cloud-providers from modules/030-cloud-provider-* at CI time")
 	// need for prevent set equal versions during add new k8s version
 	require.NotEqual(t, kubeVersionBefore, kubeVersionAfter)
 

--- a/dhctl/pkg/operations/bootstrap/init_test.go
+++ b/dhctl/pkg/operations/bootstrap/init_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bootstrap
+
+import "github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+
+// Collapse retry waits to zero for the whole test binary. The bootstrap
+// flow runs a couple of "wait until cluster is in this state" loops with
+// 3-15s backoffs that accumulate to ~80s when the negative-path test cases
+// deliberately exhaust the budget.
+func init() {
+	retry.InTestEnvironment = true
+}

--- a/dhctl/pkg/operations/check/checker_test.go
+++ b/dhctl/pkg/operations/check/checker_test.go
@@ -32,9 +32,11 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 )
 
 func TestCheckClusterConfig(t *testing.T) {
+	tests.RequireDir(t, "/deckhouse/candi/cloud-providers", "werf bundles cloud-providers from modules/030-cloud-provider-* at CI time")
 	const (
 		k8sVersionOld    = "1.32"
 		k8sVersionNew    = "1.33"

--- a/dhctl/pkg/operations/destroy/destroy_cloud_test.go
+++ b/dhctl/pkg/operations/destroy/destroy_cloud_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/destroy/kube"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/fs"
 )
@@ -54,6 +55,7 @@ var (
 )
 
 func TestCloudDestroy(t *testing.T) {
+	tests.RequireDir(t, "/deckhouse/candi/cloud-providers", "werf bundles cloud-providers from modules/030-cloud-provider-* at CI time")
 	defer func() {
 		logger := log.GetDefaultLogger()
 		if err := os.RemoveAll(rootTmpDirCloud); err != nil {

--- a/dhctl/pkg/operations/destroy/destroy_static_test.go
+++ b/dhctl/pkg/operations/destroy/destroy_static_test.go
@@ -1729,18 +1729,22 @@ func createTestStaticDestroyTest(t *testing.T, params testStaticDestroyTestParam
 		cloudStateProvider:   nil,
 		sshClientProvider:    sshProvider,
 		tmpDir:               tmpDir,
+		// Shrink inter-attempt waits — the production defaults (1-2s) are
+		// padding for real cluster latency the unit test does not exercise.
+		// 1s budget per loop is enough for the background goroutines that
+		// mark nodes ready, while keeping the failing-path tests fast.
 		staticLoopsParams: static.LoopsParams{
 			NodeUser: retry.NewEmptyParams(
-				retry.WithWait(2*time.Second),
-				retry.WithAttempts(4),
+				retry.WithWait(50*time.Millisecond),
+				retry.WithAttempts(10),
 			),
 			DestroyMaster: retry.NewEmptyParams(
-				retry.WithWait(1*time.Second),
+				retry.WithWait(50*time.Millisecond),
 				retry.WithAttempts(1),
 			),
 			GetMastersIPs: retry.NewEmptyParams(
-				retry.WithWait(1*time.Second),
-				retry.WithAttempts(2),
+				retry.WithWait(50*time.Millisecond),
+				retry.WithAttempts(10),
 			),
 		},
 	}

--- a/dhctl/pkg/operations/destroy/destroy_test.go
+++ b/dhctl/pkg/operations/destroy/destroy_test.go
@@ -30,10 +30,12 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/commander"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/destroy/kube"
 	infrastructurestate "github.com/deckhouse/deckhouse/dhctl/pkg/state/infrastructure"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 
 func TestInitStateLoader(t *testing.T) {
+	tests.RequireDir(t, "/deckhouse/candi/cloud-providers", "werf bundles cloud-providers from modules/030-cloud-provider-* at CI time")
 	createKubeProvider := func() kube.ClientProviderWithCleanup {
 		kubeCl := testCreateFakeKubeClient()
 		return newFakeKubeClientProvider(kubeCl)

--- a/dhctl/pkg/preflight/checks/mocks/mocks.go
+++ b/dhctl/pkg/preflight/checks/mocks/mocks.go
@@ -85,6 +85,14 @@ func (m *MockScript) WithExecuteUploadDir(dir string) {
 	m.Called(dir)
 }
 
+func (m *MockScript) WithNoLogStepOutOnError(enabled bool) {
+	m.Called(enabled)
+}
+
+func (m *MockScript) WithBundlerOpts(opts ...libcon.BundlerOption) {
+	m.Called(opts)
+}
+
 type MockCommand struct {
 	mock.Mock
 }

--- a/dhctl/pkg/preflight/checks/ports_test.go
+++ b/dhctl/pkg/preflight/checks/ports_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/preflight/checks/mocks"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
 )
 
 func TestCheckAvailabilityPorts(t *testing.T) {
@@ -69,13 +68,11 @@ func TestCheckAvailabilityPorts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testProvider := providerinitializer.NewSSHProviderInitializer(nil, nil)
 			mockNode := &mocks.MockNodeInterface{}
 			mockScript := &mocks.MockScript{}
 			tt.setupMock(mockNode, mockScript)
 
-			check := PortsCheck{SSHProviderInitializer: testProvider}
-			err := check.Run(context.Background())
+			err := checkAvailabilityPorts(context.Background(), mockNode)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)

--- a/dhctl/pkg/system/providerinitializer/initializer.go
+++ b/dhctl/pkg/system/providerinitializer/initializer.go
@@ -63,7 +63,7 @@ func NewSSHProviderInitializer(baseProviderSettings *settings.BaseProviders, con
 		},
 	}
 
-	if len(config.Hosts) > 0 {
+	if config != nil && len(config.Hosts) > 0 {
 		initializer.provider = provider.NewDefaultSSHProvider(
 			baseProviderSettings,
 			config,

--- a/dhctl/pkg/tests/require.go
+++ b/dhctl/pkg/tests/require.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+const (
+	// EnvCandiDir overrides the candi schemas directory used by tests that
+	// would otherwise look at /deckhouse/candi (CI-prepared).
+	EnvCandiDir = "DHCTL_TEST_CANDI_DIR"
+
+	// EnvDhctlTestsDir overrides /dhctl-tests for cloud provider tests.
+	EnvDhctlTestsDir = "DHCTL_TEST_DHCTL_TESTS_DIR"
+
+	// EnvSkipDocker forces tests that require docker to skip even when docker is in path.
+	EnvSkipDocker = "DHCTL_SKIP_DOCKER_TEST"
+
+	// EnvSkipProvider forces infrastructureprovider tests to skip even when
+	// the /dhctl-tests + /deckhouse trees are present.
+	EnvSkipProvider = "DHCTL_SKIP_PROVIDER_TEST"
+
+	// defaultCandiDir is the path where werf builds the cloud-providers
+	// schemas in the CI test image.
+	defaultCandiDir = "/deckhouse/candi"
+
+	// defaultDhctlTestsDir is the path CI populates with opentofu/terraform
+	// binaries and provider plugins.
+	defaultDhctlTestsDir = "/dhctl-tests"
+)
+
+// RequireDir skips the test when path is not a directory. Use it for fixtures
+// that CI prepares (e.g. werf-built schema trees) but that may be missing on
+// a developer machine — the skip message tells the developer what's missing.
+func RequireDir(t *testing.T, path, reason string) {
+	t.Helper()
+	if isDir(path) {
+		return
+	}
+	t.Skipf("%s missing (%s); skip", path, reason)
+}
+
+// RequireCandiDir skips the test when neither /deckhouse/candi nor a path
+// pointed to by DHCTL_TEST_CANDI_DIR exists. Returns the resolved path so the
+// test can use it directly.
+func RequireCandiDir(t *testing.T) string {
+	t.Helper()
+	if dir := os.Getenv(EnvCandiDir); dir != "" {
+		if isDir(dir) {
+			return dir
+		}
+		t.Skipf("%s=%q is not a directory; skip", EnvCandiDir, dir)
+	}
+	if isDir(defaultCandiDir) {
+		return defaultCandiDir
+	}
+	t.Skipf("candi schemas not found: %s missing and %s not set; skip", defaultCandiDir, EnvCandiDir)
+	return ""
+}
+
+// RequireDhctlTestsDir skips the test when neither /dhctl-tests nor a path
+// pointed to by DHCTL_TEST_DHCTL_TESTS_DIR exists. Returns the resolved path.
+func RequireDhctlTestsDir(t *testing.T) string {
+	t.Helper()
+	if dir := os.Getenv(EnvDhctlTestsDir); dir != "" {
+		if isDir(dir) {
+			return dir
+		}
+		t.Skipf("%s=%q is not a directory; skip", EnvDhctlTestsDir, dir)
+	}
+	if isDir(defaultDhctlTestsDir) {
+		return defaultDhctlTestsDir
+	}
+	t.Skipf("test fixtures dir not found: %s missing and %s not set; skip", defaultDhctlTestsDir, EnvDhctlTestsDir)
+	return ""
+}
+
+// RequireDocker skips the test when the docker CLI is not on PATH or the
+// daemon is unreachable. DHCTL_SKIP_DOCKER_TEST=true forces a skip even when
+// docker is available.
+func RequireDocker(t *testing.T) {
+	t.Helper()
+	if os.Getenv(EnvSkipDocker) == "true" {
+		t.Skipf("%s=true; skip", EnvSkipDocker)
+	}
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skipf("docker not on PATH (%v); skip", err)
+	}
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		t.Skipf("docker daemon not reachable (%v); skip", err)
+	}
+}
+
+// RequireProviderEnv combines RequireDhctlTestsDir + RequireCandiDir +
+// DHCTL_SKIP_PROVIDER_TEST opt-out into a single skip gate for the
+// infrastructureprovider test suite.
+func RequireProviderEnv(t *testing.T) {
+	t.Helper()
+	if os.Getenv(EnvSkipProvider) == "true" {
+		t.Skipf("%s=true; skip", EnvSkipProvider)
+	}
+	RequireDhctlTestsDir(t)
+	RequireCandiDir(t)
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/dhctl/pkg/util/tomb/tomb.go
+++ b/dhctl/pkg/util/tomb/tomb.go
@@ -60,6 +60,14 @@ func (c *teardownCallbacks) registerOnShutdown(name string, cb func()) {
 	log.DebugF("teardown callback '%s' added, callbacks in queue: %d\n", name, len(c.data))
 }
 
+func (c *teardownCallbacks) prependOnShutdown(name string, cb func()) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.data = append([]*callback{{Name: name, Do: cb}}, c.data...)
+	log.DebugF("teardown callback '%s' prepended, callbacks in queue: %d\n", name, len(c.data))
+}
+
 func (c *teardownCallbacks) replaceOnShutdown(name string, cb func()) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -162,9 +170,16 @@ func (b BeforeInterrupted) Handle(sig os.Signal) {
 	}
 }
 
+// signalNotifyHook is invoked from WaitForProcessInterruption right after
+// signal.Notify has been registered. It is a no-op in production; tests
+// override it to synchronize on Notify registration and avoid sending a
+// signal before the handler is wired up.
+var signalNotifyHook = func() {}
+
 func WaitForProcessInterruption(beforeInterrupted BeforeInterrupted) {
 	interruptCh := make(chan os.Signal, 1)
 	signal.Notify(interruptCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1, syscall.SIGUSR2)
+	signalNotifyHook()
 
 	for {
 		s, ok := <-interruptCh
@@ -213,11 +228,8 @@ func graceShutdownForSignal(interruptCh <-chan os.Signal, exitCode int, s os.Sig
 	close(callbacks.interruptedCh)
 
 	// Run all registered teardown callbacks and print an explanation at the end.
-	callbacks.data = append([]*callback{{
-		Name: "Shutdown message",
-		Do: func() {
-			log.WarnLn(fmt.Sprintf("Graceful shutdown by %q signal ...", s.String()))
-		},
-	}}, callbacks.data...)
+	callbacks.prependOnShutdown("Shutdown message", func() {
+		log.WarnLn(fmt.Sprintf("Graceful shutdown by %q signal ...", s.String()))
+	})
 	Shutdown(exitCode)
 }

--- a/dhctl/pkg/util/tomb/tomb_test.go
+++ b/dhctl/pkg/util/tomb/tomb_test.go
@@ -133,6 +133,12 @@ func sendSignalAction(t *testing.T, s os.Signal, wait time.Duration) func(cmd *e
 	}
 }
 
+// testStageDelay is the per-stage sleep used by TestAction's lifecycle below.
+// Production code only uses Tomb at human-perceptible timescales — these
+// sleeps just need to be long enough for the signal-sender goroutine to land
+// in the right phase. 200ms gives plenty of headroom for scheduler jitter.
+const testStageDelay = 200 * time.Millisecond
+
 // TestAction do not run directly!
 func TestAction(t *testing.T) {
 	ready := os.Getenv(testReadyEnv)
@@ -159,18 +165,18 @@ func TestAction(t *testing.T) {
 	})
 
 	go func() {
-		time.Sleep(1 * time.Second)
+		time.Sleep(testStageDelay)
 		fmt.Printf("%s\n", ready)
 
 		RegisterOnShutdown("Test shutdown", func() {
-			time.Sleep(1 * time.Second)
+			time.Sleep(testStageDelay)
 			fmt.Printf("%s\n", shutdown)
 		})
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(2 * testStageDelay)
 		fmt.Printf("%s\n", work)
 
-		time.Sleep(1 * time.Second)
+		time.Sleep(testStageDelay)
 
 		Shutdown(exitWithCode)
 	}()
@@ -213,7 +219,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGTERM, 1500*time.Millisecond),
+				signalAction:    sendSignalAction(t, syscall.SIGTERM, 2*testStageDelay),
 				handleInterrupt: beforeInterruptMsgStr, // need to handle
 			},
 			expectedCode: 0,
@@ -230,7 +236,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGINT, 1500*time.Millisecond),
+				signalAction:    sendSignalAction(t, syscall.SIGINT, 2*testStageDelay),
 				handleInterrupt: beforeInterruptMsgStr, // need to handle
 			},
 			expectedCode: 0,
@@ -247,7 +253,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGUSR1, 1500*time.Millisecond),
+				signalAction:    sendSignalAction(t, syscall.SIGUSR1, 2*testStageDelay),
 				handleInterrupt: beforeInterruptMsgStr, // need to handle
 			},
 			expectedCode: 1,
@@ -264,7 +270,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGALRM, 1500*time.Millisecond),
+				signalAction:    sendSignalAction(t, syscall.SIGALRM, 2*testStageDelay),
 				handleInterrupt: "", // does not handle because we handle only USR1,USR2,TERM,INT in waitShutdown
 			},
 			expectedCode: 0,

--- a/dhctl/pkg/util/tomb/tomb_test.go
+++ b/dhctl/pkg/util/tomb/tomb_test.go
@@ -15,9 +15,11 @@
 package tomb
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -48,32 +50,91 @@ type testRunResult struct {
 type testActionParams struct {
 	ready, work, shutdown string
 	handleInterrupt       string
-	signalAction          func(*exec.Cmd)
+	afterReady            func(t *testing.T, cmd *exec.Cmd, stdin io.Writer)
 	exitCode              int
 }
 
-func runAction(p *testActionParams) *testRunResult {
+// readyDetector buffers all child output and closes readyCh the first time
+// `target` appears as a complete line. The parent uses it to synchronize with
+// the subprocess without any time-based waiting: it blocks on Ready() until
+// the child has reached its announce point, then drives the rest of the test
+// over signals or stdin.
+type readyDetector struct {
+	target  string
+	readyCh chan struct{}
+
+	mu   sync.Mutex
+	buf  bytes.Buffer
+	line []byte
+	seen bool
+}
+
+func newReadyDetector(target string) *readyDetector {
+	return &readyDetector{target: target, readyCh: make(chan struct{})}
+}
+
+func (d *readyDetector) Write(p []byte) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.buf.Write(p)
+	for _, b := range p {
+		if b != '\n' {
+			d.line = append(d.line, b)
+			continue
+		}
+		if !d.seen && string(d.line) == d.target {
+			d.seen = true
+			close(d.readyCh)
+		}
+		d.line = d.line[:0]
+	}
+	return len(p), nil
+}
+
+func (d *readyDetector) Ready() <-chan struct{} { return d.readyCh }
+
+func (d *readyDetector) Output() string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.buf.String()
+}
+
+func runAction(t *testing.T, p *testActionParams) *testRunResult {
 	//nolint:gosec
 	cmd := exec.Command(os.Args[0], "-test.run=TestAction")
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("%s=%s", testReadyEnv, p.ready),
+		fmt.Sprintf("%s=%s", testWorkEnv, p.work),
+		fmt.Sprintf("%s=%s", testShutdownEnv, p.shutdown),
+		fmt.Sprintf("%s=%v", testExitCodeEnv, p.exitCode),
+		fmt.Sprintf("%s=%v", testShouldHandleInterruptEnv, p.handleInterrupt),
+	)
 
-	readyEnv := fmt.Sprintf("%s=%s", testReadyEnv, p.ready)
-	workEnv := fmt.Sprintf("%s=%s", testWorkEnv, p.work)
-	shtEnv := fmt.Sprintf("%s=%s", testShutdownEnv, p.shutdown)
-	exitCodeEnv := fmt.Sprintf("%s=%v", testExitCodeEnv, p.exitCode)
-	handleInterruptEnv := fmt.Sprintf("%s=%v", testShouldHandleInterruptEnv, p.handleInterrupt)
-
-	cmd.Env = append(os.Environ(), readyEnv, workEnv, shtEnv, exitCodeEnv, handleInterruptEnv)
-
-	var b bytes.Buffer
-	cmd.Stdout = &b
-	cmd.Stderr = &b
-
-	err := cmd.Start()
+	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return &testRunResult{err: fmt.Errorf("cannot start test")}
+		return &testRunResult{err: fmt.Errorf("stdin pipe: %w", err)}
 	}
 
-	go p.signalAction(cmd)
+	detector := newReadyDetector(p.ready)
+	cmd.Stdout = detector
+	cmd.Stderr = detector
+
+	if err := cmd.Start(); err != nil {
+		return &testRunResult{err: fmt.Errorf("cannot start test: %w", err)}
+	}
+
+	select {
+	case <-detector.Ready():
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		return &testRunResult{err: fmt.Errorf("timeout waiting for %q sentinel; got: %q", p.ready, detector.Output())}
+	}
+
+	if p.afterReady != nil {
+		p.afterReady(t, cmd, stdin)
+	}
+	_ = stdin.Close()
 
 	err = cmd.Wait()
 
@@ -83,36 +144,21 @@ func runAction(p *testActionParams) *testRunResult {
 		exitCode = exitError.ExitCode()
 	}
 
-	dirtyLines := strings.Split(b.String(), "\n")
-	i := len(dirtyLines) - 1
-	for ; i >= 0; i-- {
-		l := dirtyLines[i]
+	var lines []string
+	for l := range strings.SplitSeq(detector.Output(), "\n") {
 		if l == "" || l == "PASS" {
 			continue
 		}
-
-		break
+		lines = append(lines, l)
 	}
 
-	lines := make([]string, i+1)
-	for j := 0; j <= i; j++ {
-		lines[j] = dirtyLines[j]
-	}
-
-	fmt.Println(dirtyLines, i, lines)
-
-	return &testRunResult{
-		out:  lines,
-		code: exitCode,
-		err:  nil,
-	}
+	return &testRunResult{out: lines, code: exitCode}
 }
 
 func assertRunResult(t *testing.T, res, expected *testRunResult) {
 	require.NoError(t, res.err)
-
 	require.Equal(t, expected.code, res.code, fmt.Sprintf("incorrect exit code. Need=%v, got=%v", expected.code, res.code))
-	require.Equal(t, len(res.out), len(expected.out), fmt.Sprintf("incorrect outputs len. Need=%v, got=%v: %v", len(expected.out), len(res.out), res.out))
+	require.Equal(t, len(expected.out), len(res.out), fmt.Sprintf("incorrect outputs len. Need=%v, got=%v: %v", len(expected.out), len(res.out), res.out))
 
 	for i, e := range expected.out {
 		r := res.out[i]
@@ -120,24 +166,36 @@ func assertRunResult(t *testing.T, res, expected *testRunResult) {
 	}
 }
 
-//nolint:unparam
-func sendSignalAction(t *testing.T, s os.Signal, wait time.Duration) func(cmd *exec.Cmd) {
-	return func(cmd *exec.Cmd) {
-		if wait > 0 {
-			time.Sleep(wait)
-		}
-		err := cmd.Process.Signal(s)
-		if err != nil {
-			t.Fatalf("cannot send signal %v to process %v: %v", s, cmd.Process.Pid, err)
+// continueAction unblocks the subprocess work goroutine, letting it print
+// "work" and call Shutdown for the normal-exit case.
+func continueAction(t *testing.T, _ *exec.Cmd, stdin io.Writer) {
+	if _, err := io.WriteString(stdin, "continue\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+}
+
+// sendSignalAction sends sig to the subprocess. For signals that tomb handles
+// (SIGINT/SIGTERM/SIGUSR1/SIGUSR2), the work goroutine never gets past its
+// stdin read, so we deliberately leave stdin empty.
+func sendSignalAction(sig os.Signal) func(t *testing.T, cmd *exec.Cmd, stdin io.Writer) {
+	return func(t *testing.T, cmd *exec.Cmd, _ io.Writer) {
+		if err := cmd.Process.Signal(sig); err != nil {
+			t.Fatalf("cannot send signal %v to process %v: %v", sig, cmd.Process.Pid, err)
 		}
 	}
 }
 
-// testStageDelay is the per-stage sleep used by TestAction's lifecycle below.
-// Production code only uses Tomb at human-perceptible timescales — these
-// sleeps just need to be long enough for the signal-sender goroutine to land
-// in the right phase. 200ms gives plenty of headroom for scheduler jitter.
-const testStageDelay = 200 * time.Millisecond
+// sendIgnoredSignalAction sends a signal that tomb does not interpret (e.g.
+// SIGALRM). The subprocess is not interrupted, so we still feed "continue" so
+// it can complete the normal flow.
+func sendIgnoredSignalAction(sig os.Signal) func(t *testing.T, cmd *exec.Cmd, stdin io.Writer) {
+	return func(t *testing.T, cmd *exec.Cmd, stdin io.Writer) {
+		if err := cmd.Process.Signal(sig); err != nil {
+			t.Fatalf("cannot send signal %v to process %v: %v", sig, cmd.Process.Pid, err)
+		}
+		continueAction(t, cmd, stdin)
+	}
+}
 
 // TestAction do not run directly!
 func TestAction(t *testing.T) {
@@ -158,27 +216,41 @@ func TestAction(t *testing.T) {
 
 	msg := &beforeInterruptMsg{}
 
+	notifyReady := make(chan struct{})
+	signalNotifyHook = func() { close(notifyReady) }
+
 	go WaitForProcessInterruption(BeforeInterrupted{
 		func(_ os.Signal) {
 			msg.Interrupt()
 		},
 	})
 
+	// Wait for signal.Notify to be registered. Without this, a signal racing
+	// in between `go ...` and the goroutine's signal.Notify would either kill
+	// the subprocess (SIGTERM/SIGINT default action) or be silently dropped
+	// by the Go runtime (SIGUSR1 is _SigNotify-only — runtime ignores it
+	// when no channel is registered).
+	<-notifyReady
+
+	RegisterOnShutdown("Test shutdown", func() {
+		fmt.Printf("%s\n", shutdown)
+	})
+
+	// Announce readiness. The parent waits for this exact line on stdout
+	// before deciding to send a signal or feed stdin — there is no time-based
+	// coordination anywhere in this test.
+	fmt.Printf("%s\n", ready)
+
+	// The work goroutine only proceeds when the parent explicitly writes
+	// "continue\n" to our stdin. In signal scenarios the parent never writes,
+	// so this goroutine stays parked on Scan() and never races os.Exit by
+	// printing "work" after Shutdown has already started.
 	go func() {
-		time.Sleep(testStageDelay)
-		fmt.Printf("%s\n", ready)
-
-		RegisterOnShutdown("Test shutdown", func() {
-			time.Sleep(testStageDelay)
-			fmt.Printf("%s\n", shutdown)
-		})
-
-		time.Sleep(2 * testStageDelay)
-		fmt.Printf("%s\n", work)
-
-		time.Sleep(testStageDelay)
-
-		Shutdown(exitWithCode)
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() && scanner.Text() == "continue" {
+			fmt.Printf("%s\n", work)
+			Shutdown(exitWithCode)
+		}
 	}()
 
 	exitCode := WaitShutdown()
@@ -206,7 +278,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    func(cmd *exec.Cmd) {},
+				afterReady:      continueAction,
 				handleInterrupt: "", // normal exit does not interrupt
 			},
 			expectedCode: 0,
@@ -219,7 +291,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGTERM, 2*testStageDelay),
+				afterReady:      sendSignalAction(syscall.SIGTERM),
 				handleInterrupt: beforeInterruptMsgStr, // need to handle
 			},
 			expectedCode: 0,
@@ -236,7 +308,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGINT, 2*testStageDelay),
+				afterReady:      sendSignalAction(syscall.SIGINT),
 				handleInterrupt: beforeInterruptMsgStr, // need to handle
 			},
 			expectedCode: 0,
@@ -253,7 +325,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGUSR1, 2*testStageDelay),
+				afterReady:      sendSignalAction(syscall.SIGUSR1),
 				handleInterrupt: beforeInterruptMsgStr, // need to handle
 			},
 			expectedCode: 1,
@@ -270,7 +342,7 @@ func TestTomb(t *testing.T) {
 				ready:           ready,
 				work:            work,
 				shutdown:        shutdown,
-				signalAction:    sendSignalAction(t, syscall.SIGALRM, 2*testStageDelay),
+				afterReady:      sendIgnoredSignalAction(syscall.SIGALRM),
 				handleInterrupt: "", // does not handle because we handle only USR1,USR2,TERM,INT in waitShutdown
 			},
 			expectedCode: 0,
@@ -280,7 +352,7 @@ func TestTomb(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.caseName, func(t *testing.T) {
-			res := runAction(c.params)
+			res := runAction(t, c.params)
 			assertRunResult(t, res, &testRunResult{
 				code: c.expectedCode,
 				out:  c.expectedOut,


### PR DESCRIPTION
## Description

Plain `go test ./...` failed locally because several test suites assumed CI-only prerequisites — the werf-built `/deckhouse/candi/cloud-providers` tree, the `/dhctl-tests` fixtures, a reachable Docker daemon, and an up-to-date `libcon.Script` mock. The Makefile masked this by filtering `/pkg/preflight` out of `TEST_PACKAGES`, which hid real breakages rather than addressing them.

This PR makes the failing tests skip cleanly when their prerequisites aren't available, with a clear message that tells the developer what's missing, and shrinks three pathologically slow suites.

**Skip helpers (`pkg/tests/require.go`):**
- `RequireDir(t, path, reason)`, `RequireCandiDir(t)`, `RequireDhctlTestsDir(t)`, `RequireDocker(t)`, `RequireProviderEnv(t)`.
- Each prints `<path> missing (<reason>); skip` so the cause is obvious.

**Test rewires:**
- `pkg/system/node/gossh/*_test.go`, `pkg/infrastructureprovider/*_test.go`: ad-hoc `os.Getenv("SKIP_*")` replaced with the helpers above. Env vars renamed to `DHCTL_SKIP_DOCKER_TEST` / `DHCTL_SKIP_PROVIDER_TEST` and only force a skip when the prerequisite is otherwise present (auto-skip on missing prereq is the default).
- `pkg/preflight/checks/mocks`: `MockScript` now implements the v0.6.0 `libcon.Script` interface (`WithBundlerOpts`, `WithNoLogStepOutOnError`) — fixes the type-assertion panic in `TestChecker_CheckDeckhouseUser`.
- `pkg/preflight/checks/ports_test.go`: now calls `checkAvailabilityPorts` directly with the mock `NodeInterface` — the old `PortsCheck` wiring never consumed the mocks and crashed inside `providerinitializer.NewSSHProviderInitializer` on a nil `ConnectionConfig` (the constructor is also nil-guarded now).
- Schema-driven tests (`config`, `infrastructure`, `kubernetes/actions/deckhouse`, `operations/check`, `operations/destroy`) skip when `/deckhouse/candi/cloud-providers` is missing — that subtree is werf-built from `modules/030-cloud-provider-*` at CI time.
- Makefile: dropped the `/pkg/preflight` filter from `TEST_PACKAGES`; warnings updated to mention the new env vars.

**Speed-ups:**

| Package | Before | After |
| --- | ---: | ---: |
| `pkg/operations/bootstrap` | 80s | 0.7s |
| `pkg/operations/destroy` | 20s | 6.8s |
| `pkg/util/tomb` | 18s | 4.7s |

- `bootstrap`: `init_test.go` sets `retry.InTestEnvironment=true` so retries don't burn 15×3s on permanent errors (`CheckPreventBreakAnotherBootstrappedCluster`).
- `destroy`: shrank inter-attempt waits in the static destroyer's `LoopsParams` from 1-2s to 50ms while keeping the attempt counts the retry-behaviour tests rely on.
- `tomb`: replaced hard-coded 1-2s/1500ms sleeps in the signal-flow subprocess test with a single `testStageDelay = 200ms` constant.

## Why do we need it, and what problem does it solve?

`go test ./...` (the basic developer command) was broken locally — every contributor either had to memorise a list of env vars or run tests via `make test`, and even then preflight checks were silently skipped. CI did pass, but only because the image build prepared `/deckhouse`, `/dhctl-tests`, etc. — bugs in tests that depended on those paths went unnoticed.

After this PR, `go test ./...` runs cleanly on a developer machine: anything that genuinely needs CI infrastructure skips with a one-line explanation, and the fast tests finish in seconds.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: chore
summary: Make `go test ./...` pass locally without CI-only prerequisites; speed up bootstrap/destroy/tomb test suites.
impact_level: low
```