### PR TITLE
[docs] Add root-level example rendering for modules from source

### DIFF
--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-configuration.html
@@ -94,6 +94,10 @@ Context:
 <h2>{{ T "parameters" | humanize  }}</h2>
 <p><font size="-1">{{ T "version_of_schema" }}: {{ $configVersion }}</font></p>
 
+{{- if or (isset $data "x-doc-examples") (isset $data "x-doc-example") (isset $data "example") (isset $data "x-examples") }}
+  {{- template "format-example" ( dict "attributes" $data "linkAnchor" "parameters-settings" "name" "" ) }}
+{{- end }}
+
 <ul class="resources">
   <li>
     <div class="resources__prop_wrap"><div id="parameters-settings" data-anchor-id="parameters-settings" class="resources__prop_name anchored">

--- a/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/openapi/format-crd.html
@@ -49,6 +49,12 @@
     {{- end }}
 
     <div class="resources__prop_description">{{ partial "openapi/format-description" $description }}</div>
+
+    {{- if or (isset $versionSchema "x-doc-examples") (isset $versionSchema "x-doc-example") (isset $versionSchema "example") (isset $versionSchema "x-examples") }}
+      {{- $linkAnchor := printf "%s-%s" $kindDowncase $versionName }}
+      {{- template "format-example" ( dict "attributes" $versionSchema "linkAnchor" $linkAnchor "name" "" ) }}
+    {{- end }}
+
     <ul class="resources">
       {{- range $property, $propertyData := $versionSchema.properties }}
         


### PR DESCRIPTION
## Description

This pull request enhances the documentation templates to display example sections for parameters and CRDs when example data is available in for modules from sources.

**Display of example sections:**

* [`format-configuration.html`](diffhunk://#diff-22adee06633d6a6782018dbf50c09ed49bc3fc8b1c5e8af5eddc5c44fbccd5f0R97-R100): Adds logic to show example sections for parameters if any example-related fields are present in the data.
* [`format-crd.html`](diffhunk://#diff-4f4d8d14f78319a6b8d5846f478a558c5690229897497bfdcbd6fe7bfd1f487fR52-R57): Adds logic to display example sections for CRDs when example fields exist in the schema, with dynamic anchor links for better navigation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add root-level example rendering for modules from source.
impact_level: low
```
