### PR TITLE
[dhctl] add readme.md for opentelemetry in dhctl

### DIFF
--- a/dhctl/README.opentelemetry.md
+++ b/dhctl/README.opentelemetry.md
@@ -3,11 +3,13 @@
 This document explains how to enable, collect and view OpenTelemetry traces produced by dhctl.
 
 ## Overview
+
 dhctl can produce traces and metrics for a single run. When tracing is enabled, dhctl writes a local trace file containing all traces and metrics from that run. You can inspect the file locally with the lovie utility or convert it for ingestion into tracing backends such as Grafana Tempo.
 
 Important: Traces may include sensitive data (arguments, resource identifiers, etc.). Treat trace files accordingly.
 
 ## Enabling tracing
+
 To enable tracing for a dhctl run, set the environment variable:
 - `DHCTL_TRACE=yes`
 
@@ -17,8 +19,9 @@ Example:
 dhctl will print information about the created trace file at the very beginning of its output.
 
 ## Local trace file
+
 - File name format: `trace-%date.jsonl`
-- Location: created alongside dhctl logs (working directory or configured log directory)
+- Location: created alongside dhctl logs
 - Format: JSON Lines (each line is a JSON object representing spans/metrics/events)
 - Content: All traces and metrics produced during that dhctl run
 
@@ -26,6 +29,7 @@ Example log output (informational):
 - `Trace file: /tmp/dhctl/trace-20260514151839.jsonl`
 
 ## Viewing traces locally with lovie
+
 [lovie](https://github.com/090809/lovie) can render the trace file in a browser for visual inspection.
 
 Basic usage:
@@ -38,10 +42,12 @@ Converting to Tempo-compatible export:
   This converts the dhctl trace format into a trace file suitable for importing into Grafana Tempo (or your DOP). After conversion, follow your backend's import instructions to load the trace.
 
 ## Security and privacy
+
 - Traces may include CLI arguments, file paths, resource names and other identifiers. Scrub or redact sensitive traces before sharing with third parties.
 - Consider running dhctl with tracing only in trusted environments.
 
 ## Known limitations
+
 - Some spans may not be nested correctly in the visualization.
 - Some function names or attributes might be incomplete in the current viewer/export path.
 - Conversion/import tooling may require backend-specific adjustments.

--- a/dhctl/README.opentelemetry.md
+++ b/dhctl/README.opentelemetry.md
@@ -1,0 +1,47 @@
+# Working with OpenTelemetry for dhctl
+
+This document explains how to enable, collect and view OpenTelemetry traces produced by dhctl.
+
+## Overview
+dhctl can produce traces and metrics for a single run. When tracing is enabled, dhctl writes a local trace file containing all traces and metrics from that run. You can inspect the file locally with the lovie utility or convert it for ingestion into tracing backends such as Grafana Tempo.
+
+Important: Traces may include sensitive data (arguments, resource identifiers, etc.). Treat trace files accordingly.
+
+## Enabling tracing
+To enable tracing for a dhctl run, set the environment variable:
+- `DHCTL_TRACE=yes`
+
+Example:
+- `DHCTL_TRACE=yes dhctl <command>`
+
+dhctl will print information about the created trace file at the very beginning of its output.
+
+## Local trace file
+- File name format: `trace-%date.jsonl`
+- Location: created alongside dhctl logs (working directory or configured log directory)
+- Format: JSON Lines (each line is a JSON object representing spans/metrics/events)
+- Content: All traces and metrics produced during that dhctl run
+
+Example log output (informational):
+- `Trace file: /tmp/dhctl/trace-20260514151839.jsonl`
+
+## Viewing traces locally with lovie
+[lovie](https://github.com/090809/lovie) can render the trace file in a browser for visual inspection.
+
+Basic usage:
+- `lovie /path/to/trace-file.jsonl`
+
+This command will open your default web browser and display the run progress and spans.
+
+Converting to Tempo-compatible export:
+- `lovie tempo-export /path/to/trace-file.jsonl`
+  This converts the dhctl trace format into a trace file suitable for importing into Grafana Tempo (or your DOP). After conversion, follow your backend's import instructions to load the trace.
+
+## Security and privacy
+- Traces may include CLI arguments, file paths, resource names and other identifiers. Scrub or redact sensitive traces before sharing with third parties.
+- Consider running dhctl with tracing only in trusted environments.
+
+## Known limitations
+- Some spans may not be nested correctly in the visualization.
+- Some function names or attributes might be incomplete in the current viewer/export path.
+- Conversion/import tooling may require backend-specific adjustments.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add documentation for opentelemetry usage in dhctl

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: add usage documentation for opentelemetry in dhctl
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
