### PR TITLE
[docs] Edit example for automatic etcd backup settings

### DIFF
--- a/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE.md
+++ b/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE.md
@@ -555,14 +555,18 @@ To configure automatic etcd backups, use the [`control-plane-manager`](/modules/
 Example configuration fragment:
 
 ```yaml
-apiVersion: deckhouse.io/v1
-kind: ClusterConfiguration
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: control-plane-manager
 spec:
-  etcd:
-    backup:
-      enabled: true
-      cronSchedule: "0 1 * * *"
-      hostPath: "/var/lib/etcd"
+  version: 2
+  enabled: true
+  settings:
+    etcd:
+      backup:
+        cronSchedule: 0 14 * * *
+        enabled: true
 ```
 
 ### Cluster configuration backup

--- a/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE_RU.md
+++ b/docs/documentation/pages/admin/configuration/backup/BACKUP_AND_RESTORE_RU.md
@@ -553,14 +553,18 @@ mv etcd-backup.tar.gz /var/lib/etcd/etcd-backup.tar.gz
 Пример фрагмента конфигурации:
 
 ```yaml
-apiVersion: deckhouse.io/v1
-kind: ClusterConfiguration
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: control-plane-manager
 spec:
-  etcd:
-    backup:
-      enabled: true
-      cronSchedule: "0 1 * * *"
-      hostPath: "/var/lib/etcd"
+  version: 2
+  enabled: true
+  settings:
+    etcd:
+      backup:
+        cronSchedule: 0 14 * * *
+        enabled: true
 ```
 
 ### Резервное копирование конфигурации кластера

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/backup/BACKUP_AND_RESTORE.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/backup/BACKUP_AND_RESTORE.md
@@ -555,14 +555,18 @@ To configure automatic etcd backups, use the `control-plane-manager` module. The
 Example configuration fragment:
 
 ```yaml
-apiVersion: deckhouse.io/v1
-kind: ClusterConfiguration
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: control-plane-manager
 spec:
-  etcd:
-    backup:
-      enabled: true
-      cronSchedule: "0 1 * * *"
-      hostPath: "/var/lib/etcd"
+  version: 2
+  enabled: true
+  settings:
+    etcd:
+      backup:
+        cronSchedule: 0 14 * * *
+        enabled: true
 ```
 
 ### Cluster configuration backup

--- a/docs/site/pages/virtualization-platform/documentation/admin/platform-management/backup/BACKUP_AND_RESTORE_RU.md
+++ b/docs/site/pages/virtualization-platform/documentation/admin/platform-management/backup/BACKUP_AND_RESTORE_RU.md
@@ -553,14 +553,18 @@ mv etcd-backup.tar.gz /var/lib/etcd/etcd-backup.tar.gz
 Пример фрагмента конфигурации:
 
 ```yaml
-apiVersion: deckhouse.io/v1
-kind: ClusterConfiguration
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: control-plane-manager
 spec:
-  etcd:
-    backup:
-      enabled: true
-      cronSchedule: "0 1 * * *"
-      hostPath: "/var/lib/etcd"
+  version: 2
+  enabled: true
+  settings:
+    etcd:
+      backup:
+        cronSchedule: 0 14 * * *
+        enabled: true
 ```
 
 ### Резервное копирование конфигурации кластера


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Edit example for automatic etcd backup settings.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Example for automatic etcd backup settings has been updated.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
