### PR TITLE
[dhctl] recreate missing NodeUser

### DIFF
--- a/dhctl/pkg/kubernetes/actions/entity/node_user.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user.go
@@ -95,7 +95,7 @@ func NodeUserExists(ctx context.Context, kubeProvider kubernetes.KubeClientProvi
 
 	err = libretry.NewSilentLoopWithParamsOpts(
 		libretry.WithName("Check NodeUser %q exists", name),
-		libretry.WithAttempts(5),
+		libretry.WithAttempts(10),
 		libretry.WithWait(2*time.Second),
 	).RunContext(ctx, func() error {
 		timeoutCtx, cancel := defaultTimeoutCtx(ctx)

--- a/dhctl/pkg/kubernetes/actions/entity/node_user.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user.go
@@ -84,6 +84,25 @@ func DeleteNodeUser(ctx context.Context, kubeProvider kubernetes.KubeClientProvi
 	})
 }
 
+func NodeUserExists(ctx context.Context, kubeProvider kubernetes.KubeClientProviderWithCtx, name string) (bool, error) {
+	kubeCl, err := kubeProvider.KubeClientCtx(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	timeoutCtx, cancel := defaultTimeoutCtx(ctx)
+	defer cancel()
+
+	_, err = kubeCl.Dynamic().Resource(v1.NodeUserGVR).Get(timeoutCtx, name, metav1.GetOptions{})
+	if err != nil {
+		if k8errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("Failed to get NodeUser: %w", err)
+	}
+	return true, nil
+}
+
 type NodeUserPresentsChecker func(node corev1.Node) bool
 
 type NodeUserPresentsWaiter struct {

--- a/dhctl/pkg/kubernetes/actions/entity/node_user.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/selection"
 
+	libretry "github.com/deckhouse/lib-dhctl/pkg/retry"
 	sdk "github.com/deckhouse/module-sdk/pkg/utils"
 
 	v1 "github.com/deckhouse/deckhouse/dhctl/pkg/apis/deckhouse/v1"
@@ -90,17 +91,34 @@ func NodeUserExists(ctx context.Context, kubeProvider kubernetes.KubeClientProvi
 		return false, err
 	}
 
-	timeoutCtx, cancel := defaultTimeoutCtx(ctx)
-	defer cancel()
+	var exists bool
 
-	_, err = kubeCl.Dynamic().Resource(v1.NodeUserGVR).Get(timeoutCtx, name, metav1.GetOptions{})
-	if err != nil {
-		if k8errors.IsNotFound(err) {
-			return false, nil
+	err = libretry.NewSilentLoopWithParamsOpts(
+		libretry.WithName("Check NodeUser %q exists", name),
+		libretry.WithAttempts(5),
+		libretry.WithWait(2*time.Second),
+	).RunContext(ctx, func() error {
+		timeoutCtx, cancel := defaultTimeoutCtx(ctx)
+		defer cancel()
+
+		_, err := kubeCl.Dynamic().Resource(v1.NodeUserGVR).Get(timeoutCtx, name, metav1.GetOptions{})
+		if err != nil {
+			if k8errors.IsNotFound(err) {
+				exists = false
+				return nil
+			}
+
+			return fmt.Errorf("Failed to get NodeUser %q: %w", name, err)
 		}
-		return false, fmt.Errorf("Failed to get NodeUser: %w", err)
+
+		exists = true
+		return nil
+	})
+	if err != nil {
+		return false, err
 	}
-	return true, nil
+
+	return exists, nil
 }
 
 type NodeUserPresentsChecker func(node corev1.Node) bool

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -464,15 +464,15 @@ func (s *KubeClientSwitcher) createNodeUser(ctx context.Context) (*State, error)
 		}
 
 		s.warn(
-			"NodeUser %q is missing while converge state exists; recreating converge state",
+			"NodeUser %q is missing while converge state exists; recreating NodeUser",
 			convergeState.NodeUserCredentials.Name,
 		)
 
-		if err := s.ctx.deleteConvergeState(); err != nil {
-			return nil, fmt.Errorf("Failed to delete stale converge state: %w", err)
-		}
-
 		convergeState.NodeUserCredentials = nil
+
+		if err := s.ctx.SetConvergeState(convergeState); err != nil {
+			return nil, fmt.Errorf("Failed to reset stale node user credentials: %w", err)
+		}
 	}
 
 	s.debugStartOperation("create node user")

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -454,7 +454,25 @@ func (s *KubeClientSwitcher) createNodeUser(ctx context.Context) (*State, error)
 	}
 
 	if convergeState.NodeUserCredentials != nil {
-		return convergeState, nil
+		exists, err := entity.NodeUserExists(s.ctx.Ctx(), s.ctx, convergeState.NodeUserCredentials.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		if exists {
+			return convergeState, nil
+		}
+
+		s.warn(
+			"NodeUser %q is missing while converge state exists; recreating converge state",
+			convergeState.NodeUserCredentials.Name,
+		)
+
+		if err := s.ctx.deleteConvergeState(); err != nil {
+			return nil, fmt.Errorf("Failed to delete stale converge state: %w", err)
+		}
+
+		convergeState.NodeUserCredentials = nil
 	}
 
 	s.debugStartOperation("create node user")


### PR DESCRIPTION
## Description

Add a missing NodeUser existence check before reusing stored converge credentials.

If converge state contains `NodeUserCredentials`, but the corresponding `NodeUser` resource was removed manually or lost, dhctl now recreates converge state and generates a new NodeUser instead of trying to reuse stale credentials.

## Why do we need it, and what problem does it solve?

Previously dhctl trusted stored `NodeUserCredentials` blindly.

This caused converge failures in cases where:
- converge state still existed;
- `NodeUserCredentials` were present in cache/state;
- but the actual `NodeUser` CR no longer existed in the cluster.

In such situations dhctl attempted to switch SSH client using stale credentials and failed later during converge.

Now dhctl explicitly checks that the `NodeUser` exists in Kubernetes before reusing stored credentials. If the resource is missing, stale converge state is removed and NodeUser is recreated automatically.

## Why do we need it in the patch release (if we do)?

The fix prevents converge failures caused by stale converge state and manually removed or lost NodeUser resources.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: Recreate missing converge NodeUser when stale credentials exist in converge state
impact_level: low