### PR TITLE
[docs] Fix typo in image reference path

### DIFF
--- a/docs/documentation/pages/user/web/CONSOLE.md
+++ b/docs/documentation/pages/user/web/CONSOLE.md
@@ -301,7 +301,7 @@ You can also configure resource limits and quotas.
 
 ![Limits](../../images/console/projects-user-namespaces-commander-project-1-limitranges-core.png)
 
-![Quotas](../../images/console/projects-user-namespaces-commander-project-1-resourcequotas-core-all-podse.png)
+![Quotas](../../images/console/projects-user-namespaces-commander-project-1-resourcequotas-core-all-pods.png)
 
 ![Quotas](../../images/console/projects-user-namespaces-commander-project-1-resourcequotas-core-new-2.png)
 

--- a/docs/documentation/pages/user/web/CONSOLE_RU.md
+++ b/docs/documentation/pages/user/web/CONSOLE_RU.md
@@ -277,7 +277,7 @@ lang: ru
 
 ![Лимиты](../../images/console/projects-user-namespaces-commander-project-1-limitranges-core.png)
 
-![Квоты](../../images/console/projects-user-namespaces-commander-project-1-resourcequotas-core-all-podse.png)
+![Квоты](../../images/console/projects-user-namespaces-commander-project-1-resourcequotas-core-all-pods.png)
 
 ![Квоты](../../images/console/projects-user-namespaces-commander-project-1-resourcequotas-core-new-2.png)
 


### PR DESCRIPTION
## Description

Correct misspelled image link for resource quotas screenshot across English and Russian console documentation pages

Fix: https://github.com/deckhouse/deckhouse/pull/19735

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Fix typo in image reference path.
impact_level: low
```
