### PR TITLE
[istio] Add ambient waypoint support

### DIFF
--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -133,7 +133,16 @@ const istioValues = `
         type: "Text"
         textFormat: '[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% "%UPSTREAM_TRANSPORT_FAILURE_REASON%" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%" %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%'
       ztunnel:
-        resourcesManagement: {}
+        resourcesManagement:
+          mode: VPA
+          vpa:
+            mode: InPlaceOrRecreate
+            cpu:
+              max: "1"
+              min: "25m"
+            memory:
+              max: "2Gi"
+              min: "64Mi"
     ambient:
       enabled: false
 `

--- a/modules/110-istio/templates/_helpers.tpl
+++ b/modules/110-istio/templates/_helpers.tpl
@@ -1,8 +1,39 @@
+{{- define "istioCloudPlatform" -}}
+{{- $supportedProviders := list "aws" "gcp" "azure" -}}
+{{- if and (.Values.global.clusterConfiguration) (hasKey .Values.global.clusterConfiguration "cloud") -}}
+{{- $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower -}}
+{{- if has $currentProvider $supportedProviders -}}
+{{- $currentProvider -}}
+{{- else -}}
+{{- "none" -}}
+{{- end -}}
+{{- else -}}
+{{- "none" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "istioGlobalRevision" -}}
+{{- $version := $.Values.istio.internal.globalVersion -}}
+{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+{{- get $versionInfo "revision" -}}
+{{- end -}}
+
+{{- define "istioImageSuffix" -}}
+{{- $version := $.Values.istio.internal.globalVersion -}}
+{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+{{- get $versionInfo "imageSuffix" -}}
+{{- end -}}
+
 {{- define "istioJWTPolicy" -}}
-    third-party-jwt
-{{- end }}
+third-party-jwt
+{{- end -}}
 
 {{- define "istioNetworkName" -}}
-  {{- $context := . -}}
-  network-{{ $context.Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
-{{- end }}
+network-{{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+{{- end -}}
+
+{{- define "istioSupportsAmbient" -}}
+{{- $version := $.Values.istio.internal.globalVersion -}}
+{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+{{- if get $versionInfo "supportsAmbient" -}}true{{- end -}}
+{{- end -}}

--- a/modules/110-istio/templates/_helpers.tpl
+++ b/modules/110-istio/templates/_helpers.tpl
@@ -1,39 +1,41 @@
 {{- define "istioCloudPlatform" -}}
-{{- $supportedProviders := list "aws" "gcp" "azure" -}}
-{{- if and (.Values.global.clusterConfiguration) (hasKey .Values.global.clusterConfiguration "cloud") -}}
-{{- $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower -}}
-{{- if has $currentProvider $supportedProviders -}}
-{{- $currentProvider -}}
-{{- else -}}
-{{- "none" -}}
-{{- end -}}
-{{- else -}}
-{{- "none" -}}
-{{- end -}}
+  {{- $supportedProviders := list "aws" "gcp" "azure" -}}
+  {{- if and (.Values.global.clusterConfiguration) (hasKey .Values.global.clusterConfiguration "cloud") -}}
+    {{- $currentProvider := .Values.global.clusterConfiguration.cloud.provider | lower -}}
+    {{- if has $currentProvider $supportedProviders -}}
+      {{- $currentProvider -}}
+    {{- else -}}
+      {{- "none" -}}
+    {{- end -}}
+  {{- else -}}
+    {{- "none" -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "istioGlobalRevision" -}}
-{{- $version := $.Values.istio.internal.globalVersion -}}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
-{{- get $versionInfo "revision" -}}
+  {{- $version := $.Values.istio.internal.globalVersion -}}
+  {{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+  {{- get $versionInfo "revision" -}}
 {{- end -}}
 
 {{- define "istioImageSuffix" -}}
-{{- $version := $.Values.istio.internal.globalVersion -}}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
-{{- get $versionInfo "imageSuffix" -}}
+  {{- $version := $.Values.istio.internal.globalVersion -}}
+  {{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+  {{- get $versionInfo "imageSuffix" -}}
 {{- end -}}
 
 {{- define "istioJWTPolicy" -}}
-third-party-jwt
+  third-party-jwt
 {{- end -}}
 
 {{- define "istioNetworkName" -}}
-network-{{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+  network-{{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
 {{- end -}}
 
 {{- define "istioSupportsAmbient" -}}
-{{- $version := $.Values.istio.internal.globalVersion -}}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
-{{- if get $versionInfo "supportsAmbient" -}}true{{- end -}}
+  {{- $version := $.Values.istio.internal.globalVersion -}}
+  {{- $versionInfo := get .Values.istio.internal.versionMap $version -}}
+  {{- if get $versionInfo "supportsAmbient" -}}
+    true
+  {{- end -}}
 {{- end -}}

--- a/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
+++ b/modules/110-istio/templates/control-plane/iop/istiod/_rules_v-1-25.tpl
@@ -5,10 +5,11 @@
   - deployments
   verbs:
   - get
-  - list
   - watch
+  - list
   - update
   - patch
+  - create
   - delete
 - apiGroups:
   - ""
@@ -186,15 +187,6 @@
   verbs:
   - create
 - apiGroups:
-  - gateway.networking.k8s.io
-  resources:
-  - gatewayclasses
-  verbs:
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
   - ""
   resources:
   - secrets
@@ -240,11 +232,14 @@
 - apiGroups:
   - gateway.networking.k8s.io
   resources:
-  - gateways
-  - httproutes
-  - grpcroutes
   - gatewayclasses
+  - gateways
+  - grpcroutes
+  - httproutes
   - referencegrants
+  - tcproutes
+  - tlsroutes
+  - updroutes
   verbs:
   - get
   - watch
@@ -253,6 +248,23 @@
   - gateway.networking.k8s.io
   resources:
   - gatewayclasses/status
+  - gateways/status
+  - grpcroutes/status
+  - httproutes/status
+  - referencegrants/status
+  - tcproutes/status
+  - tlsroutes/status
+  - udproutes/status
   verbs:
   - update
+  - patch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gatewayclasses
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
 {{- end -}}

--- a/modules/110-istio/templates/ztunnel/daemonset.yaml
+++ b/modules/110-istio/templates/ztunnel/daemonset.yaml
@@ -1,28 +1,14 @@
-{{- $version := $.Values.istio.internal.globalVersion }}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version }}
-{{- $imageSuffix := get $versionInfo "imageSuffix" }}
-{{- $revision := get $versionInfo "revision" }}
-{{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-
-{{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
-{{- if ($.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
----
-apiVersion: autoscaling.k8s.io/v1
-kind: VerticalPodAutoscaler
-metadata:
-  name: ztunnel
-  namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list $ (dict "app" "ztunnel")) | nindent 2 }}
-spec:
-{{ include "helm_lib_resources_management_vpa_spec" (list "apps/v1" "DaemonSet" "ztunnel" "istio-proxy" $.Values.istio.dataPlane.ztunnel.resourcesManagement ) | nindent 2 }}
-{{- end }}
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+}}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ztunnel
-  namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list $ (dict 
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
       "app" "ztunnel"
   )) | nindent 2 }}
 spec:
@@ -35,14 +21,14 @@ spec:
       app: ztunnel
   template:
     metadata:
-      {{- include "helm_lib_module_labels" (list $ (dict 
+      {{- include "helm_lib_module_labels" (list . (dict
           "app" "ztunnel"
           "sidecar.istio.io/inject" "false"
           "istio.io/dataplane-mode" "none"
       )) | nindent 6 }}
       annotations:
         sidecar.istio.io/inject: "false"
-        istio.io/rev: {{ $revision }}
+        istio.io/rev: {{ include "istioGlobalRevision" . }}
         prometheus.io/port: "15020"
         prometheus.io/scrape: "true"
     spec:
@@ -56,13 +42,13 @@ spec:
           operator: Exists
       containers:
       - name: istio-proxy
-        image: {{ include "helm_lib_module_image" (list $ (printf "ztunnel%s" $imageSuffix)) }}
+        image: {{ include "helm_lib_module_image" (list . (printf "ztunnel%s" (include "istioImageSuffix" .))) }}
         ports:
         - containerPort: 15020
           name: ztunnel-stats
           protocol: TCP
         resources:
-          {{- include "helm_lib_resources_management_pod_resources" (list $.Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
+          {{- include "helm_lib_resources_management_pod_resources" (list .Values.istio.dataPlane.ztunnel.resourcesManagement) | nindent 10 }}
         imagePullPolicy: IfNotPresent
         securityContext:
           # K8S docs are clear that CAP_SYS_ADMIN *or* privileged: true
@@ -90,15 +76,15 @@ spec:
         - ztunnel
         env:
         - name: CA_ADDRESS
-          value: istiod-{{ $revision }}.d8-istio.svc:15012
+          value: istiod-{{ include "istioGlobalRevision" . }}.d8-istio.svc:15012
         - name: XDS_ADDRESS
-          value: istiod-{{ $revision }}.d8-istio.svc:15012
+          value: istiod-{{ include "istioGlobalRevision" . }}.d8-istio.svc:15012
         - name: RUST_LOG
           value: info
         - name: RUST_BACKTRACE
           value: "1"
         - name: ISTIO_META_CLUSTER_ID
-          value: {{ $.Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum $.Values.global.discovery.clusterUUID }}
+          value: {{ .Values.global.discovery.clusterDomain | replace "." "-" }}-{{ adler32sum .Values.global.discovery.clusterUUID }}
         - name: INPOD_ENABLED
           value: "true"
         - name: TERMINATION_GRACE_PERIOD_SECONDS

--- a/modules/110-istio/templates/ztunnel/podmonitor.yaml
+++ b/modules/110-istio/templates/ztunnel/podmonitor.yaml
@@ -1,16 +1,15 @@
-{{- $version := $.Values.istio.internal.globalVersion }}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version }}
-{{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-
-{{- if (.Values.global.enabledModules | has "operator-prometheus") }}
-{{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (.Values.global.enabledModules | has "operator-prometheus")
+}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: ztunnel
   namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list $ (dict "app" "ztunnel" "prometheus" "main")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "ztunnel" "prometheus" "main")) | nindent 2 }}
 spec:
   jobLabel: app
   podMetricsEndpoints:
@@ -21,15 +20,16 @@ spec:
       key: "token"
     honorLabels: true
     relabelings:
-    - targetLabel: tier
+    - action: replace
       replacement: cluster
-    - targetLabel: job
-      replacement: "ztunnel"
+      targetLabel: tier
+    - action: replace
+      replacement: ztunnel
+      targetLabel: job
   selector:
     matchLabels:
       app: ztunnel
   namespaceSelector:
     matchNames:
       - d8-{{ .Chart.Name }}
-{{- end }}
 {{- end }}

--- a/modules/110-istio/templates/ztunnel/rbac-for-us.yaml
+++ b/modules/110-istio/templates/ztunnel/rbac-for-us.yaml
@@ -1,15 +1,14 @@
-{{- $version := $.Values.istio.internal.globalVersion }}
-{{- $versionInfo := get .Values.istio.internal.versionMap $version }}
-{{- $supportsAmbient := get $versionInfo "supportsAmbient" }}
-
-{{- if and $supportsAmbient $.Values.istio.ambient.enabled }}
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+}}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ztunnel
-  namespace: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list $ (dict 
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict
       "app" "ztunnel"
   )) | nindent 2 }}
 ---

--- a/modules/110-istio/templates/ztunnel/vpa.yaml
+++ b/modules/110-istio/templates/ztunnel/vpa.yaml
@@ -1,0 +1,22 @@
+{{- if and
+  (include "istioSupportsAmbient" .)
+  (.Values.istio.ambient.enabled)
+  (eq .Values.istio.dataPlane.ztunnel.resourcesManagement.mode "VPA")
+  (.Values.global.enabledModules | has "vertical-pod-autoscaler")
+}}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: ztunnel
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "ztunnel")) | nindent 2 }}
+spec:
+{{- include "helm_lib_resources_management_vpa_spec" (list
+  "apps/v1"
+  "DaemonSet"
+  "ztunnel"
+  "istio-proxy"
+  .Values.istio.dataPlane.ztunnel.resourcesManagement
+) | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
## Description
Add Istio Ambient waypoint support with RBAC fixes and refactor ztunnel manifests.

## Why do we need it, and what problem does it solve?
Enables Istio Ambient mode to deploy and manage waypoints by adding required RBAC permissions for gateway.networking.k8s.io resources (tcproutes, tlsroutes, udproutes, and status updates for various route types).

Also refactors ztunnel manifests to:
- Extract VPA into a separate file for better maintainability
- Use new helper templates for version info and ambient support checks
- Simplify conditional logic

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Add ambient waypoint support with RBAC fixes for Gateway API resources.
impact_level: default
```