### PR TITLE
[docs] Fix PDF build pipeline reliability in CI

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -348,7 +348,8 @@ steps:
             "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
             "s3://${S3_BUCKET}/deckhouse-{!{ $webEnv }!}/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
             --endpoint-url "https://${S3_EP}" \
-            --region "${S3_REGION}"
+            --region "${S3_REGION}" \
+            --no-verify-ssl
         done
       done
 # </template: doc_pdf_build_template>

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3414,7 +3414,8 @@ jobs:
                 "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
                 "s3://${S3_BUCKET}/deckhouse-web-production/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
                 --endpoint-url "https://${S3_EP}" \
-                --region "${S3_REGION}"
+                --region "${S3_REGION}" \
+                --no-verify-ssl
             done
           done
     # </template: doc_pdf_build_template>

--- a/.github/workflows/docs-pdf-daily.yml
+++ b/.github/workflows/docs-pdf-daily.yml
@@ -200,7 +200,8 @@ jobs:
                 "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
                 "s3://${S3_BUCKET}/deckhouse-web-production/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
                 --endpoint-url "https://${S3_EP}" \
-                --region "${S3_REGION}"
+                --region "${S3_REGION}" \
+                --no-verify-ssl
             done
           done
     # </template: doc_pdf_build_template>

--- a/tools/docs/pdf/get_pdf_page.py
+++ b/tools/docs/pdf/get_pdf_page.py
@@ -1152,7 +1152,6 @@ if __name__ == "__main__":
         in_ci = bool(os.environ.get("CI") or os.environ.get("GITHUB_ACTIONS"))
         wkhtmltopdf_cmd = [
             "wkhtmltopdf",
-            *(["--quiet"] if in_ci else []),
             "--page-size", "A4",
             "--margin-left", "2cm",
             "--margin-right", "2cm",
@@ -1189,6 +1188,7 @@ if __name__ == "__main__":
                 wkhtmltopdf_cmd,
                 check=False,
                 timeout=600,
+                stderr=subprocess.PIPE if in_ci else None,
             )
         except subprocess.TimeoutExpired:
             print("Error: wkhtmltopdf timed out after 10 minutes.")
@@ -1197,13 +1197,18 @@ if __name__ == "__main__":
             print("Error: wkhtmltopdf not found. Please install wkhtmltopdf.")
             sys.exit(1)
 
+        wk_stderr = getattr(proc, "stderr", None)
         if not os.path.isfile(pdf_out):
+            if wk_stderr:
+                sys.stderr.buffer.write(wk_stderr)
             print(
                 f"Error: PDF was not created at {pdf_out!r} "
                 f"(wkhtmltopdf exit code {getattr(proc, 'returncode', 'n/a')})."
             )
             sys.exit(1)
         if proc.returncode != 0:
+            if wk_stderr:
+                sys.stderr.buffer.write(wk_stderr)
             print(
                 f"Warning: wkhtmltopdf exited with code {proc.returncode}; \n"
                 f"PDF saved to {pdf_out}."


### PR DESCRIPTION
## Description

- Fix S3 uploads for PDF.
- Replace quiet mode with deferred stderr capture during PDF generation so that diagnostic output is suppressed during normal runs but emitted on failure, improving debuggability without cluttering successful build logs

Fix: https://github.com/deckhouse/deckhouse/pull/19779

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix PDF build pipeline reliability in CI.
impact_level: low
```
