### PR TITLE
[istio] Enable sidecar hbone support when ambient is enabled

### DIFF
--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -136,10 +136,13 @@ spec:
       defaultConfig:
         proxyMetadata:
           CLOUD_PLATFORM: {{ $cloudPlatform }}
-          ISTIO_META_DNS_CAPTURE: "true"
           ISTIO_META_DNS_AUTO_ALLOCATE: "true"
-          PROXY_CONFIG_XDS_AGENT: "true"
+          ISTIO_META_DNS_CAPTURE: "true"
+          {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
+          ISTIO_META_ENABLE_HBONE: "true"
+          {{- end }}
           ISTIO_META_IDLE_TIMEOUT: {{ $.Values.istio.dataPlane.proxyConfig.idleTimeout }}
+          PROXY_CONFIG_XDS_AGENT: "true"
         holdApplicationUntilProxyStarts: {{ $.Values.istio.dataPlane.proxyConfig.holdApplicationUntilProxyStarts }}
     {{- if $.Values.istio.tracing.enabled }}
         tracing:


### PR DESCRIPTION
## Description
Enable HBONE support on sidecar proxies when Istio ambient mode is enabled.

## Why do we need it, and what problem does it solve?
Enabling HBONE on sidecars enables interoperability with ambient/ztunnels. This allows sidecar-mode pods to communicate with ambient-mode pods in the cluster, facilitating a smoother migration path from sidecar to ambient mode and ensuring proper connectivity between workloads using different Istio proxy modes.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Enabled HBONE support on sidecar proxies when ambient mode is enabled.
impact_level: default
```