### PR TITLE
[log-shipper] Bump Go toolchain to 1.25 for vector reloader to fix stdlib CVEs

### DIFF
--- a/modules/460-log-shipper/images/vector/reloader/go.mod
+++ b/modules/460-log-shipper/images/vector/reloader/go.mod
@@ -1,8 +1,6 @@
 module vector
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.25.8
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0

--- a/modules/460-log-shipper/images/vector/werf.inc.yaml
+++ b/modules/460-log-shipper/images/vector/werf.inc.yaml
@@ -89,7 +89,7 @@ shell:
   - chmod 0755 /vector
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-reloader-artifact
-from: {{ index $.Images "builder/golang-alpine-1.24" }}
+from: {{ index $.Images "builder/golang-alpine-1.25" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact


### PR DESCRIPTION
## Description

Bumped the build toolchain for the `reloader` binary (`/usr/bin/reloader`) inside the `vector` image of the `log-shipper` module from Go 1.24 to Go 1.25.

The `vector` binary itself is written in Rust and is not affected. Only the small Go-based `reloader` sidecar is rebuilt.

Changes:
- `modules/460-log-shipper/images/vector/werf.inc.yaml`: switched the `vector-reloader-artifact` `from:` to `builder/golang-alpine-1.25`.
- `modules/460-log-shipper/images/vector/reloader/go.mod`: bumped `go` version to `go1.25.8`.

## Why do we need it, and what problem does it solve?

Trivy reports CVEs against `usr/bin/reloader` in the `vector` image (module `log-shipper`).

## Why do we need it in the patch release (if we do)?

Required for the 1.73.x patch line. CVEs in the embedded Go stdlib are surfaced by security scanners on customer clusters and must be closed in the supported release branch.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Bumped Go version to 1.25.8 in `reloader` image to fix stdlib CVEs in Go 1.24.13 in `log-shipper`.
impact_level: low
```
