### PR TITLE
[istio] Enrich versionMap with supportsOperator flag (Basement)

### DIFF
--- a/modules/110-istio/hooks/discovery_istiod_health_test.go
+++ b/modules/110-istio/hooks/discovery_istiod_health_test.go
@@ -77,12 +77,14 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
         "1.33": {
           "revision": "v1x33",
           "fullVersion": "1.13.55",
-          "supportsAmbient": false
+          "supportsAmbient": false,
+          "supportsOperator": true
        },
        "1.88": {
           "revision": "v1x88",
           "fullVersion": "1.88.55",
-          "supportsAmbient": true
+          "supportsAmbient": true,
+          "supportsOperator": false
         }
       }
     }
@@ -139,7 +141,7 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeFalse())
-			Expect(f.ValuesGet(versionMapPath).String()).To(MatchJSON(`{"1.33":{"fullVersion":"1.13.55","revision":"v1x33","imageSuffix":"","isReady":false,"supportsAmbient":false},"1.88":{"fullVersion":"1.88.55","revision":"v1x88","imageSuffix":"","isReady":false,"supportsAmbient":true}}`))
+			Expect(f.ValuesGet(versionMapPath).String()).To(MatchJSON(`{"1.33":{"fullVersion":"1.13.55","revision":"v1x33","imageSuffix":"","isReady":false,"supportsAmbient":false,"supportsOperator":true},"1.88":{"fullVersion":"1.88.55","revision":"v1x88","imageSuffix":"","isReady":false,"supportsAmbient":true,"supportsOperator":false}}`))
 		})
 	})
 
@@ -157,8 +159,8 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeTrue())
 			versionMap := f.ValuesGet(versionMapPath).Map()
-			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": false,"supportsAmbient":false}`))
-			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": true,"supportsAmbient":true}`))
+			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": false,"supportsAmbient":false,"supportsOperator":true}`))
+			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": true,"supportsAmbient":true,"supportsOperator":false}`))
 		})
 	})
 
@@ -176,8 +178,8 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeTrue())
 			versionMap := f.ValuesGet(versionMapPath).Map()
-			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": false,"supportsAmbient":false}`))
-			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": false,"supportsAmbient":true}`))
+			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": false,"supportsAmbient":false,"supportsOperator":true}`))
+			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": false,"supportsAmbient":true,"supportsOperator":false}`))
 		})
 	})
 
@@ -200,8 +202,8 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeTrue())
 			versionMap := f.ValuesGet(versionMapPath).Map()
-			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": true,"supportsAmbient":false}`))
-			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": false,"supportsAmbient":true}`))
+			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": true,"supportsAmbient":false,"supportsOperator":true}`))
+			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": false,"supportsAmbient":true,"supportsOperator":false}`))
 		})
 	})
 

--- a/modules/110-istio/hooks/discovery_versions.go
+++ b/modules/110-istio/hooks/discovery_versions.go
@@ -67,8 +67,8 @@ func imageToIstioVersion(img string) (*IstioVersion, error) {
 	supportsAmbient := versionSemver.GreaterThanEqual(ambientMinVersion)
 
 	// Operator is supported for versions lower than 1.27.9
-	operatorFreeMinVersion := semver.MustParse("1.27.9")
-	supportsOperator := versionSemver.LessThan(operatorFreeMinVersion)
+	supportOperatorCutoffVersion := semver.MustParse("1.27.9")
+	supportsOperator := versionSemver.LessThan(supportOperatorCutoffVersion)
 
 	return &IstioVersion{
 		version: fmt.Sprintf(versionTemplate, major, minor),

--- a/modules/110-istio/hooks/discovery_versions.go
+++ b/modules/110-istio/hooks/discovery_versions.go
@@ -66,6 +66,10 @@ func imageToIstioVersion(img string) (*IstioVersion, error) {
 	ambientMinVersion := semver.MustParse("1.25.0")
 	supportsAmbient := versionSemver.GreaterThanEqual(ambientMinVersion)
 
+	// Operator free state is available starting with version 1.27.9
+	operatorFreeMinVersion := semver.MustParse("1.27.9")
+	isOperatorFree := versionSemver.GreaterThanEqual(operatorFreeMinVersion)
+
 	return &IstioVersion{
 		version: fmt.Sprintf(versionTemplate, major, minor),
 		info: istio_versions.IstioVersionInfo{
@@ -74,6 +78,7 @@ func imageToIstioVersion(img string) (*IstioVersion, error) {
 			ImageSuffix:     fmt.Sprintf(imageSuffixTemplate, major, minor, patch),
 			IsReady:         false,
 			SupportsAmbient: supportsAmbient,
+			IsOperatorFree:  isOperatorFree,
 		},
 	}, nil
 }

--- a/modules/110-istio/hooks/discovery_versions.go
+++ b/modules/110-istio/hooks/discovery_versions.go
@@ -66,19 +66,19 @@ func imageToIstioVersion(img string) (*IstioVersion, error) {
 	ambientMinVersion := semver.MustParse("1.25.0")
 	supportsAmbient := versionSemver.GreaterThanEqual(ambientMinVersion)
 
-	// Operator free state is available starting with version 1.27.9
+	// Operator is supported for versions lower than 1.27.9
 	operatorFreeMinVersion := semver.MustParse("1.27.9")
-	isOperatorFree := versionSemver.GreaterThanEqual(operatorFreeMinVersion)
+	supportsOperator := versionSemver.LessThan(operatorFreeMinVersion)
 
 	return &IstioVersion{
 		version: fmt.Sprintf(versionTemplate, major, minor),
 		info: istio_versions.IstioVersionInfo{
-			FullVersion:     fullVersion,
-			Revision:        fmt.Sprintf(revisionTemplate, major, minor),
-			ImageSuffix:     fmt.Sprintf(imageSuffixTemplate, major, minor, patch),
-			IsReady:         false,
-			SupportsAmbient: supportsAmbient,
-			IsOperatorFree:  isOperatorFree,
+			FullVersion:      fullVersion,
+			Revision:         fmt.Sprintf(revisionTemplate, major, minor),
+			ImageSuffix:      fmt.Sprintf(imageSuffixTemplate, major, minor, patch),
+			IsReady:          false,
+			SupportsAmbient:  supportsAmbient,
+			SupportsOperator: supportsOperator,
 		},
 	}, nil
 }

--- a/modules/110-istio/hooks/discovery_versions_test.go
+++ b/modules/110-istio/hooks/discovery_versions_test.go
@@ -66,42 +66,42 @@ pilotVx11x11x11x11: "old-pilot-img"
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.imageSuffix").String()).To(Equal("V1x22x3"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.isReady").Bool()).To(BeFalse())
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.supportsAmbient").Bool()).To(BeFalse())
-			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.isOperatorFree").Bool()).To(BeFalse())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.supportsOperator").Bool()).To(BeTrue())
 			// 1.55
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.fullVersion").String()).To(Equal("1.55.6"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.revision").String()).To(Equal("v1x55"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.imageSuffix").String()).To(Equal("V1x55x6"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.isReady").Bool()).To(BeFalse())
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.supportsAmbient").Bool()).To(BeTrue())
-			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.isOperatorFree").Bool()).To(BeTrue())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.supportsOperator").Bool()).To(BeFalse())
 		})
 	})
 
-	Context("Operator-free boundary version 1.27.8", func() {
+	Context("SupportsOperator boundary version 1.27.8", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global.modulesImages.digests.istio", []byte(`pilotV1x27x8: "pilot-img"`))
 			f.BindingContexts.Set(f.KubeStateSet(``))
 			f.RunHook()
 		})
 
-		It("does not mark version as operator-free", func() {
+		It("marks version as supporting operator", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.fullVersion").String()).To(Equal("1.27.8"))
-			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.isOperatorFree").Bool()).To(BeFalse())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.supportsOperator").Bool()).To(BeTrue())
 		})
 	})
 
-	Context("Operator-free boundary version 1.27.9", func() {
+	Context("SupportsOperator boundary version 1.27.9", func() {
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global.modulesImages.digests.istio", []byte(`pilotV1x27x9: "pilot-img"`))
 			f.BindingContexts.Set(f.KubeStateSet(``))
 			f.RunHook()
 		})
 
-		It("marks version as operator-free", func() {
+		It("does not mark version as supporting operator", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.fullVersion").String()).To(Equal("1.27.9"))
-			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.isOperatorFree").Bool()).To(BeTrue())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.supportsOperator").Bool()).To(BeFalse())
 		})
 	})
 

--- a/modules/110-istio/hooks/discovery_versions_test.go
+++ b/modules/110-istio/hooks/discovery_versions_test.go
@@ -66,12 +66,42 @@ pilotVx11x11x11x11: "old-pilot-img"
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.imageSuffix").String()).To(Equal("V1x22x3"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.isReady").Bool()).To(BeFalse())
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.supportsAmbient").Bool()).To(BeFalse())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.22.isOperatorFree").Bool()).To(BeFalse())
 			// 1.55
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.fullVersion").String()).To(Equal("1.55.6"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.revision").String()).To(Equal("v1x55"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.imageSuffix").String()).To(Equal("V1x55x6"))
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.isReady").Bool()).To(BeFalse())
 			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.supportsAmbient").Bool()).To(BeTrue())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.55.isOperatorFree").Bool()).To(BeTrue())
+		})
+	})
+
+	Context("Operator-free boundary version 1.27.8", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.modulesImages.digests.istio", []byte(`pilotV1x27x8: "pilot-img"`))
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("does not mark version as operator-free", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.fullVersion").String()).To(Equal("1.27.8"))
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.isOperatorFree").Bool()).To(BeFalse())
+		})
+	})
+
+	Context("Operator-free boundary version 1.27.9", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global.modulesImages.digests.istio", []byte(`pilotV1x27x9: "pilot-img"`))
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("marks version as operator-free", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.fullVersion").String()).To(Equal("1.27.9"))
+			Expect(f.ValuesGet("istio.internal.versionMap.1\\.27.isOperatorFree").Bool()).To(BeTrue())
 		})
 	})
 

--- a/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
+++ b/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
@@ -26,6 +26,7 @@ type IstioVersionInfo struct {
 	ImageSuffix     string `json:"imageSuffix"`
 	IsReady         bool   `json:"isReady"`
 	SupportsAmbient bool   `json:"supportsAmbient"`
+	IsOperatorFree  bool   `json:"isOperatorFree"`
 }
 
 func (vm IstioVersionsMap) GetVersionByRevision(rev string) string {
@@ -59,6 +60,15 @@ func (vm IstioVersionsMap) DoesSupportAmbient(fullVer string) bool {
 	for _, istioVerInfo := range vm {
 		if istioVerInfo.FullVersion == fullVer {
 			return istioVerInfo.SupportsAmbient
+		}
+	}
+	return false
+}
+
+func (vm IstioVersionsMap) IsOperatorFree(fullVer string) bool {
+	for _, istioVerInfo := range vm {
+		if istioVerInfo.FullVersion == fullVer {
+			return istioVerInfo.IsOperatorFree
 		}
 	}
 	return false

--- a/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
+++ b/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
@@ -21,12 +21,12 @@ import "encoding/json"
 type IstioVersionsMap map[string]IstioVersionInfo
 
 type IstioVersionInfo struct {
-	FullVersion     string `json:"fullVersion"`
-	Revision        string `json:"revision"`
-	ImageSuffix     string `json:"imageSuffix"`
-	IsReady         bool   `json:"isReady"`
-	SupportsAmbient  bool `json:"supportsAmbient"`
-	SupportsOperator bool `json:"supportsOperator"`
+	FullVersion      string `json:"fullVersion"`
+	Revision         string `json:"revision"`
+	ImageSuffix      string `json:"imageSuffix"`
+	IsReady          bool   `json:"isReady"`
+	SupportsAmbient  bool   `json:"supportsAmbient"`
+	SupportsOperator bool   `json:"supportsOperator"`
 }
 
 func (vm IstioVersionsMap) GetVersionByRevision(rev string) string {

--- a/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
+++ b/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
@@ -25,8 +25,8 @@ type IstioVersionInfo struct {
 	Revision        string `json:"revision"`
 	ImageSuffix     string `json:"imageSuffix"`
 	IsReady         bool   `json:"isReady"`
-	SupportsAmbient bool   `json:"supportsAmbient"`
-	IsOperatorFree  bool   `json:"isOperatorFree"`
+	SupportsAmbient  bool `json:"supportsAmbient"`
+	SupportsOperator bool `json:"supportsOperator"`
 }
 
 func (vm IstioVersionsMap) GetVersionByRevision(rev string) string {
@@ -65,10 +65,10 @@ func (vm IstioVersionsMap) DoesSupportAmbient(fullVer string) bool {
 	return false
 }
 
-func (vm IstioVersionsMap) IsOperatorFree(fullVer string) bool {
+func (vm IstioVersionsMap) DoesSupportOperator(fullVer string) bool {
 	for _, istioVerInfo := range vm {
 		if istioVerInfo.FullVersion == fullVer {
-			return istioVerInfo.IsOperatorFree
+			return istioVerInfo.SupportsOperator
 		}
 	}
 	return false

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -10,7 +10,7 @@ properties:
         type: object
         default: {}
         x-examples:
-          - {"1.25": { "fullVersion": "1.25.2", "revision": "1x25", "imageSuffix": "V1x25x2", "isReady": false, "supportsAmbient": false } } # must be real
+          - {"1.25": { "fullVersion": "1.25.2", "revision": "1x25", "imageSuffix": "V1x25x2", "isReady": false, "supportsAmbient": false, "isOperatorFree": false } } # must be real
         additionalProperties:
           type: object
           properties:
@@ -27,6 +27,9 @@ properties:
               type: boolean
               x-examples: [false]
             supportsAmbient:
+              type: boolean
+              x-examples: [false]
+            isOperatorFree:
               type: boolean
               x-examples: [false]
       kialiSigningKey:

--- a/modules/110-istio/openapi/values.yaml
+++ b/modules/110-istio/openapi/values.yaml
@@ -10,7 +10,7 @@ properties:
         type: object
         default: {}
         x-examples:
-          - {"1.25": { "fullVersion": "1.25.2", "revision": "1x25", "imageSuffix": "V1x25x2", "isReady": false, "supportsAmbient": false, "isOperatorFree": false } } # must be real
+          - {"1.25": { "fullVersion": "1.25.2", "revision": "1x25", "imageSuffix": "V1x25x2", "isReady": false, "supportsAmbient": false, "supportsOperator": true } } # must be real
         additionalProperties:
           type: object
           properties:
@@ -29,9 +29,9 @@ properties:
             supportsAmbient:
               type: boolean
               x-examples: [false]
-            isOperatorFree:
+            supportsOperator:
               type: boolean
-              x-examples: [false]
+              x-examples: [true]
       kialiSigningKey:
         type: string
         x-examples:


### PR DESCRIPTION
## Description
Added `supportsOperator` to `versionMap` controls cuttoff operator version (1.27.9); no consumers. Follow-up PRs will gate operator stack / add custom templates.


## Why do we need it, and what problem does it solve?
This pre-step in adding 1.27 non-operator support to precise control over resources which have to be deployed only for non-operator logic while we have older versions (eg 1.21, 1.25).

Also it needs for cutting off `operatorVersionsToInstall` from `versionsToInstall` as condition in `discovery_operator_versions_to_install.go`

_Changes not affect any behavior - just preparation for next steps._

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Added the supportsOperator flag in istio.internal.versionMap.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
