### PR TITLE
[operator-prometheus] suppress CVE-2026-40179 via VEX

### DIFF
--- a/modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex
+++ b/modules/200-operator-prometheus/images/prometheus-config-reloader/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-operator-prometheus-prometheus-config-reloader",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "timestamp": "2026-05-14T12:00:00.000000+03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40179"
+      },
+      "timestamp": "2026-05-14T12:00:00.000000+03:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.47.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость CVE-2026-40179 представляет собой Stored XSS в веб-интерфейсе Prometheus через имена метрик и значения меток в тултипах графиков и обозревателе метрик. Согласно официальному advisory (GHSA-vffh-x6r8-xx99), уязвимость затрагивает исключительно Prometheus версий >= 3.0 (конкретно: >= 3.0 <= 3.5.1 и >= 3.6.0 <= 3.11.1). Вектор атаки основан на поддержке UTF-8 в именах метрик и меток, которая была введена как поведение по умолчанию в Prometheus v3.x, что позволяет использовать символы '<', '>' и '\"' в именах метрик. Образ prometheus-config-reloader (собирается из prometheus-operator v0.68.0) использует библиотеку github.com/prometheus/prometheus v0.47.0 (это Prometheus 2.47.x); данная версия использует строгую валидацию имён метрик по регулярному выражению [a-zA-Z_:][a-zA-Z0-9_:]* и имён меток по [a-zA-Z_][a-zA-Z0-9_]*, что приводит к отклонению HTML/JavaScript символов на этапе приёма данных (ingestion). Кроме того, Prometheus 2.47.x не содержит Mantine UI, который является одним из основных затронутых компонентов. Инъекция XSS через специально сформированные имена метрик невозможна в данной версии. Дополнительно, бинарь /bin/prometheus-config-reloader выполняет исключительно sidecar-функции — отслеживание изменений в файлах конфигурации и триггер reload через HTTP-эндпоинт основного Prometheus, не запускает Web UI и не рендерит HTML-контент; уязвимый код в этом контексте не исполняется."
+    }
+  ]
+}

--- a/modules/200-operator-prometheus/images/prometheus-config-reloader/werf.inc.yaml
+++ b/modules/200-operator-prometheus/images/prometheus-config-reloader/werf.inc.yaml
@@ -11,3 +11,5 @@ git:
 imageSpec:
   config:
     entrypoint: ["/bin/prometheus-config-reloader"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}

--- a/modules/200-operator-prometheus/images/prometheus-operator/known_vulnerabilities.vex
+++ b/modules/200-operator-prometheus/images/prometheus-operator/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-operator-prometheus-prometheus-operator",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "timestamp": "2026-05-14T12:00:00.000000+03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40179"
+      },
+      "timestamp": "2026-05-14T12:00:00.000000+03:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.47.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость CVE-2026-40179 представляет собой Stored XSS в веб-интерфейсе Prometheus через имена метрик и значения меток в тултипах графиков и обозревателе метрик. Согласно официальному advisory (GHSA-vffh-x6r8-xx99), уязвимость затрагивает исключительно Prometheus версий >= 3.0 (конкретно: >= 3.0 <= 3.5.1 и >= 3.6.0 <= 3.11.1). Вектор атаки основан на поддержке UTF-8 в именах метрик и меток, которая была введена как поведение по умолчанию в Prometheus v3.x, что позволяет использовать символы '<', '>' и '\"' в именах метрик. Образ prometheus-operator v0.68.0 в Deckhouse использует библиотеку github.com/prometheus/prometheus v0.47.0 (это Prometheus 2.47.x) для интеграции с Prometheus API; данная версия использует строгую валидацию имён метрик по регулярному выражению [a-zA-Z_:][a-zA-Z0-9_:]* и имён меток по [a-zA-Z_][a-zA-Z0-9_]*, что приводит к отклонению HTML/JavaScript символов на этапе приёма данных (ingestion). Кроме того, Prometheus 2.47.x не содержит Mantine UI, который является одним из основных затронутых компонентов. Инъекция XSS через специально сформированные имена метрик невозможна в данной версии. Помимо этого, бинарь /bin/operator не запускает Prometheus Web UI и не рендерит пользовательский контент в HTML; уязвимый код в этом контексте не исполняется."
+    }
+  ]
+}

--- a/modules/200-operator-prometheus/images/prometheus-operator/werf.inc.yaml
+++ b/modules/200-operator-prometheus/images/prometheus-operator/werf.inc.yaml
@@ -54,3 +54,5 @@ import:
 imageSpec:
   config:
     entrypoint: ["/bin/operator"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -439,8 +439,10 @@ var DefaultImagesDigests = map[string]interface{}{
 		"pmacct":              "imageHash-openvpn-pmacct",
 	},
 	"operatorPrometheus": map[string]interface{}{
-		"prometheusConfigReloader": "imageHash-operatorPrometheus-prometheusConfigReloader",
-		"prometheusOperator":       "imageHash-operatorPrometheus-prometheusOperator",
+		"prometheusConfigReloader":            "imageHash-operatorPrometheus-prometheusConfigReloader",
+		"prometheusConfigReloaderVexArtifact": "imageHash-operatorPrometheus-prometheusConfigReloaderVexArtifact",
+		"prometheusOperator":                  "imageHash-operatorPrometheus-prometheusOperator",
+		"prometheusOperatorVexArtifact":       "imageHash-operatorPrometheus-prometheusOperatorVexArtifact",
 	},
 	"prometheus": map[string]interface{}{
 		"alertmanager":                "imageHash-prometheus-alertmanager",


### PR DESCRIPTION
## Description

Suppress false-positive **CVE-2026-40179** (Stored XSS in Prometheus Web UI, GHSA-vffh-x6r8-xx99) in the `operator-prometheus` module images via vex.

## Why do we need it, and what problem does it solve?

Fix CVE for 1.73-cse.

## Why do we need it in the patch release (if we do)?

Required for a cleaner CVE scan report on the `release-1.73` branch (targeted at `v1.73.15`). 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Suppressed false-positive CVE-2026-40179 in `operator-prometheus` and `prometheus-config-reloader` images via VEX.
impact_level: low
```
