### PR TITLE
[control-plane-manager] Control-plane templates fixes

### DIFF
--- a/candi/control-plane/etcd.yaml.tpl
+++ b/candi/control-plane/etcd.yaml.tpl
@@ -23,6 +23,9 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   priority: 2000001000
   priorityClassName: system-node-critical
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   volumes:
   - name: etcd-data
     hostPath:

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -90,6 +90,9 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   priority: 2000001000
   priorityClassName: system-node-critical
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
 {{- if .apiserver.oidcIssuerAddress }}
 {{- if .apiserver.oidcIssuerURL }}
   hostAliases:
@@ -284,6 +287,7 @@ spec:
     - name: GOGC
       value: "50"
     readinessProbe:
+      failureThreshold: 3
       httpGet:
 {{- if hasKey . "nodeIP" }}
         host: {{ .nodeIP | quote }}
@@ -291,7 +295,10 @@ spec:
         path: /healthz
         port: 6443
         scheme: HTTPS
+      periodSeconds: 1
+      timeoutSeconds: 15
     livenessProbe:
+      failureThreshold: 8
       httpGet:
 {{- if hasKey . "nodeIP" }}
         host: {{ .nodeIP | quote }}
@@ -299,7 +306,11 @@ spec:
         path: /livez
         port: 6443
         scheme: HTTPS
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 15
     startupProbe:
+      failureThreshold: 24
       httpGet:
 {{- if hasKey . "nodeIP" }}
         host: {{ .nodeIP | quote }}
@@ -307,3 +318,6 @@ spec:
         path: /livez
         port: 6443
         scheme: HTTPS
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 15

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -154,7 +154,9 @@ spec:
     - --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt
     - --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt
     - --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key
+{{- if not .apiserver.webhookURL }}
     - --authorization-mode=Node,RBAC
+{{- end }}
     - --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt
     - --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
     - --requestheader-allowed-names=front-proxy-client

--- a/dhctl/pkg/template/controlplane_manifests_test.go
+++ b/dhctl/pkg/template/controlplane_manifests_test.go
@@ -220,6 +220,9 @@ func testAPIServerConfiguration(t *testing.T) {
 					if !strings.Contains(manifest, "--authorization-config") {
 						t.Errorf("Expected authorization-config not found in %s", name)
 					}
+					if strings.Contains(manifest, "--authorization-mode") {
+						t.Errorf("Unexpected authorization-mode found in %s", name)
+					}
 				}
 			})
 

--- a/dhctl/pkg/template/controlplane_manifests_test.go
+++ b/dhctl/pkg/template/controlplane_manifests_test.go
@@ -223,6 +223,17 @@ func testAPIServerConfiguration(t *testing.T) {
 					if strings.Contains(manifest, "--authorization-mode") {
 						t.Errorf("Unexpected authorization-mode found in %s", name)
 					}
+					for _, expected := range []string{
+						"seccompProfile:",
+						"failureThreshold: 8",
+						"initialDelaySeconds: 10",
+						"timeoutSeconds: 15",
+						"failureThreshold: 24",
+					} {
+						if !strings.Contains(manifest, expected) {
+							t.Errorf("Expected kubeadm static pod default %s not found in %s", expected, name)
+						}
+					}
 				}
 			})
 

--- a/dhctl/pkg/template/controlplane_manifests_test.go
+++ b/dhctl/pkg/template/controlplane_manifests_test.go
@@ -231,7 +231,7 @@ func testAPIServerConfiguration(t *testing.T) {
 						"failureThreshold: 24",
 					} {
 						if !strings.Contains(manifest, expected) {
-							t.Errorf("Expected kubeadm static pod default %s not found in %s", expected, name)
+							t.Errorf("Expected static pod default %s not found in %s", expected, name)
 						}
 					}
 				}

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -911,15 +911,14 @@ apiserver:
 					"--authentication-token-webhook-cache-ttl=5m",
 					"--audit-webhook-config-file=/etc/kubernetes/deckhouse/extra-files/audit-webhook-config.yaml",
 				}
-				unexpectedCommands := []string{
-					"authorization-mode",
-					"authorization-webhook-config-file",
-				}
 				err = yaml.Unmarshal(kubeApiserver, &pod)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				Expect(pod.Spec.Containers[0].Command).To(ContainElements(expectedCommands))
-				Expect(pod.Spec.Containers[0].Command).ToNot(ContainElements(unexpectedCommands))
+				for _, command := range pod.Spec.Containers[0].Command {
+					Expect(command).ToNot(ContainSubstring("authorization-mode"))
+					Expect(command).ToNot(ContainSubstring("authorization-webhook-config-file"))
+				}
 
 			})
 		})

--- a/modules/040-control-plane-manager/template_tests/template_test.go
+++ b/modules/040-control-plane-manager/template_tests/template_test.go
@@ -919,6 +919,18 @@ apiserver:
 					Expect(command).ToNot(ContainSubstring("authorization-mode"))
 					Expect(command).ToNot(ContainSubstring("authorization-webhook-config-file"))
 				}
+				Expect(pod.Spec.SecurityContext).ToNot(BeNil())
+				Expect(pod.Spec.SecurityContext.SeccompProfile).ToNot(BeNil())
+				Expect(pod.Spec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+				Expect(pod.Spec.Containers[0].ReadinessProbe.FailureThreshold).To(BeEquivalentTo(3))
+				Expect(pod.Spec.Containers[0].ReadinessProbe.PeriodSeconds).To(BeEquivalentTo(1))
+				Expect(pod.Spec.Containers[0].ReadinessProbe.TimeoutSeconds).To(BeEquivalentTo(15))
+				Expect(pod.Spec.Containers[0].LivenessProbe.FailureThreshold).To(BeEquivalentTo(8))
+				Expect(pod.Spec.Containers[0].LivenessProbe.InitialDelaySeconds).To(BeEquivalentTo(10))
+				Expect(pod.Spec.Containers[0].LivenessProbe.TimeoutSeconds).To(BeEquivalentTo(15))
+				Expect(pod.Spec.Containers[0].StartupProbe.FailureThreshold).To(BeEquivalentTo(24))
+				Expect(pod.Spec.Containers[0].StartupProbe.InitialDelaySeconds).To(BeEquivalentTo(10))
+				Expect(pod.Spec.Containers[0].StartupProbe.TimeoutSeconds).To(BeEquivalentTo(15))
 
 			})
 		})


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix authorization-mode for webhookUrl mode and defaults
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fix authorization-mode for webhookUrl mode
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
