### PR TITLE
[ingress-nginx] backport update nginx to 1.30.1

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-10/patches/010-nginx-build-01.patch
+++ b/modules/402-ingress-nginx/images/controller-1-10/patches/010-nginx-build-01.patch
@@ -14,7 +14,7 @@ index f60a260f9..c035b7e49 100755
  set -o pipefail
  
 -export NGINX_VERSION=1.25.5
-+export NGINX_VERSION=1.29.5
++export NGINX_VERSION=1.30.1
  
  # Check for recent changes: https://github.com/vision5/ngx_devel_kit/compare/v0.3.3...master
  export NDK_VERSION=v0.3.3
@@ -190,7 +190,7 @@ index f60a260f9..c035b7e49 100755
 -
 -get_src d74f86ada2329016068bc5a243268f1f555edd620b6a7d6ce89295e7d6cf18da \
 -        "https://github.com/microsoft/mimalloc/archive/${MIMALOC_VERSION}.tar.gz" "mimalloc"
-+git clone -b "controller-v1.10.4-nginx-v1.29.5" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
++git clone -b "controller-v1.10.4-nginx-v1.30.1" "${SOURCE_REPO}/kubernetes/ingress-nginx-deps.git" .
  
  # improve compilation times
  CORES=$(($(grep -c ^processor /proc/cpuinfo) - 1))

--- a/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-10/werf.inc.yaml
@@ -39,8 +39,8 @@ shell:
   - cd /src
   - git clone --branch v1.2.5 --depth 1 $(cat /run/secrets/SOURCE_REPO)/yelp/dumb-init.git
   - git clone --branch 0.5.1 $(cat /run/secrets/SOURCE_REPO)/starwing/lua-protobuf
-  - git clone --branch 7-3 $(cat /run/secrets/SOURCE_REPO)/luarocks-sorces/lua-iconv
   - git clone --branch {{ $controllerBranch }} --depth 1 {{$.SOURCE_REPO}}/kubernetes/ingress-nginx.git
+  - git clone --branch 7-3 $(cat /run/secrets/SOURCE_REPO)/luarocks-sorces/lua-iconv
   - cd /src/ingress-nginx
   - patch -p1 < /patches/001-go-mod-01.patch
   - patch -p1 < /patches/002-healthcheck.patch

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -1,6 +1,6 @@
 {{ $controllerBranch := "controller-v1.12.1" }}
-{{ $nginxDepsBranch := "controller-v1.12.1-nginx-v1.29.5-modsecurity-v1.0.4" }}
-{{ $nginxVersion := "1.29.5" }}
+{{ $nginxDepsBranch := "controller-v1.12.1-nginx-v1.30.1-modsecurity-v1.0.4" }}
+{{ $nginxVersion := "1.30.1" }}
 {{ $nlohmannJsonBranch := "v3.11.3" }}
 {{ $ngxBrotliCommit := "63ca02abdcf79c9e788d2eedcc388d2335902e52" }}
 {{ $modSecurityBranch := "v3.0.14" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Updates nginx version to 1.30.1.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

To fix the following CVEs:
CVE-2026-27654 — buffer overflow in DAV COPY/MOVE with alias.
CVE-2026-27784 — MP4 crash/impact on 32-bit.
CVE-2026-32647 — MP4 crash/impact.
CVE-2026-27651 — segfault with CRAM-MD5/APOP auth retry.
CVE-2026-28753 — PTR DNS record injection into auth_http / SMTP XCLIENT.
CVE-2026-28755 — OCSP rejection bypass in stream SSL handshake.
CVE-2026-42926 — HTTP/2 backend request injection with proxy_set_body.
CVE-2026-42945 — heap buffer overflow in ngx_http_rewrite_module.
CVE-2026-42946 — heap overread in ngx_http_scgi_module / ngx_http_uwsgi_module.
CVE-2026-42934 — heap overread in ngx_http_charset_module.
CVE-2026-40460 — HTTP/3 address spoofing.
CVE-2026-40701 — use-after-free in OCSP DNS response processing with ssl_ocsp.

## Why do we need it in the patch release (if we do)?

It's a HUGE security fix.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ingress-nginx
type: fix
summary: Nginx is updated up to 1.30.1.
impact: All Ingress-nginx controller pods will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->