### PR TITLE
[istio] CNI-node readonly root filesystem enable fix

### DIFF
--- a/modules/110-istio/images/cni-v1x21x6/mount-points.yaml
+++ b/modules/110-istio/images/cni-v1x21x6/mount-points.yaml
@@ -1,7 +1,9 @@
 dirs:
 - /host/opt/cni/bin
 - /host/etc/cni/net.d
+- /tmp/istio-cni
 - /var/run/istio-cni
+- /run/istio-cni
 - /host/proc
 - /var/run/ztunnel
 - /host/var/run/netns

--- a/modules/110-istio/images/cni-v1x25x2/mount-points.yaml
+++ b/modules/110-istio/images/cni-v1x25x2/mount-points.yaml
@@ -2,6 +2,8 @@ dirs:
 - /host/opt/cni/bin
 - /host/etc/cni/net.d
 - /var/run/istio-cni
+- /run/istio-cni
+- /tmp/istio-cni
 - /host/proc
 - /var/run/ztunnel
 - /host/var/run/netns

--- a/modules/110-istio/templates/cni/configmap.yaml
+++ b/modules/110-istio/templates/cni/configmap.yaml
@@ -13,7 +13,10 @@ data:
       "name": "istio-cni",
       "type": "istio-cni",
       "log_level": "info",
-      "log_uds_address": "__LOG_UDS_ADDRESS__",
+      "log_uds_address": "/var/run/istio-cni/log.sock",
+      {{- if ($.Values.istio.internal.enableAmbientMode) }}
+      "cni_event_address": "/var/run/istio-cni/pluginevent.sock",
+      {{- end }}
       "kubernetes": {
         "kubeconfig": "__KUBECONFIG_FILEPATH__",
         "cni_bin_dir": "/opt/cni/bin",

--- a/modules/110-istio/templates/cni/daemonset.yaml
+++ b/modules/110-istio/templates/cni/daemonset.yaml
@@ -6,6 +6,8 @@ memory: 100Mi
 {{- if eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
 {{- $version := $.Values.istio.internal.globalVersion }}
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+{{- $fullVersion := get $versionInfo "fullVersion" }}
+{{- $cniLegacyTmpRunDir := semverCompare "< 1.25.0" $fullVersion }}
 {{- $imageSuffix := get $versionInfo "imageSuffix" }}
 {{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
 
@@ -72,6 +74,14 @@ spec:
         - name: install-cni
           args:
             - --log_output_level=default:info
+            {{- if $cniLegacyTmpRunDir }}
+            # Before Istio 1.25: hostPath mounted under /tmp for readOnlyRootFilesystem + containerd v2.
+            # CNI JSON on the node still lists /var/run/istio-cni/*.sock.
+            - --log-uds-address=/tmp/istio-cni/log.sock
+            {{- if ($.Values.istio.internal.enableAmbientMode) }}
+            - --cni-event-address=/tmp/istio-cni/pluginevent.sock
+            {{- end }}
+            {{- end }}
           command:
             - install-cni
           {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
@@ -154,8 +164,12 @@ spec:
               name: cni-bin-dir
             - mountPath: /host/etc/cni/net.d
               name: cni-net-dir
-            - mountPath: /var/run/istio-cni
+            - mountPath: {{ ternary "/tmp/istio-cni" "/var/run/istio-cni" $cniLegacyTmpRunDir }}
               name: cni-log-dir
+            {{- if $cniLegacyTmpRunDir }}
+            - mountPath: /run/istio-cni
+              name: cni-log-dir
+            {{- end }}
             - mountPath: /tmp
               name: install-cni-tmp
             {{- if and $supportsAmbient $.Values.istio.ambient.enabled }}


### PR DESCRIPTION
## Description
The Backport of this [PR](https://github.com/deckhouse/deckhouse/pull/19690)
Fix Istio CNI node agent startup when install-cni uses a read-only root filesystem together with containerd v2.

For Istio versions below 1.25, the host directory used for UDS sockets is now mounted under `/tmp` inside the container, and the installer is told to open log (and, in ambient mode, plugin event) sockets on those paths. The CNI configuration that the kubelet’s CNI plugin reads on the node still points at `/var/run/istio-cni/...` on the host, which is the same directory because it is bind-mounted from the host.

For Istio 1.25 and newer, behavior is unchanged: those releases use a single “agent run dir” value for both the process in the pod and the plugin configuration; splitting container vs host paths there is not supported without upstream changes.

  Original failure seen before the fix:
```
  Warning  Failed  kubelet  Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting
  "/var/run/istio-cni" to rootfs at "/var/run/istio-cni": create mountpoint for /var/run/istio-cni mount: make mountpoint "/var/run/istio-cni": mkdirat
  /run/containerd/io.containerd.runtime.v2.task/k8s.io/install-cni/rootfs/run/istio-cni: read-only file system
```
`istio-cni-node` pods will restart on nodes when this ships.

## Why do we need it, and what problem does it solve?

On some setups with `containerdv2` and `readOnlyRootFilesystem: true`, `install-cni` cannot start: the runtime must mkdir the mount target under `/var/run` → `/run` in the read-only rootfs. That blocks Istio CNI on the node and breaks
CNI chaining and mesh networking (sidecar and/or ambient, depending on configuration).

## Why do we need it in the patch release (if we do)?

Fixes a blocking regression on Deckhouse + containerd v2 + Istio 1.21.x; 1.25+ behavior under the current model is unchanged.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: CNI-node readonly root filesystem enable fix
impact: When using containerdV2, the performance of istio-cni breaks when mounting internal paths.
impact_level: high
```
