### PR TITLE
[dhctl] Fix confirmation

### DIFF
--- a/dhctl/cmd/dhctl/action.go
+++ b/dhctl/cmd/dhctl/action.go
@@ -362,7 +362,7 @@ func (i *actionIniter) initLogger(c *kingpin.ParseContext, tmpDir string) (onShu
 		return nil, err
 	}
 
-	log.InfoF("Debug log file: %s\n", logPath)
+	log.InteractiveInfoF("Debug log file: %s\n", logPath)
 
 	i.logFileMutex.Lock()
 	defer i.logFileMutex.Unlock()

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -71,7 +71,7 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause, opts *options.Options) *kingpi
 		}
 
 		if !opts.Global.SanityCheck {
-			logger.LogWarnLn(destroyApprovalsMessage)
+			log.InteractiveWarnLn(destroyApprovalsMessage)
 
 			if !input.NewConfirmation().WithYesByDefault().WithMessage("Do you really want to DELETE all cluster resources?").Ask() {
 				return fmt.Errorf("Cleanup cluster resources disallow")

--- a/dhctl/pkg/log/interactive.go
+++ b/dhctl/pkg/log/interactive.go
@@ -301,6 +301,17 @@ func InteractiveWarnLn(a ...any) {
 	logger.WarnLn(a...)
 }
 
+func InteractiveWarnF(format string, a ...any) {
+	provider := ExternalLoggerProvider(defaultLogger)
+	logger := provider()
+	l, ok := logger.(*InteractiveLoggerWrapper)
+	if ok {
+		logger = l.logger
+	}
+
+	logger.WarnFWithoutLn(format, a...)
+}
+
 func InteractiveInfoF(format string, a ...any) {
 	provider := ExternalLoggerProvider(defaultLogger)
 	logger := provider()

--- a/dhctl/pkg/util/input/confirmation.go
+++ b/dhctl/pkg/util/input/confirmation.go
@@ -16,7 +16,6 @@ package input
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"strings"
 
@@ -63,7 +62,7 @@ func (c *Confirmation) Ask() bool {
 	} else {
 		reader := bufio.NewReader(os.Stdin)
 		for {
-			log.WarnF(fmt.Sprintf("%s [y/n]: ", c.message))
+			log.InteractiveWarnF("%s [y/n]: ", c.message)
 			line, _, err := reader.ReadLine()
 			if err != nil {
 				log.ErrorF("can't read from stdin: %v\n", err)
@@ -74,15 +73,15 @@ func (c *Confirmation) Ask() bool {
 
 			switch response {
 			case "y", "yes":
-				log.InfoF("\r")
+				log.InteractiveInfoF("\r")
 				return true
 
 			case "n", "no":
-				log.InfoF("\r")
+				log.InteractiveInfoF("\r")
 				return false
 			}
 
-			log.InfoF("\r")
+			log.InteractiveInfoF("\r")
 		}
 	}
 }

--- a/dhctl/pkg/util/progressbar/progressbar.go
+++ b/dhctl/pkg/util/progressbar/progressbar.go
@@ -108,7 +108,7 @@ func InitProgressBar(param *PbParam) error {
 		return err
 	}
 
-	stopChan := make(chan struct{})
+	stopChan := make(chan struct{}, 2)
 
 	defaultpb = &Pb{
 		ProgressBarPrinter: p,

--- a/dhctl/pkg/util/progressbar/progressbar.go
+++ b/dhctl/pkg/util/progressbar/progressbar.go
@@ -51,6 +51,7 @@ type Pb struct {
 	ProgressBarPrinter *pterm.ProgressbarPrinter
 	MultiPrinter       *pterm.MultiPrinter
 	SpinnerPrinter     *pterm.SpinnerPrinter
+	StopCh             chan struct{}
 }
 
 func InitProgressBarWithDeferredFunc(name string, logger log.Logger) (func(), chan phases.Progress, error) {
@@ -107,6 +108,8 @@ func InitProgressBar(param *PbParam) error {
 		return err
 	}
 
+	stopChan := make(chan struct{})
+
 	defaultpb = &Pb{
 		ProgressBarPrinter: p,
 		MultiPrinter:       &multi,
@@ -115,7 +118,7 @@ func InitProgressBar(param *PbParam) error {
 
 	log.WithProgressBar()
 
-	go updateProgress(p, param.labelChan, param.phasesChan, staticSpinner, &multi)
+	go updateProgress(p, param.labelChan, param.phasesChan, stopChan, staticSpinner, &multi)
 
 	return nil
 }
@@ -124,6 +127,7 @@ func updateProgress(
 	p *pterm.ProgressbarPrinter,
 	labelChan chan string,
 	successChan chan phases.Progress,
+	stopChan chan struct{},
 	spinner *pterm.SpinnerPrinter,
 	mp *pterm.MultiPrinter,
 ) {
@@ -140,6 +144,8 @@ func updateProgress(
 
 	for {
 		select {
+		case <-stopChan:
+			return
 		case msg, ok := <-labelChan:
 			if !ok {
 				return
@@ -276,6 +282,10 @@ func FinishDefaultProgressBar() {
 	if pb == nil {
 		return
 	}
+
+	// stopping the updateProgress goroutine
+	pb.StopCh <- struct{}{}
+	time.Sleep(50 * time.Millisecond)
 
 	pb.ProgressBarPrinter.Add(100 - pb.ProgressBarPrinter.Current)
 	if _, err := pb.MultiPrinter.Stop(); err != nil {


### PR DESCRIPTION
## Description

Fix confirmation in dhctl

## Why do we need it, and what problem does it solve?

If dhctl run in interactive mode w/o `-v` flag, and it ask for confirmation before progress bar appears, it suppressed by logger wrapper.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Fixed confirmation in dhctl.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
