### PR TITLE
[deckhouse] clean availableRepositories on PackageRepository deletion

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository.go
@@ -30,6 +30,7 @@ const (
 	PackageRepositoryPhaseTerminating = "Terminating"
 
 	PackageRepositoryFinalizerPackageVersionExists = "packages.deckhouse.io/package-version-exists"
+	PackageRepositoryFinalizerCleanup              = "packages.deckhouse.io/cleanup"
 
 	PackageRepositoryAnnotationRegistryChecksum = "packages.deckhouse.io/registry-spec-checksum"
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1/package_repository.go
@@ -30,7 +30,6 @@ const (
 	PackageRepositoryPhaseTerminating = "Terminating"
 
 	PackageRepositoryFinalizerPackageVersionExists = "packages.deckhouse.io/package-version-exists"
-	PackageRepositoryFinalizerCleanup              = "packages.deckhouse.io/cleanup"
 
 	PackageRepositoryAnnotationRegistryChecksum = "packages.deckhouse.io/registry-spec-checksum"
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -308,6 +308,10 @@ func (r *reconciler) delete(ctx context.Context, packageRepository *v1alpha1.Pac
 	return nil
 }
 
+// cleanupApplicationPackage removes repoName from pkg.Status.AvailableRepositories.
+// If the resulting list is empty the package is no longer available from any source
+// and the CR itself is deleted; otherwise the status is patched with the trimmed list.
+// Returns nil (no-op) when the package was not contributed by repoName.
 func (r *reconciler) cleanupApplicationPackage(ctx context.Context, pkg *v1alpha1.ApplicationPackage, repoName string) error {
 	if !slices.Contains(pkg.Status.AvailableRepositories, repoName) {
 		return nil
@@ -331,6 +335,10 @@ func (r *reconciler) cleanupApplicationPackage(ctx context.Context, pkg *v1alpha
 	return nil
 }
 
+// cleanupModulePackage removes repoName from pkg.Status.AvailableRepositories.
+// If the resulting list is empty the package is no longer available from any source
+// and the CR itself is deleted; otherwise the status is patched with the trimmed list.
+// Returns nil (no-op) when the package was not contributed by repoName.
 func (r *reconciler) cleanupModulePackage(ctx context.Context, pkg *v1alpha1.ModulePackage, repoName string) error {
 	if !slices.Contains(pkg.Status.AvailableRepositories, repoName) {
 		return nil

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -293,7 +294,7 @@ func (r *reconciler) delete(ctx context.Context, packageRepository *v1alpha1.Pac
 	}
 
 	appPackages := &v1alpha1.ApplicationPackageList{}
-	if err := r.client.List(ctx, appPackages); err != nil {
+	if err := r.client.List(ctx, appPackages); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("list application packages: %w", err)
 	}
 	for _, pkg := range appPackages.Items {
@@ -303,7 +304,7 @@ func (r *reconciler) delete(ctx context.Context, packageRepository *v1alpha1.Pac
 	}
 
 	modulePackages := &v1alpha1.ModulePackageList{}
-	if err := r.client.List(ctx, modulePackages); err != nil {
+	if err := r.client.List(ctx, modulePackages); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("list module packages: %w", err)
 	}
 	for _, pkg := range modulePackages.Items {

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -130,9 +130,9 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, repo *v1alpha1.Pa
 
 	logger.Debug("handle resource")
 
-	if !controllerutil.ContainsFinalizer(repo, v1alpha1.PackageRepositoryFinalizerCleanup) {
+	if !controllerutil.ContainsFinalizer(repo, v1alpha1.PackageRepositoryFinalizerPackageVersionExists) {
 		original := repo.DeepCopy()
-		controllerutil.AddFinalizer(repo, v1alpha1.PackageRepositoryFinalizerCleanup)
+		controllerutil.AddFinalizer(repo, v1alpha1.PackageRepositoryFinalizerPackageVersionExists)
 		if err := r.client.Patch(ctx, repo, client.MergeFrom(original)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
 		}
@@ -275,19 +275,6 @@ func (r *reconciler) delete(ctx context.Context, packageRepository *v1alpha1.Pac
 
 	logger.Info("deleting PackageRepository")
 
-	operationList := &v1alpha1.PackageRepositoryOperationList{}
-	if err := r.client.List(ctx, operationList, client.MatchingLabels{
-		v1alpha1.PackagesRepositoryOperationLabelRepository: packageRepository.Name,
-	}); err != nil {
-		return fmt.Errorf("list operations: %w", err)
-	}
-
-	for _, op := range operationList.Items {
-		if err := r.client.Delete(ctx, &op); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete operation %s: %w", op.Name, err)
-		}
-	}
-
 	appPackages := &v1alpha1.ApplicationPackageList{}
 	if err := r.client.List(ctx, appPackages); err != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("list application packages: %w", err)
@@ -308,9 +295,9 @@ func (r *reconciler) delete(ctx context.Context, packageRepository *v1alpha1.Pac
 		}
 	}
 
-	if controllerutil.ContainsFinalizer(packageRepository, v1alpha1.PackageRepositoryFinalizerCleanup) {
+	if controllerutil.ContainsFinalizer(packageRepository, v1alpha1.PackageRepositoryFinalizerPackageVersionExists) {
 		original := packageRepository.DeepCopy()
-		controllerutil.RemoveFinalizer(packageRepository, v1alpha1.PackageRepositoryFinalizerCleanup)
+		controllerutil.RemoveFinalizer(packageRepository, v1alpha1.PackageRepositoryFinalizerPackageVersionExists)
 		if err := r.client.Patch(ctx, packageRepository, client.MergeFrom(original)); err != nil {
 			return fmt.Errorf("remove finalizer: %w", err)
 		}

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -79,12 +79,7 @@ func RegisterController(
 
 	return ctrl.NewControllerManagedBy(runtimeManager).
 		For(&v1alpha1.PackageRepository{}).
-		WithEventFilter(predicate.Or(
-			predicate.GenerationChangedPredicate{},
-			predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				return !obj.GetDeletionTimestamp().IsZero()
-			}),
-		)).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(packageRepositoryController)
 }
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -27,8 +28,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	registryService "github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry/service"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
@@ -76,7 +77,6 @@ func RegisterController(
 
 	return ctrl.NewControllerManagedBy(runtimeManager).
 		For(&v1alpha1.PackageRepository{}).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		Complete(packageRepositoryController)
 }
 
@@ -126,6 +126,15 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, repo *v1alpha1.Pa
 	logger := r.logger.With(slog.String("name", repo.Name))
 
 	logger.Debug("handle resource")
+
+	if !controllerutil.ContainsFinalizer(repo, v1alpha1.PackageRepositoryFinalizerCleanup) {
+		original := repo.DeepCopy()
+		controllerutil.AddFinalizer(repo, v1alpha1.PackageRepositoryFinalizerCleanup)
+		if err := r.client.Patch(ctx, repo, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
 
 	if err := r.syncRegistrySettings(ctx, repo); err != nil {
 		return ctrl.Result{}, fmt.Errorf("sync registry settings: %w", err)
@@ -260,27 +269,99 @@ func (r *reconciler) checkPaginationSupport(ctx context.Context, repo *v1alpha1.
 }
 
 func (r *reconciler) delete(ctx context.Context, packageRepository *v1alpha1.PackageRepository) error {
-	logger := r.logger.With("name", packageRepository.Name)
+	logger := r.logger.With(slog.String("name", packageRepository.Name))
 
 	logger.Info("deleting PackageRepository")
 
-	// Delete all PackageRepositoryOperations associated with this repository
 	operationList := &v1alpha1.PackageRepositoryOperationList{}
-	err := r.client.List(ctx, operationList, client.MatchingLabels{
+	if err := r.client.List(ctx, operationList, client.MatchingLabels{
 		v1alpha1.PackagesRepositoryOperationLabelRepository: packageRepository.Name,
-	})
-	if err != nil {
+	}); err != nil {
 		return fmt.Errorf("list operations: %w", err)
 	}
 
 	for _, op := range operationList.Items {
 		if err := r.client.Delete(ctx, &op); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("failed to delete operation %s: %w", op.Name, err)
+			return fmt.Errorf("delete operation %s: %w", op.Name, err)
+		}
+	}
+
+	appPackages := &v1alpha1.ApplicationPackageList{}
+	if err := r.client.List(ctx, appPackages); err != nil {
+		return fmt.Errorf("list application packages: %w", err)
+	}
+	for _, pkg := range appPackages.Items {
+		if err := r.cleanupApplicationPackage(ctx, &pkg, packageRepository.Name); err != nil {
+			return err
+		}
+	}
+
+	modulePackages := &v1alpha1.ModulePackageList{}
+	if err := r.client.List(ctx, modulePackages); err != nil {
+		return fmt.Errorf("list module packages: %w", err)
+	}
+	for _, pkg := range modulePackages.Items {
+		if err := r.cleanupModulePackage(ctx, &pkg, packageRepository.Name); err != nil {
+			return err
+		}
+	}
+
+	if controllerutil.ContainsFinalizer(packageRepository, v1alpha1.PackageRepositoryFinalizerCleanup) {
+		original := packageRepository.DeepCopy()
+		controllerutil.RemoveFinalizer(packageRepository, v1alpha1.PackageRepositoryFinalizerCleanup)
+		if err := r.client.Patch(ctx, packageRepository, client.MergeFrom(original)); err != nil {
+			return fmt.Errorf("remove finalizer: %w", err)
 		}
 	}
 
 	logger.Info("cleanup completed")
 
+	return nil
+}
+
+func (r *reconciler) cleanupApplicationPackage(ctx context.Context, pkg *v1alpha1.ApplicationPackage, repoName string) error {
+	if !slices.Contains(pkg.Status.AvailableRepositories, repoName) {
+		return nil
+	}
+
+	original := pkg.DeepCopy()
+	pkg.Status.AvailableRepositories = slices.DeleteFunc(pkg.Status.AvailableRepositories, func(name string) bool {
+		return name == repoName
+	})
+
+	if len(pkg.Status.AvailableRepositories) == 0 {
+		if err := r.client.Delete(ctx, pkg); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete application package %s: %w", pkg.Name, err)
+		}
+		return nil
+	}
+
+	if err := r.client.Status().Patch(ctx, pkg, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("patch application package %s status: %w", pkg.Name, err)
+	}
+	return nil
+}
+
+func (r *reconciler) cleanupModulePackage(ctx context.Context, pkg *v1alpha1.ModulePackage, repoName string) error {
+	if !slices.Contains(pkg.Status.AvailableRepositories, repoName) {
+		return nil
+	}
+
+	original := pkg.DeepCopy()
+	pkg.Status.AvailableRepositories = slices.DeleteFunc(pkg.Status.AvailableRepositories, func(name string) bool {
+		return name == repoName
+	})
+
+	if len(pkg.Status.AvailableRepositories) == 0 {
+		if err := r.client.Delete(ctx, pkg); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete module package %s: %w", pkg.Name, err)
+		}
+		return nil
+	}
+
+	if err := r.client.Status().Patch(ctx, pkg, client.MergeFrom(original)); err != nil {
+		return fmt.Errorf("patch module package %s status: %w", pkg.Name, err)
+	}
 	return nil
 }
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -309,9 +309,9 @@ func (r *reconciler) delete(ctx context.Context, packageRepository *v1alpha1.Pac
 }
 
 // cleanupApplicationPackage removes repoName from pkg.Status.AvailableRepositories.
-// If the resulting list is empty the package is no longer available from any source
-// and the CR itself is deleted; otherwise the status is patched with the trimmed list.
-// Returns nil (no-op) when the package was not contributed by repoName.
+// Lifecycle of the ApplicationPackage CR itself is handled by Kubernetes GC via ownerRefs;
+// this function only updates the status. Returns nil (no-op) when the package was not
+// contributed by repoName.
 func (r *reconciler) cleanupApplicationPackage(ctx context.Context, pkg *v1alpha1.ApplicationPackage, repoName string) error {
 	if !slices.Contains(pkg.Status.AvailableRepositories, repoName) {
 		return nil
@@ -322,13 +322,6 @@ func (r *reconciler) cleanupApplicationPackage(ctx context.Context, pkg *v1alpha
 		return name == repoName
 	})
 
-	if len(pkg.Status.AvailableRepositories) == 0 {
-		if err := r.client.Delete(ctx, pkg); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete application package %s: %w", pkg.Name, err)
-		}
-		return nil
-	}
-
 	if err := r.client.Status().Patch(ctx, pkg, client.MergeFrom(original)); err != nil {
 		return fmt.Errorf("patch application package %s status: %w", pkg.Name, err)
 	}
@@ -336,9 +329,9 @@ func (r *reconciler) cleanupApplicationPackage(ctx context.Context, pkg *v1alpha
 }
 
 // cleanupModulePackage removes repoName from pkg.Status.AvailableRepositories.
-// If the resulting list is empty the package is no longer available from any source
-// and the CR itself is deleted; otherwise the status is patched with the trimmed list.
-// Returns nil (no-op) when the package was not contributed by repoName.
+// Lifecycle of the ModulePackage CR itself is handled by Kubernetes GC via ownerRefs;
+// this function only updates the status. Returns nil (no-op) when the package was not
+// contributed by repoName.
 func (r *reconciler) cleanupModulePackage(ctx context.Context, pkg *v1alpha1.ModulePackage, repoName string) error {
 	if !slices.Contains(pkg.Status.AvailableRepositories, repoName) {
 		return nil
@@ -348,13 +341,6 @@ func (r *reconciler) cleanupModulePackage(ctx context.Context, pkg *v1alpha1.Mod
 	pkg.Status.AvailableRepositories = slices.DeleteFunc(pkg.Status.AvailableRepositories, func(name string) bool {
 		return name == repoName
 	})
-
-	if len(pkg.Status.AvailableRepositories) == 0 {
-		if err := r.client.Delete(ctx, pkg); err != nil && !apierrors.IsNotFound(err) {
-			return fmt.Errorf("delete module package %s: %w", pkg.Name, err)
-		}
-		return nil
-	}
 
 	if err := r.client.Status().Patch(ctx, pkg, client.MergeFrom(original)); err != nil {
 		return fmt.Errorf("patch module package %s status: %w", pkg.Name, err)

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -133,7 +133,6 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, repo *v1alpha1.Pa
 		if err := r.client.Patch(ctx, repo, client.MergeFrom(original)); err != nil {
 			return ctrl.Result{}, fmt.Errorf("add finalizer: %w", err)
 		}
-		return ctrl.Result{Requeue: true}, nil
 	}
 
 	if err := r.syncRegistrySettings(ctx, repo); err != nil {

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	registryService "github.com/deckhouse/deckhouse/deckhouse-controller/internal/registry/service"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
@@ -77,6 +78,12 @@ func RegisterController(
 
 	return ctrl.NewControllerManagedBy(runtimeManager).
 		For(&v1alpha1.PackageRepository{}).
+		WithEventFilter(predicate.Or(
+			predicate.GenerationChangedPredicate{},
+			predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return !obj.GetDeletionTimestamp().IsZero()
+			}),
+		)).
 		Complete(packageRepositoryController)
 }
 

--- a/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/active-operation.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/active-operation.yaml
@@ -6,7 +6,7 @@ metadata:
     packages.deckhouse.io/registry-spec-checksum: 2720f396ada9d3a58be0d5f8fd16c26a
   creationTimestamp: null
   finalizers:
-  - packages.deckhouse.io/cleanup
+  - packages.deckhouse.io/package-version-exists
   name: deckhouse
   resourceVersion: "3"
 spec:

--- a/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/active-operation.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/active-operation.yaml
@@ -5,8 +5,10 @@ metadata:
   annotations:
     packages.deckhouse.io/registry-spec-checksum: 2720f396ada9d3a58be0d5f8fd16c26a
   creationTimestamp: null
+  finalizers:
+  - packages.deckhouse.io/cleanup
   name: deckhouse
-  resourceVersion: "2"
+  resourceVersion: "3"
 spec:
   registry:
     ca: test-ca

--- a/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/delete-repository.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/delete-repository.yaml
@@ -14,3 +14,46 @@ spec:
 status:
   partialScanAvailable: false
   syncTime: null
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: PackageRepositoryOperation
+metadata:
+  creationTimestamp: null
+  labels:
+    packages.deckhouse.io/repository: deckhouse
+  name: deckhouse-scan-1234567890
+  resourceVersion: "1"
+spec:
+  packageRepositoryName: deckhouse
+  type: Update
+  update:
+    fullScan: true
+    timeout: 5m
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: ""
+    reason: ScanSucceeded
+    status: "True"
+    type: Completed
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: PackageRepositoryOperation
+metadata:
+  creationTimestamp: null
+  labels:
+    packages.deckhouse.io/repository: deckhouse
+  name: deckhouse-scan-1234567891
+  resourceVersion: "1"
+spec:
+  packageRepositoryName: deckhouse
+  type: Update
+  update:
+    timeout: 5m
+status:
+  conditions:
+  - lastTransitionTime: null
+    message: ""
+    reason: ScanFailed
+    status: "True"
+    type: Completed

--- a/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/successful-reconcile.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/successful-reconcile.yaml
@@ -6,7 +6,7 @@ metadata:
     packages.deckhouse.io/registry-spec-checksum: 2720f396ada9d3a58be0d5f8fd16c26a
   creationTimestamp: null
   finalizers:
-  - packages.deckhouse.io/cleanup
+  - packages.deckhouse.io/package-version-exists
   name: deckhouse
   resourceVersion: "3"
 spec:

--- a/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/successful-reconcile.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/successful-reconcile.yaml
@@ -5,8 +5,10 @@ metadata:
   annotations:
     packages.deckhouse.io/registry-spec-checksum: 2720f396ada9d3a58be0d5f8fd16c26a
   creationTimestamp: null
+  finalizers:
+  - packages.deckhouse.io/cleanup
   name: deckhouse
-  resourceVersion: "2"
+  resourceVersion: "3"
 spec:
   registry:
     ca: test-ca


### PR DESCRIPTION
## Description

Adds a cleanup flow on `PackageRepository` deletion:

- Adds the existing `packages.deckhouse.io/package-version-exists` finalizer on first reconcile.
- In `delete()`: walks `ApplicationPackage` / `ModulePackage` and removes the repo name from `.status.availableRepositories`, then removes the finalizer. Lifecycle of the package CRs themselves is left to Kubernetes GC via `ownerRef`.
- Tolerates clusters without the `ModulePackage` CRD (`meta.IsNoMatchError`).

`PackageRepositoryOperation` and `*PackageVersion` are not touched — they cascade-GC via `ownerRef`.

## Why do we need it, and what problem does it solve?

When the same package came from several `PackageRepository` CRs, `.status.availableRepositories` on `ApplicationPackage` / `ModulePackage` accumulated names and never lost them on repo deletion — the old `delete()` was unreachable because the CR had no finalizer and was removed from etcd before the controller could react.

After this PR a deleted `PackageRepository` is removed from downstream package state. The packages that no longer have any source are reaped by Kubernetes GC via `ownerRef` (a follow-up will harmonize the `ownerRef` setup in `operation-service.go` so multi-source packages are kept alive until the last contributor is gone).

### Verification (in cluster)

```sh
$ k get packagerepository test test-clone \
    -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.metadata.finalizers}{"\n"}{end}'
test: ["packages.deckhouse.io/package-version-exists"]
test-clone: ["packages.deckhouse.io/package-version-exists"]
```

**Deleting a secondary contributor leaves the packages intact and cleans references:**

```sh
$ k get applicationpackages -o name | wc -l
13
$ k get apv -l packages.deckhouse.io/repository=test-clone -o name | wc -l
31
$ k get packagerepositoryoperations -l packages.deckhouse.io/repository=test-clone -o name | wc -l
1

$ k delete packagerepository test-clone
packagerepository.deckhouse.io "test-clone" deleted

$ k get applicationpackages -o name | wc -l
13                                # packages stay — still available from `test`
$ k get applicationpackages -o jsonpath='{range .items[*]}{.metadata.name}{" -> "}{.status.availableRepositories}{"\n"}{end}'
a-k-status-tests -> ["test"]
cossacks-server -> ["test"]
...
test-icon-2 -> ["test"]           # `test-clone` removed from every package's list

$ k get apv -l packages.deckhouse.io/repository=test-clone -o name | wc -l
0                                  # cascade-GC via ownerRef
$ k get packagerepositoryoperations -l packages.deckhouse.io/repository=test-clone -o name | wc -l
0                                  # cascade-GC via ownerRef
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Cleaned availableRepositories on PackageRepository deletion.
impact_level: default
```

