### PR TITLE
[istio] CVE fixes May#1 - 1.74

### DIFF
--- a/modules/110-istio/images/operator-v1x19x7/known_vulnerabilities.vex
+++ b/modules/110-istio/images/operator-v1x19x7/known_vulnerabilities.vex
@@ -171,7 +171,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Operator не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-05-21T11:00:11.447758925Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-27T09:00:22.447758925Z"
     }
   ],
-  "timestamp": "2026-05-21T11:00:11Z"
+  "timestamp": "2026-05-27T09:00:25Z"
 }

--- a/modules/110-istio/images/operator-v1x19x7/known_vulnerabilities.vex
+++ b/modules/110-istio/images/operator-v1x19x7/known_vulnerabilities.vex
@@ -157,7 +157,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-24T08:00:33.447758925Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Operator не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:11.447758925Z"
     }
   ],
-  "timestamp": "2026-04-24T08:00Z"
+  "timestamp": "2026-05-21T11:00:11Z"
 }

--- a/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
@@ -129,7 +129,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Operator не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-05-21T11:00:11.229586503Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-27T09:00:22.229586503Z"
     }
   ],
-  "timestamp": "2026-05-21T11:00:11Z"
+  "timestamp": "2026-05-27T09:00:25Z"
 }

--- a/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/operator-v1x21x6/known_vulnerabilities.vex
@@ -101,7 +101,35 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Operator не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-24T07:59:44.229586503Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus Azure AD remote write client_secret exposed via /-/config (CVE-2026-42151, GHSA-wg65-39gg-5wfj, CWE-312) — Уязвимость относится к раскрытию client_secret конфигурации Azure AD remote write через HTTP API /-/config сервера Prometheus 3.x. Бинарник Istio Operator не запускает сервер Prometheus и не предоставляет указанный endpoint; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:01.229586503Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Operator не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:11.229586503Z"
     }
   ],
-  "timestamp": "2026-04-24T08:00Z"
+  "timestamp": "2026-05-21T11:00:11Z"
 }

--- a/modules/110-istio/images/operator-v1x25x2/patches/001-istio-go-mod.patch
+++ b/modules/110-istio/images/operator-v1x25x2/patches/001-istio-go-mod.patch
@@ -1,5 +1,5 @@
 diff --git a/go.mod b/go.mod
-index cec3efa8..73e4127f 100644
+index cec3efa8..2a37286b 100644
 --- a/go.mod
 +++ b/go.mod
 @@ -1,46 +1,47 @@
@@ -85,7 +85,7 @@ index cec3efa8..73e4127f 100644
  	github.com/cespare/xxhash/v2 v2.3.0 // indirect
  	github.com/chai2010/gettext-go v1.0.3 // indirect
 -	github.com/containerd/containerd v1.7.24 // indirect
-+	github.com/containerd/containerd v1.7.30 // indirect
++	github.com/containerd/containerd v1.7.32 // indirect
  	github.com/containerd/errdefs v0.3.0 // indirect
  	github.com/containerd/log v0.1.0 // indirect
  	github.com/containerd/platforms v0.2.1 // indirect
@@ -274,7 +274,7 @@ index cec3efa8..73e4127f 100644
 +	sigs.k8s.io/yaml v1.6.0 // indirect
  )
 diff --git a/go.sum b/go.sum
-index f432a32d..b648a548 100644
+index f432a32d..13459afc 100644
 --- a/go.sum
 +++ b/go.sum
 @@ -1,15 +1,15 @@
@@ -355,8 +355,8 @@ index f432a32d..b648a548 100644
 -github.com/containerd/containerd v1.7.24/go.mod h1:7QUzfURqZWCZV7RLNEn1XjUCQLEf0bkaK4GjUaZehxw=
 -github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
 -github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
-+github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
-+github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
++github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
++github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
  github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=
  github.com/containerd/errdefs v0.3.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
  github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/modules/110-istio/images/pilot-v1x19x7/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x19x7/known_vulnerabilities.vex
@@ -45,7 +45,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-24T07:49:02.492836027Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:11.492836027Z"
     }
   ],
-  "timestamp": "2026-04-24T07:49Z"
+  "timestamp": "2026-05-21T11:00:11Z"
 }

--- a/modules/110-istio/images/pilot-v1x19x7/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x19x7/known_vulnerabilities.vex
@@ -59,7 +59,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-05-21T11:00:11.492836027Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.45.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.45.0 (Istio 1.19.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-27T09:00:22.492836027Z"
     }
   ],
-  "timestamp": "2026-05-21T11:00:11Z"
+  "timestamp": "2026-05-27T09:00:25Z"
 }

--- a/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
@@ -45,7 +45,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-05-21T11:00:11.384917205Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-27T09:00:22.384917205Z"
     }
   ],
-  "timestamp": "2026-05-21T11:00:11Z"
+  "timestamp": "2026-05-27T09:00:25Z"
 }

--- a/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x21x6/known_vulnerabilities.vex
@@ -17,7 +17,35 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-24T07:48:52.384917205Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus Azure AD remote write client_secret exposed via /-/config (CVE-2026-42151, GHSA-wg65-39gg-5wfj, CWE-312) — Уязвимость относится к раскрытию client_secret конфигурации Azure AD remote write через HTTP API /-/config сервера Prometheus 3.x. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не предоставляет указанный endpoint; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:01.384917205Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.48.1"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.48.1 (Istio 1.21.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:11.384917205Z"
     }
   ],
-  "timestamp": "2026-04-24T07:49Z"
+  "timestamp": "2026-05-21T11:00:11Z"
 }

--- a/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
@@ -17,7 +17,35 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus stored XSS in web UI (CVE-2026-40179, GHSA-vffh-x6r8-xx99, CWE-79) — Уязвимость относится к веб-интерфейсу сервера Prometheus 3.x (Graph, Metric Explorer и др.) при отображении имён метрик и значений лейблов, в т.ч. после приёма данных через remote write или OTLP receiver. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory (актуальные затронутые версии — ветка 3.x сервера). Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-04-24T07:42:37.518263849Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42151"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.301.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus Azure AD remote write client_secret exposed via /-/config (CVE-2026-42151, GHSA-wg65-39gg-5wfj, CWE-312) — Уязвимость относится к раскрытию client_secret конфигурации Azure AD remote write через HTTP API /-/config сервера Prometheus 3.x. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не предоставляет указанный endpoint; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:01.518263849Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-42154"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.301.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-21T11:00:11.518263849Z"
     }
   ],
-  "timestamp": "2026-04-24T07:43Z"
+  "timestamp": "2026-05-21T11:00:11Z"
 }

--- a/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
+++ b/modules/110-istio/images/pilot-v1x25x2/known_vulnerabilities.vex
@@ -45,7 +45,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Prometheus remote read endpoint DoS via crafted snappy payload (CVE-2026-42154, GHSA-8rm2-7qqf-34qm, CWE-400) — Уязвимость относится к endpoint удалённого чтения /api/v1/read сервера Prometheus: некорректная валидация длины snappy-payload может привести к исчерпанию памяти и отказу в обслуживании. Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не обрабатывает запросы к /api/v1/read; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека. Эксплуатация в контексте данного компонента недоступна.",
       "timestamp": "2026-05-21T11:00:11.518263849Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44903"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/prometheus/prometheus@v0.301.0"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Prometheus stored XSS in legacy web UI heatmap (CVE-2026-44903, GHSA-fw8g-cg8f-9j28, CWE-79) — Уязвимость относится к отображению heatmap в устаревшем веб-UI сервера Prometheus (histogram bucket label values, флаг --enable-feature=old-ui). Бинарник Istio Pilot (istiod) не запускает сервер Prometheus и не открывает указанный UI; зависимость github.com/prometheus/prometheus v0.301.0 (Istio 1.25.x) подтягивается как библиотека и не включает исполняемый путь уязвимого кода из advisory. Эксплуатация в контексте данного компонента недоступна.",
+      "timestamp": "2026-05-27T09:00:22.518263849Z"
     }
   ],
-  "timestamp": "2026-05-21T11:00:11Z"
+  "timestamp": "2026-05-27T09:00:25Z"
 }


### PR DESCRIPTION
## Description
Fixed and justified CVEs, list below:

**Operator 1.19**
Justified:

- CVE-2026-42154
- CVE-2026-44903

**Operator 1.21**
Justified:

- CVE-2026-42151
- CVE-2026-42154
- CVE-2026-44903

**Operator 1.25**
Fixed:

- CVE-2026-46680

**Pilot 1.19**
Justified:

- CVE-2026-42154
- CVE-2026-44903

**Pilot 1.21**
Justified:

- CVE-2026-42151
- CVE-2026-42154
- CVE-2026-44903

**Pilot 1.25**
Justified:

- CVE-2026-42151
- CVE-2026-42154
- CVE-2026-44903

## Why do we need it, and what problem does it solve?
It keeps application in CVE-free state.

## Why do we need it in the patch release (if we do)?
It keeps application in CVE-free state.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Vex justified CVE-2026-42151, CVE-2026-42154 and CVE-2026-44903 in pilot and operator images. Fixed CVE-2026-46680 in operator 1.25
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
