### PR TITLE
[docs] Reduce CI noise in PDF generation pipelines

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -322,11 +322,15 @@ steps:
   - name: Install awscli
     if: ${{ success() }}
     run: |
-      curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-      unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
-      /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
-      echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-      rm -rf /tmp/awscliv2.zip /tmp/awscliv2
+      if command -v aws &>/dev/null; then
+        echo "AWS CLI already available: $(aws --version)"
+      else
+        curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+        unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
+        /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
+        echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+        rm -rf /tmp/awscliv2.zip /tmp/awscliv2
+      fi
 
   - name: Upload PDF files to S3
     if: ${{ success() }}

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3388,11 +3388,15 @@ jobs:
       - name: Install awscli
         if: ${{ success() }}
         run: |
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-          unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
-          /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-          rm -rf /tmp/awscliv2.zip /tmp/awscliv2
+          if command -v aws &>/dev/null; then
+            echo "AWS CLI already available: $(aws --version)"
+          else
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
+            /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
+            echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+            rm -rf /tmp/awscliv2.zip /tmp/awscliv2
+          fi
 
       - name: Upload PDF files to S3
         if: ${{ success() }}

--- a/.github/workflows/docs-pdf-daily.yml
+++ b/.github/workflows/docs-pdf-daily.yml
@@ -174,11 +174,15 @@ jobs:
       - name: Install awscli
         if: ${{ success() }}
         run: |
-          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-          unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
-          /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
-          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-          rm -rf /tmp/awscliv2.zip /tmp/awscliv2
+          if command -v aws &>/dev/null; then
+            echo "AWS CLI already available: $(aws --version)"
+          else
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
+            /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
+            echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+            rm -rf /tmp/awscliv2.zip /tmp/awscliv2
+          fi
 
       - name: Upload PDF files to S3
         if: ${{ success() }}

--- a/tools/docs/pdf/get_pdf_page.py
+++ b/tools/docs/pdf/get_pdf_page.py
@@ -1149,8 +1149,10 @@ if __name__ == "__main__":
         for chunk_path in chunk_paths:
             page_args.extend(["page", chunk_path])
 
+        in_ci = bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
         wkhtmltopdf_cmd = [
             "wkhtmltopdf",
+            *(["--quiet"] if in_ci else []),
             "--page-size", "A4",
             "--margin-left", "2cm",
             "--margin-right", "2cm",


### PR DESCRIPTION
## Description

- Guard AWS CLI installation with presence check across all workflow definitions to skip redundant downloads on runners where the binary already exists
- Suppress wkhtmltopdf progress output in CI environments by injecting quiet flag when standard CI environment variables are detected, reducing log verbosity

Ref: https://github.com/deckhouse/deckhouse/pull/19777

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Reduce CI noise in PDF generation pipelines.
impact_level: low
```
