### PR TITLE
[node-manager] Fixed caps webhooks for StaticInstance and conversions logs

### DIFF
--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/conversion.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/conversion.go
@@ -26,7 +26,7 @@ import (
 
 //nolint:revive
 func Convert_v1alpha2_SSHCredentialsSpec_To_v1alpha1_SSHCredentialsSpec(in *v1alpha2.SSHCredentialsSpec, out *SSHCredentialsSpec, s conversion.Scope) error {
-	staticinstancelog.Info("conversing from v1alpha2 to v1alpha1")
+	sshcredentialslog.Info("converting SSHCredentialsSpec from v1alpha2 to v1alpha1")
 	decodedPass, err := base64.StdEncoding.DecodeString(in.SudoPasswordEncoded)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func Convert_v1alpha2_SSHCredentialsSpec_To_v1alpha1_SSHCredentialsSpec(in *v1al
 //nolint:revive
 func Convert_v1alpha1_SSHCredentialsSpec_To_v1alpha2_SSHCredentialsSpec(in *SSHCredentialsSpec, out *v1alpha2.SSHCredentialsSpec, s conversion.Scope) error {
 	encodedPass := base64.StdEncoding.EncodeToString([]byte(in.SudoPassword))
-	staticinstancelog.Info("conversing from v1alpha1 to v1alpha2")
+	sshcredentialslog.Info("converting SSHCredentialsSpec from v1alpha1 to v1alpha2")
 
 	out.SudoPasswordEncoded = encodedPass
 	return autoConvert_v1alpha1_SSHCredentialsSpec_To_v1alpha2_SSHCredentialsSpec(in, out, s)

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha1/staticinstance_webhook.go
@@ -48,7 +48,7 @@ func (r *StaticInstance) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 type StaticInstanceCustomDefaulter struct{}
 
-// +kubebuilder:webhook:path=/mutate-deckhouse-io-v1alpha1-staticinstance,mutating=true,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=create;update,versions=v1alpha1,name=mstaticinstance.deckhouse.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-deckhouse-io-v1alpha1-staticinstance,mutating=true,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=create;update,versions=v1alpha1,name=mstaticinstancev1alpha1.deckhouse.io,admissionReviewVersions=v1
 var _ webhook.CustomDefaulter = &StaticInstanceCustomDefaulter{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
@@ -63,10 +63,9 @@ func (*StaticInstanceCustomDefaulter) Default(_ context.Context, obj runtime.Obj
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 type StaticInstanceCustomValidator struct{}
 
-// +kubebuilder:webhook:path=/validate-deckhouse-io-v1alpha1-staticinstance,mutating=false,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=update;delete,versions=v1alpha1,name=vstaticinstance.deckhouse.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-deckhouse-io-v1alpha1-staticinstance,mutating=false,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=create;update;delete,versions=v1alpha1,name=vstaticinstancev1alpha1.deckhouse.io,admissionReviewVersions=v1
 var _ webhook.CustomValidator = &StaticInstanceCustomValidator{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type

--- a/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/staticinstance_webhook.go
+++ b/modules/040-node-manager/images/caps-controller-manager/src/api/deckhouse.io/v1alpha2/staticinstance_webhook.go
@@ -46,7 +46,7 @@ func (r *StaticInstance) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
-///+kubebuilder:webhook:path=/mutate-deckhouse-io-v1alpha1-staticinstance,mutating=true,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=create;update,versions=v1alpha1,name=mstaticinstance.deckhouse.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-deckhouse-io-v1alpha2-staticinstance,mutating=true,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=create;update,versions=v1alpha2,name=mstaticinstancev1alpha2.deckhouse.io,admissionReviewVersions=v1
 
 type StaticInstanceCustomDefaulter struct{}
 
@@ -62,8 +62,7 @@ func (r *StaticInstanceCustomDefaulter) Default(_ context.Context, obj runtime.O
 	return nil
 }
 
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-deckhouse-io-v1alpha2-staticinstance,mutating=false,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=update;delete,versions=v1alpha1,name=vstaticinstance.deckhouse.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-deckhouse-io-v1alpha2-staticinstance,mutating=false,failurePolicy=fail,sideEffects=None,groups=deckhouse.io,resources=staticinstances,verbs=create;update;delete,versions=v1alpha2,name=vstaticinstancev1alpha2.deckhouse.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &StaticInstanceCustomValidator{}
 

--- a/modules/040-node-manager/templates/caps-controller-manager/webhook.yaml
+++ b/modules/040-node-manager/templates/caps-controller-manager/webhook.yaml
@@ -15,6 +15,7 @@ webhooks:
         path: /validate-deckhouse-io-v1alpha2-sshcredentials
       caBundle: {{ .Values.nodeManager.internal.capsControllerManagerWebhookCert.ca | b64enc }}
     failurePolicy: Fail
+    matchPolicy: Exact
     name: vsshcredentialsv1alpha2.deckhouse.io
     rules:
       - apiGroups:
@@ -36,6 +37,7 @@ webhooks:
         path: /validate-deckhouse-io-v1alpha1-sshcredentials
       caBundle: {{ .Values.nodeManager.internal.capsControllerManagerWebhookCert.ca | b64enc }}
     failurePolicy: Fail
+    matchPolicy: Exact
     name: vsshcredentialsv1alpha1.deckhouse.io
     rules:
       - apiGroups:
@@ -57,6 +59,7 @@ webhooks:
         path: /validate-deckhouse-io-v1alpha2-staticinstance
       caBundle: {{ .Values.nodeManager.internal.capsControllerManagerWebhookCert.ca | b64enc }}
     failurePolicy: Fail
+    matchPolicy: Exact
     name: vstaticinstancev1alpha2.deckhouse.io
     rules:
       - apiGroups:
@@ -79,6 +82,7 @@ webhooks:
         path: /validate-deckhouse-io-v1alpha1-staticinstance
       caBundle: {{ .Values.nodeManager.internal.capsControllerManagerWebhookCert.ca | b64enc }}
     failurePolicy: Fail
+    matchPolicy: Exact
     name: vstaticinstancev1alpha1.deckhouse.io
     rules:
       - apiGroups:


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR fixes the `StaticInstance` webhook kubebuilder markers for both `deckhouse.io/v1alpha1` and `deckhouse.io/v1alpha2`: it corrects version-specific webhook paths, names, and supported operations, and restores the broken `v1alpha2` mutating marker that was accidentally commented out and pointed to the wrong version. It also includes a fix for `SSHCredentials` conversion logging to make version conversion traces accurate and easier to follow.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

These changes are needed to keep source annotations and conversion diagnostics aligned with the actual API behavior. Without them, the codebase contains misleading webhook metadata and confusing conversion logs, which complicates debugging, can break future manifest generation, and makes version-specific admission behavior harder to reason about.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fixed `StaticInstance` webhook markers and corrected `SSHCredentials` conversion logs for `v1alpha1`/`v1alpha2`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
