### PR TITLE
[user-authz] ensure SPE render for webhook when APE is enabled

### DIFF
--- a/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
+++ b/ee/be/modules/140-user-authz/templates/webhook/daemonset.yaml
@@ -29,7 +29,11 @@ spec:
         memory: 50Mi
   {{- end }}
 
-{{- if or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException") }}
+{{- if or
+      (.Values.global.enabledModules | has "admission-policy-engine")
+      (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException")
+      (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")
+}}
 ---
 apiVersion: deckhouse.io/v1alpha1
 kind: SecurityPolicyException

--- a/modules/140-user-authz/template_tests/module_test.go
+++ b/modules/140-user-authz/template_tests/module_test.go
@@ -370,6 +370,35 @@ var _ = Describe("Module :: user-authz :: helm template ::", func() {
 			Expect(manifest).To(ContainSubstring("protocol: TCP"))
 		})
 
+		It("Should render SecurityPolicyException when admission-policy-engine module is enabled", func() {
+			f.ValuesSetFromYaml("global.enabledModules", `["admission-policy-engine"]`)
+			f.ValuesSetFromYaml("global.discovery.apiVersions", `[]`)
+
+			rendered := map[string]string{}
+			f.HelmRender(WithFilteredRenderOutput(rendered, []string{"webhook/daemonset.yaml"}))
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			manifest := ""
+			for k, v := range rendered {
+				if strings.Contains(k, "webhook/daemonset.yaml") {
+					manifest = v
+					break
+				}
+			}
+			if manifest == "" {
+				if len(rendered) == 1 {
+					for _, v := range rendered {
+						manifest = v
+						break
+					}
+				}
+			}
+
+			Expect(manifest).ToNot(BeEmpty())
+			Expect(manifest).To(ContainSubstring("kind: SecurityPolicyException"))
+			Expect(manifest).To(ContainSubstring("name: user-authz-webhook"))
+		})
+
 		It("Should deploy permission-browser-apiserver and supporting objects", func() {
 			Expect(f.KubernetesResource("Deployment", "d8-user-authz", "permission-browser-apiserver").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Service", "d8-user-authz", "permission-browser-apiserver").Exists()).To(BeTrue())


### PR DESCRIPTION
## Description
- Ensure `SecurityPolicyException` for `user-authz-webhook` is rendered when `admission-policy-engine` module is enabled, even if CRD discovery data is temporarily unavailable.
- Add template test coverage for this rendering path.
- This change improves recovery/bootstrap behavior of control-plane masters in degraded states.
## Why do we need it, and what problem does it solve?
In some clusters, a broken `user-authz-webhook` pod could not be deleted because admission checks denied `hostNetwork/hostPort`, causing a bootstrap deadlock (`dhctl` -> control-plane-manager -> kube-apiserver readiness).
Root cause: SPE rendering depended on discovery/capabilities state, which may be unreliable during degraded bootstrap windows.
This fix ensures SPE is rendered in the expected module-enabled scenario, so `user-authz-webhook` has the required policy exception (`hostNetwork` + `40443/TCP`) and does not require namespace label workaround.
## Why do we need it in the patch release (if we do)?
Required for patch release.
Reason: this is a critical bootstrap/recovery issue for control-plane masters. Without the fix, operators may need manual namespace policy label toggles to recover master converge, which is high operational risk.
## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: user-authz
type: fix
summary: Ensure `user-authz-webhook` SecurityPolicyException is rendered when admission-policy-engine is enabled.
impact: Reduces risk of control-plane bootstrap deadlocks caused by blocked lifecycle operations on `user-authz-webhook` pods in degraded discovery/capabilities states.
impact_level: default