### PR TITLE
bump action-download-artifact

### DIFF
--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -1039,7 +1039,7 @@ check_e2e_labels:
 {!{ if not (has $commanderProviders $provider) }!}
     - name: "Download state"
       id: download_artifact_with_state
-      uses: dawidd6/action-download-artifact@v2.23.0
+      uses: dawidd6/action-download-artifact@v21
       with:
         github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
         run_id: ${{github.event.inputs.run_id}}

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -341,7 +341,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -696,7 +696,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -1051,7 +1051,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -1406,7 +1406,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -1761,7 +1761,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -2116,7 +2116,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -2471,7 +2471,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -2826,7 +2826,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -3181,7 +3181,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -3536,7 +3536,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -3891,7 +3891,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -4246,7 +4246,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -4601,7 +4601,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}
@@ -4956,7 +4956,7 @@ jobs:
 
       - name: "Download state"
         id: download_artifact_with_state
-        uses: dawidd6/action-download-artifact@v2.23.0
+        uses: dawidd6/action-download-artifact@v21
         with:
           github_token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
           run_id: ${{github.event.inputs.run_id}}


### PR DESCRIPTION
## Description
Previously, the vulnerable action-download-artifact outdated version 2.23 was used. Replaced with v21.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Previously, the vulnerable action-download-artifact outdated version 2.23 was used. Replaced with v21.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
