### PR TITLE
[deckhouse-controller] Fix ContainerdV2 cluster default validation

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration.go
@@ -31,7 +31,9 @@ import (
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -44,6 +46,7 @@ import (
 const (
 	containerdV2UnsupportedLabel        = "node.deckhouse.io/containerd-v2-unsupported"
 	customContainerdConfigLabelSelector = "node.deckhouse.io/containerd-config=custom"
+	nodeGroupNameLabel                  = "node.deckhouse.io/group"
 )
 
 type clusterConfig struct {
@@ -84,6 +87,43 @@ func validateKubernetesVersion(version string, mm moduleManager) (*kwhvalidating
 	return allowResult(nil)
 }
 
+// listNodeGroupCRITypes returns a map of NodeGroup name -> spec.cri.type.
+func listNodeGroupCRITypes(ctx context.Context, cli client.Client) (map[string]string, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "deckhouse.io",
+		Version: "v1",
+		Kind:    "NodeGroupList",
+	})
+	if err := cli.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("list NodeGroups: %w", err)
+	}
+	out := make(map[string]string, len(list.Items))
+	for i := range list.Items {
+		t, _, _ := unstructured.NestedString(list.Items[i].Object, "spec", "cri", "type")
+		out[list.Items[i].GetName()] = t
+	}
+	return out, nil
+}
+
+// nodeEffectivelyContainerdV2 reports whether the nodes effective CRI is (or will become) ContainerdV2.
+// Returns true if the node has no NodeGroup label or the NodeGroup is not in the snapshot(just in case).
+func nodeEffectivelyContainerdV2(node *v1.Node, ngCRIType map[string]string) bool {
+	ng := node.Labels[nodeGroupNameLabel]
+	if ng == "" {
+		return true
+	}
+	t, ok := ngCRIType[ng]
+	if !ok {
+		return true
+	}
+	return t == "" || t == "ContainerdV2"
+}
+
+func formatNodeWithNG(node *v1.Node) string {
+	return fmt.Sprintf("%s (NodeGroup=%s)", node.Name, node.Labels[nodeGroupNameLabel])
+}
+
 func checkCntrdV2Support(ctx context.Context, cli client.Client) (*kwhvalidating.ValidatorResult, error) {
 	unsupportedSelector, err := labels.Parse(containerdV2UnsupportedLabel)
 	if err != nil {
@@ -93,10 +133,6 @@ func checkCntrdV2Support(ctx context.Context, cli client.Client) (*kwhvalidating
 	unsupportedNodes := &v1.NodeList{}
 	if err := cli.List(ctx, unsupportedNodes, &client.ListOptions{LabelSelector: unsupportedSelector}); err != nil {
 		return nil, fmt.Errorf("failed to list nodes with label %q: %w", containerdV2UnsupportedLabel, err)
-	}
-
-	if len(unsupportedNodes.Items) > 0 {
-		return rejectResult("Cluster has nodes that don't support ContainerdV2")
 	}
 
 	customConfigSelector, err := labels.Parse(customContainerdConfigLabelSelector)
@@ -109,8 +145,41 @@ func checkCntrdV2Support(ctx context.Context, cli client.Client) (*kwhvalidating
 		return nil, fmt.Errorf("failed to list nodes with label %q: %w", customContainerdConfigLabelSelector, err)
 	}
 
-	if len(customConfigNodes.Items) > 0 {
-		return rejectResult("Cluster has nodes with a custom containerd config, which is incompatible with ContainerdV2")
+	// Nothing flagged any node - early exit before listing NodeGroups
+	if len(unsupportedNodes.Items) == 0 && len(customConfigNodes.Items) == 0 {
+		return allowResult(nil)
+	}
+
+	ngCRI, err := listNodeGroupCRITypes(ctx, cli)
+	if err != nil {
+		return nil, err
+	}
+
+	var blockedNodes []string
+	for _, node := range unsupportedNodes.Items {
+		if nodeEffectivelyContainerdV2(&node, ngCRI) {
+			blockedNodes = append(blockedNodes, formatNodeWithNG(&node))
+		}
+	}
+	if len(blockedNodes) > 0 {
+		return rejectResult(fmt.Sprintf(
+			"Cluster has nodes that don't support ContainerdV2 and would inherit cluster default: %s. "+
+				"Pin their NodeGroups by setting spec.cri.type=Containerd, or resolve the incompatibility with ContainerdV2.",
+			strings.Join(blockedNodes, ", ")))
+	}
+
+	blockedNodes = blockedNodes[:0]
+	for _, node := range customConfigNodes.Items {
+		if nodeEffectivelyContainerdV2(&node, ngCRI) {
+			blockedNodes = append(blockedNodes, formatNodeWithNG(&node))
+		}
+	}
+	if len(blockedNodes) > 0 {
+		return rejectResult(fmt.Sprintf(
+			"Cluster has nodes with a custom containerd config, which is incompatible with ContainerdV2 "+
+				"that would inherit cluster default: %s. Pin their NodeGroups by setting "+
+				"spec.cri.type=Containerd, or remove/migrate the custom config to ContainerdV2.",
+			strings.Join(blockedNodes, ", ")))
 	}
 
 	return allowResult(nil)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
No cluster components are restarted by this change.

The validator now checks whether a node will _actually_ inherit the cluster-default ContainerdV2 before
blocking. Nodes pinned to a V1 NodeGroup are filtered out; only nodes that would genuinely move to V2 can
trigger a rejection.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

| Scenario | Before | After |
|---|---|---|
| `defaultCRI=V2`, settled cluster, secret UPDATE | reject | **allow** — unsupported nodes in V1 NGs filtered out |
| V1→V2 migration, unsupported node in V1 NG | reject | **allow** — node won't move to V2 |
| V1→V2 migration, unsupported node in NG without override (inherits default) | reject | reject — node will actually move to V2 |
| V1→V2 migration, clean cluster | allow | allow |
| CREATE with `defaultCRI=V2`, unsupported node in V1 NG | reject | **allow** |
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fix ContainerdV2 cluster default validation
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
