### PR TITLE
[docs] Improvements to the processing of OSS info pages in the PDF

### DIFF
--- a/tools/docs/pdf/get_pdf_page.py
+++ b/tools/docs/pdf/get_pdf_page.py
@@ -251,6 +251,14 @@ def generate_html_header(title: str = "Extracted content", lang: str = "ru") -> 
             margin-left: 0;
             margin-right: 0;
         }
+        /* OSS info page: constrain logo images to match website sizing */
+        .oss__item-logo,
+        .oss__item-logo img,
+        img.oss__item-logo {
+            height: 60px !important;
+            width: auto !important;
+            max-width: 100% !important;
+        }
         /* Блоки кода (Rouge/Jekyll): визуальное отделение от текста + перенос строк */
         pre,
         pre.highlight,

--- a/tools/docs/pdf/get_pdf_page.py
+++ b/tools/docs/pdf/get_pdf_page.py
@@ -1072,7 +1072,7 @@ def postprocess_extracted_docs_soup(soup: BeautifulSoup, lang: str) -> None:
     for logo_div in soup.find_all("div", class_="oss__item-logo"):
         logo_div.decompose()
     for title_a in soup.find_all("a", class_="oss__item-title"):
-        title_a["style"] = "font-weight:bold;"
+        title_a["style"] = "font-weight:bold; display:block; margin-top:1em;"
 
 
 class _ChunkWriter:

--- a/tools/docs/pdf/get_pdf_page.py
+++ b/tools/docs/pdf/get_pdf_page.py
@@ -251,14 +251,6 @@ def generate_html_header(title: str = "Extracted content", lang: str = "ru") -> 
             margin-left: 0;
             margin-right: 0;
         }
-        /* OSS info page: constrain logo images to match website sizing */
-        .oss__item-logo,
-        .oss__item-logo img,
-        img.oss__item-logo {
-            height: 60px !important;
-            width: auto !important;
-            max-width: 100% !important;
-        }
         /* Блоки кода (Rouge/Jekyll): визуальное отделение от текста + перенос строк */
         pre,
         pre.highlight,
@@ -1076,6 +1068,11 @@ def postprocess_extracted_docs_soup(soup: BeautifulSoup, lang: str) -> None:
     else:
         remove_sections_with_exact_heading(soup, "Внешние компоненты")
 
+    # OSS info page: remove logo images, bold titles
+    for logo_div in soup.find_all("div", class_="oss__item-logo"):
+        logo_div.decompose()
+    for title_a in soup.find_all("a", class_="oss__item-title"):
+        title_a["style"] = "font-weight:bold;"
 
 
 class _ChunkWriter:


### PR DESCRIPTION
## Description

This pull request makes targeted improvements to the processing of OSS info pages in the PDF version of the documentation. The changes focus on cleaning up the HTML by removing unnecessary visual elements and enhancing the formatting of section titles:
* Removed logo images.
* Enhanced section title visibility.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Improvements to the processing of OSS info pages in the PDF version of the documentation.
impact_level: low
```
