### PR TITLE
[deckhouse] recover from panics in nelm client

### DIFF
--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
@@ -207,20 +208,11 @@ type InstallOptions struct {
 func (c *Client) Install(ctx context.Context, namespace, releaseName string, opts InstallOptions) (err error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "Install")
 	defer span.End()
-
-	defer func() {
-		if r := recover(); r != nil {
-			c.logger.Error("panic in Install",
-				slog.Any("panic", r),
-				slog.String("release", releaseName),
-				slog.String("namespace", namespace),
-				slog.String("path", opts.Path),
-				slog.String("stack", string(debug.Stack())),
-			)
-			err = fmt.Errorf("panic in Install: %v", r)
-			span.SetStatus(codes.Error, err.Error())
-		}
-	}()
+	defer c.recoverPanic("Install", span, &err,
+		slog.String("release", releaseName),
+		slog.String("namespace", namespace),
+		slog.String("path", opts.Path),
+	)
 
 	span.SetAttributes(attribute.String("release", releaseName))
 	span.SetAttributes(attribute.String("namespace", namespace))
@@ -296,20 +288,11 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts InstallOptions) (out string, err error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "Render")
 	defer span.End()
-
-	defer func() {
-		if r := recover(); r != nil {
-			c.logger.Error("panic in Render",
-				slog.Any("panic", r),
-				slog.String("release", releaseName),
-				slog.String("namespace", namespace),
-				slog.String("path", opts.Path),
-				slog.String("stack", string(debug.Stack())),
-			)
-			err = fmt.Errorf("panic in Render: %v", r)
-			span.SetStatus(codes.Error, err.Error())
-		}
-	}()
+	defer c.recoverPanic("Render", span, &err,
+		slog.String("release", releaseName),
+		slog.String("namespace", namespace),
+		slog.String("path", opts.Path),
+	)
 
 	span.SetAttributes(attribute.String("release", releaseName))
 	span.SetAttributes(attribute.String("namespace", namespace))
@@ -381,19 +364,10 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 func (c *Client) Delete(ctx context.Context, namespace, releaseName string) (err error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "Delete")
 	defer span.End()
-
-	defer func() {
-		if r := recover(); r != nil {
-			c.logger.Error("panic in Delete",
-				slog.Any("panic", r),
-				slog.String("release", releaseName),
-				slog.String("namespace", namespace),
-				slog.String("stack", string(debug.Stack())),
-			)
-			err = fmt.Errorf("panic in Delete: %v", r)
-			span.SetStatus(codes.Error, err.Error())
-		}
-	}()
+	defer c.recoverPanic("Delete", span, &err,
+		slog.String("release", releaseName),
+		slog.String("namespace", namespace),
+	)
 
 	span.SetAttributes(attribute.String("release", releaseName))
 	span.SetAttributes(attribute.String("namespace", namespace))
@@ -428,17 +402,10 @@ func (c *Client) Delete(ctx context.Context, namespace, releaseName string) (err
 //
 //nolint:nonamedreturns // named returns required for defer/recover to modify return values
 func (c *Client) getRelease(ctx context.Context, namespace, releaseName string) (result *action.ReleaseGetResultV1, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			c.logger.Error("panic in getRelease",
-				slog.Any("panic", r),
-				slog.String("release", releaseName),
-				slog.String("namespace", namespace),
-				slog.String("stack", string(debug.Stack())),
-			)
-			err = fmt.Errorf("panic in getRelease: %v", r)
-		}
-	}()
+	defer c.recoverPanic("getRelease", nil, &err,
+		slog.String("release", releaseName),
+		slog.String("namespace", namespace),
+	)
 
 	res, err := action.ReleaseGet(ctx, releaseName, namespace, action.ReleaseGetOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
@@ -458,4 +425,27 @@ func (c *Client) getRelease(ctx context.Context, namespace, releaseName string) 
 	}
 
 	return res, nil
+}
+
+// recoverPanic converts a panic recovered from a deferred call into err,
+// logs it with stack trace and the supplied context fields, and marks span
+// (when non-nil) as failed. Must be deferred directly so recover() works.
+func (c *Client) recoverPanic(op string, span trace.Span, err *error, fields ...slog.Attr) {
+	r := recover()
+	if r == nil {
+		return
+	}
+
+	args := make([]any, 0, len(fields)+2)
+	args = append(args, slog.Any("panic", r))
+	for _, f := range fields {
+		args = append(args, f)
+	}
+	args = append(args, slog.String("stack", string(debug.Stack())))
+	c.logger.Error("panic in "+op, args...)
+
+	*err = fmt.Errorf("panic in %s: %v", op, r)
+	if span != nil {
+		span.SetStatus(codes.Error, (*err).Error())
+	}
 }

--- a/deckhouse-controller/internal/nelm/client.go
+++ b/deckhouse-controller/internal/nelm/client.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -200,9 +202,25 @@ type InstallOptions struct {
 }
 
 // Install installs a Helm chart as a release
-func (c *Client) Install(ctx context.Context, namespace, releaseName string, opts InstallOptions) error {
+//
+//nolint:nonamedreturns // named returns required for defer/recover to modify return values
+func (c *Client) Install(ctx context.Context, namespace, releaseName string, opts InstallOptions) (err error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "Install")
 	defer span.End()
+
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("panic in Install",
+				slog.Any("panic", r),
+				slog.String("release", releaseName),
+				slog.String("namespace", namespace),
+				slog.String("path", opts.Path),
+				slog.String("stack", string(debug.Stack())),
+			)
+			err = fmt.Errorf("panic in Install: %v", r)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
 
 	span.SetAttributes(attribute.String("release", releaseName))
 	span.SetAttributes(attribute.String("namespace", namespace))
@@ -273,9 +291,25 @@ func (c *Client) Install(ctx context.Context, namespace, releaseName string, opt
 
 // Render renders a nelm chart to YAML manifests without installing it
 // Returns the rendered manifests as a YAML string
-func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts InstallOptions) (string, error) {
+//
+//nolint:nonamedreturns // named returns required for defer/recover to modify return values
+func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts InstallOptions) (out string, err error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "Render")
 	defer span.End()
+
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("panic in Render",
+				slog.Any("panic", r),
+				slog.String("release", releaseName),
+				slog.String("namespace", namespace),
+				slog.String("path", opts.Path),
+				slog.String("stack", string(debug.Stack())),
+			)
+			err = fmt.Errorf("panic in Render: %v", r)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
 
 	span.SetAttributes(attribute.String("release", releaseName))
 	span.SetAttributes(attribute.String("namespace", namespace))
@@ -342,9 +376,24 @@ func (c *Client) Render(ctx context.Context, namespace, releaseName string, opts
 
 // Delete uninstalls a nelm release
 // Returns nil if the release doesn't exist (idempotent)
-func (c *Client) Delete(ctx context.Context, namespace, releaseName string) error {
+//
+//nolint:nonamedreturns // named returns required for defer/recover to modify return values
+func (c *Client) Delete(ctx context.Context, namespace, releaseName string) (err error) {
 	ctx, span := otel.Tracer(nelmTracer).Start(ctx, "Delete")
 	defer span.End()
+
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("panic in Delete",
+				slog.Any("panic", r),
+				slog.String("release", releaseName),
+				slog.String("namespace", namespace),
+				slog.String("stack", string(debug.Stack())),
+			)
+			err = fmt.Errorf("panic in Delete: %v", r)
+			span.SetStatus(codes.Error, err.Error())
+		}
+	}()
 
 	span.SetAttributes(attribute.String("release", releaseName))
 	span.SetAttributes(attribute.String("namespace", namespace))
@@ -376,7 +425,21 @@ func (c *Client) Delete(ctx context.Context, namespace, releaseName string) erro
 
 // getRelease is a helper method to retrieve a release by name
 // Converts nelm's ReleaseNotFoundError to ErrReleaseNotFound for consistent error handling
-func (c *Client) getRelease(ctx context.Context, namespace, releaseName string) (*action.ReleaseGetResultV1, error) {
+//
+//nolint:nonamedreturns // named returns required for defer/recover to modify return values
+func (c *Client) getRelease(ctx context.Context, namespace, releaseName string) (result *action.ReleaseGetResultV1, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			c.logger.Error("panic in getRelease",
+				slog.Any("panic", r),
+				slog.String("release", releaseName),
+				slog.String("namespace", namespace),
+				slog.String("stack", string(debug.Stack())),
+			)
+			err = fmt.Errorf("panic in getRelease: %v", r)
+		}
+	}()
+
 	res, err := action.ReleaseGet(ctx, releaseName, namespace, action.ReleaseGetOptions{
 		KubeConnectionOptions: common.KubeConnectionOptions{
 			KubeContextCurrent: c.kubeContext,


### PR DESCRIPTION
## Description

Wrap nelm library calls in `internal/nelm/client.go` (`Install` / `Render` / `Delete` / `getRelease`) with a shared `defer recover()` helper that converts a panic into a regular `error`, logs the panic value + stack via slog, and marks the OTEL span as failed. No behavior change on the happy path; affected component — `deckhouse-controller` packages subsystem only.

## Why do we need it, and what problem does it solve?

Nelm is built primarily as a CLI and `panic()`s on internal invariant violations instead of returning an error. We embed it as a Go library, so any such panic propagates up the call stack and crashes the `deckhouse-controller` pod, which then restarts and may re-hit the same `Application` reconcile loop. With the recover wrapper the panic is contained at the nelm boundary, the failing `Application` goes to an Error condition through the normal `status.Service` path, and the controller stays up.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix 
summary: Recover from panics in nelm client.
impact_level: default 
```
