### PR TITLE
[tests][docs] Disable additional markdownlint rules

### DIFF
--- a/testing/markdownlint.yaml
+++ b/testing/markdownlint.yaml
@@ -47,6 +47,10 @@ MD029:
   # List style
   style: "one_or_ordered"
 
+# MD031 - Fenced code blocks should be surrounded by blank lines
+# Disabled because it is necessary to have fenced code blocks without blank lines below in some cases, such as defining CSS classes (for Kramdown).
+MD031: false
+
 # MD033/no-inline-html - Inline HTML
 MD033: false
 
@@ -102,3 +106,6 @@ MD049:
 MD050:
   # Strong style should be consistent
   style: "consistent"
+
+# Table column style
+MD060: false

--- a/testing/markdownlint.yaml
+++ b/testing/markdownlint.yaml
@@ -107,5 +107,5 @@ MD050:
   # Strong style should be consistent
   style: "consistent"
 
-# Table column style
+# MD060 - Table column style.
 MD060: false


### PR DESCRIPTION
## Description

Disable some markdownlint rules for markdown documents:
- MD031. Suppress fenced code block blank line requirement to accommodate Kramdown CSS class annotations that demand adjacent code fences without separating blank lines
- MD060. Disable table column style enforcement to permit flexible table formatting across documentation sources

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Disable some markdownlint rules for markdown documents.
impact_level: low
```
