### PR TITLE
[ci] Fix documention workflows

### DIFF
--- a/.github/ci_includes/werf_envs.yml
+++ b/.github/ci_includes/werf_envs.yml
@@ -1,6 +1,6 @@
 {!{ define "werf_envs" }!}
 # <template: werf_envs>
-WERF_VERSION: "v2.69.0-dk"
+WERF_VERSION: "v2.69.0"
 WERF_ENV: "FE"
 WERF_TELEMETRY: "1"
 WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/ci_templates/steps.yml
+++ b/.github/ci_templates/steps.yml
@@ -182,15 +182,15 @@
 
 {!{ define "werf_install_step" }!}
 # <template: werf_install_step>
-- name: Install werf CLI
+- name: Install werf-dk CLI
   run: |
-    WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+    WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
     echo "$WERF_PATH" >> "$GITHUB_PATH"
     CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-    if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-      echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+    if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+      echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
       mkdir -p "$WERF_PATH"
-      curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+      curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
       chmod +x "$WERF_PATH/werf"
     else
       echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -27,7 +27,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
@@ -458,15 +458,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -739,15 +739,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -879,15 +879,15 @@ jobs:
           cache: false
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -998,15 +998,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1290,15 +1290,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1582,15 +1582,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1874,15 +1874,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2166,15 +2166,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2458,15 +2458,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -27,7 +27,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
@@ -223,15 +223,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -511,15 +511,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -649,15 +649,15 @@ jobs:
           cache: false
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1630,15 +1630,15 @@ jobs:
       # </template: login_rw_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -27,7 +27,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
@@ -223,15 +223,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -511,15 +511,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -649,15 +649,15 @@ jobs:
           cache: false
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -766,15 +766,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1066,15 +1066,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1366,15 +1366,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1666,15 +1666,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1966,15 +1966,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -2266,15 +2266,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -3476,15 +3476,15 @@ jobs:
       # </template: login_rw_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -44,7 +44,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
@@ -344,15 +344,15 @@ jobs:
       # </template: login_stage_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -663,15 +663,15 @@ jobs:
       # </template: login_stage_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -983,15 +983,15 @@ jobs:
       # </template: login_stage_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1303,15 +1303,15 @@ jobs:
       # </template: login_stage_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1623,15 +1623,15 @@ jobs:
       # </template: login_stage_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"
@@ -1943,15 +1943,15 @@ jobs:
       # </template: login_stage_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -41,7 +41,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -41,7 +41,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -41,7 +41,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -41,7 +41,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -41,7 +41,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test10.yml
+++ b/.github/workflows/deploy-web-test10.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test2.yml
+++ b/.github/workflows/deploy-web-test2.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test3.yml
+++ b/.github/workflows/deploy-web-test3.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test4.yml
+++ b/.github/workflows/deploy-web-test4.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test5.yml
+++ b/.github/workflows/deploy-web-test5.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test6.yml
+++ b/.github/workflows/deploy-web-test6.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test7.yml
+++ b/.github/workflows/deploy-web-test7.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test8.yml
+++ b/.github/workflows/deploy-web-test8.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/deploy-web-test9.yml
+++ b/.github/workflows/deploy-web-test9.yml
@@ -46,7 +46,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/docs-pdf-daily.yml
+++ b/.github/workflows/docs-pdf-daily.yml
@@ -26,7 +26,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
@@ -146,15 +146,15 @@ jobs:
       # </template: login_rw_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-dvp.yml
+++ b/.github/workflows/e2e-abort-dvp.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-abort-zvirt.yml
+++ b/.github/workflows/e2e-abort-zvirt.yml
@@ -40,7 +40,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -25,7 +25,7 @@ env:
   WERF_DRY_RUN: "false"
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-dvp.yml
+++ b/.github/workflows/e2e-dvp.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/e2e-zvirt.yml
+++ b/.github/workflows/e2e-zvirt.yml
@@ -57,7 +57,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -43,15 +43,15 @@ jobs:
     # </template: checkout_step>
 
     # <template: werf_install_step>
-    - name: Install werf CLI
+    - name: Install werf-dk CLI
       run: |
-        WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+        WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
         echo "$WERF_PATH" >> "$GITHUB_PATH"
         CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-        if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-          echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+        if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
           mkdir -p "$WERF_PATH"
-          curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+          curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
           chmod +x "$WERF_PATH/werf"
         else
           echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/promote_image.yml
+++ b/.github/workflows/promote_image.yml
@@ -37,7 +37,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -25,7 +25,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
@@ -96,15 +96,15 @@ jobs:
     # </template: checkout_step>
 
     # <template: werf_install_step>
-    - name: Install werf CLI
+    - name: Install werf-dk CLI
       run: |
-        WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+        WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
         echo "$WERF_PATH" >> "$GITHUB_PATH"
         CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-        if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-          echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+        if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+          echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
           mkdir -p "$WERF_PATH"
-          curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+          curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
           chmod +x "$WERF_PATH/werf"
         else
           echo "Current werf is $CACHED_VERSION, skipping download"

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -38,7 +38,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -38,7 +38,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -38,7 +38,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -38,7 +38,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -38,7 +38,7 @@ on:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -30,7 +30,7 @@ permissions:
 env:
 
   # <template: werf_envs>
-  WERF_VERSION: "v2.69.0-dk"
+  WERF_VERSION: "v2.69.0"
   WERF_ENV: "FE"
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_EXTRA_ATTRIBUTE_TEAM: "flantTeam=deckhouse/deckhouse"
@@ -220,15 +220,15 @@ jobs:
       # </template: login_dev_registry_step>
 
       # <template: werf_install_step>
-      - name: Install werf CLI
+      - name: Install werf-dk CLI
         run: |
-          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/$WERF_VERSION"
+          WERF_PATH="$RUNNER_TOOL_CACHE/werf-dk/${WERF_VERSION}-dk"
           echo "$WERF_PATH" >> "$GITHUB_PATH"
           CACHED_VERSION=$($WERF_PATH/werf version | tr -d '\n')
-          if [[ "$WERF_VERSION" != "$CACHED_VERSION" ]]; then
-            echo "Current werf is $CACHED_VERSION, downloading $WERF_VERSION";
+          if [[ "${WERF_VERSION}-dk" != "$CACHED_VERSION" ]]; then
+            echo "Current werf is $CACHED_VERSION, downloading ${WERF_VERSION}-dk";
             mkdir -p "$WERF_PATH"
-            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/$WERF_VERSION/werf
+            curl -Lsfo "$WERF_PATH/werf" https://github.com/deckhouse/delivery-kit/releases/download/${WERF_VERSION}-dk/werf
             chmod +x "$WERF_PATH/werf"
           else
             echo "Current werf is $CACHED_VERSION, skipping download"


### PR DESCRIPTION
## Description
Fix documention workflows using incorrect version of werf.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: fix
summary: Fix documention workflows.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
