### PR TITLE
[docs] Fix domains list in the getting started

### DIFF
--- a/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS.liquid
+++ b/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS.liquid
@@ -32,6 +32,7 @@
           <li><b title="E.g., <em>&quot;openvpn-admin-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">openvpn-admin</b></li>
           <li><b title="E.g., <em>&quot;prometheus-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">prometheus</b></li>
           <li><b title="E.g., <em>&quot;status-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">status</b></li>
+          <li><b title="E.g., <em>&quot;stronghold.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">stronghold</b></li>
           <li><b title="E.g., <em>&quot;tools-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">tools</b></li>
           <li><b title="E.g., <em>&quot;upmeter-kube.company.my&quot;</em><br>for the <em>&quot;%s-kube.company.my&quot; template</em>">upmeter</b></li>
         </ul>

--- a/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS_RU.liquid
+++ b/docs/site/_includes/getting_started/global/partials/DNS_OPTIONS_RU.liquid
@@ -31,7 +31,8 @@
           <li><b title="Например, <em>&quot;openvpn-admin-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">openvpn-admin</b></li>
           <li><b title="Например, <em>&quot;prometheus-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">prometheus</b></li>
           <li><b title="Например, <em>&quot;status-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">status</b></li>
-          <li><b title="Например, <em>&quot;tools-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">tools</b></li>          
+          <li><b title="Например, <em>&quot;stronghold.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">stronghold</b></li>
+          <li><b title="Например, <em>&quot;tools-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">tools</b></li>
           <li><b title="Например, <em>&quot;upmeter-kube.company.my&quot;</em><br>для шаблона <em>&quot;%s-kube.company.my&quot;</em>">upmeter</b></li>
         </ul>
         {%- if page.platform_code == 'aws' %}<p>Получить адрес балансировщика:


### PR DESCRIPTION
## Description
Updated the Quick Start documentation for manual DNS configuration.

Added the full list of Deckhouse service DNS names that must be configured when using a non-wildcard publicDomainTemplate, to make the manual DNS setup steps clearer.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Fix domains list in the getting started.
impact_level: low
```