### PR TITLE
[docs] Use containerised AWS CLI for S3 uploads

### DIFF
--- a/.github/ci_templates/web.yml
+++ b/.github/ci_templates/web.yml
@@ -319,19 +319,6 @@ steps:
     run: |
       make docs-generate-pdf DOC_VERSION="${DOC_VERSION}"
 
-  - name: Install awscli
-    if: ${{ success() }}
-    run: |
-      if command -v aws &>/dev/null; then
-        echo "AWS CLI already available: $(aws --version)"
-      else
-        curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-        unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
-        /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
-        echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-        rm -rf /tmp/awscliv2.zip /tmp/awscliv2
-      fi
-
   - name: Upload PDF files to S3
     if: ${{ success() }}
     env:
@@ -344,12 +331,17 @@ steps:
     run: |
       for lang in en ru; do
         for guide in admin user; do
-          aws s3 cp \
-            "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
-            "s3://${S3_BUCKET}/deckhouse-{!{ $webEnv }!}/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
-            --endpoint-url "https://${S3_EP}" \
-            --region "${S3_REGION}" \
-            --no-verify-ssl
+          docker run --rm \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -v "${GITHUB_WORKSPACE}/pdf:/aws/pdf:ro" \
+            amazon/aws-cli:2.27.22 \
+            s3 cp \
+              "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
+              "s3://${S3_BUCKET}/deckhouse-{!{ $webEnv }!}/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
+              --endpoint-url "https://${S3_EP}" \
+              --region "${S3_REGION}" \
+              --no-verify-ssl
         done
       done
 # </template: doc_pdf_build_template>

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -3384,19 +3384,6 @@ jobs:
         run: |
           make docs-generate-pdf DOC_VERSION="${DOC_VERSION}"
 
-      - name: Install awscli
-        if: ${{ success() }}
-        run: |
-          if command -v aws &>/dev/null; then
-            echo "AWS CLI already available: $(aws --version)"
-          else
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-            unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
-            /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
-            echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-            rm -rf /tmp/awscliv2.zip /tmp/awscliv2
-          fi
-
       - name: Upload PDF files to S3
         if: ${{ success() }}
         env:
@@ -3409,12 +3396,17 @@ jobs:
         run: |
           for lang in en ru; do
             for guide in admin user; do
-              aws s3 cp \
-                "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
-                "s3://${S3_BUCKET}/deckhouse-web-production/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
-                --endpoint-url "https://${S3_EP}" \
-                --region "${S3_REGION}" \
-                --no-verify-ssl
+              docker run --rm \
+                -e AWS_ACCESS_KEY_ID \
+                -e AWS_SECRET_ACCESS_KEY \
+                -v "${GITHUB_WORKSPACE}/pdf:/aws/pdf:ro" \
+                amazon/aws-cli:2.27.22 \
+                s3 cp \
+                  "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
+                  "s3://${S3_BUCKET}/deckhouse-web-production/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
+                  --endpoint-url "https://${S3_EP}" \
+                  --region "${S3_REGION}" \
+                  --no-verify-ssl
             done
           done
     # </template: doc_pdf_build_template>

--- a/.github/workflows/docs-pdf-daily.yml
+++ b/.github/workflows/docs-pdf-daily.yml
@@ -171,19 +171,6 @@ jobs:
         run: |
           make docs-generate-pdf DOC_VERSION="${DOC_VERSION}"
 
-      - name: Install awscli
-        if: ${{ success() }}
-        run: |
-          if command -v aws &>/dev/null; then
-            echo "AWS CLI already available: $(aws --version)"
-          else
-            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
-            unzip -q /tmp/awscliv2.zip -d /tmp/awscliv2
-            /tmp/awscliv2/aws/install -i "${HOME}/.local/aws-cli" -b "${HOME}/.local/bin"
-            echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
-            rm -rf /tmp/awscliv2.zip /tmp/awscliv2
-          fi
-
       - name: Upload PDF files to S3
         if: ${{ success() }}
         env:
@@ -196,12 +183,17 @@ jobs:
         run: |
           for lang in en ru; do
             for guide in admin user; do
-              aws s3 cp \
-                "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
-                "s3://${S3_BUCKET}/deckhouse-web-production/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
-                --endpoint-url "https://${S3_EP}" \
-                --region "${S3_REGION}" \
-                --no-verify-ssl
+              docker run --rm \
+                -e AWS_ACCESS_KEY_ID \
+                -e AWS_SECRET_ACCESS_KEY \
+                -v "${GITHUB_WORKSPACE}/pdf:/aws/pdf:ro" \
+                amazon/aws-cli:2.27.22 \
+                s3 cp \
+                  "pdf/deckhouse-${guide}-guide_${lang}.pdf" \
+                  "s3://${S3_BUCKET}/deckhouse-web-production/${DOC_VERSION}/docs-dkp/${lang}/pdf/deckhouse-${guide}-guide.pdf" \
+                  --endpoint-url "https://${S3_EP}" \
+                  --region "${S3_REGION}" \
+                  --no-verify-ssl
             done
           done
     # </template: doc_pdf_build_template>


### PR DESCRIPTION
## Description

- Replace host-level AWS CLI installation step with a pinned Docker image to execute S3 copy commands, eliminating the need to download, unzip, and install the binary on the runner
- Mount the PDF output directory as a read-only volume and pass credentials via environment variables to the ephemeral container, improving reproducibility and isolation
- Apply the change consistently across the CI template and all generated workflow definitions that produce documentation PDFs

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Use containerised AWS CLI for S3 uploads
impact_level: low
```
