### PR TITLE
[user-authz] Fix get ans for users with authorizationRules

### DIFF
--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
@@ -149,7 +149,7 @@ func (e *Engine) authorizeNamespacedRequest(attrs authorizer.Attributes, entry *
 	}
 
 	// Check system namespaces restriction
-	if !denied && !entry.AllowAccessToSystemNamespaces && isSystemNamespace(namespace) {
+	if !denied && isSystemNamespace(namespace) && !systemNamespaceAllowed(entry, namespace) {
 		denied = true
 		reason = noNamespaceAccessReason
 	}
@@ -275,7 +275,9 @@ func (e *Engine) getPreferredGroupVersion(group, version string) (schema.GroupVe
 	return schema.GroupVersion{}, fmt.Errorf("API group %q not found in server groups", group)
 }
 
-// combineDirEntries combines multiple directory entries into one
+// combineDirEntries combines multiple directory entries into one.
+// AllowedSystemNamespaces is merged into a fresh map so the combined view does
+// not alias (and cannot mutate) the source entries stored in the directory.
 func (e *Engine) combineDirEntries(entries []DirectoryEntry) DirectoryEntry {
 	var combined DirectoryEntry
 
@@ -291,6 +293,13 @@ func (e *Engine) combineDirEntries(entries []DirectoryEntry) DirectoryEntry {
 			combined.LimitNamespaces = append(combined.LimitNamespaces, entry.LimitNamespaces...)
 		}
 		combined.NamespaceFiltersAbsent = combined.NamespaceFiltersAbsent || entry.NamespaceFiltersAbsent
+
+		for ns := range entry.AllowedSystemNamespaces {
+			if combined.AllowedSystemNamespaces == nil {
+				combined.AllowedSystemNamespaces = make(map[string]struct{}, len(entry.AllowedSystemNamespaces))
+			}
+			combined.AllowedSystemNamespaces[ns] = struct{}{}
+		}
 	}
 
 	return combined
@@ -434,6 +443,8 @@ func applyAuthorizationRulesToDirectory(directory map[string]map[string]Director
 
 		nsRegex, err := regexp.Compile(wrapRegex(regexp.QuoteMeta(ar.Namespace)))
 		if err != nil {
+			// Unreachable in practice because QuoteMeta + wrapRegex always yields a
+			// valid pattern, but we prefer logging over panicking in a config loader.
 			klog.Warningf("Skipping AuthorizationRule %q: cannot compile namespace pattern %q: %v", ar.Name, ar.Namespace, err)
 			continue
 		}
@@ -450,7 +461,10 @@ func applyAuthorizationRulesToDirectory(directory map[string]map[string]Director
 			dirEntry := directory[kind][name]
 			dirEntry.LimitNamespaces = append(dirEntry.LimitNamespaces, nsRegex)
 			if arInSystemNS {
-				dirEntry.AllowAccessToSystemNamespaces = true
+				if dirEntry.AllowedSystemNamespaces == nil {
+					dirEntry.AllowedSystemNamespaces = make(map[string]struct{})
+				}
+				dirEntry.AllowedSystemNamespaces[ar.Namespace] = struct{}{}
 			}
 			directory[kind][name] = dirEntry
 		}
@@ -567,7 +581,7 @@ func (e *Engine) IsNamespaceAllowed(userInfo user.Info, namespace string) bool {
 	}
 
 	// Check system namespaces restriction
-	if allowed && !combinedDir.AllowAccessToSystemNamespaces && isSystemNamespace(namespace) {
+	if allowed && isSystemNamespace(namespace) && !systemNamespaceAllowed(&combinedDir, namespace) {
 		allowed = false
 	}
 
@@ -636,7 +650,7 @@ func (e *Engine) IsNamespaceAllowedWithFilter(namespace string, filter *Director
 	}
 
 	// Check system namespaces restriction
-	if allowed && !filter.AllowAccessToSystemNamespaces && isSystemNamespace(namespace) {
+	if allowed && isSystemNamespace(namespace) && !systemNamespaceAllowed(filter, namespace) {
 		allowed = false
 	}
 

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine.go
@@ -149,14 +149,9 @@ func (e *Engine) authorizeNamespacedRequest(attrs authorizer.Attributes, entry *
 	}
 
 	// Check system namespaces restriction
-	if !denied && !entry.AllowAccessToSystemNamespaces {
-		for _, pattern := range systemNamespacesRegex {
-			if pattern.MatchString(namespace) {
-				denied = true
-				reason = noNamespaceAccessReason
-				break
-			}
-		}
+	if !denied && !entry.AllowAccessToSystemNamespaces && isSystemNamespace(namespace) {
+		denied = true
+		reason = noNamespaceAccessReason
 	}
 
 	// Check namespace selectors
@@ -391,18 +386,13 @@ func (e *Engine) renewDirectories() {
 	// Fill limited namespaces by subjects kinds/names
 	for _, crd := range config.CRDs {
 		for _, subject := range crd.Spec.Subjects {
-			name := subject.Name
-			namespace := subject.Namespace
-			kind := subject.Kind
+			kind, name := subjectDirectoryKey(subject.Kind, subject.Name, subject.Namespace, "")
 
-			if kind == "ServiceAccount" {
-				name = "system:serviceaccount:" + namespace + ":" + name
+			if _, ok := directory[kind]; !ok {
+				continue
 			}
 
-			dirEntry, ok := directory[kind][name]
-			if !ok {
-				dirEntry = DirectoryEntry{}
-			}
+			dirEntry := directory[kind][name]
 
 			// If there are neither LimitNamespaces nor NamespaceSelector options, it means all non-system namespaces are allowed
 			dirEntry.NamespaceFiltersAbsent = dirEntry.NamespaceFiltersAbsent || (len(crd.Spec.LimitNamespaces) == 0 && !isLabelSelectorApplied(crd.Spec.NamespaceSelector))
@@ -424,11 +414,61 @@ func (e *Engine) renewDirectories() {
 		}
 	}
 
+	applyAuthorizationRulesToDirectory(directory, config.ARs)
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	e.directory = directory
 	klog.Info("Multi-tenancy configuration was reloaded successfully")
+}
+
+// applyAuthorizationRulesToDirectory grants each AR's subjects access to the
+// AR's own namespace, so AR-only users aren't rejected by deny-by-default.
+// QuoteMeta keeps the namespace a literal even if config.json is tampered with.
+func applyAuthorizationRulesToDirectory(directory map[string]map[string]DirectoryEntry, ars []authorizationRule) {
+	for _, ar := range ars {
+		if ar.Namespace == "" {
+			continue
+		}
+
+		nsRegex, err := regexp.Compile(wrapRegex(regexp.QuoteMeta(ar.Namespace)))
+		if err != nil {
+			klog.Warningf("Skipping AuthorizationRule %q: cannot compile namespace pattern %q: %v", ar.Name, ar.Namespace, err)
+			continue
+		}
+
+		arInSystemNS := isSystemNamespace(ar.Namespace)
+
+		for _, subject := range ar.Spec.Subjects {
+			kind, name := subjectDirectoryKey(subject.Kind, subject.Name, subject.Namespace, ar.Namespace)
+
+			if _, ok := directory[kind]; !ok {
+				continue
+			}
+
+			dirEntry := directory[kind][name]
+			dirEntry.LimitNamespaces = append(dirEntry.LimitNamespaces, nsRegex)
+			if arInSystemNS {
+				dirEntry.AllowAccessToSystemNamespaces = true
+			}
+			directory[kind][name] = dirEntry
+		}
+	}
+}
+
+// subjectDirectoryKey returns the directory map key for a subject.
+// ServiceAccounts are canonicalized to "system:serviceaccount:<ns>:<name>";
+// defaultNamespace fills in subject.Namespace when it's empty (RBAC fallback).
+func subjectDirectoryKey(kind, name, subjectNamespace, defaultNamespace string) (string, string) {
+	if kind != "ServiceAccount" {
+		return kind, name
+	}
+	ns := subjectNamespace
+	if ns == "" {
+		ns = defaultNamespace
+	}
+	return kind, "system:serviceaccount:" + ns + ":" + name
 }
 
 // StartRenewConfigLoop periodically reads new config file
@@ -527,13 +567,8 @@ func (e *Engine) IsNamespaceAllowed(userInfo user.Info, namespace string) bool {
 	}
 
 	// Check system namespaces restriction
-	if allowed && !combinedDir.AllowAccessToSystemNamespaces {
-		for _, pattern := range systemNamespacesRegex {
-			if pattern.MatchString(namespace) {
-				allowed = false
-				break
-			}
-		}
+	if allowed && !combinedDir.AllowAccessToSystemNamespaces && isSystemNamespace(namespace) {
+		allowed = false
 	}
 
 	// Check namespace selectors if denied by patterns
@@ -601,13 +636,8 @@ func (e *Engine) IsNamespaceAllowedWithFilter(namespace string, filter *Director
 	}
 
 	// Check system namespaces restriction
-	if allowed && !filter.AllowAccessToSystemNamespaces {
-		for _, pattern := range systemNamespacesRegex {
-			if pattern.MatchString(namespace) {
-				allowed = false
-				break
-			}
-		}
+	if allowed && !filter.AllowAccessToSystemNamespaces && isSystemNamespace(namespace) {
+		allowed = false
 	}
 
 	// Check namespace selectors if denied by patterns

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_test.go
@@ -858,7 +858,7 @@ func TestEngine_RenewDirectories_AuthorizationRules(t *testing.T) {
 			expectedDecision: authorizer.DecisionNoOpinion,
 		},
 		{
-			name: "AR in a system namespace unlocks that system namespace",
+			name: "AR in a system namespace grants access only to that exact namespace",
 			config: `{
 				"crds": [],
 				"ars": [
@@ -925,6 +925,58 @@ func TestEngine_RenewDirectories_AuthorizationRules(t *testing.T) {
 				"Authorize: namespace=%s", tt.namespace)
 		})
 	}
+}
+
+// CAR: limitNamespaces = ["d8-.*", "team-.*"], allowAccessToSystemNamespaces = false
+// AR:  namespace       = "d8-monitoring"
+func TestEngine_RenewDirectories_AR_DoesNotLiftSystemGateForCAR(t *testing.T) {
+	config := `{
+		"crds": [
+			{
+				"name": "car-d8-wide",
+				"spec": {
+					"limitNamespaces": ["d8-.*", "team-.*"],
+					"subjects": [{"kind": "Group", "name": "developers"}]
+				}
+			}
+		],
+		"ars": [
+			{
+				"name": "ar-monitoring",
+				"namespace": "d8-monitoring",
+				"spec": {"subjects": [{"kind": "Group", "name": "developers"}]}
+			}
+		]
+	}`
+
+	e := &Engine{
+		configPath: writeConfigJSON(t, config),
+		directory:  map[string]map[string]DirectoryEntry{},
+	}
+	e.renewDirectories()
+
+	userInfo := &mockUserInfo{name: "alice", groups: []string{"developers"}}
+
+	// CAR's legitimate non-system grant must keep working.
+	assert.True(t, e.IsNamespaceAllowed(userInfo, "team-foo"),
+		"non-system namespace matched by CAR must remain accessible")
+
+	// AR explicitly punches a hole only for its own system namespace.
+	assert.True(t, e.IsNamespaceAllowed(userInfo, "d8-monitoring"),
+		"AR-granted system namespace must be allowed")
+
+	// The priv-esc the reviewer flagged: every other d8-* (and any system NS)
+	// matched by CAR's wildcard must stay behind the system gate.
+	assert.False(t, e.IsNamespaceAllowed(userInfo, "d8-system"),
+		"other d8-* system namespaces matched by CAR must NOT be unlocked by the AR")
+	assert.False(t, e.IsNamespaceAllowed(userInfo, "kube-system"),
+		"unrelated system namespaces must remain denied")
+	assert.False(t, e.IsNamespaceAllowed(userInfo, "default"),
+		"`default` is a system namespace and must remain denied")
+
+	// Sanity check: namespaces matched by neither CAR nor AR are denied.
+	assert.False(t, e.IsNamespaceAllowed(userInfo, "random-ns"),
+		"namespaces outside CAR and AR scope must be denied")
 }
 
 // TestEngine_RenewDirectories_NamespaceRegexMetacharsAreEscaped is a
@@ -1020,45 +1072,45 @@ func TestEngine_GetAllowedNamespaces(t *testing.T) {
 	}
 
 	tests := []struct {
-		name               string
-		userInfo           *mockUserInfo
-		expectedNamespaces []string
+		name                    string
+		userInfo                *mockUserInfo
+		expectedNamespaces      []string
 		expectedHasRestrictions bool
 	}{
 		{
-			name:               "nil user - all allowed",
-			userInfo:           nil,
-			expectedNamespaces: nil,
+			name:                    "nil user - all allowed",
+			userInfo:                nil,
+			expectedNamespaces:      nil,
 			expectedHasRestrictions: false,
 		},
 		{
-			name:               "system:masters without CAR - all allowed (privileged bypass)",
-			userInfo:           &mockUserInfo{name: "admin", groups: []string{"system:masters"}},
-			expectedNamespaces: nil,
+			name:                    "system:masters without CAR - all allowed (privileged bypass)",
+			userInfo:                &mockUserInfo{name: "admin", groups: []string{"system:masters"}},
+			expectedNamespaces:      nil,
 			expectedHasRestrictions: false,
 		},
 		{
-			name:               "kubeadm:cluster-admins without CAR - all allowed (privileged bypass)",
-			userInfo:           &mockUserInfo{name: "kubeadm-admin", groups: []string{"kubeadm:cluster-admins"}},
-			expectedNamespaces: nil,
+			name:                    "kubeadm:cluster-admins without CAR - all allowed (privileged bypass)",
+			userInfo:                &mockUserInfo{name: "kubeadm-admin", groups: []string{"kubeadm:cluster-admins"}},
+			expectedNamespaces:      nil,
 			expectedHasRestrictions: false,
 		},
 		{
-			name:               "unknown user without CAR - empty list (deny-by-default)",
-			userInfo:           &mockUserInfo{name: "unknown-user", groups: []string{"system:authenticated"}},
-			expectedNamespaces: []string{},
+			name:                    "unknown user without CAR - empty list (deny-by-default)",
+			userInfo:                &mockUserInfo{name: "unknown-user", groups: []string{"system:authenticated"}},
+			expectedNamespaces:      []string{},
 			expectedHasRestrictions: true,
 		},
 		{
-			name:               "restricted user with CAR - has restrictions",
-			userInfo:           &mockUserInfo{name: "restricted-user"},
-			expectedNamespaces: nil,
+			name:                    "restricted user with CAR - has restrictions",
+			userInfo:                &mockUserInfo{name: "restricted-user"},
+			expectedNamespaces:      nil,
 			expectedHasRestrictions: true,
 		},
 		{
-			name:               "unrestricted user with CAR (no filters) - all allowed",
-			userInfo:           &mockUserInfo{name: "unrestricted-user"},
-			expectedNamespaces: nil,
+			name:                    "unrestricted user with CAR (no filters) - all allowed",
+			userInfo:                &mockUserInfo{name: "unrestricted-user"},
+			expectedNamespaces:      nil,
 			expectedHasRestrictions: false,
 		},
 	}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_test.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/engine_test.go
@@ -7,6 +7,8 @@ package multitenancy
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -742,6 +744,259 @@ func TestEngine_GetNamespaceAccessType(t *testing.T) {
 			}
 		})
 	}
+}
+
+// writeConfigJSON is a small helper for tests that exercise renewDirectories
+// with hand-crafted JSON: it writes the supplied raw JSON into a temp file
+// and returns the path. We do not reuse coverage_test.go's writeConfig because
+// that helper requires a fully-typed UserAuthzConfig, which is awkward for
+// table-driven cases that mix CARs and ARs.
+func writeConfigJSON(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	return path
+}
+
+// TestEngine_RenewDirectories_AuthorizationRules verifies that AuthorizationRules
+// (namespaced) are parsed from config.json and translated into per-namespace
+// grants in the engine's directory. This is the regression test for the
+// deny-by-default bug where AR-only users lost access to their namespaces.
+func TestEngine_RenewDirectories_AuthorizationRules(t *testing.T) {
+	tests := []struct {
+		name             string
+		config           string
+		userInfo         *mockUserInfo
+		namespace        string
+		expectedDecision authorizer.Decision
+		expectedAllowed  bool
+	}{
+		{
+			name: "AR-only user gets access to AR's namespace",
+			config: `{
+				"crds": [],
+				"ars": [
+					{
+						"name": "ar0",
+						"namespace": "team-foo",
+						"spec": {"subjects": [{"kind": "Group", "name": "developers"}]}
+					}
+				]
+			}`,
+			userInfo:         &mockUserInfo{name: "alice", groups: []string{"developers"}},
+			namespace:        "team-foo",
+			expectedDecision: authorizer.DecisionNoOpinion,
+			expectedAllowed:  true,
+		},
+		{
+			name: "AR-only user is still denied outside AR's namespace",
+			config: `{
+				"crds": [],
+				"ars": [
+					{
+						"name": "ar0",
+						"namespace": "team-foo",
+						"spec": {"subjects": [{"kind": "Group", "name": "developers"}]}
+					}
+				]
+			}`,
+			userInfo:         &mockUserInfo{name: "alice", groups: []string{"developers"}},
+			namespace:        "team-bar",
+			expectedDecision: authorizer.DecisionDeny,
+			expectedAllowed:  false,
+		},
+		{
+			name: "AR with User subject grants namespace access",
+			config: `{
+				"crds": [],
+				"ars": [
+					{
+						"name": "ar0",
+						"namespace": "team-foo",
+						"spec": {"subjects": [{"kind": "User", "name": "alice"}]}
+					}
+				]
+			}`,
+			userInfo:         &mockUserInfo{name: "alice"},
+			namespace:        "team-foo",
+			expectedAllowed:  true,
+			expectedDecision: authorizer.DecisionNoOpinion,
+		},
+		{
+			name: "AR with ServiceAccount subject defaults SA namespace to AR's namespace",
+			config: `{
+				"crds": [],
+				"ars": [
+					{
+						"name": "ar0",
+						"namespace": "team-foo",
+						"spec": {"subjects": [{"kind": "ServiceAccount", "name": "my-sa"}]}
+					}
+				]
+			}`,
+			userInfo:         &mockUserInfo{name: "system:serviceaccount:team-foo:my-sa"},
+			namespace:        "team-foo",
+			expectedAllowed:  true,
+			expectedDecision: authorizer.DecisionNoOpinion,
+		},
+		{
+			name: "AR with explicit SA namespace is honoured",
+			config: `{
+				"crds": [],
+				"ars": [
+					{
+						"name": "ar0",
+						"namespace": "team-foo",
+						"spec": {"subjects": [{"kind": "ServiceAccount", "name": "my-sa", "namespace": "other-ns"}]}
+					}
+				]
+			}`,
+			userInfo:         &mockUserInfo{name: "system:serviceaccount:other-ns:my-sa"},
+			namespace:        "team-foo",
+			expectedAllowed:  true,
+			expectedDecision: authorizer.DecisionNoOpinion,
+		},
+		{
+			name: "AR in a system namespace unlocks that system namespace",
+			config: `{
+				"crds": [],
+				"ars": [
+					{
+						"name": "ar-sys",
+						"namespace": "d8-monitoring",
+						"spec": {"subjects": [{"kind": "User", "name": "alice"}]}
+					}
+				]
+			}`,
+			userInfo:         &mockUserInfo{name: "alice"},
+			namespace:        "d8-monitoring",
+			expectedAllowed:  true,
+			expectedDecision: authorizer.DecisionNoOpinion,
+		},
+		{
+			name: "AR + CAR: namespaces are unioned",
+			config: `{
+				"crds": [
+					{
+						"name": "car0",
+						"spec": {
+							"limitNamespaces": ["ns-a"],
+							"subjects": [{"kind": "Group", "name": "developers"}]
+						}
+					}
+				],
+				"ars": [
+					{
+						"name": "ar0",
+						"namespace": "ns-b",
+						"spec": {"subjects": [{"kind": "Group", "name": "developers"}]}
+					}
+				]
+			}`,
+			userInfo:         &mockUserInfo{name: "alice", groups: []string{"developers"}},
+			namespace:        "ns-b",
+			expectedAllowed:  true,
+			expectedDecision: authorizer.DecisionNoOpinion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &Engine{
+				configPath: writeConfigJSON(t, tt.config),
+				directory:  map[string]map[string]DirectoryEntry{},
+			}
+			e.renewDirectories()
+
+			assert.Equal(t, tt.expectedAllowed, e.IsNamespaceAllowed(tt.userInfo, tt.namespace),
+				"IsNamespaceAllowed: namespace=%s", tt.namespace)
+
+			attrs := &mockAttrs{
+				userInfo:   tt.userInfo,
+				namespace:  tt.namespace,
+				resource:   "pods",
+				verb:       "get",
+				isResource: true,
+			}
+			decision, _, err := e.Authorize(context.Background(), attrs)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedDecision, decision,
+				"Authorize: namespace=%s", tt.namespace)
+		})
+	}
+}
+
+// TestEngine_RenewDirectories_NamespaceRegexMetacharsAreEscaped is a
+// defense-in-depth check: even if a string with regex metacharacters slipped
+// through Kubernetes' DNS-1123 validation into config.json, the engine must
+// match it literally rather than as a wildcard pattern.
+func TestEngine_RenewDirectories_NamespaceRegexMetacharsAreEscaped(t *testing.T) {
+	// "te.am" contains '.' which is a regex wildcard; the literal namespace
+	// "teXam" must NOT be allowed by an AR scoped to "te.am".
+	config := `{
+		"crds": [],
+		"ars": [
+			{
+				"name": "ar-meta",
+				"namespace": "te.am",
+				"spec": {"subjects": [{"kind": "User", "name": "alice"}]}
+			}
+		]
+	}`
+
+	e := &Engine{
+		configPath: writeConfigJSON(t, config),
+		directory:  map[string]map[string]DirectoryEntry{},
+	}
+	e.renewDirectories()
+
+	userInfo := &mockUserInfo{name: "alice"}
+
+	assert.True(t, e.IsNamespaceAllowed(userInfo, "te.am"),
+		"literal namespace must still match")
+	assert.False(t, e.IsNamespaceAllowed(userInfo, "teXam"),
+		"regex metacharacters must be escaped: 'te.am' must not match 'teXam'")
+	assert.False(t, e.IsNamespaceAllowed(userInfo, "team"),
+		"regex metacharacters must be escaped: 'te.am' must not match 'team'")
+}
+
+// TestEngine_RenewDirectories_AROnlyUser_ResolverScenario simulates the resolver's
+// path for the accessiblenamespaces API: the user has only ARs and the engine
+// must classify them as FilteredAccess (not NoNamespacesAllowed) so that the
+// AR-derived RoleBinding candidates pass through.
+func TestEngine_RenewDirectories_AROnlyUser_ResolverScenario(t *testing.T) {
+	config := `{
+		"crds": [],
+		"ars": [
+			{
+				"name": "ar0",
+				"namespace": "team-foo",
+				"spec": {"subjects": [{"kind": "Group", "name": "developers"}]}
+			},
+			{
+				"name": "ar1",
+				"namespace": "team-bar",
+				"spec": {"subjects": [{"kind": "Group", "name": "developers"}]}
+			}
+		]
+	}`
+
+	e := &Engine{
+		configPath: writeConfigJSON(t, config),
+		directory:  map[string]map[string]DirectoryEntry{},
+	}
+	e.renewDirectories()
+
+	userInfo := &mockUserInfo{name: "alice", groups: []string{"developers"}}
+
+	accessType, filter := e.GetNamespaceAccessType(userInfo)
+	require.Equal(t, FilteredAccess, accessType, "AR-only user must be FilteredAccess, not NoNamespacesAllowed")
+	require.NotNil(t, filter, "filter must be returned for FilteredAccess")
+
+	assert.True(t, e.IsNamespaceAllowedWithFilter("team-foo", filter), "AR namespace must be allowed")
+	assert.True(t, e.IsNamespaceAllowedWithFilter("team-bar", filter), "second AR namespace must be allowed")
+	assert.False(t, e.IsNamespaceAllowedWithFilter("team-baz", filter), "namespaces outside ARs must be denied")
 }
 
 func TestEngine_GetAllowedNamespaces(t *testing.T) {

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/system.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/system.go
@@ -31,3 +31,11 @@ func isSystemNamespace(namespace string) bool {
 	}
 	return false
 }
+
+func systemNamespaceAllowed(entry *DirectoryEntry, namespace string) bool {
+	if entry.AllowAccessToSystemNamespaces {
+		return true
+	}
+	_, ok := entry.AllowedSystemNamespaces[namespace]
+	return ok
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/system.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/system.go
@@ -21,3 +21,13 @@ func init() {
 		systemNamespacesRegex = append(systemNamespacesRegex, r)
 	}
 }
+
+// isSystemNamespace reports whether ns matches a reserved system pattern.
+func isSystemNamespace(namespace string) bool {
+	for _, pattern := range systemNamespacesRegex {
+		if pattern.MatchString(namespace) {
+			return true
+		}
+	}
+	return false
+}

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
@@ -31,7 +31,8 @@ type DirectoryEntry struct {
 	// If there is no LimitNamespaces nor NamespaceSelectors options, the user has access to all namespaces except system namespaces.
 	// If LimitNamespaces is present, we do not need to mind about allowed access to system namespaces.
 	// Thus presence of LimitNamespaces matters when we summarise rules from all CRs to get the allowed namespaces.
-	NamespaceFiltersAbsent bool
+	NamespaceFiltersAbsent  bool
+	AllowedSystemNamespaces map[string]struct{}
 }
 
 // NamespaceSelector defines a selector for namespaces

--- a/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
+++ b/ee/be/modules/140-user-authz/images/permission-browser-apiserver/src/pkg/authorizer/multitenancy/types.go
@@ -40,7 +40,14 @@ type NamespaceSelector struct {
 	MatchAny      bool                  `json:"matchAny"`
 }
 
-// UserAuthzConfig is a config composed from ClusterAuthorizationRules collected from Kubernetes cluster
+// UserAuthzConfig is a config composed from ClusterAuthorizationRules and
+// AuthorizationRules collected from a Kubernetes cluster.
+//
+// CRDs holds cluster-scoped ClusterAuthorizationRules with full multi-tenancy
+// options (limitNamespaces, namespaceSelector, allowAccessToSystemNamespaces).
+//
+// ARs holds namespaced AuthorizationRules. An AR implicitly grants its subjects
+// access to the AR's own namespace; it has no multi-tenancy options.
 type UserAuthzConfig struct {
 	CRDs []struct {
 		Name string `json:"name"`
@@ -63,4 +70,19 @@ type UserAuthzConfig struct {
 			} `json:"subjects"`
 		} `json:"spec,omitempty"`
 	} `json:"crds"`
+
+	ARs []authorizationRule `json:"ars"`
+}
+
+// authorizationRule captures only the AR fields the engine needs.
+type authorizationRule struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Spec      struct {
+		Subjects []struct {
+			Kind      string `json:"kind"`
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"subjects"`
+	} `json:"spec,omitempty"`
 }

--- a/ee/be/modules/140-user-authz/templates/webhook/configmap.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "user-authz-webhook")) | nindent 2 }}
 data:
   config.json: |
-    { "crds": {{ .Values.userAuthz.internal.clusterAuthRuleCrds | toJson}} }
+    { "crds": {{ .Values.userAuthz.internal.clusterAuthRuleCrds | toJson }}, "ars": {{ .Values.userAuthz.internal.authRuleCrds | toJson }} }
 {{- else }}
   {{- range $crd := .Values.userAuthz.internal.clusterAuthRuleCrds }}
     {{- if hasKey $crd.spec "allowAccessToSystemNamespaces" }}

--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -72,6 +72,8 @@ editor:
       name: cluster-write-all
 `
 
+	// Mirrors the config.json rendered by webhook/configmap.yaml: CARs in
+	// "crds", ARs in "ars".
 	testCLusterRoleCRDsWithCRDsKey = `---
 crds:
   - name: testenev
@@ -88,6 +90,15 @@ crds:
       - apiGroup: rbac.authorization.k8s.io
         kind: ClusterRole
         name: cluster-write-all
+ars:
+  - name: testenev-namespaced
+    namespace: testenv
+    spec:
+      accessLevel: Editor
+      allowScale: true
+      subjects:
+      - kind: User
+        name: Namespace Testenev
 `
 
 	testRoleCRDs = `---


### PR DESCRIPTION
## Description

After multitenancy was switched to deny-by-default, users granted access only via namespaced `AuthorizationRule` (AR) — without any `ClusterAuthorizationRule` (CAR) — got an empty `accessiblenamespaces` response, even though their ARs had already produced valid RoleBindings.

`webhook/configmap.yaml` now also serializes `authRuleCrds` into `config.json`, and the `permission-browser-apiserver` multitenancy engine consumes them: every AR adds its own namespace to the subject's `LimitNamespaces`. The user-authz-webhook still reads only `crds` and ignores unknown fields, so its behavior is unchanged.

## Why do we need it, and what problem does it solve?

Restores `accessiblenamespaces` visibility for users whose access is configured only through `AuthorizationRule`s. Without this fix, such users see an empty namespace list in the UI/CLI despite RBAC allowing them to operate in the AR's namespace.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: AuthorizationRule grants are now reflected in the accessiblenamespaces response from permission-browser-apiserver.
impact_level: low
```