### PR TITLE
[control-plane-manager] Fix module permissions for admin

### DIFF
--- a/modules/040-control-plane-manager/templates/rbac-for-us.yaml
+++ b/modules/040-control-plane-manager/templates/rbac-for-us.yaml
@@ -205,6 +205,9 @@ rules:
   - moduleconfigs
   - deckhousereleases
   - modulesources
+  - modulereleases
+  - moduledocumentations
+  - modulesettingsdefinitions
   - moduleupdatepolicies
   - modulepulloverrides
   - packagerepositories


### PR DESCRIPTION
## Description
Fixed access error when using admin.conf file: cannot delete resource modulereleases, moduledocumentations and modulesettingsdefinitions.

Before
```bash
KUBECONFIG=/etc/kubernetes/admin.conf kubectl delete mr m-s-test-v1.0.6
Error from server (Forbidden): modulereleases.deckhouse.io "m-s-test-v1.0.6" is forbidden: User "kubernetes-admin" cannot delete resource "modulereleases" in API group "deckhouse.io" at the cluster scope
```
After
```bash
KUBECONFIG=/etc/kubernetes/admin.conf kubectl delete mr m-s-test-v1.0.6
modulerelease.deckhouse.io "m-s-test-v1.0.6" deleted
```

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
Administrators cannot manage resources that administrators should be able to manage.
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Allowed admins to manage ModuleReleases, ModuleDocumentations, and ModuleSettingsDefinitions.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
