### PR TITLE
[CI] Fix for X.X.0 release tags

### DIFF
--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -184,18 +184,8 @@ jobs:
           python-version: '3.12.3'
       {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
       {!{ tmpl.Exec "login_readonly_registry_step" $ctx | strings.Indent 6 }!}
-      - name: Check tag
-        id: check-tag
-        uses: {!{ index (ds "actions") "actions/github-script" }!}
-        with:
-          result-encoding: string
-          script: |
-            const tag = context.ref.replace("refs/tags/", "");
-            const patchNumber = Number(tag.split(".")[2]);
-            return patchNumber >= 1;
       - name: List changed modules from latest released version
         id: list_changed_modules
-        if: ${{ steps.check-tag.outputs.result == 'true' }}
         env:
           IMAGE_TO: "${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}/deckhouse/fe:${{ github.ref_name }}"
           COMPARE_MAX_ATTEMPTS: 10

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -2247,18 +2247,8 @@ jobs:
           password: ${{ secrets.DECKHOUSE_REGISTRY_READ_PASSWORD }}
           logout: false
       # </template: login_readonly_registry_step>
-      - name: Check tag
-        id: check-tag
-        uses: actions/github-script@v6.4.1
-        with:
-          result-encoding: string
-          script: |
-            const tag = context.ref.replace("refs/tags/", "");
-            const patchNumber = Number(tag.split(".")[2]);
-            return patchNumber >= 1;
       - name: List changed modules from latest released version
         id: list_changed_modules
-        if: ${{ steps.check-tag.outputs.result == 'true' }}
         env:
           IMAGE_TO: "${{ secrets.DECKHOUSE_REGISTRY_READ_HOST }}/deckhouse/fe:${{ github.ref_name }}"
           COMPARE_MAX_ATTEMPTS: 10


### PR DESCRIPTION
## Description
After switching to a new release process. The "List changed modules from latest released version" step must be performed for all patch versions of the release.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix for X.X.0 release tags
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
