### PR TITLE
[node-manager]  Fix webook validation in node-controller on CRI changes in nodegroup.

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/webhook/nodegroup_webhook.go
@@ -284,8 +284,8 @@ func (w *NodeGroupValidator) Handle(ctx context.Context, req admission.Request) 
 	}
 
 	if req.Operation == "UPDATE" && oldNG != nil {
-		oldCRIType := getCRIType(oldNG, "")
-		newCRIType := getCRIType(ng, "")
+		oldCRIType := getCRIType(oldNG, clusterConfig.DefaultCRI)
+		newCRIType := getCRIType(ng, clusterConfig.DefaultCRI)
 		if oldCRIType != newCRIType {
 			customNodes, err := w.getNodesWithCustomContainerd(ctx, ng.Name)
 			if err != nil {
@@ -301,7 +301,7 @@ func (w *NodeGroupValidator) Handle(ctx context.Context, req admission.Request) 
 	}
 
 	if req.Operation == "UPDATE" {
-		if ng.Spec.CRI != nil && ng.Spec.CRI.Type == v1.CRITypeContainerdV2 {
+		if getCRIType(ng, clusterConfig.DefaultCRI) == string(v1.CRITypeContainerdV2) {
 			unsupportedNodes, err := w.getNodesWithoutContainerdV2Support(ctx, ng.Name)
 			if err != nil {
 				webhookLog.Error(err, "failed to get nodes without containerd v2 support")


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fix nodegroup webhook to use clusterConfig.DefaultCRI instead of hardcoded fallback when checking CRI type changes.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
When a user removes the spec.cri block from a NodeGroup, the webhook fails to detect the actual CRI change (to the cluster default) and skips validation for nodes with custom containerd config   or without ContainerdV2 support, allowing potentially breaking changes to pass silently.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: fix webook validation in node-controller on cri changes in nodegroup.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
