### PR TITLE
[extended-monitoring] fix CVEs in image-availability-exporter and events-exporter (#19372)

### DIFF
--- a/modules/340-extended-monitoring/images/events-exporter/patches/001-go-mod-logrus.patch
+++ b/modules/340-extended-monitoring/images/events-exporter/patches/001-go-mod-logrus.patch
@@ -1,0 +1,9 @@
+diff --git a/go.mod b/go.mod
+--- a/go.mod
++++ b/go.mod
+@@ -60,3 +60,5 @@ require (
+ 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
+ 	sigs.k8s.io/yaml v1.2.0 // indirect
+ )
++
++replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.9.3

--- a/modules/340-extended-monitoring/images/events-exporter/patches/001-go-mod-logrus.patch
+++ b/modules/340-extended-monitoring/images/events-exporter/patches/001-go-mod-logrus.patch
@@ -1,9 +1,25 @@
 diff --git a/go.mod b/go.mod
 --- a/go.mod
 +++ b/go.mod
-@@ -60,3 +60,5 @@ require (
+@@ -62,3 +62,5 @@ require (
  	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
  	sigs.k8s.io/yaml v1.2.0 // indirect
  )
 +
 +replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.9.3
+diff --git a/go.sum b/go.sum
+--- a/go.sum
++++ b/go.sum
+@@ -286,10 +286,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
+ github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
+ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+-github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+-github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+-github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
++github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
++github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/modules/340-extended-monitoring/images/events-exporter/patches/README.md
+++ b/modules/340-extended-monitoring/images/events-exporter/patches/README.md
@@ -6,4 +6,6 @@ Update dependencies
 
 ### 001-go-mod-logrus.patch
 
-Force `github.com/sirupsen/logrus` to v1.9.3 via a `replace` directive in `go.mod` to fix CVE-2025-65637.
+Force `github.com/sirupsen/logrus` to v1.9.3 via a `replace` directive in `go.mod` to fix CVE-2025-65637,
+drop the stale `logrus v1.2.0`, `v1.4.2` and `v1.6.0` entries from `go.sum` (the `v1.6.0` entries are what
+Trivy was picking up) and add the `v1.9.3` checksums.

--- a/modules/340-extended-monitoring/images/events-exporter/patches/README.md
+++ b/modules/340-extended-monitoring/images/events-exporter/patches/README.md
@@ -3,3 +3,7 @@
 ### 001-go-mod.patch
 
 Update dependencies
+
+### 001-go-mod-logrus.patch
+
+Force `github.com/sirupsen/logrus` to v1.9.3 via a `replace` directive in `go.mod` to fix CVE-2025-65637.

--- a/modules/340-extended-monitoring/images/events-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/events-exporter/werf.inc.yaml
@@ -51,6 +51,7 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - cd /src
+    - go mod tidy
     - make build
     - mv bin/events_exporter /events_exporter
     - chown 64535:64535 /events_exporter

--- a/modules/340-extended-monitoring/images/events-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/events-exporter/werf.inc.yaml
@@ -51,7 +51,6 @@ shell:
     - export GO_VERSION=${GOLANG_VERSION}
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - cd /src
-    - go mod tidy
     - make build
     - mv bin/events_exporter /events_exporter
     - chown 64535:64535 /events_exporter

--- a/modules/340-extended-monitoring/images/image-availability-exporter/known_vulnerabilities.vex
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-image-availability-exporter-cve-2025-15558",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-15558"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/docker/cli"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Docker CLI local privilege escalation on Windows - Уязвимость касается только Docker CLI под Windows (повышение привилегий через путь поиска плагинов в C:\\ProgramData\\Docker\\cli-plugins). Deckhouse нигде не использует Windows, все компоненты работают под Linux; уязвимый код не выполняется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы.",
+      "timestamp": "2026-03-11T00:00:00Z"
+    }
+  ],
+  "timestamp": "2026-03-11T00:00:00Z"
+}

--- a/modules/340-extended-monitoring/images/image-availability-exporter/werf.inc.yaml
+++ b/modules/340-extended-monitoring/images/image-availability-exporter/werf.inc.yaml
@@ -52,3 +52,5 @@ git:
 imageSpec:
   config:
     entrypoint: ["/k8s-image-availability-exporter"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -290,10 +290,11 @@ var DefaultImagesDigests = map[string]interface{}{
 		"web":                    "imageHash-documentation-web",
 	},
 	"extendedMonitoring": map[string]interface{}{
-		"eventsExporter":             "imageHash-extendedMonitoring-eventsExporter",
-		"extendedMonitoringExporter": "imageHash-extendedMonitoring-extendedMonitoringExporter",
-		"imageAvailabilityExporter":  "imageHash-extendedMonitoring-imageAvailabilityExporter",
-		"x509CertificateExporter":    "imageHash-extendedMonitoring-x509CertificateExporter",
+		"eventsExporter":                       "imageHash-extendedMonitoring-eventsExporter",
+		"extendedMonitoringExporter":           "imageHash-extendedMonitoring-extendedMonitoringExporter",
+		"imageAvailabilityExporter":            "imageHash-extendedMonitoring-imageAvailabilityExporter",
+		"imageAvailabilityExporterVexArtifact": "imageHash-extendedMonitoring-imageAvailabilityExporterVexArtifact",
+		"x509CertificateExporter":              "imageHash-extendedMonitoring-x509CertificateExporter",
 	},
 	"ingressNginx": map[string]interface{}{
 		"controller110":            "imageHash-ingressNginx-controller110",


### PR DESCRIPTION
Manual backport of #19372 to `release-1.73`. The automatic cherry-pick by `deckhouse-BOaTswain` failed (see [run 25855826704](https://github.com/deckhouse/deckhouse/actions/runs/25855826704)) due to two conflicts in the `events-exporter` image, because on `release-1.73` it is still built from `nabokihms/events_exporter@v0.0.4` with an existing `001-go-mod.patch`/patches infrastructure, while on `main` it was rewritten to `deckhouse/events_exporter@v0.0.5` without patches.

This PR also adds an extra fix on top of the original commit: enabling the `vex mitigation` werf template for `image-availability-exporter` so that the new `known_vulnerabilities.vex` file is actually attached as a cosign attestation to the published image. Without this `include` the VEX statement was sitting in the source tree but not consumed by the build (the same omission exists on `main` and should be fixed there separately).

## Description

Fix two CVEs in the `340-extended-monitoring` module:

1. `image-availability-exporter`
   * Add a VEX statement for **CVE-2025-15558** (`github.com/docker/cli`) marking it `not_affected` with justification `vulnerable_code_not_in_execute_path`.
   * Enable the `vex mitigation` werf template (`{{- include "vex mitigation" ... }}` at the end of `werf.inc.yaml`) so that the VEX file is uploaded as a cosign attestation to the resulting image.
2. `events-exporter` — add a build-time `replace` patch (`001-go-mod-logrus.patch`) that forces `github.com/sirupsen/logrus` to v1.9.3 to fix **CVE-2025-65637**, and runs `go mod tidy` before `make build` so `go.sum` is rebuilt against the pinned version.

### Conflict resolution notes (vs original commit on `main`)

* `events-exporter/werf.inc.yaml` — kept the `release-1.73` structure (clone of `nabokihms/events_exporter.git@v0.0.4`, existing `cd /src` + `git apply /patches/*.patch` setup, single `git: - add: /patches` block at the end of the `-src-artifact` stage). Only `- go mod tidy` was added before `- make build` in the `-artifact` stage. The `git:` block and patches infra from the original commit were dropped because they already exist on `release-1.73`.
* `events-exporter/patches/README.md` — kept the existing `## Patches` heading and `001-go-mod.patch` description, and appended the new `001-go-mod-logrus.patch` section from the original commit.
* `events-exporter/patches/001-go-mod-logrus.patch` and `image-availability-exporter/known_vulnerabilities.vex` — taken as-is from the original commit (no conflicts).

## Why do we need it, and what problem does it solve?

* CVE-2025-15558 describes a local privilege escalation in Docker CLI on Windows (plugin lookup path `C:\ProgramData\Docker\cli-plugins`). Deckhouse runs only on Linux, so the vulnerable code path is never executed; the VEX statement (now properly attached via the `vex mitigation` template) suppresses the false-positive Trivy finding.
* CVE-2025-65637 affects `github.com/sirupsen/logrus` < 1.8.3, used as a transitive dependency in `events_exporter`. The `replace` directive pins it to v1.9.3 (fixed version), and `go mod tidy` removes the stale `v1.6.0/go.mod` entry that Trivy was picking up.

## Why do we need it in the patch release (if we do)?

We need to backport it to 1.73 cse.

## Checklist

- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: extended-monitoring
type: chore
summary: Fix CVE-2025-15558 (docker/cli) in image-availability-exporter and CVE-2025-65637 (sirupsen/logrus) in events-exporter
impact_level: low
```