### PR TITLE
[deckhouse] make validation webhooks return Invalid reason

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -66,13 +66,13 @@ func RegisterAdmissionHandlers(
 	settings *helpers.DeckhouseSettingsContainer,
 	exts *extenders.ExtendersStack,
 ) {
-	reg.RegisterHandler("/validate/v1/deckhouse-registry-secret", RegistrySecretHandler())
-	reg.RegisterHandler("/validate/v1alpha1/module-configs", moduleConfigValidationHandler(cli, storage, metricStorage, mm, validator, settings, exts))
-	reg.RegisterHandler("/validate/v1alpha1/modules", moduleValidationHandler())
-	reg.RegisterHandler("/validate/v1/configuration-secret", clusterConfigurationHandler(mm, cli, schemaStore))
-	reg.RegisterHandler("/validate/v1/provider-configuration-secret", providerConfigurationHandler(schemaStore))
-	reg.RegisterHandler("/validate/v1/static-configuration-secret", staticConfigurationHandler(schemaStore))
-	reg.RegisterHandler("/validate/v1alpha1/update-policies", updatePolicyHandler(cli))
-	reg.RegisterHandler("/validate/v1alpha1/deckhouse-releases", DeckhouseReleaseValidationHandler(cli, metricStorage, mm, exts))
-	reg.RegisterHandler("/validate/v1alpha1/applications", applicationValidationHandler(cli, pm))
+	reg.RegisterHandler("/validate/v1/deckhouse-registry-secret", withInvalidReason(RegistrySecretHandler()))
+	reg.RegisterHandler("/validate/v1alpha1/module-configs", withInvalidReason(moduleConfigValidationHandler(cli, storage, metricStorage, mm, validator, settings, exts)))
+	reg.RegisterHandler("/validate/v1alpha1/modules", withInvalidReason(moduleValidationHandler()))
+	reg.RegisterHandler("/validate/v1/configuration-secret", withInvalidReason(clusterConfigurationHandler(mm, cli, schemaStore)))
+	reg.RegisterHandler("/validate/v1/provider-configuration-secret", withInvalidReason(providerConfigurationHandler(schemaStore)))
+	reg.RegisterHandler("/validate/v1/static-configuration-secret", withInvalidReason(staticConfigurationHandler(schemaStore)))
+	reg.RegisterHandler("/validate/v1alpha1/update-policies", withInvalidReason(updatePolicyHandler(cli)))
+	reg.RegisterHandler("/validate/v1alpha1/deckhouse-releases", withInvalidReason(DeckhouseReleaseValidationHandler(cli, metricStorage, mm, exts)))
+	reg.RegisterHandler("/validate/v1alpha1/applications", withInvalidReason(applicationValidationHandler(cli, pm)))
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// withInvalidReason makes `kubectl edit` reopen the editor on validation
+// failure: kubewebhook hard-codes HTTP 400 in the AdmissionResponse, but
+// kubectl reopens the editor only on Reason=Invalid / HTTP 422. We buffer the
+// upstream response, and if it denies the request, rewrite Result to 422 +
+// Invalid before sending it to the client.
+func withInvalidReason(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := httptest.NewRecorder()
+		next.ServeHTTP(rec, r)
+
+		body := rec.Body.Bytes()
+
+		var review admissionv1.AdmissionReview
+		if err := json.Unmarshal(body, &review); err == nil && review.Response != nil && !review.Response.Allowed {
+			msg := ""
+			if review.Response.Result != nil {
+				msg = review.Response.Result.Message
+			}
+			review.Response.Result = &metav1.Status{
+				Status:  metav1.StatusFailure,
+				Reason:  metav1.StatusReasonInvalid,
+				Code:    http.StatusUnprocessableEntity,
+				Message: msg,
+			}
+			if patched, err := json.Marshal(review); err == nil {
+				body = patched
+			}
+		}
+
+		for k, v := range rec.Header() {
+			w.Header()[k] = v
+		}
+		w.WriteHeader(rec.Code)
+		_, _ = w.Write(body)
+	})
+}

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/response_remapper_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWithInvalidReason(t *testing.T) {
+	deniedBody := mustMarshalReview(t, admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
+		Response: &admissionv1.AdmissionResponse{
+			UID:     "uid-denied",
+			Allowed: false,
+			Result: &metav1.Status{
+				Message: "spec.version=999 is unsupported",
+				Code:    http.StatusBadRequest,
+			},
+		},
+	})
+
+	allowedBody := mustMarshalReview(t, admissionv1.AdmissionReview{
+		TypeMeta: metav1.TypeMeta{APIVersion: "admission.k8s.io/v1", Kind: "AdmissionReview"},
+		Response: &admissionv1.AdmissionResponse{
+			UID:      "uid-allowed",
+			Allowed:  true,
+			Warnings: []string{"deprecated field"},
+		},
+	})
+
+	tests := []struct {
+		name      string
+		giveBody  []byte
+		giveCode  int
+		wantCode  int
+		wantCheck func(t *testing.T, body []byte)
+	}{
+		{
+			name:     "denied rewritten to 422 Invalid with original message preserved",
+			giveBody: deniedBody,
+			giveCode: http.StatusOK,
+			wantCode: http.StatusOK,
+			wantCheck: func(t *testing.T, body []byte) {
+				var got admissionv1.AdmissionReview
+				require.NoError(t, json.Unmarshal(body, &got))
+				require.NotNil(t, got.Response)
+				require.NotNil(t, got.Response.Result)
+				assert.False(t, got.Response.Allowed)
+				assert.Equal(t, metav1.StatusReasonInvalid, got.Response.Result.Reason)
+				assert.Equal(t, int32(http.StatusUnprocessableEntity), got.Response.Result.Code)
+				assert.Equal(t, metav1.StatusFailure, got.Response.Result.Status)
+				assert.Equal(t, "spec.version=999 is unsupported", got.Response.Result.Message)
+			},
+		},
+		{
+			name:     "allowed response passes through unchanged",
+			giveBody: allowedBody,
+			giveCode: http.StatusOK,
+			wantCode: http.StatusOK,
+			wantCheck: func(t *testing.T, body []byte) {
+				var got admissionv1.AdmissionReview
+				require.NoError(t, json.Unmarshal(body, &got))
+				require.NotNil(t, got.Response)
+				assert.True(t, got.Response.Allowed)
+				assert.Nil(t, got.Response.Result)
+				assert.Equal(t, []string{"deprecated field"}, got.Response.Warnings)
+			},
+		},
+		{
+			name:     "non-AdmissionReview body passes through unchanged",
+			giveBody: []byte("internal server error"),
+			giveCode: http.StatusInternalServerError,
+			wantCode: http.StatusInternalServerError,
+			wantCheck: func(t *testing.T, body []byte) {
+				assert.Equal(t, "internal server error", string(body))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.giveCode)
+				_, err := w.Write(tt.giveBody)
+				require.NoError(t, err)
+			})
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader([]byte("{}")))
+
+			withInvalidReason(upstream).ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantCode, rec.Code)
+			tt.wantCheck(t, rec.Body.Bytes())
+		})
+	}
+}
+
+func mustMarshalReview(t *testing.T, review admissionv1.AdmissionReview) []byte {
+	t.Helper()
+	out, err := json.Marshal(review)
+	require.NoError(t, err)
+	return out
+}


### PR DESCRIPTION
## Description

Wrap all validating webhook handlers in `deckhouse-controller/pkg/apis/deckhouse.io/validation/` with a thin HTTP middleware that rewrites a rejected `AdmissionReview` to return HTTP `422` with `Reason: Invalid`, instead of the `400 BadRequest` hard-coded by the upstream `slok/kubewebhook` library.

No changes to validator business logic, library version, or admission pipeline.

## Why do we need it, and what problem does it solve?

When `kubectl edit moduleconfig <name>` (or any other resource validated by our webhooks) is rejected, `kubectl` currently closes the editor and asks the user to re-edit a temp file and run `kubectl replace`. Edits made in the editor are lost.

`kubectl edit` reopens the editor with the user's edits preserved only when the server returns `Reason: Invalid` / HTTP 422 — the same way `kubectl edit deployment` behaves on a bad spec. Our webhooks return `400` because `slok/kubewebhook v2.5.0` hard-codes that status and exposes no option to override it.

This PR aligns webhook reject behavior with native Kubernetes resources: invalid input now keeps the editor open with the validator message in the header, so users can fix and re-save in place.

Editor reopens on reject, then accepts a valid edit

```
root@kuleshov-master-0:~# k edit mc a-k-test
error: moduleconfigs.deckhouse.io "a-k-test" is invalid
moduleconfig.deckhouse.io/a-k-test edited
```

The first save attempted an invalid value, the server returned 422 Invalid, and kubectl reopened the editor with the validator message in the header. The second save passed validation and was accepted.

kubectl apply with invalid spec
```
root@kuleshov-master-0:~# k apply -f - <<EOF
apiVersion: deckhouse.io/v1alpha1
kind: ModuleConfig
metadata: {name: a-k-test}
spec: {version: 999, settings: {bogusField: wat}}
EOF
Warning: resource moduleconfigs/a-k-test is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
The request is invalid: error when applying patch:
{"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"deckhouse.io/v1alpha1\",\"kind\":\"ModuleConfig\",\"metadata\":{\"annotations\":{},\"name\":\"a-k-test\"},\"spec\":{\"settings\":{\"bogusField\":\"wat\"},\"version\":999}}\n"}},"spec":{"settings":{"bogusField":"wat"},"version":999}}
to:
Resource: "deckhouse.io/v1alpha1, Resource=moduleconfigs", GroupVersionKind: "deckhouse.io/v1alpha1, Kind=ModuleConfig"
Name: "a-k-test", Namespace: ""
for: "STDIN": error when patching "STDIN": admission webhook "module-configs.deckhouse-webhook.deckhouse.io" denied the request: spec.version=999 is unsupported. Use latest version 1
```
The webhook rejected the request and kubectl reported The request is invalid: (i.e. Reason: Invalid, HTTP 422) instead of the previous Error from server (BadRequest):. The validator message (spec.version=999 is unsupported. Use latest version 1) is preserved end-to-end.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Made validation webhooks return the Invalid reason.
impact_level: default
```

