### PR TITLE
[control-plane-manager] Fix `publishAPI` migration for legacy `user-authn` v1

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2824,7 +2824,10 @@ alerts:
 
         **To complete the migration, follow the steps below:**
 
-        1. Review current settings for `publishAPI` in the resource `moduleconfig user-authn` resource.
+        1. Review current settings for `publishAPI` in the `moduleconfig user-authn` resource.
+
+           Note that legacy `user-authn` `spec.version: 1` uses `publishAPI.enable` instead of `publishAPI.enabled`.
+           No manual rewrite is required: the command in step 4 uses the normalized payload from the temporary ConfigMap.
 
         2. If the `moduleconfig control-plane-manager` resource exists, update its spec to `spec.version: 3`. If `settings.apiserver.loadBalancer` is set, migrate it to `settings.apiserver.publishAPI.loadBalancer`. If the resource does not exist, proceed to step 3.
 

--- a/global-hooks/migrate/migrate_publish_api.go
+++ b/global-hooks/migrate/migrate_publish_api.go
@@ -155,7 +155,23 @@ func extractPublishAPISettingsFromMC(mc *unstructured.Unstructured) (map[string]
 		return nil, false, nil
 	}
 
+	normalizeLegacyPublishAPISettings(publishAPISettings)
+
 	return publishAPISettings, true, nil
+}
+
+func normalizeLegacyPublishAPISettings(publishAPISettings map[string]interface{}) {
+	if publishAPISettings == nil {
+		return
+	}
+
+	if _, exists := publishAPISettings["enabled"]; !exists {
+		if legacyEnabled, legacyExists := publishAPISettings["enable"]; legacyExists {
+			publishAPISettings["enabled"] = legacyEnabled
+		}
+	}
+
+	delete(publishAPISettings, "enable")
 }
 
 func cleanupMigrationCm(input *go_hook.HookInput, kubeCl k8s.Client) error {

--- a/global-hooks/migrate/migrate_publish_api_test.go
+++ b/global-hooks/migrate/migrate_publish_api_test.go
@@ -1,0 +1,73 @@
+package hooks
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestExtractPublishAPISettingsFromMC_NormalizesLegacyEnable(t *testing.T) {
+	t.Parallel()
+
+	moduleConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"settings": map[string]interface{}{
+					"publishAPI": map[string]interface{}{
+						"enable":                      true,
+						"ingressClass":                "nginx",
+						"addKubeconfigGeneratorEntry": true,
+					},
+				},
+			},
+		},
+	}
+
+	settings, exists, err := extractPublishAPISettingsFromMC(moduleConfig)
+	if err != nil {
+		t.Fatalf("extractPublishAPISettingsFromMC returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected publishAPI settings to exist")
+	}
+	if legacyValue, hasLegacy := settings["enable"]; hasLegacy {
+		t.Fatalf("expected legacy enable key to be removed, got %#v", legacyValue)
+	}
+	if enabledValue, hasEnabled := settings["enabled"]; !hasEnabled || enabledValue != true {
+		t.Fatalf("expected enabled=true after normalization, got %#v", settings["enabled"])
+	}
+	if ingressClass := settings["ingressClass"]; ingressClass != "nginx" {
+		t.Fatalf("expected ingressClass to be preserved, got %#v", ingressClass)
+	}
+}
+
+func TestExtractPublishAPISettingsFromMC_PrefersEnabledOverLegacyEnable(t *testing.T) {
+	t.Parallel()
+
+	moduleConfig := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"settings": map[string]interface{}{
+					"publishAPI": map[string]interface{}{
+						"enable":  false,
+						"enabled": true,
+					},
+				},
+			},
+		},
+	}
+
+	settings, exists, err := extractPublishAPISettingsFromMC(moduleConfig)
+	if err != nil {
+		t.Fatalf("extractPublishAPISettingsFromMC returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected publishAPI settings to exist")
+	}
+	if legacyValue, hasLegacy := settings["enable"]; hasLegacy {
+		t.Fatalf("expected legacy enable key to be removed, got %#v", legacyValue)
+	}
+	if enabledValue := settings["enabled"]; enabledValue != true {
+		t.Fatalf("expected enabled=true to win over legacy key, got %#v", enabledValue)
+	}
+}

--- a/global-hooks/migrate/migrate_publish_api_test.go
+++ b/global-hooks/migrate/migrate_publish_api_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hooks
 
 import (

--- a/modules/040-control-plane-manager/hooks/publish_api_from_cm.go
+++ b/modules/040-control-plane-manager/hooks/publish_api_from_cm.go
@@ -59,6 +59,33 @@ type Config struct {
 	AddKubeconfigGeneratorEntry *bool        `json:"addKubeconfigGeneratorEntry,omitempty"`
 }
 
+func (c *Config) UnmarshalJSON(data []byte) error {
+	type configAlias struct {
+		Enabled                     *bool        `json:"enabled,omitempty"`
+		LegacyEnable                *bool        `json:"enable,omitempty"`
+		IngressClass                *string      `json:"ingressClass,omitempty"`
+		WhitelistSourceRanges       []string     `json:"whitelistSourceRanges,omitempty"`
+		HTTPS                       *HTTPSConfig `json:"https,omitempty"`
+		AddKubeconfigGeneratorEntry *bool        `json:"addKubeconfigGeneratorEntry,omitempty"`
+	}
+
+	var decoded configAlias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	c.Enabled = decoded.Enabled
+	if c.Enabled == nil {
+		c.Enabled = decoded.LegacyEnable
+	}
+	c.IngressClass = decoded.IngressClass
+	c.WhitelistSourceRanges = decoded.WhitelistSourceRanges
+	c.HTTPS = decoded.HTTPS
+	c.AddKubeconfigGeneratorEntry = decoded.AddKubeconfigGeneratorEntry
+
+	return nil
+}
+
 type HTTPSConfig struct {
 	Mode   *string      `json:"mode,omitempty"`
 	Global *GlobalHTTPS `json:"global,omitempty"`

--- a/modules/040-control-plane-manager/hooks/publish_api_from_cm_test.go
+++ b/modules/040-control-plane-manager/hooks/publish_api_from_cm_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package hooks
 
 import (

--- a/modules/040-control-plane-manager/hooks/publish_api_from_cm_test.go
+++ b/modules/040-control-plane-manager/hooks/publish_api_from_cm_test.go
@@ -1,0 +1,38 @@
+package hooks
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPublishAPIConfigUnmarshalJSON_SupportsLegacyEnable(t *testing.T) {
+	t.Parallel()
+
+	var config Config
+	if err := json.Unmarshal([]byte(`{"enable":true}`), &config); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+
+	if config.Enabled == nil {
+		t.Fatal("expected enabled value to be populated from legacy enable")
+	}
+	if !*config.Enabled {
+		t.Fatalf("expected enabled=true, got %v", *config.Enabled)
+	}
+}
+
+func TestPublishAPIConfigUnmarshalJSON_PrefersEnabledOverLegacyEnable(t *testing.T) {
+	t.Parallel()
+
+	var config Config
+	if err := json.Unmarshal([]byte(`{"enabled":true,"enable":false}`), &config); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+
+	if config.Enabled == nil {
+		t.Fatal("expected enabled value to be populated")
+	}
+	if !*config.Enabled {
+		t.Fatalf("expected enabled=true to win over legacy enable, got %v", *config.Enabled)
+	}
+}

--- a/modules/040-control-plane-manager/monitoring/prometheus-rules/migrate-publish-api.yaml
+++ b/modules/040-control-plane-manager/monitoring/prometheus-rules/migrate-publish-api.yaml
@@ -20,7 +20,10 @@
 
           **To complete the migration, follow the steps below:**
 
-          1. Review current settings for `publishAPI` in the resource `moduleconfig user-authn` resource.
+          1. Review current settings for `publishAPI` in the `moduleconfig user-authn` resource.
+
+             Note that legacy `user-authn` `spec.version: 1` uses `publishAPI.enable` instead of `publishAPI.enabled`.
+             No manual rewrite is required: the command in step 4 uses the normalized payload from the temporary ConfigMap.
 
           2. If the `moduleconfig control-plane-manager` resource exists, update its spec to `spec.version: 3`. If `settings.apiserver.loadBalancer` is set, migrate it to `settings.apiserver.publishAPI.loadBalancer`. If the resource does not exist, proceed to step 3.
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR hardens `publishAPI` migration from `user-authn` to `control-plane-manager` for clusters that still have legacy `user-authn` v1 settings. It normalizes `publishAPI.enable` during export, keeps `control-plane-manager` backward-compatible with already exported legacy payloads, and clarifies the alert migration steps.

### Example
`user-authn`
<img width="877" height="379" alt="image" src="https://github.com/user-attachments/assets/5162aaab-9e8a-4e1c-88e3-7c4b1afd3997" />

`d8-publishapi-config-migration`
<img width="1397" height="210" alt="image" src="https://github.com/user-attachments/assets/71f2140c-35c2-4c58-b47c-fb123e52cada" />


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Legacy `user-authn` v1 stores `publishAPI.enable`, while the migration flow and `control-plane-manager` consumer expect `enabled`. Because of that mismatch, alert-driven migration can fail or silently skip applying the intended `publishAPI` state.

## Why do we need it in the patch release (if we do)?
Without the patch, clusters with legacy `user-authn` v1 config can hit a broken or partially applied `publishAPI` migration during upgrade.

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fixed the publishAPI migration for clusters with legacy user-authn v1 settings.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
