### PR TITLE
[dhctl] Return envs prefix

### DIFF
--- a/dhctl/pkg/app/app.go
+++ b/dhctl/pkg/app/app.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 )
 
 const (
@@ -84,5 +85,5 @@ func DefineSanityFlags(cmd *kingpin.CmdClause, o *options.GlobalOptions) {
 }
 
 func configEnvName(name string) string {
-	return "DHCTL_CLI_" + name
+	return global.SSHEnvsPrefix + name
 }

--- a/dhctl/pkg/global/consts.go
+++ b/dhctl/pkg/global/consts.go
@@ -31,4 +31,6 @@ const (
 	InfrastructureStateBackupLabelKey = "dhctl.deckhouse.io/state-backup"
 
 	ConfigsNS = "kube-system"
+
+	SSHEnvsPrefix = "DHCTL_CLI_"
 )

--- a/dhctl/pkg/system/providerinitializer/providers.go
+++ b/dhctl/pkg/system/providerinitializer/providers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/deckhouse/lib-connection/pkg/settings"
 	libcon_config "github.com/deckhouse/lib-connection/pkg/ssh/config"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
 
@@ -124,6 +125,7 @@ func getProviderInitializer(baseProviderSettings *settings.BaseProviders, opts .
 		loggerProvider := log.NonInteractiveLoggerProvider()
 		sett.WithLogger(loggerProvider)
 		parser := libcon_config.NewFlagsParser(sett)
+		parser.WithEnvsPrefix(global.SSHEnvsPrefix)
 		fset := flag.NewFlagSet("my-set", flag.ExitOnError)
 		flags, err := parser.InitFlags(fset)
 		if err != nil {


### PR DESCRIPTION
## Description

Return `"DHCTL_CLI_"` environment variables prefix to dhtcl

## Why do we need it, and what problem does it solve?

Prefix was missed during lib-connection migration

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Add prefix to all ssh-related envs in dhctl.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
