### PR TITLE
[deckhouse] fix duplication controllers registration

### DIFF
--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -164,22 +164,18 @@ func NewDeckhouseReleaseController(ctx context.Context, mgr manager.Manager, dc 
 		go r.cleanupDeckhouseReleaseLoop(ctx)
 	}()
 
-	ctr, err := controller.New("deckhouse-release", mgr, controller.Options{
-		MaxConcurrentReconciles: 1,
-		CacheSyncTimeout:        3 * time.Minute,
-		NeedLeaderElection:      ptr.To(false),
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("new: %w", err)
-	}
-
 	r.logger.Info("Controller started")
 
 	if err := ctrl.NewControllerManagedBy(mgr).
+		Named(controllerName).
 		For(&v1alpha1.DeckhouseRelease{}).
 		WithEventFilter(logWrapper{r.logger, newEventFilter()}).
-		Complete(ctr); err != nil {
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+			CacheSyncTimeout:        3 * time.Minute,
+			NeedLeaderElection:      ptr.To(false),
+		}).
+		Complete(r); err != nil {
 		return fmt.Errorf("complete: %w", err)
 	}
 	return nil

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -93,16 +93,8 @@ func RegisterController(
 		return fmt.Errorf("add preflight: %w", err)
 	}
 
-	configController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		NeedLeaderElection:      ptr.To(false),
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	if err := ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.ModuleConfig{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		Watches(&v1alpha1.Module{}, ctrlhandler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
@@ -119,7 +111,11 @@ func RegisterController(
 				return false
 			},
 		})).
-		Complete(configController); err != nil {
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+			NeedLeaderElection:      ptr.To(false),
+		}).
+		Complete(r); err != nil {
 		return fmt.Errorf("complete: %w", err)
 	}
 	return nil

--- a/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/docbuilder/controller.go
@@ -52,7 +52,11 @@ import (
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
-const defaultDocumentationCheckInterval = 10 * time.Second
+const (
+	controllerName = "module-documentation"
+
+	defaultDocumentationCheckInterval = 10 * time.Second
+)
 
 type reconciler struct {
 	client               client.Client
@@ -73,17 +77,8 @@ func RegisterController(mgr manager.Manager, dc dependency.Container, logger *lo
 		logger:               logger,
 	}
 
-	ctr, err := controller.New("module-documentation", mgr, controller.Options{
-		MaxConcurrentReconciles: 1, // don't use concurrent reconciles here, because docs-builder doesn't support multiply requests at once
-		CacheSyncTimeout:        15 * time.Minute,
-		NeedLeaderElection:      ptr.To(false),
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("new: %w", err)
-	}
-
-	err = ctrl.NewControllerManagedBy(mgr).
+	err := ctrl.NewControllerManagedBy(mgr).
+		Named(controllerName).
 		For(&v1alpha1.ModuleDocumentation{}).
 		Watches(&coordv1.Lease{}, handler.EnqueueRequestsFromMapFunc(r.enqueueLeaseMapFunc), builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(event event.CreateEvent) bool {
@@ -104,7 +99,13 @@ func RegisterController(mgr manager.Manager, dc dependency.Container, logger *lo
 			},
 		})).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
-		Complete(ctr)
+		WithOptions(controller.Options{
+			// don't use concurrent reconciles here, because docs-builder doesn't support multiply requests at once
+			MaxConcurrentReconciles: 1,
+			CacheSyncTimeout:        15 * time.Minute,
+			NeedLeaderElection:      ptr.To(false),
+		}).
+		Complete(r)
 	if err != nil {
 		return fmt.Errorf("complete: %w", err)
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/override/controller.go
@@ -75,20 +75,16 @@ func RegisterController(runtimeManager manager.Manager,
 		return fmt.Errorf("add preflight: %w", err)
 	}
 
-	pullOverrideController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		CacheSyncTimeout:        cacheSyncTimeout,
-		NeedLeaderElection:      ptr.To(false),
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	if err := ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha2.ModulePullOverride{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
-		Complete(pullOverrideController); err != nil {
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+			CacheSyncTimeout:        cacheSyncTimeout,
+			NeedLeaderElection:      ptr.To(false),
+		}).
+		Complete(r); err != nil {
 		return fmt.Errorf("complete: %w", err)
 	}
 	return nil

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -119,22 +119,18 @@ func RegisterController(
 		return fmt.Errorf("add preflight: %w", err)
 	}
 
-	releaseController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		CacheSyncTimeout:        cacheSyncTimeout,
-		NeedLeaderElection:      ptr.To(false),
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	if err := ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.ModuleRelease{}).
 		// for reconcile documentation if accidentally removed
 		Owns(&v1alpha1.ModuleDocumentation{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
-		Complete(releaseController); err != nil {
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+			CacheSyncTimeout:        cacheSyncTimeout,
+			NeedLeaderElection:      ptr.To(false),
+		}).
+		Complete(r); err != nil {
 		return fmt.Errorf("complete: %w", err)
 	}
 	return nil

--- a/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/controller.go
@@ -103,17 +103,8 @@ func RegisterController(
 		return fmt.Errorf("add preflight: %w", err)
 	}
 
-	sourceController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		CacheSyncTimeout:        cacheSyncTimeout,
-		NeedLeaderElection:      ptr.To(false),
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	if err := ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.ModuleSource{}).
 		Watches(&v1alpha1.Module{}, handler.EnqueueRequestsFromMapFunc(func(_ context.Context, obj client.Object) []reconcile.Request {
 			return []reconcile.Request{{NamespacedName: client.ObjectKey{Name: obj.(*v1alpha1.Module).Properties.Source}}}
@@ -149,7 +140,12 @@ func RegisterController(
 			},
 		})).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
-		Complete(sourceController); err != nil {
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+			CacheSyncTimeout:        cacheSyncTimeout,
+			NeedLeaderElection:      ptr.To(false),
+		}).
+		Complete(r); err != nil {
 		return fmt.Errorf("complete: %w", err)
 	}
 	return nil

--- a/deckhouse-controller/pkg/controller/packages/application-package-version/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application-package-version/controller.go
@@ -71,17 +71,11 @@ func RegisterController(runtimeManager manager.Manager, dc dependency.Container,
 		dc:       dc,
 	}
 
-	applicationPackageVersionController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	return ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.ApplicationPackageVersion{}).
-		Complete(applicationPackageVersionController)
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Complete(r)
 }
 
 // Reconcile handles a single ApplicationPackageVersion event. Draft resources

--- a/deckhouse-controller/pkg/controller/packages/application/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/application/controller.go
@@ -101,18 +101,12 @@ func RegisterController(
 	r.status = status.NewService(r.client, packageRuntime.Status().GetStatus, r.logger)
 	r.status.Start(context.Background(), packageRuntime.Status().GetCh())
 
-	applicationController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	return ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.Application{}).
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
-		Complete(applicationController)
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Complete(r)
 }
 
 func (r *reconciler) preflight(ctx context.Context) error {

--- a/deckhouse-controller/pkg/controller/packages/module-package-version/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/module-package-version/controller.go
@@ -75,17 +75,11 @@ func RegisterController(runtimeManager manager.Manager, dc dependency.Container,
 		dc:       dc,
 	}
 
-	modulePackageVersionController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	return ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.ModulePackageVersion{}).
-		Complete(modulePackageVersionController)
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Complete(r)
 }
 
 // Reconcile handles a single ModulePackageVersion event. Draft resources are

--- a/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository-operation/controller.go
@@ -62,17 +62,11 @@ func RegisterController(runtimeManager manager.Manager, dc dependency.Container,
 		logger: logger,
 	}
 
-	packageRepositoryOperationController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	return ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.PackageRepositoryOperation{}).
-		Complete(packageRepositoryOperationController)
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Complete(r)
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -66,18 +66,12 @@ func RegisterController(
 		logger: logger,
 	}
 
-	packageRepositoryController, err := controller.New(controllerName, runtimeManager, controller.Options{
-		MaxConcurrentReconciles: maxConcurrentReconciles,
-		Reconciler:              r,
-	})
-	if err != nil {
-		return fmt.Errorf("create controller: %w", err)
-	}
-
 	return ctrl.NewControllerManagedBy(runtimeManager).
+		Named(controllerName).
 		For(&v1alpha1.PackageRepository{}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
-		Complete(packageRepositoryController)
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
+		Complete(r)
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Description

It fixes controllers duplication registration.

Symptoms:
```
root@paksashvili-master-0:~# dclg "reconcile application"
{"level":"info","logger":"deckhouse-controller.application-controller","msg":"reconcile application","source":"deckhouse/deckhouse-controller/pkg/controller/packages/application/controller.go:158","name":"test","namespace":"default","time":"2026-05-20T22:52:54Z"}
{"level":"info","logger":"deckhouse-controller.application-controller","msg":"reconcile application","source":"deckhouse/deckhouse-controller/pkg/controller/packages/application/controller.go:158","name":"test","namespace":"default","time":"2026-05-20T22:52:54Z"}
```

11 of 14 controllers in `deckhouse-controller/` mixed the low-level
`controller.New(...)` constructor with the high-level builder's
`Complete(...)`, accidentally registering two controllers per logical
reconciler. The duplicate had the configured name and
`MaxConcurrentReconciles` but no watches; the one that actually received
events used the GVK-derived auto-name and default concurrency. This PR
converts each to the canonical builder pattern:

```go
return ctrl.NewControllerManagedBy(mgr).
    Named(controllerName).
    For(&v1alpha1.Application{}).
    WithEventFilter(...).
    WithOptions(controller.Options{
        MaxConcurrentReconciles: maxConcurrentReconciles,
    }).
    Complete(r)
```

After the fix — one controller, watches and workers on the same
instance, configured name used everywhere:

```mermaid
flowchart TD
    RC["RegisterController()"]
    BLD["builder.Complete(r)<br/>→ Build()<br/>→ doController(r)<br/>→ doWatch() attaches sources to the same controller"]

    C["<b>single controller</b><br/>━━━━━━━━━━━━<br/>name = controllerName (from Named)<br/>MaxConcurrentReconciles = N (from WithOptions)<br/>Do = r<br/>watches: attached here<br/>queue: drained by N workers"]

    MGR[["Manager registry"]]

    RC -- "NewControllerManagedBy(mgr)<br/>.Named(controllerName)<br/>.For(...)<br/>.WithOptions({MaxConcurrentReconciles: N})<br/>.Complete(r)" --> BLD
    BLD --> C
    C -- "mgr.Add" --> MGR

    style C fill:#d4edda,stroke:#1e7e34,color:#222
    style MGR fill:#e8f0fe,stroke:#3367d6,color:#222
```

```mermaid
sequenceDiagram
    autonumber
    participant API as K8s API / Source
    participant P as Predicate filter
    participant Q as controller queue
    participant W as controller worker
    participant R as r.Reconcile (user)

    API->>P: Application CR change
    P->>Q: enqueue (passes filter)
    Q->>W: GetWithPriority()
    Note over W: metric: ActiveWorkers{controller="d8-application-controller"}++
    W->>R: reconcileHandler → c.Reconcile → c.Do.Reconcile
    R-->>W: (Result, err)
    Note over W: metric: reconcile_total{controller="d8-application-controller", ...}++
```

## Why do we need it, and what problem does it solve?

### The mistake

Every affected controller looked like this:

```go
ctr, err := controller.New("d8-application-controller", mgr, controller.Options{
    MaxConcurrentReconciles: 1,
    Reconciler:              r,
})                                              // (A) creates controller#1
// ...
return ctrl.NewControllerManagedBy(mgr).
    For(&v1alpha1.Application{}).
    WithEventFilter(...).
    Complete(ctr)                               // (B) builder creates controller#2
```

This compiles because `controller.Controller` embeds
`reconcile.Reconciler`, so `ctr` satisfies the type `Complete` expects.
But the builder's `Build()` does not treat an existing controller
specially — it always calls `doController(r)`, which always creates a
fresh `controller#2` and uses the argument as that new controller's
inner reconciler.

#### Registration flow (what gets built)

```mermaid
flowchart TD
    RC["RegisterController()"]
    BLD["builder.Complete(controller#1)<br/>→ Build()<br/>→ doController() always creates a fresh controller<br/>→ doWatch() attaches sources to that fresh controller"]

    C1["<b>controller#1</b> — what we asked for<br/>━━━━━━━━━━━━<br/>name = d8-application-controller<br/>MaxConcurrentReconciles = 1<br/>Do = r (real reconciler)<br/>watches: <b>none</b><br/>queue: empty forever"]
    C2["<b>controller#2</b> — what actually runs<br/>━━━━━━━━━━━━<br/>name = application (auto: lowercase GVK Kind)<br/>MaxConcurrentReconciles = 1 (default)<br/>Do = controller#1<br/>watches: For(Application) + predicates<br/>queue: receives events"]

    MGR[["Manager registry<br/>(now holds both controllers)"]]

    RC -- "(A) controller.New(name, mgr, Options{Reconciler: r})" --> C1
    RC -- "(B)" --> BLD
    BLD -- "newController(autoName, mgr,<br/>Options{Reconciler: controller#1})" --> C2

    C1 -- "mgr.Add" --> MGR
    C2 -- "mgr.Add (via builder)" --> MGR

    style C1 fill:#fde2e2,stroke:#c0392b,color:#222
    style C2 fill:#fff4cf,stroke:#b7950b,color:#222
    style MGR fill:#e8f0fe,stroke:#3367d6,color:#222
```

### Trace against `sigs.k8s.io/controller-runtime@v0.20.4`

- `Complete(ctr)` → `Build(ctr)` (`pkg/builder/controller.go:260`).
- `Build` → `doController(ctr)` (`pkg/builder/controller.go:278`) which:
  - sets `ctrlOptions.Reconciler = ctr` (`pkg/builder/controller.go:397-399`),
  - resolves `controllerName = strings.ToLower(gvk.Kind)` because
    `Named()` was never called (`pkg/builder/controller.go:380-388`),
  - leaves `MaxConcurrentReconciles = 0`, falling back to the default `1`
    (`pkg/controller/controller.go:177-181`),
  - calls `blder.newController(controllerName, mgr, ctrlOptions)`
    (`pkg/builder/controller.go:464`) — **this is controller#2**.
- `Build` then calls `doWatch()` (`pkg/builder/controller.go:283`), which
  attaches the `For()` / `Watches()` sources to **controller#2** only
  (`pkg/builder/controller.go:307-378`).

End state per logical reconciler:

|                                   | controller#1 (`controller.New`)         | controller#2 (builder)         |
| --------------------------------- | --------------------------------------- | ------------------------------ |
| Name (for metrics & logs)         | `d8-application-controller` (intended)  | `application` (auto from GVK)  |
| `MaxConcurrentReconciles`         | as configured                           | 1 (default)                    |
| Watches attached                  | none                                    | yes                            |
| Workqueue                         | empty forever                           | receives events                |
| Inner reconciler (`c.Do`)         | `r` (the real reconciler)               | `controller#1`                 |

Event flow:

1. Source fires → predicate → enqueued on **controller#2's** queue.
2. controller#2 worker calls `c.Reconcile(ctx, req)`
   (`pkg/internal/controller/controller.go:334`). Its `Reconcile`
   (line 101) returns `c.Do.Reconcile(...)` — i.e. **controller#1's**
   `Reconcile`, called synchronously (no extra queue hop).
3. controller#1's `Reconcile` (same line 101 in its own instance) returns
   `c.Do.Reconcile(...)` — finally the user's reconciler `r`.
4. controller#2 records all metrics under
   `controller="<lowercase-gvk-kind>"` (lines 291, 343, 356, 360, 366).

```mermaid
sequenceDiagram
    autonumber
    participant API as K8s API / Source
    participant P as Predicate filter
    participant Q2 as controller-2 queue
    participant W2 as controller-2 worker
    participant C2 as controller-2.Reconcile
    participant C1 as controller-1.Reconcile
    participant R as r.Reconcile (user)
    participant Q1 as controller-1 queue
    participant W1 as controller-1 workers (idle)

    API->>P: Application CR change
    P->>Q2: enqueue (passes filter)
    Q2->>W2: GetWithPriority()
    Note over W2: metric: ActiveWorkers{controller="application"}++
    W2->>C2: reconcileHandler → c.Reconcile
    C2->>C1: return c.Do.Reconcile(ctx, req)
    Note right of C1: synchronous call,<br/>NOT a queue hop
    C1->>R: return c.Do.Reconcile(ctx, req)
    R-->>C1: (Result, err)
    C1-->>C2: (Result, err)
    C2-->>W2: (Result, err)
    Note over W2: metric: reconcile_total{controller="application", ...}++

    rect rgb(253,226,226)
        Note over Q1,W1: controller-1 queue never receives an enqueue.<br/>Its workers block forever on GetWithPriority().<br/>Its declared MaxConcurrentReconciles is meaningless.
    end
```

Key takeaway from the diagram: there is **one queue hop** (on
controller#2), then a **synchronous wrapper chain** through
`controller#2.Reconcile → controller#1.Reconcile → r.Reconcile`. All
metrics and log lines emitted by the runtime are tagged with
controller#2's auto-name, not the configured `controllerName`.

### What this actually broke

1. **`MaxConcurrentReconciles` was silently ignored.** Configured on the
   "dead" controller#1; the real worker pool was controller#2's default
   of 1. Biggest regressions:
   - `module-release` / `module-source` / `module-config`: configured 3,
     actual 1.
   - `application` / `module-documentation`: configured 1 with explicit
     "do not parallelise" comments. The comments lied — the guard did
     not exist in running code. A future contributor adding shared
     mutable state on that promise would race in prod once the
     manager-level `GroupKindConcurrency` is raised.
2. **Prometheus series and log lines used auto-names**
   (`deckhouserelease`, `moduleconfig`, `moduledocumentation`,
   `modulepulloverride`, …) instead of the intended names from the
   `controllerName` constants. Anything keyed on the intended names did
   not match.
3. **One extra controller and goroutine pool per real controller.**
   controller#1 starts but its workers block forever on an empty queue.
   Small cost, but it's noise in pprof and in `controller_runtime_*`
   metrics.

The Linear issue describes step 2–3 above as "two passes through the
queue" — that is slightly inaccurate. There is one queue hop
(controller#2's); the inner calls are synchronous wrapper invocations.
The user-visible consequences are unchanged.

### Behavior changes worth flagging

#### Concurrency actually takes effect

Throughput will increase for any reconciler that declared
`MaxConcurrentReconciles > 1`:

- `module-release`: 1 → 3
- `module-source`: 1 → 3
- `module-config`: 1 → 3

Reviewers familiar with each domain should confirm no shared mutable
state in the reconciler races under real concurrency. If anything is
risky, the safe interim step is to lower the constant to `1` here, not
re-introduce the bug.

Controllers explicitly declaring `MaxConcurrentReconciles: 1`
(`application`, `module-documentation`, the four package controllers)
keep serialization — but now actually enforce it. No behavior change
expected.

#### Prometheus series rename

The `controller` label on `controller_runtime_*` series changes from the
auto-name to the constant:

| Old (auto-name)                | New (`controllerName` const)                  |
| ------------------------------ | --------------------------------------------- |
| `application`                  | `d8-application-controller`                   |
| `deckhouserelease`             | `d8-deckhouse-release-controller`             |
| `moduleconfig`                 | `d8-module-config-controller`                 |
| `moduledocumentation`          | `module-documentation`                        |
| `modulepulloverride`           | `d8-module-override-controller`               |
| `modulerelease`                | `d8-module-release-controller`                |
| `modulesource`                 | `d8-module-source-controller`                 |
| `applicationpackageversion`    | `d8-application-package-version-controller`   |
| `modulepackageversion`         | `d8-module-package-version-controller`        |
| `packagerepository`            | `d8-package-repository-controller`            |
| `packagerepositoryoperation`   | `d8-package-repository-operation-controller`  |

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Fix controllers duplication registration.
impact_level: low
```