### PR TITLE
[deckhouse] packages cleanup orphan nelm releases

### DIFF
--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -41,9 +41,7 @@ const (
 	// logger and telemetry name
 	nelmTracer = "nelm"
 
-	// ReleaseLabelPackageChecksum is stamped on the release storage secret to
-	// store the rendered-manifests checksum (used by shouldRunHelmUpgrade to
-	// skip no-op upgrades).
+	// ReleaseLabelPackageChecksum stores the rendered-manifests checksum on the release storage secret.
 	ReleaseLabelPackageChecksum = "packageChecksum"
 )
 
@@ -63,12 +61,11 @@ type Options struct {
 	// Timeout for Helm operations
 	Timeout time.Duration
 
-	// ResourceLabels are stamped on every Kubernetes resource rendered by the chart.
+	// ResourceLabels are stamped on every chart-rendered resource.
 	ResourceLabels map[string]string
-	// ResourceAnnotations are stamped on every Kubernetes resource rendered by the chart.
+	// ResourceAnnotations are stamped on every chart-rendered resource.
 	ResourceAnnotations map[string]string
-	// ReleaseInfoAnnotations are stamped on the Release.Info — visible to
-	// action.ReleaseList and used as ownership markers by orphan cleanup.
+	// ReleaseInfoAnnotations are stamped on Release.Info (visible via action.ReleaseList).
 	ReleaseInfoAnnotations map[string]string
 }
 
@@ -89,25 +86,21 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithResourceLabels sets labels stamped on every Kubernetes resource
-// rendered by the chart.
+// WithResourceLabels sets labels stamped on every chart-rendered resource.
 func WithResourceLabels(labels map[string]string) Option {
 	return func(o *Options) {
 		maps.Copy(o.ResourceLabels, labels)
 	}
 }
 
-// WithResourceAnnotations sets annotations stamped on every Kubernetes
-// resource rendered by the chart.
+// WithResourceAnnotations sets annotations stamped on every chart-rendered resource.
 func WithResourceAnnotations(annotations map[string]string) Option {
 	return func(o *Options) {
 		maps.Copy(o.ResourceAnnotations, annotations)
 	}
 }
 
-// WithReleaseInfoAnnotations sets annotations stamped on the Release.Info.
-// Use it for ownership markers that the orphan-release cleanup pass relies
-// on to find releases managed by this client (visible via action.ReleaseList).
+// WithReleaseInfoAnnotations sets annotations stamped on Release.Info.
 func WithReleaseInfoAnnotations(annotations map[string]string) Option {
 	return func(o *Options) {
 		maps.Copy(o.ReleaseInfoAnnotations, annotations)
@@ -164,17 +157,13 @@ type ReleaseRef struct {
 
 // ListOptions contains options for listing Helm releases.
 type ListOptions struct {
-	// Selector filters releases by Release.Info annotations: a release is
-	// included only if every key/value pair in Selector matches its
-	// annotations. Empty selector returns every release.
+	// Selector filters releases by Release.Info annotations; all key/value
+	// pairs must match. Empty selector matches every release.
 	Selector map[string]string
 }
 
-// ListReleases returns nelm releases cluster-wide whose Release.Info matches
-// the given selector.
-//
-// Filter is applied client-side: action.ReleaseList has no server-side
-// selector and returns every helm release in the cluster.
+// ListReleases returns nelm releases cluster-wide matching opts.Selector.
+// The filter is applied client-side — action.ReleaseList has no server-side selector.
 func (c *Client) ListReleases(ctx context.Context, opts ListOptions) ([]ReleaseRef, error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "ListReleases")
 	defer span.End()

--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -61,12 +61,13 @@ type Options struct {
 	// Timeout for Helm operations
 	Timeout time.Duration
 
-	// ResourceLabels are stamped on every chart-rendered resource.
-	ResourceLabels map[string]string
+	// ResourcesLabels are stamped on every chart-rendered resource.
+	ResourcesLabels map[string]string
 	// ResourceAnnotations are stamped on every chart-rendered resource.
-	ResourceAnnotations map[string]string
-	// ReleaseInfoAnnotations are stamped on Release.Info (visible via action.ReleaseList).
-	ReleaseInfoAnnotations map[string]string
+	ResourcesAnnotations map[string]string
+
+	// ReleaseAnnotations are stamped on Release.Info (visible via action.ReleaseList).
+	ReleaseAnnotations map[string]string
 }
 
 // Option is a functional option for configuring the nelm client
@@ -86,24 +87,24 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithResourceLabels sets labels stamped on every chart-rendered resource.
-func WithResourceLabels(labels map[string]string) Option {
+// WithResourcesLabels sets labels stamped on every chart-rendered resource.
+func WithResourcesLabels(labels map[string]string) Option {
 	return func(o *Options) {
-		maps.Copy(o.ResourceLabels, labels)
+		maps.Copy(o.ResourcesLabels, labels)
 	}
 }
 
-// WithResourceAnnotations sets annotations stamped on every chart-rendered resource.
-func WithResourceAnnotations(annotations map[string]string) Option {
+// WithResourcesAnnotations sets annotations stamped on every chart-rendered resource.
+func WithResourcesAnnotations(annotations map[string]string) Option {
 	return func(o *Options) {
-		maps.Copy(o.ResourceAnnotations, annotations)
+		maps.Copy(o.ResourcesAnnotations, annotations)
 	}
 }
 
-// WithReleaseInfoAnnotations sets annotations stamped on Release.Info.
-func WithReleaseInfoAnnotations(annotations map[string]string) Option {
+// WithReleaseAnnotations sets annotations stamped on Release.Info.
+func WithReleaseAnnotations(annotations map[string]string) Option {
 	return func(o *Options) {
-		maps.Copy(o.ReleaseInfoAnnotations, annotations)
+		maps.Copy(o.ReleaseAnnotations, annotations)
 	}
 }
 
@@ -127,11 +128,11 @@ func New(logger *log.Logger, opts ...Option) *Client {
 
 	// Set default options with history limit of 10 revisions
 	defaultOpts := &Options{
-		HistoryMax:             10,
-		ResourceAnnotations:    make(map[string]string),
-		ResourceLabels:         make(map[string]string),
-		ReleaseInfoAnnotations: make(map[string]string),
-		Timeout:                2 * time.Minute,
+		HistoryMax:           10,
+		ResourcesAnnotations: make(map[string]string),
+		ResourcesLabels:      make(map[string]string),
+		ReleaseAnnotations:   make(map[string]string),
+		Timeout:              3 * time.Minute,
 	}
 
 	// Apply any provided options
@@ -276,11 +277,8 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 		valuesSet = append(valuesSet, opts.RootValues)
 	}
 
-	labels := maps.Clone(c.opts.ResourceLabels)
+	labels := maps.Clone(c.opts.ResourcesLabels)
 	if len(opts.ResourcesLabels) > 0 {
-		if labels == nil {
-			labels = make(map[string]string, len(opts.ResourcesLabels))
-		}
 		maps.Copy(labels, opts.ResourcesLabels)
 	}
 
@@ -317,11 +315,11 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 		DefaultChartAPIVersion: "v2",
 		ReleaseInstallRuntimeOptions: common.ReleaseInstallRuntimeOptions{
 			ExtraLabels:             labels,
-			ExtraAnnotations:        c.opts.ResourceAnnotations,
+			ExtraAnnotations:        c.opts.ResourcesAnnotations,
 			NoInstallStandaloneCRDs: true,
 			ReleaseHistoryLimit:     int(c.opts.HistoryMax),
 			ReleaseLabels:           opts.ReleaseLabels,
-			ReleaseInfoAnnotations:  c.opts.ReleaseInfoAnnotations,
+			ReleaseInfoAnnotations:  c.opts.ReleaseAnnotations,
 			ReleaseStorageDriver:    c.driver,
 			ForceAdoption:           true,
 		},
@@ -350,11 +348,8 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 		valuesSet = append(valuesSet, opts.RootValues)
 	}
 
-	labels := maps.Clone(c.opts.ResourceLabels)
+	labels := maps.Clone(c.opts.ResourcesLabels)
 	if len(opts.ResourcesLabels) > 0 {
-		if labels == nil {
-			labels = make(map[string]string, len(opts.ResourcesLabels))
-		}
 		maps.Copy(labels, opts.ResourcesLabels)
 	}
 
@@ -372,7 +367,7 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 		DefaultChartVersion:    "0.2.0",
 		DefaultChartAPIVersion: "v2",
 		ExtraLabels:            labels,
-		ExtraAnnotations:       c.opts.ResourceAnnotations,
+		ExtraAnnotations:       c.opts.ResourcesAnnotations,
 		ReleaseName:            releaseName,
 		ReleaseNamespace:       namespace,
 		ReleaseStorageDriver:   c.driver,

--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -41,8 +41,10 @@ const (
 	// logger and telemetry name
 	nelmTracer = "nelm"
 
-	// LabelPackageChecksum release label for storing checksum
-	LabelPackageChecksum = "packageChecksum"
+	// ReleaseLabelPackageChecksum is stamped on the release storage secret to
+	// store the rendered-manifests checksum (used by shouldRunHelmUpgrade to
+	// skip no-op upgrades).
+	ReleaseLabelPackageChecksum = "packageChecksum"
 )
 
 var (
@@ -61,10 +63,13 @@ type Options struct {
 	// Timeout for Helm operations
 	Timeout time.Duration
 
-	// Labels to apply to Kubernetes resources
-	Labels map[string]string
-	// Annotations to apply to Kubernetes resources
-	Annotations map[string]string
+	// ResourceLabels are stamped on every Kubernetes resource rendered by the chart.
+	ResourceLabels map[string]string
+	// ResourceAnnotations are stamped on every Kubernetes resource rendered by the chart.
+	ResourceAnnotations map[string]string
+	// ReleaseInfoAnnotations are stamped on the Release.Info — visible to
+	// action.ReleaseList and used as ownership markers by orphan cleanup.
+	ReleaseInfoAnnotations map[string]string
 }
 
 // Option is a functional option for configuring the nelm client
@@ -84,17 +89,28 @@ func WithTimeout(timeout time.Duration) Option {
 	}
 }
 
-// WithLabels sets labels to be applied to all releases
-func WithLabels(labels map[string]string) Option {
+// WithResourceLabels sets labels stamped on every Kubernetes resource
+// rendered by the chart.
+func WithResourceLabels(labels map[string]string) Option {
 	return func(o *Options) {
-		maps.Copy(o.Labels, labels)
+		maps.Copy(o.ResourceLabels, labels)
 	}
 }
 
-// WithAnnotations sets annotations to be applied to all releases
-func WithAnnotations(annotations map[string]string) Option {
+// WithResourceAnnotations sets annotations stamped on every Kubernetes
+// resource rendered by the chart.
+func WithResourceAnnotations(annotations map[string]string) Option {
 	return func(o *Options) {
-		maps.Copy(o.Annotations, annotations)
+		maps.Copy(o.ResourceAnnotations, annotations)
+	}
+}
+
+// WithReleaseInfoAnnotations sets annotations stamped on the Release.Info.
+// Use it for ownership markers that the orphan-release cleanup pass relies
+// on to find releases managed by this client (visible via action.ReleaseList).
+func WithReleaseInfoAnnotations(annotations map[string]string) Option {
+	return func(o *Options) {
+		maps.Copy(o.ReleaseInfoAnnotations, annotations)
 	}
 }
 
@@ -108,8 +124,8 @@ type Client struct {
 	logger *log.Logger
 }
 
-// New creates a new nelm client for the specified namespace
-// It initializes the nelm logger and applies any provided options
+// New creates a new nelm client.
+// It initializes the nelm logger and applies any provided options.
 func New(logger *log.Logger, opts ...Option) *Client {
 	// Set the default nelm logger to our custom adapter
 	one.Do(func() {
@@ -118,10 +134,11 @@ func New(logger *log.Logger, opts ...Option) *Client {
 
 	// Set default options with history limit of 10 revisions
 	defaultOpts := &Options{
-		HistoryMax:  10,
-		Annotations: make(map[string]string),
-		Labels:      make(map[string]string),
-		Timeout:     2 * time.Minute,
+		HistoryMax:             10,
+		ResourceAnnotations:    make(map[string]string),
+		ResourceLabels:         make(map[string]string),
+		ReleaseInfoAnnotations: make(map[string]string),
+		Timeout:                2 * time.Minute,
 	}
 
 	// Apply any provided options
@@ -176,7 +193,7 @@ func (c *Client) GetChecksum(ctx context.Context, namespace, releaseName string)
 
 	// Try to get checksum from storage labels first
 	if res.Release != nil {
-		if checksum, ok := res.Release.StorageLabels[LabelPackageChecksum]; ok {
+		if checksum, ok := res.Release.StorageLabels[ReleaseLabelPackageChecksum]; ok {
 			return checksum, nil
 		}
 	}
@@ -214,7 +231,7 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 		valuesSet = append(valuesSet, opts.RootValues)
 	}
 
-	labels := maps.Clone(c.opts.Labels)
+	labels := maps.Clone(c.opts.ResourceLabels)
 	if len(opts.ResourcesLabels) > 0 {
 		if labels == nil {
 			labels = make(map[string]string, len(opts.ResourcesLabels))
@@ -255,10 +272,11 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 		DefaultChartAPIVersion: "v2",
 		ReleaseInstallRuntimeOptions: common.ReleaseInstallRuntimeOptions{
 			ExtraLabels:             labels,
-			ExtraAnnotations:        c.opts.Annotations,
+			ExtraAnnotations:        c.opts.ResourceAnnotations,
 			NoInstallStandaloneCRDs: true,
 			ReleaseHistoryLimit:     int(c.opts.HistoryMax),
 			ReleaseLabels:           opts.ReleaseLabels,
+			ReleaseInfoAnnotations:  c.opts.ReleaseInfoAnnotations,
 			ReleaseStorageDriver:    c.driver,
 			ForceAdoption:           true,
 		},
@@ -287,7 +305,7 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 		valuesSet = append(valuesSet, opts.RootValues)
 	}
 
-	labels := maps.Clone(c.opts.Labels)
+	labels := maps.Clone(c.opts.ResourceLabels)
 	if len(opts.ResourcesLabels) > 0 {
 		if labels == nil {
 			labels = make(map[string]string, len(opts.ResourcesLabels))
@@ -309,7 +327,7 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 		DefaultChartVersion:    "0.2.0",
 		DefaultChartAPIVersion: "v2",
 		ExtraLabels:            labels,
-		ExtraAnnotations:       c.opts.Annotations,
+		ExtraAnnotations:       c.opts.ResourceAnnotations,
 		ReleaseName:            releaseName,
 		ReleaseNamespace:       namespace,
 		ReleaseStorageDriver:   c.driver,

--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -156,6 +156,44 @@ func New(logger *log.Logger, opts ...Option) *Client {
 	}
 }
 
+// ReleaseRef identifies a nelm release (a logical install, not a specific revision).
+type ReleaseRef struct {
+	Namespace string
+	Name      string
+}
+
+// ListReleases returns nelm releases cluster-wide whose Release.Info carries
+// an annotation key=value matching the given marker.
+//
+// Client-side filter: action.ReleaseList has no server-side selector and
+// returns every helm release in the cluster.
+func (c *Client) ListReleases(ctx context.Context, annotationKey, annotationValue string) ([]ReleaseRef, error) {
+	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "ListReleases")
+	defer span.End()
+
+	result, err := action.ReleaseList(ctx, action.ReleaseListOptions{
+		KubeConnectionOptions: common.KubeConnectionOptions{
+			KubeContextCurrent: c.kubeContext,
+		},
+		ReleaseStorageDriver: c.driver,
+		OutputNoPrint:        true,
+		ReleaseNamespace:     "", // cluster-wide
+	})
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return nil, fmt.Errorf("list nelm releases: %w", err)
+	}
+
+	refs := make([]ReleaseRef, 0, len(result.Releases))
+	for _, r := range result.Releases {
+		if r.Annotations[annotationKey] != annotationValue {
+			continue
+		}
+		refs = append(refs, ReleaseRef{Namespace: r.Namespace, Name: r.Name})
+	}
+	return refs, nil
+}
+
 // LastStatus returns the revision number and status of the latest release
 // Returns ("0", "", nil) if the release doesn't exist
 func (c *Client) LastStatus(ctx context.Context, namespace, releaseName string) (string, string, error) {

--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -162,12 +162,20 @@ type ReleaseRef struct {
 	Name      string
 }
 
-// ListReleases returns nelm releases cluster-wide whose Release.Info carries
-// an annotation key=value matching the given marker.
+// ListOptions contains options for listing Helm releases.
+type ListOptions struct {
+	// Selector filters releases by Release.Info annotations: a release is
+	// included only if every key/value pair in Selector matches its
+	// annotations. Empty selector returns every release.
+	Selector map[string]string
+}
+
+// ListReleases returns nelm releases cluster-wide whose Release.Info matches
+// the given selector.
 //
-// Client-side filter: action.ReleaseList has no server-side selector and
-// returns every helm release in the cluster.
-func (c *Client) ListReleases(ctx context.Context, annotationKey, annotationValue string) ([]ReleaseRef, error) {
+// Filter is applied client-side: action.ReleaseList has no server-side
+// selector and returns every helm release in the cluster.
+func (c *Client) ListReleases(ctx context.Context, opts ListOptions) ([]ReleaseRef, error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "ListReleases")
 	defer span.End()
 
@@ -186,12 +194,22 @@ func (c *Client) ListReleases(ctx context.Context, annotationKey, annotationValu
 
 	refs := make([]ReleaseRef, 0, len(result.Releases))
 	for _, r := range result.Releases {
-		if r.Annotations[annotationKey] != annotationValue {
+		if !matchAll(r.Annotations, opts.Selector) {
 			continue
 		}
 		refs = append(refs, ReleaseRef{Namespace: r.Namespace, Name: r.Name})
 	}
 	return refs, nil
+}
+
+// matchAll reports whether all key/value pairs from selector are present in target.
+func matchAll(target, selector map[string]string) bool {
+	for k, v := range selector {
+		if target[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // LastStatus returns the revision number and status of the latest release

--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -63,7 +63,7 @@ type Options struct {
 
 	// ResourcesLabels are stamped on every chart-rendered resource.
 	ResourcesLabels map[string]string
-	// ResourceAnnotations are stamped on every chart-rendered resource.
+	// ResourcesAnnotations are stamped on every chart-rendered resource.
 	ResourcesAnnotations map[string]string
 
 	// ReleaseAnnotations are stamped on Release.Info (visible via action.ReleaseList).

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -43,9 +43,7 @@ const (
 	chartFile    = "Chart.yaml" // Helm chart metadata file
 	templatesDir = "templates"  // Helm templates directory
 
-	// managedByAnnotation marks a release as owned by this service. Stamped on
-	// Release.Info so it is visible to action.ReleaseList; used by orphan
-	// cleanup as the ownership marker.
+	// managedByAnnotation marks a release as owned by this service.
 	managedByAnnotation      = "packages.deckhouse.io/managed-by"
 	managedByAnnotationValue = "deckhouse"
 )
@@ -299,12 +297,8 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 	return nil
 }
 
-// Cleanup uninstalls nelm releases owned by this service (carrying the
-// managed-by annotation in Release.Info) whose name is not in keep.
-//
-// keep keys are of the form "<namespace>/<release-name>" — the caller decides
-// which releases must remain. Releases without the managed-by annotation are
-// skipped: they are not ours.
+// Cleanup uninstalls releases owned by this service (carrying the managed-by
+// annotation) whose name is not in keep. keep keys are "<namespace>/<release-name>".
 func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}) {
 	releases, err := s.client.ListReleases(ctx, nelm.ListOptions{
 		Selector: map[string]string{managedByAnnotation: managedByAnnotationValue},

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -25,6 +25,7 @@ import (
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/google/uuid"
+	"github.com/werf/nelm/pkg/action"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -42,6 +43,12 @@ const (
 
 	chartFile    = "Chart.yaml" // Helm chart metadata file
 	templatesDir = "templates"  // Helm templates directory
+
+	// managedByAnnotation marks a release as owned by this service. Stamped on
+	// Release.Info so it is visible to action.ReleaseList; used by orphan
+	// cleanup as the ownership marker.
+	managedByAnnotation      = "packages.deckhouse.io/managed-by"
+	managedByAnnotationValue = "deckhouse"
 )
 
 const (
@@ -77,9 +84,14 @@ type Service struct {
 
 // NewService creates a new nelm service for managing Helm releases.
 func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status *status.Service, logger *log.Logger) *Service {
-	nelmClient := nelm.New(logger, nelm.WithLabels(map[string]string{
-		"heritage": "deckhouse",
-	}))
+	nelmClient := nelm.New(logger,
+		nelm.WithResourceLabels(map[string]string{
+			"heritage": "deckhouse",
+		}),
+		nelm.WithReleaseInfoAnnotations(map[string]string{
+			managedByAnnotation: managedByAnnotationValue,
+		}),
+	)
 
 	return &Service{
 		tmpDir:         os.TempDir(),
@@ -272,7 +284,7 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 		ValuesPaths:     []string{valuesPath},
 		RootValues:      pkg.GetRuntimeValues(),
 		ReleaseLabels: map[string]string{
-			nelm.LabelPackageChecksum: checksum,
+			nelm.ReleaseLabelPackageChecksum: checksum,
 		},
 		ResourcesLabels: map[string]string{
 			health.LabelKey: pkg.GetName(),
@@ -286,6 +298,52 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 	s.monitorManager.AddMonitor(namespace, pkg.GetName(), renderedManifests)
 
 	return nil
+}
+
+// CleanupOrphans uninstalls nelm releases owned by this service (carrying the
+// managed-by annotation in Release.Info) whose name is not in keep.
+//
+// keep keys are of the form "<namespace>/<release-name>" — the caller decides
+// which releases must remain. Releases without the managed-by annotation are
+// skipped: they are not ours.
+func (s *Service) CleanupOrphans(ctx context.Context, keep map[string]struct{}) {
+	result, err := action.ReleaseList(ctx, action.ReleaseListOptions{
+		OutputNoPrint:    true,
+		ReleaseNamespace: "", // cluster-wide
+	})
+	if err != nil {
+		s.logger.Warn("failed to list releases", log.Err(err))
+		return
+	}
+
+	var deleted, failed int
+	for _, r := range result.Releases {
+		if r.Annotations[managedByAnnotation] != managedByAnnotationValue {
+			continue
+		}
+		if _, alive := keep[r.Namespace+"/"+r.Name]; alive {
+			continue
+		}
+
+		if err := s.client.Delete(ctx, r.Namespace, r.Name); err != nil {
+			s.logger.Warn("failed to delete orphan release",
+				slog.String("namespace", r.Namespace),
+				slog.String("release", r.Name),
+				log.Err(err))
+			failed++
+			continue
+		}
+		s.logger.Info("deleted orphan release",
+			slog.String("namespace", r.Namespace),
+			slog.String("release", r.Name))
+		deleted++
+	}
+
+	if deleted > 0 || failed > 0 {
+		s.logger.Info("orphan release cleanup complete",
+			slog.Int("deleted", deleted),
+			slog.Int("failed", failed))
+	}
 }
 
 // shouldRunHelmUpgrade determines if a Helm upgrade is needed.

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
@@ -82,10 +83,10 @@ type Service struct {
 // NewService creates a new nelm service for managing Helm releases.
 func NewService(cache runtimecache.Cache, callback drift.AbsentCallback, status *status.Service, logger *log.Logger) *Service {
 	nelmClient := nelm.New(logger,
-		nelm.WithResourceLabels(map[string]string{
+		nelm.WithResourcesLabels(map[string]string{
 			"heritage": "deckhouse",
 		}),
-		nelm.WithReleaseInfoAnnotations(map[string]string{
+		nelm.WithReleaseAnnotations(map[string]string{
 			managedByAnnotation: managedByAnnotationValue,
 		}),
 	)
@@ -299,7 +300,7 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 
 // Cleanup uninstalls releases owned by this service (carrying the managed-by
 // annotation) whose name is not in keep. keep keys are "<namespace>/<release-name>".
-func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}) {
+func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}, ignoreNamespaces ...string) {
 	releases, err := s.client.ListReleases(ctx, nelm.ListOptions{
 		Selector: map[string]string{managedByAnnotation: managedByAnnotationValue},
 	})
@@ -312,7 +313,12 @@ func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}) {
 		if _, alive := keep[r.Namespace+"/"+r.Name]; alive {
 			continue
 		}
-		if err := s.client.Delete(ctx, r.Namespace, r.Name); err != nil {
+
+		if slices.Contains(ignoreNamespaces, r.Namespace) {
+			continue
+		}
+
+		if err = s.client.Delete(ctx, r.Namespace, r.Name); err != nil {
 			s.logger.Warn("failed to delete orphan release",
 				slog.String("namespace", r.Namespace),
 				slog.String("release", r.Name),

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -299,14 +299,16 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 	return nil
 }
 
-// CleanupOrphans uninstalls nelm releases owned by this service (carrying the
+// Cleanup uninstalls nelm releases owned by this service (carrying the
 // managed-by annotation in Release.Info) whose name is not in keep.
 //
 // keep keys are of the form "<namespace>/<release-name>" — the caller decides
 // which releases must remain. Releases without the managed-by annotation are
 // skipped: they are not ours.
-func (s *Service) CleanupOrphans(ctx context.Context, keep map[string]struct{}) {
-	releases, err := s.client.ListReleases(ctx, managedByAnnotation, managedByAnnotationValue)
+func (s *Service) Cleanup(ctx context.Context, keep map[string]struct{}) {
+	releases, err := s.client.ListReleases(ctx, nelm.ListOptions{
+		Selector: map[string]string{managedByAnnotation: managedByAnnotationValue},
+	})
 	if err != nil {
 		s.logger.Warn("failed to list releases", log.Err(err))
 		return

--- a/deckhouse-controller/internal/packages/nelm/service.go
+++ b/deckhouse-controller/internal/packages/nelm/service.go
@@ -25,7 +25,6 @@ import (
 
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"github.com/google/uuid"
-	"github.com/werf/nelm/pkg/action"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -307,42 +306,22 @@ func (s *Service) Upgrade(ctx context.Context, namespace string, pkg Package) er
 // which releases must remain. Releases without the managed-by annotation are
 // skipped: they are not ours.
 func (s *Service) CleanupOrphans(ctx context.Context, keep map[string]struct{}) {
-	result, err := action.ReleaseList(ctx, action.ReleaseListOptions{
-		OutputNoPrint:    true,
-		ReleaseNamespace: "", // cluster-wide
-	})
+	releases, err := s.client.ListReleases(ctx, managedByAnnotation, managedByAnnotationValue)
 	if err != nil {
 		s.logger.Warn("failed to list releases", log.Err(err))
 		return
 	}
 
-	var deleted, failed int
-	for _, r := range result.Releases {
-		if r.Annotations[managedByAnnotation] != managedByAnnotationValue {
-			continue
-		}
+	for _, r := range releases {
 		if _, alive := keep[r.Namespace+"/"+r.Name]; alive {
 			continue
 		}
-
 		if err := s.client.Delete(ctx, r.Namespace, r.Name); err != nil {
 			s.logger.Warn("failed to delete orphan release",
 				slog.String("namespace", r.Namespace),
 				slog.String("release", r.Name),
 				log.Err(err))
-			failed++
-			continue
 		}
-		s.logger.Info("deleted orphan release",
-			slog.String("namespace", r.Namespace),
-			slog.String("release", r.Name))
-		deleted++
-	}
-
-	if deleted > 0 || failed > 0 {
-		s.logger.Info("orphan release cleanup complete",
-			slog.Int("deleted", deleted),
-			slog.Int("failed", failed))
 	}
 }
 

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -643,34 +643,45 @@ func (r *Runtime) Stop() {
 	r.scheduler.Stop()
 }
 
-// PreservePackage identifies one downloaded package version to preserve during cleanup.
+// PreservePackage identifies one downloaded package version + its owning
+// Application instance to preserve during Cleanup.
+//
+// Name/Repository/Version address the package artifact on disk; Namespace and
+// Instance identify the Application CR that owns its installed nelm release.
 type PreservePackage struct {
-	// Name is the downloaded package directory name.
-	Name string
-	// Version is the downloaded package version name.
-	Version string
-	// Repository is the downloaded repository directory name.
+	Name       string
 	Repository string
+	Version    string
+	Namespace  string
+	Instance   string
 }
 
-// Cleanup removes deployed packages that are not listed in preserve from both app and module deployers.
+// Cleanup garbage-collects state left over from previous controller runs.
+// Called once during preflight, before the reconcile loop starts:
+//   - removes downloaded package versions on disk not listed in preserve;
+//   - removes orphan nelm release secrets cluster-wide whose owning Application
+//     is not listed in preserve (delegated to the nelm service).
 func (r *Runtime) Cleanup(ctx context.Context, preserve []PreservePackage) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	converted := make([]deployer.PreservePackage, 0, len(preserve))
-	for _, packageVersion := range preserve {
-		converted = append(converted, deployer.PreservePackage{
-			Name:       packageVersion.Name,
-			Repository: packageVersion.Repository,
-			Version:    packageVersion.Version,
+	fsPreserve := make([]deployer.PreservePackage, 0, len(preserve))
+	keepReleases := make(map[string]struct{}, len(preserve))
+	for _, p := range preserve {
+		fsPreserve = append(fsPreserve, deployer.PreservePackage{
+			Name:       p.Name,
+			Repository: p.Repository,
+			Version:    p.Version,
 		})
+		keepReleases[p.Namespace+"/"+apps.BuildName(p.Namespace, p.Instance)] = struct{}{}
 	}
 
-	if err := r.appDeployer.Cleanup(ctx, converted); err != nil {
+	if err := r.appDeployer.Cleanup(ctx, fsPreserve); err != nil {
 		r.logger.Warn("cleanup apps failed", log.Err(err))
 		return
 	}
+
+	r.nelmService.CleanupOrphans(ctx, keepReleases)
 }
 
 // Status returns package status service for external access

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -643,8 +643,8 @@ func (r *Runtime) Stop() {
 	r.scheduler.Stop()
 }
 
-// Preserve identifies one installed Package instance to preserve during Cleanup.
-type Preserve struct {
+// PreservePackage identifies one installed Package instance to preserve during Cleanup.
+type PreservePackage struct {
 	PackageName string
 	Repository  string
 	Version     string
@@ -655,7 +655,7 @@ type Preserve struct {
 
 // Cleanup removes downloaded application packages on disk and orphan nelm
 // releases in the cluster that are not in preserve. Runs once during preflight.
-func (r *Runtime) Cleanup(ctx context.Context, preserves []Preserve) {
+func (r *Runtime) Cleanup(ctx context.Context, preserves []PreservePackage) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -643,12 +643,12 @@ func (r *Runtime) Stop() {
 	r.scheduler.Stop()
 }
 
-// PreservePackage identifies one downloaded package version + its owning
+// PreserveApp identifies one downloaded package version + its owning
 // Application instance to preserve during Cleanup.
 //
 // Name/Repository/Version address the package artifact on disk; Namespace and
 // Instance identify the Application CR that owns its installed nelm release.
-type PreservePackage struct {
+type PreserveApp struct {
 	Name       string
 	Repository string
 	Version    string
@@ -656,12 +656,15 @@ type PreservePackage struct {
 	Instance   string
 }
 
-// Cleanup garbage-collects state left over from previous controller runs.
-// Called once during preflight, before the reconcile loop starts:
-//   - removes downloaded package versions on disk not listed in preserve;
+// CleanupApps garbage-collects state left over from previous controller runs
+// for Application instances. Called once during preflight, before the reconcile
+// loop starts:
+//   - removes downloaded application package versions on disk not in preserve;
 //   - removes orphan nelm release secrets cluster-wide whose owning Application
-//     is not listed in preserve (delegated to the nelm service).
-func (r *Runtime) Cleanup(ctx context.Context, preserve []PreservePackage) {
+//     is not in preserve (delegated to the nelm service).
+//
+// Module cleanup is a separate concern — modules have no per-instance identity.
+func (r *Runtime) CleanupApps(ctx context.Context, preserve []PreserveApp) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -681,7 +684,7 @@ func (r *Runtime) Cleanup(ctx context.Context, preserve []PreservePackage) {
 		return
 	}
 
-	r.nelmService.CleanupOrphans(ctx, keepReleases)
+	r.nelmService.Cleanup(ctx, keepReleases)
 }
 
 // Status returns package status service for external access

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -643,11 +643,9 @@ func (r *Runtime) Stop() {
 	r.scheduler.Stop()
 }
 
-// PreserveApp identifies one downloaded package version + its owning
-// Application instance to preserve during Cleanup.
-//
-// Name/Repository/Version address the package artifact on disk; Namespace and
-// Instance identify the Application CR that owns its installed nelm release.
+// PreserveApp identifies one installed Application instance to preserve during
+// CleanupApps. Name/Repository/Version address the package on disk; Namespace
+// and Instance identify the owning Application CR.
 type PreserveApp struct {
 	Name       string
 	Repository string
@@ -656,14 +654,8 @@ type PreserveApp struct {
 	Instance   string
 }
 
-// CleanupApps garbage-collects state left over from previous controller runs
-// for Application instances. Called once during preflight, before the reconcile
-// loop starts:
-//   - removes downloaded application package versions on disk not in preserve;
-//   - removes orphan nelm release secrets cluster-wide whose owning Application
-//     is not in preserve (delegated to the nelm service).
-//
-// Module cleanup is a separate concern — modules have no per-instance identity.
+// CleanupApps removes downloaded application packages on disk and orphan nelm
+// releases in the cluster that are not in preserve. Runs once during preflight.
 func (r *Runtime) CleanupApps(ctx context.Context, preserve []PreserveApp) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -643,32 +643,32 @@ func (r *Runtime) Stop() {
 	r.scheduler.Stop()
 }
 
-// PreserveApp identifies one installed Application instance to preserve during
-// CleanupApps. Name/Repository/Version address the package on disk; Namespace
-// and Instance identify the owning Application CR.
-type PreserveApp struct {
-	Name       string
-	Repository string
-	Version    string
-	Namespace  string
-	Instance   string
+// Preserve identifies one installed Package instance to preserve during Cleanup.
+type Preserve struct {
+	PackageName string
+	Repository  string
+	Version     string
+
+	ReleaseName      string
+	ReleaseNamespace string
 }
 
-// CleanupApps removes downloaded application packages on disk and orphan nelm
+// Cleanup removes downloaded application packages on disk and orphan nelm
 // releases in the cluster that are not in preserve. Runs once during preflight.
-func (r *Runtime) CleanupApps(ctx context.Context, preserve []PreserveApp) {
+func (r *Runtime) Cleanup(ctx context.Context, preserves []Preserve) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	fsPreserve := make([]deployer.PreservePackage, 0, len(preserve))
-	keepReleases := make(map[string]struct{}, len(preserve))
-	for _, p := range preserve {
+	fsPreserve := make([]deployer.PreservePackage, 0, len(preserves))
+	keepReleases := make(map[string]struct{}, len(preserves))
+	for _, preserve := range preserves {
 		fsPreserve = append(fsPreserve, deployer.PreservePackage{
-			Name:       p.Name,
-			Repository: p.Repository,
-			Version:    p.Version,
+			Name:       preserve.PackageName,
+			Repository: preserve.Repository,
+			Version:    preserve.Version,
 		})
-		keepReleases[p.Namespace+"/"+apps.BuildName(p.Namespace, p.Instance)] = struct{}{}
+
+		keepReleases[preserve.ReleaseNamespace+"/"+preserve.ReleaseName] = struct{}{}
 	}
 
 	if err := r.appDeployer.Cleanup(ctx, fsPreserve); err != nil {
@@ -676,7 +676,8 @@ func (r *Runtime) CleanupApps(ctx context.Context, preserve []PreserveApp) {
 		return
 	}
 
-	r.nelmService.Cleanup(ctx, keepReleases)
+	// do not cleanup modules namespace
+	r.nelmService.Cleanup(ctx, keepReleases, "d8-system")
 }
 
 // Status returns package status service for external access

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -654,7 +654,7 @@ type PreservePackage struct {
 }
 
 // Cleanup removes downloaded application packages on disk and orphan nelm
-// releases in the cluster that are not in preserve. Runs once during preflight.
+// releases in the cluster that are not in preserves. Runs once during preflight.
 func (r *Runtime) Cleanup(ctx context.Context, preserves []PreservePackage) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/deckhouse-controller/internal/packages/values/schema/storage.go
+++ b/deckhouse-controller/internal/packages/values/schema/storage.go
@@ -125,7 +125,7 @@ func prepareSchemas(settings, values []byte) (map[Type]*spec.Schema, error) {
 
 		res[TypeValues] = transformers.Transform(
 			schemaObj,
-			&transformers.Extend{Parent: res[TypeValues]},
+			&transformers.Extend{Parent: res[TypeSettings]},
 			&transformers.AdditionalProperties{},
 		)
 

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -142,7 +142,7 @@ func (r *reconciler) preflight(ctx context.Context) error {
 		})
 	}
 
-	r.runtime.Cleanup(ctx, preserve)
+	r.runtime.CleanupApps(ctx, preserve)
 
 	r.logger.Debug("controller is ready")
 

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -72,7 +72,7 @@ type packageRuntime interface {
 	UpdateApp(repo registry.Remote, inst packageruntime.App)
 	RemoveApp(namespace, name string)
 	Status() *packagestatus.Service
-	CleanupApps(ctx context.Context, preserve []packageruntime.PreserveApp)
+	Cleanup(ctx context.Context, preserve []packageruntime.Preserve)
 }
 
 func RegisterController(
@@ -131,18 +131,19 @@ func (r *reconciler) preflight(ctx context.Context) error {
 		return fmt.Errorf("list applications: %w", err)
 	}
 
-	preserve := make([]packageruntime.PreserveApp, 0, len(appsList.Items))
+	preserve := make([]packageruntime.Preserve, 0, len(appsList.Items))
 	for _, app := range appsList.Items {
-		preserve = append(preserve, packageruntime.PreserveApp{
-			Name:       app.Spec.PackageName,
-			Repository: app.Spec.PackageRepositoryName,
-			Version:    app.Spec.PackageVersion,
-			Namespace:  app.Namespace,
-			Instance:   app.Name,
+		preserve = append(preserve, packageruntime.Preserve{
+			PackageName: app.Spec.PackageName,
+			Repository:  app.Spec.PackageRepositoryName,
+			Version:     app.Spec.PackageVersion,
+
+			ReleaseName:      apps.BuildName(app.Namespace, app.Name),
+			ReleaseNamespace: app.Namespace,
 		})
 	}
 
-	r.runtime.CleanupApps(ctx, preserve)
+	r.runtime.Cleanup(ctx, preserve)
 
 	r.logger.Debug("controller is ready")
 

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -72,7 +72,7 @@ type packageRuntime interface {
 	UpdateApp(repo registry.Remote, inst packageruntime.App)
 	RemoveApp(namespace, name string)
 	Status() *packagestatus.Service
-	Cleanup(ctx context.Context, preserve []packageruntime.Preserve)
+	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
 }
 
 func RegisterController(
@@ -131,9 +131,9 @@ func (r *reconciler) preflight(ctx context.Context) error {
 		return fmt.Errorf("list applications: %w", err)
 	}
 
-	preserve := make([]packageruntime.Preserve, 0, len(appsList.Items))
+	preserve := make([]packageruntime.PreservePackage, 0, len(appsList.Items))
 	for _, app := range appsList.Items {
-		preserve = append(preserve, packageruntime.Preserve{
+		preserve = append(preserve, packageruntime.PreservePackage{
 			PackageName: app.Spec.PackageName,
 			Repository:  app.Spec.PackageRepositoryName,
 			Version:     app.Spec.PackageVersion,

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -72,7 +72,7 @@ type packageRuntime interface {
 	UpdateApp(repo registry.Remote, inst packageruntime.App)
 	RemoveApp(namespace, name string)
 	Status() *packagestatus.Service
-	Cleanup(ctx context.Context, preserve []packageruntime.PreservePackage)
+	CleanupApps(ctx context.Context, preserve []packageruntime.PreserveApp)
 }
 
 func RegisterController(
@@ -131,9 +131,9 @@ func (r *reconciler) preflight(ctx context.Context) error {
 		return fmt.Errorf("list applications: %w", err)
 	}
 
-	preserve := make([]packageruntime.PreservePackage, 0, len(appsList.Items))
+	preserve := make([]packageruntime.PreserveApp, 0, len(appsList.Items))
 	for _, app := range appsList.Items {
-		preserve = append(preserve, packageruntime.PreservePackage{
+		preserve = append(preserve, packageruntime.PreserveApp{
 			Name:       app.Spec.PackageName,
 			Repository: app.Spec.PackageRepositoryName,
 			Version:    app.Spec.PackageVersion,

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -131,12 +131,14 @@ func (r *reconciler) preflight(ctx context.Context) error {
 		return fmt.Errorf("list applications: %w", err)
 	}
 
-	var preserve []packageruntime.PreservePackage
+	preserve := make([]packageruntime.PreservePackage, 0, len(appsList.Items))
 	for _, app := range appsList.Items {
 		preserve = append(preserve, packageruntime.PreservePackage{
 			Name:       app.Spec.PackageName,
-			Version:    app.Spec.PackageVersion,
 			Repository: app.Spec.PackageRepositoryName,
+			Version:    app.Spec.PackageVersion,
+			Namespace:  app.Namespace,
+			Instance:   app.Name,
 		})
 	}
 

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -449,4 +449,4 @@ func (o *operatorStub) Status() *packagestatus.Service {
 	return packagestatus.NewService()
 }
 
-func (o *operatorStub) Cleanup(_ context.Context, _ []packageoperator.PreserveApp) {}
+func (o *operatorStub) CleanupApps(_ context.Context, _ []packageoperator.PreserveApp) {}

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -449,4 +449,4 @@ func (o *operatorStub) Status() *packagestatus.Service {
 	return packagestatus.NewService()
 }
 
-func (o *operatorStub) CleanupApps(_ context.Context, _ []packageoperator.PreserveApp) {}
+func (o *operatorStub) Cleanup(_ context.Context, _ []packageoperator.PreservePackage) {}

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -449,4 +449,4 @@ func (o *operatorStub) Status() *packagestatus.Service {
 	return packagestatus.NewService()
 }
 
-func (o *operatorStub) Cleanup(_ context.Context, _ []packageoperator.PreservePackage) {}
+func (o *operatorStub) Cleanup(_ context.Context, _ []packageoperator.PreserveApp) {}


### PR DESCRIPTION
## Description

Adds a preflight pass that uninstalls **orphan nelm releases** — releases left in the cluster after their owning `Application` CR was already removed (typical leftover when the controller crashes mid-finalizer).

- On every `Install`, the nelm service stamps `packages.deckhouse.io/managed-by=deckhouse` as a `Release.Info` annotation (via `WithReleaseAnnotations`).
- During controller preflight (after the existing FS cleanup), the service lists releases cluster-wide via `action.ReleaseList`, filters by the managed-by annotation, and uninstalls those whose `(namespace, release-name)` is no longer in the live Application snapshot.
- Releases in protected namespaces (currently `d8-system`) are skipped via an explicit ignore-list — defence-in-depth on top of the annotation filter.

Helm releases not produced by this controller (Deckhouse modules in `d8-system`, anything without the managed-by marker) carry no marker **and** sit in an ignored namespace, so they are never touched.

## Why do we need it, and what problem does it solve?

Continues the existing FS cleanup work. If the controller crashes between Application deletion and the corresponding `nelm uninstall` (mid-finalizer), the release-secrets remain in the cluster forever. Over time these accumulate as garbage with no operator to reclaim them. This change reconciles release state with `Application` CR state on every controller start.


### Test plan

End-to-end check in a dev cluster (using the existing `status-tests` Application which constantly reconciles):

```text
# 1. managed-by annotation is set on Install
$ release_annotations default sh.helm.release.v1.default.status-tests.v2681
{ "packages.deckhouse.io/managed-by": "deckhouse" }

# 2. snapshot before: 10 status-tests revisions, 103 module releases in d8-system
Before: d8-system=103, status-tests revs=10

# 3. force-delete Application (skip finalizer) → orphan
$ k -n default delete app status-tests --grace-period=0 --force
application.deckhouse.io "status-tests" force deleted

# 4. restart controller → preflight cleanup
$ k -n d8-system rollout restart deploy/deckhouse

# 5. cleanup log
{"level":"info","logger":"...nelm-service","msg":"deleted orphan release",
 "namespace":"default","release":"default.status-tests",...}
{"level":"info","logger":"...nelm-service","msg":"orphan release cleanup complete",
 "deleted":1,"failed":0,...}

# 6. result
status-tests secrets:  (none)
d8-system modules:     103 → 103  (untouched)
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Packages cleanup orphan nelm releases.
impact_level: default
```

