### PR TITLE
[deckhouse] enhance scheduler

### DIFF
--- a/deckhouse-controller/internal/packages/runtime/apps.go
+++ b/deckhouse-controller/internal/packages/runtime/apps.go
@@ -151,8 +151,16 @@ func (r *Runtime) loadApp(ctx context.Context, repo registry.Remote, packagePath
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Optimistically register the app before AddNode so a successful schedule
+	// can resolve it; if AddNode rejects the addition (dependency cycle),
+	// roll back the map entry so we never expose a package the scheduler
+	// never accepted.
 	r.apps[app.GetName()] = app
-	r.scheduler.AddNode(app)
+	if err = r.scheduler.AddNode(app); err != nil {
+		delete(r.apps, app.GetName())
+		span.SetStatus(codes.Error, err.Error())
+		return "", status.NewError("DependencyCycle", err)
+	}
 
 	return app.GetVersion().String(), nil
 }

--- a/deckhouse-controller/internal/packages/runtime/modules.go
+++ b/deckhouse-controller/internal/packages/runtime/modules.go
@@ -123,8 +123,16 @@ func (r *Runtime) loadModule(ctx context.Context, repo registry.Remote, packageP
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Optimistically register the module before AddNode so a successful
+	// schedule can resolve it; if AddNode rejects the addition (dependency
+	// cycle), roll back the map entry so we never expose a package the
+	// scheduler never accepted.
 	r.modules[module.GetName()] = module
-	r.scheduler.AddNode(module)
+	if err = r.scheduler.AddNode(module); err != nil {
+		delete(r.modules, module.GetName())
+		span.SetStatus(codes.Error, err.Error())
+		return "", status.NewError("DependencyCycle", err)
+	}
 
 	return module.GetVersion().String(), nil
 }

--- a/deckhouse-controller/internal/packages/runtime/runtime.go
+++ b/deckhouse-controller/internal/packages/runtime/runtime.go
@@ -693,7 +693,10 @@ func (r *Runtime) ResumeScheduler() {
 	r.scheduler.Resume()
 }
 
-// CheckConstraints checks constraints in scheduler
-func (r *Runtime) CheckConstraints(constraints schedule.Constraints) error {
-	return r.scheduler.CheckConstraints(constraints)
+// CheckConstraints validates the proposed package constraints against the
+// current cluster state and dependency graph. The `name` is the scheduler-side
+// identifier (apps.BuildName for applications, module name for modules) and is
+// used by the cycle simulation step to identify the proposed graph vertex.
+func (r *Runtime) CheckConstraints(name string, constraints schedule.Constraints) error {
+	return r.scheduler.CheckConstraints(name, constraints)
 }

--- a/deckhouse-controller/internal/packages/schedule/dump.go
+++ b/deckhouse-controller/internal/packages/schedule/dump.go
@@ -16,7 +16,6 @@ package schedule
 
 import (
 	"maps"
-	"slices"
 
 	"sigs.k8s.io/yaml"
 
@@ -34,8 +33,6 @@ type nodeDump struct {
 	Order        Order                 `json:"order" yaml:"order"`
 	State        nodeState             `json:"state" yaml:"state"`
 	Status       checker.Result        `json:"status" yaml:"status"`
-	Followees    []string              `json:"followees,omitempty" yaml:"followees,omitempty"`
-	Followers    []string              `json:"followers,omitempty" yaml:"followers,omitempty"`
 	Dependencies map[string]Dependency `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
 }
 
@@ -54,8 +51,6 @@ func (s *Scheduler) Dump() []byte {
 			Order:        n.order,
 			State:        n.state,
 			Status:       n.status,
-			Followees:    slices.Collect(maps.Keys(n.followees)),
-			Followers:    slices.Collect(maps.Keys(n.followers)),
 			Dependencies: maps.Clone(n.dependencies),
 		}
 	}
@@ -83,8 +78,6 @@ func (s *Scheduler) DumpByName(name string) []byte {
 		Order:        n.order,
 		State:        n.state,
 		Status:       n.status,
-		Followees:    slices.Collect(maps.Keys(n.followees)),
-		Followers:    slices.Collect(maps.Keys(n.followers)),
 		Dependencies: maps.Clone(n.dependencies),
 	}
 

--- a/deckhouse-controller/internal/packages/schedule/node.go
+++ b/deckhouse-controller/internal/packages/schedule/node.go
@@ -48,7 +48,7 @@ type Constraints struct {
 	Order        Order                 // Scheduling priority; lower values run first.
 	Kubernetes   *semver.Constraints   // Kubernetes version constraint (e.g., ">=1.21")
 	Deckhouse    *semver.Constraints   // Deckhouse version constraint (e.g., ">=1.60")
-	Dependencies map[string]Dependency // Inter-package dependencies; keyed by package name.
+	Dependencies map[string]Dependency // Inter-package dependencies; keyed by package name. Source of topological ordering and checker inputs.
 }
 
 // Dependency describes a requirement on another package, with an optional
@@ -66,74 +66,33 @@ type Order uint
 // used to evaluate eligibility on each scheduling pass.
 type node struct {
 	name    string          // Unique package name; also used as the graph vertex key.
-	version *semver.Version // Current installed version; used by dependency checkers of followers.
+	version *semver.Version // Current installed version; used by dependency checkers of dependents.
 
 	state nodeState // Lifecycle phase: idle → scheduled → active.
 	order Order     // Scheduling priority; lower values run before higher ones.
 
 	status checker.Result // Last computed enabled/disabled result from the checker chain.
 
-	followees    map[string]struct{}   // Packages this node waits for before it can be scheduled.
-	followers    map[string]struct{}   // Packages that are waiting on this node to become active.
-	dependencies map[string]Dependency // Declared dependency constraints (version bounds, optional flag).
+	dependencies map[string]Dependency // Declared dependency constraints — source of topological ordering and checker inputs.
 
 	checkers []checker.Checker // Ordered list of checkers to evaluate
 }
 
-// addNode creates a node from a Package, wires followee/follower edges in both
-// directions, attaches version/condition/dependency checkers, and inserts the
-// node into the graph. It does NOT trigger a scheduling pass — the caller is
-// responsible for that.
+// addNode creates a node from a Package, attaches the checker chain, and
+// inserts the node into the graph. It does NOT trigger a scheduling pass —
+// the caller is responsible for that.
 //
-// If a node with the same name already exists (version update), its stale
-// reverse edges are cleaned up before the new node is inserted. This prevents
-// old followees from keeping the package as a follower after its constraints change.
+// Ordering is derived from n.dependencies by topoSort; enable state is
+// computed by the checker chain.
 func (s *Scheduler) addNode(pkg Package) {
-	// Clean up stale reverse edges from the previous node (if any).
-	// Without this, a dependency dropped in the new version would still
-	// hold a followers["name"] reference and spuriously trigger this node.
-	if old, ok := s.nodes[pkg.GetName()]; ok {
-		for dep := range old.followees {
-			if parent, ok := s.nodes[dep]; ok {
-				delete(parent.followers, old.name)
-			}
-		}
-	}
+	constraints := pkg.GetConstraints()
 
 	n := &node{
 		name:         pkg.GetName(),
 		version:      pkg.GetVersion(),
 		state:        nodeStateIdle,
-		followees:    make(map[string]struct{}),
-		followers:    make(map[string]struct{}),
-		dependencies: maps.Clone(pkg.GetConstraints().Dependencies),
-	}
-
-	constraints := pkg.GetConstraints()
-
-	n.order = constraints.Order
-
-	for dep := range constraints.Dependencies {
-		n.followees[dep] = struct{}{}
-
-		if parent, ok := s.nodes[dep]; ok {
-			parent.followers[n.name] = struct{}{}
-		}
-	}
-
-	if n.name != packageGlobal {
-		n.followees[packageGlobal] = struct{}{}
-
-		// all packages should be subscribed to global
-		if global, ok := s.nodes[packageGlobal]; ok {
-			global.followers[n.name] = struct{}{}
-		}
-	}
-
-	for _, existing := range s.nodes {
-		if _, ok := existing.followees[n.name]; ok {
-			n.followers[existing.name] = struct{}{}
-		}
+		order:        constraints.Order,
+		dependencies: maps.Clone(constraints.Dependencies),
 	}
 
 	if constraints.Kubernetes != nil && s.kubeVersionGetter != nil {
@@ -149,7 +108,7 @@ func (s *Scheduler) addNode(pkg Package) {
 	}
 
 	if len(constraints.Dependencies) > 0 && s.dependencyGetter != nil {
-		deps := make(map[string]dependency.Dependency)
+		deps := make(map[string]dependency.Dependency, len(constraints.Dependencies))
 		for name, dep := range constraints.Dependencies {
 			deps[name] = dependency.Dependency{
 				Constraint: dep.Constraint,

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -159,8 +159,8 @@ func (s *Scheduler) CheckConstraints(name string, constraints Constraints) error
 
 	if len(constraints.Dependencies) > 0 && s.dependencyGetter != nil {
 		deps := make(map[string]dependency.Dependency, len(constraints.Dependencies))
-		for name, dep := range constraints.Dependencies {
-			deps[name] = dependency.Dependency{
+		for depName, dep := range constraints.Dependencies {
+			deps[depName] = dependency.Dependency{
 				Constraint: dep.Constraint,
 				Optional:   dep.Optional,
 			}

--- a/deckhouse-controller/internal/packages/schedule/scheduler.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler.go
@@ -130,9 +130,16 @@ func (s *Scheduler) Resume() {
 	s.schedule()
 }
 
-// CheckConstraints evaluates the given constraints against the current cluster state
-// and returns an error describing the first unsatisfied constraint, or nil if all are met.
-func (s *Scheduler) CheckConstraints(constraints Constraints) error {
+// CheckConstraints evaluates the given constraints against the current cluster
+// state and the current dependency graph. Returns an error describing the
+// first unsatisfied constraint (version, dependency) or a *CycleError if
+// adding a node named `name` with these dependencies would create a
+// topological cycle. Returns nil only when every check passes and the
+// proposed addition would leave the dep graph acyclic.
+//
+// `name` is the scheduler-side identifier of the package that would be added.
+// It is used by the cycle-simulation step to identify the proposed graph vertex.
+func (s *Scheduler) CheckConstraints(name string, constraints Constraints) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -151,7 +158,7 @@ func (s *Scheduler) CheckConstraints(constraints Constraints) error {
 	}
 
 	if len(constraints.Dependencies) > 0 && s.dependencyGetter != nil {
-		deps := make(map[string]dependency.Dependency)
+		deps := make(map[string]dependency.Dependency, len(constraints.Dependencies))
 		for name, dep := range constraints.Dependencies {
 			deps[name] = dependency.Dependency{
 				Constraint: dep.Constraint,
@@ -166,37 +173,68 @@ func (s *Scheduler) CheckConstraints(constraints Constraints) error {
 		return errors.New(res.Message)
 	}
 
+	return s.simulateCycle(name, constraints)
+}
+
+// simulateCycle returns a *CycleError if adding (or replacing) a node named
+// `name` with the given constraints would create a topological cycle in the
+// current graph. Used by both CheckConstraints (admission-time pre-check) and
+// AddNode (the authoritative gate before any mutation).
+//
+// Must be called with s.mu held in some mode.
+func (s *Scheduler) simulateCycle(name string, constraints Constraints) error {
+	snapshot := make(map[string]*node, len(s.nodes)+1)
+	for nodeName, n := range s.nodes {
+		if nodeName == name {
+			continue
+		}
+
+		snapshot[nodeName] = n
+	}
+
+	snapshot[name] = &node{
+		name:         name,
+		order:        constraints.Order,
+		dependencies: constraints.Dependencies,
+	}
+
+	if _, err := topoSort(snapshot); err != nil {
+		return err
+	}
+
 	return nil
 }
 
-// AddNode registers a single package, wires its dependency edges into the
-// existing graph, and triggers a full scheduling pass. Newly-eligible
-// dependents are advanced automatically.
-func (s *Scheduler) AddNode(pkg Package) {
+// AddNode registers a single package, wires it into the existing graph, and
+// triggers a full scheduling pass. Newly-eligible dependents are advanced
+// automatically.
+//
+// Returns a *CycleError (without mutating any state) if adding the package
+// would close a dependency cycle. Callers are expected to handle the error —
+// typically by surfacing a status condition on the corresponding CR — and to
+// retry once the manifest is fixed.
+func (s *Scheduler) AddNode(pkg Package) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if err := s.simulateCycle(pkg.GetName(), pkg.GetConstraints()); err != nil {
+		return err
+	}
 
 	s.addNode(pkg)
 
 	s.schedule()
+
+	return nil
 }
 
-// RemoveNode removes a package from the graph, cleans up all dependency
-// edges that reference it, and triggers a full reschedule.
+// RemoveNode removes a package from the graph and triggers a full reschedule.
 func (s *Scheduler) RemoveNode(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	n, ok := s.nodes[name]
-	if !ok {
+	if _, ok := s.nodes[name]; !ok {
 		return
-	}
-
-	// Remove this node from the followers set of every node it depends on.
-	for dep := range n.followees {
-		if parent, ok := s.nodes[dep]; ok {
-			delete(parent.followers, name)
-		}
 	}
 
 	delete(s.nodes, name)
@@ -228,38 +266,6 @@ func (s *Scheduler) Complete(completed string) {
 	}
 
 	s.schedule()
-}
-
-// Trigger resets a node's direct followers to idle, then runs a full
-// scheduling pass so they are re-evaluated and potentially rescheduled.
-func (s *Scheduler) Trigger(name string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.trigger(name)
-	s.schedule()
-}
-
-// trigger resets a node's direct followers to idle.
-func (s *Scheduler) trigger(name string) {
-	n, ok := s.nodes[name]
-	if !ok {
-		return
-	}
-
-	for follower := range n.followers {
-		if fn, ok := s.nodes[follower]; ok {
-			fn.state = nodeStateIdle
-		}
-	}
-}
-
-// reconverge resets all nodes to idle
-// forcing the entire graph to re-converge from scratch.
-func (s *Scheduler) reconverge() {
-	for _, n := range s.nodes {
-		n.state = nodeStateIdle
-	}
 }
 
 // Reschedule reverts the named package to idle and runs a full scheduling
@@ -306,32 +312,40 @@ func (s *Scheduler) schedule() {
 }
 
 // compute recomputes the enabled status for all nodes in topological order,
-// guaranteeing that dependencies are resolved before dependents. Nodes that
-// lose eligibility emit an [EventDisable]. If any status changed, reconverge
-// is called to reset the graph for a fresh scheduling pass.
+// guaranteeing that dependencies are resolved before dependents. Nodes whose
+// Enabled status flipped are individually reset to idle so they re-enter the
+// scheduling path on the next pass; nodes that lose eligibility emit an
+// [EventDisable]. No global reconverge happens — canSchedule no longer gates
+// on per-dep state, so one node's status change cannot invalidate another
+// node's schedulability beyond the live order-tier check.
 func (s *Scheduler) compute() []*node {
-	var changed bool
-	sorted := topoSort(s.nodes)
+	// AddNode is the authoritative cycle gate, so topoSort should never
+	// return an error here. The disabled-mark-active loop below walks `sorted`
+	// and relies on that invariant; a cycle slipping through (gate bug) would
+	// leave its members frozen at nodeStateIdle, surfaced quickly by stalled
+	// higher-tier nodes via canSchedule's order-tier gate.
+	sorted, _ := topoSort(s.nodes)
 	for _, n := range sorted {
 		current := n.status.Enabled
 		n.status = checker.Check(n.checkers...)
-		if current != n.status.Enabled {
-			changed = true
+		if current == n.status.Enabled {
+			continue
+		}
 
-			if !n.status.Enabled {
-				s.send(Event{Name: n.name, Kind: EventDisable, Reason: n.status.Reason, Message: n.status.Message})
-			}
+		// Status flipped — reset this node so the next schedule pass can
+		// either re-schedule it (now enabled) or mark it active via the
+		// disabled-mark-active loop below (now disabled).
+		n.state = nodeStateIdle
+
+		if !n.status.Enabled {
+			s.send(Event{Name: n.name, Kind: EventDisable, Reason: n.status.Reason, Message: n.status.Message})
 		}
 	}
 
-	if changed {
-		s.reconverge()
-	}
-
-	// Disabled nodes have nothing to wait for — mark them active so they
-	// do not block higher-order or dependent nodes. If a node later becomes
-	// enabled, the status change above triggers reconverge (resetting all
-	// states to idle), so it will go through normal scheduling.
+	// Disabled nodes have nothing to wait for — mark them active so they do
+	// not block higher-order nodes via canSchedule's order-tier gate. Nodes
+	// that later flip back to enabled are reset to idle by the loop above and
+	// go through normal scheduling from there.
 	for _, n := range sorted {
 		if n.state == nodeStateIdle && !n.status.Enabled {
 			n.state = nodeStateActive
@@ -341,22 +355,17 @@ func (s *Scheduler) compute() []*node {
 	return sorted
 }
 
-// canSchedule returns true if a node is eligible to transition from idle to scheduled.
-// Three conditions must hold:
-//  1. The node must be enabled (all dependency checks passed).
-//  2. All direct dependencies (followees) must be active.
-//  3. All nodes with a strictly lower Order must be active.
+// canSchedule returns true if a node is eligible to transition from idle to
+// scheduled. Two conditions must hold:
+//  1. The node must be enabled (all checkers passed).
+//  2. All nodes with a strictly lower Order must be active.
+//
+// Dependency-level ordering between same-tier nodes is encoded in the checker
+// chain (the dependency.Getter contract returns versions only for nodes that
+// have reached nodeStateActive).
 func (s *Scheduler) canSchedule(n *node) bool {
 	if !n.status.Enabled {
 		return false
-	}
-
-	for dep := range n.followees {
-		if existing, ok := s.nodes[dep]; ok {
-			if existing.state != nodeStateActive {
-				return false
-			}
-		}
 	}
 
 	for _, other := range s.nodes {

--- a/deckhouse-controller/internal/packages/schedule/scheduler_test.go
+++ b/deckhouse-controller/internal/packages/schedule/scheduler_test.go
@@ -1,0 +1,424 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schedule_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/packages/schedule"
+)
+
+// globalName is the literal sentinel used by Scheduler internally; it lives
+// here as a constant so the tests document the contract rather than scatter
+// magic strings.
+const globalName = "global"
+
+// testPackage is a minimal Package implementation used to drive Scheduler
+// behavior from tests; production code uses apps.Application / modules.Module.
+type testPackage struct {
+	name        string
+	version     *semver.Version
+	constraints schedule.Constraints
+}
+
+// GetName returns the package identifier.
+func (p *testPackage) GetName() string { return p.name }
+
+// GetVersion returns the parsed package version.
+func (p *testPackage) GetVersion() *semver.Version { return p.version }
+
+// GetConstraints returns the package's scheduler constraints.
+func (p *testPackage) GetConstraints() schedule.Constraints { return p.constraints }
+
+// mustVersion parses s into a *semver.Version or panics; tests use known-good values.
+func mustVersion(s string) *semver.Version {
+	v, err := semver.NewVersion(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// SchedulerSuite exercises the public Scheduler API end-to-end.
+type SchedulerSuite struct {
+	suite.Suite
+
+	versions map[string]*semver.Version
+	sched    *schedule.Scheduler
+}
+
+// TestSchedulerSuite is the testing.T entry point that runs the suite.
+func TestSchedulerSuite(t *testing.T) {
+	suite.Run(t, new(SchedulerSuite))
+}
+
+// SetupTest builds a fresh scheduler and version map for every test so cases
+// remain isolated. The dependency getter reads from s.versions, letting each
+// test simulate module presence/absence by direct map mutation.
+func (s *SchedulerSuite) SetupTest() {
+	s.versions = make(map[string]*semver.Version)
+	s.sched = schedule.NewScheduler(
+		schedule.WithDependencyGetter(func(name string) *semver.Version {
+			return s.versions[name]
+		}),
+	)
+}
+
+// TearDownTest closes the event channel so a leaked goroutine never wedges
+// the next test.
+func (s *SchedulerSuite) TearDownTest() {
+	s.sched.Stop()
+}
+
+// activateGlobal registers the implicit global package, resumes the scheduler,
+// and drives global to active. Drains all setup events so the test can assert
+// only on the events it triggers itself.
+func (s *SchedulerSuite) activateGlobal() {
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    globalName,
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 0,
+		},
+	}))
+
+	s.sched.Resume()
+	s.sched.Complete(globalName)
+	s.drainEvents()
+}
+
+// drainEvents non-blockingly empties the scheduler's event channel.
+func (s *SchedulerSuite) drainEvents() {
+	for {
+		select {
+		case <-s.sched.Ch():
+		default:
+			return
+		}
+	}
+}
+
+// collectEvents non-blockingly drains and returns the events currently buffered
+// on the scheduler's event channel. Scheduler operations are synchronous, so
+// all events emitted by the preceding call are present by the time this runs.
+func (s *SchedulerSuite) collectEvents() []schedule.Event {
+	var events []schedule.Event
+	for {
+		select {
+		case e := <-s.sched.Ch():
+			events = append(events, e)
+		default:
+			return events
+		}
+	}
+}
+
+// eventNames returns the names of events of the given kind from the slice.
+func eventNames(events []schedule.Event, kind schedule.EventKind) []string {
+	var names []string
+	for _, e := range events {
+		if e.Kind == kind {
+			names = append(names, e.Name)
+		}
+	}
+
+	return names
+}
+
+// TestAddNodeAndSchedule covers the happy-path lifecycle: a node added after
+// global completes is enabled and scheduled on the same scheduling pass.
+func (s *SchedulerSuite) TestAddNodeAndSchedule() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "alpha",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+		},
+	}))
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "alpha")
+}
+
+// TestOrderTierGate confirms that canSchedule's order-tier check holds a
+// higher-tier node back until every lower-tier node is active.
+func (s *SchedulerSuite) TestOrderTierGate() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "critical",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: 1},
+	}))
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "functional",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+
+	scheduled := eventNames(s.collectEvents(), schedule.EventSchedule)
+	s.Contains(scheduled, "critical")
+	s.NotContains(scheduled, "functional", "functional must wait for critical to be active")
+
+	s.sched.Complete("critical")
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "functional")
+}
+
+// TestDisabledNodeUnblocksHigherTier exercises the "mark disabled nodes active"
+// behavior in compute(): a lower-tier node that loses eligibility must not
+// stall higher tiers via the order-tier gate.
+func (s *SchedulerSuite) TestDisabledNodeUnblocksHigherTier() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "lower",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 1,
+			Dependencies: map[string]schedule.Dependency{
+				"never-installed": {},
+			},
+		},
+	}))
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "higher",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+
+	scheduled := eventNames(s.collectEvents(), schedule.EventSchedule)
+	s.NotContains(scheduled, "lower", "lower lost eligibility and must not be scheduled")
+	s.Contains(scheduled, "higher", "higher must not be blocked by the disabled lower-tier node")
+}
+
+// TestMandatoryDependency verifies that a mandatory dep being absent disables
+// the consumer, and that installing the dep flips it back to enabled.
+func (s *SchedulerSuite) TestMandatoryDependency() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "consumer",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"parent": {},
+			},
+		},
+	}))
+
+	// Consumer is born disabled (parent absent); compute() emits no event in
+	// this case because there was no enabled→disabled flip. Just assert it
+	// stays out of the scheduled set.
+	s.NotContains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
+
+	s.versions["parent"] = mustVersion("1.0.0")
+	s.sched.Schedule()
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
+}
+
+// TestConditionalDependencyAbsentIsOK confirms that an optional dep being
+// absent does NOT disable the consumer — only a version mismatch would.
+func (s *SchedulerSuite) TestConditionalDependencyAbsentIsOK() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "consumer",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"optional": {Optional: true},
+			},
+		},
+	}))
+
+	events := s.collectEvents()
+	s.Contains(eventNames(events, schedule.EventSchedule), "consumer")
+	s.NotContains(eventNames(events, schedule.EventDisable), "consumer")
+}
+
+// TestEnabledToDisabledFlipEmitsEventDisable verifies that compute() fires
+// EventDisable when a previously-enabled node loses eligibility (e.g. its
+// dependency is removed from the cluster).
+func (s *SchedulerSuite) TestEnabledToDisabledFlipEmitsEventDisable() {
+	s.activateGlobal()
+
+	s.versions["parent"] = mustVersion("1.0.0")
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "consumer",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"parent": {},
+			},
+		},
+	}))
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
+
+	// Parent disappears — consumer must flip enabled→disabled.
+	delete(s.versions, "parent")
+	s.sched.Schedule()
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventDisable), "consumer")
+}
+
+// TestStatusFlipResetsOnlyAffectedNode is the regression guard for the
+// reconverge removal: when one node's Enabled status flips, other nodes'
+// state must not be reset.
+func (s *SchedulerSuite) TestStatusFlipResetsOnlyAffectedNode() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "stable",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "flapper",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: schedule.FunctionalOrder,
+			Dependencies: map[string]schedule.Dependency{
+				"absent": {},
+			},
+		},
+	}))
+
+	s.sched.Complete("stable")
+	s.drainEvents()
+
+	// stable is now active. Flip flapper from disabled → enabled by installing
+	// its dep. compute() must reset flapper to idle but leave stable alone.
+	s.versions["absent"] = mustVersion("1.0.0")
+	s.sched.Schedule()
+
+	events := s.collectEvents()
+	scheduled := eventNames(events, schedule.EventSchedule)
+	s.Contains(scheduled, "flapper")
+	s.NotContains(scheduled, "stable", "stable was already active; status flip on flapper must not reset it")
+}
+
+// TestAddNodeRejectsCyclicAddition pins AddNode as the authoritative cycle
+// gate: when adding a node would close a dep cycle with an already-registered
+// node, AddNode returns a *CycleError without mutating the graph. Subsequent
+// higher-tier additions schedule normally because the cycle never entered
+// s.nodes.
+func (s *SchedulerSuite) TestAddNodeRejectsCyclicAddition() {
+	s.activateGlobal()
+
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "alpha",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 1,
+			Dependencies: map[string]schedule.Dependency{
+				"beta": {},
+			},
+		},
+	}))
+
+	err := s.sched.AddNode(&testPackage{
+		name:    "beta",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 1,
+			Dependencies: map[string]schedule.Dependency{
+				"alpha": {},
+			},
+		},
+	})
+
+	s.Require().Error(err)
+
+	var cyc *schedule.CycleError
+	s.Require().ErrorAs(err, &cyc)
+	s.ElementsMatch([]string{"alpha", "beta"}, cyc.Members)
+
+	// Cycle never entered the graph — a higher-tier consumer still schedules.
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        "consumer",
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: schedule.FunctionalOrder},
+	}))
+
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), "consumer")
+}
+
+// TestCheckConstraintsRejectsDependencyCycle pins the admission-time cycle
+// gate: when checking constraints for a node whose dependencies would close
+// a cycle with an already-registered node, CheckConstraints returns a
+// *CycleError naming the participants. The graph is not mutated.
+func (s *SchedulerSuite) TestCheckConstraintsRejectsDependencyCycle() {
+	s.activateGlobal()
+
+	// alpha depends on a future beta; no cycle yet (beta isn't in the graph).
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:    "alpha",
+		version: mustVersion("1.0.0"),
+		constraints: schedule.Constraints{
+			Order: 1,
+			Dependencies: map[string]schedule.Dependency{
+				"beta": {},
+			},
+		},
+	}))
+	s.drainEvents()
+
+	// Populate versions so the dep checker chain passes (proposed beta's dep
+	// on alpha is satisfied); cycle simulation is what we want to evaluate.
+	s.versions["alpha"] = mustVersion("1.0.0")
+
+	// Proposed beta depends on alpha. Adding it would create alpha → beta → alpha.
+	err := s.sched.CheckConstraints("beta", schedule.Constraints{
+		Order: 1,
+		Dependencies: map[string]schedule.Dependency{
+			"alpha": {},
+		},
+	})
+
+	s.Require().Error(err)
+
+	var cyc *schedule.CycleError
+	s.Require().ErrorAs(err, &cyc)
+	s.ElementsMatch([]string{"alpha", "beta"}, cyc.Members)
+}
+
+// TestPauseSuppressesScheduling confirms that AddNode does not advance state
+// while the scheduler is paused, and that Resume drains the pending work.
+func (s *SchedulerSuite) TestPauseSuppressesScheduling() {
+	// Scheduler starts paused by construction.
+	s.Require().NoError(s.sched.AddNode(&testPackage{
+		name:        globalName,
+		version:     mustVersion("1.0.0"),
+		constraints: schedule.Constraints{Order: 0},
+	}))
+
+	s.Empty(s.collectEvents(), "paused scheduler must not emit events")
+
+	s.sched.Resume()
+	s.Contains(eventNames(s.collectEvents(), schedule.EventSchedule), globalName)
+}

--- a/deckhouse-controller/internal/packages/schedule/topo.go
+++ b/deckhouse-controller/internal/packages/schedule/topo.go
@@ -16,25 +16,50 @@ package schedule
 
 import (
 	"cmp"
+	"fmt"
 	"slices"
+	"strings"
 )
+
+// CycleError reports a topological cycle in the dependency graph. Members are
+// the participating node names, sorted alphabetically for deterministic output.
+type CycleError struct {
+	Members []string
+}
+
+// Error renders the cycle members in a single line suitable for K8s admission
+// rejections and operator-facing logs.
+func (e *CycleError) Error() string {
+	return fmt.Sprintf("dependency cycle through: %s", strings.Join(e.Members, ", "))
+}
 
 // topoSort returns nodes in topological order respecting dependency edges,
 // with Order as the primary tiebreaker and name as the secondary tiebreaker
 // for nodes at the same topological level.
-// Nodes involved in cycles are silently omitted from the result.
-func topoSort(nodes map[string]*node) []*node {
+//
+// Predecessor edges are derived from n.dependencies directly.
+//
+// On cycle, returns the partial sort plus a *CycleError naming the
+// participants. Callers (CheckConstraints, AddNode) use this to reject
+// configurations that introduce cycles before they hit the live scheduler
+// graph. compute() falls back gracefully if a cycle ever slips through,
+// relying on its disabled-mark-active walk over s.nodes to unblock
+// higher-tier packages.
+func topoSort(nodes map[string]*node) ([]*node, error) {
 	if len(nodes) == 0 {
-		return nil
+		return nil, nil
 	}
 
-	// Compute in-degree: count of followees that actually exist in nodes.
+	// Build the reverse dep map locally so we know whose in-degree to
+	// decrement when a node is processed.
+	dependents := make(map[string][]string, len(nodes))
 	inDegree := make(map[string]int, len(nodes))
 	for name, n := range nodes {
 		deg := 0
-		for dep := range n.followees {
+		for dep := range n.dependencies {
 			if _, ok := nodes[dep]; ok {
 				deg++
+				dependents[dep] = append(dependents[dep], name)
 			}
 		}
 		inDegree[name] = deg
@@ -48,7 +73,7 @@ func topoSort(nodes map[string]*node) []*node {
 		}
 	}
 
-	var result []*node
+	result := make([]*node, 0, len(nodes))
 	for len(ready) > 0 {
 		// Sort ready nodes: Order ASC, then name ASC for determinism.
 		slices.SortFunc(ready, func(a, b *node) int {
@@ -63,16 +88,30 @@ func topoSort(nodes map[string]*node) []*node {
 		ready = ready[1:]
 		result = append(result, n)
 
-		// Decrement in-degree for all followers.
-		for followerName := range n.followers {
-			inDegree[followerName]--
-			if inDegree[followerName] == 0 {
-				if fn, ok := nodes[followerName]; ok {
-					ready = append(ready, fn)
+		// Decrement in-degree for everyone that depends on n.
+		for _, dependentName := range dependents[n.name] {
+			inDegree[dependentName]--
+			if inDegree[dependentName] == 0 {
+				if dn, ok := nodes[dependentName]; ok {
+					ready = append(ready, dn)
 				}
 			}
 		}
 	}
 
-	return result
+	// Any node still carrying positive in-degree participates in a cycle.
+	if len(result) < len(nodes) {
+		members := make([]string, 0, len(nodes)-len(result))
+		for name, deg := range inDegree {
+			if deg > 0 {
+				members = append(members, name)
+			}
+		}
+
+		slices.Sort(members)
+
+		return result, &CycleError{Members: members}
+	}
+
+	return result, nil
 }

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -45,7 +45,7 @@ type moduleStorage interface {
 
 type packageManager interface {
 	ValidateSettings(ctx context.Context, name string, settings addonutils.Values) (settingscheck.Result, error)
-	CheckConstraints(constraints schedule.Constraints) error
+	CheckConstraints(name string, constraints schedule.Constraints) error
 }
 
 type moduleManager interface {

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application.go
@@ -161,8 +161,10 @@ func validateAppAgainstApv(ctx context.Context, cli client.Client, manager packa
 		constraints.Dependencies = modules
 	}
 
-	// Delegate to the manager which checks the parsed constraints against actual cluster state.
-	return manager.CheckConstraints(constraints)
+	// Delegate to the manager which checks the parsed constraints against the
+	// actual cluster state and rejects on dependency cycles. The name is the
+	// scheduler-side identifier (namespace.name) used by the cycle simulation.
+	return manager.CheckConstraints(apps.BuildName(app.Namespace, app.Name), constraints)
 }
 
 // validateAppSettings validates Application.spec.settings against the OpenAPI settings


### PR DESCRIPTION
## Description

Hardens the scheduler with **topological cycle detection** as an authoritative pre-mutation gate, plus the simplifications that fall out of it. Subscribe / reload-propagation work is deferred to a follow-up PR.

**Cycle detection.** New `*CycleError` type. `topoSort` now returns `([]*node, error)`, with predecessor edges derived directly from `n.dependencies` (instead of the dual-purpose `n.followees` set, which is removed — see below). A new `simulateCycle(name, constraints)` runs a snapshot topo sort with the proposed node included and is called by both pre-mutation paths:

- `AddNode(pkg) error` — rejects the addition *without mutating state* if it would close a cycle.
- `CheckConstraints(name string, constraints)` — admission-time pre-check; signature gains the `name` of the would-be node.

Runtime callers (`runtime/apps.go`, `runtime/modules.go`) roll back the optimistic registration on cycle and surface a `DependencyCycle` status error. The admission webhook (`pkg/apis/deckhouse.io/validation/validate_application.go`) passes `apps.BuildName(ns, name)` into `CheckConstraints`. The validation interface in `register.go` follows the signature.

**`compute()` cleanup.** Drops the global `reconverge` — when a node's `Enabled` flips, only that node is reset to idle. With `canSchedule` no longer gating on per-dep state, one node's status change cannot invalidate another node's schedulability beyond the order-tier check, so per-node reset is sufficient and correct.

**Removal of `followees` / `followers` / `Trigger`.** On `main`, `n.followees` / `n.followers` served a dual purpose: dep edges *and* a reload-propagation graph walked by `Trigger`. The same set being both ordering and reload made cycles impossible in either. This PR removes the dual-purpose machinery entirely:

- `node.followees`, `node.followers` fields — gone.
- `addNode`'s edge-wiring loop, `RemoveNode`'s follower cleanup — gone.
- `Scheduler.Trigger` and the package-local `trigger` — gone (no external callers — confirmed with grep).
- `dump.go`'s `Followees` / `Followers` columns — gone.

Ordering is preserved by `topoSort` walking `n.dependencies`; enable state by the checker chain (the `dependency.Getter` returns versions only for active nodes, so consumers stay disabled until parents are active and `compute()`'s flip-detection handles the transition).

The subscribe / reload-propagation concept will re-introduce a *single-purpose* subscription graph in a follow-up — at which point `followees` / `followers` come back, but as subscription edges only, with mutual loops legal because they no longer overlap with the dep graph.

**Tests.** New `scheduler_test.go` with 10 cases covering the happy path, order-tier gating, mandatory/optional dependency semantics, status-flip event emission, the isolated-reset guarantee (regression guard for the `reconverge` removal), and both cycle gates (`AddNode` rejection, `CheckConstraints` rejection).

## Why do we need it, and what problem does it solve?

Three concrete problems on `main`:

- **No cycle detection at admission or registration.** A malformed manifest with a circular dep slipped silently into the live graph; affected nodes simply froze at `idle` with no diagnostic. The admission webhook accepted the manifest; the controller registered it; the scheduler then quietly failed to make progress on the involved nodes. Now `AddNode` rejects the addition without mutating state, and the admission webhook rejects it before it ever reaches the controller — both with a `*CycleError` naming the participants so operators see exactly which packages form the cycle.
- **Global `reconverge` on every status flip.** Resetting every node to `idle` whenever any one node's `Enabled` changed produced unnecessary churn and spurious `EventSchedule` re-emissions. With `canSchedule` no longer gating on followee state, one node's flip cannot invalidate another's schedulability beyond the order-tier check — so the per-node reset added here is sufficient and correct, and the global reset is dead weight.
- **`followees` / `followers` had two meanings stitched together.** The same set was used as the dep graph (must be acyclic) and as the reload-propagation graph (legitimately wants to support mutual edges, e.g. two packages that should reload each other when either changes values). Folding both into one set blocked the reload use case and made every edge ambiguous in the code. Removing the dual-purpose machinery clears the way for a single-purpose subscription graph in the next PR.

The net effect: the dep graph is provably acyclic (gated by `simulateCycle`), `compute()` is simpler and produces less event churn, and the scheduler's data structures now carry exactly one responsibility each — `n.dependencies` owns ordering, the checker chain owns enable state, `canSchedule` owns the order-tier gate. No overlap.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: chore
summary: Enhance scheduler.
impact_level: low
```