### PR TITLE
[docs] Disable final-images-only for PDF builds

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -314,6 +314,7 @@ steps:
       WERF_ENV: "development"
       WERF_REPO: "${{ steps.check_dev_registry.outputs.web_registry_path }}"
 {!{- end }!}
+      WERF_FINAL_IMAGES_ONLY: "false"
       DOC_VERSION: "${{ env.DOC_VERSION }}"
     run: |
       make docs-generate-pdf DOC_VERSION="${DOC_VERSION}"

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3380,6 +3380,7 @@ jobs:
           WERF_ENV: "EE"
           WERF_REPO: "${{ steps.check_rw_registry.outputs.web_registry_path || steps.check_dev_registry.outputs.web_registry_path }}"
           WERF_SECONDARY_REPO: "${{ steps.check_dev_registry.outputs.web_registry_path }}"
+          WERF_FINAL_IMAGES_ONLY: "false"
           DOC_VERSION: "${{ env.DOC_VERSION }}"
         run: |
           make docs-generate-pdf DOC_VERSION="${DOC_VERSION}"

--- a/.github/workflows/docs-pdf-daily.yml
+++ b/.github/workflows/docs-pdf-daily.yml
@@ -166,6 +166,7 @@ jobs:
           WERF_ENV: "EE"
           WERF_REPO: "${{ steps.check_rw_registry.outputs.web_registry_path || steps.check_dev_registry.outputs.web_registry_path }}"
           WERF_SECONDARY_REPO: "${{ steps.check_dev_registry.outputs.web_registry_path }}"
+          WERF_FINAL_IMAGES_ONLY: "false"
           DOC_VERSION: "${{ env.DOC_VERSION }}"
         run: |
           make docs-generate-pdf DOC_VERSION="${DOC_VERSION}"


### PR DESCRIPTION
## Description

- Set WERF_FINAL_IMAGES_ONLY to false across all PDF generation pipelines to expose intermediate stage images required by the documentation build process
- Apply the fix uniformly to CI templates, daily scheduled runs, and pre-release workflows to ensure consistent werf behaviour during PDF generation

Fix: https://github.com/deckhouse/deckhouse/pull/19776

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix CI for generating PDF documentation files.
impact_level: low
```
