### PR TITLE
[docs] Update terraform-manager description

### DIFF
--- a/modules/040-terraform-manager/docs/CONFIGURATION_RU.md
+++ b/modules/040-terraform-manager/docs/CONFIGURATION_RU.md
@@ -1,6 +1,6 @@
 ---
 title: "Модуль terraform-manager: настройки"
-description: Параметры модуля terraform-manager. 
+description: Параметры модуля terraform-manager Deckhouse. 
 ---
 
 <!-- SCHEMA -->

--- a/modules/040-terraform-manager/docs/CONFIGURATION_RU.md
+++ b/modules/040-terraform-manager/docs/CONFIGURATION_RU.md
@@ -1,6 +1,6 @@
 ---
 title: "Модуль terraform-manager: настройки"
-description: Параметры модуля terraform-manager Deckhouse. 
+description: Параметры модуля terraform-manager. 
 ---
 
 <!-- SCHEMA -->

--- a/modules/040-terraform-manager/docs/README.md
+++ b/modules/040-terraform-manager/docs/README.md
@@ -3,7 +3,8 @@ title: "The terraform-manager module"
 description: Description of the Deckhouse terraform-manager module. Ensures that the objects in the cluster correspond to the Terraform state.
 ---
 
-The module provide tools for working with Terraform in the Kubernetes cluster.
+The module is responsible for monitoring and synchronizing the state of the underlying infrastructure and persistent nodes in the cloud environment.
+The implementation is based on Terraform and is used in the Deckhouse Kubernetes Platform for interaction with supported cloud providers.
 
 * The module consists of 2 parts:
   * `terraform-auto-converger` — checks the Terraform state and applies non-destructive changes;

--- a/modules/040-terraform-manager/docs/README.md
+++ b/modules/040-terraform-manager/docs/README.md
@@ -1,6 +1,6 @@
 ---
 title: "The terraform-manager module"
-description: Description of the Deckhouse terraform-manager module. Ensures that the objects in the cluster correspond to the Terraform state.
+description: Description of the Deckhouse Kubernetes Platform terraform-manager module. Ensures that the objects in the cluster correspond to the Terraform state.
 ---
 
 The module is responsible for monitoring and synchronizing the state of the underlying infrastructure and persistent nodes in the cloud environment.

--- a/modules/040-terraform-manager/docs/README_RU.md
+++ b/modules/040-terraform-manager/docs/README_RU.md
@@ -3,12 +3,13 @@ title: "Модуль terraform-manager"
 description: Описание модуля terraform-manager Deckhouse. Модуль следит за приведением объектов в кластере к состоянию, описанному в Terraform state.   
 ---
 
-Модуль предоставляет инструменты для работы с состоянием Terraform'а в кластере Kubernetes.
+Модуль отвечает за отслеживание и синхронизацию состояния базовой инфраструктуры и постоянных узлов в облачной среде.
+Реализация основана на Terraform и применяется в Deckhouse Kubernetes Platform для взаимодействия с поддерживаемыми облачными провайдерами.
 
 * Модуль состоит из двух частей:
-  * `terraform-auto-converger` — проверяет состояние Terraform'а и применяет недеструктивные изменения;
-  * `terraform-state-exporter` — проверяет состояние Terraform'а и экспортирует метрики кластера.
+  * `terraform-auto-converger` — проверяет состояние Terraform и применяет недеструктивные изменения;
+  * `terraform-state-exporter` — проверяет состояние Terraform и экспортирует метрики кластера.
 
-* Модуль включен по умолчанию, если в кластере есть Secret'ы:
+* Модуль включен по умолчанию, если в кластере есть секреты:
   * `kube-system/d8-provider-cluster-configuration`;
   * `d8-system/d8-cluster-terraform-state`.

--- a/modules/040-terraform-manager/docs/README_RU.md
+++ b/modules/040-terraform-manager/docs/README_RU.md
@@ -1,6 +1,6 @@
 ---
 title: "Модуль terraform-manager"
-description: Описание модуля terraform-manager Deckhouse. Модуль следит за приведением объектов в кластере к состоянию, описанному в Terraform state.   
+description: Описание модуля terraform-manager Deckhouse Kubernetes Platform. Модуль следит за приведением объектов в кластере к состоянию, описанному в Terraform state.   
 ---
 
 Модуль отвечает за отслеживание и синхронизацию состояния базовой инфраструктуры и постоянных узлов в облачной среде.

--- a/modules/040-terraform-manager/openapi/doc-ru-config-values.yaml
+++ b/modules/040-terraform-manager/openapi/doc-ru-config-values.yaml
@@ -16,6 +16,6 @@ properties:
       Если значение не указано или указано `false`, будет использоваться [автоматика](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).
   tolerations:
     description: |
-      Структура, аналогичная`spec.tolerations` пода Kubernetes.
+      Структура, аналогичная `spec.tolerations` пода Kubernetes.
 
       Если значение не указано или указано `false`, будет использоваться [автоматика](https://deckhouse.ru/products/kubernetes-platform/documentation/v1/#выделение-узлов-под-определенный-вид-нагрузки).


### PR DESCRIPTION
## Description
Updates the module description to better reflect its purpose and implementation. The wording is clarified to avoid suggesting direct Terraform usage in Kubernetes and to more accurately describe the module’s role in tracking and synchronizing infrastructure state in Deckhouse Kubernetes Platform.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Update terraform-manager description
impact_level: low
```
