### PR TITLE
[node-manager] Add RBAC rules for node-manager

### DIFF
--- a/modules/040-node-manager/crds/mcm.yaml
+++ b/modules/040-node-manager/crds/mcm.yaml
@@ -231,52 +231,6 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: alicloudmachineclasses.machine.sapcloud.io
-  labels:
-    heritage: deckhouse
-    module: node-manager
-    app: machine-controller-manager
-spec:
-  group: machine.sapcloud.io
-  scope: Namespaced
-  names:
-    kind: AlicloudMachineClass
-    plural: alicloudmachineclasses
-    singular: alicloudmachineclass
-    shortNames:
-    - alicloudcls
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
-      additionalPrinterColumns:
-        - name: Instance Type
-          type: string
-          jsonPath: .spec.instanceType
-        - name: Region
-          type: string
-          priority: 1
-          jsonPath: .spec.region
-        - name: Age
-          type: date
-          description: >
-            CreationTimestamp is a timestamp representing the server time when this object was created.
-            It is not guaranteed to be set in happens-before order across separate operations.
-            Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-            Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-          jsonPath: .metadata.creationTimestamp
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-
----
-
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
   name: yandexmachineclasses.machine.sapcloud.io
   labels:
     heritage: deckhouse
@@ -308,36 +262,6 @@ spec:
             Clients may not set this value. It is represented in RFC3339 form and is in UTC.
             Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
           jsonPath: .metadata.creationTimestamp
-      subresources:
-        status: {}
-      schema:
-        openAPIV3Schema:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-
----
-
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: packetmachineclasses.machine.sapcloud.io
-  labels:
-    heritage: deckhouse
-    module: node-manager
-    app: machine-controller-manager
-spec:
-  group: machine.sapcloud.io
-  scope: Namespaced
-  names:
-    kind: PacketMachineClass
-    plural: packetmachineclasses
-    singular: packetmachineclass
-    shortNames:
-    - packetcls
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
       subresources:
         status: {}
       schema:

--- a/modules/040-node-manager/crds/mcm.yaml
+++ b/modules/040-node-manager/crds/mcm.yaml
@@ -228,6 +228,7 @@ spec:
 
 ---
 
+# Not used by Deckhouse, required because MCM lists this resource.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -317,6 +318,7 @@ spec:
 
 ---
 
+# Not used by Deckhouse, required because MCM lists this resource.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/modules/040-node-manager/crds/mcm.yaml
+++ b/modules/040-node-manager/crds/mcm.yaml
@@ -231,6 +231,52 @@ spec:
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: alicloudmachineclasses.machine.sapcloud.io
+  labels:
+    heritage: deckhouse
+    module: node-manager
+    app: machine-controller-manager
+spec:
+  group: machine.sapcloud.io
+  scope: Namespaced
+  names:
+    kind: AlicloudMachineClass
+    plural: alicloudmachineclasses
+    singular: alicloudmachineclass
+    shortNames:
+    - alicloudcls
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Instance Type
+          type: string
+          jsonPath: .spec.instanceType
+        - name: Region
+          type: string
+          priority: 1
+          jsonPath: .spec.region
+        - name: Age
+          type: date
+          description: >
+            CreationTimestamp is a timestamp representing the server time when this object was created.
+            It is not guaranteed to be set in happens-before order across separate operations.
+            Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+            Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+          jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: yandexmachineclasses.machine.sapcloud.io
   labels:
     heritage: deckhouse
@@ -262,6 +308,36 @@ spec:
             Clients may not set this value. It is represented in RFC3339 form and is in UTC.
             Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
           jsonPath: .metadata.creationTimestamp
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: packetmachineclasses.machine.sapcloud.io
+  labels:
+    heritage: deckhouse
+    module: node-manager
+    app: machine-controller-manager
+spec:
+  group: machine.sapcloud.io
+  scope: Namespaced
+  names:
+    kind: PacketMachineClass
+    plural: packetmachineclasses
+    singular: packetmachineclass
+    shortNames:
+    - packetcls
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
       subresources:
         status: {}
       schema:

--- a/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
@@ -23,8 +23,6 @@ rules:
    - azuremachineclasses
    - gcpmachineclasses
    - openstackmachineclasses
-   - alicloudmachineclasses
-   - packetmachineclasses
    - vspheremachineclasses
    - yandexmachineclasses
    - machinedeployments
@@ -34,8 +32,6 @@ rules:
    - azuremachineclasses/status
    - gcpmachineclasses/status
    - openstackmachineclasses/status
-   - alicloudmachineclasses/status
-   - packetmachineclasses/status
    - vspheremachineclasses/status
    - yandexmachineclasses/status
    - machinedeployments/status

--- a/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
@@ -23,6 +23,7 @@ rules:
    - azuremachineclasses
    - gcpmachineclasses
    - openstackmachineclasses
+   # Not used by Deckhouse, required because MCM lists these resources.
    - alicloudmachineclasses
    - packetmachineclasses
    - vspheremachineclasses
@@ -34,6 +35,7 @@ rules:
    - azuremachineclasses/status
    - gcpmachineclasses/status
    - openstackmachineclasses/status
+   # Not used by Deckhouse, required because MCM accesses these status resources.
    - alicloudmachineclasses/status
    - packetmachineclasses/status
    - vspheremachineclasses/status

--- a/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
@@ -23,6 +23,8 @@ rules:
    - azuremachineclasses
    - gcpmachineclasses
    - openstackmachineclasses
+   - alicloudmachineclasses
+   - packetmachineclasses
    - vspheremachineclasses
    - yandexmachineclasses
    - machinedeployments
@@ -32,6 +34,8 @@ rules:
    - azuremachineclasses/status
    - gcpmachineclasses/status
    - openstackmachineclasses/status
+   - alicloudmachineclasses/status
+   - packetmachineclasses/status
    - vspheremachineclasses/status
    - yandexmachineclasses/status
    - machinedeployments/status

--- a/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
@@ -1,14 +1,6 @@
 ---
 # Access level: SuperAdmin.
-# Full access to all node-manager resources.
-# Adds write access to Kubernetes Node resources.
-# - node-manager deckhouse.io resources (instances, instancetypescatalogs, nodegroups, nodegroupconfigurations, nodeusers, sshcredentials, staticinstances)
-# - Node Feature Discovery resources
-# - Machine Controller Manager resources
-# - Cluster API resources
-# - CAPS infrastructure resources owned by node-manager
-# - Kubernetes Node resources
-# Provider-specific Cluster API infrastructure resources must be covered by cloud-provider modules.
+# Full access to all resources.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -18,118 +10,11 @@ metadata:
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:
-  - deckhouse.io
+  - '*'
   resources:
-  - instances
-  - instancetypescatalogs
-  - nodegroups
-  - nodegroupconfigurations
-  - nodeusers
-  - sshcredentials
-  - staticinstances
+  - '*'
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  verbs:
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - nfd.k8s-sigs.io
-  resources:
-  - nodefeatures
-  - nodefeaturegroups
-  - nodefeaturerules
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - machine.sapcloud.io
-  resources:
-  - openstackmachineclasses
-  - awsmachineclasses
-  - azuremachineclasses
-  - vspheremachineclasses
-  - gcpmachineclasses
-  - yandexmachineclasses
-  - machines
-  - machinesets
-  - machinedeployments
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - clusters
-  - machinedeployments
-  - machinedrainrules
-  - machinehealthchecks
-  - machinepools
-  - machines
-  - machinesets
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - infrastructure.cluster.x-k8s.io
-  resources:
-  - deckhousecontrolplanes
-  - staticclusters
-  - staticmachines
-  - staticmachinetemplates
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
-- apiGroups:
-  - runtime.cluster.x-k8s.io
-  resources:
-  - extensionconfigs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-  - deletecollection
+  - '*'
 ---
 # Access level: ClusterAdmin.
 # Includes User, PrivilegedUser, Editor, Admin, and ClusterEditor permissions.

--- a/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
@@ -1,20 +1,54 @@
 ---
+# Access level: SuperAdmin.
+# Full access to all node-manager resources:
+# - node-manager deckhouse.io resources (instances, instancetypescatalogs, nodegroups, nodegroupconfigurations, nodeusers, sshcredentials, staticinstances)
+# - Node Feature Discovery resources
+# - Machine Controller Manager resources
+# - Cluster API resources
+# - CAPS infrastructure resources owned by node-manager
+# Provider-specific Cluster API infrastructure resources must be covered by cloud-provider modules.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:node-manager:user
+    user-authz.deckhouse.io/access-level: SuperAdmin
+  name: d8:user-authz:node-manager:super-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:
   - deckhouse.io
   resources:
+  - instances
+  - instancetypescatalogs
   - nodegroups
+  - nodegroupconfigurations
+  - nodeusers
+  - sshcredentials
+  - staticinstances
   verbs:
   - get
   - list
   - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturegroups
+  - nodefeaturerules
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - machine.sapcloud.io
   resources:
@@ -23,9 +57,7 @@ rules:
   - azuremachineclasses
   - vspheremachineclasses
   - gcpmachineclasses
-  - alicloudmachineclasses
   - yandexmachineclasses
-  - packetmachineclasses
   - machines
   - machinesets
   - machinedeployments
@@ -33,45 +65,50 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - cluster.x-k8s.io
   resources:
+  - clusters
+  - machinedeployments
+  - machinedrainrules
+  - machinehealthchecks
+  - machinepools
   - machines
   - machinesets
-  - machinedeployments
-  - machinepools
-  - machinehealthchecks
-  - clusters
   verbs:
   - get
   - list
   - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
-  - vcdmachinetemplates
-  - huaweicloudmachinetemplates
-  - dynamixmachinetemplates
-  - zvirtmachinetemplates
-  - deckhousemachinetemplates
+  - deckhousecontrolplanes
+  - staticclusters
+  - staticmachines
   - staticmachinetemplates
   verbs:
   - get
   - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterEditor
-  name: d8:user-authz:node-manager:cluster-editor
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 - apiGroups:
-  - deckhouse.io
+  - runtime.cluster.x-k8s.io
   resources:
-  - nodegroups
+  - extensionconfigs
   verbs:
   - get
   - list
@@ -82,6 +119,17 @@ rules:
   - delete
   - deletecollection
 ---
+# Access level: ClusterAdmin.
+# Includes User, PrivilegedUser, Editor, Admin, and ClusterEditor permissions.
+# Full access:
+# - node-manager deckhouse.io resources (instances, nodegroups, nodegroupconfigurations, nodeusers, sshcredentials, staticinstances)
+# Read access:
+# - Node Feature Discovery resources
+# - Machine Controller Manager resources
+# - Cluster API resources
+# - node-manager infrastructure resources
+# Write access:
+# - cluster-autoscaler and fencing-agent configuration resources
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -93,13 +141,31 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
+  - instances
   - nodegroups
+  - nodegroupconfigurations
+  - nodeusers
+  - sshcredentials
+  - staticinstances
   verbs:
+  - get
+  - list
+  - watch
   - create
   - update
   - patch
   - delete
   - deletecollection
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturegroups
+  - nodefeaturerules
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - machine.sapcloud.io
   resources:
@@ -115,8 +181,11 @@ rules:
   - machinesets
   - machinedeployments
   verbs:
-  - patch
+  - get
+  - list
+  - watch
   - update
+  - patch
   - delete
   - deletecollection
 - apiGroups:
@@ -126,6 +195,20 @@ rules:
   verbs:
   - patch
   - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machinedeployments
+  - machinedrainrules
+  - machinehealthchecks
+  - machinepools
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cluster.x-k8s.io
   resources:
@@ -145,6 +228,17 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
+  - deckhousecontrolplanes
+  - staticclusters
+  - staticmachines
+  - staticmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
   - vcdmachinetemplates
   - huaweicloudmachinetemplates
   - dynamixmachinetemplates
@@ -157,3 +251,96 @@ rules:
   - patch
   - delete
   - deletecollection
+---
+# Access level: ClusterEditor.
+# Includes User, PrivilegedUser, Editor, and Admin permissions.
+# Adds write access to public node-manager resources (instances, nodegroups, nodegroupconfigurations, staticinstances).
+# Adds read access to nodegroupconfigurations and staticinstances.
+# Allowed verbs: create, update, patch, delete, deletecollection.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterEditor
+  name: d8:user-authz:node-manager:cluster-editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - nodegroupconfigurations
+  - staticinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - instances
+  - nodegroups
+  - nodegroupconfigurations
+  - staticinstances
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+---
+# Access level: Admin.
+# Includes User, PrivilegedUser, and Editor permissions.
+# Uses node-manager read access from User.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Admin
+  name: d8:user-authz:node-manager:admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules: []
+---
+# Access level: Editor.
+# Includes User and PrivilegedUser permissions.
+# Uses node-manager read access from User.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Editor
+  name: d8:user-authz:node-manager:editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules: []
+---
+# Access level: PrivilegedUser.
+# Includes User permissions.
+# Uses node-manager read access from User.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: PrivilegedUser
+  name: d8:user-authz:node-manager:privileged-user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules: []
+---
+# Access level: User.
+# Read access:
+# - public node-manager resources (instances, nodegroups)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:node-manager:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - instances
+  - nodegroups
+  verbs:
+  - get
+  - list
+  - watch

--- a/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
@@ -1,11 +1,13 @@
 ---
 # Access level: SuperAdmin.
-# Full access to all node-manager resources:
+# Full access to all node-manager resources.
+# Adds write access to Kubernetes Node resources.
 # - node-manager deckhouse.io resources (instances, instancetypescatalogs, nodegroups, nodegroupconfigurations, nodeusers, sshcredentials, staticinstances)
 # - Node Feature Discovery resources
 # - Machine Controller Manager resources
 # - Cluster API resources
 # - CAPS infrastructure resources owned by node-manager
+# - Kubernetes Node resources
 # Provider-specific Cluster API infrastructure resources must be covered by cloud-provider modules.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -29,6 +31,16 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
   - create
   - update
   - patch
@@ -130,6 +142,8 @@ rules:
 # - node-manager infrastructure resources
 # Write access:
 # - cluster-autoscaler and fencing-agent configuration resources
+# Node write access:
+# - Kubernetes Node resources (update, patch)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -256,7 +270,8 @@ rules:
 # Includes User, PrivilegedUser, Editor, and Admin permissions.
 # Adds write access to public node-manager resources (instances, nodegroups, nodegroupconfigurations, staticinstances).
 # Adds read access to nodegroupconfigurations and staticinstances.
-# Allowed verbs: create, update, patch, delete, deletecollection.
+# Adds update and patch access to Kubernetes Node resources.
+# Allowed public resource verbs: create, update, patch, delete, deletecollection.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -274,6 +289,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+  - patch
 - apiGroups:
   - deckhouse.io
   resources:


### PR DESCRIPTION
## Description

Adds module-scoped RBAC v1 extension for node-manager
Also removes unused `alicloudmachineclasses` and `packetmachineclasses` MCM CRDs and related controller RBAC rules.

## Why do we need it, and what problem does it solve?

The change provides explicit user-authz RBAC rules for node-manager resources according to the access-level model.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Added RBAC rules for node-manager.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
