### PR TITLE
[istio] Fix CVE May#1 - 1.73

### DIFF
--- a/modules/110-istio/images/operator-v1x19x7/known_vulnerabilities.vex
+++ b/modules/110-istio/images/operator-v1x19x7/known_vulnerabilities.vex
@@ -157,7 +157,35 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-22T15:22:41.738294165Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Operator не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:18:01.738294165Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:18:22.738294165Z"
     }
   ],
-  "timestamp": "2026-04-23T11:28Z"
+  "timestamp": "2026-05-20T15:18:44Z"
 }

--- a/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
@@ -101,7 +101,49 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-22T15:16:18.524739084Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus Azure AD remote write client_secret exposed via /-/config (CVE-2026-42151, GHSA-wg65-39gg-5wfj, CWE-312) — Уязвимость относится к раскрытию client_secret конфигурации Azure AD remote write через HTTP API /-/config сервера Prometheus 3.x. Бинарник Istio Operator не запускает сервер Prometheus и не предоставляет указанный endpoint; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:21:01.524739084Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Operator не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:21:12.524739084Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:21:22.524739084Z"
     }
   ],
-  "timestamp": "2026-04-22T15:16Z"
+  "timestamp": "2026-05-20T15:21:35Z"
 }

--- a/modules/110-istio/images/pilot-v1x19x7/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x19x7/known_vulnerabilities.vex
@@ -45,7 +45,35 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-22T15:23:14.529183647Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:18:01.529183647Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:18:22.529183647Z"
     }
   ],
-  "timestamp": "2026-04-22T15:23Z"
+  "timestamp": "2026-05-20T15:18:44Z"
 }

--- a/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
@@ -17,7 +17,49 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-22T15:19:12.483627051Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus Azure AD remote write client_secret exposed via /-/config (CVE-2026-42151, GHSA-wg65-39gg-5wfj, CWE-312) — Уязвимость относится к раскрытию client_secret конфигурации Azure AD remote write через HTTP API /-/config сервера Prometheus 3.x. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не предоставляет указанный endpoint; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T14:07:01.483627051Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T14:07:12.483627051Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T14:07:22.483627051Z"
     }
   ],
-  "timestamp": "2026-04-22T15:19Z"
+  "timestamp": "2026-05-20T14:07:23Z"
 }

--- a/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
@@ -17,7 +17,49 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-23T11:21:18.406527193Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.301.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus Azure AD remote write client_secret exposed via /-/config (CVE-2026-42151, GHSA-wg65-39gg-5wfj, CWE-312) — Уязвимость относится к раскрытию client_secret конфигурации Azure AD remote write через HTTP API /-/config сервера Prometheus 3.x. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не предоставляет указанный endpoint; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:25:01.406527193Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.301.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:25:12.406527193Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.301.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-20T15:25:22.406527193Z"
     }
   ],
-  "timestamp": "2026-04-23T11:21Z"
+  "timestamp": "2026-05-20T15:25:45Z"
 }


### PR DESCRIPTION
## Description
Fixed or justified CVEs (list below)

**Operator 1-19**
justified:
- CVE-2026-42154
- CVE-2026-44903

**Pilot 1-19**
justified:
- CVE-2026-42154
- CVE-2026-44903

**Operator 1-21**
justified:
- CVE-2026-42151
- CVE-2026-42154
- CVE-2026-44903

**Pilot 1-21**
justified:
- CVE-2026-42151
- CVE-2026-42154
- CVE-2026-44903

**Pilot 1-25**
justified:
- CVE-2026-42151
- CVE-2026-42154
- CVE-2026-44903

## Why do we need it, and what problem does it solve?

It keeps application in CVE-free state.

## Why do we need it in the patch release (if we do)?

It keeps application in CVE-free state.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: fixed CVEs in module images
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
