### PR TITLE
[deckhouse] fix deckhouse requirement

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -433,12 +433,7 @@ func (r *Runtime) buildHealthService() error {
 // The scheduler starts paused and is resumed after initial package loading completes.
 func (r *Runtime) buildScheduler(cli kclient.Client) {
 	deckhouseVersionGetter := func() (*semver.Version, error) {
-		discovery := r.addonModuleManager.GetGlobal().GetValues(false).GetKeySection("discovery")
-		if len(discovery) == 0 {
-			return nil, fmt.Errorf("discovery section not found in global values")
-		}
-
-		value, ok := discovery[deckhouseVersionValue]
+		value, ok := r.addonModuleManager.GetGlobal().GetValues(false)[deckhouseVersionValue]
 		if !ok {
 			return nil, fmt.Errorf("deckhouse version not found in global values")
 		}


### PR DESCRIPTION
## Description
It fixes deckhouse requirement for packages.

## Why do we need it, and what problem does it solve?
Deckhouse requirement currently does not work.

Before: 
```
root@paksashvili-master-0:~# k apply -f packages/app.yaml
Error from server: error when creating "packages/app.yaml": admission webhook "applications.deckhouse-webhook.deckhouse.io" denied the request: get version: deckhouse version not found in global values
```

After:
```
root@paksashvili-master-0:~# k apply -f packages/app.yaml
application.deckhouse.io/test created
root@paksashvili-master-0:~# k get apv test-test-v0.0.9 -o json | jq .status.packageMetadata
{
  "changelog": {},
  "description": {},
  "requirements": {
    "deckhouse": "> v0.0.0"
  },
  "stage": "Preview"
}
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix deckhouse requirement for packages.
impact_level: low
```

