### PR TITLE
[candi] bashible cleanup script improvements

### DIFF
--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -98,7 +98,8 @@ BLOCK
 }
 
 stop_services() {
-  log_info "systemctl stop $@"
+  log_info "systemctl disable + stop $@"
+  systemctl disable $@ 2>/dev/null || true
   systemctl stop $@ 2>/dev/null || true
 }
 

--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -227,6 +227,17 @@ if [ "$CLEANUP_FAILED" -ne 0 ]; then
   exit 2
 fi
 
+# Recreate mountpoint dirs for fstab entries we wiped above, so devices nested
+# under cleaned paths (e.g. a user-managed /var/lib/containerd/logs) can be
+# remounted on next boot.
+if [ -r /etc/fstab ]; then
+  while read -r src mp _; do
+    case "$src" in ''|\#*) continue ;; esac
+    case "$mp" in /*) ;; *) continue ;; esac
+    [ -d "$mp" ] || mkdir -p "$mp" 2>/dev/null || log_err "Failed to recreate mountpoint dir $mp"
+  done < /etc/fstab
+fi
+
 # Inform which cleaned paths are still present in /etc/fstab — their devices will be
 # remounted (empty, since we wiped them) on next boot. This is informational only.
 FSTAB_HITS=()

--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -132,13 +132,20 @@ remove_path() {
   [ ! -e "$path" ] && return 0
 
   for i in {1..5}; do
-    # If the path is a separate mount, wipe its data first so the device comes up empty
-    # on next bootstrap, then unmount it. -xdev keeps find on this device, so it never
-    # crosses into PVC or other nested mounted volumes.
-    if mountpoint -q "$path"; then
-      log_info "Clearing data on volume at $path"
-      find "$path" -xdev -mindepth 1 -delete 2>/dev/null
-      umount -l "$path" 2>/dev/null || true
+    if [ -d "$path" ]; then
+      # Detach nested mounts (e.g. pod/CSI/PVC volumes), deepest first, so the rm below
+      # cannot recurse into them and delete data we do not own. Their data is never touched.
+      mount | grep -F "$path" | awk '{print $3}' | grep -vxF "$path" | sort -r | xargs -r -n1 umount -l 2>/dev/null
+
+      # If the path itself is a separate mount, wipe its data (so the device comes up empty
+      # on next bootstrap) and unmount it, but keep the empty directory: it is a mountpoint
+      # and an fstab entry may remount the device here on reboot. -xdev keeps find on this device.
+      if mountpoint -q "$path"; then
+        log_info "Clearing data on volume at $path"
+        find "$path" -xdev -mindepth 1 -delete 2>/dev/null
+        umount -l "$path" 2>/dev/null || true
+        return 0
+      fi
     fi
     rm -rf "$path" 2>/dev/null && return 0
     sleep 1
@@ -215,10 +222,8 @@ if [ "$CLEANUP_FAILED" -ne 0 ]; then
   exit 2
 fi
 
-log_info "Cleanup completed successfully, restoring MOTD"
-restore_motd_message
-
-# Check if any of the cleaned paths are still in fstab — they will be remounted on next boot.
+# Inform which cleaned paths are still present in /etc/fstab — their devices will be
+# remounted (empty, since we wiped them) on next boot. This is informational only.
 FSTAB_HITS=()
 for p in "${PATHS_TO_REMOVE[@]}" /var/lib/bashible; do
   while IFS= read -r hit; do
@@ -229,20 +234,17 @@ done
 if [ "${#FSTAB_HITS[@]}" -gt 0 ]; then
   echo ""
   echo "################################################################################"
-  echo "# WARNING: the following paths are present in /etc/fstab as mountpoints:"
+  echo "# NOTE: the following paths are present in /etc/fstab and will be remounted on"
+  echo "# next boot:"
   for p in "${FSTAB_HITS[@]}"; do
     echo "#   $p"
   done
-  echo "#"
-  echo "# Remove or comment out those entries from /etc/fstab before rebooting,"
   echo "################################################################################"
   echo ""
-  # Exit before removing the script (below) so it stays on disk. A retry then re-runs
-  # it and re-hits this safeguard, instead of caps-controller-manager treating a
-  # missing script as "done" and rebooting with a stale /etc/fstab entry.
-  log_err "Skipping reboot: manual /etc/fstab cleanup required (see WARNING above)"
-  exit 3
 fi
+
+log_info "Cleanup completed successfully, restoring MOTD"
+restore_motd_message
 
 # Remove the script (and the rest of /var/lib/bashible) last, only once we are
 # committed to rebooting — every earlier exit path keeps it on disk for a rerun.

--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -137,14 +137,19 @@ remove_path() {
       # cannot recurse into them and delete data we do not own. Their data is never touched.
       mount | grep -F "$path" | awk '{print $3}' | grep -vxF "$path" | sort -r | xargs -r -n1 umount -l 2>/dev/null
 
-      # If the path itself is a separate mount, wipe its data (so the device comes up empty
-      # on next bootstrap) and unmount it, but keep the empty directory: it is a mountpoint
-      # and an fstab entry may remount the device here on reboot. -xdev keeps find on this device.
+      # If the path itself is a separate mount, wipe its data so the device comes up empty
+      # on next bootstrap, then unmount it. -xdev keeps find on this device. The empty
+      # directory is kept as a mountpoint so an fstab entry can remount the device on reboot.
+      # If the wipe fails (read-only fs, busy entries, I/O error) retry, and let the loop
+      # report failure rather than rebooting with stale data still on the device.
       if mountpoint -q "$path"; then
         log_info "Clearing data on volume at $path"
-        find "$path" -xdev -mindepth 1 -delete 2>/dev/null
-        umount -l "$path" 2>/dev/null || true
-        return 0
+        if find "$path" -xdev -mindepth 1 -delete 2>/dev/null; then
+          umount -l "$path" 2>/dev/null || true
+          return 0
+        fi
+        sleep 1
+        continue
       fi
     fi
     rm -rf "$path" 2>/dev/null && return 0

--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -242,25 +242,23 @@ fi
 log_info "Cleanup completed successfully, restoring MOTD"
 restore_motd_message
 
-# Warn if any cleaned paths are still in fstab — they will be remounted on next boot.
-# The user must remove those entries manually before rebooting.
+# Check if any of the cleaned paths are still in fstab — they will be remounted on next boot.
 FSTAB_HITS=()
 for p in "${PATHS_TO_REMOVE[@]}" /var/lib/bashible; do
-  if grep -qsF "$p" /etc/fstab 2>/dev/null; then
-    FSTAB_HITS+=("$p")
-  fi
+  while IFS= read -r hit; do
+    FSTAB_HITS+=("$hit")
+  done < <(grep -sF "$p" /etc/fstab 2>/dev/null | grep -v '^\s*#')
 done
 
 if [ "${#FSTAB_HITS[@]}" -gt 0 ]; then
   echo ""
   echo "################################################################################"
-  echo "# WARNING: the following paths are present in /etc/fstab:"
+  echo "# WARNING: the following paths are present in /etc/fstab as mountpoints:"
   for p in "${FSTAB_HITS[@]}"; do
     echo "#   $p"
   done
   echo "#"
   echo "# Remove or comment out those entries from /etc/fstab before rebooting,"
-  echo "# otherwise the devices will be remounted and bootstrap may fail again."
   echo "################################################################################"
   echo ""
   log_err "Skipping reboot: manual /etc/fstab cleanup required (see WARNING above)"

--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -19,7 +19,6 @@ MOTD_FILE="/etc/motd"
 MARKER="D8_CLEANUP_STATIC_NODE"
 CLEANUP_FAILED=0
 SCRIPT_PATH="/var/lib/bashible/cleanup_static_node.sh"
-SCRIPT_BACKUP="/tmp/cleanup_static_node.sh.bak"
 
 PATHS_TO_REMOVE=(
   /var/cache/registrypackages
@@ -133,27 +132,13 @@ remove_path() {
   [ ! -e "$path" ] && return 0
 
   for i in {1..5}; do
-    if [ -d "$path" ]; then
-      # For each mountpoint under $path (deepest first): if it's a persistent writable volume,
-      # clear its data before unmounting so the device comes up empty on next boot.
-      while IFS= read -r mnt; do
-        local fstype
-        fstype=$(findmnt --noheadings --output FSTYPE --mountpoint "$mnt" 2>/dev/null)
-        case "$fstype" in
-          overlay|tmpfs|nsfs|autofs|erofs)
-            # No persistent data — just unmount (erofs is read-only, find -delete would fail)
-            ;;
-          *)
-            # Persistent writable volume (ext4, xfs, nfs4, etc.) — clear data first
-            log_info "Clearing data on $fstype volume at $mnt"
-            if ! find "$mnt" -mindepth 1 -delete 2>/dev/null; then
-              log_err "ERROR: failed to clear data at $mnt"
-              CLEANUP_FAILED=1
-            fi
-            ;;
-        esac
-        umount -l "$mnt" 2>/dev/null || true
-      done < <(mount | grep -F "$path" | awk '{print $3}' | sort -r)
+    # If the path is a separate mount, wipe its data first so the device comes up empty
+    # on next bootstrap, then unmount it. -xdev keeps find on this device, so it never
+    # crosses into PVC or other nested mounted volumes.
+    if mountpoint -q "$path"; then
+      log_info "Clearing data on volume at $path"
+      find "$path" -xdev -mindepth 1 -delete 2>/dev/null
+      umount -l "$path" 2>/dev/null || true
     fi
     rm -rf "$path" 2>/dev/null && return 0
     sleep 1
@@ -167,10 +152,6 @@ remove_path() {
 
 # --- Main ---
 log_info "Starting static node cleanup"
-
-# Backup current script for potential rerun
-cp -f "$0" "$SCRIPT_BACKUP" 2>/dev/null || log_err "Failed to backup cleanup script to $SCRIPT_BACKUP"
-chmod +x "$SCRIPT_BACKUP" 2>/dev/null || true
 
 if [ "$1" != "--yes-i-am-sane-and-i-understand-what-i-am-doing" ]; then
   log_err "Needed flag isn't passed, exit without any action (--yes-i-am-sane-and-i-understand-what-i-am-doing)"
@@ -188,6 +169,8 @@ done
 
 # Kill Processes
 kill_and_wait "bash /var/lib/bashible/bashible"
+# Remove the bashible entrypoint right away so it cannot be re-launched while we clean up.
+remove_path /var/lib/bashible/bashible.sh
 kill_and_wait "containerd-shim"
 
 # Remove immutable bit
@@ -227,14 +210,7 @@ EOF_CRON
   (cat /root/old_crontab; echo "@reboot /root/d8-user-cleanup.sh") | crontab -
 fi
 
-remove_path /var/lib/bashible/ || CLEANUP_FAILED=1
-
 if [ "$CLEANUP_FAILED" -ne 0 ]; then
-  if [ ! -f "$SCRIPT_PATH" ]; then
-    mkdir -p /var/lib/bashible/
-    cp -f "$SCRIPT_BACKUP" "$SCRIPT_PATH"
-    chmod +x "$SCRIPT_PATH"
-  fi
   log_err "Cleanup finished with errors. Reboot the server and run as root user $SCRIPT_PATH --yes-i-am-sane-and-i-understand-what-i-am-doing again, or fix the issues above manually"
   exit 2
 fi
@@ -261,9 +237,16 @@ if [ "${#FSTAB_HITS[@]}" -gt 0 ]; then
   echo "# Remove or comment out those entries from /etc/fstab before rebooting,"
   echo "################################################################################"
   echo ""
+  # Exit before removing the script (below) so it stays on disk. A retry then re-runs
+  # it and re-hits this safeguard, instead of caps-controller-manager treating a
+  # missing script as "done" and rebooting with a stale /etc/fstab entry.
   log_err "Skipping reboot: manual /etc/fstab cleanup required (see WARNING above)"
   exit 3
 fi
+
+# Remove the script (and the rest of /var/lib/bashible) last, only once we are
+# committed to rebooting — every earlier exit path keeps it on disk for a rerun.
+remove_path /var/lib/bashible/
 
 log_info "Rebooting"
 shutdown -r -t 5

--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -130,18 +130,35 @@ kill_and_wait() {
 remove_path() {
   local path="$1"
 
-  # if it does not exist
   [ ! -e "$path" ] && return 0
 
   for i in {1..5}; do
     if [ -d "$path" ]; then
-      mount | grep -F "$path" | awk '{print $3}' | sort -r | xargs -r umount -l 2>/dev/null
+      # For each mountpoint under $path (deepest first): if it's a persistent writable volume,
+      # clear its data before unmounting so the device comes up empty on next boot.
+      while IFS= read -r mnt; do
+        local fstype
+        fstype=$(findmnt --noheadings --output FSTYPE --mountpoint "$mnt" 2>/dev/null)
+        case "$fstype" in
+          overlay|tmpfs|nsfs|autofs|erofs)
+            # No persistent data — just unmount (erofs is read-only, find -delete would fail)
+            ;;
+          *)
+            # Persistent writable volume (ext4, xfs, nfs4, etc.) — clear data first
+            log_info "Clearing data on $fstype volume at $mnt"
+            if ! find "$mnt" -mindepth 1 -delete 2>/dev/null; then
+              log_err "ERROR: failed to clear data at $mnt"
+              CLEANUP_FAILED=1
+            fi
+            ;;
+        esac
+        umount -l "$mnt" 2>/dev/null || true
+      done < <(mount | grep -F "$path" | awk '{print $3}' | sort -r)
     fi
     rm -rf "$path" 2>/dev/null && return 0
     sleep 1
   done
 
-  # if it exists after attempting to delete
   if [ -e "$path" ]; then
     log_err "ERROR: failed to remove $path"
     return 1

--- a/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
+++ b/candi/bashible/common-steps/all/003_create_static_node_cleanup_script.sh.tpl
@@ -190,12 +190,6 @@ done
 kill_and_wait "bash /var/lib/bashible/bashible"
 kill_and_wait "containerd-shim"
 
-# Unmount
-log_info "Unmounting kubelet/containerd mounts"
-for dir in /var/lib/kubelet /var/lib/containerd; do
-  mount | grep "$dir" | awk '{print $3}' | sort -r | xargs -r umount -l 2>/dev/null
-done
-
 # Remove immutable bit
 if [ -d /var/lib/containerd/io.containerd.snapshotter.v1.erofs ]; then
   chattr -R -i /var/lib/containerd/io.containerd.snapshotter.v1.erofs 2>/dev/null || true
@@ -245,8 +239,35 @@ if [ "$CLEANUP_FAILED" -ne 0 ]; then
   exit 2
 fi
 
-log_info "Cleanup completed successfully, restoring MOTD and rebooting"
+log_info "Cleanup completed successfully, restoring MOTD"
 restore_motd_message
+
+# Warn if any cleaned paths are still in fstab — they will be remounted on next boot.
+# The user must remove those entries manually before rebooting.
+FSTAB_HITS=()
+for p in "${PATHS_TO_REMOVE[@]}" /var/lib/bashible; do
+  if grep -qsF "$p" /etc/fstab 2>/dev/null; then
+    FSTAB_HITS+=("$p")
+  fi
+done
+
+if [ "${#FSTAB_HITS[@]}" -gt 0 ]; then
+  echo ""
+  echo "################################################################################"
+  echo "# WARNING: the following paths are present in /etc/fstab:"
+  for p in "${FSTAB_HITS[@]}"; do
+    echo "#   $p"
+  done
+  echo "#"
+  echo "# Remove or comment out those entries from /etc/fstab before rebooting,"
+  echo "# otherwise the devices will be remounted and bootstrap may fail again."
+  echo "################################################################################"
+  echo ""
+  log_err "Skipping reboot: manual /etc/fstab cleanup required (see WARNING above)"
+  exit 3
+fi
+
+log_info "Rebooting"
 shutdown -r -t 5
 EOF
 {{- end }}

--- a/dhctl/pkg/operations/destroy/static/destroyer.go
+++ b/dhctl/pkg/operations/destroy/static/destroyer.go
@@ -275,20 +275,10 @@ func (d *Destroyer) destroyCluster(ctx context.Context, autoApprove bool) error 
 	return nil
 }
 
-// cleanupManualInterventionExitCode is the exit code cleanup_static_node.sh returns
-// when it skips the reboot because /etc/fstab still references cleaned-up mountpoints.
-// Retrying cannot fix it — an operator must edit /etc/fstab first — so we stop the loop.
-const cleanupManualInterventionExitCode = 3
-
-func isManualCleanupRequired(err error) bool {
-	var ee *exec.ExitError
-	return errors.As(err, &ee) && ee.ExitCode() == cleanupManualInterventionExitCode
-}
-
 func (d *Destroyer) processStaticHost(ctx context.Context, sshClient libcon.SSHClient, host session.Host, stdOutErrHandler func(l string), cmd string) error {
 	d.logger().LogDebugF("Starting cleanup process for host %s\n", host)
 
-	err := retry.NewLoopWithParams(d.destroyMasterLoopParams(host)).BreakIf(isManualCleanupRequired).RunContext(ctx, func() error {
+	err := retry.NewLoopWithParams(d.destroyMasterLoopParams(host)).RunContext(ctx, func() error {
 		c := sshClient.Command(cmd)
 		c.Sudo(ctx)
 		c.WithTimeout(30 * time.Second)
@@ -310,10 +300,6 @@ func (d *Destroyer) processStaticHost(ctx context.Context, sshClient libcon.SSHC
 		return err
 	})
 	if err != nil {
-		if isManualCleanupRequired(err) {
-			return fmt.Errorf("static node cleanup on host %s requires manual /etc/fstab cleanup before it can finish (see the warning above): %w", host.String(), err)
-		}
-
 		return err
 	}
 

--- a/dhctl/pkg/operations/destroy/static/destroyer.go
+++ b/dhctl/pkg/operations/destroy/static/destroyer.go
@@ -275,10 +275,20 @@ func (d *Destroyer) destroyCluster(ctx context.Context, autoApprove bool) error 
 	return nil
 }
 
+// cleanupManualInterventionExitCode is the exit code cleanup_static_node.sh returns
+// when it skips the reboot because /etc/fstab still references cleaned-up mountpoints.
+// Retrying cannot fix it — an operator must edit /etc/fstab first — so we stop the loop.
+const cleanupManualInterventionExitCode = 3
+
+func isManualCleanupRequired(err error) bool {
+	var ee *exec.ExitError
+	return errors.As(err, &ee) && ee.ExitCode() == cleanupManualInterventionExitCode
+}
+
 func (d *Destroyer) processStaticHost(ctx context.Context, sshClient libcon.SSHClient, host session.Host, stdOutErrHandler func(l string), cmd string) error {
 	d.logger().LogDebugF("Starting cleanup process for host %s\n", host)
 
-	err := retry.NewLoopWithParams(d.destroyMasterLoopParams(host)).RunContext(ctx, func() error {
+	err := retry.NewLoopWithParams(d.destroyMasterLoopParams(host)).BreakIf(isManualCleanupRequired).RunContext(ctx, func() error {
 		c := sshClient.Command(cmd)
 		c.Sudo(ctx)
 		c.WithTimeout(30 * time.Second)
@@ -300,6 +310,10 @@ func (d *Destroyer) processStaticHost(ctx context.Context, sshClient libcon.SSHC
 		return err
 	})
 	if err != nil {
+		if isManualCleanupRequired(err) {
+			return fmt.Errorf("static node cleanup on host %s requires manual /etc/fstab cleanup before it can finish (see the warning above): %w", host.String(), err)
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
## Description

- `/var/lib/containerd` mounted as LVM volume (ext4/xfs) - contents are now wiped with `find -mindepth 1 -delete` before unmount
- `/var/lib/containerd/logs` (or any other nested external mount) - lazily unmounted before parent wipe; data on the nested device is preserved
- erofs snapshots inside `/var/lib/containerd/io.containerd.snapshotter.v1.erofs/` - unmounted without data wipe (read-only fs)
- overlay, tmpfs, nsfs, autofs - unmounted without data wipe (no persistent data)
- `/etc/fstab` entries - mountpoint directories are recreated after cleanup so external devices can remount cleanly on next boot; an informational note lists which cleaned paths will be remounted (devices are already wiped, so they come up empty)

## Why do we need it, and what problem does it solve?

When Kubernetes data directories (`/var/lib/containerd`, `/var/lib/kubelet`, `/var/lib/etcd`, etc.) are on separate block devices, the old cleanup script deleted the mountpoint directory but left data on the device intact. On next boot systemd remounted the device with stale data, causing node bootstrap to fail.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed static node cleanup to wipe data on externally mounted volumes before unmounting, preventing stale data from causing re-bootstrap failures.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
