### PR TITLE
[release-1.73][log-shipper] Bump Go toolchain to 1.25 for vector reloader to fix stdlib CVEs

### DIFF
--- a/modules/460-log-shipper/images/vector/reloader/go.mod
+++ b/modules/460-log-shipper/images/vector/reloader/go.mod
@@ -1,6 +1,6 @@
 module vector
 
-go 1.19
+go 1.25.8
 
 require (
 	github.com/fsnotify/fsnotify v1.6.0

--- a/modules/460-log-shipper/images/vector/werf.inc.yaml
+++ b/modules/460-log-shipper/images/vector/werf.inc.yaml
@@ -87,7 +87,7 @@ shell:
   - chmod 0755 /vector
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-reloader-artifact
-fromImage: builder/golang-alpine-1.24
+fromImage: builder/golang-alpine-1.25
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact


### PR DESCRIPTION
Manual backport of #19849 to `release-1.73` (the automated cherry-pick failed in https://github.com/deckhouse/deckhouse/actions/runs/25917441418).

## Description

Bumped the build toolchain for the `reloader` binary (`/usr/bin/reloader`) inside the `vector` image of the `log-shipper` module from Go 1.24 to Go 1.25.

The `vector` binary itself is written in Rust and is not affected. Only the small Go-based `reloader` sidecar is rebuilt.

Changes:
- `modules/460-log-shipper/images/vector/werf.inc.yaml`: bumped builder image to `builder/golang-alpine-1.25` (kept `release-1.73` `fromImage:` syntax).
- `modules/460-log-shipper/images/vector/reloader/go.mod`: bumped `go` directive to `1.25.8`.

## Conflict resolution

- `werf.inc.yaml`: on `main` this entry was already refactored to `from: {{ index $.Images "builder/golang-alpine-1.X" }}`. On `release-1.73` the convention is still `fromImage: builder/golang-alpine-1.X`, so I kept the `fromImage:` form and only changed the version `1.24 -> 1.25`.
- `go.mod`: on `release-1.73` the `go` directive was `1.19`. Bumped it directly to `1.25.8` to match the intent of the original PR.

## Why do we need it, and what problem does it solve?

Trivy reports CVEs against `usr/bin/reloader` in the `vector` image (module `log-shipper`).

## Why do we need it in the patch release (if we do)?

Required for the 1.73.x patch line. CVEs in the embedded Go stdlib are surfaced by security scanners on customer clusters and must be closed in the supported release branch.

## Changelog entries

```changes
section: log-shipper
type: fix
summary: Bump Go version to 1.25.8 in reloader image to fix stdlib CVEs in Go 1.24.13.
impact_level: low
```
