### PR TITLE
[dhctl] Add new phases to bootstrap

### DIFF
--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -315,14 +315,14 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 
 	bootstrapState := NewBootstrapState(stateCache)
 
-	if shouldStop, err := b.PhasedExecutionContext.StartPhase(ctx, phases.BaseInfraPhase, true, stateCache); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.StartPhase(ctx, phases.PreInfraPreflightsPhase, true, stateCache); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
 	}
 
-	_, baseInfraSpan := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.BaseInfra")
-	defer baseInfraSpan.End()
+	_, preflightSpan := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.PreInfraPreflights")
+	defer preflightSpan.End()
 
 	var nodeIP string
 	var devicePath string
@@ -340,6 +340,15 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		InstallConfig: deckhouseInstallConfig,
 		BuildInfo:     b.Options.BuildInfo,
 	})
+
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.BaseInfraPhase, false, stateCache, nil); err != nil {
+		return err
+	} else if shouldStop {
+		return nil
+	}
+
+	_, baseInfraSpan := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.BaseInfra")
+	defer baseInfraSpan.End()
 
 	if metaConfig.ClusterType == config.CloudClusterType {
 		_, cloudPreflightSpan := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.CloudPreflight")
@@ -387,6 +396,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			}
 
 			log.DebugLn("Base infrastructure was created")
+			b.PhasedExecutionContext.CompleteSubPhase(phases.BaseInfraSubPhaseBaseInfra)
 
 			var cloudDiscoveryData map[string]interface{}
 			err = json.Unmarshal(baseOutputs.CloudDiscovery, &cloudDiscoveryData)
@@ -417,6 +427,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			}
 
 			log.DebugLn("First control-plane node was created")
+			b.PhasedExecutionContext.CompleteSubPhase(phases.BaseInfraSubPhaseFirstMaster)
 
 			deckhouseInstallConfig.CloudDiscovery = baseOutputs.CloudDiscovery
 			deckhouseInstallConfig.InfrastructureState = baseOutputs.InfrastructureState
@@ -454,10 +465,21 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 			return err
 		}
 
+		if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.PostInfraPreflightsPhase, false, stateCache, nil); err != nil {
+			return err
+		} else if shouldStop {
+			return nil
+		}
+
 		if err := preflightRunner.Run(ctx, preflight.PhasePostInfra); err != nil {
 			return err
 		}
 	} else {
+		if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.PostInfraPreflightsPhase, false, stateCache, nil); err != nil {
+			return err
+		} else if shouldStop {
+			return nil
+		}
 		_, staticPreflightSpan := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.StaticPreflight")
 		defer staticPreflightSpan.End()
 
@@ -523,14 +545,6 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 
 	baseInfraSpan.End()
 
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.RegistryPackagesProxyPhase, false, stateCache, nil); err != nil {
-		return err
-	} else if shouldStop {
-		return nil
-	}
-	_, registryPackagesProxySpan := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.RegistryPackagesProxy")
-	defer registryPackagesProxySpan.End()
-
 	if b.SSHProviderInitializer.CheckHosts() {
 		sshProvider, err := b.SSHProviderInitializer.GetSSHProvider(ctx)
 		if err != nil {
@@ -547,9 +561,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		}
 	}
 
-	registryPackagesProxySpan.End()
-
-	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.ExecuteBashibleBundlePhase, false, stateCache, nil); err != nil {
+	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.InstallKubernetesPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
@@ -564,13 +576,14 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	}
 
 	err = RunBashiblePipeline(ctx, &BashiblePipelineParams{
-		Node:           nodeInterface,
-		NodeIP:         nodeIP,
-		DevicePath:     devicePath,
-		MetaConfig:     metaConfig,
-		CommanderMode:  b.CommanderMode,
-		GlobalOpts:     &b.Options.Global,
-		LoggerProvider: b.loggerProvider,
+		Node:                   nodeInterface,
+		NodeIP:                 nodeIP,
+		DevicePath:             devicePath,
+		MetaConfig:             metaConfig,
+		CommanderMode:          b.CommanderMode,
+		GlobalOpts:             &b.Options.Global,
+		LoggerProvider:         b.loggerProvider,
+		PhasedExecutionContext: b.PhasedExecutionContext,
 	})
 
 	if err != nil {
@@ -657,6 +670,7 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 				masterAddressesForSSH,
 				b.InfrastructureContext,
 				&b.Options.Global,
+				b.PhasedExecutionContext,
 			)
 		})
 		if err != nil {
@@ -666,14 +680,15 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 		additionalNodesSpan.End()
 	}
 
+	if err := controlplane.NewManagerReadinessChecker(kubernetes.NewSimpleKubeClientGetter(&client.KubernetesClient{KubeClient: kubeCl})).IsReadyAll(ctx); err != nil {
+		return err
+	}
+	b.PhasedExecutionContext.CompleteSubPhase(phases.InstallAdditionalMastersAndStaticNodesSubPhaseWait)
+
 	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.CreateResourcesPhase, false, stateCache, nil); err != nil {
 		return err
 	} else if shouldStop {
 		return nil
-	}
-
-	if err := controlplane.NewManagerReadinessChecker(kubernetes.NewSimpleKubeClientGetter(&client.KubernetesClient{KubeClient: kubeCl})).IsReadyAll(ctx); err != nil {
-		return err
 	}
 
 	err = createResources(
@@ -834,6 +849,7 @@ func bootstrapAdditionalNodesForCloudCluster(
 	masterAddressesForSSH map[string]string,
 	infrastructureContext *infrastructure.Context,
 	globalOptions *options.GlobalOptions,
+	PhasedExecutionContext phases.DefaultPhasedExecutionContext,
 ) error {
 	ctx, span := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.AdditionalNodesForCloudCluster")
 	defer span.End()
@@ -847,6 +863,8 @@ func bootstrapAdditionalNodesForCloudCluster(
 	if operations.IsSequentialNodesBootstrap(metaConfig) {
 		bootstrapAdditionalTerraNodeGroups = operations.BootstrapSequentialTerraNodes
 	}
+
+	PhasedExecutionContext.CompleteSubPhase(phases.InstallAdditionalMastersAndStaticNodesSubPhaseAdditionalMasters)
 
 	if err := bootstrapAdditionalTerraNodeGroups(ctx, kubeCl, metaConfig, terraNodeGroups, infrastructureContext, globalOptions); err != nil {
 		return err
@@ -865,6 +883,8 @@ func bootstrapAdditionalNodesForCloudCluster(
 		if err := entity.WaitForNodesBecomeReady(ctx, kubeCl, ngs); err != nil {
 			return err
 		}
+
+		PhasedExecutionContext.CompleteSubPhase(phases.InstallAdditionalMastersAndStaticNodeSubPhaseStaticNodes)
 
 		return nil
 	})

--- a/dhctl/pkg/operations/bootstrap/steps.go
+++ b/dhctl/pkg/operations/bootstrap/steps.go
@@ -51,6 +51,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap/deps"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap/registry"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/bootstrap/rpp"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/telemetry"
@@ -69,14 +70,15 @@ type ModulePreparator interface {
 }
 
 type BashiblePipelineParams struct {
-	Node           libcon.Interface
-	NodeIP         string
-	MetaConfig     *config.MetaConfig
-	DevicePath     string
-	CommanderMode  bool
-	IsDebug        bool
-	GlobalOpts     *options.GlobalOptions
-	LoggerProvider dhctllog.LoggerProvider
+	Node                   libcon.Interface
+	NodeIP                 string
+	MetaConfig             *config.MetaConfig
+	DevicePath             string
+	CommanderMode          bool
+	IsDebug                bool
+	GlobalOpts             *options.GlobalOptions
+	LoggerProvider         dhctllog.LoggerProvider
+	PhasedExecutionContext phases.DefaultPhasedExecutionContext
 }
 
 func (p *BashiblePipelineParams) Validate() error {
@@ -143,6 +145,7 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 	if err != nil {
 		return err
 	}
+	params.PhasedExecutionContext.CompleteSubPhase(phases.InstallKubernetesSubPhaseBundlePreparation)
 
 	ready, err := bashible.AlreadyRun(ctx)
 	if err != nil {
@@ -180,6 +183,7 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 	}
 
 	defer registryPackagesProxyCleanup()
+	params.PhasedExecutionContext.CompleteSubPhase(phases.InstallKubernetesSubPhaseRegistryPackagesProxy)
 
 	if err = PrepareBashibleBundle(ctx, nodeIP, devicePath, cfg, templateController, params.GlobalOpts); err != nil {
 		return err
@@ -211,10 +215,17 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 		}
 	}
 
-	return bashible.ExecuteBundle(ctx, dhbashible.ExecuteBundleParams{
+	params.PhasedExecutionContext.CompleteSubPhase(phases.InstallKubernetesSubPhaseNodePreparation)
+
+	if err := bashible.ExecuteBundle(ctx, dhbashible.ExecuteBundleParams{
 		BundleDir:     templateController.TmpDir,
 		CommanderMode: params.CommanderMode,
-	})
+	}); err != nil {
+		return err
+	}
+
+	params.PhasedExecutionContext.CompleteSubPhase(phases.InstallKubernetesSubPhaseExecuteBashibleBundle)
+	return nil
 }
 
 func getModulesPreparators(params *BashiblePipelineParams) []ModulePreparator {

--- a/dhctl/pkg/operations/phases/phases.go
+++ b/dhctl/pkg/operations/phases/phases.go
@@ -62,11 +62,14 @@ type ClusterConfig struct {
 // Define common operations phases for such operations as bootstrap, converge and destroy.
 // Notice that each operation could define own phases (like attach operation do).
 const (
+	// metaphase for all
+	PreparationPhase OperationPhase = "Preparation"
 	// bootstrap and converge both
 	BaseInfraPhase OperationPhase = "BaseInfra"
 	// bootstrap only
-	RegistryPackagesProxyPhase             OperationPhase = "RegistryPackagesProxyBundle"
-	ExecuteBashibleBundlePhase             OperationPhase = "ExecuteBashibleBundle"
+	PreInfraPreflightsPhase                OperationPhase = "PreInfraPreflights"
+	PostInfraPreflightsPhase               OperationPhase = "PostInfraPreflights"
+	InstallKubernetesPhase                 OperationPhase = "InstallKubernetes"
 	InstallDeckhousePhase                  OperationPhase = "InstallDeckhouse"
 	CreateResourcesPhase                   OperationPhase = "CreateResources"
 	InstallAdditionalMastersAndStaticNodes OperationPhase = "InstallAdditionalMastersAndStaticNodes"
@@ -113,11 +116,66 @@ const (
 	InstallDeckhouseSubPhaseWait    OperationSubPhase = "WaitForFirstMasterReady"
 )
 
+// preparation sub phases
+const (
+	PreparationSubPhaseImagesDownload   OperationSubPhase = "ImagesDownload"
+	PreparationSubPhaseConfigValidation OperationSubPhase = "ConfigValidation"
+	PreparationSubPhaseCachePreparation OperationSubPhase = "CachePreparation"
+	PreparationSubPhaseStatePreparation OperationSubPhase = "StatePreparation"
+)
+
+// base infra sub phases
+const (
+	BaseInfraSubPhaseBaseInfra   OperationSubPhase = "BaseInfra"
+	BaseInfraSubPhaseFirstMaster OperationSubPhase = "FirstMaster"
+)
+
+// install kubernetes sub phases
+const (
+	InstallKubernetesSubPhaseBundlePreparation     OperationSubPhase = "BashibleBundlePrepartion"
+	InstallKubernetesSubPhaseRegistryPackagesProxy OperationSubPhase = "RegistryPackagesProxy"
+	InstallKubernetesSubPhaseNodePreparation       OperationSubPhase = "NodePreparation"
+	InstallKubernetesSubPhaseExecuteBashibleBundle OperationSubPhase = "ExecuteBashibleBundle"
+)
+
+// InstallAdditionalMastersAndStaticNodes sub phases
+const (
+	InstallAdditionalMastersAndStaticNodesSubPhaseAdditionalMasters OperationSubPhase = "AdditionalMasters"
+	InstallAdditionalMastersAndStaticNodeSubPhaseStaticNodes        OperationSubPhase = "StaticNodes"
+	InstallAdditionalMastersAndStaticNodesSubPhaseWait              OperationSubPhase = "WaitForControlPlaneManagerReadiness"
+)
+
 func BootstrapPhases() []PhaseWithSubPhases {
 	return []PhaseWithSubPhases{
-		{Phase: BaseInfraPhase, includeIf: ifNotStatic},
-		{Phase: RegistryPackagesProxyPhase},
-		{Phase: ExecuteBashibleBundlePhase},
+		// PreparationPhase is not implemented yet
+		// {
+		// 	Phase: PreparationPhase,
+		// 	SubPhases: []OperationSubPhase{
+		// 		PreparationSubPhaseImagesDownload,
+		// 		PreparationSubPhaseConfigValidation,
+		// 		PreparationSubPhaseCachePreparation,
+		// 		PreparationSubPhaseStatePreparation,
+		// 	},
+		// },
+		{Phase: PreInfraPreflightsPhase},
+		{
+			Phase:     BaseInfraPhase,
+			includeIf: ifNotStatic,
+			SubPhases: []OperationSubPhase{
+				BaseInfraSubPhaseBaseInfra,
+				BaseInfraSubPhaseFirstMaster,
+			},
+		},
+		{Phase: PostInfraPreflightsPhase},
+		{
+			Phase: InstallKubernetesPhase,
+			SubPhases: []OperationSubPhase{
+				InstallKubernetesSubPhaseBundlePreparation,
+				InstallKubernetesSubPhaseRegistryPackagesProxy,
+				InstallKubernetesSubPhaseNodePreparation,
+				InstallKubernetesSubPhaseExecuteBashibleBundle,
+			},
+		},
 		{
 			Phase: InstallDeckhousePhase,
 			SubPhases: []OperationSubPhase{
@@ -126,7 +184,14 @@ func BootstrapPhases() []PhaseWithSubPhases {
 				InstallDeckhouseSubPhaseWait,
 			},
 		},
-		{Phase: InstallAdditionalMastersAndStaticNodes},
+		{
+			Phase: InstallAdditionalMastersAndStaticNodes,
+			SubPhases: []OperationSubPhase{
+				InstallAdditionalMastersAndStaticNodesSubPhaseAdditionalMasters,
+				InstallAdditionalMastersAndStaticNodeSubPhaseStaticNodes,
+				InstallAdditionalMastersAndStaticNodesSubPhaseWait,
+			},
+		},
 		{Phase: CreateResourcesPhase},
 		{Phase: ExecPostBootstrapPhase},
 		{Phase: FinalizationPhase},

--- a/dhctl/pkg/operations/phases/progress_test.go
+++ b/dhctl/pkg/operations/phases/progress_test.go
@@ -75,8 +75,7 @@ func TestProgressTracker(t *testing.T) {
 
 	require.NoError(t, progressTracker.Progress("", "", "", opts))
 	require.NoError(t, progressTracker.Progress(phases.BaseInfraPhase, "", "", opts))
-	require.NoError(t, progressTracker.Progress(phases.RegistryPackagesProxyPhase, "", "", opts))
-	require.NoError(t, progressTracker.Progress(phases.ExecuteBashibleBundlePhase, "", "", opts))
+	require.NoError(t, progressTracker.Progress(phases.InstallKubernetesPhase, "", "", opts))
 	require.NoError(t, progressTracker.Progress("", "", phases.InstallDeckhouseSubPhaseConnect, opts))
 	require.NoError(t, progressTracker.Progress("", "", phases.InstallDeckhouseSubPhaseInstall, opts))
 	require.NoError(t, progressTracker.Progress("", "", phases.InstallDeckhouseSubPhaseWait, opts))
@@ -217,7 +216,6 @@ func TestProgressTracker_Complete(t *testing.T) {
 
 	require.NoError(t, progressTracker.Progress("", "", "", opts))
 	require.NoError(t, progressTracker.Progress(phases.BaseInfraPhase, "", "", opts))
-	require.NoError(t, progressTracker.Complete(phases.RegistryPackagesProxyPhase))
 
 	lastPhases := phases.BootstrapPhases()
 	for i := range lastPhases {
@@ -402,9 +400,6 @@ func TestProgressTracker_Progress_ExcludesPhase(t *testing.T) {
 
 	assert.NotContains(t, phaseNames, string(phases.BaseInfraPhase),
 		"BaseInfraPhase must not appear in progress for Bootstrap Static",
-	)
-	assert.Equal(t, string(phases.RegistryPackagesProxyPhase), string(result[0].CurrentPhase),
-		"first phase for Bootstrap Static should be RegistryPackagesProxy",
 	)
 }
 

--- a/dhctl/pkg/util/progressbar/progressbar.go
+++ b/dhctl/pkg/util/progressbar/progressbar.go
@@ -216,11 +216,12 @@ func ErrorF(format string, a ...any) {
 }
 
 func phaseToString(p phases.Progress, completed bool) string {
-	// Butify bootstrap: phases with subphases
+	// Beautify bootstrap: phases with subphases
 	phasesMap := make(map[phases.OperationPhase]string)
+	phasesMap[phases.PreInfraPreflightsPhase] = "Common preflight checks"
+	phasesMap[phases.PostInfraPreflightsPhase] = "Static and post-infra preflight checks"
 	phasesMap[phases.BaseInfraPhase] = "Base Infrastructure"
-	phasesMap[phases.RegistryPackagesProxyPhase] = "Preparing registry packages proxy"
-	phasesMap[phases.ExecuteBashibleBundlePhase] = "Bootstrap Kubernetes on first master node"
+	phasesMap[phases.InstallKubernetesPhase] = "Install Kubernetes on the first master node"
 	phasesMap[phases.InstallDeckhousePhase] = "Install Deckhouse"
 	phasesMap[phases.CreateResourcesPhase] = "Create resources"
 	phasesMap[phases.InstallAdditionalMastersAndStaticNodes] = "Install additional master nodes and CloudPermanent nodes"
@@ -246,22 +247,60 @@ func phaseToString(p phases.Progress, completed bool) string {
 	subphasesMap[phases.InstallDeckhouseSubPhaseWait] = "Wait for the first master readiness"
 	subphasesMap[phases.OperationSubPhase(phases.CheckInfra)] = "Check Infrastructure"
 	subphasesMap[phases.OperationSubPhase(phases.CheckConfiguration)] = "Check configuration"
+	subphasesMap[phases.BaseInfraSubPhaseBaseInfra] = "Base Infrastructure"
+	subphasesMap[phases.BaseInfraSubPhaseFirstMaster] = "First master node"
+	subphasesMap[phases.InstallAdditionalMastersAndStaticNodesSubPhaseAdditionalMasters] = "Install additional master nodes"
+	subphasesMap[phases.InstallAdditionalMastersAndStaticNodeSubPhaseStaticNodes] = "Install additional static nodes"
+	subphasesMap[phases.InstallAdditionalMastersAndStaticNodesSubPhaseWait] = "Wait for control plane manager become ready"
+	subphasesMap[phases.InstallKubernetesSubPhaseBundlePreparation] = "Prepare bashible bundle"
+	subphasesMap[phases.InstallKubernetesSubPhaseRegistryPackagesProxy] = "Prepare registry packages proxy"
+	subphasesMap[phases.InstallKubernetesSubPhaseNodePreparation] = "Prepare node"
+	subphasesMap[phases.InstallKubernetesSubPhaseExecuteBashibleBundle] = "Execute bashible bundle"
 
+	// TODO: too complicated, has to be refactored
 	msg := ""
 	if completed {
 		if p.CompletedSubPhase != "" {
-			msg = fmt.Sprintf("%s: %s", phasesMap[p.CurrentPhase], subphasesMap[p.CompletedSubPhase])
+			currentPhase, ok := phasesMap[p.CurrentPhase]
+			if !ok {
+				currentPhase = string(p.CurrentPhase)
+			}
+			subPhase, ok := subphasesMap[p.CompletedSubPhase]
+			if !ok {
+				subPhase = string(p.CompletedSubPhase)
+			}
+			msg = fmt.Sprintf("%s: %s", currentPhase, subPhase)
 		} else {
-			msg = phasesMap[p.CompletedPhase]
+			completedPhase, ok := phasesMap[p.CompletedPhase]
+			if !ok {
+				completedPhase = string(p.CompletedPhase)
+			}
+			msg = completedPhase
 		}
 	} else {
 		if p.CurrentSubPhase != "" {
-			msg = fmt.Sprintf("%s: %s", phasesMap[p.CurrentPhase], subphasesMap[p.CurrentSubPhase])
+			currentPhase, ok := phasesMap[p.CurrentPhase]
+			if !ok {
+				currentPhase = string(p.CurrentPhase)
+			}
+			subPhase, ok := subphasesMap[p.CurrentSubPhase]
+			if !ok {
+				subPhase = string(p.CurrentSubPhase)
+			}
+			msg = fmt.Sprintf("%s: %s", currentPhase, subPhase)
 		} else {
 			if p.CurrentPhase != "" {
-				msg = phasesMap[p.CurrentPhase]
+				phase, ok := phasesMap[p.CurrentPhase]
+				if !ok {
+					phase = string(p.CurrentPhase)
+				}
+				msg = phase
 			} else {
-				msg = phasesMap[p.CompletedPhase]
+				phase, ok := phasesMap[p.CompletedPhase]
+				if !ok {
+					phase = string(p.CompletedPhase)
+				}
+				msg = phase
 			}
 		}
 	}


### PR DESCRIPTION
## Description

Add phases to bootstap process in dhctl, move some actions to another phase. Now phases will looks like this:
 - PreInfraPreflights
 - BaseInfra (Cloud only)
   - BaseInfra
   - FirstMasterNodeCreation
 - PostInfraPreflights
 - InstallKubernetes
   - BundlePrepartion
   - RegistryPackagesProxy
   - NodePreparation
   - ExecuteBashibleBundle
 - InstallDeckhouse
   - ConnectToMaster
   - InstallDeckhouse
   - WaitForFirstMasterReady
 - InstallAdditionalMastersAndStaticNodes
   - AdditionalMasters
   - StaticNodes
   - ControlPlaneManagerReadiness
 - CreateResources
 - ExecPostBootstrap
 - Finalization

## Why do we need it, and what problem does it solve?

To improve user experience and make bootstrap process more clear and transparent for end user, we'll add new phases to bootstrap.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Refactor phases in dhctl bootstrap
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
