### PR TITLE
[user-authz] extend cluster-admin clusterrole  with kubelet-api-admin rights

### DIFF
--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -257,9 +257,18 @@ write:
 {{site.data.i18n.common.role[page.lang] | capitalize }} `ClusterAdmin` ({{site.data.i18n.common.includes_rules_from[page.lang]}} `User`, `PrivilegedUser`, `Editor`, `Admin`, `ClusterEditor`):
 
 ```text
+proxy:
+    - nodes
 read-write:
     - deckhouse.io/clusterauthorizationrules
     - namespaces
+    - nodes/configz
+    - nodes/healthz
+    - nodes/log
+    - nodes/metrics
+    - nodes/pods
+    - nodes/proxy
+    - nodes/stats
 write:
     - limitranges
     - networking.k8s.io/networkpolicies

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -266,9 +266,18 @@ write:
 {{site.data.i18n.common.role[page.lang] | capitalize }} `ClusterAdmin` ({{site.data.i18n.common.includes_rules_from[page.lang]}} `User`, `PrivilegedUser`, `Editor`, `Admin`, `ClusterEditor`):
 
 ```text
+proxy:
+    - nodes
 read-write:
     - deckhouse.io/clusterauthorizationrules
     - namespaces
+    - nodes/configz
+    - nodes/healthz
+    - nodes/log
+    - nodes/metrics
+    - nodes/pods
+    - nodes/proxy
+    - nodes/stats
 write:
     - limitranges
     - networking.k8s.io/networkpolicies

--- a/modules/140-user-authz/templates/cluster-roles.yaml
+++ b/modules/140-user-authz/templates/cluster-roles.yaml
@@ -361,7 +361,7 @@
   - roles
   - rolebindings
   verbs:
-{{- include "user_authz_verbs" "rw" }}
+{{- include "user_authz_verbs" "w" }}
 - apiGroups:
   - ""
   resources:

--- a/modules/140-user-authz/templates/cluster-roles.yaml
+++ b/modules/140-user-authz/templates/cluster-roles.yaml
@@ -19,6 +19,8 @@
   - deletecollection
   - patch
   - update
+  {{- else if eq $mode "p" }}
+  - proxy
   {{- end }}
 {{- end -}}
 
@@ -359,7 +361,25 @@
   - roles
   - rolebindings
   verbs:
-{{- include "user_authz_verbs" "w" }}
+{{- include "user_authz_verbs" "rw" }}
+- apiGroups:
+  - ""
+  resources:
+  - nodes/log
+  - nodes/metrics
+  - nodes/proxy
+  - nodes/stats
+  - nodes/configz
+  - nodes/healthz
+  - nodes/pods
+  verbs:
+{{- include "user_authz_verbs" "rw" }}
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+{{- include "user_authz_verbs" "p" }}
 {{- end }}
 
 {{- define "user_authz_super_admin_rules" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
`kube-apiserver-kubelet-client` (group kubeadm:cluster-admin since kubeadm 1.29+) loses kubelet api admin permissions. Add missing permissions to user-authz:cluster-admin.

Related to: https://github.com/deckhouse/deckhouse/pull/19667

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Resolve:

```
root@a25871219664-1-con-1-33-master-0:~# kubectl -n d8-system logs -f webhook-handler-8464648fdc-4444w
Error from server (Forbidden): Forbidden (user=kube-apiserver-kubelet-client, verb=get, resource=nodes, subresource(s)=[proxy])
 ( pods/log webhook-handler-8464648fdc-4444w)
root@a25871219664-1-con-1-33-master-0:~# kubectl -n d8-system logs -f deckhouse-9857d99cf-kcfhf
Error from server (Forbidden): Forbidden (user=kube-apiserver-kubelet-client, verb=get, resource=nodes, subresource(s)=[proxy])
 ( pods/log deckhouse-9857d99cf-kcfhf)
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: user-authz
type: fix
summary: Extend cluster-admin clusterrole  with kubelet-api-admin rights.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
