### PR TITLE
[dhctl] Fix panic in in-cluster converge-migration

### DIFF
--- a/dhctl/pkg/operations/converge/controller/master_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/master_node_group.go
@@ -64,6 +64,10 @@ func (c *MasterNodeGroupController) populateNodeToHost(ctx *context.Context) err
 		return nil
 	}
 
+	if ctx.SSHProviderInitializer == nil {
+		return nil
+	}
+
 	var userPassedHosts []session.Host
 	sshProvider, err := ctx.SSHProviderInitializer.GetSSHProvider(ctx.Ctx())
 	if err != nil {

--- a/dhctl/pkg/system/providerinitializer/initializer.go
+++ b/dhctl/pkg/system/providerinitializer/initializer.go
@@ -75,6 +75,10 @@ func NewSSHProviderInitializer(baseProviderSettings *settings.BaseProviders, con
 }
 
 func (i *SSHProviderInitializer) GetSSHProvider(_ context.Context) (libcon.SSHProvider, error) {
+	if i == nil {
+		return nil, nil
+	}
+
 	i.mut.Lock()
 	defer i.mut.Unlock()
 
@@ -102,6 +106,10 @@ func (i *SSHProviderInitializer) Cleanup(ctx context.Context) error {
 }
 
 func (i *SSHProviderInitializer) GetKubeProvider(ctx context.Context) libcon.KubeProvider {
+	if i == nil {
+		return nil
+	}
+
 	cfg := &kube.Config{}
 	runnerInterface, err := provider.GetRunnerInterface(ctx, cfg, i.baseProviderSettings, i)
 	if err != nil {
@@ -129,6 +137,10 @@ func (i *SSHProviderInitializer) IsLegacyMode() bool {
 }
 
 func (i *SSHProviderInitializer) CheckHosts() bool {
+	if i == nil {
+		return false
+	}
+
 	if i.config != nil {
 		if len(i.config.Hosts) > 0 {
 			return true

--- a/dhctl/pkg/system/providerinitializer/initializer.go
+++ b/dhctl/pkg/system/providerinitializer/initializer.go
@@ -119,11 +119,19 @@ func (i *SSHProviderInitializer) GetKubeProvider(ctx context.Context) libcon.Kub
 }
 
 func (i *SSHProviderInitializer) GetSettings() *settings.BaseProviders {
-	return i.baseProviderSettings
+	if i != nil {
+		return i.baseProviderSettings
+	}
+
+	return nil
 }
 
 func (i *SSHProviderInitializer) GetConfig() *sshconfig.ConnectionConfig {
-	return i.config
+	if i != nil {
+		return i.config
+	}
+
+	return nil
 }
 
 // IsLegacyMode reports whether the connection config opts the SSH backend


### PR DESCRIPTION
## Description

Fix panic in in-cluster converge-migration

## Why do we need it, and what problem does it solve?

In-cluster converge-mirgation panics now due to call of `ctx.SSHProviderInitializer.GetSSHProvider` in populateNodeToHost, what is `nil` if we run it w/o SSH.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fix panic in in-cluster converge-migration run of dhctl.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
