### PR TITLE
[cloud-provider-*] Migrate user-authz role templates to use the helm-lib helper

### DIFF
--- a/ee/modules/030-cloud-provider-dynamix/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-dynamix/template_tests/module_test.go
@@ -221,6 +221,51 @@ var _ = Describe("Module :: cloud-provider-dynamix :: helm template ::", func() 
 			capdDeployment := f.KubernetesResource("Deployment", "d8-cloud-provider-dynamix", "capd-controller-manager")
 			Expect(capdDeployment.Exists()).To(BeTrue())
 			Expect(capdDeployment.Field("spec.template.metadata.labels.cluster\\.x-k8s\\.io/provider").String()).To(Equal("infrastructure-dynamix"))
+
+			userAuthzUser := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-dynamix:user")
+			Expect(userAuthzUser.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dynamixinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dynamixclusters
+  - dynamixmachines
+  - dynamixmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch`))
+
+			userAuthzClusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-dynamix:cluster-admin")
+			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dynamixinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - dynamixclusters
+  - dynamixmachines
+  - dynamixmachinetemplates
+  verbs:
+  - patch
+  - update`))
 		})
 
 		It("must not render security labels and SPE without admission-policy-engine", func() {

--- a/ee/modules/030-cloud-provider-dynamix/templates/user-authz-cluster-roles.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,5 @@
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-dynamix" -}}
+{{- $_ := set $userAuthzConfig "capiResources" (list "dynamixclusters" "dynamixmachines" "dynamixmachinetemplates") -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "dynamixinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-huaweicloud/template_tests/module_test.go
@@ -352,6 +352,51 @@ var _ = Describe("Module :: cloud-provider-huaweicloud :: helm template ::", fun
 			Expect(cddDeployment.Field("spec.template.metadata.annotations.kubectl\\.kubernetes\\.io/default-logs-container").String()).To(Equal("cloud-data-discoverer"))
 			Expect(cddDeployment.Field("spec.template.metadata.annotations.checksum/config").String()).NotTo(BeEmpty())
 
+			userAuthzUser := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-huaweicloud:user")
+			Expect(userAuthzUser.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - huaweicloudinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - huaweicloudclusters
+  - huaweicloudmachines
+  - huaweicloudmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch`))
+
+			userAuthzClusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-huaweicloud:cluster-admin")
+			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - huaweicloudinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - huaweicloudclusters
+  - huaweicloudmachines
+  - huaweicloudmachinetemplates
+  verbs:
+  - patch
+  - update`))
+
 			cddVPA := f.KubernetesResource("VerticalPodAutoscaler", "d8-cloud-provider-huaweicloud", "cloud-data-discoverer")
 			Expect(cddVPA.Exists()).To(BeTrue())
 			Expect(cddVPA.Field("spec.updatePolicy.updateMode").String()).To(Equal("Initial"))

--- a/ee/modules/030-cloud-provider-huaweicloud/templates/user-authz-cluster-roles.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-huaweicloud:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - huaweicloudinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-huaweicloud:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - huaweicloudinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-huaweicloud" -}}
+{{- $_ := set $userAuthzConfig "capiResources" (list "huaweicloudclusters" "huaweicloudmachines" "huaweicloudmachinetemplates") -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "huaweicloudinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-openstack/template_tests/module_test.go
@@ -224,6 +224,28 @@ func openstackCheck(f *Config, k8sVer string) {
 
 		Expect(namespace.Exists()).To(BeTrue())
 		Expect(registrySecret.Exists()).To(BeTrue())
+		Expect(userAuthzUser.Exists()).To(BeTrue())
+		Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+		Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - openstackinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch`))
+		Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - openstackinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update`))
 
 		// user story #1
 		providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")

--- a/ee/modules/030-cloud-provider-openstack/templates/user-authz-cluster-roles.yaml
+++ b/ee/modules/030-cloud-provider-openstack/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,4 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-openstack:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - openstackinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-openstack:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - openstackinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-openstack" -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "openstackinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
+++ b/ee/modules/030-cloud-provider-vcd/template_tests/module_test.go
@@ -284,6 +284,68 @@ var _ = Describe("Module :: cloud-provider-vcd :: helm template ::", func() {
 			Expect(len(providerSpecificCAPISecretData) >= 1).To(BeTrue())
 			Expect(len(providerSpecificCAPISecretData["cluster.yaml"].String()) > 0).To(BeTrue())
 
+			userAuthzUser := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-vcd:user")
+			Expect(userAuthzUser.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - vcdinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vcdclusters
+  - vcdclustertemplates
+  - vcdmachines
+  - vcdmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - vcdaffinityrules
+  verbs:
+  - get
+  - list
+  - watch`))
+
+			userAuthzClusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-vcd:cluster-admin")
+			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - vcdinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vcdclusters
+  - vcdclustertemplates
+  - vcdmachines
+  - vcdmachinetemplates
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - vcdaffinityrules
+  verbs:
+  - patch
+  - update`))
+
 			masterAffinityRule := f.KubernetesGlobalResource("VCDAffinityRule", "sandbox-master")
 			Expect(masterAffinityRule.Exists()).To(BeTrue())
 			Expect(masterAffinityRule.Parse().String()).To(MatchYAML(`

--- a/ee/modules/030-cloud-provider-vcd/templates/user-authz-cluster-roles.yaml
+++ b/ee/modules/030-cloud-provider-vcd/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,28 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-vcd:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
+{{- define "cloud_provider_vcd_user_authz_additional_user_rules" -}}
 - apiGroups:
   - deckhouse.io
   resources:
-  - vcdinstanceclasses
+  - vcdaffinityrules
   verbs:
   - get
   - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-vcd:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
+{{- end -}}
+
+{{- define "cloud_provider_vcd_user_authz_additional_cluster_admin_rules" -}}
 - apiGroups:
   - deckhouse.io
   resources:
-  - vcdinstanceclasses
+  - vcdaffinityrules
   verbs:
-  - create
-  - delete
-  - deletecollection
   - patch
   - update
+{{- end -}}
+
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-vcd" -}}
+{{- $_ := set $userAuthzConfig "capiResources" (list "vcdclusters" "vcdclustertemplates" "vcdmachines" "vcdmachinetemplates") -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "vcdinstanceclasses" -}}
+{{- $_ := set $userAuthzConfig "additionalUserRules" (include "cloud_provider_vcd_user_authz_additional_user_rules" . | fromYamlArray) -}}
+{{- $_ := set $userAuthzConfig "additionalClusterAdminRules" (include "cloud_provider_vcd_user_authz_additional_cluster_admin_rules" . | fromYamlArray) -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/template_tests/module_test.go
@@ -364,6 +364,26 @@ var _ = Describe("Module :: cloud-provider-vsphere :: helm template ::", func() 
 			Expect(registrySecret.Exists()).To(BeTrue())
 			Expect(userAuthzUser.Exists()).To(BeTrue())
 			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - vsphereinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch`))
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - vsphereinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update`))
 
 			// user story #1
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/templates/user-authz-cluster-roles.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,4 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-vsphere:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - vsphereinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-vsphere:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - vsphereinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-vsphere" -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "vsphereinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/template_tests/module_test.go
@@ -158,6 +158,51 @@ var _ = Describe("Module :: cloud-provider-zvirt :: helm template ::", func() {
 			Expect(cddDeployment.Field("spec.template.spec.dnsPolicy").String()).To(Equal("ClusterFirstWithHostNet"))
 			Expect(cddDeployment.Field("spec.template.spec.tolerations").String()).To(MatchYAML(tolerationsAnyNodeWithUninitialized))
 
+			userAuthzUser := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-zvirt:user")
+			Expect(userAuthzUser.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - zvirtinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - zvirtclusters
+  - zvirtmachines
+  - zvirtmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch`))
+
+			userAuthzClusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-zvirt:cluster-admin")
+			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - zvirtinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - zvirtclusters
+  - zvirtmachines
+  - zvirtmachinetemplates
+  verbs:
+  - patch
+  - update`))
+
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")
 			Expect(providerRegistrationSecret.Exists()).To(BeTrue())
 			Expect(providerRegistrationSecret.Field(fmt.Sprintf("metadata.labels.%s", registrationLabelKey)).String()).To(Equal(""))

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/templates/user-authz-cluster-roles.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,5 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-zvirt:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - zvirtinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-zvirt:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - zvirtinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-zvirt" -}}
+{{- $_ := set $userAuthzConfig "capiResources" (list "zvirtclusters" "zvirtmachines" "zvirtmachinetemplates") -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "zvirtinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.71.10
-digest: sha256:af3005d2d7a541aa1fc41bbcbcf6e5b1f3677ea7eb70b74c865593455168d822
-generated: "2026-05-08T20:57:02.773129+07:00"
+  version: 1.71.12
+digest: sha256:d31472c1e41b17d01873101fe5bfc4a8d41210399b0738e05f6cea5449829130
+generated: "2026-05-19T16:56:44.321773+07:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.71.10"
+    version: "1.71.12"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.71.10
+version: 1.71.12

--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -39,6 +39,8 @@
 | **Cloud Data Discoverer** |
 | [helm_lib_cloud_data_discoverer_manifests](#helm_lib_cloud_data_discoverer_manifests) |
 | [helm_lib_cloud_data_discoverer_pod_monitor](#helm_lib_cloud_data_discoverer_pod_monitor) |
+| **Cloud Provider User Authz Roles** |
+| [helm_lib_cloud_provider_user_authz_cluster_roles](#helm_lib_cloud_provider_user_authz_cluster_roles) |
 | **Csi Controller** |
 | [helm_lib_csi_image_with_common_fallback](#helm_lib_csi_image_with_common_fallback) |
 | **Dns Policy** |
@@ -632,6 +634,24 @@ list:
 `{{ include "helm_lib_cloud_data_discoverer_pod_monitor" (list . $config) }} `
 
 
+## Cloud Provider User Authz Roles
+
+### helm_lib_cloud_provider_user_authz_cluster_roles
+
+ Renders user-authz ClusterRoles for provider-specific cloud resources. 
+ Includes User and ClusterAdmin ClusterRoles. 
+ Supported configuration parameters: 
+ + providerName (required) — provider name segment used in ClusterRole names. 
+ + instanceClassResource (required) — Deckhouse instance class resource name granted by the rules. 
+ + capiResources (optional, default: `[]`) — CAPI infrastructure resource names granted by the rules. 
+ + additionalUserRules (optional, default: `[]`) — extra rules appended to the User ClusterRole. 
+ + additionalClusterAdminRules (optional, default: `[]`) — extra rules appended to the ClusterAdmin ClusterRole. 
+
+#### Usage
+
+`{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $config) }} `
+
+
 ## Csi Controller
 
 ### helm_lib_csi_image_with_common_fallback
@@ -681,11 +701,13 @@ list:
 
 #### Usage
 
-`{{ include "helm_lib_envs_for_proxy" . }} `
+`{{ include "helm_lib_envs_for_proxy" . }} or {{ include "helm_lib_envs_for_proxy" (list . (list "extra1" "extra2")) }} `
 
 #### Arguments
 
+list:
 -  Template context with .Values, .Chart, etc 
+-  List of additional NO_PROXY entries (optional) 
 
 ## High Availability
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_provider_user_authz_roles.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_cloud_provider_user_authz_roles.tpl
@@ -1,0 +1,83 @@
+{{- /* Usage: {{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $config) }} */ -}}
+{{- /* Renders user-authz ClusterRoles for provider-specific cloud resources. */ -}}
+{{- /* Includes User and ClusterAdmin ClusterRoles. */ -}}
+{{- /* Supported configuration parameters: */ -}}
+{{- /* + providerName (required) — provider name segment used in ClusterRole names. */ -}}
+{{- /* + instanceClassResource (required) — Deckhouse instance class resource name granted by the rules. */ -}}
+{{- /* + capiResources (optional, default: `[]`) — CAPI infrastructure resource names granted by the rules. */ -}}
+{{- /* + additionalUserRules (optional, default: `[]`) — extra rules appended to the User ClusterRole. */ -}}
+{{- /* + additionalClusterAdminRules (optional, default: `[]`) — extra rules appended to the ClusterAdmin ClusterRole. */ -}}
+{{- define "helm_lib_cloud_provider_user_authz_cluster_roles" -}}
+  {{- $context := index . 0 -}}
+  {{- $config := index . 1 -}}
+  {{- $providerName := required "helm_lib_cloud_provider_user_authz_cluster_roles: providerName is required" (get $config "providerName") -}}
+  {{- $instanceClassResource := required "helm_lib_cloud_provider_user_authz_cluster_roles: instanceClassResource is required" (get $config "instanceClassResource") -}}
+  {{- $capiResources := dig "capiResources" (list) $config -}}
+  {{- $additionalUserRules := dig "additionalUserRules" (list) $config -}}
+  {{- $additionalClusterAdminRules := dig "additionalClusterAdminRules" (list) $config -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:{{ $providerName }}:user
+  {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - {{ $instanceClassResource }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- if $capiResources }}
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  {{- range $capiResources }}
+  - {{ . }}
+  {{- end }}
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
+{{- with $additionalUserRules }}
+{{ toYaml . }}
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:{{ $providerName }}:cluster-admin
+  {{- include "helm_lib_module_labels" (list $context) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - {{ $instanceClassResource }}
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+{{- if $capiResources }}
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  {{- range $capiResources }}
+  - {{ . }}
+  {{- end }}
+  verbs:
+  - patch
+  - update
+{{- end }}
+{{- with $additionalClusterAdminRules }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_envs_for_proxy.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_envs_for_proxy.tpl
@@ -1,8 +1,18 @@
-{{- /* Usage: {{ include "helm_lib_envs_for_proxy" . }} */ -}}
+{{- /* Usage: {{ include "helm_lib_envs_for_proxy" . }} or {{ include "helm_lib_envs_for_proxy" (list . (list "extra1" "extra2")) }} */ -}}
 {{- /* Add HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables for container */ -}}
 {{- /* depends on [proxy settings](https://deckhouse.io/products/kubernetes-platform/documentation/v1/reference/api/global.html#parameters-modules-proxy) */ -}}
 {{- define "helm_lib_envs_for_proxy" }}
-  {{- $context := . -}} {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- /* Template context with .Values, .Chart, etc */ -}}
+  {{- /* List of additional NO_PROXY entries (optional) */ -}}
+  {{- $context := . -}}
+  {{- $extraNoProxy := list -}}
+
+  {{- /* If a list is passed, then the first element is the context, and the second is the extraNoProxy list. */ -}}
+  {{- if kindIs "slice" . }}
+    {{- $context = index . 0 -}}
+    {{- $extraNoProxy = index . 1 -}}
+  {{- end }}
+
   {{- if $context.Values.global.clusterConfiguration }}
     {{- if $context.Values.global.clusterConfiguration.proxy }}
       {{- if $context.Values.global.clusterConfiguration.proxy.httpProxy }}
@@ -20,6 +30,9 @@
       {{- $noProxy := list "127.0.0.1" "169.254.169.254" "registry.d8-system.svc" $context.Values.global.clusterConfiguration.clusterDomain $context.Values.global.clusterConfiguration.podSubnetCIDR $context.Values.global.clusterConfiguration.serviceSubnetCIDR }}
       {{- if $context.Values.global.clusterConfiguration.proxy.noProxy }}
         {{- $noProxy = concat $noProxy $context.Values.global.clusterConfiguration.proxy.noProxy }}
+      {{- end }}
+      {{- if $extraNoProxy }}
+        {{- $noProxy = concat $noProxy $extraNoProxy }}
       {{- end }}
 - name: NO_PROXY
   value: {{ $noProxy | join "," | quote }}

--- a/modules/030-cloud-provider-aws/template_tests/module_test.go
+++ b/modules/030-cloud-provider-aws/template_tests/module_test.go
@@ -185,6 +185,26 @@ var _ = Describe("Module :: cloud-provider-aws :: helm template ::", func() {
 			Expect(registrySecret.Exists()).To(BeTrue())
 			Expect(userAuthzUser.Exists()).To(BeTrue())
 			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - awsinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch`))
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - awsinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update`))
 
 			// user story #1
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")

--- a/modules/030-cloud-provider-aws/templates/user-authz-cluster-roles.yaml
+++ b/modules/030-cloud-provider-aws/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,4 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:{{.Chart.Name }}:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - awsinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:{{ .Chart.Name }}:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - awsinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-aws" -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "awsinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/modules/030-cloud-provider-azure/template_tests/module_test.go
+++ b/modules/030-cloud-provider-azure/template_tests/module_test.go
@@ -194,6 +194,28 @@ var _ = Describe("Module :: cloud-provider-azure :: helm template ::", func() {
 
 			Expect(namespace.Exists()).To(BeTrue())
 			Expect(registrySecret.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Exists()).To(BeTrue())
+			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - azureinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch`))
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - azureinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update`))
 
 			// user story #1
 

--- a/modules/030-cloud-provider-azure/templates/user-authz-cluster-roles.yaml
+++ b/modules/030-cloud-provider-azure/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,4 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-azure:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - azureinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-azure:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - azureinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-azure" -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "azureinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/modules/030-cloud-provider-dvp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-dvp/template_tests/module_test.go
@@ -208,6 +208,51 @@ var _ = Describe("Module :: cloud-provider-dvp :: helm template ::", func() {
 			cddVPA := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "cloud-data-discoverer")
 			Expect(cddVPA.Exists()).To(BeTrue())
 
+			userAuthzUser := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-dvp:user")
+			Expect(userAuthzUser.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dvpinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - deckhouseclusters
+  - deckhousemachines
+  - deckhousemachinetemplates
+  verbs:
+  - get
+  - list
+  - watch`))
+
+			userAuthzClusterAdmin := f.KubernetesGlobalResource("ClusterRole", "d8:user-authz:cloud-provider-dvp:cluster-admin")
+			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - dvpinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - deckhouseclusters
+  - deckhousemachines
+  - deckhousemachinetemplates
+  verbs:
+  - patch
+  - update`))
+
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")
 			Expect(providerRegistrationSecret.Exists()).To(BeTrue())
 			Expect(providerRegistrationSecret.Field(fmt.Sprintf("metadata.labels.%s", registrationLabelKey)).String()).To(Equal(""))

--- a/modules/030-cloud-provider-dvp/templates/user-authz-cluster-roles.yaml
+++ b/modules/030-cloud-provider-dvp/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,5 @@
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-dvp" -}}
+{{- $_ := set $userAuthzConfig "capiResources" (list "deckhouseclusters" "deckhousemachines" "deckhousemachinetemplates") -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "dvpinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/modules/030-cloud-provider-gcp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-gcp/template_tests/module_test.go
@@ -219,6 +219,28 @@ var _ = Describe("Module :: cloud-provider-gcp :: helm template ::", func() {
 
 			Expect(namespace.Exists()).To(BeTrue())
 			Expect(registrySecret.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Exists()).To(BeTrue())
+			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - gcpinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch`))
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - gcpinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update`))
 
 			// user story #1
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")

--- a/modules/030-cloud-provider-gcp/templates/user-authz-cluster-roles.yaml
+++ b/modules/030-cloud-provider-gcp/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,4 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-gcp:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - gcpinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-gcp:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - gcpinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-gcp" -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "gcpinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/modules/030-cloud-provider-yandex/template_tests/module_test.go
+++ b/modules/030-cloud-provider-yandex/template_tests/module_test.go
@@ -315,6 +315,26 @@ var _ = Describe("Module :: cloud-provider-yandex :: helm template ::", func() {
 			Expect(registrySecret.Exists()).To(BeTrue())
 			Expect(userAuthzUser.Exists()).To(BeTrue())
 			Expect(userAuthzClusterAdmin.Exists()).To(BeTrue())
+			Expect(userAuthzUser.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - yandexinstanceclasses
+  verbs:
+  - get
+  - list
+  - watch`))
+			Expect(userAuthzClusterAdmin.Field("rules").String()).To(MatchYAML(`
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - yandexinstanceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update`))
 
 			// user story #1
 			providerRegistrationSecret := f.KubernetesResource("Secret", "kube-system", "d8-node-manager-cloud-provider")

--- a/modules/030-cloud-provider-yandex/templates/user-authz-cluster-roles.yaml
+++ b/modules/030-cloud-provider-yandex/templates/user-authz-cluster-roles.yaml
@@ -1,36 +1,4 @@
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:cloud-provider-yandex:user
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - yandexinstanceclasses
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:cloud-provider-yandex:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - deckhouse.io
-  resources:
-  - yandexinstanceclasses
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - patch
-  - update
+{{- $userAuthzConfig := dict -}}
+{{- $_ := set $userAuthzConfig "providerName" "cloud-provider-yandex" -}}
+{{- $_ := set $userAuthzConfig "instanceClassResource" "yandexinstanceclasses" -}}
+{{- include "helm_lib_cloud_provider_user_authz_cluster_roles" (list . $userAuthzConfig) }}

--- a/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
@@ -138,11 +138,6 @@ rules:
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:
-  - vcdmachinetemplates
-  - huaweicloudmachinetemplates
-  - dynamixmachinetemplates
-  - zvirtmachinetemplates
-  - deckhousemachinetemplates
   - staticmachinetemplates
   verbs:
   - create


### PR DESCRIPTION
## Description

Finalize migration of cloud-provider `user-authz` ClusterRoles to the shared `helm-lib` helper and add template rendering coverage for provider-specific RBAC rules.

The change:
- switches cloud-provider `user-authz` role rendering to the shared `helm_lib_cloud_provider_user_authz_cluster_roles` helper;
- adds template tests that verify rendered `user-authz` rules for standard providers, CAPI-based providers, and the VCD-specific case.

## Why do we need it, and what problem does it solve?

This PR completes RBAC v1 alignment for cloud-provider modules and reduces duplication in provider-specific role templates.

Before this change, cloud-provider `user-authz` roles were being migrated to shared templating, but the migration was incomplete and coverage of rendered rules was inconsistent across providers. As a result, provider-specific RBAC rules were harder to maintain and regressions in rendered permissions could go unnoticed.

With this PR:
- cloud-provider `user-authz` roles are rendered through a single shared helper;
- provider-specific exceptions remain explicit where needed;
- rendering tests verify the actual RBAC rules for affected providers.

This improves maintainability of RBAC templates and lowers the risk of breaking access for non-`SuperAdmin` users working with cloud-provider resources.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-aws, cloud-provider-azure, cloud-provider-dvp, cloud-provider-dynamix, cloud-provider-gcp, cloud-provider-huaweicloud, cloud-provider-openstack, cloud-provider-vcd, cloud-provider-vsphere, cloud-provider-yandex, cloud-provider-zvirt
type: feature
summary: Migrated cloud-provider RBAC v1 `user-authz` ClusterRoles to a shared `helm-lib` template.
impact_level: default
```