### PR TITLE
exclude irrelevant images from non root user validation

### DIFF
--- a/tools/cve/check-non-root.sh
+++ b/tools/cve/check-non-root.sh
@@ -20,13 +20,11 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
+# Example:
+#  ["istio pilotV1x19x7"]="1337:1337"
+#  ["istio pilotV1x21x6"]="1337:1337"
 declare -A allowed_users=(
-  ["istio operatorV1x21x6"]="1337:1337"
-  ["istio operatorV1x16x2"]="1337:1337"
-  ["istio operatorV1x19x7"]="1337:1337"
-  ["istio pilotV1x16x2"]="1337:1337"
-  ["istio pilotV1x19x7"]="1337:1337"
-  ["istio pilotV1x21x6"]="1337:1337"
+
 )
 
 declare -A allowed_components=(
@@ -82,7 +80,7 @@ function check_user() {
   allowed_component=$(get_allowed_components "$user")
   allowed_user=$(get_allowed_users "$image_report_name")
 
-  if [ "$user" == "null" ] || [ "$user" == "root" ] || [ "$user" == "0:0" ]; then
+  if [ "$user" == "null" ] || [ "$user" == "root" ] || [ "$user" == "root:root" ] || [ "$user" == "0:0" ]; then
     result="ERROR"
     if [ "$user" == "null" ]; then
       user="root"

--- a/tools/cve/check-non-root.sh
+++ b/tools/cve/check-non-root.sh
@@ -40,6 +40,10 @@ declare -A skip_components=(
 )
 declare -A skip_components_images=(
   ["d8ShutdownInhibitor"]="skip"
+  ["terraformManager"]="skip"
+  ["baseTerraform"]="skip"
+  ["baseOpentofu"]="skip"
+  ["candi"]="skip"
 )
 # Function to get skip components
 function get_skip_components() {

--- a/tools/cve/check-non-root.sh
+++ b/tools/cve/check-non-root.sh
@@ -20,11 +20,8 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
-# Example:
-#  ["istio pilotV1x19x7"]="1337:1337"
-#  ["istio pilotV1x21x6"]="1337:1337"
 declare -A allowed_users=(
-
+  ["common debugContainer"]="root:root"
 )
 
 declare -A allowed_components=(

--- a/tools/cve/check-non-root.sh
+++ b/tools/cve/check-non-root.sh
@@ -20,8 +20,11 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m' # No Color
 
+# Example:
+#  ["istio pilotV1x19x7"]="1337:1337"
+#  ["istio pilotV1x21x6"]="1337:1337"
 declare -A allowed_users=(
-  ["common debugContainer"]="root:root"
+
 )
 
 declare -A allowed_components=(
@@ -39,6 +42,7 @@ declare -A skip_components_images=(
   ["baseTerraform"]="skip"
   ["baseOpentofu"]="skip"
   ["candi"]="skip"
+  ["debugContainer"]="skip"
 )
 # Function to get skip components
 function get_skip_components() {


### PR DESCRIPTION
## Description

There are some images that are not running in cluster, user is not set in containers.

## Why do we need it, and what problem does it solve?

Now we have false-positive alerting from non-root user validation


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type:  chore
summary: exclude irrelevant images from non root user validation
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
