### PR TITLE
[network-gateway] Update dnsmasq to v2.92-alt2 to fix security vulnerabilities

### DIFF
--- a/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
+++ b/ee/modules/450-network-gateway/images/dnsmasq/werf.inc.yaml
@@ -1,3 +1,8 @@
+{{- define "alt change repos" }}
+{{- $new_date := "2026/05/17" }}
+- sed -i "s|/archive/p11/date/[^/]*/[^/]*/[^/]*/|/archive/p11/date/{{ $new_date }}/|g" /etc/apt/sources.list.d/alt.list
+{{- end }}
+
 {{- $binaries := "/usr/lib64/libsqlite3.so* /usr/sbin/dnsmasq /lib64/libnss_*" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
@@ -5,6 +10,10 @@ fromImage: common/relocate-artifact
 final: false
 shell:
   beforeInstall:
+  {{- include "alt change repos" . | nindent 2 }}
+  {{- include "alt packages proxy" . | nindent 2 }}
+  {{- include "alt dist upgrade" . | nindent 2 }}
+  - apt-get update
   - apt-get install -y dnsmasq libsqlite3
   install:
   - /binary_replace.sh -i "{{ $binaries }}" -o /relocate


### PR DESCRIPTION
## Description

Updated `dnsmasq` binary in the `network-gateway` module to version `2.92-alt2`. This update addresses multiple security vulnerabilities identified in CVE reports.

## Why do we need it, and what problem does it solve?

The update is required to mitigate several security risks in the `dnsmasq` component. It fixes the following vulnerabilities:

- CVE-2026-2291
- CVE-2026-4890
- CVE-2026-4891
- CVE-2026-4892
- CVE-2026-4893
- CVE-2026-5172

The fix is implemented by pointing to a specific ALT Linux p11 archive repository (2026/05/17) that contains the patched version of the package.

## Why do we need it in the patch release?

It is necessary to backport these changes into the patch release to ensure the security of the network gateway component in existing installations.

```bash
[root@aa57715cb35a /]# rpm -q --changelog dnsmasq | head -n 3
* Wed May 13 2026 Mikhail Efremov <sem@altlinux.org> 2.92-alt2
- Patches from upstream (fixes: CVE-2026-2291, CVE-2026-4890,
  CVE-2026-4891, CVE-2026-4892, CVE-2026-4893, CVE-2026-5172).

[root@aa57715cb35a /]# rpm -qi dnsmasq
Name        : dnsmasq
Version     : 2.92
Release     : alt2
DistTag     : p11+418016.100.1.1
Architecture: x86_64
Install Date: Mon May 18 13:02:06 2026
Group       : System/Servers
Size        : 899123
License     : GPLv2+
Signature   : RSA/SHA512, Wed May 13 15:20:32 2026, Key ID e1130f0e925e1ff4
Source RPM  : dnsmasq-2.92-alt2.src.rpm
Build Date  : Wed May 13 15:20:29 2026
Build Host  : sem-p11.hasher.altlinux.org
Relocations : (not relocatable)
Packager    : Mikhail Efremov <sem@altlinux.org>
Vendor      : ALT Linux Team
URL         : https://thekelleys.org.uk/dnsmasq/
Summary     : A lightweight caching nameserver
```

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: network-gateway
type: fix
summary: Updated dnsmasq to v2.92-alt2 to address multiple security vulnerabilities.
```