### PR TITLE
[user-authn] Validate and alert on conflicting LDAP TLS settings in DexProvider

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1331,6 +1331,36 @@ alerts:
         Dex AuthRequest objects quota usage is higher than 80% in namespace &quot;d8-user-authn&quot;.
       severity: "4"
       markupFormat: markdown
+    - name: D8DexProviderLDAPTLSConflict
+      sourceFile: modules/150-user-authn/monitoring/prometheus-rules/dex-deprecation.yaml
+      moduleUrl: 150-user-authn
+      module: user-authn
+      edition: ce
+      description: |
+        DexProvider `{{ $labels.name }}` combines mutually exclusive LDAP TLS settings: `{{ $labels.conflict }}`. Dex silently ignores the redundant flag, which masks misconfiguration:
+
+        * `insecureNoSSL + startTLS`: TLS is disabled (ldap://, port 389), so `startTLS` is ignored.
+        * `insecureNoSSL + insecureSkipVerify`: TLS is disabled, there is no certificate to verify.
+        * `insecureNoSSL + rootCAData`: TLS is disabled, the CA chain is ignored.
+
+        The CRD schema rejects this combination on create/update; this DexProvider was created before the validation was added and remains active.
+
+        Update the DexProvider to remove the conflict:
+
+        * Plaintext LDAP (port 389): keep `spec.ldap.insecureNoSSL: true`, remove `startTLS`, `insecureSkipVerify`, and `rootCAData`.
+        * STARTTLS on port 389: set `spec.ldap.insecureNoSSL: false`, `spec.ldap.startTLS: true`. Use `insecureSkipVerify` or `rootCAData` as needed.
+        * `ldaps://` on port 636: leave `insecureNoSSL` and `startTLS` at `false`. Use `insecureSkipVerify` or `rootCAData` as appropriate.
+
+        Audit all LDAP DexProvider objects:
+
+        ```bash
+        kubectl get dexproviders.deckhouse.io -o yaml \
+          | yq '.items[] | select(.spec.type=="LDAP") | {name: .metadata.name, ldap: .spec.ldap | pick(["insecureNoSSL","startTLS","insecureSkipVerify","rootCAData"])}'
+        ```
+      summary: |
+        DexProvider {{ $labels.name }} has a conflicting LDAP TLS configuration.
+      severity: "8"
+      markupFormat: markdown
     - name: D8EtcdDatabaseHighFragmentationRatio
       sourceFile: modules/040-control-plane-manager/monitoring/prometheus-rules/etcd-maintenance.yaml
       moduleUrl: 040-control-plane-manager

--- a/modules/150-user-authn/crds/dex-provider.yaml
+++ b/modules/150-user-authn/crds/dex-provider.yaml
@@ -355,6 +355,13 @@ spec:
                   required: ['host', 'userSearch']
                   description: |
                     Parameters of the LDAP.
+                  x-kubernetes-validations:
+                    - rule: "!(self.insecureNoSSL && self.startTLS)"
+                      message: "spec.ldap.insecureNoSSL and spec.ldap.startTLS are mutually exclusive: insecureNoSSL disables TLS entirely (ldap://, port 389), while startTLS upgrades a plain connection to TLS."
+                    - rule: "!(self.insecureNoSSL && self.insecureSkipVerify)"
+                      message: "spec.ldap.insecureSkipVerify has no effect when spec.ldap.insecureNoSSL is true: TLS is disabled and there is no certificate to verify."
+                    - rule: "!(self.insecureNoSSL && has(self.rootCAData) && self.rootCAData != '')"
+                      message: "spec.ldap.rootCAData is ignored when spec.ldap.insecureNoSSL is true: TLS is disabled. Remove rootCAData or set insecureNoSSL to false."
                   properties:
                     host:
                       type: string
@@ -371,12 +378,16 @@ spec:
                         Following field is required if the LDAP host is not using TLS (port 389).
                         This option inherently leaks passwords to anyone on the same network as Dex.
                         Equals to false by default.
+
+                        Mutually exclusive with `startTLS`, `insecureSkipVerify`, and `rootCAData`: when `insecureNoSSL` is true, TLS is disabled and those settings have no effect.
                     startTLS:
                       type: boolean
                       default: false
                       description: |
                         When connecting to the server, connect using the ldap:// protocol then issue
-                        a [StartTLS](https://www.digitalocean.com/community/tutorials/how-to-encrypt-openldap-connections-using-starttls) command. If unspecified, connections will use the ldaps:// protocol
+                        a [StartTLS](https://www.digitalocean.com/community/tutorials/how-to-encrypt-openldap-connections-using-starttls) command. If unspecified, connections will use the ldaps:// protocol.
+
+                        Mutually exclusive with `insecureNoSSL`.
                     usernamePrompt:
                       type: string
                       default: 'LDAP username'
@@ -387,6 +398,8 @@ spec:
                       type: string
                       description: |
                         A CA chain to validate the provider in PEM format.
+
+                        Has no effect when `insecureNoSSL` is true.
                       x-doc-examples:
                       - |
                         ```yaml
@@ -402,6 +415,8 @@ spec:
                         If a custom certificate isn't provided, this option can be used to turn off
                         TLS certificate checks. As noted, it is insecure and shouldn't be used outside
                         of explorative phases.
+
+                        Has no effect when `insecureNoSSL` is true.
                     bindDN:
                       type: string
                       x-doc-examples: ['uid=serviceaccount,cn=users,dc=example,dc=com']

--- a/modules/150-user-authn/crds/doc-ru-dex-provider.yaml
+++ b/modules/150-user-authn/crds/doc-ru-dex-provider.yaml
@@ -239,18 +239,26 @@ spec:
                     insecureNoSSL:
                       description: |
                         Подключаться к каталогу LDAP не по защищенному порту.
+
+                        Несовместимо с `startTLS`, `insecureSkipVerify` и `rootCAData`: если `insecureNoSSL: true`, TLS отключён и эти параметры не имеют эффекта.
                     startTLS:
                       description: |
                         Использовать [STARTTLS](https://www.digitalocean.com/community/tutorials/how-to-encrypt-openldap-connections-using-starttls) для шифрования.
+
+                        Несовместимо с `insecureNoSSL`.
                     usernamePrompt:
                       description: |
                         Строка, которая будет отображаться возле поля для имени пользователя в форме ввода логина и пароля.
                     rootCAData:
                       description: |
                         Цепочка CA в формате PEM, используемая для валидации TLS.
+
+                        Не используется при `insecureNoSSL: true`.
                     insecureSkipVerify:
                       description: |
                         Не производить проверку подлинности провайдера с помощью TLS. Небезопасно, не рекомендуется использовать в production-окружениях.
+
+                        Не используется при `insecureNoSSL: true`.
                     bindDN:
                       description: |
                         Путь до сервис-аккаунта приложения в LDAP.

--- a/modules/150-user-authn/docs/internal/demo/dex-provider.yaml
+++ b/modules/150-user-authn/docs/internal/demo/dex-provider.yaml
@@ -8,7 +8,6 @@ spec:
   displayName: OpenLDAP Demo
   ldap:
     host: ldap-service.openldap-demo:389
-    insecureSkipVerify: true
     insecureNoSSL: true
 
     bindDN: cn=admin,dc=example,dc=org

--- a/modules/150-user-authn/hooks/alert_on_deprecated_dex_provider_tls.go
+++ b/modules/150-user-authn/hooks/alert_on_deprecated_dex_provider_tls.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
+	"github.com/flant/addon-operator/sdk"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+// This hook scans DexProvider resources for LDAP TLS configurations that
+// combine mutually exclusive flags. Dex silently ignores the redundant flag
+// (see github.com/dexidp/dex connector/ldap/ldap.go switch on InsecureNoSSL),
+// which masks misconfiguration. The CRD now rejects new conflicting objects;
+// this hook produces a metric so that pre-existing objects (which CEL does
+// not re-validate retroactively, thanks to CRD validation ratcheting) trigger
+// the D8DexProviderLDAPTLSConflict alert until updated.
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/user-authn",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "dex_providers_tls_audit",
+			ApiVersion: "deckhouse.io/v1",
+			Kind:       "DexProvider",
+			FilterFunc: filterDexProviderTLSAudit,
+		},
+	},
+}, auditDexProviderLDAPTLSConflicts)
+
+const (
+	dexTLSConflictMetricName  = "d8_dex_provider_ldap_tls_conflict"
+	dexTLSConflictMetricGroup = "d8_dex_provider_ldap_tls_conflict"
+
+	conflictInsecureNoSSLStartTLS          = "insecureNoSSL+startTLS"
+	conflictInsecureNoSSLInsecureSkipVerif = "insecureNoSSL+insecureSkipVerify"
+	conflictInsecureNoSSLRootCAData        = "insecureNoSSL+rootCAData"
+)
+
+type dexProviderTLSAudit struct {
+	Name               string
+	IsLDAP             bool
+	InsecureNoSSL      bool
+	StartTLS           bool
+	InsecureSkipVerify bool
+	HasRootCAData      bool
+}
+
+func filterDexProviderTLSAudit(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	out := dexProviderTLSAudit{Name: obj.GetName()}
+
+	providerType, _, err := unstructured.NestedString(obj.Object, "spec", "type")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.type from DexProvider %q: %w", out.Name, err)
+	}
+	if providerType != "LDAP" {
+		return out, nil
+	}
+	out.IsLDAP = true
+
+	out.InsecureNoSSL, _, err = unstructured.NestedBool(obj.Object, "spec", "ldap", "insecureNoSSL")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.ldap.insecureNoSSL from DexProvider %q: %w", out.Name, err)
+	}
+	out.StartTLS, _, err = unstructured.NestedBool(obj.Object, "spec", "ldap", "startTLS")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.ldap.startTLS from DexProvider %q: %w", out.Name, err)
+	}
+	out.InsecureSkipVerify, _, err = unstructured.NestedBool(obj.Object, "spec", "ldap", "insecureSkipVerify")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.ldap.insecureSkipVerify from DexProvider %q: %w", out.Name, err)
+	}
+	rootCA, _, err := unstructured.NestedString(obj.Object, "spec", "ldap", "rootCAData")
+	if err != nil {
+		return nil, fmt.Errorf("read spec.ldap.rootCAData from DexProvider %q: %w", out.Name, err)
+	}
+	out.HasRootCAData = rootCA != ""
+
+	return out, nil
+}
+
+func auditDexProviderLDAPTLSConflicts(_ context.Context, input *go_hook.HookInput) error {
+	input.MetricsCollector.Expire(dexTLSConflictMetricGroup)
+
+	snaps := input.Snapshots.Get("dex_providers_tls_audit")
+	for p, err := range sdkobjectpatch.SnapshotIter[dexProviderTLSAudit](snaps) {
+		if err != nil {
+			return fmt.Errorf("iterate dex_providers_tls_audit snapshots: %w", err)
+		}
+		if !p.IsLDAP || !p.InsecureNoSSL {
+			continue
+		}
+		if p.StartTLS {
+			emitDexTLSConflict(input, p.Name, conflictInsecureNoSSLStartTLS)
+		}
+		if p.InsecureSkipVerify {
+			emitDexTLSConflict(input, p.Name, conflictInsecureNoSSLInsecureSkipVerif)
+		}
+		if p.HasRootCAData {
+			emitDexTLSConflict(input, p.Name, conflictInsecureNoSSLRootCAData)
+		}
+	}
+	return nil
+}
+
+func emitDexTLSConflict(input *go_hook.HookInput, name, conflict string) {
+	input.MetricsCollector.Set(
+		dexTLSConflictMetricName,
+		1,
+		map[string]string{"name": name, "conflict": conflict},
+		metrics.WithGroup(dexTLSConflictMetricGroup),
+	)
+}

--- a/modules/150-user-authn/hooks/alert_on_deprecated_dex_provider_tls_test.go
+++ b/modules/150-user-authn/hooks/alert_on_deprecated_dex_provider_tls_test.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+
+	"github.com/deckhouse/deckhouse/pkg/metrics-storage/operation"
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("User Authn hooks :: alert_on_deprecated_dex_provider_tls ::", func() {
+	f := HookExecutionConfigInit(`{"userAuthn":{"internal": {}}}`, "")
+	f.RegisterCRD("deckhouse.io", "v1", "DexProvider", false)
+
+	expireOp := operation.MetricOperation{
+		Group:  "d8_dex_provider_ldap_tls_conflict",
+		Action: operation.ActionExpireMetrics,
+	}
+	setOp := func(name, conflict string) operation.MetricOperation {
+		return operation.MetricOperation{
+			Name:   "d8_dex_provider_ldap_tls_conflict",
+			Value:  ptr.To(1.0),
+			Labels: map[string]string{"name": name, "conflict": conflict},
+			Action: operation.ActionGaugeSet,
+			Group:  "d8_dex_provider_ldap_tls_conflict",
+		}
+	}
+
+	Context("No DexProvider objects", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(""))
+			f.RunHook()
+		})
+		It("Expires metric, sets nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(ConsistOf(expireOp))
+		})
+	})
+
+	Context("DexProvider with type OIDC", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: deckhouse.io/v1
+kind: DexProvider
+metadata:
+  name: gitlab
+spec:
+  type: OIDC
+  displayName: GitLab
+  oidc:
+    clientID: abc
+    clientSecret: xyz
+    issuer: https://gitlab.example.com
+`))
+			f.RunHook()
+		})
+		It("Expires metric, sets nothing for non-LDAP providers", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(ConsistOf(expireOp))
+		})
+	})
+
+	Context("LDAP provider with valid configuration (no conflict)", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: deckhouse.io/v1
+kind: DexProvider
+metadata:
+  name: ldap-ok
+spec:
+  type: LDAP
+  displayName: ok
+  ldap:
+    host: ldap.example.org:389
+    startTLS: true
+    insecureSkipVerify: true
+    userSearch:
+      baseDN: ou=People,dc=x
+      username: uid
+      idAttr: uid
+      emailAttr: mail
+      nameAttr: cn
+`))
+			f.RunHook()
+		})
+		It("Expires metric, sets nothing", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.MetricsCollector.CollectedMetrics()).To(ConsistOf(expireOp))
+		})
+	})
+
+	Context("LDAP provider with insecureNoSSL + startTLS", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: deckhouse.io/v1
+kind: DexProvider
+metadata:
+  name: ldap-bad-starttls
+spec:
+  type: LDAP
+  displayName: bad
+  ldap:
+    host: ldap.example.org:389
+    insecureNoSSL: true
+    startTLS: true
+    userSearch:
+      baseDN: ou=People,dc=x
+      username: uid
+      idAttr: uid
+      emailAttr: mail
+      nameAttr: cn
+`))
+			f.RunHook()
+		})
+		It("Emits conflict metric with label insecureNoSSL+startTLS", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(2))
+			Expect(m[0]).To(BeEquivalentTo(expireOp))
+			Expect(m[1]).To(BeEquivalentTo(setOp("ldap-bad-starttls", "insecureNoSSL+startTLS")))
+		})
+	})
+
+	Context("LDAP provider with insecureNoSSL + insecureSkipVerify + rootCAData", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(`
+apiVersion: deckhouse.io/v1
+kind: DexProvider
+metadata:
+  name: ldap-bad-multi
+spec:
+  type: LDAP
+  displayName: bad
+  ldap:
+    host: ldap.example.org:389
+    insecureNoSSL: true
+    insecureSkipVerify: true
+    rootCAData: "-----BEGIN CERTIFICATE-----\nMIIFaDC...\n-----END CERTIFICATE-----\n"
+    userSearch:
+      baseDN: ou=People,dc=x
+      username: uid
+      idAttr: uid
+      emailAttr: mail
+      nameAttr: cn
+`))
+			f.RunHook()
+		})
+		It("Emits two conflict metrics", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m).To(HaveLen(3))
+			Expect(m[0]).To(BeEquivalentTo(expireOp))
+			Expect(m[1:]).To(ConsistOf(
+				setOp("ldap-bad-multi", "insecureNoSSL+insecureSkipVerify"),
+				setOp("ldap-bad-multi", "insecureNoSSL+rootCAData"),
+			))
+		})
+	})
+
+	Context("Conflict is resolved on the next reconcile", func() {
+		const bad = `
+apiVersion: deckhouse.io/v1
+kind: DexProvider
+metadata:
+  name: ldap-flip
+spec:
+  type: LDAP
+  displayName: flip
+  ldap:
+    host: ldap.example.org:389
+    insecureNoSSL: true
+    startTLS: true
+    userSearch:
+      baseDN: ou=People,dc=x
+      username: uid
+      idAttr: uid
+      emailAttr: mail
+      nameAttr: cn
+`
+		const fixed = `
+apiVersion: deckhouse.io/v1
+kind: DexProvider
+metadata:
+  name: ldap-flip
+spec:
+  type: LDAP
+  displayName: flip
+  ldap:
+    host: ldap.example.org:389
+    insecureNoSSL: true
+    userSearch:
+      baseDN: ou=People,dc=x
+      username: uid
+      idAttr: uid
+      emailAttr: mail
+      nameAttr: cn
+`
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(bad))
+			f.RunHook()
+			f.BindingContexts.Set(f.KubeStateSet(fixed))
+			f.RunHook()
+		})
+		It("Last run expires the conflict metric and emits nothing else", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			m := f.MetricsCollector.CollectedMetrics()
+			Expect(m[len(m)-1]).To(BeEquivalentTo(expireOp))
+		})
+	})
+})

--- a/modules/150-user-authn/hooks/get_dex_providers_crds_test.go
+++ b/modules/150-user-authn/hooks/get_dex_providers_crds_test.go
@@ -99,7 +99,6 @@ spec:
   ldap:
     host: ldap-service.openldap-demo:389
     insecureNoSSL: true
-    insecureSkipVerify: true
     bindDN: cn=admin,dc=example,dc=org
     bindPW: admin
     usernamePrompt: Email Address

--- a/modules/150-user-authn/monitoring/prometheus-rules/dex-deprecation.yaml
+++ b/modules/150-user-authn/monitoring/prometheus-rules/dex-deprecation.yaml
@@ -1,0 +1,36 @@
+- name: d8.user-authn.deprecation
+  rules:
+  - alert: D8DexProviderLDAPTLSConflict
+    expr: d8_dex_provider_ldap_tls_conflict == 1
+    labels:
+      severity_level: "8"
+      tier: cluster
+      d8_module: user-authn
+      d8_component: dex
+    annotations:
+      plk_markup_format: markdown
+      plk_protocol_version: "1"
+      plk_create_group_if_not_exists__d8_user_authn_deprecations: "UserAuthnDeprecations,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_user_authn_deprecations: "UserAuthnDeprecations,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      summary: DexProvider `{{ $labels.name }}` has a conflicting LDAP TLS configuration.
+      description: |
+        DexProvider `{{ $labels.name }}` combines mutually exclusive LDAP TLS settings: `{{ $labels.conflict }}`. Dex silently ignores the redundant flag, which masks misconfiguration:
+
+        * `insecureNoSSL + startTLS`: TLS is disabled (ldap://, port 389), so `startTLS` is ignored.
+        * `insecureNoSSL + insecureSkipVerify`: TLS is disabled, there is no certificate to verify.
+        * `insecureNoSSL + rootCAData`: TLS is disabled, the CA chain is ignored.
+
+        The CRD schema rejects this combination on create/update; this DexProvider was created before the validation was added and remains active.
+
+        Update the DexProvider to remove the conflict:
+
+        * Plaintext LDAP (port 389): keep `spec.ldap.insecureNoSSL: true`, remove `startTLS`, `insecureSkipVerify`, and `rootCAData`.
+        * STARTTLS on port 389: set `spec.ldap.insecureNoSSL: false`, `spec.ldap.startTLS: true`. Use `insecureSkipVerify` or `rootCAData` as needed.
+        * `ldaps://` on port 636: leave `insecureNoSSL` and `startTLS` at `false`. Use `insecureSkipVerify` or `rootCAData` as appropriate.
+
+        Audit all LDAP DexProvider objects:
+
+        ```bash
+        kubectl get dexproviders.deckhouse.io -o yaml \
+          | yq '.items[] | select(.spec.type=="LDAP") | {name: .metadata.name, ldap: .spec.ldap | pick(["insecureNoSSL","startTLS","insecureSkipVerify","rootCAData"])}'
+        ```


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
`DexProvider`'s `spec.ldap` exposed three independent TLS boolean flags  (`insecureNoSSL`, `startTLS`, `insecureSkipVerify`) plus `rootCAData`,  without any cross-validation. The combinations below are silently  ignored by Dex (see `connector/ldap/dap.go` switch on `InsecureNoSSL`)  and therefore mask misconfiguration:

  * `insecureNoSSL` + `startTLS` — TLS is disabled (ldap://, port 389),
    `startTLS` is ignored.
  * `insecureNoSSL` + `insecureSkipVerify` — TLS is disabled, no
    certificate to verify.
  * `insecureNoSSL` + `rootCAData` — TLS is disabled, CA is ignored.

  This PR:

  1. Adds three CEL rules (`x-kubernetes-validations`) on `spec.ldap` rejecting the combinations above. The YAML anchor `&ldap` ensures both `v1alpha1` and `v1` versions get the same rules.
  2. Updates English and Russian descriptions of `insecureNoSSL`, `startTLS`, `insecureSkipVerify`, and `rootCAData` to call out the constraint.
  3. Adds a hook `alert_on_deprecated_dex_provider_tls.go` that scans existing `DexProvider` objects and emits `d8_dex_provider_ldap_tls_conflict{name,conflict}` for each conflicting LDAP combination. CRD validation only runs on create/update and CRD validation ratcheting lets legacy invalid objects survive partial updates — without the alert they would stay silent.
  4. Adds a `PrometheusRule` `D8DexProviderLDAPTLSConflict` (`severity_level: "8"`, grouped under `UserAuthnDeprecations` PLK group) with a migration runbook in the description.
  5. Removes `insecureSkipVerify: true` from the internal demo (`docs/internal/demo/dex-provider.yaml`) and from the hook test fixture (`get_dex_providers_crds_test.go`): both combined it with `insecureNoSSL: true` and would now fail CRD validation.

  No restarts required. Existing valid `DexProvider` objects are unaffected.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Today an operator can ship a `DexProvider` like `{insecureNoSSL: true, startTLS: true, rootCAData: ...}` and it will be accepted by the API server. Dex will silently fall back to plain `ldap://` and ignore the TLS-related fields, which looks like working TLS but isn't. The CRD now refuses such combinations up front, and the new alert lets cluster operators discover any pre-existing objects that were created before the validation landed.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not necessarily.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authn
type: fix
summary: Reject mutually exclusive LDAP TLS settings in DexProvider; alert on legacy objects.
impact: |
  spec.ldap.insecureNoSSL combined with startTLS, insecureSkipVerify, or a non-empty rootCAData is now rejected by the CRD. Pre-existing DexProvider objects with such combinations keep working but trigger
  D8DexProviderLDAPTLSConflict until updated. Audit with: kubectl get dexproviders.deckhouse.io -o yaml | yq '.items[] | select(.spec.type=="LDAP") | {name: .metadata.name, ldap: .spec.ldap | pick(["insecureNoSSL","startTLS","insecureSkipVerify","rootCAData"])}'
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
