### PR TITLE
[cloud-provider-*] Migrate images to builder/golang

### DIFF
--- a/ee/modules/030-cloud-provider-dynamix/images/capd-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/capd-controller-manager/werf.inc.yaml
@@ -31,7 +31,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 fromCacheVersion: "2025-02-14.2"
 mount:
 {{ include "mount points for golang builds" . }}

--- a/ee/modules/030-cloud-provider-dynamix/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/cloud-controller-manager/werf.inc.yaml
@@ -30,7 +30,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/ee/modules/030-cloud-provider-dynamix/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/cloud-data-discoverer/werf.inc.yaml
@@ -55,7 +55,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-dynamix/images/dynamix-csi-driver/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/dynamix-csi-driver/werf.inc.yaml
@@ -51,7 +51,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/ee/modules/030-cloud-provider-dynamix/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-dynamix/images/terraform-manager/werf.inc.yaml
@@ -41,7 +41,7 @@ shell:
 ---
 image: terraform-provider-decort
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/caphc-controller-manager/werf.inc.yaml
@@ -30,7 +30,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-controller-manager/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-bookworm" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/cloud-data-discoverer/werf.inc.yaml
@@ -55,7 +55,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/huaweicloud-csi-driver/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-huaweicloud/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-huaweicloud/images/terraform-manager/werf.inc.yaml
@@ -42,7 +42,7 @@ shell:
 ---
 image: terraform-provider-huaweicloud
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cinder-csi-plugin/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
@@ -64,9 +64,6 @@ secrets:
 - id: GOPROXY
   value: {{ $.GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" $ | nindent 2 }}
-  - apk add --no-cache make
   install:
   - cd /src
   - export GOPROXY=$(cat /run/secrets/GOPROXY)

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-controller-manager/werf.inc.yaml
@@ -46,7 +46,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
@@ -58,9 +58,6 @@ secrets:
 - id: GOPROXY
   value: {{ $.GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" $ | nindent 2 }}
-  - apk add --no-cache make
   install:
   - cd /src
   - export GOPROXY=$(cat /run/secrets/GOPROXY)

--- a/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/cloud-data-discoverer/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-openstack/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-openstack/images/terraform-manager/werf.inc.yaml
@@ -41,7 +41,7 @@ shell:
 ---
 image: terraform-provider-openstack
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -53,9 +53,6 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make bash
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src

--- a/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager-legacy/werf.inc.yaml
@@ -38,7 +38,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/capcd-controller-manager/werf.inc.yaml
@@ -38,7 +38,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager-legacy/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-controller-manager/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer-legacy/werf.inc.yaml
@@ -62,7 +62,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/cloud-data-discoverer/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager-legacy/werf.inc.yaml
@@ -53,7 +53,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager/werf.inc.yaml
@@ -43,7 +43,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/terraform-manager/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/terraform-manager/werf.inc.yaml
@@ -45,7 +45,7 @@ shell:
 ---
 image: terraform-provider-vcd-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -57,9 +57,6 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make bash
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
 {{- range $_, $version := $version_map }}

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin-legacy/werf.inc.yaml
@@ -48,7 +48,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
+++ b/ee/modules/030-cloud-provider-vcd/images/vcd-csi-plugin/werf.inc.yaml
@@ -48,7 +48,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-controller-manager/werf.inc.yaml
@@ -46,7 +46,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/cloud-data-discoverer/werf.inc.yaml
@@ -63,7 +63,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/terraform-manager/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
 ---
 image: terraform-provider-vsphere
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin-legacy/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin-legacy/werf.inc.yaml
@@ -44,7 +44,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-csi-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/images/vsphere-csi-plugin/werf.inc.yaml
@@ -54,7 +54,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/capz-controller-manager/werf.inc.yaml
@@ -33,7 +33,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-controller-manager/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/cloud-data-discoverer/werf.inc.yaml
@@ -58,7 +58,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/terraform-manager/werf.inc.yaml
@@ -41,7 +41,7 @@ shell:
 ---
 image: terraform-provider-ovirt
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -53,9 +53,6 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make bash
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/images/zvirt-csi-driver/werf.inc.yaml
@@ -62,7 +62,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/modules/030-cloud-provider-azure/images/azuredisk-csi/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/azuredisk-csi/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src

--- a/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-controller-manager/werf.inc.yaml
@@ -47,7 +47,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src

--- a/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/cloud-data-discoverer/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/modules/030-cloud-provider-azure/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-azure/images/terraform-manager/werf.inc.yaml
@@ -43,7 +43,7 @@ shell:
 ---
 image: terraform-provider-azure
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -56,8 +56,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make git openssh-client
+  - pm install git ssh-static
   install:
     - cd /src
     - export GOPROXY=$(cat /run/secrets/GOPROXY)

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg

--- a/modules/030-cloud-provider-dvp/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/cloud-controller-manager/werf.inc.yaml
@@ -35,7 +35,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
   - fromPath: ~/go-pkg-cache
     to: /go/pkg

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/werf.inc.yaml
@@ -50,7 +50,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/werf.inc.yaml
@@ -63,7 +63,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 - fromPath: ~/go-pkg-cache
   to: /go/pkg

--- a/modules/030-cloud-provider-dvp/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/werf.inc.yaml
@@ -41,7 +41,7 @@ shell:
   - rm -rf .git manifest/test/
 ---
 image: terraform-provider-kubernetes
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 mount:
 - fromPath: ~/go-pkg-cache
@@ -52,9 +52,6 @@ import:
   to: /src
   before: install
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make bash
   install:
   - export GOPROXY={{ $.GOPROXY }}
   - cd /src

--- a/modules/030-cloud-provider-gcp/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-controller-manager/werf.inc.yaml
@@ -47,7 +47,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
@@ -59,9 +59,6 @@ secrets:
 - id: GOPROXY
   value: {{ $.GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" $ | nindent 2 }}
-  - apk add --no-cache make
   install:
   - cd /src
   - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download

--- a/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/cloud-data-discoverer/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/modules/030-cloud-provider-gcp/images/pd-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/pd-csi-plugin/werf.inc.yaml
@@ -65,7 +65,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src

--- a/modules/030-cloud-provider-gcp/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-gcp/images/terraform-manager/werf.inc.yaml
@@ -41,7 +41,7 @@ shell:
 ---
 image: terraform-provider-gcp
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -25,7 +25,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-data-discoverer/werf.inc.yaml
@@ -52,7 +52,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
   add: /src

--- a/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-metrics-exporter/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-migrator/werf.inc.yaml
@@ -32,7 +32,7 @@ shell:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src

--- a/modules/030-cloud-provider-yandex/images/terraform-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/terraform-manager/werf.inc.yaml
@@ -41,7 +41,7 @@ shell:
 ---
 image: terraform-provider-yandex
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -53,9 +53,6 @@ secrets:
 - id: GOPROXY
   value: {{ .GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make bash
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src

--- a/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/yandex-csi-plugin/werf.inc.yaml
@@ -31,7 +31,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /go/src/app


### PR DESCRIPTION
## Description

Migrate the remaining `cloud-provider-*` module Go artifact builds to the unified `builder/golang` image.

Changes include:
- replacing `builder/golang-alpine` / `builder/golang-bookworm` with `builder/golang` in `werf.inc.yaml` for the remaining cloud-provider modules;
- removing Alpine-specific `beforeInstall` / `apk add` steps where the required tools are already present in `builder/golang`;
- switching `modules/030-cloud-provider-azure/images/terraform-manager/werf.inc.yaml` to `pm install git ssh-static`, because these dependencies are still required and are not built into the base builder image;
- keeping runtime stages, `common/relocate-artifact`, provider-specific discovery/CCM/CSI logic, and legacy/new module split unchanged.

This continues the migration pattern already used for `cloud-provider-aws`.

## Why do we need it, and what problem does it solve?

This standardizes Go artifact builds for the remaining cloud-provider modules on a single supported builder image.

Using one `builder/golang` contract instead of multiple distro-specific builder variants reduces maintenance overhead, removes Alpine-specific package-management assumptions from module templates.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-azure, cloud-provider-dvp, cloud-provider-dynamix, cloud-provider-gcp, cloud-provider-huaweicloud, cloud-provider-openstack, cloud-provider-vcd, cloud-provider-vsphere, cloud-provider-yandex, cloud-provider-zvirt
type: feature
summary: Migrated remaining cloud-provider Go artifact builds to the unified `builder/golang` image.
impact_level: default
```