### PR TITLE
[prometheus] fix additional CVEs in grafana-v10 (follow-up to #19378)

### DIFF
--- a/modules/300-prometheus/images/grafana-v10/known_vulnerabilities.vex
+++ b/modules/300-prometheus/images/grafana-v10/known_vulnerabilities.vex
@@ -60,6 +60,20 @@
       "status": "not_affected",
       "justification": "inline_mitigations_already_exist",
       "impact_statement": "Уязвимость CVE-2026-27877 связана с тем, что при использовании public dashboards вместе с direct data-sources пароли всех direct data-sources раскрываются в публичной выдаче, даже если эти data-sources не используются в дашборде. Данная утечка происходит только для data-sources, работающих в режиме direct (атрибут access: direct). В Deckhouse-сборке Grafana все провижионируемые data-sources заданы исключительно в режиме access: proxy (см. modules/300-prometheus/templates/grafana/secret-datasources-list.yaml: main, main-old, longterm, main-uncached-*) — все запросы к Prometheus/Trickster проходят через grafana-server и аутентифицируются bearer-токеном prometheus-token из секрета, никаких direct-data-sources не создаётся. Соответственно, даже если оператор кластера включит public dashboards, утекать будет нечему: список direct-datasources пустой. Уязвимая комбинация условий (public dashboards + direct data-sources) в типовой инсталляции отсутствует."
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40179"
+      },
+      "timestamp": "2026-05-14T12:00:00.000000+03:00",
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v1.8.2-0.20221021121301-51a44e6657c3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_present",
+      "impact_statement": "Уязвимость CVE-2026-40179 представляет собой Stored XSS в веб-интерфейсе Prometheus через имена метрик и значения меток в тултипах графиков и обозревателе метрик. Согласно официальному advisory (GHSA-vffh-x6r8-xx99), уязвимость затрагивает исключительно Prometheus версий >= 3.0 (конкретно: >= 3.0 <= 3.5.1 и >= 3.6.0 <= 3.11.1). Вектор атаки основан на поддержке UTF-8 в именах метрик и меток, которая была введена как поведение по умолчанию в Prometheus v3.x, что позволяет использовать символы '<', '>' и '\"' в именах метрик. Grafana v10.4.19 импортирует github.com/prometheus/prometheus как Go-библиотеку версии v1.8.2-0.20221021121301-51a44e6657c3 — это срез Prometheus 2.x, использующийся только для парсера PromQL, типов (pkg/labels, pkg/parser, model, promql) и работы с правилами алертинга. Данная версия использует строгую валидацию имён метрик по регулярному выражению [a-zA-Z_:][a-zA-Z0-9_:]* и имён меток по [a-zA-Z_][a-zA-Z0-9_]*, что приводит к отклонению HTML/JavaScript символов на этапе приёма данных (ingestion). Кроме того, Prometheus 2.x не содержит Mantine UI и тот вариант Old React UI с dangerouslySetInnerHTML в Metric Explorer, которые являются основными затронутыми компонентами. Сам Grafana использует собственный фронтенд и не рендерит метрики через Prometheus Web UI компоненты — уязвимый код в этом контексте не исполняется. Инъекция XSS через специально сформированные имена метрик невозможна в данной версии Prometheus, вендорированной в Grafana."
     }
   ]
 }

--- a/modules/300-prometheus/images/grafana-v10/patches/003-cve-go-mod.patch
+++ b/modules/300-prometheus/images/grafana-v10/patches/003-cve-go-mod.patch
@@ -132,7 +132,8 @@ index c3ffcd57..07ea3ab9 100644
 -	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 +	cloud.google.com/go/compute/metadata v0.9.0 // indirect
  	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
- 	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
+-	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
++	github.com/Azure/go-ntlmssp v0.1.1 // indirect
  	github.com/Masterminds/goutils v1.1.1 // indirect
 @@ -291,7 +291,7 @@ require (
  	github.com/armon/go-metrics v0.4.1 // indirect
@@ -181,6 +182,13 @@ index c3ffcd57..07ea3ab9 100644
  )
  
  require (
+@@ -436,5 +436,5 @@ require (
+ 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+ 	github.com/google/gnostic-models v0.6.8 // indirect
+ 	github.com/grafana/grafana-openapi-client-go v0.0.0-20231213163343-bd475d63fb79 // @grafana/backend-platform
+-	github.com/moby/spdystream v0.2.0 // indirect
++	github.com/moby/spdystream v0.5.1 // indirect
+ 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 @@ -453,6 +453,7 @@ require (
  	cloud.google.com/go/auth/oauth2adapt v0.2.3 // indirect
  	cloud.google.com/go/longrunning v0.5.11 // indirect
@@ -220,6 +228,16 @@ index ecf17254..08b24158 100644
  cloud.google.com/go/contactcenterinsights v1.3.0/go.mod h1:Eu2oemoePuEFc/xKFPjbTuPSj0fYJcPls9TFlPNnHHY=
  cloud.google.com/go/contactcenterinsights v1.4.0/go.mod h1:L2YzkGbPsv+vMQMCADxJoT9YiTTnSEd6fEvCeHTYVck=
  cloud.google.com/go/contactcenterinsights v1.6.0/go.mod h1:IIDlT6CLcDoyv79kDv8iWxMSTZhLxSCofVV5W6YFM/w=
+@@ -1275,7 +1275,7 @@ github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E+UnOVAOCHxYAfBLOY4DCe2Wj
+ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
+ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
+-github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e h1:NeAW1fUYUEWhft7pkxDf6WoUvEZJ/uOKsvtpjLnn8MU=
+-github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
++github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
++github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
+ github.com/AzureAD/microsoft-authentication-library-for-go v0.4.0/go.mod h1:Vt9sXTKwMyGcOxSmLDMnGPgqsUg7m8pe215qMLrDXw4=
+ github.com/AzureAD/microsoft-authentication-library-for-go v0.7.0/go.mod h1:BDJ5qMFKx9DugEg3+uQSDCdbYPr5s9vBTrL9P8TpqOU=
+ github.com/AzureAD/microsoft-authentication-library-for-go v1.1.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 @@ -1461,9 +1461,8 @@ github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f h1:y06x6vGnFYf
  github.com/axiomhq/hyperloglog v0.0.0-20191112132149-a4c4c47bc57f/go.mod h1:2stgcRjl6QmW+gU2h5E7BQXg4HU0gzxKWDuT5HviN9s=
  github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
@@ -343,6 +361,15 @@ index ecf17254..08b24158 100644
  github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
  github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
  github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
+@@ -2712,6 +2712,6 @@ github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6U
+ github.com/moby/moby v27.5.1+incompatible h1:/pN59F/t3U7Q4FPzV88nzqf7Fp0qqCSL2KzhZaiKcKw=
+ github.com/moby/moby v27.5.1+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
+-github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
+-github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
++github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
++github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+ github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
+ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 @@ -2996,7 +2996,6 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
  github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
  github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/modules/300-prometheus/images/grafana-v10/patches/README.md
+++ b/modules/300-prometheus/images/grafana-v10/patches/README.md
@@ -21,3 +21,5 @@ Update Go dependencies to fix CVEs
 - [CVE-2026-33487](https://github.com/advisories/GHSA-479m-364c-43vc) — `github.com/russellhaering/goxmldsig` bumped to `v1.6.0`
 - [CVE-2026-34986](https://github.com/advisories/GHSA-78h2-9frx-2jm8) — `github.com/go-jose/go-jose/v3` bumped to `v3.0.5`
 - [CVE-2026-1229](https://github.com/advisories/GHSA-q9hv-hpm4-hj6x) — `github.com/cloudflare/circl` bumped to `v1.6.3`
+- [CVE-2026-35469](https://github.com/advisories/GHSA-pc3f-x583-g7j2) — `github.com/moby/spdystream` bumped to `v0.5.1`
+- [CVE-2026-32952](https://github.com/advisories/GHSA-pjcq-xvwq-hhpj) — `github.com/Azure/go-ntlmssp` bumped to `v0.1.1`


### PR DESCRIPTION
## Description

Follow-up to #19378 that closes 3 additional `CVE-2026` findings against the `300-prometheus/images/grafana-v10` image, which were not covered by the original PR but are present in current image-scanner reports for both `main` and `release-1.73` (see #19812 for the matching backport).

### Per image

- **`grafana-v10`** (`v10.4.19`)
  - **Bumped** via `patches/003-cve-go-mod.patch` (extension to the existing patch, two new hunks for `go.mod` + two for `go.sum`):
    - **CVE-2026-35469** — `github.com/moby/spdystream` `v0.2.0` → `v0.5.1` (indirect, pulled in by `k8s.io/*` apimachinery). Upstream advisory: [GHSA-pc3f-x583-g7j2](https://github.com/advisories/GHSA-pc3f-x583-g7j2) (DoS through unbounded message reads).
    - **CVE-2026-32952** — `github.com/Azure/go-ntlmssp` `v0.0.0-20220621081337-cb9428e4ac1e` → `v0.1.1` (indirect). Upstream advisory: [GHSA-pjcq-xvwq-hhpj](https://github.com/Azure/go-ntlmssp/security/advisories/GHSA-pjcq-xvwq-hhpj) (DoS via malformed NTLM messages).
  - **VEX** (extends `known_vulnerabilities.vex`, picked up automatically by the existing `{{ include "vex mitigation" ... }}` block in `grafana-v10/werf.inc.yaml`):
    - **CVE-2026-40179** (Prometheus stored XSS in tooltips / Metric Explorer via UTF-8 metric/label names, [GHSA-vffh-x6r8-xx99](https://github.com/prometheus/prometheus/security/advisories/GHSA-vffh-x6r8-xx99)) — `status: not_affected`, `justification: vulnerable_code_not_present`. Grafana 10.4.19 vendors `github.com/prometheus/prometheus@v1.8.2-0.20221021121301-51a44e6657c3` (a Prometheus 2.x slice used only for PromQL parser, `pkg/labels`, `pkg/parser`, `model`, `promql` and rules), which enforces the legacy strict regexes `[a-zA-Z_:][a-zA-Z0-9_:]*` for metric names and `[a-zA-Z_][a-zA-Z0-9_]*` for label names — `<`, `>`, `"` are rejected on ingestion. UTF-8 in metric names was introduced in Prometheus 3.0; the upstream advisory is explicitly scoped to Prometheus >= 3.0. The vulnerable sinks (Mantine UI / Old React Metric Explorer `dangerouslySetInnerHTML`) are not present in 2.x at all, and Grafana ships its own frontend, so none of the affected code paths exist in this image.

## Why do we need it, and what problem does it solve?

These three CVEs surface in current image-scanner reports against `grafana-v10`. They were not part of the dependency set bumped in #19378. Closing them in a separate, focused PR keeps the diff small (~50 lines across 4 files) and the rationale auditable; the backport #19812 picks up the same changeset for `release-1.73`.

## Why do we need it in the patch release (if we do)?

Yes — the matching backport PR for `release-1.73` is #19812. Once both are merged, the next 1.73 patch release plus `main` will have a clean scan for these three findings.

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: prometheus
type: fix
summary: Fix additional CVEs in grafana-v10 (CVE-2026-35469 spdystream, CVE-2026-32952 go-ntlmssp via patches/003-cve-go-mod.patch bump); add VEX for CVE-2026-40179 (Prometheus stored XSS — not present in vendored Prometheus 2.x library).
impact_level: low
```
