### PR TITLE
[docs] Exclude PDF assets from documentation version upload

### DIFF
--- a/docs/documentation/.helm/templates/10-job-s3.yaml
+++ b/docs/documentation/.helm/templates/10-job-s3.yaml
@@ -99,6 +99,10 @@ spec:
           - --ca-bundle
           - /.aws/s3-root.crt
           - --delete
+          - --exclude
+          - "en/pdf/*"
+          - --exclude
+          - "ru/pdf/*"
           - --endpoint-url
           - https://{{ .Values.global.doc_s3_ep }}
           - --region


### PR DESCRIPTION
## Description

Add exclusion rules for locale-specific PDF directories on the website during S3 synchronisation to prevent the delete flag from removing pre-existing PDF artefacts on each deployment cycle


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Exclude PDF assets from documentation version upload.
impact_level: low
```
