### PR TITLE
[go_lib/controlplane] Add certificate expiration API for local control-plane PKI inspection

### DIFF
--- a/go_lib/controlplane/kubeconfig/expiration.go
+++ b/go_lib/controlplane/kubeconfig/expiration.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+)
+
+type ExpirationOption func(*expirationOptions)
+
+type expirationOptions struct {
+	kubeconfigDir    string
+	files            []File
+	ignoreReadErrors bool
+}
+
+type ClientCertificateExpiration struct {
+	File     File
+	Path     string
+	NotAfter time.Time
+}
+
+var defaultExpirationFiles = []File{
+	Admin,
+	ControllerManager,
+	Scheduler,
+	SuperAdmin,
+}
+
+// WithKubeconfigDir overrides the directory used by ListClientCertificateExpirations.
+func WithKubeconfigDir(dir string) ExpirationOption {
+	return func(o *expirationOptions) {
+		o.kubeconfigDir = dir
+	}
+}
+
+// WithFiles restricts ListClientCertificateExpirations to the provided kubeconfig files.
+func WithFiles(files ...File) ExpirationOption {
+	return func(o *expirationOptions) {
+		o.files = append(o.files, files...)
+	}
+}
+
+// WithIgnoreReadErrors enables partial success and returns read failures as errors.Join(...).
+func WithIgnoreReadErrors() ExpirationOption {
+	return func(o *expirationOptions) {
+		o.ignoreReadErrors = true
+	}
+}
+
+func ListClientCertificateExpirations(opts ...ExpirationOption) ([]ClientCertificateExpiration, error) {
+	options := newExpirationOptions(opts...)
+	files := expirationFiles(options)
+
+	result := make([]ClientCertificateExpiration, 0, len(files))
+	var errs []error
+
+	for _, file := range files {
+		path := filepath.Join(options.kubeconfigDir, string(file))
+		expiration, err := clientCertificateExpiration(path)
+		if err != nil {
+			if !options.ignoreReadErrors {
+				return nil, err
+			}
+
+			errs = append(errs, err)
+			continue
+		}
+
+		result = append(result, expiration)
+	}
+
+	return result, errors.Join(errs...)
+}
+
+func GetClientCertificateExpiration(path string) (ClientCertificateExpiration, error) {
+	return clientCertificateExpiration(path)
+}
+
+func clientCertificateExpiration(path string) (ClientCertificateExpiration, error) {
+	cert, err := loadClientCertificate(path)
+	if err != nil {
+		return ClientCertificateExpiration{}, err
+	}
+
+	return ClientCertificateExpiration{
+		File:     canonicalFile(path),
+		Path:     filepath.Clean(path),
+		NotAfter: cert.NotAfter,
+	}, nil
+}
+
+func loadClientCertificate(path string) (*x509.Certificate, error) {
+	config, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kubeconfig %q: %w", path, err)
+	}
+
+	authInfo, err := currentAuthInfo(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read kubeconfig %q: %w", path, err)
+	}
+
+	if len(authInfo.ClientCertificateData) > 0 {
+		block, _ := pem.Decode(authInfo.ClientCertificateData)
+		if block == nil || len(block.Bytes) == 0 {
+			return nil, fmt.Errorf("failed to read kubeconfig %q: client-certificate-data is not valid PEM", path)
+		}
+
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read kubeconfig %q: client-certificate-data is not a valid certificate: %w", path, err)
+		}
+
+		return cert, nil
+	}
+
+	if authInfo.ClientCertificate != "" {
+		clientCertPath := authInfo.ClientCertificate
+		if !filepath.IsAbs(clientCertPath) {
+			clientCertPath = filepath.Join(filepath.Dir(path), clientCertPath)
+		}
+
+		cert, err := pkiutil.LoadCert(clientCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read kubeconfig %q: %w", path, err)
+		}
+
+		return cert, nil
+	}
+
+	return nil, fmt.Errorf("failed to read kubeconfig %q: client certificate is not configured", path)
+}
+
+func newExpirationOptions(opts ...ExpirationOption) *expirationOptions {
+	options := &expirationOptions{
+		kubeconfigDir: DefaultOutDir,
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}
+
+func expirationFiles(options *expirationOptions) []File {
+	selected := make(map[File]struct{})
+	files := options.files
+	if len(files) == 0 {
+		files = defaultExpirationFiles
+	}
+
+	for _, file := range files {
+		selected[file] = struct{}{}
+	}
+
+	result := make([]File, 0, len(selected))
+	for file := range selected {
+		result = append(result, file)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return string(result[i]) < string(result[j])
+	})
+
+	return result
+}
+
+func canonicalFile(path string) File {
+	base := File(filepath.Base(filepath.Clean(path)))
+
+	for _, file := range append(defaultExpirationFiles, Kubelet) {
+		if base == file {
+			return file
+		}
+	}
+
+	return base
+}
+
+func currentAuthInfo(config *clientcmdapi.Config) (*clientcmdapi.AuthInfo, error) {
+	currentContext, ok := config.Contexts[config.CurrentContext]
+	if !ok {
+		return nil, fmt.Errorf("current context %q not found", config.CurrentContext)
+	}
+
+	authInfo, ok := config.AuthInfos[currentContext.AuthInfo]
+	if !ok {
+		return nil, fmt.Errorf("auth info %q not found", currentContext.AuthInfo)
+	}
+
+	return authInfo, nil
+}

--- a/go_lib/controlplane/kubeconfig/expiration_test.go
+++ b/go_lib/controlplane/kubeconfig/expiration_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func TestLoadClientCertificate(t *testing.T) {
+	dir := t.TempDir()
+	opt := makeExpirationTestOptions(t, dir)
+
+	var rep KubeconfigApplyReport
+	require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
+
+	cert, err := loadClientCertificate(filepath.Join(dir, string(Admin)))
+	require.NoError(t, err)
+	assert.Equal(t, "kubernetes-admin", cert.Subject.CommonName)
+}
+
+func TestListClientCertificateExpirations_DefaultExcludesKubelet(t *testing.T) {
+	dir := t.TempDir()
+	opt := makeExpirationTestOptions(t, dir)
+
+	for _, file := range []File{SuperAdmin, Admin, Scheduler, ControllerManager, Kubelet} {
+		var rep KubeconfigApplyReport
+		require.NoError(t, createKubeConfigFile(file, opt, &rep))
+	}
+
+	expirations, err := ListClientCertificateExpirations(WithKubeconfigDir(dir))
+	require.NoError(t, err)
+
+	require.Len(t, expirations, 4)
+	assert.Equal(t, []File{Admin, ControllerManager, Scheduler, SuperAdmin}, expirationFiles(newExpirationOptions(WithKubeconfigDir(dir))))
+
+	files := make([]File, 0, len(expirations))
+	for _, expiration := range expirations {
+		files = append(files, expiration.File)
+	}
+
+	assert.Equal(t, []File{Admin, ControllerManager, Scheduler, SuperAdmin}, files)
+	assert.NotContains(t, files, Kubelet)
+}
+
+func TestListClientCertificateExpirations_IgnoreReadErrors(t *testing.T) {
+	dir := t.TempDir()
+	opt := makeExpirationTestOptions(t, dir)
+
+	var rep KubeconfigApplyReport
+	require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
+
+	_, err := ListClientCertificateExpirations(
+		WithKubeconfigDir(dir),
+		WithFiles(Admin, Admin, Scheduler),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), filepath.Join(dir, string(Scheduler)))
+
+	expirations, err := ListClientCertificateExpirations(
+		WithKubeconfigDir(dir),
+		WithFiles(Admin, Admin, Scheduler),
+		WithIgnoreReadErrors(),
+	)
+	require.Error(t, err)
+	require.Len(t, expirations, 1)
+	assert.Equal(t, Admin, expirations[0].File)
+	assert.Contains(t, err.Error(), filepath.Join(dir, string(Scheduler)))
+}
+
+func TestGetClientCertificateExpiration_NormalizesKnownAndUnknownPaths(t *testing.T) {
+	dir := t.TempDir()
+	opt := makeExpirationTestOptions(t, dir)
+
+	var rep KubeconfigApplyReport
+	require.NoError(t, createKubeConfigFile(Scheduler, opt, &rep))
+
+	customConfigPath := filepath.Join(dir, "custom.conf")
+	config, err := buildConfig(mustGetFileSpec(t, Admin, opt))
+	require.NoError(t, err)
+	require.NoError(t, clientcmd.WriteToFile(*config, customConfigPath))
+
+	knownExpiration, err := GetClientCertificateExpiration(filepath.Join(dir, string(Scheduler)))
+	require.NoError(t, err)
+	assert.Equal(t, Scheduler, knownExpiration.File)
+
+	unknownExpiration, err := GetClientCertificateExpiration(customConfigPath)
+	require.NoError(t, err)
+	assert.Equal(t, File("custom.conf"), unknownExpiration.File)
+	assert.Equal(t, filepath.Clean(customConfigPath), unknownExpiration.Path)
+}
+
+func TestLoadClientCertificate_FileReference(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := createCACert(t)
+
+	clientCertConfig := pkiutil.CertConfig{
+		Config:              certutilConfig(t, "test-user"),
+		NotAfter:            time.Now().Add(24 * time.Hour),
+		EncryptionAlgorithm: constants.EncryptionAlgorithmRSA2048,
+	}
+	clientCert, _, err := pkiutil.NewCertAndKey(caCert, caKey, clientCertConfig)
+	require.NoError(t, err)
+
+	certFile := filepath.Join(dir, "client.crt")
+	require.NoError(t, os.WriteFile(certFile, pkiutil.EncodeCertificate(clientCert), 0o600))
+
+	buildFileRefConfig := func(certPath string) *clientcmdapi.Config {
+		return &clientcmdapi.Config{
+			Clusters: map[string]*clientcmdapi.Cluster{
+				"test-cluster": {
+					Server:                   "https://1.2.3.4:6443",
+					CertificateAuthorityData: pkiutil.EncodeCertificate(caCert),
+				},
+			},
+			Contexts: map[string]*clientcmdapi.Context{
+				"ctx": {Cluster: "test-cluster", AuthInfo: "test-user"},
+			},
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"test-user": {ClientCertificate: certPath},
+			},
+			CurrentContext: "ctx",
+		}
+	}
+
+	t.Run("absolute path", func(t *testing.T) {
+		kubeconfigPath := filepath.Join(dir, "abs.conf")
+		require.NoError(t, clientcmd.WriteToFile(*buildFileRefConfig(certFile), kubeconfigPath))
+
+		cert, err := loadClientCertificate(kubeconfigPath)
+		require.NoError(t, err)
+		assert.Equal(t, "test-user", cert.Subject.CommonName)
+	})
+
+	t.Run("relative path resolved against kubeconfig dir", func(t *testing.T) {
+		kubeconfigPath := filepath.Join(dir, "rel.conf")
+		require.NoError(t, clientcmd.WriteToFile(*buildFileRefConfig("client.crt"), kubeconfigPath))
+
+		cert, err := loadClientCertificate(kubeconfigPath)
+		require.NoError(t, err)
+		assert.Equal(t, "test-user", cert.Subject.CommonName)
+	})
+}
+
+func certutilConfig(t *testing.T, commonName string) certutil.Config {
+	t.Helper()
+	return certutil.Config{
+		CommonName: commonName,
+		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+}
+
+func makeExpirationTestOptions(t *testing.T, outDir string) *options {
+	t.Helper()
+
+	caCert, caKey := createCACert(t)
+	certProvider := &mockCertProvider{
+		caCert:   caCert,
+		caKey:    caKey,
+		notAfter: time.Now().Add(365 * 24 * time.Hour),
+	}
+
+	return &options{
+		OutDir:               outDir,
+		ClusterName:          "test-cluster",
+		ControlPlaneEndpoint: "https://1.2.3.4:6443",
+		LocalAPIEndpoint:     "https://127.0.0.1:6443",
+		CertProvider:         certProvider,
+		EncryptionAlgorithm:  constants.EncryptionAlgorithmRSA2048,
+		NodeName:             "test-node",
+	}
+}
+
+func mustGetFileSpec(t *testing.T, file File, opt *options) *fileSpec {
+	t.Helper()
+
+	spec, err := getFileSpec(file, opt)
+	require.NoError(t, err)
+
+	return spec
+}

--- a/go_lib/controlplane/pki/expiration.go
+++ b/go_lib/controlplane/pki/expiration.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+)
+
+type ExpirationOption func(*expirationOptions)
+
+type expirationOptions struct {
+	certificatesDir  string
+	leafCertificates []LeafCertName
+	rootCertificates []RootCertName
+	ignoreReadErrors bool
+}
+
+type CertificateExpiration struct {
+	Name      string
+	Path      string
+	NotAfter  time.Time
+	Authority RootCertName
+	IsCA      bool
+}
+
+type certificateInventoryItem struct {
+	name      string
+	relPath   string
+	authority RootCertName
+}
+
+// WithCertificatesDir overrides the directory used by ListCertificateExpirations.
+func WithCertificatesDir(dir string) ExpirationOption {
+	return func(o *expirationOptions) {
+		o.certificatesDir = dir
+	}
+}
+
+// WithLeafCertificates restricts ListCertificateExpirations to the provided leaf certificates.
+func WithLeafCertificates(names ...LeafCertName) ExpirationOption {
+	return func(o *expirationOptions) {
+		o.leafCertificates = append(o.leafCertificates, names...)
+	}
+}
+
+// WithRootCertificates restricts ListCertificateExpirations to the provided root certificates.
+func WithRootCertificates(names ...RootCertName) ExpirationOption {
+	return func(o *expirationOptions) {
+		o.rootCertificates = append(o.rootCertificates, names...)
+	}
+}
+
+// WithIgnoreReadErrors enables partial success and returns read failures as errors.Join(...).
+func WithIgnoreReadErrors() ExpirationOption {
+	return func(o *expirationOptions) {
+		o.ignoreReadErrors = true
+	}
+}
+
+func ListCertificateExpirations(opts ...ExpirationOption) ([]CertificateExpiration, error) {
+	options := newExpirationOptions(opts...)
+
+	inventory, err := buildCertificateInventory(options)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]CertificateExpiration, 0, len(inventory))
+	var errs []error
+
+	for _, item := range inventory {
+		expiration, err := loadCertificateExpiration(filepath.Join(options.certificatesDir, item.relPath), item)
+		if err != nil {
+			if !options.ignoreReadErrors {
+				return nil, err
+			}
+
+			errs = append(errs, err)
+
+			continue
+		}
+
+		result = append(result, expiration)
+	}
+
+	return result, errors.Join(errs...)
+}
+
+func GetCertificateExpiration(path string) (CertificateExpiration, error) {
+	item, ok := lookupKnownCertificate(path)
+	if !ok {
+		item = inventoryItemFromPath(path)
+	}
+
+	return loadCertificateExpiration(path, item)
+}
+
+func newExpirationOptions(opts ...ExpirationOption) *expirationOptions {
+	options := &expirationOptions{
+		certificatesDir: constants.DefaultCertificatesDir,
+	}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}
+
+func buildCertificateInventory(options *expirationOptions) ([]certificateInventoryItem, error) {
+	rootItems, leafItems := defaultCertificateInventory()
+
+	selected := make(map[string]certificateInventoryItem)
+
+	if len(options.rootCertificates) == 0 && len(options.leafCertificates) == 0 {
+		for _, item := range rootItems {
+			selected[item.relPath] = item
+		}
+		for _, item := range leafItems {
+			selected[item.relPath] = item
+		}
+
+		return sortedInventory(selected), nil
+	}
+
+	for _, name := range options.rootCertificates {
+		item, ok := rootItems[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown root certificate %q", name)
+		}
+		selected[item.relPath] = item
+	}
+
+	for _, name := range options.leafCertificates {
+		item, ok := leafItems[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown leaf certificate %q", name)
+		}
+		selected[item.relPath] = item
+	}
+
+	return sortedInventory(selected), nil
+}
+
+func loadCertificateExpiration(path string, item certificateInventoryItem) (CertificateExpiration, error) {
+	cert, err := pkiutil.LoadCert(path)
+	if err != nil {
+		return CertificateExpiration{}, fmt.Errorf("failed to load certificate %q: %w", path, err)
+	}
+
+	return CertificateExpiration{
+		Name:      item.name,
+		Path:      filepath.Clean(path),
+		NotAfter:  cert.NotAfter,
+		Authority: item.authority,
+		IsCA:      cert.IsCA,
+	}, nil
+}
+
+func defaultCertificateInventory() (map[RootCertName]certificateInventoryItem, map[LeafCertName]certificateInventoryItem) {
+	rootItems := make(map[RootCertName]certificateInventoryItem, len(defaultCertTreeScheme))
+	leafItems := make(map[LeafCertName]certificateInventoryItem)
+
+	for rootName, leafNames := range defaultCertTreeScheme {
+		rootItems[rootName] = certificateInventoryItem{
+			name:    string(rootName),
+			relPath: certificateRelPath(string(rootName)),
+		}
+
+		for _, leafName := range leafNames {
+			leafItems[leafName] = certificateInventoryItem{
+				name:      string(leafName),
+				relPath:   certificateRelPath(string(leafName)),
+				authority: rootName,
+			}
+		}
+	}
+
+	return rootItems, leafItems
+}
+
+func sortedInventory(items map[string]certificateInventoryItem) []certificateInventoryItem {
+	paths := make([]string, 0, len(items))
+	for path := range items {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	result := make([]certificateInventoryItem, 0, len(paths))
+	for _, path := range paths {
+		result = append(result, items[path])
+	}
+
+	return result
+}
+
+// knownCertsByRelPath is a precomputed lookup map built once from the static
+// defaultCertTreeScheme. It maps each certificate's relative path to its
+// inventory item so that lookupKnownCertificate avoids rebuilding maps on
+// every call.
+var knownCertsByRelPath = func() map[string]certificateInventoryItem {
+	rootItems, leafItems := defaultCertificateInventory()
+	m := make(map[string]certificateInventoryItem, len(rootItems)+len(leafItems))
+	for _, item := range rootItems {
+		m[item.relPath] = item
+	}
+	for _, item := range leafItems {
+		m[item.relPath] = item
+	}
+	return m
+}()
+
+func lookupKnownCertificate(path string) (certificateInventoryItem, bool) {
+	for _, suffix := range pathSuffixes(path) {
+		if item, ok := knownCertsByRelPath[suffix]; ok {
+			return item, true
+		}
+	}
+
+	return certificateInventoryItem{}, false
+}
+
+func inventoryItemFromPath(path string) certificateInventoryItem {
+	cleanPath := filepath.Clean(path)
+	base := filepath.Base(cleanPath)
+
+	return certificateInventoryItem{
+		name:    strings.TrimSuffix(base, filepath.Ext(base)),
+		relPath: cleanPath,
+	}
+}
+
+func certificateRelPath(name string) string {
+	return filepath.Join(strings.Split(name, "/")...) + ".crt"
+}
+
+func pathSuffixes(path string) []string {
+	cleanPath := filepath.ToSlash(filepath.Clean(path))
+	parts := strings.Split(cleanPath, "/")
+	suffixes := make([]string, 0, len(parts))
+
+	for i := range parts {
+		suffix := strings.Join(parts[i:], "/")
+		if suffix == "" {
+			continue
+		}
+
+		suffixes = append(suffixes, suffix)
+	}
+
+	return suffixes
+}

--- a/go_lib/controlplane/pki/expiration_test.go
+++ b/go_lib/controlplane/pki/expiration_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto"
+	"crypto/x509"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func TestListCertificateExpirations_DefaultInventory(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := CreatePKIBundle(
+		"test-node",
+		"cluster.local",
+		makeTestConfig(t, dir).AdvertiseAddress,
+		"10.96.0.0/12",
+		WithPKIDir(dir),
+	)
+	require.NoError(t, err)
+
+	expirations, err := ListCertificateExpirations(WithCertificatesDir(dir))
+	require.NoError(t, err)
+	require.Len(t, expirations, 10)
+
+	paths := make([]string, 0, len(expirations))
+	for _, expiration := range expirations {
+		paths = append(paths, expiration.Path)
+	}
+
+	assert.True(t, sort.StringsAreSorted(paths))
+	assert.NotContains(t, paths, filepath.Join(dir, "sa.crt"))
+}
+
+func TestListCertificateExpirations_IgnoreReadErrors(t *testing.T) {
+	dir := t.TempDir()
+	caCert, _ := makeTestCACert(t, "kubernetes")
+
+	require.NoError(t, writeCert(dir, string(CACertName), caCert))
+
+	_, err := ListCertificateExpirations(
+		WithCertificatesDir(dir),
+		WithRootCertificates(CACertName, CACertName, EtcdCACertName),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), filepath.Join(dir, "etcd", "ca.crt"))
+
+	expirations, err := ListCertificateExpirations(
+		WithCertificatesDir(dir),
+		WithRootCertificates(CACertName, CACertName, EtcdCACertName),
+		WithIgnoreReadErrors(),
+	)
+	require.Error(t, err)
+	require.Len(t, expirations, 1)
+	assert.Equal(t, string(CACertName), expirations[0].Name)
+	assert.Contains(t, err.Error(), filepath.Join(dir, "etcd", "ca.crt"))
+}
+
+func TestGetCertificateExpiration_NormalizesKnownAndUnknownPaths(t *testing.T) {
+	dir := t.TempDir()
+	etcdCACert, etcdCAKey := makeTestCACert(t, "etcd-ca")
+	etcdServerCert := makeTestLeafCert(t, "etcd-server", etcdCACert, etcdCAKey)
+	customCert, _ := makeTestCACert(t, "custom-ca")
+
+	require.NoError(t, writeCert(dir, string(EtcdServerCertName), etcdServerCert))
+	require.NoError(t, writeCert(dir, "custom/custom-cert", customCert))
+
+	knownPath := filepath.Join(dir, "etcd", "server.crt")
+	knownExpiration, err := GetCertificateExpiration(knownPath)
+	require.NoError(t, err)
+	assert.Equal(t, string(EtcdServerCertName), knownExpiration.Name)
+	assert.Equal(t, EtcdCACertName, knownExpiration.Authority)
+	assert.False(t, knownExpiration.IsCA)
+	assert.Equal(t, filepath.Clean(knownPath), knownExpiration.Path)
+
+	unknownPath := filepath.Join(dir, "custom", "custom-cert.crt")
+	unknownExpiration, err := GetCertificateExpiration(unknownPath)
+	require.NoError(t, err)
+	assert.Equal(t, "custom-cert", unknownExpiration.Name)
+	assert.Empty(t, unknownExpiration.Authority)
+	assert.True(t, unknownExpiration.IsCA)
+	assert.Equal(t, filepath.Clean(unknownPath), unknownExpiration.Path)
+}
+
+func makeTestLeafCert(t *testing.T, commonName string, caCert *x509.Certificate, caKey crypto.Signer) *x509.Certificate {
+	t.Helper()
+
+	key, err := pkiutil.NewPrivateKey(constants.EncryptionAlgorithmRSA2048)
+	require.NoError(t, err)
+
+	cert, err := pkiutil.NewSignedCert(pkiutil.CertConfig{
+		Config: certutil.Config{
+			CommonName: commonName,
+			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		},
+		CertificateValidityPeriod: constants.CertificateValidityPeriod,
+	}, key, caCert, caKey)
+	require.NoError(t, err)
+
+	return cert
+}

--- a/go_lib/controlplane/util/pkiutil/io.go
+++ b/go_lib/controlplane/util/pkiutil/io.go
@@ -28,6 +28,11 @@ import (
 	"k8s.io/client-go/util/keyutil"
 )
 
+// LoadCert loads an X.509 certificate from the given file path.
+func LoadCert(path string) (*x509.Certificate, error) {
+	return loadCert(path)
+}
+
 // LoadKey loads a private key from the given file path.
 // Only RSA and ECDSA formats are accepted.
 func LoadKey(path string) (crypto.Signer, error) {
@@ -54,6 +59,9 @@ func loadCert(path string) (*x509.Certificate, error) {
 	certs, err := certutil.CertsFromFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't load certificate file %s: %w", path, err)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("certificate file %s contains no certificates", path)
 	}
 	// Safely pick the first one because the sender's certificate must come first in the list.
 	// For details, see: https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -17,71 +17,15 @@ limitations under the License.
 package controlplaneoperation
 
 import (
-	"crypto/x509"
-	"encoding/pem"
-	"fmt"
-	"log/slog"
-	"os"
-	"path/filepath"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/kubeconfig"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki"
 	"github.com/deckhouse/deckhouse/pkg/log"
 
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
 	"control-plane-manager/internal/constants"
 )
-
-// readCertExpiration reads a PEM certificate file and returns its NotAfter time.
-func readCertExpiration(certPath string) (metav1.Time, error) {
-	data, err := os.ReadFile(certPath)
-	if err != nil {
-		return metav1.Time{}, fmt.Errorf("read %s: %w", certPath, err)
-	}
-
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return metav1.Time{}, fmt.Errorf("no PEM block in %s", certPath)
-	}
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return metav1.Time{}, fmt.Errorf("parse %s: %w", certPath, err)
-	}
-
-	return metav1.NewTime(cert.NotAfter), nil
-}
-
-// readKubeconfigCertExpiration extracts client certificate NotAfter from a kubeconfig file.
-func readKubeconfigCertExpiration(kubeconfigPath string) (metav1.Time, error) {
-	config, err := clientcmd.LoadFromFile(kubeconfigPath)
-	if err != nil {
-		return metav1.Time{}, fmt.Errorf("load kubeconfig %s: %w", kubeconfigPath, err)
-	}
-
-	ctx, ok := config.Contexts[config.CurrentContext]
-	if !ok {
-		return metav1.Time{}, fmt.Errorf("current context not found in %s", kubeconfigPath)
-	}
-
-	authInfo, ok := config.AuthInfos[ctx.AuthInfo]
-	if !ok || len(authInfo.ClientCertificateData) == 0 {
-		return metav1.Time{}, fmt.Errorf("no client-certificate-data in %s", kubeconfigPath)
-	}
-
-	block, _ := pem.Decode(authInfo.ClientCertificateData)
-	if block == nil {
-		return metav1.Time{}, fmt.Errorf("no PEM block in client-certificate-data of %s", kubeconfigPath)
-	}
-
-	cert, err := x509.ParseCertificate(block.Bytes)
-	if err != nil {
-		return metav1.Time{}, fmt.Errorf("parse client cert from %s: %w", kubeconfigPath, err)
-	}
-
-	return metav1.NewTime(cert.NotAfter), nil
-}
 
 // observeCertExpirationsForStaticPod reads leaf cert and kubeconfig client cert expirations for one static pod component.
 func observeCertExpirationsForStaticPod(component controlplanev1alpha1.OperationComponent, kubeconfigDir string, logger *log.Logger) (controlplanev1alpha1.ObservedComponentState, bool) {
@@ -92,27 +36,32 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 
 	certExpiry := make(map[string]metav1.Time)
 
-	for _, leafName := range deps.leafCertFiles() {
-		baseName := string(leafName)
-		certPath := filepath.Join(constants.KubernetesPkiPath, baseName+".crt")
-		expiry, err := readCertExpiration(certPath)
-		if err != nil {
-			logger.Warn("cannot read cert expiration",
-				slog.String("cert", certPath), log.Err(err))
-			continue
+	if leafNames := deps.leafCertFiles(); len(leafNames) > 0 {
+		expirations, err := pki.ListCertificateExpirations(
+			pki.WithCertificatesDir(constants.KubernetesPkiPath),
+			pki.WithLeafCertificates(leafNames...),
+			pki.WithIgnoreReadErrors(),
+		)
+		for _, e := range joinedErrors(err) {
+			logger.Warn("cannot read cert expiration", log.Err(e))
 		}
-		certExpiry[baseName+".crt"] = expiry
+		for _, exp := range expirations {
+			certExpiry[exp.Name+".crt"] = metav1.NewTime(exp.NotAfter)
+		}
 	}
 
-	for _, file := range deps.KubeconfigFiles {
-		kubeconfigPath := filepath.Join(kubeconfigDir, string(file))
-		expiry, err := readKubeconfigCertExpiration(kubeconfigPath)
-		if err != nil {
-			logger.Warn("cannot read kubeconfig cert expiration",
-				slog.String("kubeconfig", kubeconfigPath), log.Err(err))
-			continue
+	if len(deps.KubeconfigFiles) > 0 {
+		expirations, err := kubeconfig.ListClientCertificateExpirations(
+			kubeconfig.WithKubeconfigDir(kubeconfigDir),
+			kubeconfig.WithFiles(deps.KubeconfigFiles...),
+			kubeconfig.WithIgnoreReadErrors(),
+		)
+		for _, e := range joinedErrors(err) {
+			logger.Warn("cannot read kubeconfig cert expiration", log.Err(e))
 		}
-		certExpiry[string(file)] = expiry
+		for _, exp := range expirations {
+			certExpiry[string(exp.File)] = metav1.NewTime(exp.NotAfter)
+		}
 	}
 
 	if len(certExpiry) == 0 {
@@ -121,4 +70,18 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 	return controlplanev1alpha1.ObservedComponentState{
 		CertificatesExpirationDate: certExpiry,
 	}, true
+}
+
+// joinedErrors unwraps an errors.Join result into individual errors. If err is
+// nil it returns nil; if err is a plain (non-joined) error it is returned as a
+// single-element slice.
+func joinedErrors(err error) []error {
+	if err == nil {
+		return nil
+	}
+	type multiErr interface{ Unwrap() []error }
+	if me, ok := err.(multiErr); ok {
+		return me.Unwrap()
+	}
+	return []error{err}
 }


### PR DESCRIPTION
## Description
Add a read-only certificate expiration API to `go_lib/controlplane` and switch `control-plane-manager` expiration observation to the shared implementation. This PR provides the library part of the local control-plane certificate inspection feature and is consumed by the companion `deckhouse-cli` PR [#355](https://github.com/deckhouse/deckhouse-cli/pull/355).

- adds expiration readers to `go_lib/controlplane/pki` for known PKI certificates and single-file inspection
- adds expiration readers to `go_lib/controlplane/kubeconfig` for embedded and file-based client certificates
- reuses the shared API in `control-plane-manager` instead of manual PEM and kubeconfig parsing in the observer
- keeps the API read-only and focused on expiration metadata, without changing certificate issuance or rotation flows
- preserves partial-success handling for `control-plane-manager` through `WithIgnoreReadErrors()`

## Why do we need it, and what problem does it solve?
The feature requires a single source of truth for checking the expiration of local control-plane SSL certificates. Before this change, consumers had to parse certificate files and kubeconfigs themselves, which duplicated logic, made behavior harder to align across components, and forced `control-plane-manager` to keep its own inspection code.

This PR introduces a dedicated read-only expiration API in `go_lib/controlplane` for both PKI certificates and kubeconfig client certificates. It makes certificate expiration inspection reusable for local tooling and internal controllers, and it lets `control-plane-manager` consume the same inventory and parsing rules that are exposed to the companion `d8` command in [deckhouse-cli#355](https://github.com/deckhouse/deckhouse-cli/pull/355).

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Add a shared `controlplane` API for reading local control-plane certificate expiration
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
