### PR TITLE
[ingress-nginx] Fixed staled metric `ingress_nginx_validation_suspended`

### DIFF
--- a/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
+++ b/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook/metrics"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
 	v1 "k8s.io/api/core/v1"
@@ -90,12 +91,12 @@ func setAnnotationValidationSuspendedHandleIngressNginxControllers(_ context.Con
 	// First run → set blocking annotations on all controllers
 	if !configMapExists {
 		setValidationSuspendedAnnotationToAll(controllersSnapshot, input)
-		input.MetricsCollector.Set(validationSuspendMetricName, 1.0, nil)
+		input.MetricsCollector.Set(validationSuspendMetricName, 1.0, nil, metrics.WithGroup(validationSuspendMetricName))
 	}
 
 	// If at least one controller has annotation → set metric
 	if anyControllerHasAnnotationValidationSuspended(controllersSnapshot) {
-		input.MetricsCollector.Set(validationSuspendMetricName, 1.0, nil)
+		input.MetricsCollector.Set(validationSuspendMetricName, 1.0, nil, metrics.WithGroup(validationSuspendMetricName))
 	}
 
 	return nil

--- a/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended_test.go
+++ b/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended_test.go
@@ -82,6 +82,7 @@ var _ = Describe("ingress-nginx :: hooks :: setAnnotationValidationSuspendedHand
 			}
 
 			Expect(hasMetric(f.MetricsCollector.CollectedMetrics())).To(BeTrue())
+			Expect(hasMetricWithGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeTrue())
 		})
 	})
 
@@ -115,6 +116,7 @@ var _ = Describe("ingress-nginx :: hooks :: setAnnotationValidationSuspendedHand
 		It("expires the validation suspended metric", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(hasMetric(f.MetricsCollector.CollectedMetrics())).To(BeFalse())
+			Expect(hasExpireForGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeTrue())
 		})
 	})
 })
@@ -123,6 +125,25 @@ func hasMetric(metrics []operation.MetricOperation) bool {
 	const metricName = "ingress_nginx_validation_suspended"
 	for _, m := range metrics {
 		if m.Name == metricName {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMetricWithGroup(metrics []operation.MetricOperation, group string) bool {
+	const metricName = "ingress_nginx_validation_suspended"
+	for _, m := range metrics {
+		if m.Name == metricName && m.Group == group {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExpireForGroup(metrics []operation.MetricOperation, group string) bool {
+	for _, m := range metrics {
+		if m.Action == operation.ActionExpireMetrics && m.Group == group {
 			return true
 		}
 	}

--- a/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended_test.go
+++ b/modules/402-ingress-nginx/hooks/set_annotation_validation_suspended_test.go
@@ -43,7 +43,7 @@ var _ = Describe("ingress-nginx :: hooks :: setAnnotationValidationSuspendedHand
 		It("does nothing", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers").Array()).To(BeEmpty())
-			Expect(hasMetric(f.MetricsCollector.CollectedMetrics())).To(BeFalse())
+			Expect(hasMetricInGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeFalse())
 		})
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("ingress-nginx :: hooks :: setAnnotationValidationSuspendedHand
 		It("does nothing and does not set metric", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers").Array()).To(BeEmpty())
-			Expect(hasMetric(f.MetricsCollector.CollectedMetrics())).To(BeFalse())
+			Expect(hasMetricInGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeFalse())
 		})
 	})
 
@@ -81,8 +81,7 @@ var _ = Describe("ingress-nginx :: hooks :: setAnnotationValidationSuspendedHand
 				Expect(has).To(BeTrue(), "controller %s is missing the suspended annotation", item.GetName())
 			}
 
-			Expect(hasMetric(f.MetricsCollector.CollectedMetrics())).To(BeTrue())
-			Expect(hasMetricWithGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeTrue())
+			Expect(hasMetricInGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeTrue())
 		})
 	})
 
@@ -96,7 +95,7 @@ var _ = Describe("ingress-nginx :: hooks :: setAnnotationValidationSuspendedHand
 		It("does nothing because ConfigMap exists", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("ingressNginx.internal.ingressControllers").Array()).To(BeEmpty())
-			Expect(hasMetric(f.MetricsCollector.CollectedMetrics())).To(BeFalse())
+			Expect(hasMetricInGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeFalse())
 		})
 	})
 
@@ -115,26 +114,16 @@ var _ = Describe("ingress-nginx :: hooks :: setAnnotationValidationSuspendedHand
 
 		It("expires the validation suspended metric", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(hasMetric(f.MetricsCollector.CollectedMetrics())).To(BeFalse())
+			Expect(hasMetricInGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeFalse())
 			Expect(hasExpireForGroup(f.MetricsCollector.CollectedMetrics(), validationSuspendMetricName)).To(BeTrue())
 		})
 	})
 })
 
-func hasMetric(metrics []operation.MetricOperation) bool {
+func hasMetricInGroup(metrics []operation.MetricOperation, group string) bool {
 	const metricName = "ingress_nginx_validation_suspended"
 	for _, m := range metrics {
-		if m.Name == metricName {
-			return true
-		}
-	}
-	return false
-}
-
-func hasMetricWithGroup(metrics []operation.MetricOperation, group string) bool {
-	const metricName = "ingress_nginx_validation_suspended"
-	for _, m := range metrics {
-		if m.Name == metricName && m.Group == group {
+		if m.Name == metricName && m.Group == group && m.Action != operation.ActionExpireMetrics {
 			return true
 		}
 	}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR switches the `ingress_nginx_validation_suspended` metric to an explicit metric group, so its expiration and updates are applied consistently.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously, `ingress_nginx_validation_suspended` was written and expired using different metric groups. Because of that, the metric could remain on /metrics/hooks after the suspension annotation was removed, leaving the alert stuck in firing state.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

<details>
<summary>Manual test</summary>

1. Create five `IngressNginxController` resources.
2. Delete the `ingress-nginx-validation-suspended` ConfigMap to trigger the hook:
```bash
   d8 k -n d8-ingress-nginx delete cm ingress-nginx-validation-suspended
```

<img width="928" height="265" alt="image" src="https://github.com/user-attachments/assets/12684a5b-908c-418b-98e7-4da1299aa281" />

3. Verify that the hook adds the `network.deckhouse.io/ingress-nginx-validation-suspended` annotation to the controllers.
4. Remove the suspension annotation from all `IngressNginxController` resources.

<img width="1234" height="236" alt="image" src="https://github.com/user-attachments/assets/7d245db2-a5a8-4e0c-8cab-ae4d095498ef" />

6. Verify that both the `ingress_nginx_validation_suspended` metric and the `NginxIngressValidationIsDisabled` alert disappear.

<img width="1920" height="774" alt="image" src="https://github.com/user-attachments/assets/164dd161-9f6c-4235-aade-3336e97be8e0" />

<img width="875" height="197" alt="image" src="https://github.com/user-attachments/assets/409da711-7249-46c4-bcdf-4ad1f1c3d9e0" />

</details>

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed stale `ingress_nginx_validation_suspended` hook metric and false-positive alert after the suspension annotation is removed from all IngressNginxController resources in `ingress-nginx`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
