### PR TITLE
[cni-cilium] Add node based VPA for cilium agent

### DIFF
--- a/modules/021-cni-cilium/templates/agent/daemonset.yaml
+++ b/modules/021-cni-cilium/templates/agent/daemonset.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "agent")) | nindent 2 }}
 spec:
+  scope: "kubernetes.io/hostname"
   {{- include "helm_lib_resources_management_vpa_spec"  (list "apps/v1" "DaemonSet" "agent" "cilium-agent" .Values.cniCilium.resourcesManagement ) | nindent 2}}
   {{- if (eq .Values.cniCilium.resourcesManagement.mode "VPA") }}
     {{- include "helm_lib_vpa_kube_rbac_proxy_resources" . | nindent 4 }}


### PR DESCRIPTION
## Description
Add scope to the cilium-agent VPA to respect a node for DaemonSet

result:

```yaml
apiVersion: autoscaling.k8s.io/v1
kind: VerticalPodAutoscaler
metadata:
  annotations:
    meta.helm.sh/release-name: cni-cilium
    meta.helm.sh/release-namespace: d8-system
    werf.io/fail-mode: IgnoreAndContinueDeployProcess
    werf.io/track-termination-mode: NonBlocking
  creationTimestamp: "2025-12-18T15:00:47Z"
  generation: 5
  labels:
    app: agent
    app.kubernetes.io/managed-by: Helm
    heritage: deckhouse
    module: cni-cilium
  name: agent
  namespace: d8-cni-cilium
  resourceVersion: "788321458"
  uid: 21c0afd7-029c-462d-a13d-fe7ab8e01a62
spec:
  resourcePolicy:
    containerPolicies:
    - containerName: cilium-agent
      controlledValues: RequestsAndLimits
      maxAllowed:
        cpu: "4"
        memory: 4Gi
      minAllowed:
        cpu: 100m
        memory: 128Mi
    - containerName: kube-rbac-proxy
      maxAllowed:
        cpu: 20m
        memory: 25Mi
      minAllowed:
        cpu: 10m
        memory: 25Mi
  scope: kubernetes.io/hostname
  targetRef:
    apiVersion: apps/v1
    kind: DaemonSet
    name: agent
  updatePolicy:
    updateMode: Initial
status:
  conditions:
  - lastTransitionTime: "2026-05-09T06:40:54Z"
    status: "False"
    type: RecommendationProvided
  groups:
  - containerRecommendations:
    - containerName: cilium-agent
      target:
        cpu: 100m
        memory: 320Mi
    - containerName: kube-rbac-proxy
      target:
        cpu: 12m
        memory: 25Mi
    scopeValue: test-master-0
  - containerRecommendations:
    - containerName: cilium-agent
      target:
        cpu: 100m
        memory: 192Mi
    - containerName: kube-rbac-proxy
      target:
        cpu: 12m
        memory: 25Mi
    scopeValue: test-worker-6447e7ac-5c56d-769rg
  - containerRecommendations:
    - containerName: cilium-agent
      target:
        cpu: 100m
        memory: 128Mi
    - containerName: kube-rbac-proxy
      target:
        cpu: 12m
        memory: 25Mi
    scopeValue: test-worker-6447e7ac-5c56d-xl6js
  - containerRecommendations:
    - containerName: cilium-agent
      target:
        cpu: 100m
        memory: 128Mi
    - containerName: kube-rbac-proxy
      target:
        cpu: 12m
        memory: 25Mi
    scopeValue: test-worker-6447e7ac-5c56d-z6dnb
```

## Why do we need it, and what problem does it solve?
Recommendations would be kept from the desired node, not from the highest values as in the usual DaemonSet VPA

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: feature
summary: VPA recommendations based on an agent's node utilization
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
