### PR TITLE
[control-plane-manager] Narrow `apiserver-kubelet-client` credentials scope

### DIFF
--- a/go_lib/controlplane/pki/pki_test.go
+++ b/go_lib/controlplane/pki/pki_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package pki
 
 import (
+	"crypto/x509"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -143,6 +145,23 @@ func TestCreatePKIBundle_CustomScheme_EtcdOnly(t *testing.T) {
 		_, err := os.Stat(filepath.Join(dir, f))
 		assert.True(t, os.IsNotExist(err), "file %s should not exist in etcd-only scheme", f)
 	}
+}
+
+func TestCreatePKIBundle_ApiserverKubeletClientHasNoOrganization(t *testing.T) {
+	dir := t.TempDir()
+	_, err := CreatePKIBundle(
+		"test-node",
+		"cluster.local",
+		net.ParseIP("10.0.0.1"),
+		"10.96.0.0/12",
+		WithPKIDir(dir),
+	)
+	require.NoError(t, err)
+	cert, _, err := pkiutil.LoadCertAndKey(dir, string(ApiserverKubeletClientCertName))
+	require.NoError(t, err)
+	assert.Equal(t, "kube-apiserver-kubelet-client", cert.Subject.CommonName)
+	assert.Empty(t, cert.Subject.Organization)
+	assert.Contains(t, cert.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
 }
 
 func readAllFiles(t *testing.T, dir string, files []string) map[string][]byte {

--- a/go_lib/controlplane/pki/spec.go
+++ b/go_lib/controlplane/pki/spec.go
@@ -205,9 +205,8 @@ func getLeafCertSpec(name LeafCertName) certSpec[LeafCertName] {
 			BuildConfig: func(cfg config) certConfig {
 				return certConfig{
 					Config: certutil.Config{
-						CommonName:   "kube-apiserver-kubelet-client",
-						Organization: []string{"kubeadm:cluster-admins"},
-						Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+						CommonName: "kube-apiserver-kubelet-client",
+						Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 					},
 					EncryptionAlgorithm:       cfg.EncryptionAlgorithmType,
 					CertificateValidityPeriod: cfg.CertValidityPeriod,

--- a/modules/040-control-plane-manager/templates/rbac-for-us.yaml
+++ b/modules/040-control-plane-manager/templates/rbac-for-us.yaml
@@ -136,12 +136,10 @@ rules:
 - apiGroups: [""]
   resources: ["nodes/status"]
   verbs: ["get", "patch", "update"]
-# Required for kube-apiserver-kubelet-client (group kubeadm:cluster-admins per kubeadm 1.29+ defaults):
-# every kubelet API call from apiserver (exec, attach, logs, portforward) is authorized as nodes/proxy.
-# Deliberately kept OUT of user-authz:cluster-admin so that the high-level ClusterAdmin role
-# (granted to users via ClusterAuthorizationRule.accessLevel=ClusterAdmin) does NOT silently turn
-# into a root-on-every-node permission via the kubelet API. nodes/proxy is admin.conf-specific
-# and lives only in this supplement bound to Group/kubeadm:cluster-admins.
+# nodes/proxy is intentionally granted only via the admin.conf path
+# (Group/kubeadm:cluster-admins) and not via user-authz:cluster-admin.
+# This prevents the high-level ClusterAdmin access level from silently becoming
+# root-on-every-node through the kubelet API.
 - apiGroups: [""]
   resources: ["nodes/proxy"]
   verbs: ["get", "create"]


### PR DESCRIPTION
## Description
This change stops issuing `apiserver-kubelet-client.crt` with `O = kubeadm:cluster-admins`. Access to the kubelet API remains provided by the dedicated `ClusterRoleBinding` introduced in [#19943](https://github.com/deckhouse/deckhouse/pull/19943).

Critical control-plane behavior is not expanded by this PR, but the updated PKI spec can trigger regeneration of `apiserver-kubelet-client.crt` on reconciliation because the certificate subject no longer matches the previous template.

## Why do we need it, and what problem does it solve?
Before this change, `kube-apiserver` could still inherit broad permissions through the `kubeadm:cluster-admins` group embedded into `apiserver-kubelet-client.crt`, even though kubelet access was already moved to a dedicated binding in [#19943](https://github.com/deckhouse/deckhouse/pull/19943). This PR completes that transition and makes the kube-apiserver kubelet client rely only on the intended `User/kube-apiserver-kubelet-client -> ClusterRole/system:kubelet-api-admin` path.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Stop issuing `apiserver-kubelet-client` credentials in the `kubeadm:cluster-admins` group and rely on the dedicated kubelet API binding.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
