### PR TITLE
[chore] Mark CustomPrometheusRule as deprecated

### DIFF
--- a/modules/300-prometheus/crds/customprometheusrules.yaml
+++ b/modules/300-prometheus/crds/customprometheusrules.yaml
@@ -20,6 +20,7 @@ spec:
       served: true
       storage: false
       deprecated: true
+      deprecationWarning: "CustomPrometheusRules is deprecated; use ObservabilityMetricsRulesGroup or ClusterObservabilityMetricsRulesGroup instead."
       schema: &schema
         openAPIV3Schema:
           type: object
@@ -82,4 +83,6 @@ spec:
     - name: v1
       served: true
       storage: true
+      deprecated: true
+      deprecationWarning: "CustomPrometheusRules is deprecated; use ObservabilityMetricsRulesGroup or ClusterObservabilityMetricsRulesGroup instead."
       schema: *schema


### PR DESCRIPTION
## Description
Marks CustomPrometheusRule as depricated CRD

## Why do we need it, and what problem does it solve?
ObservabilityMetricsRulesGroup and ClusterObservabilityMetricsRulesGroup should be used to create custom prometheus recording and alerting rules groups. CustomPrometheusRule is outdated.

## Why do we need it in the patch release (if we do)?
Not necessarily. It's a deprication warning, it only adds deprication warning. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: prometheus
type: chore
summary: Marks CustomPrometheusRule as depricated CRD
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
