### PR TITLE
[user-authn] refactoring basic-auth-proxy

### DIFF
--- a/modules/150-user-authn/images/basic-auth-proxy/app/cmd/main.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/cmd/main.go
@@ -17,8 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -30,22 +33,28 @@ func main() {
 	handler := proxy.New()
 
 	rootCmd := &cobra.Command{
-		Use:   "basic-auth-proxy",
-		Short: "Basic auth proxy for Kubernetes API Server",
-		Long:  `Basic auth proxy for Kubernetes API Server`,
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("--------------------------------")
-			fmt.Println("[ Starting Basic auth proxy ]")
-			fmt.Println("--------------------------------")
-			handler.Run()
+		Use:           "basic-auth-proxy",
+		Short:         "Basic auth proxy for Kubernetes API Server",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			fmt.Fprintln(out, "--------------------------------")
+			fmt.Fprintln(out, "[ Starting Basic auth proxy ]")
+			fmt.Fprintln(out, "--------------------------------")
+
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			return handler.Run(ctx)
 		},
 	}
 
 	rootCmd.PersistentFlags().StringVar(&handler.ListenAddress, "listen", ":7332", "listen address and port")
 	rootCmd.PersistentFlags().StringVar(&handler.CertPath, "cert-path", "/some/cert/path", "directory with client.crt and client.key files")
 	rootCmd.PersistentFlags().StringVar(&handler.KubernetesAPIServerURL, "api-server-url", "https://kubernetes.default", "Kubernetes api server URL")
-	rootCmd.PersistentFlags().DurationVar(&handler.AuthCacheTTL, "auth-cache-ttl", 10*time.Second, "Crowd auth cache TTL")
-	rootCmd.PersistentFlags().DurationVar(&handler.GroupsCacheTTL, "groups-cache-ttl", 2*time.Minute, "Crowd groups cache TTL")
+	rootCmd.PersistentFlags().DurationVar(&handler.AuthCacheTTL, "auth-cache-ttl", 10*time.Second, "Authentication cache TTL (applies to negative results)")
+	rootCmd.PersistentFlags().DurationVar(&handler.GroupsCacheTTL, "groups-cache-ttl", 2*time.Minute, "Groups cache TTL (applies to successful authentication results)")
 
 	rootCmd.PersistentFlags().StringVar(&handler.CrowdBaseURL, "crowd-base-url", "", "URL of Atlassian Crowd")
 	rootCmd.PersistentFlags().StringVar(&handler.CrowdApplicationLogin, "crowd-application-login", "", "login of Atlassian Crowd application")
@@ -66,8 +75,8 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&handler.LDAPClientSecret, "ldap-client-secret", "", "clientSecret of LDAP OIDC application")
 	rootCmd.PersistentFlags().StringArrayVar(&handler.LDAPScopes, "ldap-scope", nil, "Scopes passed from LDAP OIDC provider settings")
 
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Printf("starting basic auth proxy error: %s", err)
+	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
+		fmt.Fprintf(rootCmd.ErrOrStderr(), "basic-auth-proxy: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/modules/150-user-authn/images/basic-auth-proxy/app/go.mod
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/go.mod
@@ -1,8 +1,6 @@
 module basic-auth-proxy
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.25.0
 
 require (
 	github.com/ReneKroon/ttlcache v1.7.0

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/crowd.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/crowd.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -28,11 +29,19 @@ import (
 	"time"
 )
 
+// CrowdConfig groups NewCrowd parameters.
+type CrowdConfig struct {
+	APIURL        string
+	Login         string
+	Password      string
+	AllowedGroups []string
+}
+
 type Crowd struct {
 	client *crowdClient
 }
 
-func NewCrowd(apiURL, login, password string, allowedGroups []string) Provider {
+func NewCrowd(cfg CrowdConfig) (Provider, error) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -45,28 +54,30 @@ func NewCrowd(apiURL, login, password string, allowedGroups []string) Provider {
 			IdleConnTimeout:       30 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
 		},
 	}
 
-	groups := make(map[string]struct{})
-	for _, group := range allowedGroups {
+	groups := make(map[string]struct{}, len(cfg.AllowedGroups))
+	for _, group := range cfg.AllowedGroups {
 		groups[group] = struct{}{}
 	}
 
 	return &Crowd{
 		client: &crowdClient{
-			apiURL:        strings.TrimSuffix(apiURL, "/"),
-			login:         login,
-			password:      password,
+			apiURL:        strings.TrimSuffix(cfg.APIURL, "/"),
+			login:         cfg.Login,
+			password:      cfg.Password,
 			allowedGroups: groups,
 			httpClient:    client,
 		},
-	}
+	}, nil
 }
 
-func (p *Crowd) ValidateCredentials(login, password string) ([]string, error) {
-	_, err := p.client.MakeRequest("/session", http.MethodPost, struct {
+func (p *Crowd) ValidateCredentials(ctx context.Context, login, password string) ([]string, error) {
+	_, err := p.client.MakeRequest(ctx, "/session", http.MethodPost, struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
 	}{Username: login, Password: password})
@@ -74,7 +85,7 @@ func (p *Crowd) ValidateCredentials(login, password string) ([]string, error) {
 		return nil, err
 	}
 
-	body, err := p.client.MakeRequest("/user/group/nested?username="+login, http.MethodGet, nil)
+	body, err := p.client.MakeRequest(ctx, "/user/group/nested?username="+login, http.MethodGet, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -96,19 +107,19 @@ type crowdClient struct {
 	httpClient    *http.Client
 }
 
-func (c *crowdClient) MakeRequest(url, method string, jsonPayload interface{}) (string, error) {
+func (c *crowdClient) MakeRequest(ctx context.Context, url, method string, jsonPayload any) (string, error) {
 	var body io.Reader
 	if jsonPayload != nil {
 		jsonData, err := json.Marshal(jsonPayload)
 		if err != nil {
-			return "", fmt.Errorf("crowd request error: %+v", err)
+			return "", fmt.Errorf("crowd request marshal: %w", err)
 		}
 		body = bytes.NewReader(jsonData)
 	}
 
-	req, err := http.NewRequest(method, fmt.Sprintf("%s/rest/usermanagement/1%s", c.apiURL, url), body)
+	req, err := http.NewRequestWithContext(ctx, method, fmt.Sprintf("%s/rest/usermanagement/1%s", c.apiURL, url), body)
 	if err != nil {
-		return "", fmt.Errorf("crowd request error: %+v", err)
+		return "", fmt.Errorf("crowd request build: %w", err)
 	}
 
 	req.SetBasicAuth(c.login, c.password)
@@ -117,17 +128,17 @@ func (c *crowdClient) MakeRequest(url, method string, jsonPayload interface{}) (
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("crowd request error: %+v", err)
+		return "", fmt.Errorf("crowd request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("crowd request error: %v", err)
+		return "", fmt.Errorf("crowd response read: %w", err)
 	}
 
 	if (resp.StatusCode != http.StatusOK) && (resp.StatusCode != http.StatusCreated) {
-		return "", fmt.Errorf("crowd request was not successful: %v %v", resp.StatusCode, string(responseBody))
+		return "", fmt.Errorf("crowd request was not successful: %d %s", resp.StatusCode, string(responseBody))
 	}
 
 	return string(responseBody), nil
@@ -139,12 +150,11 @@ func (c *crowdClient) GetGroups(body string) ([]string, error) {
 			Name string `json:"name"`
 		} `json:"groups"`
 	}
-	var groups []string
-
 	if err := json.Unmarshal([]byte(body), &crowdGroups); err != nil {
-		return groups, err
+		return nil, err
 	}
 
+	groups := make([]string, 0, len(crowdGroups.Groups))
 	for _, value := range crowdGroups.Groups {
 		if len(c.allowedGroups) > 0 {
 			if _, ok := c.allowedGroups[value.Name]; ok {

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/ldap.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/ldap.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -28,6 +29,16 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// LDAPConfig groups NewLDAP parameters to avoid the boolean-parameter parade.
+type LDAPConfig struct {
+	URL                  string
+	ClientID             string
+	ClientSecret         string
+	Scopes               []string
+	GetUserInfo          bool
+	BasicAuthUnsupported bool
+}
+
 type LDAPProvider struct {
 	httpClient  *http.Client
 	oidc        *oidc.Provider
@@ -36,7 +47,7 @@ type LDAPProvider struct {
 	getUserInfo bool
 }
 
-func NewLDAP(oidcURL, clientID, clientSecret string, getUserInfo, basicAuthUnsupported bool, scopes []string) Provider {
+func NewLDAP(ctx context.Context, cfg LDAPConfig) (Provider, error) {
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -49,40 +60,41 @@ func NewLDAP(oidcURL, clientID, clientSecret string, getUserInfo, basicAuthUnsup
 			IdleConnTimeout:       30 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
 		},
 	}
 
-	provider, err := oidc.NewProvider(oidc.ClientContext(context.Background(), httpClient), oidcURL)
+	oidcProvider, err := oidc.NewProvider(oidc.ClientContext(ctx, httpClient), cfg.URL)
 	if err != nil {
-		panic(err) // TODO: handle error
+		return nil, fmt.Errorf("create LDAP OIDC provider %q: %w", cfg.URL, err)
 	}
 
-	config := oauth2.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		Endpoint:     provider.Endpoint(),
-		Scopes:       scopes,
+	oauthCfg := oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Endpoint:     oidcProvider.Endpoint(),
+		Scopes:       cfg.Scopes,
 	}
-
-	if basicAuthUnsupported {
-		config.Endpoint.AuthStyle = oauth2.AuthStyleInParams
+	if cfg.BasicAuthUnsupported {
+		oauthCfg.Endpoint.AuthStyle = oauth2.AuthStyleInParams
 	}
 
 	return &LDAPProvider{
 		logger:      capnslog.NewPackageLogger("basic-auth-proxy", "ldap provider"),
 		httpClient:  httpClient,
-		oidc:        provider,
-		oauth2:      &config,
-		getUserInfo: getUserInfo,
-	}
+		oidc:        oidcProvider,
+		oauth2:      &oauthCfg,
+		getUserInfo: cfg.GetUserInfo,
+	}, nil
 }
 
-func (p *LDAPProvider) ValidateCredentials(login, password string) ([]string, error) {
+func (p *LDAPProvider) ValidateCredentials(ctx context.Context, login, password string) ([]string, error) {
 	p.logger.Info("validate credentials via LDAP (password grant)")
 
 	token, err := p.oauth2.PasswordCredentialsToken(
-		oidc.ClientContext(context.Background(), p.httpClient),
+		oidc.ClientContext(ctx, p.httpClient),
 		login,
 		password,
 	)
@@ -90,26 +102,26 @@ func (p *LDAPProvider) ValidateCredentials(login, password string) ([]string, er
 		return nil, err
 	}
 
-	if p.getUserInfo {
-		p.logger.Info("get user info from Dex for LDAP user")
-
-		info, err := p.oidc.UserInfo(
-			oidc.ClientContext(context.Background(), p.httpClient),
-			oauth2.StaticTokenSource(token),
-		)
-		if err != nil {
-			return nil, err
-		}
-
-		claims := struct {
-			Groups []string `json:"groups"`
-		}{}
-		if err = info.Claims(&claims); err != nil {
-			return nil, err
-		}
-
-		return claims.Groups, nil
+	if !p.getUserInfo {
+		return nil, nil
 	}
 
-	return nil, nil
+	p.logger.Info("get user info from Dex for LDAP user")
+
+	info, err := p.oidc.UserInfo(
+		oidc.ClientContext(ctx, p.httpClient),
+		oauth2.StaticTokenSource(token),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	claims := struct {
+		Groups []string `json:"groups"`
+	}{}
+	if err = info.Claims(&claims); err != nil {
+		return nil, err
+	}
+
+	return claims.Groups, nil
 }

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/oidc.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/oidc.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"time"
@@ -28,6 +29,16 @@ import (
 	"golang.org/x/oauth2"
 )
 
+// OIDCConfig groups NewOIDC parameters.
+type OIDCConfig struct {
+	URL                  string
+	ClientID             string
+	ClientSecret         string
+	Scopes               []string
+	GetUserInfo          bool
+	BasicAuthUnsupported bool
+}
+
 type OpenIDConnect struct {
 	httpClient  *http.Client
 	oidc        *oidc.Provider
@@ -36,7 +47,7 @@ type OpenIDConnect struct {
 	getUserInfo bool
 }
 
-func NewOIDC(oidcURL, clientID, clientSecret string, getUserInfo, basicAuthUnsupported bool, scopes []string) Provider {
+func NewOIDC(ctx context.Context, cfg OIDCConfig) (Provider, error) {
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
@@ -49,57 +60,61 @@ func NewOIDC(oidcURL, clientID, clientSecret string, getUserInfo, basicAuthUnsup
 			IdleConnTimeout:       30 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
 		},
 	}
 
-	provider, err := oidc.NewProvider(oidc.ClientContext(context.Background(), httpClient), oidcURL)
+	oidcProvider, err := oidc.NewProvider(oidc.ClientContext(ctx, httpClient), cfg.URL)
 	if err != nil {
-		panic(err) // TODO: handle error
+		return nil, fmt.Errorf("create OIDC provider %q: %w", cfg.URL, err)
 	}
 
-	config := oauth2.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		Endpoint:     provider.Endpoint(),
-		Scopes:       scopes,
+	oauthCfg := oauth2.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		Endpoint:     oidcProvider.Endpoint(),
+		Scopes:       cfg.Scopes,
 	}
-
-	if basicAuthUnsupported {
-		config.Endpoint.AuthStyle = oauth2.AuthStyleInParams
+	if cfg.BasicAuthUnsupported {
+		oauthCfg.Endpoint.AuthStyle = oauth2.AuthStyleInParams
 	}
 
 	return &OpenIDConnect{
 		logger:      capnslog.NewPackageLogger("basic-auth-proxy", "oidc provider"),
 		httpClient:  httpClient,
-		oidc:        provider,
-		oauth2:      &config,
-		getUserInfo: getUserInfo,
-	}
+		oidc:        oidcProvider,
+		oauth2:      &oauthCfg,
+		getUserInfo: cfg.GetUserInfo,
+	}, nil
 }
 
-func (p *OpenIDConnect) ValidateCredentials(login, password string) ([]string, error) {
+func (p *OpenIDConnect) ValidateCredentials(ctx context.Context, login, password string) ([]string, error) {
 	p.logger.Info("validate credentials")
-	token, err := p.oauth2.PasswordCredentialsToken(oidc.ClientContext(context.Background(), p.httpClient), login, password)
+	token, err := p.oauth2.PasswordCredentialsToken(oidc.ClientContext(ctx, p.httpClient), login, password)
 	if err != nil {
 		return nil, err
 	}
 	p.logger.Info("validate credentials successful")
-	if p.getUserInfo {
-		p.logger.Info("get user info")
-		info, err := p.oidc.UserInfo(oidc.ClientContext(context.Background(), p.httpClient), oauth2.StaticTokenSource(token))
-		if err != nil {
-			return nil, err
-		}
-		p.logger.Info("get user info successful")
-		// TODO: get the groups claim from the claimMappings settings of the provider
-		claims := struct {
-			Groups []string `json:"groups"`
-		}{}
-		if err = info.Claims(&claims); err != nil {
-			return nil, err
-		}
-		return claims.Groups, nil
+
+	if !p.getUserInfo {
+		return nil, nil
 	}
-	return nil, nil
+
+	p.logger.Info("get user info")
+	info, err := p.oidc.UserInfo(oidc.ClientContext(ctx, p.httpClient), oauth2.StaticTokenSource(token))
+	if err != nil {
+		return nil, err
+	}
+	p.logger.Info("get user info successful")
+
+	// TODO: get the groups claim from the claimMappings settings of the provider
+	claims := struct {
+		Groups []string `json:"groups"`
+	}{}
+	if err = info.Claims(&claims); err != nil {
+		return nil, err
+	}
+	return claims.Groups, nil
 }

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/provider.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/provider/provider.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package provider
 
+import "context"
+
+// Provider validates user credentials against an upstream IdP and returns
+// the user's groups on success. ctx must be propagated to outbound calls.
 type Provider interface {
-	ValidateCredentials(login string, password string) ([]string, error)
+	ValidateCredentials(ctx context.Context, login, password string) ([]string, error)
 }

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy.go
@@ -17,8 +17,14 @@ limitations under the License.
 package proxy
 
 import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/binary"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -26,6 +32,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ReneKroon/ttlcache"
@@ -45,6 +52,10 @@ const (
 	caFilepath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 
 	defaultFlushInterval = 50 * time.Second
+
+	// extraHeaderPrefix is the prefix kube-apiserver maps to user.Info.Extra
+	// (see --requestheader-extra-headers-prefix); must be stripped on ingress.
+	extraHeaderPrefix = "X-Remote-Extra-"
 )
 
 var _ http.Handler = &Handler{}
@@ -84,25 +95,154 @@ type Handler struct {
 	provider provider.Provider
 
 	prometheusRegistry *prometheus.Registry
+
+	// cacheKeyHMACKey is a per-process random key for HMAC-SHA256 over
+	// (login, password) so the raw password never lands in the cache map.
+	cacheKeyHMACKey []byte
 }
 
 func New() *Handler {
 	c := ttlcache.NewCache()
 	c.SkipTtlExtensionOnHit(true)
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		panic(fmt.Errorf("init cache HMAC key: %w", err))
+	}
+
 	return &Handler{
-		cache:       c,
-		CrowdGroups: []string{},
-		OIDCScopes:  []string{},
-		LDAPScopes:  []string{},
-		logger:      capnslog.NewPackageLogger("basic-auth-proxy", "proxy")}
+		cache:           c,
+		CrowdGroups:     []string{},
+		OIDCScopes:      []string{},
+		LDAPScopes:      []string{},
+		logger:          capnslog.NewPackageLogger("basic-auth-proxy", "proxy"),
+		cacheKeyHMACKey: key,
+	}
 }
 
-func (h *Handler) Run() {
+// Run wires the proxy together and serves until the listener fails.
+// Setup errors are returned so main can exit with a non-zero code.
+func (h *Handler) Run(ctx context.Context) error {
 	h.logger.Printf("-- Listening on: %s", h.ListenAddress)
 	h.logger.Printf("-- Kubernetes API URL: %s", h.KubernetesAPIServerURL)
 	h.logger.Printf("-- Auth Cache TTL: %v", h.AuthCacheTTL)
 	h.logger.Printf("-- Groups Cache TTL: %v", h.GroupsCacheTTL)
 
+	if err := h.initProvider(ctx); err != nil {
+		return err
+	}
+
+	u, err := url.Parse(h.KubernetesAPIServerURL)
+	if err != nil {
+		return fmt.Errorf("parse api-server-url %q: %w", h.KubernetesAPIServerURL, err)
+	}
+
+	transport, err := h.buildHTTPTransport(h.CertPath)
+	if err != nil {
+		return err
+	}
+
+	h.reverseProxy = httputil.NewSingleHostReverseProxy(u)
+	h.reverseProxy.Transport = transport
+	h.reverseProxy.FlushInterval = defaultFlushInterval
+
+	mux := http.NewServeMux()
+
+	h.prometheusRegistry = prometheus.NewRegistry()
+	requestCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "http_requests_total",
+		Help: "Count of all HTTP requests.",
+	}, []string{"handler", "code", "method"})
+
+	if err := h.prometheusRegistry.Register(requestCounter); err != nil {
+		return fmt.Errorf("register prometheus metrics: %w", err)
+	}
+	if err := h.prometheusRegistry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})); err != nil {
+		return fmt.Errorf("register process metrics: %w", err)
+	}
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		m := httpsnoop.CaptureMetrics(h, w, r)
+		requestCounter.With(prometheus.Labels{
+			"handler": "/",
+			"code":    strconv.Itoa(m.Code),
+			"method":  r.Method,
+		}).Inc()
+	})
+	mux.Handle("/metrics", promhttp.HandlerFor(h.prometheusRegistry, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	caCert, err := os.ReadFile(caFilepath)
+	if err != nil {
+		return fmt.Errorf("read api-server CA %q: %w", caFilepath, err)
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		return fmt.Errorf("parse api-server CA %q", caFilepath)
+	}
+
+	readyClient := &http.Client{
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    caCertPool,
+			},
+		},
+	}
+
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		req, reqErr := http.NewRequestWithContext(r.Context(), http.MethodGet, h.KubernetesAPIServerURL+"/version", nil)
+		if reqErr != nil {
+			h.logger.Error(reqErr)
+			http.Error(w, "Error", http.StatusInternalServerError)
+			return
+		}
+		resp, getErr := readyClient.Do(req)
+		if getErr != nil {
+			h.logger.Error(getErr)
+			http.Error(w, "Error", http.StatusInternalServerError)
+			return
+		}
+		_ = resp.Body.Close()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	server := &http.Server{
+		Addr:              h.ListenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		BaseContext:       func(net.Listener) context.Context { return ctx },
+	}
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		err := server.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			serverErrCh <- err
+		}
+		close(serverErrCh)
+	}()
+
+	select {
+	case err := <-serverErrCh:
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shutdown: %w", err)
+		}
+		return nil
+	}
+}
+
+func (h *Handler) initProvider(ctx context.Context) error {
 	enabledProviders := 0
 	if h.CrowdBaseURL != "" {
 		enabledProviders++
@@ -113,114 +253,79 @@ func (h *Handler) Run() {
 	if h.LDAPBaseURL != "" {
 		enabledProviders++
 	}
-
 	if enabledProviders > 1 {
-		h.logger.Fatal("only one auth provider can be used")
+		return fmt.Errorf("only one auth provider can be configured, got %d", enabledProviders)
 	}
 
-	if h.CrowdBaseURL != "" {
-		h.provider = provider.NewCrowd(h.CrowdBaseURL, h.CrowdApplicationLogin, h.CrowdApplicationPassword, h.CrowdGroups)
-		h.logger.Printf("-- Crowd URL: %s", h.CrowdBaseURL)
-	}
-
-	if h.OIDCBaseURL != "" {
-		h.provider = provider.NewOIDC(h.OIDCBaseURL, h.OIDCClientID, h.OIDCClientSecret, h.OIDCGetUserInfo,
-			h.OIDCBasicAuthUnsupported, h.OIDCScopes)
-		h.logger.Printf("-- OIDC URL: %s", h.OIDCBaseURL)
-	}
-
-	if h.LDAPBaseURL != "" {
-		h.provider = provider.NewLDAP(h.LDAPBaseURL, h.LDAPClientID, h.LDAPClientSecret, h.LDAPGetUserInfo,
-			h.LDAPBasicAuthUnsupported, h.LDAPScopes)
-		h.logger.Printf("-- LDAP OIDC URL: %s", h.LDAPBaseURL)
-	}
-
-	u, _ := url.Parse(h.KubernetesAPIServerURL)
-
-	h.reverseProxy = httputil.NewSingleHostReverseProxy(u)
-	h.reverseProxy.Transport = h.buildHTTPTransport(h.CertPath)
-	h.reverseProxy.FlushInterval = defaultFlushInterval
-
-	h.prometheusRegistry = prometheus.NewRegistry()
-	requestCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "http_requests_total",
-		Help: "Count of all HTTP requests.",
-	}, []string{"handler", "code", "method"})
-
-	err := h.prometheusRegistry.Register(requestCounter)
-	if err != nil {
-		h.logger.Fatalf("cannot register prometheus metrics: %s", err)
-	}
-
-	err = h.prometheusRegistry.Register(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	if err != nil {
-		h.logger.Fatalf("cannot register process metrics: %s", err)
-	}
-
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		m := httpsnoop.CaptureMetrics(h, w, r)
-		requestCounter.With(prometheus.Labels{
-			"handler": "/",
-			"code":    strconv.Itoa(m.Code),
-			"method":  r.Method,
-		}).Inc()
-	})
-	http.Handle("/metrics", promhttp.HandlerFor(h.prometheusRegistry, promhttp.HandlerOpts{}))
-	http.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("ok"))
-	})
-
-	caCert, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
-	if err != nil {
-		h.logger.Fatal(err)
-	}
-
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
-
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: caCertPool,
-			},
-		},
-	}
-
-	http.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
-		if _, err = client.Get(h.KubernetesAPIServerURL + "/version"); err != nil {
-			h.logger.Error(err)
-			http.Error(w, "Error", http.StatusInternalServerError)
-		} else {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
+	switch {
+	case h.CrowdBaseURL != "":
+		p, err := provider.NewCrowd(provider.CrowdConfig{
+			APIURL:        h.CrowdBaseURL,
+			Login:         h.CrowdApplicationLogin,
+			Password:      h.CrowdApplicationPassword,
+			AllowedGroups: h.CrowdGroups,
+		})
+		if err != nil {
+			return fmt.Errorf("init Crowd provider: %w", err)
 		}
-	})
+		h.provider = p
+		h.logger.Printf("-- Crowd URL: %s", h.CrowdBaseURL)
 
-	h.logger.Fatal(http.ListenAndServe(h.ListenAddress, nil))
+	case h.OIDCBaseURL != "":
+		p, err := provider.NewOIDC(ctx, provider.OIDCConfig{
+			URL:                  h.OIDCBaseURL,
+			ClientID:             h.OIDCClientID,
+			ClientSecret:         h.OIDCClientSecret,
+			Scopes:               h.OIDCScopes,
+			GetUserInfo:          h.OIDCGetUserInfo,
+			BasicAuthUnsupported: h.OIDCBasicAuthUnsupported,
+		})
+		if err != nil {
+			return fmt.Errorf("init OIDC provider: %w", err)
+		}
+		h.provider = p
+		h.logger.Printf("-- OIDC URL: %s", h.OIDCBaseURL)
+
+	case h.LDAPBaseURL != "":
+		p, err := provider.NewLDAP(ctx, provider.LDAPConfig{
+			URL:                  h.LDAPBaseURL,
+			ClientID:             h.LDAPClientID,
+			ClientSecret:         h.LDAPClientSecret,
+			Scopes:               h.LDAPScopes,
+			GetUserInfo:          h.LDAPGetUserInfo,
+			BasicAuthUnsupported: h.LDAPBasicAuthUnsupported,
+		})
+		if err != nil {
+			return fmt.Errorf("init LDAP provider: %w", err)
+		}
+		h.provider = p
+		h.logger.Printf("-- LDAP OIDC URL: %s", h.LDAPBaseURL)
+
+	default:
+		return fmt.Errorf("no auth provider configured")
+	}
+	return nil
 }
-func (h *Handler) buildHTTPTransport(certPath string) *http.Transport {
+
+func (h *Handler) buildHTTPTransport(certPath string) (*http.Transport, error) {
 	cert, err := tls.LoadX509KeyPair(
 		filepath.Join(certPath, certFilename),
 		filepath.Join(certPath, keyFilename),
 	)
 	if err != nil {
-		h.logger.Fatalf("loading certificates: %+v", err)
+		return nil, fmt.Errorf("loading client certificates from %q: %w", certPath, err)
 	}
 
 	caCerts := x509.NewCertPool()
 	caCert, err := os.ReadFile(caFilepath)
 	if err != nil {
-		h.logger.Fatalf("append CA cert: %+v", err)
+		return nil, fmt.Errorf("read api-server CA %q: %w", caFilepath, err)
+	}
+	if !caCerts.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("parse api-server CA %q", caFilepath)
 	}
 
-	ok := caCerts.AppendCertsFromPEM(caCert)
-	if !ok {
-		h.logger.Fatal("failed to parse CA certificate")
-	}
-
-	transport := &http.Transport{
+	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
@@ -231,11 +336,11 @@ func (h *Handler) buildHTTPTransport(certPath string) *http.Transport {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig: &tls.Config{
+			MinVersion:   tls.VersionTLS12,
 			Certificates: []tls.Certificate{cert},
 			RootCAs:      caCerts,
 		},
-	}
-	return transport
+	}, nil
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -247,7 +352,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	groups, err := h.validateCredentials(basicLogin, basicPassword)
+	groups, err := h.validateCredentials(r.Context(), basicLogin, basicPassword)
 	if err != nil {
 		h.logger.Errorf("403 Forbidden, authentication problem: %s", err.Error())
 		http.Error(w, "Forbidden", http.StatusForbidden)
@@ -262,32 +367,69 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.modifyRequest(w, r, basicLogin, groups)
 }
 
-func (h *Handler) validateCredentials(login, password string) ([]string, error) {
-	userID := login + ":" + password
+// cacheEntry distinguishes a negative result (err != nil, AuthCacheTTL)
+// from a successful auth with empty groups (err == nil, GroupsCacheTTL).
+// Collapsing both into a bare nil caused the auth-bypass on cache hit.
+type cacheEntry struct {
+	groups []string
+	err    error
+}
 
-	if value, exists := h.cache.Get(userID); exists {
-		if value != nil {
-			return value.([]string), nil
+// cacheKey returns HMAC-SHA256 over length-prefixed (login, password).
+// Length-prefixing avoids collisions like ("ab","cd") vs ("a","bcd").
+func (h *Handler) cacheKey(login, password string) string {
+	mac := hmac.New(sha256.New, h.cacheKeyHMACKey)
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(login)))
+	_, _ = mac.Write(lenBuf[:])
+	_, _ = mac.Write([]byte(login))
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(len(password)))
+	_, _ = mac.Write(lenBuf[:])
+	_, _ = mac.Write([]byte(password))
+	return string(mac.Sum(nil))
+}
+
+func (h *Handler) validateCredentials(ctx context.Context, login, password string) ([]string, error) {
+	key := h.cacheKey(login, password)
+
+	if value, exists := h.cache.Get(key); exists {
+		entry, ok := value.(cacheEntry)
+		if !ok {
+			h.logger.Errorf("unexpected cache entry type %T, ignoring", value)
+		} else {
+			return entry.groups, entry.err
 		}
-		return []string{}, nil
 	}
 
-	groups, err := h.provider.ValidateCredentials(login, password)
+	groups, err := h.provider.ValidateCredentials(ctx, login, password)
 	if err != nil {
 		h.logger.Errorf("error during validating user credentials: %+v", err)
-		h.cache.SetWithTTL(userID, nil, h.AuthCacheTTL)
+		h.cache.SetWithTTL(key, cacheEntry{err: err}, h.AuthCacheTTL)
 		return nil, err
 	}
 
-	h.cache.SetWithTTL(userID, groups, h.GroupsCacheTTL)
+	h.cache.SetWithTTL(key, cacheEntry{groups: groups}, h.GroupsCacheTTL)
 	h.logger.Printf("received groups for %s: %s", login, groups)
 	return groups, nil
 }
 
-func (h *Handler) modifyRequest(w http.ResponseWriter, r *http.Request, login string, groups []string) {
-	r.Header.Del("Authorization")
-	r.Header.Set("X-Remote-User", login)
+// stripIdentityHeaders drops client-supplied X-Remote-* identity headers.
+// kube-apiserver trusts them on our mTLS channel, so leaving them through
+// would let any client become cluster-admin via `X-Remote-Group: system:masters`.
+func stripIdentityHeaders(h http.Header) {
+	h.Del("Authorization")
+	h.Del("X-Remote-User")
+	h.Del("X-Remote-Group")
+	for k := range h {
+		if strings.HasPrefix(k, extraHeaderPrefix) {
+			h.Del(k)
+		}
+	}
+}
 
+func (h *Handler) modifyRequest(w http.ResponseWriter, r *http.Request, login string, groups []string) {
+	stripIdentityHeaders(r.Header)
+	r.Header.Set("X-Remote-User", login)
 	for _, group := range groups {
 		r.Header.Add("X-Remote-Group", group)
 	}

--- a/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy_test.go
+++ b/modules/150-user-authn/images/basic-auth-proxy/app/pkg/proxy/proxy_test.go
@@ -1,0 +1,464 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"slices"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeProvider records call count and the last ctx for cache assertions.
+type fakeProvider struct {
+	calls  atomic.Int64
+	groups []string
+	err    error
+
+	lastCtx atomic.Pointer[context.Context]
+}
+
+func (p *fakeProvider) ValidateCredentials(ctx context.Context, _, _ string) ([]string, error) {
+	p.calls.Add(1)
+	p.lastCtx.Store(&ctx)
+	return p.groups, p.err
+}
+
+// newTestHandler wires a Handler to a fakeProvider and closes the ttlcache
+// janitor on test end so goroutines don't leak.
+func newTestHandler(t *testing.T, p *fakeProvider, authTTL, groupsTTL time.Duration) *Handler {
+	t.Helper()
+	h := New()
+	h.provider = p
+	h.AuthCacheTTL = authTTL
+	h.GroupsCacheTTL = groupsTTL
+	t.Cleanup(func() {
+		h.cache.Close()
+	})
+	return h
+}
+
+func TestHandler_ValidateCredentials(t *testing.T) {
+	t.Parallel()
+
+	authErr := errors.New("invalid_grant")
+
+	tests := []struct {
+		name      string
+		newProv   func() *fakeProvider
+		login     string
+		password  string
+		repeats   int
+		wantErr   error
+		wantGrps  []string
+		wantCalls int64
+	}{
+		{
+			name:      "negative result is cached and returned as error on every hit",
+			newProv:   func() *fakeProvider { return &fakeProvider{err: authErr} },
+			login:     "user",
+			password:  "wrong",
+			repeats:   3,
+			wantErr:   authErr,
+			wantGrps:  nil,
+			wantCalls: 1,
+		},
+		{
+			name:      "positive result with groups is cached",
+			newProv:   func() *fakeProvider { return &fakeProvider{groups: []string{"admins", "devs"}} },
+			login:     "alice",
+			password:  "ok",
+			repeats:   3,
+			wantErr:   nil,
+			wantGrps:  []string{"admins", "devs"},
+			wantCalls: 1,
+		},
+		{
+			name:      "successful auth with empty groups (LDAP getUserInfo=false) is cached as success",
+			newProv:   func() *fakeProvider { return &fakeProvider{} },
+			login:     "bob",
+			password:  "ok",
+			repeats:   3,
+			wantErr:   nil,
+			wantGrps:  nil,
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+
+			p := tt.newProv()
+			h := newTestHandler(t, p, 10*time.Second, 2*time.Minute)
+
+			for i := range tt.repeats {
+				groups, err := h.validateCredentials(ctx, tt.login, tt.password)
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("call %d: got err %v, want %v", i, err, tt.wantErr)
+				}
+				if !slices.Equal(groups, tt.wantGrps) {
+					t.Fatalf("call %d: got groups %v, want %v", i, groups, tt.wantGrps)
+				}
+			}
+
+			if got := p.calls.Load(); got != tt.wantCalls {
+				t.Fatalf("provider call count: got %d, want %d (cache must serve repeats)", got, tt.wantCalls)
+			}
+		})
+	}
+}
+
+// TestHandler_NegativeCacheExpiresAndProviderIsRetried checks that after
+// AuthCacheTTL the negative entry is gone and the provider is hit again.
+// Uses wall-clock sleep because ttlcache's janitor goroutine deadlocks
+// testing/synctest; TTL is kept tiny so the test stays sub-second.
+func TestHandler_NegativeCacheExpiresAndProviderIsRetried(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ttl  = 50 * time.Millisecond
+		wait = 200 * time.Millisecond
+	)
+
+	p := &fakeProvider{err: errors.New("invalid_grant")}
+	h := newTestHandler(t, p, ttl, 2*time.Minute)
+
+	if _, err := h.validateCredentials(t.Context(), "u", "wrong"); err == nil {
+		t.Fatal("first call: expected error, got nil")
+	}
+	if _, err := h.validateCredentials(t.Context(), "u", "wrong"); err == nil {
+		t.Fatal("second call (cache hit): expected error, got nil")
+	}
+	if got := p.calls.Load(); got != 1 {
+		t.Fatalf("provider calls before expiry: got %d, want 1", got)
+	}
+
+	time.Sleep(wait)
+
+	if _, err := h.validateCredentials(t.Context(), "u", "wrong"); err == nil {
+		t.Fatal("third call (after expiry): expected error, got nil")
+	}
+	if got := p.calls.Load(); got != 2 {
+		t.Fatalf("provider calls after expiry: got %d, want 2 (cache must have expired)", got)
+	}
+}
+
+// TestHandler_UnexpectedCacheTypeIsRefetched: an unexpected cache value
+// type must not panic and must trigger a refetch from the provider.
+func TestHandler_UnexpectedCacheTypeIsRefetched(t *testing.T) {
+	t.Parallel()
+
+	want := []string{"g1"}
+	p := &fakeProvider{groups: want}
+	h := newTestHandler(t, p, 10*time.Second, 2*time.Minute)
+
+	key := h.cacheKey("u", "p")
+	h.cache.SetWithTTL(key, "garbage-not-a-cacheEntry", 10*time.Second)
+
+	got, err := h.validateCredentials(t.Context(), "u", "p")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if c := p.calls.Load(); c != 1 {
+		t.Fatalf("provider calls: got %d, want 1 (unexpected cache type must trigger refetch)", c)
+	}
+}
+
+// TestHandler_CacheKey_DoesNotLeakPassword: password must not appear in
+// the cache key (HMAC, not concatenation).
+func TestHandler_CacheKey_DoesNotLeakPassword(t *testing.T) {
+	t.Parallel()
+
+	const password = "s3cr3t-do-not-leak"
+	h := newTestHandler(t, &fakeProvider{}, 10*time.Second, 2*time.Minute)
+
+	key := h.cacheKey("alice", password)
+	if len(key) == 0 {
+		t.Fatal("expected non-empty cache key")
+	}
+	if bytes.Contains([]byte(key), []byte(password)) {
+		t.Fatal("password leaked into cache key (must be hashed, not concatenated)")
+	}
+
+	// Determinism: same inputs → same key.
+	if h.cacheKey("alice", password) != key {
+		t.Fatal("cache key must be deterministic for the lifetime of the Handler")
+	}
+
+	// Different password → different key.
+	if h.cacheKey("alice", password+"x") == key {
+		t.Fatal("different password must yield different cache key")
+	}
+
+	// Per-process key: a second Handler must derive a different key for the
+	// same inputs (no cross-process predictable key).
+	h2 := newTestHandler(t, &fakeProvider{}, 10*time.Second, 2*time.Minute)
+	if h2.cacheKey("alice", password) == key {
+		t.Fatal("cache key must be derived with a per-process random HMAC key")
+	}
+}
+
+// TestHandler_CacheKey_DomainSeparation: pairs with identical
+// concatenations must produce different keys (length-prefix is in effect).
+func TestHandler_CacheKey_DomainSeparation(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(t, &fakeProvider{}, 10*time.Second, 2*time.Minute)
+
+	tests := []struct {
+		name             string
+		loginA, passwdA  string
+		loginB, passwdB  string
+	}{
+		{"plain concat collision", "ab", "cd", "a", "bcd"},
+		{"nul-byte collision", "attacker\x00", "X", "attacker", "\x00X"},
+		{"colon-byte collision", "user", ":secret", "user:", "secret"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if h.cacheKey(tt.loginA, tt.passwdA) == h.cacheKey(tt.loginB, tt.passwdB) {
+				t.Fatalf("cache key collision between (%q,%q) and (%q,%q): length-prefixing missing?",
+					tt.loginA, tt.passwdA, tt.loginB, tt.passwdB)
+			}
+		})
+	}
+}
+
+// TestHandler_ServeHTTP is the e2e regression for the cache-bypass and
+// the X-Remote-* header-injection privesc.
+func TestHandler_ServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	type upstreamObservation struct {
+		headers http.Header
+	}
+
+	tests := []struct {
+		name              string
+		provider          *fakeProvider
+		basicAuth         [2]string
+		extraHeaders      http.Header
+		repeats           int
+		wantStatus        int
+		wantUpstream      int64
+		wantProvCalls     int64
+		wantBasicAuth     bool
+		assertLastRequest func(t *testing.T, obs upstreamObservation)
+	}{
+		{
+			name:          "valid credentials are proxied upstream and cached",
+			provider:      &fakeProvider{groups: []string{"devs"}},
+			basicAuth:     [2]string{"alice", "ok"},
+			repeats:       3,
+			wantStatus:    http.StatusOK,
+			wantUpstream:  3,
+			wantProvCalls: 1,
+			wantBasicAuth: true,
+			assertLastRequest: func(t *testing.T, obs upstreamObservation) {
+				t.Helper()
+				if got := obs.headers.Get("X-Remote-User"); got != "alice" {
+					t.Fatalf("X-Remote-User: got %q, want %q", got, "alice")
+				}
+				if got := obs.headers.Values("X-Remote-Group"); !slices.Equal(got, []string{"devs"}) {
+					t.Fatalf("X-Remote-Group: got %v, want %v", got, []string{"devs"})
+				}
+			},
+		},
+		{
+			name:          "invalid credentials yield 403 on every call within AuthCacheTTL (bypass regression)",
+			provider:      &fakeProvider{err: errors.New("invalid_grant")},
+			basicAuth:     [2]string{"user", "wrong"},
+			repeats:       3,
+			wantStatus:    http.StatusForbidden,
+			wantUpstream:  0,
+			wantProvCalls: 1,
+			wantBasicAuth: true,
+		},
+		{
+			name:          "request without basic auth yields 401",
+			provider:      &fakeProvider{},
+			repeats:       1,
+			wantStatus:    http.StatusUnauthorized,
+			wantUpstream:  0,
+			wantProvCalls: 0,
+			wantBasicAuth: false,
+		},
+		{
+			name:      "client-supplied X-Remote-* headers MUST NOT leak to upstream (privilege escalation regression)",
+			provider:  &fakeProvider{groups: []string{"devs"}},
+			basicAuth: [2]string{"alice", "ok"},
+			extraHeaders: http.Header{
+				"X-Remote-User":           []string{"attacker"},
+				"X-Remote-Group":          []string{"system:masters", "system:cluster-admins"},
+				"X-Remote-Extra-Scopes":   []string{"cluster-admin"},
+				"X-Remote-Extra-Whatever": []string{"evil"},
+			},
+			repeats:       1,
+			wantStatus:    http.StatusOK,
+			wantUpstream:  1,
+			wantProvCalls: 1,
+			wantBasicAuth: true,
+			assertLastRequest: func(t *testing.T, obs upstreamObservation) {
+				t.Helper()
+				if got := obs.headers.Get("X-Remote-User"); got != "alice" {
+					t.Fatalf("X-Remote-User: got %q, want %q (client-supplied value must be overwritten)", got, "alice")
+				}
+				if got := obs.headers.Values("X-Remote-Group"); !slices.Equal(got, []string{"devs"}) {
+					t.Fatalf("X-Remote-Group: got %v, want %v (client-supplied groups must not leak)", got, []string{"devs"})
+				}
+				for k := range obs.headers {
+					if len(k) >= len(extraHeaderPrefix) && k[:len(extraHeaderPrefix)] == extraHeaderPrefix {
+						t.Fatalf("X-Remote-Extra-* header %q must not be forwarded, got %v", k, obs.headers.Values(k))
+					}
+				}
+				if got := obs.headers.Get("Authorization"); got != "" {
+					t.Fatalf("Authorization header must be stripped, got %q", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				upstreamHits atomic.Int64
+				lastObs      atomic.Pointer[upstreamObservation]
+			)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				upstreamHits.Add(1)
+				obs := upstreamObservation{headers: r.Header.Clone()}
+				lastObs.Store(&obs)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(upstream.Close)
+
+			u, err := url.Parse(upstream.URL)
+			if err != nil {
+				t.Fatalf("parse upstream url: %v", err)
+			}
+
+			h := newTestHandler(t, tt.provider, 10*time.Second, 2*time.Minute)
+			h.reverseProxy = httputil.NewSingleHostReverseProxy(u)
+
+			for i := range tt.repeats {
+				rec := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces", nil)
+				if tt.wantBasicAuth {
+					req.SetBasicAuth(tt.basicAuth[0], tt.basicAuth[1])
+				}
+				for k, vs := range tt.extraHeaders {
+					for _, v := range vs {
+						req.Header.Add(k, v)
+					}
+				}
+
+				h.ServeHTTP(rec, req)
+
+				if rec.Code != tt.wantStatus {
+					t.Fatalf("call %d: status got %d, want %d", i, rec.Code, tt.wantStatus)
+				}
+			}
+
+			if got := upstreamHits.Load(); got != tt.wantUpstream {
+				t.Fatalf("upstream hits: got %d, want %d", got, tt.wantUpstream)
+			}
+			if got := tt.provider.calls.Load(); got != tt.wantProvCalls {
+				t.Fatalf("provider calls: got %d, want %d", got, tt.wantProvCalls)
+			}
+			if tt.assertLastRequest != nil {
+				obs := lastObs.Load()
+				if obs == nil {
+					t.Fatal("expected upstream to be called at least once")
+				}
+				tt.assertLastRequest(t, *obs)
+			}
+		})
+	}
+}
+
+// TestStripIdentityHeaders is a focused unit test for the helper.
+func TestStripIdentityHeaders(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   http.Header
+		want http.Header
+	}{
+		{
+			name: "removes X-Remote-User",
+			in:   http.Header{"X-Remote-User": []string{"attacker"}, "X-Other": []string{"keep"}},
+			want: http.Header{"X-Other": []string{"keep"}},
+		},
+		{
+			name: "removes all X-Remote-Group values",
+			in:   http.Header{"X-Remote-Group": []string{"system:masters", "evil"}},
+			want: http.Header{},
+		},
+		{
+			name: "removes any X-Remote-Extra-* header",
+			in: http.Header{
+				"X-Remote-Extra-Scopes":     []string{"cluster-admin"},
+				"X-Remote-Extra-Department": []string{"infra"},
+				"X-Real-Ip":                 []string{"keep"},
+			},
+			want: http.Header{"X-Real-Ip": []string{"keep"}},
+		},
+		{
+			name: "removes all identity headers at once",
+			in: http.Header{
+				"X-Remote-User":         []string{"attacker"},
+				"X-Remote-Group":        []string{"system:masters"},
+				"X-Remote-Extra-Scopes": []string{"x"},
+				"User-Agent":            []string{"curl/1"},
+			},
+			want: http.Header{"User-Agent": []string{"curl/1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			stripIdentityHeaders(tt.in)
+			if len(tt.in) != len(tt.want) {
+				t.Fatalf("len: got %d, want %d (got %v)", len(tt.in), len(tt.want), tt.in)
+			}
+			for k, want := range tt.want {
+				got := tt.in.Values(k)
+				if !slices.Equal(got, want) {
+					t.Fatalf("header %q: got %v, want %v", k, got, want)
+				}
+			}
+		})
+	}
+}

--- a/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
+++ b/modules/150-user-authn/templates/basic-auth-proxy/deployment.yaml
@@ -145,7 +145,7 @@ spec:
         {{- if eq $type "LDAP" }}
         - --ldap-base-url=https://{{ include "helm_lib_module_public_domain" (list . "dex") }}/
         - --ldap-client-id=kubernetes
-        - --ldap-client-secret={{ .Values.userAuthn.internal.kubernetesDexClientAppSecret | quote }}
+        - {{ printf "--ldap-client-secret=%s" .Values.userAuthn.internal.kubernetesDexClientAppSecret | quote }}
         - --ldap-include-user-info-claims=true
         - --ldap-basic-auth-unsupported={{ $config.basicAuthUnsupported | default false }}
         {{- if $config.scopes }}


### PR DESCRIPTION
## Description

Refactor and harden `basic-auth-proxy` in the `user-authn` module:

- improve request handling on the proxy boundary;
- improve authentication cache implementation;
- derive cache keys with a keyed hash instead of raw input concatenation;
- propagate `context.Context` through provider calls;
- return provider initialization errors instead of panicking;
- add graceful shutdown on `SIGTERM`;
- add regression unit tests.

This recreates only the `basic-auth-proxy` deployment in `d8-user-authn`.

## Why do we need it, and what problem does it solve?

This improves robustness and maintainability of the basic-auth path used by LDAP, OIDC, and Crowd providers. It also reduces sensitive data exposure in process memory and makes provider startup/runtime failures easier to handle and test.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Improve basic-auth-proxy request handling, cache implementation, and shutdown behavior.
impact_level: default
```