### PR TITLE
[node-manager] prevent kube-api-proxy outage when upstreams.json contains null or empty data

### DIFF
--- a/candi/bashible/common-steps/all/001_configure_kubernetes_api_proxy.sh.tpl
+++ b/candi/bashible/common-steps/all/001_configure_kubernetes_api_proxy.sh.tpl
@@ -13,17 +13,23 @@
 # limitations under the License.
 
 mkdir -p /etc/kubernetes/kubernetes-api-proxy
-# Read previously discovered IP
 
-bb-sync-file /etc/kubernetes/kubernetes-api-proxy/upstreams.json - << EOF
 {{- if eq .runType "Normal" }}
-{{ .clusterMasterKubeAPIEndpoints | toJson }}
+upstreams_json='{{ .clusterMasterKubeAPIEndpoints | toJson }}'
+if ! jq -e 'arrays | length > 0' <<< "${upstreams_json}" > /dev/null 2>&1; then
+  bb-log-error "clusterMasterKubeAPIEndpoints is empty or invalid, skipping upstreams.json update to prevent kube-api-proxy outage"
+  exit 1
+fi
+bb-sync-file /etc/kubernetes/kubernetes-api-proxy/upstreams.json - << EOF
+${upstreams_json}
+EOF
 {{- else if eq .runType "ClusterBootstrap" }}
+bb-sync-file /etc/kubernetes/kubernetes-api-proxy/upstreams.json - << EOF
 {{- $list := list }}
   {{- $list = append $list "$(bb-d8-node-ip):6443" }}
 {{ toJson $list }}
-{{- end }}
 EOF
+{{- end }}
 
 {{ if eq .runType "Normal" }}
 bb-sync-file /etc/kubernetes/kubernetes-api-proxy/ca.crt - << EOF

--- a/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
+++ b/modules/040-node-manager/hooks/discover_apiserver_endpoints.go
@@ -44,6 +44,12 @@ const (
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	Queue: "/modules/node-manager",
+	Schedule: []go_hook.ScheduleConfig{
+		{
+			Name:    "discover_apiserver_endpoints",
+			Crontab: "*/5 * * * *",
+		},
+	},
 	Kubernetes: []go_hook.KubernetesConfig{
 		{
 			Name:       "kube_apiserver",

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
@@ -143,6 +143,12 @@ func (cb *ContextBuilder) Build() (BashibleContextData, map[string][]byte, map[s
 	hashMap := make(map[string]hash.Hash, len(cb.clusterInputData.NodeGroups))
 	clusterMasterKubeAPIEndpoints, clusterMasterRPPAddresses, clusterMasterRPPBootstrapAddresses := clusterMasterEndpointAddresses(cb.clusterInputData.ClusterMasterEndpoints)
 
+	if len(clusterMasterKubeAPIEndpoints) == 0 {
+		return BashibleContextData{}, nil, map[string]error{
+			"clusterMasterKubeAPIEndpoints": fmt.Errorf("no kube-api endpoints available"),
+		}
+	}
+
 	commonContext := &tplContextCommon{
 		versionMapWrapper:                  versionMapFromMap(cb.versionMap),
 		RunType:                            "Normal",

--- a/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
+++ b/modules/040-node-manager/images/bashible-apiserver/src/pkg/template/context_builder.go
@@ -143,12 +143,6 @@ func (cb *ContextBuilder) Build() (BashibleContextData, map[string][]byte, map[s
 	hashMap := make(map[string]hash.Hash, len(cb.clusterInputData.NodeGroups))
 	clusterMasterKubeAPIEndpoints, clusterMasterRPPAddresses, clusterMasterRPPBootstrapAddresses := clusterMasterEndpointAddresses(cb.clusterInputData.ClusterMasterEndpoints)
 
-	if len(clusterMasterKubeAPIEndpoints) == 0 {
-		return BashibleContextData{}, nil, map[string]error{
-			"clusterMasterKubeAPIEndpoints": fmt.Errorf("no kube-api endpoints available"),
-		}
-	}
-
 	commonContext := &tplContextCommon{
 		versionMapWrapper:                  versionMapFromMap(cb.versionMap),
 		RunType:                            "Normal",

--- a/modules/040-node-manager/images/kubernetes-api-proxy/src/internal/upstream/fallback.go
+++ b/modules/040-node-manager/images/kubernetes-api-proxy/src/internal/upstream/fallback.go
@@ -50,6 +50,7 @@ func WithFileWatcher(filePath string) FallbackListOption {
 			func(upstreams []*Upstream) {
 				l.Reconcile(upstreams, false)
 			},
+			l.logger,
 		)
 
 		l.watcher = watcher

--- a/modules/040-node-manager/images/kubernetes-api-proxy/src/internal/upstream/filewatcher.go
+++ b/modules/040-node-manager/images/kubernetes-api-proxy/src/internal/upstream/filewatcher.go
@@ -75,12 +75,10 @@ func (fw *fileWatcher) Stop() {
 func (fw *fileWatcher) triggerChangedOutside() {
 	changedFile, err := os.Open(fw.filePath)
 	if err != nil {
-		if fw.logger != nil {
-			fw.logger.Warn("failed to open upstreams file, keeping existing upstreams",
-				slog.String("path", fw.filePath),
-				slog.String("error", err.Error()),
-			)
-		}
+		fw.logger.Warn("failed to open upstreams file, keeping existing upstreams",
+			slog.String("path", fw.filePath),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 	defer changedFile.Close() //nolint:errcheck
@@ -88,21 +86,18 @@ func (fw *fileWatcher) triggerChangedOutside() {
 	var upstreamRecords []string
 
 	if err := json.NewDecoder(changedFile).Decode(&upstreamRecords); err != nil {
-		if fw.logger != nil {
-			fw.logger.Warn("failed to decode upstreams file, keeping existing upstreams",
-				slog.String("path", fw.filePath),
-				slog.String("error", err.Error()),
-			)
-		}
+		fw.logger.Warn("failed to decode upstreams file, keeping existing upstreams",
+			slog.String("path", fw.filePath),
+			slog.String("error", err.Error()),
+		)
 		return
 	}
 
 	if len(upstreamRecords) == 0 {
-		if fw.logger != nil {
-			fw.logger.Warn("upstreams file is empty or null, keeping existing upstreams",
-				slog.String("path", fw.filePath),
-			)
-		}
+		fw.logger.Warn("upstreams file is empty or null, keeping existing upstreams",
+			slog.String("path", fw.filePath),
+		)
+
 		return
 	}
 

--- a/modules/040-node-manager/images/kubernetes-api-proxy/src/internal/upstream/filewatcher.go
+++ b/modules/040-node-manager/images/kubernetes-api-proxy/src/internal/upstream/filewatcher.go
@@ -19,8 +19,11 @@ package upstream
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"os"
 	"time"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 // fileWatcher watches and writes a file for changes
@@ -28,12 +31,14 @@ type fileWatcher struct {
 	filePath string
 	onChange func([]*Upstream)
 	ticker   *time.Ticker
+	logger   *log.Logger
 }
 
-func newFileWatcher(filePath string, onChange func([]*Upstream)) *fileWatcher {
+func newFileWatcher(filePath string, onChange func([]*Upstream), logger *log.Logger) *fileWatcher {
 	return &fileWatcher{
 		filePath: filePath,
 		onChange: onChange,
+		logger:   logger,
 	}
 }
 
@@ -70,6 +75,12 @@ func (fw *fileWatcher) Stop() {
 func (fw *fileWatcher) triggerChangedOutside() {
 	changedFile, err := os.Open(fw.filePath)
 	if err != nil {
+		if fw.logger != nil {
+			fw.logger.Warn("failed to open upstreams file, keeping existing upstreams",
+				slog.String("path", fw.filePath),
+				slog.String("error", err.Error()),
+			)
+		}
 		return
 	}
 	defer changedFile.Close() //nolint:errcheck
@@ -77,6 +88,21 @@ func (fw *fileWatcher) triggerChangedOutside() {
 	var upstreamRecords []string
 
 	if err := json.NewDecoder(changedFile).Decode(&upstreamRecords); err != nil {
+		if fw.logger != nil {
+			fw.logger.Warn("failed to decode upstreams file, keeping existing upstreams",
+				slog.String("path", fw.filePath),
+				slog.String("error", err.Error()),
+			)
+		}
+		return
+	}
+
+	if len(upstreamRecords) == 0 {
+		if fw.logger != nil {
+			fw.logger.Warn("upstreams file is empty or null, keeping existing upstreams",
+				slog.String("path", fw.filePath),
+			)
+		}
 		return
 	}
 
@@ -89,7 +115,7 @@ func (fw *fileWatcher) triggerChangedOutside() {
 }
 
 func (fw *fileWatcher) triggerChangedInside(upstreams []*Upstream) {
-	changeFile, err := os.OpenFile(fw.filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0640)
+	changeFile, err := os.OpenFile(fw.filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o640)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Description

Adds validation and observability to prevent kubernetes-api-proxy upstreams.json from being overwritten with invalid data, and improves endpoint discovery reliability.

Changes:

- `001_configure_kubernetes_api_proxy.sh.tpl` -  validate clusterMasterKubeAPIEndpoints with jq before writing `upstreams.json`, if empty or null log error and exit 1 so bashible retries on next run
- `discover_apiserver_endpoints.go`: add `cron */5 * * * *` so the hook runs periodically in addition to Kubernetes events
- `filewatcher.go`: log warnings when upstreams file is missing, undecodable, or empty/null
- `filewatcher.go`  add explicit len == 0 guard that was previously absent


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  node-manager
type: fix
summary: Prevented a kube-api-proxy outage when upstreams.json contains null or empty data.
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
