### PR TITLE
[deckhouse] package health monitor

### DIFF
--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -121,6 +121,7 @@ func New(logger *log.Logger, opts ...Option) *Client {
 		HistoryMax:  10,
 		Annotations: make(map[string]string),
 		Labels:      make(map[string]string),
+		Timeout:     2 * time.Minute,
 	}
 
 	// Apply any provided options
@@ -191,6 +192,8 @@ type InstallOptions struct {
 
 	ReleaseLabels map[string]string // Labels to apply to the release
 
+	ResourcesLabels map[string]string // Labels to apply to all resources
+
 	// OnTrackingEvent is an optional callback invoked with progress updates
 	// as Kubernetes resources are being tracked for readiness during install.
 	OnTrackingEvent func(name string, report progrep.ProgressReport)
@@ -209,6 +212,14 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 	var valuesSet []string
 	if len(opts.RootValues) > 0 {
 		valuesSet = append(valuesSet, opts.RootValues)
+	}
+
+	labels := maps.Clone(c.opts.Labels)
+	if len(opts.ResourcesLabels) > 0 {
+		if labels == nil {
+			labels = make(map[string]string, len(opts.ResourcesLabels))
+		}
+		maps.Copy(labels, opts.ResourcesLabels)
 	}
 
 	// reportCh receives progress reports from nelm during resource tracking.
@@ -243,7 +254,7 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 		DefaultChartVersion:    "0.2.0",
 		DefaultChartAPIVersion: "v2",
 		ReleaseInstallRuntimeOptions: common.ReleaseInstallRuntimeOptions{
-			ExtraLabels:             c.opts.Labels,
+			ExtraLabels:             labels,
 			ExtraAnnotations:        c.opts.Annotations,
 			NoInstallStandaloneCRDs: true,
 			ReleaseHistoryLimit:     int(c.opts.HistoryMax),
@@ -276,6 +287,14 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 		valuesSet = append(valuesSet, opts.RootValues)
 	}
 
+	labels := maps.Clone(c.opts.Labels)
+	if len(opts.ResourcesLabels) > 0 {
+		if labels == nil {
+			labels = make(map[string]string, len(opts.ResourcesLabels))
+		}
+		maps.Copy(labels, opts.ResourcesLabels)
+	}
+
 	res, err := action.ChartRender(ctx, action.ChartRenderOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.kubeContext,
@@ -289,7 +308,7 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 		DefaultChartName:       releaseName,
 		DefaultChartVersion:    "0.2.0",
 		DefaultChartAPIVersion: "v2",
-		ExtraLabels:            c.opts.Labels,
+		ExtraLabels:            labels,
 		ExtraAnnotations:       c.opts.Annotations,
 		ReleaseName:            releaseName,
 		ReleaseNamespace:       namespace,

--- a/deckhouse-controller/internal/packages/health/health.go
+++ b/deckhouse-controller/internal/packages/health/health.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"fmt"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/health/monitor"
+)
+
+// Health is the reduced workload-health snapshot for one package.
+// State is the machine-readable enum; consumers map it into a K8s
+// condition's reason field (the enum values are already valid reason
+// strings). Message carries the dominant-workload detail
+// ("Kind/Name: cause") and flows into the condition's message field.
+// StateScaled is the all-healthy case and carries no Message.
+type Health struct {
+	State   State
+	Message string
+}
+
+type State string
+
+// State values returned to callbacks. The zero value of State is the
+// empty string, not StateUnknown — code that switches on State should
+// rely on the named constants below, not on default-value behavior.
+const (
+	// StateUnknown means the package has no known workloads.
+	StateUnknown State = "Unknown"
+	// StateReconciling means at least one workload is rolling out
+	// (generation drift, replicas catching up, revision swap) and none
+	// have failed. The controller is still doing work; ask again later.
+	StateReconciling State = "Reconciling"
+	// StateScaled means every workload is at the desired replica count
+	// and the controller has nothing left to reconcile.
+	StateScaled State = "Scaled"
+	// StateDegraded means at least one workload is Failed, or has been
+	// observed Terminating while still in cache.
+	StateDegraded State = "Degraded"
+)
+
+// Event is the payload delivered to Callback on every package-health
+// transition. It carries only what the consumer needs: the new State
+// and a short human-readable Message naming the dominant workload (for
+// example "Deployment/api: ProgressDeadlineExceeded"). The package name
+// is the first argument of Callback and is intentionally not duplicated
+// here. Because Callback is invoked only on transitions, State always
+// differs from the value reported in the previous Event for the same
+// package.
+type Event struct {
+	Health Health
+}
+
+// reducePackage collapses per-workload statuses into a single State and
+// produces a Message that names the dominant workload.
+//
+// State mapping (in precedence order, first match wins):
+//
+//	any Failed or Terminating workload → StateDegraded
+//	any InProgress workload            → StateReconciling
+//	all Current workloads              → StateScaled
+//	empty input                        → StateUnknown
+//
+// The Message picks the dominant workload at the workload level:
+// Failed > Terminating > InProgress. StateScaled carries no Message —
+// "everything is fine" has no dominant workload worth naming.
+func reducePackage(workloads []monitor.WorkloadStatus) Health {
+	if len(workloads) == 0 {
+		return Health{State: StateUnknown}
+	}
+
+	var (
+		failed, terminating, progress *monitor.WorkloadStatus
+	)
+	for i := range workloads {
+		w := &workloads[i]
+		switch w.Health {
+		case monitor.Failed:
+			if failed == nil {
+				failed = w
+			}
+		case monitor.Terminating:
+			if terminating == nil {
+				terminating = w
+			}
+		case monitor.InProgress:
+			if progress == nil {
+				progress = w
+			}
+		}
+	}
+
+	switch {
+	case failed != nil:
+		return Health{State: StateDegraded, Message: formatMessage(failed)}
+	case terminating != nil:
+		return Health{State: StateDegraded, Message: formatMessage(terminating)}
+	case progress != nil:
+		return Health{State: StateReconciling, Message: formatMessage(progress)}
+	default:
+		return Health{State: StateScaled}
+	}
+}
+
+// formatMessage builds a "Kind/Name: cause" or "Kind/Name" string from a
+// single workload status, suitable for a K8s condition's message field.
+// Returns the empty string for a nil input so callers in the all-Current
+// branch don't need to handle "no dominant workload" specially.
+func formatMessage(w *monitor.WorkloadStatus) string {
+	if w == nil {
+		return ""
+	}
+	if w.Cause == "" {
+		return fmt.Sprintf("%s/%s", w.Kind, w.Name)
+	}
+	return fmt.Sprintf("%s/%s: %s", w.Kind, w.Name, w.Cause)
+}

--- a/deckhouse-controller/internal/packages/health/monitor/monitor.go
+++ b/deckhouse-controller/internal/packages/health/monitor/monitor.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/deckhouse/deckhouse/pkg/log"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +28,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 // indexName is the name under which the per-package indexer is

--- a/deckhouse-controller/internal/packages/health/monitor/monitor.go
+++ b/deckhouse-controller/internal/packages/health/monitor/monitor.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// indexName is the name under which the per-package indexer is
+// registered on each informer's cache. It is private because callers list
+// workloads through the Service, not through the indexer directly.
+const indexName = "package"
+
+// workloadKind is a stable map key for per-kind state (indexers, sync funcs).
+// It is intentionally a string so the value can be used directly in log
+// fields and error messages without a separate conversion.
+type workloadKind string
+
+const (
+	kindDeployment  workloadKind = "Deployment"
+	kindStatefulSet workloadKind = "StatefulSet"
+)
+
+// Monitor watches Deployments and StatefulSets carrying a configurable
+// package label and emits a per-package []WorkloadStatus on every change
+// via the Reconcile callback. The monitor is reduction-agnostic — it does
+// not know about Health, transitions, or subscribers. That belongs one
+// layer up in the health package.
+type Monitor struct {
+	factory  informers.SharedInformerFactory
+	indexers map[workloadKind]cache.Indexer
+	syncs    map[workloadKind]cache.InformerSynced
+	queue    workqueue.TypedRateLimitingInterface[string]
+
+	reconcile Reconcile
+	labelKey  string
+
+	logger *log.Logger
+
+	// once guards Run against accidental re-entry.
+	once sync.Once
+	// cancel is set by Run (under once) and called by Stop.
+	cancel context.CancelFunc
+	// done is closed when the worker goroutine has fully exited; Stop
+	// blocks on it to provide synchronous shutdown.
+	done chan struct{}
+}
+
+// Reconcile is invoked from the monitor's worker goroutine with every
+// known WorkloadStatus for the given package.
+type Reconcile func(name string, status []WorkloadStatus)
+
+// NewMonitor constructs a Monitor. It wires up the shared informer
+// factory, the typed informers, and the per-package indexer, but does
+// not start any goroutines or perform any I/O; that happens in Start.
+// All three arguments are required.
+//
+// The factory installs a server-side label selector on labelKey so the
+// API server only sends workloads that carry the package label. This
+// matches what the local indexer requires anyway and avoids caching every
+// Deployment/StatefulSet in the cluster.
+func NewMonitor(client kubernetes.Interface, reconcile Reconcile, labelKey string, logger *log.Logger) (*Monitor, error) {
+	// Resync period is 0: the watch is authoritative and we have nothing
+	// useful to do on a periodic full re-list.
+	s := &Monitor{
+		factory: informers.NewSharedInformerFactoryWithOptions(client, 0,
+			informers.WithTransform(stripUnusedFields),
+			informers.WithTweakListOptions(func(o *metav1.ListOptions) {
+				o.LabelSelector = labelKey
+			}),
+		),
+		indexers: make(map[workloadKind]cache.Indexer, 2),
+		syncs:    make(map[workloadKind]cache.InformerSynced, 2),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "health"},
+		),
+
+		reconcile: reconcile,
+		labelKey:  labelKey,
+		logger:    logger,
+		done:      make(chan struct{}),
+	}
+
+	if err := s.registerInformer(kindDeployment, s.factory.Apps().V1().Deployments().Informer()); err != nil {
+		return nil, fmt.Errorf("register Deployment informer: %w", err)
+	}
+	if err := s.registerInformer(kindStatefulSet, s.factory.Apps().V1().StatefulSets().Informer()); err != nil {
+		return nil, fmt.Errorf("register StatefulSet informer: %w", err)
+	}
+
+	return s, nil
+}
+
+// registerInformer attaches the package indexer and event handlers to a
+// SharedIndexInformer. Both must be installed before factory.Start so that
+// the initial list is indexed and dispatched correctly.
+func (m *Monitor) registerInformer(kind workloadKind, inf cache.SharedIndexInformer) error {
+	index := cache.Indexers{
+		indexName: m.packageIndexFunc,
+	}
+
+	if err := inf.AddIndexers(index); err != nil {
+		return fmt.Errorf("add '%s' indexer: %w", kind, err)
+	}
+
+	if _, err := inf.AddEventHandler(m.eventHandler()); err != nil {
+		return fmt.Errorf("add '%s' event handler: %w", kind, err)
+	}
+
+	m.indexers[kind] = inf.GetIndexer()
+	m.syncs[kind] = inf.HasSynced
+
+	return nil
+}
+
+// packageIndexFunc returns the package label value for an object, or an
+// empty slice if the object has no package label. Objects without the
+// label are simply not indexed under any package and can therefore never
+// reach reconcile via this indexer.
+func (m *Monitor) packageIndexFunc(obj any) ([]string, error) {
+	meta, err := metaFor(obj)
+	if err != nil || meta == nil {
+		return nil, err
+	}
+
+	v, ok := meta.GetLabels()[m.labelKey]
+	if !ok || v == "" {
+		return nil, nil
+	}
+
+	return []string{v}, nil
+}
+
+// metaFor returns the ObjectMeta of an informer-cache object, transparently
+// unwrapping cache.DeletedFinalStateUnknown tombstones that the cache
+// constructs when it detects a delete via a relist. Returning (nil, nil)
+// for a nil input is intentional: callers can treat "no metadata" the same
+// as "no package label."
+func metaFor(obj any) (metav1.Object, error) {
+	if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = d.Obj
+	}
+
+	if obj == nil {
+		return nil, nil
+	}
+
+	m, ok := obj.(metav1.Object)
+	if !ok {
+		return nil, fmt.Errorf("object %T does not implement metav1.Object", obj)
+	}
+
+	return m, nil
+}
+
+// eventHandler returns the cache event handler attached to every informer.
+// It enqueues the package label value, so events for workloads without
+// the label are dropped before they reach the workqueue. The workqueue
+// then coalesces bursts of events for the same package into a single
+// reconcile. The same handler works for all workload kinds because the
+// downstream collect() step lists by package across every indexer.
+//
+// UpdateFunc enqueues both the old and new package labels: when a
+// workload is relabeled from package A to package B, both packages must
+// be re-reconciled so A drops the workload and B picks it up. The
+// workqueue dedupes when the labels are equal, so the double enqueue is
+// free in the common case.
+func (m *Monitor) eventHandler() cache.ResourceEventHandlerFuncs {
+	enqueue := func(obj any) {
+		meta, err := metaFor(obj)
+		if err != nil || meta == nil {
+			return
+		}
+
+		if pkg := meta.GetLabels()[m.labelKey]; pkg != "" {
+			m.queue.Add(pkg)
+		}
+	}
+
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: enqueue,
+		UpdateFunc: func(oldObj, newObj any) {
+			enqueue(oldObj)
+			enqueue(newObj)
+		},
+		DeleteFunc: enqueue,
+	}
+}
+
+// stripUnusedFields drops fields the reducer never reads (PodTemplateSpec,
+// ManagedFields, VolumeClaimTemplates) before objects enter the cache.
+// This shrinks the cache footprint substantially without changing any
+// reducer-visible behavior. Status is preserved; the reducer reads it
+// directly.
+func stripUnusedFields(obj any) (any, error) {
+	switch o := obj.(type) {
+	case *appsv1.Deployment:
+		o.ManagedFields = nil
+		o.Spec.Template = corev1.PodTemplateSpec{}
+	case *appsv1.StatefulSet:
+		o.ManagedFields = nil
+		o.Spec.Template = corev1.PodTemplateSpec{}
+		o.Spec.VolumeClaimTemplates = nil
+	}
+
+	return obj, nil
+}
+
+// Start launches the monitor's background goroutine and returns
+// immediately. Safe to call more than once; only the first call has any
+// effect. Pair every Start with a Stop.
+func (m *Monitor) Start() {
+	m.once.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		m.cancel = cancel
+		go m.run(ctx)
+	})
+}
+
+// Stop cancels the internal context and waits for the worker goroutine
+// to fully exit (caches stopped, queue drained, in-flight reconciles
+// finished). A no-op if Start was never called.
+func (m *Monitor) Stop() {
+	if m.cancel == nil {
+		return
+	}
+	m.cancel()
+	<-m.done
+}
+
+// run owns the lifecycle of the worker goroutine. The defers run in
+// LIFO order, so close(done) fires last — after the queue is fully shut
+// down — which is what makes Done a reliable "completely stopped" signal.
+//
+// The ctx-watcher goroutine is the load-bearing piece: workqueue.Get
+// does not respect ctx, so without an explicit ShutDown call, a worker
+// blocked in Get would never see ctx cancellation and run() would
+// deadlock. ShutDown is idempotent, so the deferred call below is safe.
+//
+// A failed cache sync is treated as a fatal startup error: log and
+// return rather than serve stale or empty results to reconcile.
+func (m *Monitor) run(ctx context.Context) {
+	defer close(m.done)
+	defer m.queue.ShutDown()
+
+	m.factory.Start(ctx.Done())
+
+	synced := make([]cache.InformerSynced, 0, len(m.syncs))
+	for _, fn := range m.syncs {
+		synced = append(synced, fn)
+	}
+
+	if !cache.WaitForCacheSync(ctx.Done(), synced...) {
+		m.logger.Warn("timed out waiting for caches to sync")
+		return
+	}
+	m.logger.Info("caches synced")
+
+	go func() {
+		<-ctx.Done()
+		m.queue.ShutDown()
+	}()
+
+	wait.UntilWithContext(ctx, m.runWorker, time.Second)
+}

--- a/deckhouse-controller/internal/packages/health/monitor/reconcile.go
+++ b/deckhouse-controller/internal/packages/health/monitor/reconcile.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// runWorker drains the queue until it is shut down. Returning from this
+// function causes wait.UntilWithContext to immediately re-call it after a
+// one-second delay; once the queue is shut down Get returns shutdown=true
+// and the worker exits for good.
+func (m *Monitor) runWorker(_ context.Context) {
+	for m.processNext() {
+	}
+}
+
+// processNext pops one package key, collects every workload that belongs
+// to it, and hands the slice to the Reconcile callback. A failing collect
+// re-enqueues the key with rate-limited backoff; on success the key is
+// forgotten so its backoff resets. Reconcile itself returns no error and
+// is never retried. Returns false only when the queue has been shut down.
+func (m *Monitor) processNext() bool {
+	pkg, shutdown := m.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer m.queue.Done(pkg)
+
+	status, err := m.collect(pkg)
+	if err != nil {
+		m.queue.AddRateLimited(pkg)
+		return true
+	}
+
+	m.reconcile(pkg, status)
+	m.queue.Forget(pkg)
+
+	return true
+}
+
+// collect lists every workload that belongs to a package across all
+// indexers and reduces each to a WorkloadStatus. The package label is the
+// only filter; namespace is intentionally not part of the package identity
+// in this PoC.
+func (m *Monitor) collect(pkg string) ([]WorkloadStatus, error) {
+	var out []WorkloadStatus
+	for kind, idx := range m.indexers {
+		objs, err := idx.ByIndex(indexName, pkg)
+		if err != nil {
+			return nil, fmt.Errorf("list %s by package %q: %w", kind, pkg, err)
+		}
+
+		for _, obj := range objs {
+			if st, ok := classify(obj); ok {
+				out = append(out, st)
+			}
+		}
+	}
+
+	return out, nil
+}
+
+// classify dispatches to the typed reducer for an indexer-cache object. The
+// type switch is intentionally kept here rather than behind an interface:
+// the set of workload kinds is closed and the spec calls for typed reducers.
+func classify(obj any) (WorkloadStatus, bool) {
+	switch v := obj.(type) {
+	case *appsv1.Deployment:
+		return reduceDeployment(v), true
+	case *appsv1.StatefulSet:
+		return reduceStatefulSet(v), true
+	default:
+		return WorkloadStatus{}, false
+	}
+}

--- a/deckhouse-controller/internal/packages/health/monitor/reducer.go
+++ b/deckhouse-controller/internal/packages/health/monitor/reducer.go
@@ -1,0 +1,136 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// WorkloadHealth is the per-workload health classification produced by the
+// per-type reducers. Consumers (typically a package-level reducer in another
+// package) compare against these constants to roll up many workloads into
+// one verdict.
+type WorkloadHealth int
+
+// WorkloadHealth values, in increasing severity for the typical reduction:
+// Current is healthy steady state; InProgress is a rollout in progress;
+// Failed is terminal (the controller has given up); Terminating is
+// "object has DeletionTimestamp but is still in cache."
+const (
+	Current WorkloadHealth = iota
+	InProgress
+	Failed
+	Terminating
+)
+
+// WorkloadStatus pairs a workload's health with identifying metadata so the
+// package-level reducer can build a dominant-cause reason string. Kind is
+// the workload kind ("Deployment" or "StatefulSet"), Name is the object's
+// metadata.name, and Cause is a short free-form description of why this
+// status was reached (e.g. "ProgressDeadlineExceeded", "rolling update").
+type WorkloadStatus struct {
+	Kind   string
+	Name   string
+	Health WorkloadHealth
+	Cause  string
+}
+
+// reduceDeployment classifies a Deployment according to the rules in the
+// package-level docs.
+func reduceDeployment(d *appsv1.Deployment) WorkloadStatus {
+	s := WorkloadStatus{Kind: "Deployment", Name: d.Name}
+
+	if d.DeletionTimestamp != nil {
+		s.Health = Terminating
+		s.Cause = "deletion in progress"
+		return s
+	}
+
+	for _, c := range d.Status.Conditions {
+		if c.Type == appsv1.DeploymentProgressing && c.Reason == "ProgressDeadlineExceeded" {
+			s.Health = Failed
+			s.Cause = "ProgressDeadlineExceeded"
+			return s
+		}
+	}
+
+	if d.Generation != d.Status.ObservedGeneration {
+		s.Health = InProgress
+		s.Cause = "generation not yet observed"
+		return s
+	}
+
+	if d.Spec.Paused {
+		s.Health = InProgress
+		s.Cause = "deployment paused"
+		return s
+	}
+
+	desired := int32(1)
+	if d.Spec.Replicas != nil {
+		desired = *d.Spec.Replicas
+	}
+
+	switch {
+	case d.Status.UpdatedReplicas < desired:
+		s.Health = InProgress
+		s.Cause = "updated replicas below desired"
+	case d.Status.Replicas > d.Status.UpdatedReplicas:
+		s.Health = InProgress
+		s.Cause = "old replicas terminating"
+	case d.Status.AvailableReplicas < desired:
+		s.Health = InProgress
+		s.Cause = "replicas not ready"
+	default:
+		s.Health = Current
+	}
+	return s
+}
+
+// reduceStatefulSet classifies a StatefulSet.
+func reduceStatefulSet(ss *appsv1.StatefulSet) WorkloadStatus {
+	s := WorkloadStatus{Kind: "StatefulSet", Name: ss.Name}
+
+	if ss.DeletionTimestamp != nil {
+		s.Health = Terminating
+		s.Cause = "deletion in progress"
+		return s
+	}
+	if ss.Generation != ss.Status.ObservedGeneration {
+		s.Health = InProgress
+		s.Cause = "generation not yet observed"
+		return s
+	}
+
+	desired := int32(1)
+	if ss.Spec.Replicas != nil {
+		desired = *ss.Spec.Replicas
+	}
+
+	switch {
+	case ss.Status.CurrentRevision != ss.Status.UpdateRevision:
+		s.Health = InProgress
+		s.Cause = "rolling update"
+	case ss.Status.ReadyReplicas < desired:
+		s.Health = InProgress
+		s.Cause = "replicas not ready"
+	case ss.Status.UpdatedReplicas < desired:
+		s.Health = InProgress
+		s.Cause = "updated replicas below desired"
+	default:
+		s.Health = Current
+	}
+	return s
+}

--- a/deckhouse-controller/internal/packages/health/service.go
+++ b/deckhouse-controller/internal/packages/health/service.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"fmt"
+	"sync"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/health/monitor"
+	"github.com/deckhouse/deckhouse/pkg/log"
+)
+
+// LabelKey is the workload label whose value identifies the owning
+// package. The same constant is used by the indexer, the event handlers,
+// and any caller that wants to add the label to a workload manifest.
+const LabelKey = "health.deckhouse.io/package"
+
+// Service watches per-package workload statuses via an embedded Monitor
+// and reduces them to a single State per package. Transitions are
+// edge-triggered: the configured Callback is invoked only when a
+// package's reduced State differs from the last reported value.
+//
+// The Service owns the Monitor and its lifecycle. Construction is
+// I/O-free; goroutines and informers start in Start and stop in Stop.
+type Service struct {
+	monitor *monitor.Monitor
+
+	// mu guards lastHealth. The reconcile callback holds it only for the
+	// read-compare-write of one package's entry; the user's Callback is
+	// invoked after the lock drops so it can never deadlock against the
+	// Service.
+	mu         sync.Mutex
+	lastHealth map[string]State
+	callback   Callback
+}
+
+// Callback is invoked from the reconcile goroutine whenever a package's
+// reduced health changes. The callback must not block and must not call
+// back into the Service.
+type Callback func(name string, event Event)
+
+// NewService constructs a Service. It does not start any goroutines or
+// perform any I/O; that happens in Start. The callback is invoked on
+// every package health transition and must be non-nil and non-blocking.
+func NewService(client kubernetes.Interface, cb Callback, logger *log.Logger) (*Service, error) {
+	s := &Service{
+		callback:   cb,
+		lastHealth: make(map[string]State),
+	}
+
+	mon, err := monitor.NewMonitor(client, s.reconcile, LabelKey, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create monitor: %w", err)
+	}
+	s.monitor = mon
+
+	return s, nil
+}
+
+// Start launches the background reconcile goroutine and returns
+// immediately. Safe to call more than once; only the first call has any
+// effect. Pair every Start with a Stop to release informer and queue
+// resources.
+func (s *Service) Start() {
+	s.monitor.Start()
+}
+
+// Stop waits for the reconcile goroutine to drain (caches stopped,
+// queue shut down, in-flight reconciles finished). Must be called after
+// Start.
+func (s *Service) Stop() {
+	s.monitor.Stop()
+}
+
+// reconcile is the Monitor's Reconcile callback. It reduces the per-workload
+// statuses to a single State, dedupes against the last reported value, and
+// fires the user callback only on a real transition. The lock is held only
+// for the read-compare-write of one map entry; the user callback runs after
+// it drops, so a slow callback can't block other reconciles from updating
+// state — though it will still serialize with them on the worker goroutine.
+func (s *Service) reconcile(name string, status []monitor.WorkloadStatus) {
+	current := reducePackage(status)
+
+	s.mu.Lock()
+	previous, had := s.lastHealth[name]
+	if !had {
+		previous = StateUnknown
+	}
+	if current.State == StateUnknown {
+		delete(s.lastHealth, name)
+	} else {
+		s.lastHealth[name] = current.State
+	}
+	s.mu.Unlock()
+
+	if current.State == previous {
+		return
+	}
+
+	s.callback(name, Event{Health: current})
+}

--- a/deckhouse-controller/internal/packages/nelm/drift/manager.go
+++ b/deckhouse-controller/internal/packages/nelm/drift/manager.go
@@ -15,7 +15,7 @@
 // Package monitor provides resource monitoring for Helm releases deployed via nelm.
 // It periodically checks that all resources from a release manifest are present in the cluster,
 // helping detect configuration drift or accidental deletions.
-package monitor
+package drift
 
 import (
 	"context"

--- a/deckhouse-controller/internal/packages/nelm/drift/monitor.go
+++ b/deckhouse-controller/internal/packages/nelm/drift/monitor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitor
+package drift
 
 import (
 	"context"

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -31,7 +31,8 @@ import (
 	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/nelm"
-	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/nelm/monitor"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/health"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/nelm/drift"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/status"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
@@ -67,7 +68,7 @@ type Service struct {
 	tmpDir string // Temporary directory for values files
 
 	client         *nelm.Client // nelm client for Helm operations
-	monitorManager *monitor.Manager
+	monitorManager *drift.Manager
 
 	status *status.Service
 
@@ -75,7 +76,7 @@ type Service struct {
 }
 
 // NewService creates a new nelm service for managing Helm releases.
-func NewService(cache runtimecache.Cache, callback monitor.AbsentCallback, status *status.Service, logger *log.Logger) *Service {
+func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status *status.Service, logger *log.Logger) *Service {
 	nelmClient := nelm.New(logger, nelm.WithLabels(map[string]string{
 		"heritage": "deckhouse",
 	}))
@@ -84,7 +85,7 @@ func NewService(cache runtimecache.Cache, callback monitor.AbsentCallback, statu
 		tmpDir:         os.TempDir(),
 		client:         nelmClient,
 		status:         status,
-		monitorManager: monitor.New(cache, nelmClient, callback, logger),
+		monitorManager: drift.New(cache, nelmClient, callback, logger),
 		logger:         logger.Named(nelmServiceTracer),
 	}
 }
@@ -161,6 +162,9 @@ func (s *Service) Render(ctx context.Context, namespace string, pkg Package) (st
 		Path:        pkg.GetPath(),
 		ValuesPaths: []string{valuesPath},
 		RootValues:  pkg.GetRuntimeValues(),
+		ResourcesLabels: map[string]string{
+			health.LabelKey: pkg.GetName(),
+		},
 	})
 }
 
@@ -235,6 +239,9 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 		Path:        pkg.GetPath(),
 		ValuesPaths: []string{valuesPath},
 		RootValues:  pkg.GetRuntimeValues(),
+		ResourcesLabels: map[string]string{
+			health.LabelKey: pkg.GetName(),
+		},
 	})
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -263,10 +270,13 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 		OnTrackingEvent: s.status.UpdateTracking,
 		Path:            pkg.GetPath(),
 		ValuesPaths:     []string{valuesPath},
+		RootValues:      pkg.GetRuntimeValues(),
 		ReleaseLabels: map[string]string{
 			nelm.LabelPackageChecksum: checksum,
 		},
-		RootValues: pkg.GetRuntimeValues(),
+		ResourcesLabels: map[string]string{
+			health.LabelKey: pkg.GetName(),
+		},
 	})
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -319,7 +329,7 @@ func (s *Service) shouldRunHelmUpgrade(ctx context.Context, namespace, releaseNa
 	}
 
 	if err = s.monitorManager.CheckResources(ctx, releaseName); err != nil {
-		if errors.Is(err, monitor.ErrAbsentManifest) {
+		if errors.Is(err, drift.ErrAbsentManifest) {
 			return true, nil
 		}
 

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -42,6 +42,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer"
 	erofsdeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer/erofs"
 	symlinkdeploy "github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/deployer/symlink"
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/health"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/modules"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/nelm"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/runtime/debug"
@@ -86,6 +87,7 @@ type Runtime struct {
 	hookEventHandler *hookevent.Handler // Routes Kube/schedule events into hook tasks
 	queueService     *queue.Service     // Per-package task queues with retry
 	nelmService      *nelm.Service      // Helm release management and drift monitoring
+	healthService    *health.Service    // Resources health monitor
 	appDeployer      deployerI          // Deploys and undeploys application package images
 	moduleDeployer   deployerI          // Deploys and undeploys module package images
 
@@ -159,6 +161,11 @@ func New(cli kclient.Client, moduleManager moduleManagerI, dc dependency.Contain
 	// Build NELM service with its own client and runtime cache for resource monitoring
 	if err := r.buildNelmService(); err != nil {
 		return nil, fmt.Errorf("build nelm service: %w", err)
+	}
+
+	// Build Health service with its own client
+	if err := r.buildHealthService(); err != nil {
+		return nil, fmt.Errorf("build health service: %w", err)
 	}
 
 	// Build object patcher with optimized rate limits for batch operations
@@ -381,6 +388,35 @@ func (r *Runtime) buildNelmService() error {
 	return nil
 }
 
+// buildHealthService creates the workload-health service that drives ConditionScaled.
+//
+// The service watches workloads tagged with the health.LabelKey package label and
+// reduces their per-workload statuses into a single State per package — Scaled,
+// Reconciling, Degraded, or Unknown. Transitions are pushed back into the status
+// service via r.status.UpdateHealth, which encodes them on ConditionScaled.
+//
+// Construction is I/O-free apart from client.Init; informers and the reconcile
+// goroutine start later via r.healthService.Start, paired with Stop on shutdown.
+func (r *Runtime) buildHealthService() error {
+	client := klient.New(klient.WithLogger(r.logger.Named("health-monitor-client")))
+	client.WithContextName(shapp.KubeContext)
+	client.WithConfigPath(shapp.KubeConfig)
+	client.WithRateLimiterSettings(shapp.KubeClientQps, shapp.KubeClientBurst)
+
+	if err := client.Init(); err != nil {
+		return fmt.Errorf("initialize health service client: %w", err)
+	}
+
+	healthService, err := health.NewService(client, r.status.UpdateHealth, r.logger)
+	if err != nil {
+		return fmt.Errorf("create health service failed: %w", err)
+	}
+
+	r.healthService = healthService
+
+	return nil
+}
+
 // buildScheduler creates the package scheduler with version checks and lifecycle callbacks.
 //
 // The scheduler controls package enable/disable based on:
@@ -493,6 +529,7 @@ func (r *Runtime) buildScheduler(cli kclient.Client) {
 // appropriate handler, driving the enable/disable lifecycle for all packages.
 func (r *Runtime) Run() {
 	r.hookEventHandler.Start()
+	r.healthService.Start()
 
 	go func() {
 		for event := range r.scheduler.Ch() {
@@ -590,6 +627,9 @@ func (r *Runtime) Stop() {
 
 	// Clean up resource monitors
 	r.nelmService.StopMonitors()
+
+	// Stop health monitoring
+	r.healthService.Stop()
 
 	// Stop generating new events
 	r.scheduleManager.Stop()

--- a/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
+++ b/deckhouse-controller/internal/packages/runtime/tasks/run/task.go
@@ -98,7 +98,6 @@ func (t *task) Execute(ctx context.Context) error {
 
 	t.status.SetConditionTrue(t.pkg.GetName(), status.ConditionManifestsApplied)
 	t.status.SetConditionTrue(t.pkg.GetName(), status.ConditionHooksProcessed)
-	t.status.SetConditionTrue(t.pkg.GetName(), status.ConditionScaled)
 
 	return nil
 }

--- a/deckhouse-controller/internal/packages/status/service.go
+++ b/deckhouse-controller/internal/packages/status/service.go
@@ -21,6 +21,8 @@ import (
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/werf/nelm/pkg/legacy/progrep"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/health"
 )
 
 const (
@@ -249,6 +251,41 @@ func (s *Service) UpdateSettings(name string, settings addonutils.Values) {
 
 	status.Settings = settings
 	status.setCondition(Condition{Type: ConditionConfigured, Status: metav1.ConditionTrue})
+}
+
+// UpdateHealth applies a workload-health transition to ConditionScaled.
+// State mapping to K8s condition status:
+//
+//	StateScaled                          → True,    Reason="Scaled"
+//	StateReconciling, StateDegraded      → False,   Reason=State, Message=workload detail
+//	StateUnknown                         → Unknown, Reason="" (no workloads to observe)
+//
+// If the package is not tracked by the service, the update is silently ignored.
+func (s *Service) UpdateHealth(name string, event health.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	status, ok := s.statuses[name]
+	if !ok {
+		return
+	}
+
+	cond := Condition{Type: ConditionScaled}
+	switch event.Health.State {
+	case health.StateScaled:
+		cond.Status = metav1.ConditionTrue
+		cond.Reason = ConditionReason(health.StateScaled)
+	case health.StateUnknown:
+		cond.Status = metav1.ConditionUnknown
+	default:
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = ConditionReason(event.Health.State)
+		cond.Message = event.Health.Message
+	}
+
+	if status.setCondition(cond) {
+		s.ch <- name
+	}
 }
 
 // HandleError processes an error and extracts status conditions from it

--- a/deckhouse-controller/pkg/controller/packages/application/status/rules.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules.go
@@ -55,14 +55,11 @@ const (
 	ConditionReady = "Ready"
 
 	// ConditionScaled reflects the runtime scaling state of the application.
-	// True at steady state. May become Unknown when the previous version was
-	// disabled before the new one was applied, when reconcile cannot trust the
-	// running state, or when a hard dependency was disabled under the running
-	// app. False when manifests failed. In some reconcile scenarios the value
-	// can be set by another controller, so it does not always follow directly
-	// from the current reconcile error.
-	// Possible reasons: RequirementsUnmet, DownloadFailed, HookInitializationFailed,
-	// HookFailed, ManifestsApplyFailed, Scaled (when True).
+	// Owned exclusively by the workload health monitor — no other condition
+	// influences this value. True at steady state, False when at least one
+	// workload is rolling out (Reconciling) or failed (Degraded), Unknown
+	// when there are no workloads to observe yet.
+	// Possible reasons: Reconciling (False), Degraded (False), Scaled (True).
 	ConditionScaled = "Scaled"
 
 	// ConditionManaged reflects whether the controller is actively managing the
@@ -135,6 +132,11 @@ func canonicalReason(internalCond, internalReason string) string {
 			return internalReason
 		}
 		return "ManifestsApplyFailed"
+	case intScaled:
+		// The health monitor is the only non-True writer of intScaled, and it
+		// produces canonical external reasons directly ("Reconciling",
+		// "Degraded"). No translation needed — pass through.
+		return internalReason
 	}
 
 	return ""
@@ -340,19 +342,14 @@ func mapReady(state condmap.State) metav1.Condition {
 	return metav1.Condition{}
 }
 
-// mapScaled mirrors the internal Scaled condition, including Unknown. Tasks set
-// Unknown when scaling state cannot be determined (e.g. the old version was
-// disabled before the new one was applied). A disabled dependency on a running
-// app forces Scaled=Unknown — the cause is external, so we cannot honestly
-// claim either True or False.
+// mapScaled mirrors the internal Scaled condition verbatim. Scaled is owned
+// by a separate controller (the workload health monitor) and is not derived
+// from any other condition — install/update/dependency signals never override
+// it. When the internal condition is absent, external Scaled is Unknown.
 func mapScaled(state condmap.State) metav1.Condition {
-	if isDependencyDisabled(state) {
-		return emit(state, ConditionScaled, metav1.ConditionUnknown, intRequirementsMet)
-	}
-
 	status, ok := state.GetIntStatus(intScaled)
 	if !ok {
-		return metav1.Condition{}
+		return metav1.Condition{Type: ConditionScaled, Status: metav1.ConditionUnknown}
 	}
 
 	return emit(state, ConditionScaled, status, intScaled)

--- a/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/rules_test.go
@@ -294,20 +294,28 @@ func TestScaledRule(t *testing.T) {
 		{
 			name: "false when Scaled is false",
 			opts: []mappingOption{
-				withInternalCondition(string(intstatus.ConditionScaled), metav1.ConditionFalse, "ClusterNotReady"),
+				withInternalCondition(string(intstatus.ConditionScaled), metav1.ConditionFalse, "Degraded"),
 			},
 			expected: map[string]*expectedCondition{
-				// canonicalReason has no entry for intScaled — Scaled mirrors raw status with empty reason.
-				ConditionScaled: {status: metav1.ConditionFalse, reason: ""},
+				ConditionScaled: {status: metav1.ConditionFalse, reason: "Degraded"},
 			},
 		},
 		{
-			name: "not affected by RequirementsMet",
+			name: "false when Scaled is false with Reconciling reason",
+			opts: []mappingOption{
+				withInternalCondition(string(intstatus.ConditionScaled), metav1.ConditionFalse, "Reconciling"),
+			},
+			expected: map[string]*expectedCondition{
+				ConditionScaled: {status: metav1.ConditionFalse, reason: "Reconciling"},
+			},
+		},
+		{
+			name: "unknown when internal Scaled is absent",
 			opts: []mappingOption{
 				withInternalCondition(string(intstatus.ConditionRequirementsMet), metav1.ConditionFalse, "RequirementsNotMet"),
 			},
 			expected: map[string]*expectedCondition{
-				ConditionScaled: nil,
+				ConditionScaled: {status: metav1.ConditionUnknown, reason: ""},
 			},
 		},
 	}
@@ -441,9 +449,9 @@ func TestConfigurationAppliedRule(t *testing.T) {
 // TestDependencyDisabled covers the case where an installed and running
 // application loses a hard dependency (e.g. a module it depends on was
 // disabled). The cause is external, so user-facing signals (Installed, Ready)
-// go False, while runtime/configuration signals (Scaled,
-// ConfigurationApplied, Managed) go Unknown — managing is meaningless until
-// the dependency returns.
+// go False, while ConfigurationApplied and Managed go Unknown — managing is
+// meaningless until the dependency returns. Scaled is excluded: it is owned
+// by the workload health monitor and mirrors the internal condition as-is.
 func TestDependencyDisabled(t *testing.T) {
 	// Realistic runtime state: app was running with all internal conditions
 	// True from the previous successful reconcile, then RequirementsMet flipped
@@ -465,9 +473,10 @@ func TestDependencyDisabled(t *testing.T) {
 			opts: runningInternals,
 			expected: map[string]*expectedCondition{
 				// Installed overrides stickiness — the user must see the app stopped being installed.
-				ConditionInstalled:            {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
-				ConditionReady:                {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
-				ConditionScaled:               {status: metav1.ConditionUnknown, reason: "RequirementsUnmet"},
+				ConditionInstalled: {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
+				ConditionReady:     {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
+				// Scaled mirrors its internal condition (True here) — the health monitor is its sole writer.
+				ConditionScaled:               {status: metav1.ConditionTrue, reason: ConditionScaled},
 				ConditionConfigurationApplied: {status: metav1.ConditionUnknown, reason: "RequirementsUnmet"},
 				ConditionManaged:              {status: metav1.ConditionUnknown, reason: "RequirementsUnmet"},
 				// UpdateInstalled is silent — the dependency-disabled state is the dominant signal.
@@ -480,7 +489,7 @@ func TestDependencyDisabled(t *testing.T) {
 			expected: map[string]*expectedCondition{
 				ConditionInstalled:            {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
 				ConditionReady:                {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
-				ConditionScaled:               {status: metav1.ConditionUnknown, reason: "RequirementsUnmet"},
+				ConditionScaled:               {status: metav1.ConditionTrue, reason: ConditionScaled},
 				ConditionConfigurationApplied: {status: metav1.ConditionUnknown, reason: "RequirementsUnmet"},
 				ConditionManaged:              {status: metav1.ConditionUnknown, reason: "RequirementsUnmet"},
 				ConditionUpdateInstalled:      nil,
@@ -495,8 +504,8 @@ func TestDependencyDisabled(t *testing.T) {
 			expected: map[string]*expectedCondition{
 				ConditionInstalled: {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
 				ConditionReady:     {status: metav1.ConditionFalse, reason: "RequirementsUnmet"},
-				// Runtime/config signals stay absent for a first install — there's no running state to describe.
-				ConditionScaled:               nil,
+				// Scaled goes Unknown when its internal condition is absent — health monitor hasn't reported yet.
+				ConditionScaled:               {status: metav1.ConditionUnknown, reason: ""},
 				ConditionConfigurationApplied: nil,
 				ConditionManaged:              nil,
 				ConditionUpdateInstalled:      nil,


### PR DESCRIPTION
## Description

Adds a workload-health monitor that watches the Deployments and StatefulSets owned by each package and drives the package's `Scaled` condition from observed cluster state instead of from the install/upgrade outcome.

**New packages**

- `deckhouse-controller/internal/packages/health` — `Service` reduces per-workload statuses into a package-level `State` (`Scaled` / `Reconciling` / `Degraded` / `Unknown`), dedupes against the last reported value, and fires a callback only on real transitions. Reduction precedence: `Failed` or `Terminating` → `Degraded`; any `InProgress` → `Reconciling`; all `Current` → `Scaled`; empty → `Unknown`. The `Message` names the dominant workload (`Deployment/api: ProgressDeadlineExceeded`).
- `deckhouse-controller/internal/packages/health/monitor` — `Monitor` owns shared informers for Deployments and StatefulSets, a per-package indexer keyed by the `health.deckhouse.io/package` label, and a rate-limited workqueue. Server-side label selector filters at the API server; an informer transform strips `PodTemplateSpec`, `ManagedFields`, and `VolumeClaimTemplates` before objects enter the cache.

**Wiring**

- `runtime.Runtime` gains `healthService`, built in `New`, started in `Run`, stopped in `Stop`. Transitions flow through `r.status.UpdateHealth` → `ConditionScaled`.
- `nelm.Service.Render` / `Upgrade` stamp `health.deckhouse.io/package=<name>` on every rendered resource via the new `ResourcesLabels` option on `nelm.InstallOptions` / `RenderOptions`. This is what makes the monitor able to find them.

**Condition rules**

External `ConditionScaled` (in `deckhouse-controller/pkg/controller/packages/application/status/rules.go`) is now passed through verbatim from the internal condition. Reasons collapse to `Scaled` (True), `Reconciling` / `Degraded` (False), `Unknown` (no observed workloads). The dependency-disabled override is gone — `Scaled` no longer reads from other conditions.

**Other**

- Renamed `packages/nelm/monitor` → `packages/nelm/drift` to remove the name collision with the new `health/monitor`. The package was always about release drift / absent-manifest detection.
- `nelm.Client` default `Timeout` set to 2 minutes.

No changes to critical cluster components; the monitor only observes workload status and writes to a single condition.

## Why do we need it, and what problem does it solve?

`ConditionScaled` previously piggy-backed on the install path: a successful `helm upgrade` flipped it to `True`, and a wide range of unrelated failures (requirements unmet, hook failures, dependency disabled) could push it to `False` or `Unknown`. That made it unreliable as a runtime health signal — it described the *last reconcile* rather than *what is actually running*.

After this change, `ConditionScaled` is owned exclusively by the workload health monitor and answers the question users actually ask: **are this package's pods up?** A pod that crash-loops after a successful install will now flip `Scaled` to `False (Degraded)` instead of leaving it stuck on `True`.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Add package health monitor.
```