### PR TITLE
[node-controller] golangci-lint fix

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/controller/instance/instance/instance_service.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/instance/instance/instance_service.go
@@ -49,5 +49,5 @@ func (s *InstanceService) ReconcileFinalization(ctx context.Context, instance *d
 	if err := s.finalizeAfterMachineDeletion(ctx, instance, result.MachineGone); err != nil {
 		return FinalizationResult{}, err
 	}
-	return FinalizationResult{MachineGone: result.MachineGone}, nil
+	return FinalizationResult(result), nil
 }


### PR DESCRIPTION
## Description

node-controller  golangci-lint fix

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: chore
summary: node-controller golangci-lint fix
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
