### PR TITLE
[csi-vsphere] Fix templates and openapi specs

### DIFF
--- a/ee/se-plus/modules/030-csi-vsphere/openapi/values.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/openapi/values.yaml
@@ -27,6 +27,8 @@ properties:
               type: string
             path:
               type: string
+            storagePolicyName:
+              type: string
             zones:
               type: array
               items:
@@ -150,3 +152,16 @@ properties:
                 datastoreURL:
                   type: string
             description: List of datastores
+          storagePolicies:
+            type: array
+            items:
+              type: object
+              required: [name, id]
+              properties:
+                name:
+                  type: string
+                  minLength: 1
+                id:
+                  type: string
+                  minLength: 1
+            description: List of storage policies

--- a/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/deployment.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/deployment.yaml
@@ -106,6 +106,11 @@ spec:
             secretKeyRef:
               name: cloud-data-discoverer
               key: region
+        - name: ZONES
+          valueFrom:
+            secretKeyRef:
+              name: cloud-data-discoverer
+              key: zones
         - name: REGION_TAG_CATEGORY
           valueFrom:
             secretKeyRef:

--- a/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/secret.yaml
+++ b/ee/se-plus/modules/030-csi-vsphere/templates/cloud-data-discoverer/secret.yaml
@@ -13,6 +13,7 @@ data:
   password: {{ .provider.password | b64enc | quote }}
   insecure: {{ .provider.insecure | toString | b64enc | quote }}
   region: {{ .region | b64enc | quote }}
+  zones: {{ .zones | join "," | b64enc | quote }}
   regionTagCategory: {{ .regionTagCategory | b64enc | quote }}
   zoneTagCategory: {{ .zoneTagCategory | b64enc | quote }}
   vmFolderPath: {{ .vmFolderPath | b64enc | quote }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The OpenAPI schemas and `cloud-data-discoverer` templates have been updated.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
This patch provides a minimal fix for the Deckhouse queue hang caused by the hooks and schemas being out of sync with the `cloud-data-discoverer` codebase.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

The Deckhouse queue gets stuck, and the module is effectively unusable.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: csi-vsphere
type: fix
summary: Fixed the Deckhouse queue getting stuck
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
