### PR TITLE
[container-base] Implement package manager to node-manager (candi)

### DIFF
--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,5 +1,7 @@
 # version=v1.0.20
 REGISTRY_PATH: registry.deckhouse.io/container-factory
 base/distroless: "sha256:86d87712dec2781115bea04a3a269d2c61ba9c5e9c75d20db467b0aa066f3a6c" # from: builder/scratch
+builder/golang-1.25: "sha256:de9e6934364c9273445ab2364d540acfdc40ea78f3f5439751757ef36390eef9" # from: base/distroless
+builder/golang-1.26: "sha256:dd8cc64d1b082a996a89279514a620b12c6928b6824cec68e59cd438d333263e" # from: base/distroless
 builder/golang: "sha256:dd8cc64d1b082a996a89279514a620b12c6928b6824cec68e59cd438d333263e" # from: base/distroless
 minget: "sha256:71467545ce0c913df0341abb09e2e762f3ad3b96e36147b65e1c3065f3db028a" # from: builder/scratch

--- a/modules/040-node-manager/images/bashible-apiserver/werf.inc.yaml
+++ b/modules/040-node-manager/images/bashible-apiserver/werf.inc.yaml
@@ -27,7 +27,7 @@ git:
     - 'go.sum'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact

--- a/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/capi-controller-manager/werf.inc.yaml
@@ -30,7 +30,7 @@ shell:
   - rm -rf .git hack test
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -44,8 +44,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make bash git
+  - pm install git
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src

--- a/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/caps-controller-manager/werf.inc.yaml
@@ -35,7 +35,7 @@ git:
     - "**/*.go"
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
+++ b/modules/040-node-manager/images/cluster-autoscaler/werf.inc.yaml
@@ -45,7 +45,7 @@ shell:
   - rm -rf /src/cloudprovider/azure/test
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}-src-artifact

--- a/modules/040-node-manager/images/early-oom/werf.inc.yaml
+++ b/modules/040-node-manager/images/early-oom/werf.inc.yaml
@@ -8,7 +8,7 @@ git:
   to: /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-node-manager/images/fencing-agent/werf.inc.yaml
+++ b/modules/040-node-manager/images/fencing-agent/werf.inc.yaml
@@ -7,7 +7,7 @@ git:
   to: /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-node-manager/images/kubernetes-api-proxy/werf.inc.yaml
+++ b/modules/040-node-manager/images/kubernetes-api-proxy/werf.inc.yaml
@@ -7,7 +7,7 @@ git:
   to: /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
+++ b/modules/040-node-manager/images/machine-controller-manager/werf.inc.yaml
@@ -27,7 +27,7 @@ shell:
   - rm -rf /src/.git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-node-manager/images/node-controller/werf.inc.yaml
+++ b/modules/040-node-manager/images/node-controller/werf.inc.yaml
@@ -40,7 +40,7 @@ git:
     - 'go.sum'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact

--- a/modules/040-node-manager/images/node-group-exporter/werf.inc.yaml
+++ b/modules/040-node-manager/images/node-group-exporter/werf.inc.yaml
@@ -10,7 +10,7 @@ git:
     - '**/*'
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ $.ImageName }}-src-artifact


### PR DESCRIPTION
## Description
Migrate `040-node-manager` to a unified golang builder with integrated Container Base package manager and Go GOST compilation toolchain.

## Why do we need it, and what problem does it solve?
Standardizes the build process, implement Go GOST

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: feature
summary: Migrated node-manager (candi) builds to the unified builder with package manager and Go toolchain.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
