### PR TITLE
[dhctl] stronghold waiter fix for #19793

### DIFF
--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/stronghold.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/stronghold.go
@@ -31,10 +31,10 @@ const (
 )
 
 type StrongholdReadinessChecker struct {
-	getter kubernetes.KubeClientProviderWithCtx
+	getter kubernetes.KubeClientProvider
 }
 
-func NewStrongholdReadinessChecker(getter kubernetes.KubeClientProviderWithCtx) *StrongholdReadinessChecker {
+func NewStrongholdReadinessChecker(getter kubernetes.KubeClientProvider) *StrongholdReadinessChecker {
 	return &StrongholdReadinessChecker{
 		getter: getter,
 	}
@@ -44,12 +44,9 @@ func NewStrongholdReadinessChecker(getter kubernetes.KubeClientProviderWithCtx) 
 // The nodeName parameter is ignored because the check is cluster-wide.
 // Returns true (skip) when the d8-stronghold namespace or the StatefulSet does not exist.
 func (c *StrongholdReadinessChecker) IsReady(ctx context.Context, _ string) (bool, error) {
-	kubeClient, err := c.getter.KubeClientCtx(ctx)
-	if err != nil {
-		return false, fmt.Errorf("could not get kube client: %w", err)
-	}
+	kubeClient := c.getter.KubeClient()
 
-	_, err = kubeClient.CoreV1().Namespaces().Get(ctx, strongholdNamespace, metav1.GetOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Get(ctx, strongholdNamespace, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.DebugLn("Namespace d8-stronghold not found, skipping Stronghold readiness check")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix wrong usage of KubeClientProviderWithCtx instead of KubeClientProvider

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: fix wrong usage of KubeClientProviderWithCtx instead of KubeClientProvider from main
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
