### PR TITLE
[cloud-provider-aws] Migrate to Cilium CNI

### DIFF
--- a/modules/030-cloud-provider-aws/template_tests/module_test.go
+++ b/modules/030-cloud-provider-aws/template_tests/module_test.go
@@ -181,6 +181,8 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
 
 			cddDeployment := f.KubernetesResource("Deployment", moduleNamespace, "cloud-data-discoverer")
 
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+
 			Expect(namespace.Exists()).To(BeTrue())
 			Expect(registrySecret.Exists()).To(BeTrue())
 			Expect(userAuthzUser.Exists()).To(BeTrue())
@@ -205,6 +207,15 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
   - deletecollection
   - patch
   - update`))
+
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("cilium"))))
+			actualCiliumConfig, err := base64.StdEncoding.DecodeString(cniSecret.Field("data.cilium").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(actualCiliumConfig)).To(MatchJSON(`{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}`))
 
 			// user story #1
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")
@@ -421,6 +432,31 @@ storageclass.kubernetes.io/is-default-class: "true"
 				d := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "cloud-data-discoverer")
 				Expect(d.Exists()).To(BeFalse())
 			})
+		})
+	})
+
+	Context("AWS with existing CNI secret data", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderAws", moduleValues)
+			f.ValuesSet("cloudProviderAws.internal.cniSecretData", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`cni: %s
+flannel: %s
+`,
+				base64.StdEncoding.EncodeToString([]byte("flannel")),
+				base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`)),
+			))))
+			f.HelmRender()
+		})
+
+		It("Should render CNI secret from internal value", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("flannel"))))
+			Expect(cniSecret.Field("data.flannel").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`))))
+			Expect(cniSecret.Field("data.cilium").Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/030-cloud-provider-aws/templates/cni.yaml
+++ b/modules/030-cloud-provider-aws/templates/cni.yaml
@@ -1,3 +1,7 @@
+{{- $ciliumConfig := `{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}` }}
 ---
 apiVersion: v1
 kind: Secret
@@ -9,5 +13,6 @@ data:
 {{- if hasKey .Values.cloudProviderAws.internal "cniSecretData" }}
   {{- .Values.cloudProviderAws.internal.cniSecretData | b64dec | nindent 2 }}
 {{- else }}
-  cni: {{ b64enc "simple-bridge" | quote }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ $ciliumConfig | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Update the default CNI configuration in the `cloud-provider-aws` module. The configuration switches from `simple-bridge` to `cilium` using VXLAN tunneling mode and BPF masquerade mode.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously, the default CNI in AWS was `simple-bridge`, which utilized native VPC routing. Moving to Cilium with VXLAN as the default unifies the cluster networking configuration across different infrastructure providers.

By utilizing standard VXLAN encapsulation, we eliminate the dependency on specific cloud routing mechanisms and platform limits (such as VPC Route Table quotas). This approach simplifies cluster operational support and maintenance, providing a single, predictable network profile that behaves identically in AWS, bare-metal, and other environments.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-aws
type: feature
summary: Migrated AWS to Cilium CNI by default for new clusters.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
