### PR TITLE
[cloud-provider-azure][cloud-provider-gcp] Migrate to Cilium CNI

### DIFF
--- a/modules/030-cloud-provider-azure/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-azure/candi/cni-bootstrap.yml
@@ -1,4 +1,6 @@
 schemaVersion: 1
-name: simple-bridge
+name: cilium
 config:
-  default: {}
+  default:
+    tunnelMode: VXLAN
+    masqueradeMode: BPF

--- a/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT.md
@@ -13,6 +13,12 @@ description: "Configuring Azure for Deckhouse cloud provider operation."
 The provider supports working with only one disk in the virtual machine template. Make sure the template contains only one disk.
 {% endalert %}
 
+{% alert level="warning" %}
+Starting with DKP version 1.77, Azure uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
+
+New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+{% endalert %}
+
 To rule the Microsoft Azure cloud, you need an account and at least a single [Subscription connected to id](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/create-subscription).
 
 You have to create a service account with Microsoft Azure so that Deckhouse Kubernetes Platform can manage cloud resources:

--- a/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT.md
@@ -6,7 +6,7 @@ description: "Configuring Azure for Deckhouse cloud provider operation."
 {% include notice_envinronment.liquid %}
 
 {% alert level="warning" %}
-**Caution!** Only [regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-region) where `Availability Zones` are available are supported.
+Only [regions](https://docs.microsoft.com/en-us/azure/availability-zones/az-region) where `Availability Zones` are available are supported.
 {% endalert %}
 
 {% alert level="warning" %}
@@ -16,7 +16,7 @@ The provider supports working with only one disk in the virtual machine template
 {% alert level="warning" %}
 Starting with DKP version 1.77, Azure uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
 
-New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+New clusters require Linux kernel version 5.8 or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
 {% endalert %}
 
 To rule the Microsoft Azure cloud, you need an account and at least a single [Subscription connected to id](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/create-subscription).

--- a/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT_RU.md
@@ -16,7 +16,7 @@ description: "Настройка Azure для работы облачного п
 {% alert level="warning" %}
 Начиная с версии DKP 1.77, в Azure CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 Для управления облаком Microsoft Azure необходимо иметь соответствующую учетную запись и хотя бы одну привязанную [подписку (Subscription)](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/create-subscription).

--- a/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT_RU.md
@@ -13,6 +13,12 @@ description: "Настройка Azure для работы облачного п
 Провайдер поддерживает работу только с одним диском в шаблоне виртуальной машины. Убедитесь, что шаблон содержит только один диск.
 {% endalert %}
 
+{% alert level="warning" %}
+Начиная с версии DKP 1.77, в Azure CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+{% endalert %}
+
 Для управления облаком Microsoft Azure необходимо иметь соответствующую учетную запись и хотя бы одну привязанную [подписку (Subscription)](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/create-subscription).
 
 Для управления ресурсами в облаке Microsoft Azure средствами Deckhouse Kubernetes Platform необходимо создать service account. Для этого:

--- a/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-azure/candi/docs/ENVIRONMENT_RU.md
@@ -6,7 +6,7 @@ description: "Настройка Azure для работы облачного п
 {% include notice_envinronment.liquid %}
 
 {% alert level="warning" %}
-**Внимание!** Поддерживаются только [регионы](https://docs.microsoft.com/ru-ru/azure/availability-zones/az-region), в которых доступны `Availability Zones`.
+Поддерживаются только [регионы](https://docs.microsoft.com/ru-ru/azure/availability-zones/az-region), в которых доступны `Availability Zones`.
 {% endalert %}
 
 {% alert level="warning" %}
@@ -14,9 +14,11 @@ description: "Настройка Azure для работы облачного п
 {% endalert %}
 
 {% alert level="warning" %}
-Начиная с версии DKP 1.77, в Azure CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+Начиная с DKP 1.77, для новых кластеров в Azure по умолчанию используется CNI `cilium`. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров на всех узлах требуется ядро Linux версии 5.8 или новее. Также убедитесь, что правила межсетевого экрана разрешают межузловой UDP-трафик, необходимый для работы Cilium VXLAN.
+
+Подробнее в разделах [«Требования к установке»](/products/kubernetes-platform/documentation/v1/installing/), [«Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документации модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 Для управления облаком Microsoft Azure необходимо иметь соответствующую учетную запись и хотя бы одну привязанную [подписку (Subscription)](https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/create-subscription).

--- a/modules/030-cloud-provider-azure/docs/README.md
+++ b/modules/030-cloud-provider-azure/docs/README.md
@@ -18,7 +18,7 @@ Features of the `cloud-provider-azure` module:
 {% alert level="warning" %}
 Starting with DKP version 1.77, Azure uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
 
-New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+New clusters require Linux kernel version 5.8 or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
 {% endalert %}
 
 {% alert level="warning" %}

--- a/modules/030-cloud-provider-azure/docs/README.md
+++ b/modules/030-cloud-provider-azure/docs/README.md
@@ -12,8 +12,14 @@ Features of the `cloud-provider-azure` module:
   - The CCM module creates LoadBalancers for Kubernetes Service objects that have the `LoadBalancer` type;
   - The CCM module updates the metadata of the cluster nodes according to the configuration parameters and deletes nodes that are no longer in Azure;
 - Provisioning nodes in Azure using the `CSI storage` component;
-- Enabling the necessary CNI plugin (using the [simple bridge](/modules/cni-simple-bridge/));
+- Enabling the necessary CNI plugin (using [cni-cilium](/modules/cni-cilium/));
 - Registering with the [node-manager](/modules/node-manager/) module so that [AzureInstanceClasses](cr.html#azureinstanceclass) can be used when creating the [NodeGroup](/modules/node-manager/cr.html#nodegroup).
+
+{% alert level="warning" %}
+Starting with DKP version 1.77, Azure uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
+
+New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+{% endalert %}
 
 {% alert level="warning" %}
 When using load balancers, outgoing traffic also goes through it. If no balancer has UDP rules, all outgoing UDP traffic is blocked. As a result, such utilities as `ntpdate` and `chrony` do not work. To solve the problem, you need to add a load balancing rule with any UDP port to an existing balancer yourself, or create a service in the cluster with the LoadBalancer type with any UDP port.

--- a/modules/030-cloud-provider-azure/docs/README_RU.md
+++ b/modules/030-cloud-provider-azure/docs/README_RU.md
@@ -18,7 +18,7 @@ description: "Управление облачными ресурсами в Deck
 {% alert level="warning" %}
 Начиная с версии DKP 1.77, в Azure CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 {% alert level="warning" %}

--- a/modules/030-cloud-provider-azure/docs/README_RU.md
+++ b/modules/030-cloud-provider-azure/docs/README_RU.md
@@ -13,12 +13,14 @@ description: "Управление облачными ресурсами в Deck
   - Актуализирует метаданные узлов кластера согласно описанным параметрам конфигурации и удаляет из кластера узлы, которых уже нет в Azure.
 - Заказывает диски в Azure с помощью компонента `CSI storage`.
 - Включает необходимый CNI (использует [cni-cilium](/modules/cni-cilium/)).
-- Регистрируется в модуле [`node-manager`](/modules/node-manager/), чтобы [AzureInstanceClass'ы](cr.html#azureinstanceclass) можно было использовать при описании [NodeGroup](/modules/node-manager/cr.html#nodegroup).
+- Регистрируется в модуле [node-manager](/modules/node-manager/), чтобы [AzureInstanceClass'ы](cr.html#azureinstanceclass) можно было использовать при описании [NodeGroup](/modules/node-manager/cr.html#nodegroup).
 
 {% alert level="warning" %}
-Начиная с версии DKP 1.77, в Azure CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+Начиная с DKP 1.77, для новых кластеров в Azure по умолчанию используется CNI `cilium`. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров на всех узлах требуется ядро Linux версии 5.8 или новее. Также убедитесь, что правила межсетевого экрана разрешают межузловой UDP-трафик, необходимый для работы Cilium VXLAN.
+
+Подробнее в разделах [«Требования к установке»](/products/kubernetes-platform/documentation/v1/installing/), [«Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документации модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 {% alert level="warning" %}

--- a/modules/030-cloud-provider-azure/docs/README_RU.md
+++ b/modules/030-cloud-provider-azure/docs/README_RU.md
@@ -12,8 +12,14 @@ description: "Управление облачными ресурсами в Deck
   - Создает LoadBalancer'ы для Service-объектов Kubernetes с типом `LoadBalancer`.
   - Актуализирует метаданные узлов кластера согласно описанным параметрам конфигурации и удаляет из кластера узлы, которых уже нет в Azure.
 - Заказывает диски в Azure с помощью компонента `CSI storage`.
-- Включает необходимый CNI (использует [simple bridge](/modules/cni-simple-bridge/)).
+- Включает необходимый CNI (использует [cni-cilium](/modules/cni-cilium/)).
 - Регистрируется в модуле [`node-manager`](/modules/node-manager/), чтобы [AzureInstanceClass'ы](cr.html#azureinstanceclass) можно было использовать при описании [NodeGroup](/modules/node-manager/cr.html#nodegroup).
+
+{% alert level="warning" %}
+Начиная с версии DKP 1.77, в Azure CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+{% endalert %}
 
 {% alert level="warning" %}
 Для корректной работы утилит, таких как `ntpdate` и `chrony`, при использовании балансировщиков нагрузки важно убедиться, что у балансировщика есть соответствующие правила для обработки UDP-трафика. В случае блокировки исходящего UDP-трафика, можно добавить новое правило к существующему балансировщику или создать новый сервис с типом LoadBalancer и UDP-портом, чтобы обеспечить правильную маршрутизацию UDP-запросов.

--- a/modules/030-cloud-provider-azure/template_tests/module_test.go
+++ b/modules/030-cloud-provider-azure/template_tests/module_test.go
@@ -191,9 +191,20 @@ var _ = Describe("Module :: cloud-provider-azure :: helm template ::", func() {
 			userAuthzClusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-azure:cluster-admin")
 
 			cddDeployment := f.KubernetesResource("Deployment", moduleNamespace, "cloud-data-discoverer")
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
 
 			Expect(namespace.Exists()).To(BeTrue())
 			Expect(registrySecret.Exists()).To(BeTrue())
+
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("cilium"))))
+			actualCiliumConfig, err := base64.StdEncoding.DecodeString(cniSecret.Field("data.cilium").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(actualCiliumConfig)).To(MatchJSON(`{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}`))
+
 			Expect(userAuthzUser.Exists()).To(BeTrue())
 			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
 			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
@@ -382,6 +393,31 @@ var _ = Describe("Module :: cloud-provider-azure :: helm template ::", func() {
 
 			d := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "cloud-data-discoverer")
 			Expect(d.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Azure with existing CNI secret data", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderAzure", moduleValues)
+			f.ValuesSet("cloudProviderAzure.internal.cniSecretData", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`cni: %s
+flannel: %s
+`,
+				base64.StdEncoding.EncodeToString([]byte("flannel")),
+				base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`)),
+			))))
+			f.HelmRender()
+		})
+
+		It("Should render CNI secret from internal value", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("flannel"))))
+			Expect(cniSecret.Field("data.flannel").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`))))
+			Expect(cniSecret.Field("data.cilium").Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/030-cloud-provider-azure/template_tests/module_test.go
+++ b/modules/030-cloud-provider-azure/template_tests/module_test.go
@@ -18,7 +18,7 @@ limitations under the License.
 
 User-stories:
 1. There are module settings. They must be exported via Secret d8-node-manager-cloud-provider.
-2. There are applications which must be deployed — cloud-controller-manager, azure-csi-driver, simple-bridge.
+2. There are applications which must be deployed — cloud-controller-manager, azure-csi-driver, cni-cilium.
 
 */
 

--- a/modules/030-cloud-provider-azure/templates/cni.yaml
+++ b/modules/030-cloud-provider-azure/templates/cni.yaml
@@ -1,3 +1,7 @@
+{{- $ciliumConfig := `{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}` }}
 ---
 apiVersion: v1
 kind: Secret
@@ -9,5 +13,6 @@ data:
 {{- if hasKey .Values.cloudProviderAzure.internal "cniSecretData" }}
   {{- .Values.cloudProviderAzure.internal.cniSecretData | b64dec | nindent 2 }}
 {{- else }}
-  cni: {{ b64enc "simple-bridge" | quote }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ $ciliumConfig | b64enc | quote }}
 {{- end }}

--- a/modules/030-cloud-provider-gcp/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-gcp/candi/cni-bootstrap.yml
@@ -1,4 +1,6 @@
 schemaVersion: 1
-name: simple-bridge
+name: cilium
 config:
-  default: {}
+  default:
+    tunnelMode: VXLAN
+    masqueradeMode: BPF

--- a/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT.md
@@ -15,6 +15,12 @@ You need to create a service account so that Deckhouse Kubernetes Platform can m
 The provider supports working with only one disk in the virtual machine template. Make sure the template contains only one disk.
 {% endalert %}
 
+{% alert level="warning" %}
+Starting with DKP version 1.77, GCP uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
+
+New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+{% endalert %}
+
 ## Setup using Google Cloud Console
 
 Follow this [link](https://console.cloud.google.com/iam-admin/serviceaccounts), select your project and create a new service account or select an existing one.

--- a/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT.md
@@ -8,7 +8,7 @@ description: "Configuring GCP for Deckhouse cloud provider operation."
 You need to create a service account so that Deckhouse Kubernetes Platform can manage resources in the Google Cloud. Below is a brief sequence of steps to create a service account. If you need detailed instructions, you can find them in the [provider's documentation](https://cloud.google.com/iam/docs/service-accounts).
 
 {% alert level="warning" %}
-**Note!** The created `service account key` cannot be restored, you can only delete and create a new one.
+The created `service account key` cannot be restored, you can only delete and create a new one.
 {% endalert %}
 
 {% alert level="warning" %}

--- a/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT_RU.md
@@ -15,6 +15,12 @@ description: "Настройка GCP для работы облачного пр
 Провайдер поддерживает работу только с одним диском в шаблоне виртуальной машины. Убедитесь, что шаблон содержит только один диск.
 {% endalert %}
 
+{% alert level="warning" %}
+Начиная с версии DKP 1.77, в GCP CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+{% endalert %}
+
 ## Настройка через Google Cloud Console
 
 Перейдите [по ссылке](https://console.cloud.google.com/iam-admin/serviceaccounts), выберите проект и создайте новый service account (также можно выбрать уже существующий).

--- a/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT_RU.md
@@ -8,7 +8,7 @@ description: "Настройка GCP для работы облачного пр
 Чтобы Deckhouse Kubernetes Platform могла управлять ресурсами, в Google Cloud необходимо создать service account. Далее представлена краткая последовательность действий по созданию service account. Если вам необходима более подробная инструкция, вы можете найти ее [в документации провайдера](https://cloud.google.com/iam/docs/service-accounts).
 
 {% alert level="warning" %}
-**Внимание!** Созданный `service account key` невозможно восстановить, только удалить и создать новый.
+Созданный `service account key` невозможно восстановить, только удалить и создать новый.
 {% endalert %}
 
 {% alert level="warning" %}
@@ -16,9 +16,11 @@ description: "Настройка GCP для работы облачного пр
 {% endalert %}
 
 {% alert level="warning" %}
-Начиная с версии DKP 1.77, в GCP CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+Начиная с DKP 1.77, для новых кластеров в GCP по умолчанию используется CNI `cilium`. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров на всех узлах требуется ядро Linux версии 5.8 или новее. Также убедитесь, что правила межсетевого экрана разрешают межузловой UDP-трафик, необходимый для работы Cilium VXLAN.
+
+Подробнее в разделах [«Требования к установке»](/products/kubernetes-platform/documentation/v1/installing/), [«Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документации модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 ## Настройка через Google Cloud Console

--- a/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-gcp/candi/docs/ENVIRONMENT_RU.md
@@ -18,7 +18,7 @@ description: "Настройка GCP для работы облачного пр
 {% alert level="warning" %}
 Начиная с версии DKP 1.77, в GCP CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 ## Настройка через Google Cloud Console

--- a/modules/030-cloud-provider-gcp/docs/README.md
+++ b/modules/030-cloud-provider-gcp/docs/README.md
@@ -18,5 +18,5 @@ Features of the `cloud-provider-gcp` module:
 {% alert level="warning" %}
 Starting with DKP version 1.77, GCP uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
 
-New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+New clusters require Linux kernel version 5.8 or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
 {% endalert %}

--- a/modules/030-cloud-provider-gcp/docs/README.md
+++ b/modules/030-cloud-provider-gcp/docs/README.md
@@ -12,5 +12,11 @@ Features of the `cloud-provider-gcp` module:
   - Creating LoadBalancers for Kubernetes Service objects of the `LoadBalancer` type.
   - Updating cluster node metadata of the cluster nodes according to the configuration parameters and deletes nodes that are no longer in GCP.
 - Provisioning disks in GCP using the `CSI storage` component.
-- Enabling the necessary CNI plugin (uses the [simple bridge](/modules/cni-simple-bridge/)).
+- Enabling the necessary CNI plugin (uses the [cni-cilium](/modules/cni-cilium/)).
 - Register in the [node-manager](/modules/node-manager/) module so that [GCPInstanceClasses](cr.html#gcpinstanceclass) can be used when creating the [NodeGroup](/modules/node-manager/cr.html#nodegroup).
+
+{% alert level="warning" %}
+Starting with DKP version 1.77, GCP uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
+
+New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+{% endalert %}

--- a/modules/030-cloud-provider-gcp/docs/README_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/README_RU.md
@@ -18,5 +18,5 @@ description: "Управление облачными ресурсами в Deck
 {% alert level="warning" %}
 Начиная с версии DKP 1.77, в GCP CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}

--- a/modules/030-cloud-provider-gcp/docs/README_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/README_RU.md
@@ -16,7 +16,9 @@ description: "Управление облачными ресурсами в Deck
 - Регистрация в модуле [node-manager](/modules/node-manager/) для использования [GCPInstanceClass'ов](cr.html#gcpinstanceclass) при описании [NodeGroup](/modules/node-manager/cr.html#nodegroup).
 
 {% alert level="warning" %}
-Начиная с версии DKP 1.77, в GCP CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+Начиная с DKP 1.77, для новых кластеров в GCP по умолчанию используется CNI `cilium`. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров на всех узлах требуется ядро Linux версии 5.8 или новее. Также убедитесь, что правила межсетевого экрана разрешают межузловой UDP-трафик, необходимый для работы Cilium VXLAN.
+
+Подробнее в разделах [«Требования к установке»](/products/kubernetes-platform/documentation/v1/installing/), [«Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документации модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}

--- a/modules/030-cloud-provider-gcp/docs/README_RU.md
+++ b/modules/030-cloud-provider-gcp/docs/README_RU.md
@@ -12,5 +12,11 @@ description: "Управление облачными ресурсами в Deck
   - Создание LoadBalancer'ов для Service-объектов Kubernetes с типом `LoadBalancer`.
   - Актуализация метаданных узлов кластера согласно описанным параметрам конфигурации и удаление из кластера узлов, которых уже нет в GCP.
 - Заказ дисков в GCP с помощью компонента `CSI storage`.
-- Включение необходимого CNI (использует [simple bridge](/modules/cni-simple-bridge/)).
+- Включение необходимого CNI (использует [cni-cilium](/modules/cni-cilium/)).
 - Регистрация в модуле [node-manager](/modules/node-manager/) для использования [GCPInstanceClass'ов](cr.html#gcpinstanceclass) при описании [NodeGroup](/modules/node-manager/cr.html#nodegroup).
+
+{% alert level="warning" %}
+Начиная с версии DKP 1.77, в GCP CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+{% endalert %}

--- a/modules/030-cloud-provider-gcp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-gcp/template_tests/module_test.go
@@ -216,9 +216,20 @@ var _ = Describe("Module :: cloud-provider-gcp :: helm template ::", func() {
 			userAuthzClusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-gcp:cluster-admin")
 
 			cddDeployment := f.KubernetesResource("Deployment", moduleNamespace, "cloud-data-discoverer")
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
 
 			Expect(namespace.Exists()).To(BeTrue())
 			Expect(registrySecret.Exists()).To(BeTrue())
+
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("cilium"))))
+			actualCiliumConfig, err := base64.StdEncoding.DecodeString(cniSecret.Field("data.cilium").String())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(string(actualCiliumConfig)).To(MatchJSON(`{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}`))
+
 			Expect(userAuthzUser.Exists()).To(BeTrue())
 			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
 			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
@@ -507,6 +518,31 @@ storageclass.kubernetes.io/is-default-class: "true"
 				d := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "cloud-data-discoverer")
 				Expect(d.Exists()).To(BeFalse())
 			})
+		})
+	})
+
+	Context("GCP with existing CNI secret data", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("cloudProviderGcp", moduleValues)
+			f.ValuesSet("cloudProviderGcp.internal.cniSecretData", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`cni: %s
+flannel: %s
+`,
+				base64.StdEncoding.EncodeToString([]byte("flannel")),
+				base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`)),
+			))))
+			f.HelmRender()
+		})
+
+		It("Should render CNI secret from internal value", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			cniSecret := f.KubernetesResource("Secret", "kube-system", "d8-cni-configuration")
+			Expect(cniSecret.Exists()).To(BeTrue())
+			Expect(cniSecret.Field("data.cni").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte("flannel"))))
+			Expect(cniSecret.Field("data.flannel").String()).To(Equal(base64.StdEncoding.EncodeToString([]byte(`{"podNetworkMode":"host-gw"}`))))
+			Expect(cniSecret.Field("data.cilium").Exists()).To(BeFalse())
 		})
 	})
 

--- a/modules/030-cloud-provider-gcp/templates/cni.yaml
+++ b/modules/030-cloud-provider-gcp/templates/cni.yaml
@@ -1,3 +1,7 @@
+{{- $ciliumConfig := `{
+  "mode": "VXLAN",
+  "masqueradeMode": "BPF"
+}` }}
 ---
 apiVersion: v1
 kind: Secret
@@ -9,5 +13,6 @@ data:
 {{- if hasKey .Values.cloudProviderGcp.internal "cniSecretData" }}
   {{- .Values.cloudProviderGcp.internal.cniSecretData | b64dec | nindent 2 }}
 {{- else }}
-  cni: {{ b64enc "simple-bridge" | quote }}
+  cni: {{ b64enc "cilium" | quote }}
+  cilium: {{ $ciliumConfig | b64enc | quote }}
 {{- end }}

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
@@ -60,22 +60,9 @@ Recommended quotas for a new cluster:
 ## Yandex Cloud integration
 
 {% alert level="warning" %}
-Starting with DKP version 1.76, Yandex Cloud uses the `cilium` CNI by default for new clusters.
+Starting with DKP version 1.76, Yandex Cloud uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
 
-When using CentOS 8, you must explicitly enable the `cni-simple-bridge` module in the `config.yml` file.
-
-{% offtopic title="Example configuration for CentOS 8 in Yandex Cloud..." %}
-
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-simple-bridge
-spec:
-  enabled: true
-```
-
-{% endofftopic %}
+New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
 {% endalert %}
 
 ### Configuring security groups
@@ -87,6 +74,8 @@ Do not delete the default rules that allow for traffic to pass in any direction 
 {% endalert %}
 
 This section provides general guidelines for setting up a security group. Incorrect configuration of security groups may affect the performance of the cluster. Please consult [security group usage details](https://cloud.yandex.com/en/docs/vpc/concepts/security-groups#security-groups-notes) in Yandex Cloud before using it in production environments.
+
+If the cluster uses `cilium` in VXLAN mode, make sure security groups allow inter-node UDP traffic on the ports required for Cilium. For details, see [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html).
 
 1. Find out in which cloud network the Deckhouse Kubernetes Platform cluster is running.
 

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT.md
@@ -62,7 +62,7 @@ Recommended quotas for a new cluster:
 {% alert level="warning" %}
 Starting with DKP version 1.76, Yandex Cloud uses the `cilium` CNI by default for new clusters. Existing clusters keep the current CNI configuration.
 
-New clusters require Linux kernel version `5.8` or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
+New clusters require Linux kernel version 5.8 or newer on all nodes. Make sure firewalls or security groups allow inter-node UDP traffic for Cilium VXLAN. For details, see the [installation requirements](/products/kubernetes-platform/documentation/v1/installing/), [Network interaction of the platform components](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html), and the [`cni-cilium` module documentation](/modules/cni-cilium/).
 {% endalert %}
 
 ### Configuring security groups

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
@@ -60,22 +60,9 @@ description: "Настройка Yandex Cloud для работы облачно
 ## Интеграция с Yandex Cloud
 
 {% alert level="warning" %}
-Начиная с версии DKP 1.76, в Yandex Cloud CNI `cilium` используется по умолчанию для новых кластеров.
+Начиная с версии DKP 1.76, в Yandex Cloud CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-При использовании CentOS 8 необходимо явно включить модуль `cni-simple-bridge` в файле `config.yml`.
-
-{% offtopic title="Пример конфигурации CNI для CentOS 8 в Yandex Cloud..." %}
-
-```yaml
-apiVersion: deckhouse.io/v1alpha1
-kind: ModuleConfig
-metadata:
-  name: cni-simple-bridge
-spec:
-  enabled: true
-```
-
-{% endofftopic %}
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 ### Настройка групп безопасности
@@ -87,6 +74,8 @@ spec:
 {% endalert %}
 
 Ниже приведены общие рекомендации по настройке группы безопасности. Некорректная настройка групп безопасности может сказаться на работоспособности кластера. Пожалуйста, ознакомьтесь с [особенностями работы групп безопасности](https://cloud.yandex.ru/ru/docs/vpc/concepts/security-groups#security-groups-notes) в Yandex Cloud перед использованием в продуктивных средах.
+
+Если в кластере используется `cilium` в режиме VXLAN, убедитесь, что группы безопасности разрешают межузловой UDP-трафик на портах, необходимых Cilium. Подробнее см. [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html).
 
 1. Определите облачную сеть, в которой работает кластер Deckhouse Kubernetes Platform.
 

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
@@ -62,7 +62,7 @@ description: "Настройка Yandex Cloud для работы облачно
 {% alert level="warning" %}
 Начиная с версии DKP 1.76, в Yandex Cloud CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что файрволы и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 ### Настройка групп безопасности

--- a/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
+++ b/modules/030-cloud-provider-yandex/candi/docs/ENVIRONMENT_RU.md
@@ -60,9 +60,11 @@ description: "Настройка Yandex Cloud для работы облачно
 ## Интеграция с Yandex Cloud
 
 {% alert level="warning" %}
-Начиная с версии DKP 1.76, в Yandex Cloud CNI `cilium` используется по умолчанию для новых кластеров. В существующих кластерах текущая конфигурация CNI сохраняется.
+Начиная с DKP 1.77, для новых кластеров в Yandex Cloud по умолчанию используется CNI `cilium`. В существующих кластерах текущая конфигурация CNI сохраняется.
 
-Для новых кластеров требуется ядро Linux версии `5.8` или новее на всех узлах. Также убедитесь, что правила межсетевого экрана и группы безопасности разрешают межузловой UDP-трафик для Cilium VXLAN. Подробнее см. [требования к установке](/products/kubernetes-platform/documentation/v1/installing/), [раздел «Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документацию модуля `cni-cilium`](/modules/cni-cilium/).
+Для новых кластеров на всех узлах требуется ядро Linux версии 5.8 или новее. Также убедитесь, что правила межсетевого экрана разрешают межузловой UDP-трафик, необходимый для работы Cilium VXLAN.
+
+Подробнее в разделах [«Требования к установке»](/products/kubernetes-platform/documentation/v1/installing/), [«Сетевое взаимодействие компонентов платформы»](/products/kubernetes-platform/documentation/v1/reference/network_interaction.html) и [документации модуля `cni-cilium`](/modules/cni-cilium/).
 {% endalert %}
 
 ### Настройка групп безопасности


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Update the default CNI configuration in the `cloud-provider-azure` and `cloud-provider-gcp` modules. The configuration switches from `simple-bridge` to `cilium` using VXLAN tunneling mode and BPF masquerade mode.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously, the default CNI in AWS was `simple-bridge`, which utilized native VPC routing. Moving to Cilium with VXLAN as the default unifies the cluster networking configuration across different infrastructure providers.

By utilizing standard VXLAN encapsulation, we eliminate the dependency on specific cloud routing mechanisms and platform limits (such as VPC Route Table quotas). This approach simplifies cluster operational support and maintenance, providing a single, predictable network profile that behaves identically in Azure, GCP, bare-metal, and other environments.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-azure
type: feature
summary: Migrated to Cilium CNI by default for new clusters.
impact_level: default
---
section: cloud-provider-gcp
type: feature
summary: Migrated to Cilium CNI by default for new clusters.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
