### PR TITLE
[cni-cilium] Fixing CPU overload caused by cilium agents on nodes with many CPU cores.

### DIFF
--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -43,6 +43,15 @@ spec:
         - -ec
         - |
           cp -a /var/lib/cilium-rw/bpf /var/lib/cilium/;
+          # Cap Go runtime parallelism to avoid scheduler scaling problems on
+          # high-CPU nodes (golang/go#65064, golang/go#68399). Default
+          # GOMAXPROCS=NumCPU burns 1+ CPU core in runtime.(*lfstack).pop and
+          # runtime.gcDrain on 32+ core machines with no throughput benefit;
+          # min(NumCPU, 8) covers cilium-agent's actual parallelism needs.
+          # An explicit GOMAXPROCS env var (if set) takes precedence.
+          NPROC=$(grep -c '^processor' /proc/cpuinfo)
+          [ "${NPROC:-0}" -gt 8 ] && NPROC=8
+          export GOMAXPROCS="${GOMAXPROCS:-$NPROC}"
           exec cilium-agent --config-dir=/tmp/cilium/config-map \
                             --prometheus-serve-addr=127.0.0.1:9092
         startupProbe:

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -43,15 +43,6 @@ spec:
         - -ec
         - |
           cp -a /var/lib/cilium-rw/bpf /var/lib/cilium/;
-          # Cap Go runtime parallelism to avoid scheduler scaling problems on
-          # high-CPU nodes (golang/go#65064, golang/go#68399). Default
-          # GOMAXPROCS=NumCPU burns 1+ CPU core in runtime.(*lfstack).pop and
-          # runtime.gcDrain on 32+ core machines with no throughput benefit;
-          # min(NumCPU, 8) covers cilium-agent's actual parallelism needs.
-          # An explicit GOMAXPROCS env var (if set) takes precedence.
-          NPROC=$(grep -c '^processor' /proc/cpuinfo)
-          [ "${NPROC:-0}" -gt 8 ] && NPROC=8
-          export GOMAXPROCS="${GOMAXPROCS:-$NPROC}"
           exec cilium-agent --config-dir=/tmp/cilium/config-map \
                             --prometheus-serve-addr=127.0.0.1:9092
         startupProbe:
@@ -111,6 +102,8 @@ spec:
             resourceFieldRef:
               resource: limits.memory
               divisor: '1'
+        - name: GOMAXPROCS
+          value: "8"
         - name: KUBERNETES_SERVICE_HOST
           value: "127.0.0.1"
         - name: KUBERNETES_SERVICE_PORT


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Set `GOMAXPROCS = 8` at `cilium-agent` start.

On nodes with many CPUs (32+), Go runtime's default `GOMAXPROCS = NumCPU` causes severe scheduler / GC scaling overhead in `cilium-agent`, even under low actual workload. This change caps `GOMAXPROCS` at 8, which is sufficient for cilium-agent's real parallelism needs (BPF map operations, endpoint regeneration, K8s informers).

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

On a 224-CPU production node, `cilium-agent` was burning **1.8 CPU cores steady-state** with active hubble. Pprof analysis showed the cost was almost half Go runtime overhead:
- `runtime.(*lfstack).pop` — 24.53% flat (lock-free stack contention)
- `runtime.gcDrain` — 57.23% cum (GC mark phase)
- `runtime.scanobject` — 16.15% cum
This is a known Go runtime scaling problem on high-CPU machines, tracked upstream in:
- https://github.com/golang/go/issues/21056
- https://github.com/golang/go/issues/68399 (GC worker scaling)

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Fixed Cilium agent CPU overload on nodes with many CPUs.
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
