### PR TITLE
[user-authn] add kubernetes-dex-client-configuration secret for console consumption

### DIFF
--- a/ee/cse/modules/150-user-authn/openapi/values.yaml
+++ b/ee/cse/modules/150-user-authn/openapi/values.yaml
@@ -34,6 +34,13 @@ properties:
         - ["nn2wezldn5xgm2lhfvtwk3tfojqxi33sfuymx4u44scceizf"]
         items:
           type: string
+      kubeconfigClientEncodedNames:
+        type: array
+        default: []
+        x-examples:
+        - ["nn2wezldn5xgm2lhfvtwk3tfojqxi33sfuymx4u44scceizf"]
+        items:
+          type: string
       discoveredDexClusterIP:
         type: string
       discoveredDexCA:

--- a/modules/150-user-authn/hooks/generate_kubeconfig_encoded_names.go
+++ b/modules/150-user-authn/hooks/generate_kubeconfig_encoded_names.go
@@ -19,9 +19,11 @@ package hooks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/tidwall/gjson"
 
 	"github.com/deckhouse/deckhouse/go_lib/encoding"
 )
@@ -30,29 +32,101 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnBeforeHelm: &go_hook.OrderedConfig{Order: 10},
 }, kubeconfigNamesHandler)
 
+// kubeconfigPublishAPIClientID is the client_id of the OAuth2Client that
+// covers the publishAPI kubeconfig entry. Mirrored verbatim in
+// `templates/dex/kubeconfig-oauth2clients.yaml`,
+// `templates/dex/kubernetes-dex-client-configuration.yaml` and the trustedPeers
+// list in `templates/dex/oauth2client.yaml`. Keep them in sync.
+const kubeconfigPublishAPIClientID = "kubeconfig-publish-api"
+
+// slugifyKubeconfigID mirrors the slug transform applied to client_id in
+// `templates/dex/kubernetes-dex-client-configuration.yaml`,
+// `templates/dex/kubeconfig-oauth2clients.yaml` and the trustedPeers list in
+// `templates/dex/oauth2client.yaml`. Keep them in sync.
+func slugifyKubeconfigID(id string) string {
+	s := strings.ReplaceAll(id, "@", "-at-")
+	s = strings.ReplaceAll(s, ":", "-")
+	return s
+}
+
 func kubeconfigNamesHandler(_ context.Context, input *go_hook.HookInput) error {
 	const (
-		kubeconfigsPath  = "userAuthn.kubeconfigGenerator"
-		encodedNamesPath = "userAuthn.internal.kubeconfigEncodedNames"
+		kubeconfigsPath             = "userAuthn.kubeconfigGenerator"
+		encodedNamesPath            = "userAuthn.internal.kubeconfigEncodedNames"
+		clientEncodedNamesPath      = "userAuthn.internal.kubeconfigClientEncodedNames"
+		publishAPIEncodedNamePath   = "userAuthn.internal.kubeconfigPublishAPIEncodedName"
+		publishAPIEnabledPath       = "userAuthn.internal.publishAPI.enabled"
+		publishAPIAddKubeconfigPath = "userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry"
 	)
+
+	kubeconfigs := input.ConfigValues.Get(kubeconfigsPath).Array()
+
+	legacyEncodedNames := make([]string, 0, len(kubeconfigs))
+	clientEncodedNames := make([]string, 0, len(kubeconfigs))
+	clientIDs := make([]string, 0, len(kubeconfigs))
+
+	for i, entry := range kubeconfigs {
+		legacy := fmt.Sprintf("kubeconfig-generator-%d", i)
+		legacyEncodedNames = append(legacyEncodedNames, encoding.ToFnvLikeDex(legacy))
+
+		id := entry.Get("id").String()
+		clientID := fmt.Sprintf("kubeconfig-%s", slugifyKubeconfigID(id))
+		clientIDs = append(clientIDs, clientID)
+		clientEncodedNames = append(clientEncodedNames, encoding.ToFnvLikeDex(clientID))
+	}
+
+	if err := validateKubeconfigClientIDs(kubeconfigs, clientIDs); err != nil {
+		return err
+	}
 
 	if !input.ConfigValues.Exists(kubeconfigsPath) {
 		input.Values.Remove(encodedNamesPath)
-		return nil
+		input.Values.Remove(clientEncodedNamesPath)
+	} else {
+		input.Values.Set(encodedNamesPath, legacyEncodedNames)
+		input.Values.Set(clientEncodedNamesPath, clientEncodedNames)
 	}
 
-	kubeconfigsLength, err := input.ConfigValues.ArrayCount(kubeconfigsPath)
-	if err != nil {
-		return fmt.Errorf("get %s length: %v", kubeconfigsPath, err)
+	if input.Values.Get(publishAPIEnabledPath).Bool() && input.Values.Get(publishAPIAddKubeconfigPath).Bool() {
+		input.Values.Set(publishAPIEncodedNamePath, encoding.ToFnvLikeDex(kubeconfigPublishAPIClientID))
+	} else {
+		input.Values.Remove(publishAPIEncodedNamePath)
 	}
 
-	encodedNames := make([]string, 0, kubeconfigsLength)
+	return nil
+}
 
-	for i := 0; i < kubeconfigsLength; i++ {
-		name := encoding.ToFnvLikeDex(fmt.Sprintf("kubeconfig-generator-%d", i))
-		encodedNames = append(encodedNames, name)
+// validateKubeconfigClientIDs catches client_id collisions caused by the
+// id→slug transform:
+//
+//   - C1: a slug-derived client_id collides with the legacy
+//     `kubeconfig-generator-N` for any N in the current entry range, or with
+//     the reserved publishAPI client_id.
+//   - C2: two entries slugify to the same client_id.
+func validateKubeconfigClientIDs(kubeconfigs []gjson.Result, clientIDs []string) error {
+	legacyReserved := make(map[string]struct{}, len(clientIDs)+1)
+	for i := range clientIDs {
+		legacyReserved[fmt.Sprintf("kubeconfig-generator-%d", i)] = struct{}{}
 	}
+	legacyReserved[kubeconfigPublishAPIClientID] = struct{}{}
 
-	input.Values.Set(encodedNamesPath, encodedNames)
+	seen := make(map[string]int, len(clientIDs))
+	for i, clientID := range clientIDs {
+		if _, ok := legacyReserved[clientID]; ok {
+			return fmt.Errorf(
+				"userAuthn.kubeconfigGenerator[%d].id=%q produces reserved client_id %q "+
+					"(reserved: kubeconfig-generator-N for the current entry range, and %q)",
+				i, kubeconfigs[i].Get("id").String(), clientID, kubeconfigPublishAPIClientID)
+		}
+		if prev, ok := seen[clientID]; ok {
+			return fmt.Errorf(
+				"userAuthn.kubeconfigGenerator[%d].id=%q and [%d].id=%q slugify to the same client_id %q; "+
+					"ids must produce distinct client_ids after replacing '@'→'-at-' and ':'→'-'",
+				prev, kubeconfigs[prev].Get("id").String(),
+				i, kubeconfigs[i].Get("id").String(),
+				clientID)
+		}
+		seen[clientID] = i
+	}
 	return nil
 }

--- a/modules/150-user-authn/hooks/generate_kubeconfig_encoded_names_test.go
+++ b/modules/150-user-authn/hooks/generate_kubeconfig_encoded_names_test.go
@@ -54,6 +54,73 @@ var _ = Describe("User Authn hooks :: generate kubeconfig encoded names ::", fun
 			Expect(f.ValuesGet("userAuthn.internal.kubeconfigEncodedNames").String()).To(MatchJSON(`[
 "nn2wezldn5xgm2lhfvtwk3tfojqxi33sfuymx4u44scceizf", "nn2wezldn5xgm2lhfvtwk3tfojqxi33sfuy4x4u44scceizf"
 ]`))
+			Expect(f.ValuesGet("userAuthn.internal.kubeconfigClientEncodedNames").String()).To(MatchJSON(`[
+"nn2wezldn5xgm2lhfvvxkytfmnxw4ztjm4ww63tfzpzjzzeeeirsk", "nn2wezldn5xgm2lhfvvxkytfmnxw4ztjm4wxi53pzpzjzzeeeirsk"
+]`))
+			Expect(f.ValuesGet("userAuthn.internal.kubeconfigPublishAPIEncodedName").Exists()).To(BeFalse(),
+				"publishAPI encoded name must not be set when publishAPI is disabled")
+		})
+	})
+
+	Context("With publishAPI enabled and addKubeconfigGeneratorEntry", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ValuesSet("userAuthn.internal.publishAPI.enabled", true)
+			f.ValuesSet("userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry", true)
+			f.RunHook()
+		})
+
+		It("Should set kubeconfigPublishAPIEncodedName", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("userAuthn.internal.kubeconfigPublishAPIEncodedName").String()).To(Equal(
+				"nn2wezldn5xgm2lhfvyhkytmnfzwqllbobu4x4u44scceizf"))
+		})
+	})
+
+	Context("With colliding slug client_ids", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ConfigValuesSetFromYaml("userAuthn.kubeconfigGenerator", []byte(`[
+{"id": "prod:eu", "masterURI": "https://a.master", "description": "a"},
+{"id": "prod-eu", "masterURI": "https://b.master", "description": "b"}
+]`))
+			f.RunHook()
+		})
+
+		It("Should fail with a clear error", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+			Expect(f.GoHookError).To(MatchError(ContainSubstring(`slugify to the same client_id "kubeconfig-prod-eu"`)))
+		})
+	})
+
+	Context("With id colliding with legacy kubeconfig-generator-N", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ConfigValuesSetFromYaml("userAuthn.kubeconfigGenerator", []byte(`[
+{"id": "generator-1", "masterURI": "https://a.master", "description": "a"},
+{"id": "other", "masterURI": "https://b.master", "description": "b"}
+]`))
+			f.RunHook()
+		})
+
+		It("Should fail with a clear error", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+			Expect(f.GoHookError).To(MatchError(ContainSubstring(`reserved client_id "kubeconfig-generator-1"`)))
+		})
+	})
+
+	Context("With id colliding with publishAPI reserved client_id", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext())
+			f.ConfigValuesSetFromYaml("userAuthn.kubeconfigGenerator", []byte(`[
+{"id": "publish-api", "masterURI": "https://a.master", "description": "a"}
+]`))
+			f.RunHook()
+		})
+
+		It("Should fail with a clear error", func() {
+			Expect(f).NotTo(ExecuteSuccessfully())
+			Expect(f.GoHookError).To(MatchError(ContainSubstring(`reserved client_id "kubeconfig-publish-api"`)))
 		})
 	})
 })

--- a/modules/150-user-authn/openapi/values.yaml
+++ b/modules/150-user-authn/openapi/values.yaml
@@ -34,6 +34,18 @@ properties:
         - ["nn2wezldn5xgm2lhfvtwk3tfojqxi33sfuymx4u44scceizf"]
         items:
           type: string
+      kubeconfigClientEncodedNames:
+        type: array
+        default: []
+        x-examples:
+        - ["nn2wezldn5xgm2lhfvsxqylnobwgls7sttsiiirdeu"]
+        items:
+          type: string
+      kubeconfigPublishAPIEncodedName:
+        type: string
+        default: ""
+        x-examples:
+        - "nn2wezldn5xgm2lhfvyhkytmnfzwqllbobu4x4u44scceizf"
       discoveredDexClusterIP:
         type: string
       discoveredDexCA:

--- a/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
+++ b/modules/150-user-authn/template_tests/kubeconfig_generator_config_test.go
@@ -180,6 +180,7 @@ Multiline
 
 			JustBeforeEach(func() {
 				encodedNames := make([]string, 0)
+				clientEncodedNames := make([]string, 0)
 				for i, a := range apis {
 					hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.id", i), a.id)
 					hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.masterCA", i), a.masterCA)
@@ -188,9 +189,13 @@ Multiline
 
 					name := encoding.ToFnvLikeDex(fmt.Sprintf("kubeconfig-generator-%d", i))
 					encodedNames = append(encodedNames, name)
+
+					clientEncodedNames = append(clientEncodedNames,
+						encoding.ToFnvLikeDex(fmt.Sprintf("kubeconfig-%s", a.id)))
 				}
 
 				hec.ValuesSet("userAuthn.internal.kubeconfigEncodedNames", encodedNames)
+				hec.ValuesSet("userAuthn.internal.kubeconfigClientEncodedNames", clientEncodedNames)
 
 				hec.HelmRender()
 			})

--- a/modules/150-user-authn/template_tests/kubernetes_dex_client_configuration_test.go
+++ b/modules/150-user-authn/template_tests/kubernetes_dex_client_configuration_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/tidwall/gjson"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/go_lib/encoding"
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const newSecretName = "kubernetes-dex-client-configuration"
+
+func unmarshalNewSecret(hec *Config) []byte {
+	resource := hec.KubernetesResource("Secret", "d8-user-authn", newSecretName)
+	Expect(resource.Exists()).To(BeTrue())
+
+	b64ConfigStr := []byte(resource.Field("data.config\\.yaml").String())
+	configStr, err := base64.StdEncoding.DecodeString(string(b64ConfigStr))
+	Expect(err).ToNot(HaveOccurred())
+
+	var parsed map[string]any
+	err = yaml.Unmarshal(configStr, &parsed)
+	Expect(err).ToNot(HaveOccurred())
+
+	jsonBytes, err := json.Marshal(parsed)
+	Expect(err).ToNot(HaveOccurred())
+
+	return jsonBytes
+}
+
+var _ = Describe("Module :: user-authn :: helm template :: kubernetes-dex-client-configuration", func() {
+	hec := SetupHelmConfig("")
+
+	const (
+		k8sCa             = "---k8s CA---\nmultiline\n"
+		dexClientAppSecret = "client-app-secret-value"
+	)
+
+	BeforeEach(func() {
+		hec.ValuesSet("global.discovery.kubernetesVersion", "1.29.0")
+		hec.ValuesSet("global.modules.publicDomainTemplate", "%s.example.com")
+		hec.ValuesSet("global.modules.ingressClass", "nginx")
+		hec.ValuesSet("global.modules.https.mode", "CertManager")
+		hec.ValuesSet("global.modules.https.certManager.clusterIssuerName", "letsencrypt")
+		hec.ValuesSet("global.modulesImages.registry.base", "registry.example.com")
+		hec.ValuesSet("global.enabledModules", []string{"cert-manager"})
+		hec.ValuesSet("global.discovery.d8SpecificNodeCountByRole.system", 2)
+		hec.ValuesSet("global.discovery.kubernetesCA", k8sCa)
+
+		hec.ValuesSet("userAuthn.internal.kubernetesDexClientAppSecret", dexClientAppSecret)
+		hec.ValuesSet("userAuthn.internal.dexTLS.crt", "do not use, but set")
+		hec.ValuesSet("userAuthn.internal.dexTLS.key", "do not use, but set")
+		hec.ValuesSet("userAuthn.internal.dexTLS.ca", k8sCa)
+
+		hec.ValuesSet("userAuthn.internal.selfSignedCA.cert", "do not use, but set")
+		hec.ValuesSet("userAuthn.internal.selfSignedCA.key", "do not use, but set")
+	})
+
+	Context("Neither publishAPI nor kubeconfigGenerator", func() {
+		BeforeEach(func() {
+			hec.ValuesSet("userAuthn.internal.publishAPI.enabled", false)
+			hec.HelmRender()
+		})
+
+		It("Should NOT render the new secret", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			resource := hec.KubernetesResource("Secret", "d8-user-authn", newSecretName)
+			Expect(resource.Exists()).To(BeFalse())
+		})
+	})
+
+	Context("publishAPI only", func() {
+		BeforeEach(func() {
+			hec.ValuesSet("userAuthn.internal.publishAPI.enabled", true)
+			hec.ValuesSet("userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry", true)
+			hec.ValuesSet("userAuthn.internal.publishAPI.publishedAPIKubeconfigGeneratorMasterCA", "publish-api-ca")
+			hec.ValuesSet("userAuthn.internal.discoveredDexCA", "discoveredDexCAText")
+			hec.ValuesSet("userAuthn.internal.kubeconfigPublishAPIEncodedName",
+				encoding.ToFnvLikeDex("kubeconfig-publish-api"))
+			hec.HelmRender()
+		})
+
+		It("Should render exactly one publishAPI cluster entry with idpCA", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			jsonBytes := unmarshalNewSecret(hec)
+
+			Expect(gjson.GetBytes(jsonBytes, "idpCA").String()).To(Equal("discoveredDexCAText\n"))
+
+			clusters := gjson.GetBytes(jsonBytes, "clusters").Array()
+			Expect(clusters).To(HaveLen(1))
+
+			cl := clusters[0]
+			Expect(cl.Get("id").String()).To(Equal("api.example.com"))
+			Expect(cl.Get("name").String()).To(Equal("api.example.com"))
+			Expect(cl.Get("masterURI").String()).To(Equal("https://api.example.com"))
+			Expect(cl.Get("masterCA").String()).To(Equal("publish-api-ca"))
+			Expect(cl.Get("clientID").String()).To(Equal("kubeconfig-publish-api"))
+			Expect(cl.Get("clientSecret").String()).To(Equal(dexClientAppSecret))
+			Expect(cl.Get("issuer").String()).To(Equal("https://dex.example.com/"))
+		})
+
+		It("Should not include any legacy snake_case fields", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			jsonBytes := unmarshalNewSecret(hec)
+
+			for _, legacyKey := range []string{
+				"listen", "logo_uri", "web_path_prefix", "debug",
+				"trusted_root_ca", "idp_ca_pem", "kubectl_version",
+			} {
+				Expect(gjson.GetBytes(jsonBytes, legacyKey).Exists()).
+					To(BeFalse(), "legacy top-level field %q should be absent", legacyKey)
+			}
+
+			cl := gjson.GetBytes(jsonBytes, "clusters.0")
+			for _, legacyKey := range []string{
+				"client_id", "client_secret", "k8s_master_uri",
+				"k8s_ca_pem", "redirect_uri", "short_description", "scopes",
+			} {
+				Expect(cl.Get(legacyKey).Exists()).
+					To(BeFalse(), "legacy cluster field %q should be absent", legacyKey)
+			}
+		})
+	})
+
+	Context("kubeconfigGenerator only", func() {
+		apis := []struct {
+			id        string
+			masterCA  string
+			masterURI string
+		}{
+			{id: "first", masterCA: "ca-for-first", masterURI: "https://first.master"},
+			{id: "second", masterCA: "", masterURI: "https://second.master"},
+		}
+
+		BeforeEach(func() {
+			hec.ValuesSet("userAuthn.internal.publishAPI.enabled", false)
+			encodedNames := make([]string, 0, len(apis))
+			clientEncodedNames := make([]string, 0, len(apis))
+			for i, a := range apis {
+				hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.id", i), a.id)
+				hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.masterCA", i), a.masterCA)
+				hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.masterURI", i), a.masterURI)
+				hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.description", i), "desc")
+				encodedNames = append(encodedNames, encoding.ToFnvLikeDex(fmt.Sprintf("kubeconfig-generator-%d", i)))
+				clientEncodedNames = append(clientEncodedNames, encoding.ToFnvLikeDex(fmt.Sprintf("kubeconfig-%s", a.id)))
+			}
+			hec.ValuesSet("userAuthn.internal.kubeconfigEncodedNames", encodedNames)
+			hec.ValuesSet("userAuthn.internal.kubeconfigClientEncodedNames", clientEncodedNames)
+			hec.HelmRender()
+		})
+
+		It("Should render one entry per kubeconfigGenerator item, no publishAPI entry", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			jsonBytes := unmarshalNewSecret(hec)
+
+			clusters := gjson.GetBytes(jsonBytes, "clusters").Array()
+			Expect(clusters).To(HaveLen(len(apis)))
+
+			for i, a := range apis {
+				cl := clusters[i]
+				Expect(cl.Get("id").String()).To(Equal(a.id))
+				Expect(cl.Get("name").String()).To(Equal(a.id))
+				Expect(cl.Get("masterURI").String()).To(Equal(a.masterURI))
+				Expect(cl.Get("clientID").String()).To(Equal(fmt.Sprintf("kubeconfig-%s", a.id)))
+				Expect(cl.Get("clientSecret").String()).To(Equal(dexClientAppSecret))
+				Expect(cl.Get("issuer").String()).To(Equal("https://dex.example.com/"))
+			}
+
+			Expect(clusters[0].Get("masterCA").String()).To(Equal(apis[0].masterCA))
+			Expect(clusters[1].Get("masterCA").String()).To(Equal(k8sCa))
+		})
+	})
+
+	Context("clientID slugification", func() {
+		slugCases := []struct {
+			id       string
+			clientID string
+		}{
+			{id: "admin@bastion", clientID: "kubeconfig-admin-at-bastion"},
+			{id: "prod:eu-west", clientID: "kubeconfig-prod-eu-west"},
+			{id: "plain.with.dots-and_underscores", clientID: "kubeconfig-plain.with.dots-and_underscores"},
+		}
+
+		BeforeEach(func() {
+			hec.ValuesSet("userAuthn.internal.publishAPI.enabled", false)
+			encodedNames := make([]string, 0, len(slugCases))
+			clientEncodedNames := make([]string, 0, len(slugCases))
+			for i, c := range slugCases {
+				hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.id", i), c.id)
+				hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.masterURI", i), "https://m")
+				hec.ValuesSet(fmt.Sprintf("userAuthn.kubeconfigGenerator.%v.description", i), "d")
+				encodedNames = append(encodedNames, encoding.ToFnvLikeDex(fmt.Sprintf("kubeconfig-generator-%d", i)))
+				clientEncodedNames = append(clientEncodedNames, encoding.ToFnvLikeDex(c.clientID))
+			}
+			hec.ValuesSet("userAuthn.internal.kubeconfigEncodedNames", encodedNames)
+			hec.ValuesSet("userAuthn.internal.kubeconfigClientEncodedNames", clientEncodedNames)
+			hec.HelmRender()
+		})
+
+		It("Should slugify '@' to '-at-' and ':' to '-'", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			jsonBytes := unmarshalNewSecret(hec)
+
+			clusters := gjson.GetBytes(jsonBytes, "clusters").Array()
+			Expect(clusters).To(HaveLen(len(slugCases)))
+
+			for i, c := range slugCases {
+				Expect(clusters[i].Get("clientID").String()).To(Equal(c.clientID))
+				Expect(clusters[i].Get("id").String()).To(Equal(c.id))
+			}
+		})
+
+		It("Should include both legacy and new trustedPeers in OAuth2Client", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			oauth2Client := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk")
+			Expect(oauth2Client.Exists()).To(BeTrue())
+
+			peers := oauth2Client.Field("trustedPeers").Array()
+			peerSet := make(map[string]bool, len(peers))
+			for _, p := range peers {
+				peerSet[p.String()] = true
+			}
+
+			for i, c := range slugCases {
+				Expect(peerSet[fmt.Sprintf("kubeconfig-generator-%d", i)]).
+					To(BeTrue(), "legacy trustedPeer kubeconfig-generator-%d must remain in phase 1", i)
+				Expect(peerSet[c.clientID]).
+					To(BeTrue(), "new trustedPeer %q must be added", c.clientID)
+			}
+		})
+
+		It("Should create a separate OAuth2Client for every slug-based clientID", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			for _, c := range slugCases {
+				crName := encoding.ToFnvLikeDex(c.clientID)
+				oc := hec.KubernetesResource("OAuth2Client", "d8-user-authn", crName)
+				Expect(oc.Exists()).To(BeTrue(), "OAuth2Client for %q (CR %q) must exist", c.clientID, crName)
+				Expect(oc.Field("id").String()).To(Equal(c.clientID))
+				Expect(oc.Field("name").String()).To(Equal(c.clientID))
+				Expect(oc.Field("secret").String()).To(Equal(dexClientAppSecret))
+
+				uris := []string{}
+				for _, u := range oc.Field("redirectURIs").Array() {
+					uris = append(uris, u.String())
+				}
+				Expect(uris).To(ContainElement("/device/callback"))
+				Expect(uris).NotTo(ContainElement(ContainSubstring("/callback/")),
+					"new slug-based OAuth2Client must NOT expose the legacy kubeconfig UI redirect_uri")
+			}
+		})
+	})
+
+	Context("publishAPI and kubeconfigGenerator together", func() {
+		BeforeEach(func() {
+			hec.ValuesSet("userAuthn.internal.publishAPI.enabled", true)
+			hec.ValuesSet("userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry", true)
+			hec.ValuesSet("userAuthn.internal.publishAPI.publishedAPIKubeconfigGeneratorMasterCA", "publish-api-ca")
+
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.0.id", "extra")
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.0.masterURI", "https://extra.master")
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.0.masterCA", "extra-ca")
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.0.description", "extra")
+			hec.ValuesSet("userAuthn.internal.kubeconfigEncodedNames",
+				[]string{encoding.ToFnvLikeDex("kubeconfig-generator-0")})
+			hec.ValuesSet("userAuthn.internal.kubeconfigClientEncodedNames",
+				[]string{encoding.ToFnvLikeDex("kubeconfig-extra")})
+
+			hec.HelmRender()
+		})
+
+		It("Should render publishAPI entry first, kubeconfigGenerator entries after", func() {
+			Expect(hec.RenderError).ToNot(HaveOccurred())
+			jsonBytes := unmarshalNewSecret(hec)
+
+			clusters := gjson.GetBytes(jsonBytes, "clusters").Array()
+			Expect(clusters).To(HaveLen(2))
+
+			Expect(clusters[0].Get("id").String()).To(Equal("api.example.com"))
+			Expect(clusters[0].Get("masterCA").String()).To(Equal("publish-api-ca"))
+
+			Expect(clusters[1].Get("id").String()).To(Equal("extra"))
+			Expect(clusters[1].Get("masterCA").String()).To(Equal("extra-ca"))
+		})
+	})
+})

--- a/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
+++ b/modules/150-user-authn/template_tests/kubernetes_oauth2client_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/deckhouse/deckhouse/go_lib/encoding"
 	. "github.com/deckhouse/deckhouse/testing/helm"
 )
 
@@ -113,6 +114,168 @@ var _ = Describe("Module :: user-authn :: helm template :: kubernetes oauth2clie
 		It("Should not deploy kubernetes OAuth2Client", func() {
 			Expect(hec.RenderError).ShouldNot(HaveOccurred())
 			Expect(hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("Full scenario: dex-authenticator + dex-client + publishAPI + kubeconfigGenerator", func() {
+		BeforeEach(func() {
+			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorCRDs", `
+- name: with-access
+  encodedName: encWithAccess
+  allowAccessToKubernetes: true
+  namespace: d8-with-access
+  credentials:
+    appDexSecret: s1
+    cookieSecret: c1
+  spec:
+    applicationDomain: with-access.example.com
+    applicationIngressCertificateSecretName: cert-1
+- name: no-access
+  encodedName: encNoAccess
+  namespace: d8-no-access
+  credentials:
+    appDexSecret: s2
+    cookieSecret: c2
+  spec:
+    applicationDomain: no-access.example.com
+    applicationIngressCertificateSecretName: cert-2
+`)
+			hec.ValuesSetFromYaml("userAuthn.internal.dexAuthenticatorNames", `
+"with-access@d8-with-access":
+  name: "with-access-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-with-access"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames: {}
+"no-access@d8-no-access":
+  name: "no-access-dex-authenticator"
+  truncated: false
+  hash: ""
+  secretName: "dex-authenticator-no-access"
+  secretTruncated: false
+  secretHash: ""
+  ingressNames: {}
+`)
+			hec.ValuesSetFromYaml("userAuthn.internal.dexClientCRDs", `
+- id: my-app@d8-test
+  encodedID: nvqxe33pftwgs5dpojstkylhojpwggrcgji
+  legacyID: my-app:d8-test
+  legacyEncodedID: nvqxe33pfvtwk3tfmrqxe33pftwgs5dpojstkylhojpwggrcgji
+  name: my-app
+  namespace: d8-test
+  clientSecret: my-app-secret
+  spec:
+    redirectURIs:
+    - https://my-app.example.com/callback
+    trustedPeers: []
+    allowedGroups: []
+  labels: {}
+  annotations: {}
+  allowAccessToKubernetes: true
+- id: my-app-no-k8s@d8-test
+  encodedID: nvqxe33pftxhi33mmuxgs5dpojstkylhojpwggrcgji
+  legacyID: my-app-no-k8s:d8-test
+  legacyEncodedID: nvqxe33pftxhi33mmuxgs5dpojstkylhojpwggrcgji-legacy
+  name: my-app-no-k8s
+  namespace: d8-test
+  clientSecret: my-app-no-k8s-secret
+  spec:
+    redirectURIs:
+    - https://no-k8s.example.com/callback
+    trustedPeers: []
+    allowedGroups: []
+  labels: {}
+  annotations: {}
+  allowAccessToKubernetes: false
+`)
+			hec.ValuesSet("userAuthn.internal.publishAPI.enabled", true)
+			hec.ValuesSet("userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry", true)
+			hec.ValuesSet("userAuthn.internal.publishAPI.publishedAPIKubeconfigGeneratorMasterCA", "publish-api-ca")
+
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.0.id", "plain")
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.0.masterURI", "https://plain.master")
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.0.description", "plain desc")
+
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.1.id", "prod:eu")
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.1.masterURI", "https://prod-eu.master")
+			hec.ValuesSet("userAuthn.kubeconfigGenerator.1.description", "prod eu desc")
+
+			hec.ValuesSet("userAuthn.internal.kubeconfigEncodedNames", []string{
+				encoding.ToFnvLikeDex("kubeconfig-generator-0"),
+				encoding.ToFnvLikeDex("kubeconfig-generator-1"),
+			})
+			hec.ValuesSet("userAuthn.internal.kubeconfigClientEncodedNames", []string{
+				encoding.ToFnvLikeDex("kubeconfig-plain"),
+				encoding.ToFnvLikeDex("kubeconfig-prod-eu"),
+			})
+			hec.ValuesSet("userAuthn.internal.kubeconfigPublishAPIEncodedName",
+				encoding.ToFnvLikeDex("kubeconfig-publish-api"))
+
+			hec.HelmRender()
+		})
+
+		It("Should render OAuth2Client with all expected trustedPeers, redirectURIs and secret", func() {
+			Expect(hec.RenderError).ShouldNot(HaveOccurred())
+
+			oauth2Client := hec.KubernetesResource("OAuth2Client", "d8-user-authn", "nn2wezlsnzsxizltzpzjzzeeeirsk")
+			Expect(oauth2Client.Exists()).To(BeTrue())
+
+			Expect(oauth2Client.Field("id").String()).To(Equal("kubernetes"))
+			Expect(oauth2Client.Field("name").String()).To(Equal("kubernetes"))
+			Expect(oauth2Client.Field("secret").String()).To(Equal("plainstring"))
+
+			peers := []string{}
+			for _, p := range oauth2Client.Field("trustedPeers").Array() {
+				peers = append(peers, p.String())
+			}
+			Expect(peers).To(ConsistOf(
+				"with-access-d8-with-access-dex-authenticator",
+				"my-app@d8-test",
+				"kubeconfig-generator",
+				"kubeconfig-publish-api",
+				"kubeconfig-generator-0",
+				"kubeconfig-plain",
+				"kubeconfig-generator-1",
+				"kubeconfig-prod-eu",
+			))
+
+			uris := []string{}
+			for _, u := range oauth2Client.Field("redirectURIs").Array() {
+				uris = append(uris, u.String())
+			}
+			Expect(uris).To(ConsistOf(
+				"https://kubeconfig.example.com/callback/0",
+				"https://kubeconfig.example.com/callback/1",
+				"https://kubeconfig.example.com/callback/",
+				"https://with-access.example.com/dex-authenticator/callback",
+			))
+		})
+
+		It("Should render a separate OAuth2Client for each slug-based clientID and for publishAPI", func() {
+			Expect(hec.RenderError).ShouldNot(HaveOccurred())
+
+			for _, c := range []struct{ clientID string }{
+				{clientID: "kubeconfig-publish-api"},
+				{clientID: "kubeconfig-plain"},
+				{clientID: "kubeconfig-prod-eu"},
+			} {
+				crName := encoding.ToFnvLikeDex(c.clientID)
+				oc := hec.KubernetesResource("OAuth2Client", "d8-user-authn", crName)
+				Expect(oc.Exists()).To(BeTrue(), "OAuth2Client %s (CR %s) must exist", c.clientID, crName)
+				Expect(oc.Field("id").String()).To(Equal(c.clientID))
+
+				uris := []string{}
+				for _, u := range oc.Field("redirectURIs").Array() {
+					uris = append(uris, u.String())
+				}
+				Expect(uris).To(ConsistOf(
+					"http://localhost:8000",
+					"http://localhost:18000",
+					"/device/callback",
+				))
+			}
 		})
 	})
 })

--- a/modules/150-user-authn/templates/dex/kubeconfig-oauth2clients.yaml
+++ b/modules/150-user-authn/templates/dex/kubeconfig-oauth2clients.yaml
@@ -1,0 +1,36 @@
+{{- $context := . }}
+{{- if and ($context.Values.userAuthn.internal.publishAPI.enabled) ($context.Values.userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry) }}
+---
+apiVersion: dex.coreos.com/v1
+kind: OAuth2Client
+metadata:
+  name: {{ $context.Values.userAuthn.internal.kubeconfigPublishAPIEncodedName }}
+  namespace: d8-{{ $context.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list $context (dict "app" "kubernetes-dex-clients")) | nindent 2 }}
+id: kubeconfig-publish-api
+name: kubeconfig-publish-api
+secret: {{ $context.Values.userAuthn.internal.kubernetesDexClientAppSecret | quote }}
+redirectURIs:
+- http://localhost:8000
+- http://localhost:18000
+- /device/callback
+{{- end }}
+{{- if $context.Values.userAuthn.kubeconfigGenerator }}
+  {{- range $index, $cluster := $context.Values.userAuthn.kubeconfigGenerator }}
+    {{- $slug := $cluster.id | replace "@" "-at-" | replace ":" "-" }}
+---
+apiVersion: dex.coreos.com/v1
+kind: OAuth2Client
+metadata:
+  name: {{ index $context.Values.userAuthn.internal.kubeconfigClientEncodedNames $index }}
+  namespace: d8-{{ $context.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list $context (dict "app" "kubernetes-dex-clients")) | nindent 2 }}
+id: kubeconfig-{{ $slug }}
+name: kubeconfig-{{ $slug }}
+secret: {{ $context.Values.userAuthn.internal.kubernetesDexClientAppSecret | quote }}
+redirectURIs:
+- http://localhost:8000
+- http://localhost:18000
+- /device/callback
+  {{- end }}
+{{- end }}

--- a/modules/150-user-authn/templates/dex/kubernetes-dex-client-configuration.yaml
+++ b/modules/150-user-authn/templates/dex/kubernetes-dex-client-configuration.yaml
@@ -1,0 +1,40 @@
+{{- if or (and (.Values.userAuthn.internal.publishAPI.enabled) (.Values.userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry)) (.Values.userAuthn.kubeconfigGenerator) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kubernetes-dex-client-configuration
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "dex")) | nindent 2 }}
+data:
+  config.yaml: |-
+    {{- include "kubernetes_dex_client_configuration_conf" . | b64enc | nindent 4 }}
+{{- end }}
+
+
+{{- define "kubernetes_dex_client_configuration_conf" }}
+  {{- with .Values.userAuthn.internal.discoveredDexCA }}
+idpCA: | {{- . | nindent 2 }}
+  {{- end }}
+clusters:
+  {{- if and (.Values.userAuthn.internal.publishAPI.enabled) (.Values.userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry) }}
+    {{- $publishAPIDomain := include "helm_lib_module_public_domain" (list . "api") }}
+- id: {{ $publishAPIDomain | quote }}
+  name: {{ $publishAPIDomain | quote }}
+  masterURI: {{ printf "https://%s" $publishAPIDomain | quote }}
+  masterCA: {{ .Values.userAuthn.internal.publishAPI.publishedAPIKubeconfigGeneratorMasterCA | quote }}
+  clientID: "kubeconfig-publish-api"
+  clientSecret: {{ .Values.userAuthn.internal.kubernetesDexClientAppSecret | quote }}
+  issuer: "https://{{ include "helm_lib_module_public_domain" (list . "dex") }}/"
+  {{- end }}
+  {{- range $cluster := .Values.userAuthn.kubeconfigGenerator }}
+    {{- $slug := $cluster.id | replace "@" "-at-" | replace ":" "-" }}
+- id: {{ $cluster.id | quote }}
+  name: {{ $cluster.id | quote }}
+  masterURI: {{ $cluster.masterURI | quote }}
+  masterCA: {{ ($cluster.masterCA | default $.Values.global.discovery.kubernetesCA) | quote }}
+  clientID: {{ printf "kubeconfig-%s" $slug | quote }}
+  clientSecret: {{ $.Values.userAuthn.internal.kubernetesDexClientAppSecret | quote }}
+  issuer: "https://{{ include "helm_lib_module_public_domain" (list $ "dex") }}/"
+  {{- end }}
+{{- end }}

--- a/modules/150-user-authn/templates/dex/oauth2client.yaml
+++ b/modules/150-user-authn/templates/dex/oauth2client.yaml
@@ -35,10 +35,15 @@ trustedPeers:
 {{- end }}
 {{- if $context.Values.userAuthn.internal.publishAPI.enabled }}
 - kubeconfig-generator
+  {{- if $context.Values.userAuthn.internal.publishAPI.addKubeconfigGeneratorEntry }}
+- kubeconfig-publish-api
+  {{- end }}
 {{- end }}
 {{- if $context.Values.userAuthn.kubeconfigGenerator}}
   {{- range $index, $cluster := $context.Values.userAuthn.kubeconfigGenerator }}
 - kubeconfig-generator-{{ $index }}
+    {{- $slug := $cluster.id | replace "@" "-at-" | replace ":" "-" }}
+- kubeconfig-{{ $slug }}
   {{- end }}
 {{- end }}
 redirectURIs:


### PR DESCRIPTION
## Description

  Phase 1 of the kubeconfig-generator deprecation plan (see `agentic_docs/plans/kubeconfig_generator_deprecate.md`).

  Renders a new internal `Secret d8-user-authn/kubernetes-dex-client-configuration` alongside the existing legacy `Secret kubeconfig-generator`. The new secret carries the same data in a cleaner shape (camelCase, dead `dex-k8s-authenticator`-specific fields dropped) and is intended for the console module — it will switch to it in a later release.

  Each entry in `userAuthn.kubeconfigGenerator[]` now also gets its own dedicated `OAuth2Client` named `kubeconfig-{slug(id)}` with label `app: kubernetes-dex-clients`, in addition to the existing legacy `kubeconfig-generator-N` client. This means after rollout `d8 k -n d8-user-authn get oauth2clients` will show roughly **twice** as many OAuth2Clients per `kubeconfigGenerator[]` entry — that's expected: the legacy `kubeconfig-generator-N` clients stay so existing kubeconfigs keep working; they will be removed in a later phase together with the UI generator itself (deadline 2026-09-01).

  `trustedPeers` in the OAuth2Client `kubernetes` are extended with the new `kubeconfig-{slug}` client_ids; legacy peers remain untouched.

  Slug transform: `@` → `-at-`, `:` → `-`, anything else from the allowed `id` pattern (`[@.:0-9a-z._-]+`) passes through. Identifiable client_id values in Dex audit logs are a side benefit.

  **No user-visible change in this phase.** The legacy generator UI continues to work; the console continues to read the legacy secret until the phase 2 PR lands in the console repo.

## Why do we need it, and what problem does it solve?

The deprecated `kubeconfig-generator` UI is scheduled for removal on 2026-09-01. The external `console` module was supposed to replace it, but currently piggybacks on the legacy `Secret kubeconfig-generator` to generate per-user kubeconfigs. This PR introduces a clean, dedicated secret that the console can switch to, decoupling its lifecycle from the legacy UI stack.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: chore
summary: Added rendering of a new internal `kubernetes-dex-client-configuration` Secret alongside the legacy `kubeconfig-generator` Secret in `user-authn`.
impact_level: low
```
