### PR TITLE
[docs-builder] allow only root crds paths

### DIFF
--- a/docs/site/backends/docs-builder/internal/docs/upload.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload.go
@@ -151,7 +151,7 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 		return filepath.Join(svc.baseDir, contentDir, moduleName, channel, fileName), true
 	}
 
-	if strings.HasPrefix(fileName, "crds") ||
+	if isAllowedCRDPath(fileName) ||
 		fileName == "openapi" ||
 		fileName == "openapi/conversions" ||
 		fileName == "openapi/config-values.yaml" ||
@@ -164,6 +164,46 @@ func (svc *Service) getLocalPath(moduleName, channel, fileName string) (string, 
 	}
 
 	return "", false
+}
+
+// isAllowedCRDPath reports whether the given path under crds/ may be uploaded
+// to Hugo's data directory.
+//
+// Two constraints shape the rule:
+//
+//  1. Hugo loads everything in data/ as structured data and supports only
+//     yaml/yml/json/toml/xml formats. Non-data files (e.g. crds/README.md,
+//     crds/update.sh) fail the whole build with
+//     `unmarshal of format "" is not supported` and the module gets dropped
+//     as "broken".
+//  2. The docs-builder-template renders crds/ as a flat map — one file per
+//     CRD spec (see layouts/_partials/module-resources.html and
+//     openapi/format-crd.html). Subdirectories like crds/native/foo.yaml
+//     would be loaded into a nested map and silently corrupt the CRD section
+//     of the page.
+//
+// So we accept only:
+//   - the crds directory entry itself (needed so MkdirAll can create it);
+//   - direct children of crds/ with a data extension (.yaml/.yml/.json).
+//
+// Everything else (subdirectories and non-data files at any depth) is
+// rejected.
+func isAllowedCRDPath(path string) bool {
+	if path == "crds" {
+		return true
+	}
+
+	rest, ok := strings.CutPrefix(path, "crds/")
+	if !ok || strings.Contains(rest, "/") {
+		return false
+	}
+
+	switch filepath.Ext(rest) {
+	case ".yaml", ".yml", ".json":
+		return true
+	default:
+		return false
+	}
 }
 
 func hasBlockedPrefix(path string) bool {

--- a/docs/site/backends/docs-builder/internal/docs/upload_test.go
+++ b/docs/site/backends/docs-builder/internal/docs/upload_test.go
@@ -78,6 +78,91 @@ func TestLoadHandlerGetLocalPath(t *testing.T) {
 			true,
 		},
 		{
+			"crds",
+			"/app/hugo/data/modules/moduleName/stable/crds",
+			true,
+		},
+		{
+			"./crds/object.yaml",
+			"/app/hugo/data/modules/moduleName/stable/crds/object.yaml",
+			true,
+		},
+		{
+			"crds/object.yml",
+			"/app/hugo/data/modules/moduleName/stable/crds/object.yml",
+			true,
+		},
+		{
+			"crds/object.json",
+			"/app/hugo/data/modules/moduleName/stable/crds/object.json",
+			true,
+		},
+		// The docs templates treat crds/ as a flat map (one file == one CRD).
+		// Subdirectories must be rejected regardless of what's inside, so the
+		// CRD section renders correctly and no garbage is loaded into data/.
+		{
+			"crds/native",
+			"",
+			false,
+		},
+		{
+			"crds/native/object.yaml",
+			"",
+			false,
+		},
+		{
+			"crds/cert-manager/cert.yaml",
+			"",
+			false,
+		},
+		{
+			"crds/gatekeeper/templates/template.yaml",
+			"",
+			false,
+		},
+		// Non-data files at the top level of crds/ must be rejected too — Hugo's
+		// data loader cannot unmarshal them and fails the whole module build
+		// with `unmarshal of format "" is not supported`.
+		{
+			"crds/README.md",
+			"",
+			false,
+		},
+		{
+			"crds/pull_dex_crds.sh",
+			"",
+			false,
+		},
+		{
+			"crds/x-pull-crds.sh",
+			"",
+			false,
+		},
+		// And the same files under subdirectories — rejected by the no-subdir
+		// rule above, but kept here as regression cases for the original bug
+		// (operator-trivy: crds/native/README.md).
+		{
+			"crds/native/README.md",
+			"",
+			false,
+		},
+		{
+			"crds/gatekeeper/README.md",
+			"",
+			false,
+		},
+		{
+			"crds/native/update.sh",
+			"",
+			false,
+		},
+		// Paths that merely start with the literal "crds" must not be matched.
+		{
+			"crdsxxx/object.yaml",
+			"",
+			false,
+		},
+		{
 			"openapi/doc-ru-config-values.yaml",
 			"/app/hugo/data/modules/moduleName/stable/openapi/doc-ru-config-values.yaml",
 			true,


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: documentation
type: fix
summary: Allow only root crds paths for documentation builder.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
