### PR TITLE
[loki] suppress CVE-2026-40179 via VEX

### DIFF
--- a/modules/462-loki/images/loki/known_vulnerabilities.vex
+++ b/modules/462-loki/images/loki/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "merged-vex-loki-loki",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "timestamp": "2026-05-14T12:00:00.000000+03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40179"
+      },
+      "timestamp": "2026-05-14T12:00:00.000000+03:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.43.1-0.20230419161410-69155c6ba1e9"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость CVE-2026-40179 представляет собой Stored XSS в веб-интерфейсе Prometheus через имена метрик и значения меток в тултипах графиков и обозревателе метрик. Согласно официальному advisory (GHSA-vffh-x6r8-xx99), уязвимость затрагивает исключительно Prometheus версий >= 3.0 (конкретно: >= 3.0 <= 3.5.1 и >= 3.6.0 <= 3.11.1). Вектор атаки основан на поддержке UTF-8 в именах метрик и меток, которая была введена как поведение по умолчанию в Prometheus v3.x, что позволяет использовать символы '<', '>' и '\"' в именах метрик. Образ loki в Deckhouse собирается из Grafana Loki v2.9.15 и использует библиотеку github.com/prometheus/prometheus в pseudo-версии v0.43.1-0.20230419161410-69155c6ba1e9 (коммит на ветке pre-3.x, соответствует линейке Prometheus 2.43.x). В данной версии используется строгая валидация имён метрик по регулярному выражению [a-zA-Z_:][a-zA-Z0-9_:]* и имён меток по [a-zA-Z_][a-zA-Z0-9_]*, что приводит к отклонению HTML/JavaScript символов на этапе приёма данных. Кроме того, библиотека prometheus/prometheus используется в Loki только как набор Go-типов для PromQL/LogQL-совместимости (parser, labels, model, storage), а не как самостоятельный сервер: бинарь /usr/bin/loki не запускает Prometheus Web UI, не содержит Mantine UI (введён только в Prometheus 3.x) и не рендерит HTML-содержимое из метрик/меток. Уязвимый код в данном контексте не скомпилирован и не исполняется."
+    }
+  ]
+}

--- a/modules/462-loki/images/loki/werf.inc.yaml
+++ b/modules/462-loki/images/loki/werf.inc.yaml
@@ -57,3 +57,5 @@ git:
 imageSpec:
   config:
     entrypoint: ["/usr/bin/loki"]
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -363,7 +363,8 @@ var DefaultImagesDigests = map[string]interface{}{
 		"vector": "imageHash-logShipper-vector",
 	},
 	"loki": map[string]interface{}{
-		"loki": "imageHash-loki-loki",
+		"loki":            "imageHash-loki-loki",
+		"lokiVexArtifact": "imageHash-loki-lokiVexArtifact",
 	},
 	"metallb": map[string]interface{}{
 		"l2lbController":    "imageHash-metallb-l2lbController",


### PR DESCRIPTION
## Description

Suppress false-positive **CVE-2026-40179** (Stored XSS in Prometheus Web UI, GHSA-vffh-x6r8-xx99) in the `loki` module image via vex.

## Why do we need it, and what problem does it solve?

Fix CVE for 1.73-cse

## Why do we need it in the patch release (if we do)?

Required for a cleaner CVE scan report on the `release-1.73` branch (targeted at `v1.73.15`). `status/backport` label is set so the change is auto-cherry-picked alongside the other VEX/CVE PRs already going into the same milestone.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Suppressed false-positive CVE-2026-40179 in the `loki` image via VEX.
impact_level: low
```
