### PR TITLE
[docs] Add Cache-Control headers to S3 proxy locations

### DIFF
--- a/docs/site/.helm/templates/10-cm-frontend.yaml
+++ b/docs/site/.helm/templates/10-cm-frontend.yaml
@@ -286,6 +286,8 @@ data:
             proxy_read_timeout      30s;
             proxy_send_timeout      30s;
 
+            add_header Cache-Control "public, max-age=1800" always;
+
             proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
         }
 
@@ -311,6 +313,7 @@ data:
             proxy_ignore_headers    Cache-Control;
 
             add_header Content-Disposition 'attachment; filename="${pdf_file}"';
+            add_header Cache-Control "public, max-age=1800" always;
 
             proxy_set_header Host   {{ .Values.global.doc_s3_bucket_public_url }};
 
@@ -350,6 +353,8 @@ data:
             proxy_read_timeout      30s;
             proxy_send_timeout      30s;
 
+            add_header Cache-Control "public, max-age=1800" always;
+
             proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
         }
 
@@ -381,6 +386,8 @@ data:
             proxy_connect_timeout   30s;
             proxy_read_timeout      30s;
             proxy_send_timeout      30s;
+
+            add_header Cache-Control "public, max-age=1800" always;
 
             proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
         }

--- a/docs/site/.helm/templates/10-cm-moduleslibrary.yaml
+++ b/docs/site/.helm/templates/10-cm-moduleslibrary.yaml
@@ -143,6 +143,8 @@ data:
             proxy_read_timeout      30s;
             proxy_send_timeout      30s;
 
+            add_header Cache-Control "public, max-age=1800" always;
+
             proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
         }
 
@@ -201,6 +203,8 @@ data:
             proxy_read_timeout      30s;
             proxy_send_timeout      30s;
 
+            add_header Cache-Control "public, max-age=1800" always;
+
             proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
         }
 
@@ -233,6 +237,8 @@ data:
             proxy_connect_timeout   30s;
             proxy_read_timeout      30s;
             proxy_send_timeout      30s;
+
+            add_header Cache-Control "public, max-age=1800" always;
 
             proxy_pass              https://{{ .Values.global.doc_s3_bucket_public_url }};
         }


### PR DESCRIPTION
## Description

Website serving updates:
- Adds HTTP caching headers to the NGINX configuration in both the `frontend` and `moduleslibrary` Helm templates. The main goal is to instruct clients and proxies to cache responses for up to 30 minutes, which should improve performance and reduce load on the backend.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add Cache-Control headers to S3 proxy locations.
impact_level: low
```
