### PR TITLE
[deckhouse] Validate AP and APV draft in webhook

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
@@ -50,6 +50,11 @@ func applicationValidationHandler(cli client.Client, manager packageManager) htt
 			return allowResult(nil)
 		}
 
+		ap := new(v1alpha1.ApplicationPackage)
+		if err := cli.Get(ctx, client.ObjectKey{Name: app.Spec.PackageName}, ap); err != nil {
+			return rejectResult(fmt.Sprintf("get application package: %v", err))
+		}
+
 		name := apps.BuildName(app.Namespace, app.Name)
 
 		res, err := manager.ValidateSettings(ctx, name, app.Spec.Settings.GetMap())
@@ -100,6 +105,10 @@ func validateAppAgainstApv(ctx context.Context, cli client.Client, manager packa
 	apv := new(v1alpha1.ApplicationPackageVersion)
 	if err := cli.Get(ctx, client.ObjectKey{Name: name}, apv); err != nil {
 		return fmt.Errorf("get application package version: %w", err)
+	}
+
+	if apv.IsDraft() {
+		return fmt.Errorf("application package version '%s' is draft", name)
 	}
 
 	if err := validateAppSettings(apv, app); err != nil {

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -200,8 +200,6 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, app *v1alpha1.App
 	if err := r.client.Get(ctx, client.ObjectKey{Name: app.Spec.PackageName}, ap); err != nil {
 		logger.Debug("application package not found", slog.String("package", app.Spec.PackageName), log.Err(err))
 
-		// TODO: Completed = "false"
-
 		return fmt.Errorf("get application package '%s': %w", app.Spec.PackageName, err)
 	}
 
@@ -213,16 +211,12 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, app *v1alpha1.App
 	if err := r.client.Get(ctx, client.ObjectKey{Name: apvName}, apv); err != nil {
 		logger.Debug("application package version not found", slog.String("apv", apvName), log.Err(err))
 
-		// TODO: Completed = "false"
-
 		return fmt.Errorf("get application package version '%s': %w", apv.Name, err)
 	}
 
 	// check if application package version is not draft
 	if apv.IsDraft() {
 		logger.Debug("application package version is in draft", slog.String("apv", apvName))
-
-		// TODO: Completed = "false"
 
 		return fmt.Errorf("application package version '%s' is draft", apvName)
 	}
@@ -327,8 +321,6 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, app *v1alpha1.App
 		},
 		Settings: app.Spec.Settings.GetMap(),
 	})
-
-	// TODO: Completed = "true"
 
 	// set finalizer if it is not set
 	if !controllerutil.ContainsFinalizer(app, v1alpha1.ApplicationFinalizerStatisticRegistered) {

--- a/deckhouse-controller/pkg/controller/packages/application/controller_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller_test.go
@@ -299,8 +299,6 @@ func (suite *ControllerTestSuite) TestReconcile() {
 			NamespacedName: client.ObjectKey{Name: app.Name, Namespace: app.Namespace},
 		})
 		require.NoError(suite.T(), err)
-		app = suite.getApplication("test-app", "foobar")
-		// TODO: Completed = "false" // require conditions with reason VersionNotFound
 	})
 
 	suite.Run("version is draft", func() {


### PR DESCRIPTION

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Validate AP and APV draft in webhook

### 1. `ApplicationPackage` does not exist

```console
$ cat <<'EOF' | k apply -f -
apiVersion: deckhouse.io/v1alpha1
kind: Application
metadata:
  name: test-missing-ap
spec:
  packageName: does-not-exist
  packageRepositoryName: test
  packageVersion: v1.0.1
  settings:
    replicas: 1
    triggersEnabled: false
EOF
Error from server: error when creating "STDIN": admission webhook "applications.deckhouse-webhook.deckhouse.io" denied the request: get application package: ApplicationPackage.deckhouse.io "does-not-exist" not found
```

### 2. `ApplicationPackageVersion` is in draft

```console
$ k label apv test-artem-test-v1.0.1 packages.deckhouse.io/draft=true --overwrite
applicationpackageversion.deckhouse.io/test-artem-test-v1.0.1 labeled

$ cat <<'EOF' | k apply -f -
apiVersion: deckhouse.io/v1alpha1
kind: Application
metadata:
  name: test-draft
spec:
  packageName: artem-test
  packageRepositoryName: test
  packageVersion: v1.0.1
  settings:
    replicas: 1
    triggersEnabled: false
EOF
Error from server: error when creating "STDIN": admission webhook "applications.deckhouse-webhook.deckhouse.io" denied the request: application package version 'test-artem-test-v1.0.1' is draft
```
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: chore
summary: Validate AP and APV draft in webhook.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
