### PR TITLE
[candi] rpp-get install fix

### DIFF
--- a/modules/007-registrypackages/images/rpp-get/src/config.go
+++ b/modules/007-registrypackages/images/rpp-get/src/config.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -52,29 +51,6 @@ type cliConfig struct {
 	kubeAPIServerEndpoints string
 }
 
-func loadConfig(ctx context.Context, args []string) (config, error) {
-	cli, err := parseArgs(args)
-	if err != nil {
-		return config{}, err
-	}
-
-	if err := cli.resolve(ctx); err != nil {
-		return config{}, err
-	}
-
-	if cli.mode != modeUninstall {
-		if !filepath.IsAbs(cli.tempDir) {
-			return config{}, fmt.Errorf("temp-dir must be an absolute path, got %q", cli.tempDir)
-		}
-
-		if err := os.MkdirAll(cli.tempDir, 0o755); err != nil {
-			return config{}, fmt.Errorf("create temp dir: %w", err)
-		}
-	}
-
-	return cli.config, nil
-}
-
 func defaultConfig() config {
 	return config{
 		tempDir:        defaultTempDir,
@@ -84,7 +60,7 @@ func defaultConfig() config {
 	}
 }
 
-func parseArgs(args []string) (cliConfig, error) {
+func parseConfig(args []string) (cliConfig, error) {
 	if len(args) == 0 {
 		return cliConfig{}, fmt.Errorf("mode is required, expected one of: %s, %s, %s", modeFetch, modeInstall, modeUninstall)
 	}
@@ -191,6 +167,7 @@ func (c *cliConfig) resolveFromKube(ctx context.Context) error {
 		return fmt.Errorf("init kube client from kubelet config: %w", err)
 	}
 	if err == nil {
+		log.Printf("rpp endpoints not provided via flag or env, querying kube-apiserver via kubelet config for pods app=registry-packages-proxy in d8-cloud-instance-manager")
 		return c.retryKubeFetch(ctx, func(_ int) (kube.Client, error) {
 			return kubeClient, nil
 		})
@@ -201,6 +178,7 @@ func (c *cliConfig) resolveFromKube(ctx context.Context) error {
 		return errNoBootstrapAPIServerEndpoints
 	}
 
+	log.Printf("rpp endpoints not provided and no kubelet config found, querying kube-apiserver directly via bootstrap endpoints %v for pods app=registry-packages-proxy in d8-cloud-instance-manager", apiServerEndpoints)
 	return c.retryKubeFetch(ctx, func(attempt int) (kube.Client, error) {
 		endpoint := apiServerEndpoints[(attempt-1)%len(apiServerEndpoints)]
 		return kube.NewBootstrapClient(endpoint)
@@ -211,7 +189,8 @@ func (c *cliConfig) retryKubeFetch(ctx context.Context, clientFn func(attempt in
 	var lastErr error
 	for attempt := 1; attempt <= kubeRetries; attempt++ {
 		if attempt > 1 {
-			log.Printf("kube retry %d/%d (previous error: %v)", attempt, kubeRetries, lastErr)
+			log.Printf("kube-apiserver request failed (attempt %d/%d): %s; retrying in %s",
+				attempt-1, kubeRetries, friendlyKubeError(lastErr), kubeRetryDelay)
 			if err := waitRetry(ctx, kubeRetryDelay); err != nil {
 				return err
 			}
@@ -229,7 +208,8 @@ func (c *cliConfig) retryKubeFetch(ctx context.Context, clientFn func(attempt in
 		}
 		return nil
 	}
-	return lastErr
+	return fmt.Errorf("kube-apiserver unreachable after %d attempts: %s (last error: %w)",
+		kubeRetries, friendlyKubeError(lastErr), lastErr)
 }
 
 func (c *cliConfig) fetchFromKube(ctx context.Context, kubeClient kube.Client) error {
@@ -247,4 +227,27 @@ func (c *cliConfig) fetchFromKube(ctx context.Context, kubeClient kube.Client) e
 	c.token = token
 	log.Printf("rpp endpoints obtained from kube: %v", c.endpoints)
 	return nil
+}
+
+func friendlyKubeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "EOF"):
+		return "connection closed by kube-apiserver before response (EOF) — apiserver may be down, restarting, or rejecting the connection"
+	case strings.Contains(msg, "connection refused"):
+		return "kube-apiserver refused the connection — apiserver is not listening on this address"
+	case strings.Contains(msg, "no such host"):
+		return "kube-apiserver host could not be resolved — check DNS or endpoint configuration"
+	case strings.Contains(msg, "i/o timeout"), strings.Contains(msg, "context deadline exceeded"):
+		return "kube-apiserver did not respond in time — apiserver overloaded or network blocked"
+	case strings.Contains(msg, "x509"), strings.Contains(msg, "certificate"):
+		return "TLS handshake with kube-apiserver failed — check CA bundle"
+	case strings.Contains(msg, "401"), strings.Contains(msg, "403"):
+		return "kube-apiserver rejected credentials — token missing or insufficient RBAC for pods in d8-cloud-instance-manager"
+	default:
+		return msg
+	}
 }

--- a/modules/007-registrypackages/images/rpp-get/src/config_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/config_test.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 )
 
-func TestParseArgs(t *testing.T) {
+func TestParseConfig(t *testing.T) {
 	t.Run("valid install mode", func(t *testing.T) {
-		cli, err := parseArgs([]string{"install", "pkg:sha256:abc"})
+		cli, err := parseConfig([]string{"install", "pkg:sha256:abc"})
 		if err != nil {
-			t.Fatalf("parseArgs() error = %v", err)
+			t.Fatalf("parseConfig() error = %v", err)
 		}
 		if cli.mode != modeInstall {
 			t.Errorf("mode = %q, want %q", cli.mode, modeInstall)
@@ -36,9 +36,9 @@ func TestParseArgs(t *testing.T) {
 	})
 
 	t.Run("valid fetch mode", func(t *testing.T) {
-		cli, err := parseArgs([]string{"fetch"})
+		cli, err := parseConfig([]string{"fetch"})
 		if err != nil {
-			t.Fatalf("parseArgs() error = %v", err)
+			t.Fatalf("parseConfig() error = %v", err)
 		}
 		if cli.mode != modeFetch {
 			t.Errorf("mode = %q, want %q", cli.mode, modeFetch)
@@ -46,9 +46,9 @@ func TestParseArgs(t *testing.T) {
 	})
 
 	t.Run("valid uninstall mode", func(t *testing.T) {
-		cli, err := parseArgs([]string{"uninstall", "mypkg"})
+		cli, err := parseConfig([]string{"uninstall", "mypkg"})
 		if err != nil {
-			t.Fatalf("parseArgs() error = %v", err)
+			t.Fatalf("parseConfig() error = %v", err)
 		}
 		if cli.mode != modeUninstall {
 			t.Errorf("mode = %q, want %q", cli.mode, modeUninstall)
@@ -56,23 +56,23 @@ func TestParseArgs(t *testing.T) {
 	})
 
 	t.Run("unknown mode", func(t *testing.T) {
-		_, err := parseArgs([]string{"deploy", "pkg:sha256:abc"})
+		_, err := parseConfig([]string{"deploy", "pkg:sha256:abc"})
 		if err == nil {
-			t.Fatal("parseArgs() error = nil, want error for unknown mode")
+			t.Fatal("parseConfig() error = nil, want error for unknown mode")
 		}
 	})
 
 	t.Run("no args", func(t *testing.T) {
-		_, err := parseArgs(nil)
+		_, err := parseConfig(nil)
 		if err == nil {
-			t.Fatal("parseArgs() error = nil, want error for empty args")
+			t.Fatal("parseConfig() error = nil, want error for empty args")
 		}
 	})
 
 	t.Run("force flag default is false", func(t *testing.T) {
-		cli, err := parseArgs([]string{"install"})
+		cli, err := parseConfig([]string{"install"})
 		if err != nil {
-			t.Fatalf("parseArgs() error = %v", err)
+			t.Fatalf("parseConfig() error = %v", err)
 		}
 		if cli.force {
 			t.Error("force = true, want false by default")
@@ -80,9 +80,9 @@ func TestParseArgs(t *testing.T) {
 	})
 
 	t.Run("force flag enabled", func(t *testing.T) {
-		cli, err := parseArgs([]string{"install", "--force"})
+		cli, err := parseConfig([]string{"install", "--force"})
 		if err != nil {
-			t.Fatalf("parseArgs() error = %v", err)
+			t.Fatalf("parseConfig() error = %v", err)
 		}
 		if !cli.force {
 			t.Error("force = false, want true when --force passed")

--- a/modules/007-registrypackages/images/rpp-get/src/main.go
+++ b/modules/007-registrypackages/images/rpp-get/src/main.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"rpp-get/rpp"
 )
@@ -49,7 +50,7 @@ func main() {
 }
 
 func run(ctx context.Context, logger *log.Logger) error {
-	cfg, err := loadConfig(ctx, os.Args[1:])
+	cfg, err := parseConfig(os.Args[1:])
 	if err != nil {
 		return err
 	}
@@ -62,6 +63,16 @@ func run(ctx context.Context, logger *log.Logger) error {
 			modeInstall,
 			modeUninstall,
 		)
+	}
+
+	if cfg.mode != modeUninstall {
+		if !filepath.IsAbs(cfg.tempDir) {
+			return fmt.Errorf("temp-dir must be an absolute path, got %q", cfg.tempDir)
+		}
+
+		if err := os.MkdirAll(cfg.tempDir, 0o755); err != nil {
+			return fmt.Errorf("create temp dir: %w", err)
+		}
 	}
 
 	recorder, err := rpp.NewResultRecorder(cfg.resultPath)
@@ -87,6 +98,47 @@ func run(ctx context.Context, logger *log.Logger) error {
 	}
 
 	client := rpp.NewClient(rppCfg, logger, recorder)
+
+	if cfg.mode == modeInstall && !cfg.force {
+		statuses, err := client.Classify(cfg.packages)
+		if err != nil {
+			return err
+		}
+
+		installed := make([]string, 0, len(statuses))
+		missing := make([]string, 0, len(statuses))
+		for _, s := range statuses {
+			if s.Installed {
+				installed = append(installed, s.Name)
+			} else {
+				missing = append(missing, s.Name)
+			}
+		}
+
+		logger.Printf("packages already installed (%d): %s", len(installed), strings.Join(installed, ", "))
+		logger.Printf("packages to install (%d): %s", len(missing), strings.Join(missing, ", "))
+
+		if len(missing) == 0 {
+			logger.Printf("nothing to install, skipping endpoint resolution")
+			return client.InstallMissing(ctx, statuses)
+		}
+
+		logger.Printf("resolving rpp endpoints because %d package(s) need installation: %s",
+			len(missing), strings.Join(missing, ", "))
+
+		if err := cfg.resolve(ctx); err != nil {
+			return err
+		}
+		client.UpdateAuth(cfg.endpoints, cfg.token)
+
+		return client.InstallMissing(ctx, statuses)
+	}
+
+	if err := cfg.resolve(ctx); err != nil {
+		return err
+	}
+
+	client.UpdateAuth(cfg.endpoints, cfg.token)
 
 	switch cfg.mode {
 	case modeFetch:

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
@@ -76,6 +76,39 @@ func NewClient(cfg Config, logger *log.Logger, recorder *ResultRecorder) *Client
 	}
 }
 
+type InstallStatus struct {
+	Name      string
+	raw       string
+	Installed bool
+}
+
+func (c *Client) Classify(packages []string) ([]InstallStatus, error) {
+	refs, err := c.newPackageRefs(packages)
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := make([]InstallStatus, 0, len(refs))
+	for _, ref := range refs {
+		installed, err := c.isPackageInstalled(ref)
+		if err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, InstallStatus{
+			Name:      ref.name,
+			raw:       ref.raw,
+			Installed: installed,
+		})
+	}
+	return statuses, nil
+}
+
+func (c *Client) UpdateAuth(endpoints []string, token string) {
+	c.cfg.Endpoints = endpoints
+	c.cfg.Token = token
+	c.httpClient = newHTTPClient(c.cfg)
+}
+
 func installWorkerCount() int {
 	workers := runtime.NumCPU()
 	if workers < 1 {
@@ -101,6 +134,24 @@ func (c *Client) InstallAll(ctx context.Context, args []string) error {
 	}
 
 	return c.runAll(ctx, refs, c.installPackage)
+}
+
+func (c *Client) InstallMissing(ctx context.Context, statuses []InstallStatus) error {
+	missing := make([]packageRef, 0, len(statuses))
+	for _, s := range statuses {
+		if s.Installed {
+			if err := c.writeResult(resultSkipped, s.Name); err != nil {
+				return err
+			}
+			continue
+		}
+		ref, err := c.newPackageRef(s.raw)
+		if err != nil {
+			return err
+		}
+		missing = append(missing, ref)
+	}
+	return c.runAll(ctx, missing, c.installPackage)
 }
 
 func (c *Client) runAll(ctx context.Context, refs []packageRef, action func(context.Context, packageRef) error) error {


### PR DESCRIPTION
## Description

Implemented an early exit fast-path for the rpp-get install command 

## Why do we need it, and what problem does it solve?

rpp-get install previously queried the Kubernetes API for endpoints even when all packages were already installed locally. This caused unnecessary delays and opaque API errors. Now, it checks local state first, skips API queries if packages are present, and provides clear logs for API connection issue

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registry-packages-proxy
type: fix
summary: Added a fast path for already installed packages and improved logging in rpp-get.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
