### PR TITLE
[user-authz] Add permission-browser availability alert

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3844,17 +3844,17 @@ alerts:
       module: user-authz
       edition: ce
       description: |-
-        Deckhouse has detected unavailable replicas in the `permission-browser-apiserver` Deployment in the `d8-user-authz` namespace.
+        Deckhouse has detected unavailable replicas in the `permission-browser-apiserver` deployment in the `d8-user-authz` namespace.
         Permission Browser requests can fail while this alert is active.
 
-        Check Deployment and Pod states:
+        Check deployment and pod states:
         ```bash
         d8 k -n d8-user-authz get deploy permission-browser-apiserver
         d8 k -n d8-user-authz get pods -l app=permission-browser-apiserver
         ```
       summary: |
         Permission Browser API server has unavailable replicas.
-      severity: "5"
+      severity: "6"
       markupFormat: markdown
     - name: D8UsingFeatureGateWillBeDeprecated
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -3838,6 +3838,24 @@ alerts:
         Too many UpmeterHookProbe objects in the cluster.
       severity: "9"
       markupFormat: markdown
+    - name: D8UserAuthzPermissionBrowserUnavailable
+      sourceFile: modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
+      moduleUrl: 140-user-authz
+      module: user-authz
+      edition: ce
+      description: |-
+        Deckhouse has detected unavailable replicas in the `permission-browser-apiserver` Deployment in the `d8-user-authz` namespace.
+        Permission Browser requests can fail while this alert is active.
+
+        Check Deployment and Pod states:
+        ```bash
+        d8 k -n d8-user-authz get deploy permission-browser-apiserver
+        d8 k -n d8-user-authz get pods -l app=permission-browser-apiserver
+        ```
+      summary: |
+        Permission Browser API server has unavailable replicas.
+      severity: "5"
+      markupFormat: markdown
     - name: D8UsingFeatureGateWillBeDeprecated
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/control-plane-manager.yaml
       moduleUrl: 040-control-plane-manager
@@ -7278,3 +7296,4 @@ modules-having-alerts:
     - terraform-manager
     - upmeter
     - user-authn
+    - user-authz

--- a/modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
@@ -1,0 +1,34 @@
+- name: d8.user-authz.permission-browser-apiserver.availability
+  rules:
+  - alert: D8UserAuthzPermissionBrowserUnavailable
+    expr: |
+      (
+        kube_deployment_spec_replicas{
+          namespace="d8-user-authz",
+          deployment="permission-browser-apiserver"
+        }
+        -
+        kube_deployment_status_replicas_available{
+          namespace="d8-user-authz",
+          deployment="permission-browser-apiserver"
+        }
+      ) > 0
+    for: 5m
+    labels:
+      severity_level: "5"
+      tier: cluster
+      d8_module: user-authz
+      d8_component: permission-browser-apiserver
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      summary: Permission Browser API server has unavailable replicas.
+      description: |-
+        Deckhouse has detected unavailable replicas in the `permission-browser-apiserver` Deployment in the `d8-user-authz` namespace.
+        Permission Browser requests can fail while this alert is active.
+
+        Check Deployment and Pod states:
+        ```bash
+        d8 k -n d8-user-authz get deploy permission-browser-apiserver
+        d8 k -n d8-user-authz get pods -l app=permission-browser-apiserver
+        ```

--- a/modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
+++ b/modules/140-user-authz/monitoring/prometheus-rules/permission-browser-apiserver.yaml
@@ -15,19 +15,21 @@
       ) > 0
     for: 5m
     labels:
-      severity_level: "5"
+      severity_level: "6"
       tier: cluster
       d8_module: user-authz
       d8_component: permission-browser-apiserver
     annotations:
       plk_protocol_version: "1"
       plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_user_authz_permission_browser_unavailable: "D8UserAuthzPermissionBrowserUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authz_permission_browser_unavailable: "D8UserAuthzPermissionBrowserUnavailable,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       summary: Permission Browser API server has unavailable replicas.
       description: |-
-        Deckhouse has detected unavailable replicas in the `permission-browser-apiserver` Deployment in the `d8-user-authz` namespace.
+        Deckhouse has detected unavailable replicas in the `permission-browser-apiserver` deployment in the `d8-user-authz` namespace.
         Permission Browser requests can fail while this alert is active.
 
-        Check Deployment and Pod states:
+        Check deployment and pod states:
         ```bash
         d8 k -n d8-user-authz get deploy permission-browser-apiserver
         d8 k -n d8-user-authz get pods -l app=permission-browser-apiserver

--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -150,6 +150,7 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 
 	Context("With custom resources (incl. limitNamespaces), enabledMultiTenancy and controlPlaneConfigurator", func() {
 		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.enabledModules", `["operator-prometheus", "operator-prometheus-crd"]`)
 			f.ValuesSetFromYaml("userAuthz.internal.clusterAuthRuleCrds", testCLusterRoleCRDsWithLimitNamespaces)
 			f.ValuesSetFromYaml("userAuthz.internal.authRuleCrds", testRoleCRDs)
 			f.ValuesSetFromYaml("userAuthz.internal.customClusterRoles", customClusterRolesFlat)
@@ -374,6 +375,12 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:permission-browser-apiserver:auth-delegator").Exists()).To(BeTrue())
 		})
 
+		It("Should render permission-browser availability alert", func() {
+			rule := f.KubernetesResource("PrometheusRule", "d8-system", "user-authz-permission-browser-apiserver")
+			Expect(rule.Exists()).To(BeTrue())
+			Expect(rule.Field("spec.groups").String()).To(ContainSubstring("D8UserAuthzPermissionBrowserUnavailable"))
+		})
+
 		It("Should configure permission-browser-apiserver deployment correctly", func() {
 			deploy := f.KubernetesResource("Deployment", "d8-user-authz", "permission-browser-apiserver")
 			Expect(deploy.Field("spec.template.spec.containers.0.args").String()).To(ContainSubstring("--secure-port=8443"))
@@ -405,6 +412,7 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 	Context("Namespace access permissions based on edition", func() {
 		Context("EE edition (non-CE)", func() {
 			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.enabledModules", `["operator-prometheus", "operator-prometheus-crd"]`)
 				f.ValuesSet("global.deckhouseEdition", "EE")
 				f.ValuesSet("userAuthz.enableMultiTenancy", true)
 				f.HelmRender()
@@ -457,6 +465,7 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 
 		Context("EE edition (non-CE) with MultiTenancy disabled", func() {
 			BeforeEach(func() {
+				f.ValuesSetFromYaml("global.enabledModules", `["operator-prometheus", "operator-prometheus-crd"]`)
 				f.ValuesSet("global.deckhouseEdition", "EE")
 				f.ValuesSet("userAuthz.enableMultiTenancy", false)
 				f.HelmRender()
@@ -477,6 +486,10 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 
 			It("system:authenticated should not get accessiblenamespaces discovery", func() {
 				Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:accessible-namespaces-reader:system-authenticated").Exists()).To(BeFalse())
+			})
+
+			It("Should not render permission-browser availability alert", func() {
+				Expect(f.KubernetesResource("PrometheusRule", "d8-system", "user-authz-permission-browser-apiserver").Exists()).To(BeFalse())
 			})
 		})
 

--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -488,8 +488,10 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 				Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:user-authz:accessible-namespaces-reader:system-authenticated").Exists()).To(BeFalse())
 			})
 
-			It("Should not render permission-browser availability alert", func() {
-				Expect(f.KubernetesResource("PrometheusRule", "d8-system", "user-authz-permission-browser-apiserver").Exists()).To(BeFalse())
+			It("Should render permission-browser availability alert", func() {
+				rule := f.KubernetesResource("PrometheusRule", "d8-system", "user-authz-permission-browser-apiserver")
+				Expect(rule.Exists()).To(BeTrue())
+				Expect(rule.Field("spec.groups").String()).To(ContainSubstring("D8UserAuthzPermissionBrowserUnavailable"))
 			})
 		})
 

--- a/modules/140-user-authz/templates/monitoring.yaml
+++ b/modules/140-user-authz/templates/monitoring.yaml
@@ -1,1 +1,3 @@
+{{- if .Values.userAuthz.enableMultiTenancy }}
 {{- include "helm_lib_prometheus_rules" (list . "d8-system") }}
+{{- end }}

--- a/modules/140-user-authz/templates/monitoring.yaml
+++ b/modules/140-user-authz/templates/monitoring.yaml
@@ -1,3 +1,1 @@
-{{- if .Values.userAuthz.enableMultiTenancy }}
 {{- include "helm_lib_prometheus_rules" (list . "d8-system") }}
-{{- end }}


### PR DESCRIPTION
## Description
Adds monitoring for Permission Browser availability in `user-authz`:
- New Prometheus alert rule for `permission-browser-apiserver` deployment unavailability.
- Rule is rendered only when `userAuthz.enableMultiTenancy=true` (to avoid false alerts when component is disabled).
- Added template tests to verify:
  - alert is rendered when multi-tenancy is enabled;
  - alert is not rendered when multi-tenancy is disabled.
This change does **not** restart or reconfigure critical cluster components directly (control-plane, ingress, Prometheus runtime config beyond normal rule reload).
## Why do we need it, and what problem does it solve?
Permission Browser is used in UI authorization flows; when `permission-browser-apiserver` is unavailable, users can face permission-check failures in the interface.
Before this change, there was no dedicated alert to proactively signal this condition.  
Now operators get a clear alert and can react faster, reducing MTTR and improving visibility for on-call teams.
## Why do we need it in the patch release (if we do)?
Not necessarily.
This is a low-risk monitoring improvement (new alert + tests) and not a runtime bugfix.
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: user-authz
type: feature
summary: Added alert for `permission-browser-apiserver` unavailability in `user-authz`.
impact_level: default