### PR TITLE
[dhctl] Fix static preflights for dhctl run outside install container

### DIFF
--- a/dhctl/pkg/preflight/checks/deckhouse_user.go
+++ b/dhctl/pkg/preflight/checks/deckhouse_user.go
@@ -23,12 +23,14 @@ import (
 
 	libcon "github.com/deckhouse/lib-connection/pkg"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/directoryconfig"
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 )
 
 type DeckhouseUserCheck struct {
 	NodeInterface libcon.Interface
+	dc            *directoryconfig.DirectoryConfig
 }
 
 const DeckhouseUserCheckName preflight.CheckName = "deckhouse-user"
@@ -46,7 +48,7 @@ func (DeckhouseUserCheck) RetryPolicy() preflight.RetryPolicy {
 }
 
 func (c DeckhouseUserCheck) Run(ctx context.Context) error {
-	file, err := template.RenderAndSavePreflightCheckDeckhouseUserScript(nil)
+	file, err := template.RenderAndSavePreflightCheckDeckhouseUserScript(c.dc)
 	if err != nil {
 		return err
 	}
@@ -65,8 +67,8 @@ func (c DeckhouseUserCheck) Run(ctx context.Context) error {
 	return nil
 }
 
-func DeckhouseUser(nodeInterface libcon.Interface) preflight.Check {
-	check := DeckhouseUserCheck{NodeInterface: nodeInterface}
+func DeckhouseUser(nodeInterface libcon.Interface, dc *directoryconfig.DirectoryConfig) preflight.Check {
+	check := DeckhouseUserCheck{NodeInterface: nodeInterface, dc: dc}
 	return preflight.Check{
 		Name:        DeckhouseUserCheckName,
 		Description: check.Description(),

--- a/dhctl/pkg/preflight/checks/localhost.go
+++ b/dhctl/pkg/preflight/checks/localhost.go
@@ -23,12 +23,14 @@ import (
 
 	libcon "github.com/deckhouse/lib-connection/pkg"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/directoryconfig"
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/template"
 )
 
 type LocalhostDomainCheck struct {
 	NodeInterface libcon.Interface
+	dc            *directoryconfig.DirectoryConfig
 }
 
 const LocalhostDomainCheckName preflight.CheckName = "resolve-localhost"
@@ -46,7 +48,7 @@ func (LocalhostDomainCheck) RetryPolicy() preflight.RetryPolicy {
 }
 
 func (c LocalhostDomainCheck) Run(ctx context.Context) error {
-	file, err := template.RenderAndSavePreflightCheckLocalhostScript(nil)
+	file, err := template.RenderAndSavePreflightCheckLocalhostScript(c.dc)
 	if err != nil {
 		return err
 	}
@@ -65,8 +67,8 @@ func (c LocalhostDomainCheck) Run(ctx context.Context) error {
 	return nil
 }
 
-func LocalhostDomain(nodeInterface libcon.Interface) preflight.Check {
-	check := LocalhostDomainCheck{NodeInterface: nodeInterface}
+func LocalhostDomain(nodeInterface libcon.Interface, dc *directoryconfig.DirectoryConfig) preflight.Check {
+	check := LocalhostDomainCheck{NodeInterface: nodeInterface, dc: dc}
 	return preflight.Check{
 		Name:        LocalhostDomainCheckName,
 		Description: check.Description(),

--- a/dhctl/pkg/preflight/checks/ports.go
+++ b/dhctl/pkg/preflight/checks/ports.go
@@ -23,6 +23,7 @@ import (
 
 	libcon "github.com/deckhouse/lib-connection/pkg"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/directoryconfig"
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/helper"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
@@ -31,6 +32,7 @@ import (
 
 type PortsCheck struct {
 	SSHProviderInitializer *providerinitializer.SSHProviderInitializer
+	dc                     *directoryconfig.DirectoryConfig
 }
 
 const PortsCheckName preflight.CheckName = "ports-availability"
@@ -52,11 +54,11 @@ func (c PortsCheck) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return checkAvailabilityPorts(ctx, nodeInterface)
+	return checkAvailabilityPorts(ctx, nodeInterface, c.dc)
 }
 
-func checkAvailabilityPorts(ctx context.Context, nodeInterface libcon.Interface) error {
-	file, err := template.RenderAndSavePreflightCheckPortsScript(nil)
+func checkAvailabilityPorts(ctx context.Context, nodeInterface libcon.Interface, dc *directoryconfig.DirectoryConfig) error {
+	file, err := template.RenderAndSavePreflightCheckPortsScript(dc)
 	if err != nil {
 		return err
 	}
@@ -79,8 +81,8 @@ func checkAvailabilityPorts(ctx context.Context, nodeInterface libcon.Interface)
 	return nil
 }
 
-func Ports(sshProviderInitializer *providerinitializer.SSHProviderInitializer) preflight.Check {
-	check := PortsCheck{SSHProviderInitializer: sshProviderInitializer}
+func Ports(sshProviderInitializer *providerinitializer.SSHProviderInitializer, dc *directoryconfig.DirectoryConfig) preflight.Check {
+	check := PortsCheck{SSHProviderInitializer: sshProviderInitializer, dc: dc}
 	return preflight.Check{
 		Name:        PortsCheckName,
 		Description: check.Description(),

--- a/dhctl/pkg/preflight/checks/ports_test.go
+++ b/dhctl/pkg/preflight/checks/ports_test.go
@@ -72,7 +72,7 @@ func TestCheckAvailabilityPorts(t *testing.T) {
 			mockScript := &mocks.MockScript{}
 			tt.setupMock(mockNode, mockScript)
 
-			err := checkAvailabilityPorts(context.Background(), mockNode)
+			err := checkAvailabilityPorts(context.Background(), mockNode, nil)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)

--- a/dhctl/pkg/preflight/checks/ssh_tunnel.go
+++ b/dhctl/pkg/preflight/checks/ssh_tunnel.go
@@ -27,6 +27,7 @@ import (
 	"github.com/deckhouse/lib-connection/pkg/ssh"
 	"github.com/deckhouse/lib-connection/pkg/ssh/utils"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/directoryconfig"
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/helper"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
@@ -35,6 +36,7 @@ import (
 
 type SSHTunnelCheck struct {
 	SSHProviderInitializer *providerinitializer.SSHProviderInitializer
+	dc                     *directoryconfig.DirectoryConfig
 }
 
 const (
@@ -67,11 +69,11 @@ func (c SSHTunnelCheck) Run(ctx context.Context) error {
 	if !ok {
 		return nil
 	}
-	checkScript, err := template.RenderAndSavePreflightReverseTunnelOpenScript(healthURL(defaultTunnelRemotePort), nil)
+	checkScript, err := template.RenderAndSavePreflightReverseTunnelOpenScript(healthURL(defaultTunnelRemotePort), c.dc)
 	if err != nil {
 		return fmt.Errorf("render reverse tunnel script: %w", err)
 	}
-	killScript, err := template.RenderAndSaveKillReverseTunnelScript(localhost, strconv.Itoa(defaultTunnelRemotePort), nil)
+	killScript, err := template.RenderAndSaveKillReverseTunnelScript(localhost, strconv.Itoa(defaultTunnelRemotePort), c.dc)
 	if err != nil {
 		return fmt.Errorf("render kill tunnel script: %w", err)
 	}
@@ -141,8 +143,8 @@ func startHTTPServer(ctx context.Context, port int) (shutdownServerFunc, error) 
 	return func() { _ = server.Shutdown(ctx) }, nil
 }
 
-func SSHTunnel(sshProviderInitializer *providerinitializer.SSHProviderInitializer) preflight.Check {
-	check := SSHTunnelCheck{SSHProviderInitializer: sshProviderInitializer}
+func SSHTunnel(sshProviderInitializer *providerinitializer.SSHProviderInitializer, dc *directoryconfig.DirectoryConfig) preflight.Check {
+	check := SSHTunnelCheck{SSHProviderInitializer: sshProviderInitializer, dc: dc}
 	return preflight.Check{
 		Name:        SSHTunnelCheckName,
 		Description: check.Description(),

--- a/dhctl/pkg/preflight/suites/static.go
+++ b/dhctl/pkg/preflight/suites/static.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config/directoryconfig"
 	preflight "github.com/deckhouse/deckhouse/dhctl/pkg/preflight"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/preflight/checks"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/helper"
@@ -34,19 +35,24 @@ type StaticDeps struct {
 
 func NewStaticSuite(deps StaticDeps, ctx context.Context) (preflight.Suite, error) {
 	nodeInterface, err := helper.GetNodeInterface(ctx, deps.SSHProviderInitializer, deps.SSHProviderInitializer.GetSettings())
+	dc := &directoryconfig.DirectoryConfig{
+		DownloadDir:      deps.MetaConfig.DownloadRootDir,
+		DownloadCacheDir: deps.MetaConfig.DownloadCacheDir,
+	}
+
 	return preflight.NewSuite(
 		checks.CidrIntersectionStatic(deps.MetaConfig),
 		checks.StaticInstancesIPDuplication(deps.MetaConfig),
 		checks.SingleSSHHost(deps.SSHProviderInitializer),
 		checks.SSHCredential(deps.SSHProviderInitializer),
-		checks.SSHTunnel(deps.SSHProviderInitializer),
+		checks.SSHTunnel(deps.SSHProviderInitializer, dc),
 		checks.StaticInstancesSSHCredentials(deps.MetaConfig, deps.SSHProviderInitializer),
-		checks.DeckhouseUser(nodeInterface),
+		checks.DeckhouseUser(nodeInterface, dc),
 		checks.StaticSystemRequirements(deps.SSHProviderInitializer),
 		checks.Python(nodeInterface),
 		checks.RegistryProxy(deps.MetaConfig, deps.SSHProviderInitializer, deps.LegacyMode),
-		checks.Ports(deps.SSHProviderInitializer),
-		checks.LocalhostDomain(nodeInterface),
+		checks.Ports(deps.SSHProviderInitializer, dc),
+		checks.LocalhostDomain(nodeInterface, dc),
 		checks.SudoAllowed(nodeInterface),
 		checks.TimeDrift(nodeInterface),
 	), err


### PR DESCRIPTION
## Description

Fix static preflights for dhctl run outside an install container

## Why do we need it, and what problem does it solve?

If we're running bootstrap process outside an install container, some preflight checks are failed to render templates due to lack of DirectorConfig propagation.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix static preflights for dhctl run outside an install container.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
