### PR TITLE
[csi-vsphere] Add storage policies support

### DIFF
--- a/ee/se-plus/modules/030-csi-vsphere/hooks/discover.go
+++ b/ee/se-plus/modules/030-csi-vsphere/hooks/discover.go
@@ -145,14 +145,14 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 
 	input.Values.Set("csiVsphere.internal.providerDiscoveryData", discoveryData)
 
-	if err := handleDiscoveryDataVolumeTypes(input, discoveryData.Datastores); err != nil {
+	if err := handleDiscoveryDataVolumeTypes(input, discoveryData.Datastores, discoveryData.StoragePolicies); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, zonedDataStores []cloudDataV1.VsphereDatastore) error {
+func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, zonedDataStores []cloudDataV1.VsphereDatastore, storagePolicies []cloudDataV1.VsphereStoragePolicy) error {
 	storageClassStorageDomain := make(map[string]cloudDataV1.VsphereDatastore)
 
 	for _, ds := range zonedDataStores {
@@ -181,16 +181,43 @@ func handleDiscoveryDataVolumeTypes(input *go_hook.HookInput, zonedDataStores []
 		storageClassSnapshots[s.Name] = s
 	}
 
-	storageClasses := make([]storageClass, 0, len(zonedDataStores))
-	for name, domain := range storageClassStorageDomain {
+	lenStorageClasses := len(storageClassStorageDomain)
+	if len(storagePolicies) > 0 {
+		lenStorageClasses *= len(storagePolicies)
+	}
+	storageClasses := make([]storageClass, 0, lenStorageClasses)
+	for name, ds := range storageClassStorageDomain {
+		var excluded bool
+		for _, esc := range classExcludes.Array() {
+			rg := regexp.MustCompile("^(" + esc.String() + ")$")
+			if rg.MatchString(getStorageClassName(ds.Name)) {
+				excluded = true
+				break
+			}
+		}
+		if excluded {
+			continue
+		}
+
 		sc := storageClass{
 			Name:          name,
-			Path:          domain.InventoryPath,
-			Zones:         domain.Zones,
-			DatastoreType: domain.DatastoreType,
-			DatastoreURL:  domain.DatastoreURL,
+			Path:          ds.InventoryPath,
+			Zones:         ds.Zones,
+			DatastoreType: ds.DatastoreType,
+			DatastoreURL:  ds.DatastoreURL,
 		}
 		storageClasses = append(storageClasses, sc)
+
+		for _, sp := range storagePolicies {
+			storageClasses = append(storageClasses, storageClass{
+				Name:              getStorageClassName(fmt.Sprintf("%s-%s", name, sp.Name)),
+				Path:              ds.InventoryPath,
+				Zones:             ds.Zones,
+				DatastoreType:     ds.DatastoreType,
+				DatastoreURL:      ds.DatastoreURL,
+				StoragePolicyName: sp.Name,
+			})
+		}
 	}
 
 	sort.SliceStable(storageClasses, func(i, j int) bool {
@@ -224,9 +251,10 @@ func getStorageClassName(value string) string {
 }
 
 type storageClass struct {
-	Name          string   `json:"name"`
-	Path          string   `json:"path"`
-	Zones         []string `json:"zones"`
-	DatastoreType string   `json:"datastoreType"`
-	DatastoreURL  string   `json:"datastoreURL"`
+	Name              string   `json:"name"`
+	Path              string   `json:"path"`
+	Zones             []string `json:"zones"`
+	DatastoreType     string   `json:"datastoreType"`
+	DatastoreURL      string   `json:"datastoreURL"`
+	StoragePolicyName string   `json:"storagePolicyName,omitempty"`
 }

--- a/ee/se-plus/modules/030-csi-vsphere/hooks/discover_test.go
+++ b/ee/se-plus/modules/030-csi-vsphere/hooks/discover_test.go
@@ -154,6 +154,12 @@ csiVsphere:
 		  "ZONE-TEST"
 		]
 	  }
+  ],
+  "storagePolicies": [
+    {
+      "name": "Gold Policy",
+      "id": "policy-gold"
+    }
   ]
 }
 `
@@ -193,6 +199,16 @@ data:
 	]
   },
   {
+	"datastoreType": "DatastoreCluster",
+	"datastoreURL": "",
+	"name": "test-1-k8s-3cf5ce84-gold-policy",
+	"path": "/DCTEST/datastore/test_1_k8s",
+	"storagePolicyName": "Gold Policy",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  },
+  {
 	"datastoreType": "Datastore",
     "datastoreURL":"ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/",
 	"name": "test-1-lun101-b39d82fa",
@@ -203,9 +219,29 @@ data:
   },
   {
 	"datastoreType": "Datastore",
+    "datastoreURL":"ds:///vmfs/volumes/503a9af1-291d17b0-52e0-1d01842f428c/",
+	"name": "test-1-lun101-b39d82fa-gold-policy",
+	"path": "/DCTEST/datastore/test_1_Lun101",
+	"storagePolicyName": "Gold Policy",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  },
+  {
+	"datastoreType": "Datastore",
     "datastoreURL":"ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/",
 	"name": "test-1-lun102-0403073a",
 	"path": "/DCTEST/datastore/test_1_Lun102",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  },
+  {
+	"datastoreType": "Datastore",
+    "datastoreURL":"ds:///vmfs/volumes/55832249-30a68048-496f-33f77fed3c5c/",
+	"name": "test-1-lun102-0403073a-gold-policy",
+	"path": "/DCTEST/datastore/test_1_Lun102",
+	"storagePolicyName": "Gold Policy",
 	"zones": [
 	  "ZONE-TEST"
 	]
@@ -233,6 +269,16 @@ data:
 	"datastoreURL": "",
 	"name": "test-1-k8s-3cf5ce84",
 	"path": "/DCTEST/datastore/test_1_k8s",
+	"zones": [
+	  "ZONE-TEST"
+	]
+  },
+  {
+	"datastoreType": "DatastoreCluster",
+	"datastoreURL": "",
+	"name": "test-1-k8s-3cf5ce84-gold-policy",
+	"path": "/DCTEST/datastore/test_1_k8s",
+	"storagePolicyName": "Gold Policy",
 	"zones": [
 	  "ZONE-TEST"
 	]

--- a/ee/se-plus/modules/030-csi-vsphere/openapi/values.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/openapi/values.yaml
@@ -27,6 +27,8 @@ properties:
               type: string
             path:
               type: string
+            storagePolicyName:
+              type: string
             zones:
               type: array
               items:

--- a/ee/se-plus/modules/030-csi-vsphere/openapi/values.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/openapi/values.yaml
@@ -150,3 +150,16 @@ properties:
                 datastoreURL:
                   type: string
             description: List of datastores
+          storagePolicies:
+            type: array
+            items:
+              type: object
+              required: [name, id]
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                id:
+                  type: string
+                  minLength: 1
+            description: List of storage policies

--- a/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
@@ -219,7 +219,6 @@ var _ = Describe("Module :: csi-vsphere :: helm template ::", func() {
 			Expect(scMydsname2.Exists()).To(BeTrue())
 
 			Expect(scMydsname1.Field("parameters.DatastoreURL").String()).To(Equal("ds:///vmfs/volumes/hash1/"))
-			Expect(scMydsname1.Field("parameters.StoragePolicyName").Exists()).To(BeFalse())
 			Expect(scMydsname1GoldPolicy.Field("parameters.DatastoreURL").String()).To(Equal("ds:///vmfs/volumes/hash1/"))
 			Expect(scMydsname1GoldPolicy.Field("parameters.StoragePolicyName").String()).To(Equal("Gold Policy"))
 			Expect(scMydsname2.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())

--- a/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
+++ b/ee/se-plus/modules/030-csi-vsphere/template_tests/module_test.go
@@ -68,6 +68,12 @@ internal:
     datastoreURL: ds:///vmfs/volumes/hash1/
     path: /my/ds/path/mydsname1
     zones: ["zonea", "zoneb"]
+  - name: mydsname1-gold-policy
+    datastoreType: Datastore
+    datastoreURL: ds:///vmfs/volumes/hash1/
+    path: /my/ds/path/mydsname1
+    storagePolicyName: Gold Policy
+    zones: ["zonea", "zoneb"]
   - name: mydsname2
     datastoreType: Datastore
     datastoreURL: ds:///vmfs/volumes/hash2/
@@ -205,11 +211,17 @@ var _ = Describe("Module :: csi-vsphere :: helm template ::", func() {
 
 			// user story #3
 			scMydsname1 := f.KubernetesGlobalResource("StorageClass", "mydsname1")
+			scMydsname1GoldPolicy := f.KubernetesGlobalResource("StorageClass", "mydsname1-gold-policy")
 			scMydsname2 := f.KubernetesGlobalResource("StorageClass", "mydsname2")
 
 			Expect(scMydsname1.Exists()).To(BeTrue())
+			Expect(scMydsname1GoldPolicy.Exists()).To(BeTrue())
 			Expect(scMydsname2.Exists()).To(BeTrue())
 
+			Expect(scMydsname1.Field("parameters.DatastoreURL").String()).To(Equal("ds:///vmfs/volumes/hash1/"))
+			Expect(scMydsname1.Field("parameters.StoragePolicyName").Exists()).To(BeFalse())
+			Expect(scMydsname1GoldPolicy.Field("parameters.DatastoreURL").String()).To(Equal("ds:///vmfs/volumes/hash1/"))
+			Expect(scMydsname1GoldPolicy.Field("parameters.StoragePolicyName").String()).To(Equal("Gold Policy"))
 			Expect(scMydsname2.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 
 			Expect(cddDeployment.Exists()).To(BeTrue())

--- a/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/deployment.yaml
@@ -106,6 +106,11 @@ spec:
             secretKeyRef:
               name: cloud-data-discoverer
               key: region
+        - name: ZONES
+          valueFrom:
+            secretKeyRef:
+              name: cloud-data-discoverer
+              key: zones
         - name: REGION_TAG_CATEGORY
           valueFrom:
             secretKeyRef:

--- a/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/secret.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/secret.yaml
@@ -13,6 +13,7 @@ data:
   password: {{ .provider.password | b64enc | quote }}
   insecure: {{ .provider.insecure | toString | b64enc | quote }}
   region: {{ .region | b64enc | quote }}
+  zones: {{ .zones | join "," | b64enc | quote }}
   regionTagCategory: {{ .regionTagCategory | b64enc | quote }}
   zoneTagCategory: {{ .zoneTagCategory | b64enc | quote }}
   vmFolderPath: {{ .vmFolderPath | b64enc | quote }}

--- a/ee/se-plus/modules/030-csi-vsphere/templates/csi/storageclass.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/templates/csi/storageclass.yaml
@@ -11,6 +11,9 @@ metadata:
 provisioner: csi.vsphere.vmware.com
 parameters:
   DatastoreURL: {{ $storageClass.datastoreURL | quote }}
+  {{- if ne $storageClass.storagePolicyName ""}}
+  StoragePolicyName: {{ $storageClass.storagePolicyName | quote }}
+  {{- end }}
 allowedTopologies:
 - matchLabelExpressions:
   - key: failure-domain.beta.kubernetes.io/region


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The OpenAPI schemas and hooks have been aligned with the current `cloud-data-discoverer` codebase from the `cloud-provider-vsphere` module, because `csi-vsphere` and `cloud-provider-vsphere` share the same codebase but have different OpenAPI schemas and hooks.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
A mismatch between the schemas and hooks can cause the Deckhouse queue to hang.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
We’ll make a patch in a separate PR.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: csi-vsphere
type: fix
summary: Migrated storage policy support  from the `cloud-provider-vsphere` module.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
