### PR TITLE
[istio] Add CARGO_PROXY to ztunnel image build

### DIFF
--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -118,6 +118,8 @@ import:
 mount:
 {{ include "mount points for golang builds" . }}
 secrets:
+- id: GOPROXY
+  value: {{ .GOPROXY }}
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
 shell:
@@ -132,12 +134,12 @@ shell:
 
   - export GOROOT=/usr/local/go GOPATH=/go
   - export PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
-  - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY)
+  - export GO_VERSION=${GOLANG_VERSION}
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
   - export TARGETARCH=amd64 ARCH="x86_64"
   - export BAZEL_VERSION="6.5.0" USE_BAZEL_VERSION="6.5.0"
   - cd /src/proxy
-  - go mod download
+  - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
   - export BAZEL_OUTPUT_BASE=$(bazel info output_base)
   - mkdir -p ${BAZEL_OUTPUT_BASE}/external
   - tar -zxf /tmp/bazel-deps/external.tar.gz -C ${BAZEL_OUTPUT_BASE}/external

--- a/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -44,6 +44,11 @@ import:
   add: /src/ztunnel
   to: /src/ztunnel
   before: install
+secrets:
+- id: CARGO_PROXY
+  value: {{ .CargoProxy }}
+- id: SOURCE_REPO
+  value: {{ .SOURCE_REPO }}
 shell:
   beforeInstall:
   {{- include "alt packages proxy" . | nindent 2 }}
@@ -51,6 +56,16 @@ shell:
   install:
   - export CARGO_NET_GIT_FETCH_WITH_CLI=true
   - cd /src/ztunnel
+  - |
+    export CARGO_PROXY=$(cat /run/secrets/CARGO_PROXY)
+    if ! [[ "${CARGO_PROXY}" = "false" ]]; then
+      echo '[source.crates-io]' >> .cargo/config.toml
+      echo 'replace-with = "crates-io-mirror"' >> .cargo/config.toml
+      echo '[registries.crates-io-mirror]' >> .cargo/config.toml
+      echo 'index = "sparse+http://'${CARGO_PROXY}'/index/"' >> .cargo/config.toml
+    fi
+  - git config --global url."$(cat /run/secrets/SOURCE_REPO)".insteadOf https://github.com
+  - echo "StrictHostKeyChecking accept-new" > ~/.ssh/config
   - |
     cargo build \
     --release 


### PR DESCRIPTION
## Description
Added CARGO_PROXY to ztunnel build.

## Why do we need it, and what problem does it solve?
This fixed build of ztunnel in isolated environment.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Added CARGO_PROXY to ztunnel image build
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
