### PR TITLE
[ingress-nginx] refactoring rbacv1

### DIFF
--- a/modules/402-ingress-nginx/templates/user-authz-cluster-roles.yaml
+++ b/modules/402-ingress-nginx/templates/user-authz-cluster-roles.yaml
@@ -3,14 +3,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: Editor
-  name: d8:user-authz:ingress-nginx:editor
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:ingress-nginx:user
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:
   - deckhouse.io
   resources:
-  - ingressnginxcontrollers
+  - ingressnginxcontrollers/status
   verbs:
   - get
   - list
@@ -29,6 +29,9 @@ rules:
   resources:
   - ingressnginxcontrollers
   verbs:
+  - get
+  - list
+  - watch
   - create
   - delete
   - deletecollection

--- a/modules/402-ingress-nginx/templates/user-authz-cluster-roles.yaml
+++ b/modules/402-ingress-nginx/templates/user-authz-cluster-roles.yaml
@@ -1,21 +1,3 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:ingress-nginx:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - ingressnginxcontrollers/status
-  verbs:
-  - get
-  - list
-  - watch
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/modules/402-ingress-nginx/templates/user-authz-cluster-roles.yaml
+++ b/modules/402-ingress-nginx/templates/user-authz-cluster-roles.yaml
@@ -19,3 +19,11 @@ rules:
   - deletecollection
   - patch
   - update
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - ingressnginxcontrollers/status
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR adjusts the RBACv1 permissions for access to IngressNginxController resources.

Users with access levels below `ClusterEditor` can no longer view the main `ingressnginxcontrollers` resource, because its spec may contain sensitive data. 

Full read and management access to `ingressnginxcontrollers` remains available only to users with the `ClusterEditor` access level or higher.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Because `IngressNginxController` contains sensitive configuration in its main resource spec, and in RBACv1 that resource was readable by access levels that are too broad for that kind of data exposure.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Manual test

<details>
<summary>TEST RBAC</summary>

1. Create user

```yaml
apiVersion: deckhouse.io/v1
kind: ClusterAuthorizationRule
metadata:
  name: test-ingress-user
spec:
  accessLevel: User
  subjects:
  - kind: User
    name: test-ingress-user
---
apiVersion: deckhouse.io/v1
kind: ClusterAuthorizationRule
metadata:
  name: test-ingress-admin
spec:
  accessLevel: Admin
  subjects:
  - kind: User
    name: test-ingress-admin
---
apiVersion: deckhouse.io/v1
kind: ClusterAuthorizationRule
metadata:
  name: test-ingress-cluster-editor
spec:
  accessLevel: ClusterEditor
  subjects:
  - kind: User
    name: test-ingress-cluster-editor
```

2. Check /GET

<img width="1751" height="302" alt="image" src="https://github.com/user-attachments/assets/f19ebda3-3ee8-4f06-b61d-a867caeeadbc" />

3. Check /List

<img width="1751" height="302" alt="image" src="https://github.com/user-attachments/assets/0ee5869a-e48c-45e6-8b11-f357e800f776" />



</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: chore
summary: Refactored RBACv1 roles (User and ClusterEditor) for the IngressNginxController resource in `ingress-nginx`.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
