### PR TITLE
fix registry path

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -175,7 +175,8 @@ steps:
     {!{- if eq $buildType "release" }!}
       STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
       export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
-      export WERF_REPO="${STAGE_REGISTRY_PATH}"
+      export WERF_REPO="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/common"
+      export WERF_FINAL_REPO="${STAGE_REGISTRY_PATH}"
     {!{- else }!}
       DEV_REGISTRY_PATH="${DECKHOUSE_DEV_REGISTRY_HOST}/${REGISTRY_PATH}"
       export REGISTRY_PATH="${DEV_REGISTRY_PATH}"

--- a/.github/scripts/python/compare_internal_modules.py
+++ b/.github/scripts/python/compare_internal_modules.py
@@ -47,6 +47,8 @@ whitelist = [
     "release-channel-version-prebuild",
     "tests-prebuild",
     "tests",
+    "dev/candi",
+    "common/candi",
 ]
 
 # Find and read build reports

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -485,7 +485,8 @@ jobs:
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
-          export WERF_REPO="${STAGE_REGISTRY_PATH}"
+          export WERF_REPO="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/common"
+          export WERF_FINAL_REPO="${STAGE_REGISTRY_PATH}"
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -810,7 +811,8 @@ jobs:
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
-          export WERF_REPO="${STAGE_REGISTRY_PATH}"
+          export WERF_REPO="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/common"
+          export WERF_FINAL_REPO="${STAGE_REGISTRY_PATH}"
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -1135,7 +1137,8 @@ jobs:
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
-          export WERF_REPO="${STAGE_REGISTRY_PATH}"
+          export WERF_REPO="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/common"
+          export WERF_FINAL_REPO="${STAGE_REGISTRY_PATH}"
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -1448,7 +1451,8 @@ jobs:
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
-          export WERF_REPO="${STAGE_REGISTRY_PATH}"
+          export WERF_REPO="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/common"
+          export WERF_FINAL_REPO="${STAGE_REGISTRY_PATH}"
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -1761,7 +1765,8 @@ jobs:
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
-          export WERF_REPO="${STAGE_REGISTRY_PATH}"
+          export WERF_REPO="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/common"
+          export WERF_FINAL_REPO="${STAGE_REGISTRY_PATH}"
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then
@@ -2074,7 +2079,8 @@ jobs:
           REGISTRY_SUFFIX=$(echo ${WERF_ENV} | tr '[:upper:]' '[:lower:]')
           STAGE_REGISTRY_PATH="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/${REGISTRY_SUFFIX}"
           export REGISTRY_PATH="${STAGE_REGISTRY_PATH}"
-          export WERF_REPO="${STAGE_REGISTRY_PATH}"
+          export WERF_REPO="${DECKHOUSE_REGISTRY_STAGE_HOST}/deckhouse/common"
+          export WERF_FINAL_REPO="${STAGE_REGISTRY_PATH}"
 
           # Registry path to publish images for Git tags.
           if [[ -n ${DECKHOUSE_REGISTRY_STAGE_HOST:-} ]] ; then


### PR DESCRIPTION
## Description
Introduced deckhouse/common as a shared WERF cache repository to avoid full rebuilds for each DKP edition. Final images are now copied into deckhouse/\<edition\> repos in the stage registry. Also added dev/candi and common/candi to the whitelist since they differ between editions.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Add shared deckhouse/common WERF cache to avoid per-edition rebuilds and whitelist dev/candi and common/candi images
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
