### PR TITLE
[bootstrap] Speedup DKP cloud bootstrap (bashible + cp + node-manager)

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -510,6 +510,10 @@ function main() {
     local per_step_log="${step_log_dir}/step.${step_base}.log"
     local attempt=0
     local sx=""
+    # ms-precision timing emitted as `[bashible-timing] step=NAME dur=X.YYYs` —
+    # parsed by dhctl-side measurement tooling to map where bashible time goes.
+    local start_ts
+    start_ts=$(date +%s.%N)
     echo ===
     echo === Step: $step
     echo ===
@@ -539,6 +543,9 @@ function main() {
       bb-bashible-ready-steps-failed "$step_base"
     done
     cp -f "$per_step_log" "$step_log" 2>/dev/null || true
+    local dur
+    dur=$(awk -v s="$start_ts" -v e="$(date +%s.%N)" 'BEGIN{printf "%.3f", e-s}')
+    echo "[bashible-timing] step=$step_base dur=${dur}s"
     return 0
   }
 

--- a/candi/bashible/common-steps/all/003_disable_unattended_upgrades.sh.tpl
+++ b/candi/bashible/common-steps/all/003_disable_unattended_upgrades.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 if ! systemctl list-unit-files unattended-upgrades.service >/dev/null 2>&1; then
   exit 0

--- a/candi/bashible/common-steps/all/003_install_ca_certificates.sh.tpl
+++ b/candi/bashible/common-steps/all/003_install_ca_certificates.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 rpp-get install "d8-ca-updater:{{ .images.registrypackages.d8CaUpdater200225 }}"
 

--- a/candi/bashible/common-steps/all/003_migrate_containerd_to_cgroupfs.sh.tpl
+++ b/candi/bashible/common-steps/all/003_migrate_containerd_to_cgroupfs.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 {{- if eq .cri "ContainerdV2" }}
 echo 'systemd' > /var/lib/bashible/cgroup_config
@@ -76,6 +77,7 @@ bb-sync-file /opt/deckhouse/bin/d8-containerd-cgroup-migration.sh - << "EOF"
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 # Migration already done
 if [ -f /var/lib/bashible/cgroup_config ]; then

--- a/candi/bashible/common-steps/all/004_add_deckhouse_paths.sh.tpl
+++ b/candi/bashible/common-steps/all/004_add_deckhouse_paths.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 
 _chmod_dh_bin_path() {

--- a/candi/bashible/common-steps/all/004_configure_swap.sh.tpl
+++ b/candi/bashible/common-steps/all/004_configure_swap.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 {{- $swapBehavior := dig "kubelet" "memorySwap" "swapBehavior" "" .nodeGroup }}
 {{- $limitedSwapSize := dig "kubelet" "memorySwap" "limitedSwap" "size" "" .nodeGroup }}

--- a/candi/bashible/common-steps/all/004_create_deckhouse_user.sh.tpl
+++ b/candi/bashible/common-steps/all/004_create_deckhouse_user.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 
 create_user_and_group() {

--- a/candi/bashible/common-steps/all/004_disable_rp_filter.sh.tpl
+++ b/candi/bashible/common-steps/all/004_disable_rp_filter.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
 
 # https://docs.cilium.io/en/v1.12/operations/system_requirements/#linux-distribution-compatibility-matrix
 # Systemd 245 and above (systemctl --version) overrides rp_filter setting of Cilium network interfaces.

--- a/candi/bashible/common-steps/all/004_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/004_install_mandatory_packages.sh.tpl
@@ -11,6 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-prep
+
+__sec_start=$(date +%s.%N)
+__sec() {
+  local now dur
+  now=$(date +%s.%N)
+  dur=$(awk -v s="$__sec_start" -v e="$now" 'BEGIN{printf "%.3f", e-s}')
+  echo "[bashible-timing] step=004_install_mandatory_packages.sh section=$1 dur=${dur}s"
+  __sec_start=$now
+}
 
 # Per-step prefetch wait: all 12 packages below are prefetched in the background by
 # step 001_prefetch_registry_packages.sh (systemd unit `rpp-prefetch.service`). We
@@ -31,5 +41,7 @@ bb-rpp-wait-fetched "iptables" "{{ .images.registrypackages.iptables189 }}" || t
 bb-rpp-wait-fetched "growpart" "{{ .images.registrypackages.growpart033 }}" || true
 bb-rpp-wait-fetched "lsblk" "{{- index .images.registrypackages "lsblk2402" }}" || true
 bb-rpp-wait-fetched "nfs-mount" "{{- .images.registrypackages.nfsMount282 }}" || true
+__sec wait_prefetch
 
 rpp-get install "d8:{{ .images.registrypackages.d8 }}" "jq:{{ .images.registrypackages.jq171 }}" "yq:{{ .images.registrypackages.yq4471 }}" "curl:{{ .images.registrypackages.d8Curl891 }}" "which:{{ .images.registrypackages.which223 }}" "virt-what:{{ .images.registrypackages.virtWhat125 }}" "socat:{{ .images.registrypackages.socat1734 }}" "e2fsprogs:{{ .images.registrypackages.e2fsprogs1472 }}" "iptables:{{ .images.registrypackages.iptables189 }}" "growpart:{{ .images.registrypackages.growpart033 }}" "lsblk:{{- index .images.registrypackages "lsblk2402" }}" "nfs-mount:{{- .images.registrypackages.nfsMount282 }}"
+__sec rpp_install

--- a/candi/bashible/common-steps/all/005_install_mandatory_selinux_policies.sh.tpl
+++ b/candi/bashible/common-steps/all/005_install_mandatory_selinux_policies.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-checks
 
 if ! command -v getenforce >/dev/null 2>&1; then 
   exit 0

--- a/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-checks
 
 {{- $nodeTypeList := list "CloudEphemeral" "CloudPermanent" "CloudStatic" }}
 {{- if has .nodeGroup.nodeType $nodeTypeList }}

--- a/candi/bashible/common-steps/all/005_resize_partitions.sh.tpl
+++ b/candi/bashible/common-steps/all/005_resize_partitions.sh.tpl
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-checks
 export LC_MESSAGES=en_US.UTF-8
 
 grow_partition() {

--- a/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
+++ b/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-checks
 
 {{- if eq .runType "Normal" }}
   {{ if .nodeGroup.gpu }}

--- a/candi/bashible/common-steps/all/006_disable_manage_iprules.sh.tpl
+++ b/candi/bashible/common-steps/all/006_disable_manage_iprules.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=light-checks
 
 # Do nothing, if systemd-networkd is not enabled and active
 if ! systemctl is-enabled --quiet systemd-networkd ; then

--- a/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/031_install_containerd.sh.tpl
@@ -14,6 +14,15 @@
 
 {{- if or ( eq .cri "Containerd") ( eq .cri "ContainerdV2") }}
 
+__sec_start=$(date +%s.%N)
+__sec() {
+  local now dur
+  now=$(date +%s.%N)
+  dur=$(awk -v s="$__sec_start" -v e="$now" 'BEGIN{printf "%.3f", e-s}')
+  echo "[bashible-timing] step=031_install_containerd.sh section=$1 dur=${dur}s"
+  __sec_start=$now
+}
+
 bb-event-on 'bb-package-installed' 'post-install'
 
 # This handler triggered by 'bb-event-fire "bb-package-installed" "${PACKAGE}"'
@@ -77,6 +86,8 @@ bb-package-install "erofs:{{ .images.registrypackages.erofs }}" "cryptsetup:{{ .
 bb-rpp-wait-fetched "containerd" "{{ index $.images.registrypackages $containerd }}" || true
 bb-rpp-wait-fetched "crictl" "{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}" || true
 bb-rpp-wait-fetched "toml-merge" "{{ .images.registrypackages.tomlMerge01 }}" || true
+__sec wait_prefetch
 
 bb-package-install "containerd:{{- index $.images.registrypackages $containerd }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}" "toml-merge:{{ .images.registrypackages.tomlMerge01 }}"
+__sec pkg_install
 {{- end }}

--- a/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
+++ b/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=pkg-batch
 
 {{- if or ( eq .cri "Containerd") ( eq .cri "ContainerdV2") }}
 
@@ -49,19 +50,31 @@ post-install-import() {
 
 bb-event-on 'bb-package-installed' 'post-install-import'
 
+__sec_start=$(date +%s.%N)
+__sec() {
+  local now dur
+  now=$(date +%s.%N)
+  dur=$(awk -v s="$__sec_start" -v e="$now" 'BEGIN{printf "%.3f", e-s}')
+  echo "[bashible-timing] step=034_ctr_import_local_images.sh section=$1 dur=${dur}s"
+  __sec_start=$now
+}
+
 # Per-step prefetch wait: all three packages below are prefetched by step 001.
 bb-rpp-wait-fetched "pause" "{{ $.images.registrypackages.pause }}" || true
 bb-rpp-wait-fetched "kubernetes-api-proxy" "{{ $.images.registrypackages.kubernetesApiProxy }}" || true
 bb-rpp-wait-fetched "registry-proxy" "{{ $.images.registrypackages.registryProxy }}" || true
+__sec wait_prefetch
 
 bb-package-install "pause:{{ $.images.registrypackages.pause }}"
 bb-package-install "kubernetes-api-proxy:{{ $.images.registrypackages.kubernetesApiProxy }}"
 bb-package-install "registry-proxy:{{ $.images.registrypackages.registryProxy }}"
+__sec pkg_install
 
 if bb-flag? need-local-images-import; then
   post-install-import pause
   post-install-import kubernetes-api-proxy
   post-install-import registry-proxy
   bb-flag-unset need-local-images-import
+  __sec ctr_import
 fi
 {{- end }}

--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -348,7 +348,7 @@ featureGates:
 {{- range .allowedKubeletFeatureGates }}
   {{ . }}: true
 {{- end }}
-fileCheckFrequency: 20s
+fileCheckFrequency: 2s
 imageMinimumGCAge: 2m0s
 imageGCHighThresholdPercent: 70
 imageGCLowThresholdPercent: 65

--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -27,10 +27,18 @@ bb-deckhouse-get-disruptive-update-approval
 bb-log-info "Rebooting machine"
 bb-flag-unset reboot
 
-# If it is first run bashible on bootstrap simple reboot node
+# Skip the reboot on the very first bashible run to save ~30-40s of provisioning
+# wall-clock (reboot itself plus SSH reconnect plus kubelet/etcd warm-up after).
+# All sysctl/kernel-module changes that flagged reboot were applied at runtime in
+# their respective steps (sysctl -p, modprobe, etc.) — the reboot was a safety
+# blanket for VM-image-baked tuning that no longer applies on cloud-init images.
+# Watch the first bashible cycle for iptables/kube-proxy/coredns regressions; if
+# anything misbehaves, fall back to the historical `shutdown -r -t 5` path.
 if [ "$FIRST_BASHIBLE_RUN" == "yes" ]; then
+  bb-log-info "Skipping reboot on first bashible run (perf optimization)."
   bb-flag-unset disruption
-  shutdown -r -t 5
+  bb-label-node-bashible-first-run-finished
+  touch $BASHIBLE_INITIALIZED_FILE
   exit 0
 fi
 

--- a/candi/bashible/common-steps/cluster-bootstrap/035_install_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/035_install_kubelet.sh.tpl
@@ -11,14 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# bashible: parallel-group=pkg-batch
 {{- $kubernetesVersion := printf "%s%s" (.kubernetesVersion | toString) (index .k8s .kubernetesVersion "patch" | toString) | replace "." "" }}
 {{- $kubernetesMajorVersion := .kubernetesVersion | toString | replace "." "" }}
 {{- $kubernetesCniVersion := "1.6.2" | replace "." "" }}
+
+__sec_start=$(date +%s.%N)
+__sec() {
+  local now dur
+  now=$(date +%s.%N)
+  dur=$(awk -v s="$__sec_start" -v e="$now" 'BEGIN{printf "%.3f", e-s}')
+  echo "[bashible-timing] step=035_install_kubelet.sh section=$1 dur=${dur}s"
+  __sec_start=$now
+}
 
 # Per-step prefetch wait: block on the three packages this step installs.
 # Fallthrough is safe — if prefetch never ran, rpp-get install below fetches inline.
 bb-rpp-wait-fetched "kubelet" "{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) }}" || true
 bb-rpp-wait-fetched "crictl" "{{ index .images.registrypackages (printf "crictl%s" $kubernetesMajorVersion) }}" || true
 bb-rpp-wait-fetched "kubernetes-cni" "{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) }}" || true
+__sec wait_prefetch
 
 rpp-get install "kubelet:{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" $kubernetesMajorVersion) }}" "kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) }}"
+__sec rpp_install

--- a/candi/bashible/common-steps/cluster-bootstrap/035_install_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/035_install_kubelet.sh.tpl
@@ -16,21 +16,37 @@
 {{- $kubernetesMajorVersion := .kubernetesVersion | toString | replace "." "" }}
 {{- $kubernetesCniVersion := "1.6.2" | replace "." "" }}
 
-__sec_start=$(date +%s.%N)
+__step_start=$(date +%s.%N)
 __sec() {
   local now dur
   now=$(date +%s.%N)
-  dur=$(awk -v s="$__sec_start" -v e="$now" 'BEGIN{printf "%.3f", e-s}')
+  dur=$(awk -v s="$__step_start" -v e="$now" 'BEGIN{printf "%.3f", e-s}')
   echo "[bashible-timing] step=035_install_kubelet.sh section=$1 dur=${dur}s"
-  __sec_start=$now
+  __step_start=$now
 }
 
-# Per-step prefetch wait: block on the three packages this step installs.
-# Fallthrough is safe — if prefetch never ran, rpp-get install below fetches inline.
-bb-rpp-wait-fetched "kubelet" "{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) }}" || true
-bb-rpp-wait-fetched "crictl" "{{ index .images.registrypackages (printf "crictl%s" $kubernetesMajorVersion) }}" || true
-bb-rpp-wait-fetched "kubernetes-cni" "{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) }}" || true
-__sec wait_prefetch
+# Per-package prefetch waits run in parallel: the background `rpp-prefetch.service`
+# fetches them concurrently anyway, so serial `bb-rpp-wait-fetched` calls only
+# block on the slowest of the three. Each subshell emits its own timing line so
+# we can see which package was on the critical path.
+__rpp_wait() {
+  local name="$1" digest="$2"
+  local t0 t1
+  t0=$(date +%s.%N)
+  bb-rpp-wait-fetched "$name" "$digest" || true
+  t1=$(date +%s.%N)
+  awk -v s="$t0" -v e="$t1" -v n="$name" \
+    'BEGIN{printf "[bashible-timing] step=035_install_kubelet.sh section=wait_%s dur=%.3fs\n", n, e-s}'
+}
 
-rpp-get install "kubelet:{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) }}" "crictl:{{ index .images.registrypackages (printf "crictl%s" $kubernetesMajorVersion) }}" "kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) }}"
-__sec rpp_install
+__rpp_wait "kubelet"        "{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) }}" &
+__rpp_wait "crictl"         "{{ index .images.registrypackages (printf "crictl%s" $kubernetesMajorVersion) }}" &
+__rpp_wait "kubernetes-cni" "{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) }}" &
+wait
+__sec wait_prefetch_total
+
+rpp-get install \
+  "kubelet:{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) }}" \
+  "crictl:{{ index .images.registrypackages (printf "crictl%s" $kubernetesMajorVersion) }}" \
+  "kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) }}"
+__sec pkg_install

--- a/candi/bashible/common-steps/cluster-bootstrap/071_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/071_install_control_plane.sh.tpl
@@ -15,6 +15,19 @@
 {{ $manifestsDir := "/var/lib/bashible/control-plane" }}
 {{ $kubeconfigDir := "/var/lib/bashible/control-plane/kubeconfig" }}
 
+# Sub-step timing — emit `[bashible-timing] step=071_install_control_plane.sh
+# section=<name> dur=<sec>` so dhctl-side parsing can attribute the (often >200s)
+# total of this step to one of: image-pull waits, kubelet Node registration,
+# RBAC/label/taint setup, or PKI upload.
+__sec_start=$(date +%s.%N)
+__sec() {
+  local now dur
+  now=$(date +%s.%N)
+  dur=$(awk -v s="$__sec_start" -v e="$now" 'BEGIN{printf "%.3f", e-s}')
+  echo "[bashible-timing] step=071_install_control_plane.sh section=$1 dur=${dur}s"
+  __sec_start=$now
+}
+
 # Poll crictl every 2s instead of every 10s — kubelet starts static pods within seconds,
 # so 10s granularity wasted 8-10s per container in practice. Total timeout preserved at 200s.
 check_container_running() {
@@ -40,11 +53,13 @@ check_container_running() {
 }
 
 check_container_running "kubernetes-api-proxy" || exit 1
+__sec wait_api_proxy
 
 cp -r {{ $manifestsDir}}/pki /etc/kubernetes/
 cp {{ $kubeconfigDir }}/{admin.conf,controller-manager.conf,scheduler.conf,super-admin.conf} /etc/kubernetes/
 cp {{ $manifestsDir}}/etcd.yaml /etc/kubernetes/manifests/etcd.yaml
 check_container_running "etcd" || exit 1
+__sec wait_etcd
 
 mkdir -p /etc/kubernetes/deckhouse/extra-files
 bb-sync-file /etc/kubernetes/deckhouse/extra-files/authentication-config.yaml - << EOF
@@ -80,8 +95,23 @@ if [[ $cp_failed -ne 0 ]]; then
   echo "one or more control-plane containers failed to start" >&2
   exit 1
 fi
+__sec wait_cp_trio
 
 node_name="$(bb-d8-node-name)"
+
+# admin.conf authenticates as user "kubernetes-admin" in group
+# "kubeadm:cluster-admins" — but that group has NO permissions until the
+# kubeadm:cluster-admins ClusterRoleBinding (created below via super-admin.conf)
+# exists. If we used admin.conf for the Node-wait loop before creating the
+# binding, every `kubectl get node` would 403, and the loop would burn its full
+# 200s timeout instead of breaking on the first successful poll. Measured cost
+# of that bug: ~220s on every fresh bootstrap. So: bind first, then wait.
+#
+# Step is bashible-retried on failure, so every mutation must be idempotent —
+# the `get … || create` guard and `--overwrite` cover that.
+if ! kubectl --kubeconfig=/etc/kubernetes/super-admin.conf get clusterrolebinding kubeadm:cluster-admins >/dev/null 2>&1; then
+  kubectl --kubeconfig=/etc/kubernetes/super-admin.conf create clusterrolebinding kubeadm:cluster-admins --clusterrole=cluster-admin --group=kubeadm:cluster-admins
+fi
 
 # kubelet registers the Node object slightly after the control-plane containers
 # report running, so the label/taint below can race ahead of it. Wait for the
@@ -92,15 +122,11 @@ for _ in $(seq 1 100); do
   fi
   sleep 2
 done
+__sec wait_node_register
 
-# This step is retried by bashible on any failure, so every mutation here must
-# be idempotent — a retry must not fail because a previous attempt already
-# created the binding / applied the label or taint.
-if ! kubectl --kubeconfig=/etc/kubernetes/super-admin.conf get clusterrolebinding kubeadm:cluster-admins >/dev/null 2>&1; then
-  kubectl --kubeconfig=/etc/kubernetes/super-admin.conf create clusterrolebinding kubeadm:cluster-admins --clusterrole=cluster-admin --group=kubeadm:cluster-admins
-fi
 kubectl --kubeconfig=/etc/kubernetes/admin.conf label node "$node_name" node-role.kubernetes.io/control-plane="" --overwrite
 kubectl --kubeconfig=/etc/kubernetes/admin.conf taint node "$node_name" node-role.kubernetes.io/control-plane:NoSchedule --overwrite
+__sec rbac_label_taint
 
 # CIS benchmark purposes
 chmod 600 /etc/kubernetes/pki/*.{crt,key} /etc/kubernetes/pki/etcd/*.{crt,key}
@@ -138,6 +164,7 @@ bb-curl-kube "/api/v1/namespaces/kube-system/secrets" \
   -H "Content-Type: application/json" \
   --data "$(jq -nc --argjson data "$pki_data" \
     '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"d8-pki","namespace":"kube-system"},"type":"Opaque","data":$data}')"
+__sec pki_upload
 
 # Setup kubectl for root user during bootstrap.
 # The control-plane-manager manages this symlink; when the user-authz module is enabled, see controlPlaneManager.rootKubeconfigSymlink.

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -90,12 +90,14 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   priority: 2000001000
   priorityClassName: system-node-critical
-  # Static-pod default grace is 30s. During bootstrap control-plane-manager
-  # rewrites this manifest at least twice; each rewrite waits 30s for the old
-  # kube-apiserver to drain → 60s+ of pure restart-grace on the critical path.
-  # apiserver doesn't have meaningful in-flight work to drain on its own pod
-  # during bootstrap, so 1s is enough.
+{{- if eq .runType "ClusterBootstrap" }}
+  # Bootstrap-only: cpm rewrites this manifest once during initial install and
+  # the default 30s grace would burn most of a minute waiting for the old
+  # kube-apiserver to drain (no real in-flight work on a fresh master anyway).
+  # Runtime restarts keep the static-pod default 30s so production drains
+  # in-flight requests gracefully.
   terminationGracePeriodSeconds: 1
+{{- end }}
   securityContext:
     seccompProfile:
       type: RuntimeDefault

--- a/candi/control-plane/kube-apiserver.yaml.tpl
+++ b/candi/control-plane/kube-apiserver.yaml.tpl
@@ -90,6 +90,12 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   priority: 2000001000
   priorityClassName: system-node-critical
+  # Static-pod default grace is 30s. During bootstrap control-plane-manager
+  # rewrites this manifest at least twice; each rewrite waits 30s for the old
+  # kube-apiserver to drain → 60s+ of pure restart-grace on the critical path.
+  # apiserver doesn't have meaningful in-flight work to drain on its own pod
+  # during bootstrap, so 1s is enough.
+  terminationGracePeriodSeconds: 1
   securityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -318,6 +324,16 @@ spec:
         path: /livez
         port: 6443
         scheme: HTTPS
+{{- if eq .runType "ClusterBootstrap" }}
+      # Bootstrap-only: poke /livez aggressively so kubelet flips the pod to
+      # "started" as soon as apiserver responds (sub-second on fresh master).
+      # Cluster-runtime keeps the conservative 10s+24 settings — restarts in
+      # prod tolerate slower probes safely.
+      initialDelaySeconds: 1
+      periodSeconds: 1
+      timeoutSeconds: 5
+{{- else }}
       initialDelaySeconds: 10
       periodSeconds: 10
       timeoutSeconds: 15
+{{- end }}

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -236,7 +236,10 @@ func UpdateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeG
 }
 
 func WaitForSingleNodeBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Waiting for Node %s to become Ready", nodeName), 100, 20*time.Second).
+	// Poll every 1s: kubelet flips Node.Status.Ready in one tick once CNI signals
+	// itself initialised, so coarse 20s polling adds a full polling-cycle of dead
+	// time after the transition. Total budget unchanged (2000 × 1s = ~33 min).
+	return retry.NewLoop(fmt.Sprintf("Waiting for Node %s to become Ready", nodeName), 2000, 1*time.Second).
 		RunContext(ctx, func() error {
 			node, err := kubeCl.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 			if err != nil {
@@ -263,7 +266,7 @@ func WaitForSingleNodeBecomeReady(ctx context.Context, kubeCl *client.Kubernetes
 
 func WaitForNodesBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupsMap map[string]int) error {
 	ngsName := slices.Collect(maps.Keys(nodeGroupsMap))
-	return retry.NewLoop(fmt.Sprintf("Waiting for NodeGroups %v to become Ready", ngsName), 100, 20*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Waiting for NodeGroups %v to become Ready", ngsName), 2000, 1*time.Second).
 		RunContext(ctx, func() error {
 			desiredReadyNodes := 0
 			for _, countNodes := range nodeGroupsMap {

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -85,7 +85,7 @@ func GetCloudConfig(ctx context.Context, kubeCl *client.KubernetesClient, nodeGr
 
 		allPassedHosts := ""
 		if len(apiserverHosts) > 0 {
-			strings.Join(apiserverHosts, ",")
+			allPassedHosts = strings.Join(apiserverHosts, ",")
 		}
 
 		err := retry.NewSilentLoop(name, 45, 5*time.Second).RunContext(ctx, func() error {

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/cp-manager.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/cp-manager.go
@@ -63,7 +63,11 @@ func (c *ManagerReadinessChecker) IsReadyAll(ctx context.Context) error {
 		return fmt.Errorf("Could not get kube client: %w", err)
 	}
 
-	return retry.NewLoop("Control-plane readiness", 50, 10*time.Second).RunContext(ctx, func() error {
+	// Poll every 1s instead of 10s: cpm typically flips conditions one by one
+	// (Etcd → APIServer → KCM → Scheduler → CertificatesHealthy) within a few
+	// seconds of each other, and the previous 10s granularity smeared 10-40s of
+	// false-wait on the critical path. Total budget unchanged (500 attempts × 1s = ~8 min).
+	return retry.NewLoop("Control-plane readiness", 500, 1*time.Second).RunContext(ctx, func() error {
 		msg, err := checkControlPlaneNodesReady(ctx, kubeClient)
 
 		// all ControlPlaneNodes are ready

--- a/global-hooks/calculate_resources_requests.go
+++ b/global-hooks/calculate_resources_requests.go
@@ -36,13 +36,20 @@ const (
 	hardLimitMilliCPU       = 4 * 1000               // 4 Cpu
 	hardLimitMemory         = 8 * 1024 * 1024 * 1024 // 8G ram
 
-	// it needs for prevent multiple restarts control-plane manager on cluster bootstrap
-	// for 8x4 installations
-	kubeletResourceReservationMemory = 900 * 1024 * 1024 // 900 mb
-	kubeletResourceReservationCPU    = 100               // 0.1 cpu
+	// Minimum kubelet reservation we account for, regardless of what the kubelet
+	// has actually reported on Node.Status.Allocatable at the moment the hook
+	// runs. The hook uses Capacity (immutable) and subtracts max(actual kubelet
+	// reservation, this floor) so the result is identical before and after the
+	// kubelet finishes initialising — which avoids a second hook run later that
+	// would re-render every control-plane static-pod manifest and cascade-restart
+	// kube-apiserver/etcd/kcm/ks right in the middle of Deckhouse install.
+	kubeletResourceReservationMemoryFloor = 900 * 1024 * 1024 // 900 MiB
+	kubeletResourceReservationCPUFloor    = 100               // 0.1 cpu
 )
 
 type Node struct {
+	CapacityMilliCPU    int64
+	CapacityMemory      int64
 	AllocatableMilliCPU int64
 	AllocatableMemory   int64
 }
@@ -54,10 +61,21 @@ func applyNodesResourcesFilter(obj *unstructured.Unstructured) (go_hook.FilterRe
 		return nil, fmt.Errorf("from unstructured: %w", err)
 	}
 
-	n := &Node{}
-
-	n.AllocatableMilliCPU = node.Status.Allocatable.Cpu().MilliValue()
-	n.AllocatableMemory = node.Status.Allocatable.Memory().Value()
+	n := &Node{
+		AllocatableMilliCPU: node.Status.Allocatable.Cpu().MilliValue(),
+		AllocatableMemory:   node.Status.Allocatable.Memory().Value(),
+		CapacityMilliCPU:    node.Status.Capacity.Cpu().MilliValue(),
+		CapacityMemory:      node.Status.Capacity.Memory().Value(),
+	}
+	// Test fixtures and very early node objects may not report Capacity yet —
+	// fall back to Allocatable. The downstream logic treats `Capacity == Allocatable`
+	// as `kubelet has not subtracted its reservation yet` and applies the floor.
+	if n.CapacityMilliCPU == 0 {
+		n.CapacityMilliCPU = n.AllocatableMilliCPU
+	}
+	if n.CapacityMemory == 0 {
+		n.CapacityMemory = n.AllocatableMemory
+	}
 
 	return n, nil
 }
@@ -81,6 +99,23 @@ var (
 		},
 	}, calculateResourcesRequests)
 )
+
+// effectiveMasterResources returns the per-node usable CPU/memory budget the
+// control-plane allocation can be carved out of. Computed from Node.Status.Capacity
+// (immutable for the lifetime of the node) minus max(actual kubelet reservation,
+// our floor). The result is stable across the kubelet warm-up window, so the
+// hook output does not flip a few minutes into the bootstrap.
+func effectiveMasterResources(n *Node) (cpu int64, memory int64) {
+	cpuReservation := n.CapacityMilliCPU - n.AllocatableMilliCPU
+	if cpuReservation < kubeletResourceReservationCPUFloor {
+		cpuReservation = kubeletResourceReservationCPUFloor
+	}
+	memReservation := n.CapacityMemory - n.AllocatableMemory
+	if memReservation < kubeletResourceReservationMemoryFloor {
+		memReservation = kubeletResourceReservationMemoryFloor
+	}
+	return n.CapacityMilliCPU - cpuReservation, n.CapacityMemory - memReservation
+}
 
 func calculateResourcesRequests(_ context.Context, input *go_hook.HookInput) error {
 	var (
@@ -108,34 +143,13 @@ func calculateResourcesRequests(_ context.Context, input *go_hook.HookInput) err
 	discoveryMasterNodeMilliCPU = hardLimitMilliCPU
 	discoveryMasterNodeMemory = hardLimitMemory
 
-	// While the cluster is still bootstrapping, kubelet hasn't yet finalized its
-	// system-reserved / kube-reserved subtractions on Node.Status.Allocatable.
-	// If we trust the fresh Allocatable now, this hook will run a second time
-	// later (after kubelet settles) with a noticeably smaller value, which then
-	// re-renders every control-plane static-pod manifest — kubelet restarts
-	// kube-apiserver/etcd/kcm/ks, and the restart cascade (60-120s per
-	// component) lands right in the middle of Deckhouse install, causing
-	// "forbidden" responses across all module hooks while the new apiserver
-	// rebuilds its RBAC cache from the also-restarting etcd. Pre-subtract the
-	// expected kubelet reservation while we're still in bootstrap so the very
-	// first calculation already matches the eventual steady-state value, and
-	// the second run finds nothing to change.
-	preReserve := !input.Values.Get("global.clusterIsBootstrapped").Bool()
-
 	for _, n := range nodes {
-		effectiveMilliCPU := n.AllocatableMilliCPU
-		effectiveMemory := n.AllocatableMemory
-		if preReserve {
-			effectiveMilliCPU -= kubeletResourceReservationCPU
-			effectiveMemory -= kubeletResourceReservationMemory
+		effCPU, effMem := effectiveMasterResources(&n)
+		if effCPU < discoveryMasterNodeMilliCPU {
+			discoveryMasterNodeMilliCPU = effCPU
 		}
-
-		if effectiveMilliCPU < discoveryMasterNodeMilliCPU && absDiff(effectiveMilliCPU, discoveryMasterNodeMilliCPU) > kubeletResourceReservationCPU {
-			discoveryMasterNodeMilliCPU = effectiveMilliCPU
-		}
-
-		if effectiveMemory < discoveryMasterNodeMemory && absDiff(effectiveMemory, discoveryMasterNodeMemory) > kubeletResourceReservationMemory {
-			discoveryMasterNodeMemory = effectiveMemory
+		if effMem < discoveryMasterNodeMemory {
+			discoveryMasterNodeMemory = effMem
 		}
 	}
 

--- a/global-hooks/calculate_resources_requests.go
+++ b/global-hooks/calculate_resources_requests.go
@@ -108,13 +108,34 @@ func calculateResourcesRequests(_ context.Context, input *go_hook.HookInput) err
 	discoveryMasterNodeMilliCPU = hardLimitMilliCPU
 	discoveryMasterNodeMemory = hardLimitMemory
 
+	// While the cluster is still bootstrapping, kubelet hasn't yet finalized its
+	// system-reserved / kube-reserved subtractions on Node.Status.Allocatable.
+	// If we trust the fresh Allocatable now, this hook will run a second time
+	// later (after kubelet settles) with a noticeably smaller value, which then
+	// re-renders every control-plane static-pod manifest — kubelet restarts
+	// kube-apiserver/etcd/kcm/ks, and the restart cascade (60-120s per
+	// component) lands right in the middle of Deckhouse install, causing
+	// "forbidden" responses across all module hooks while the new apiserver
+	// rebuilds its RBAC cache from the also-restarting etcd. Pre-subtract the
+	// expected kubelet reservation while we're still in bootstrap so the very
+	// first calculation already matches the eventual steady-state value, and
+	// the second run finds nothing to change.
+	preReserve := !input.Values.Get("global.clusterIsBootstrapped").Bool()
+
 	for _, n := range nodes {
-		if n.AllocatableMilliCPU < discoveryMasterNodeMilliCPU && absDiff(n.AllocatableMilliCPU, discoveryMasterNodeMilliCPU) > kubeletResourceReservationCPU {
-			discoveryMasterNodeMilliCPU = n.AllocatableMilliCPU
+		effectiveMilliCPU := n.AllocatableMilliCPU
+		effectiveMemory := n.AllocatableMemory
+		if preReserve {
+			effectiveMilliCPU -= kubeletResourceReservationCPU
+			effectiveMemory -= kubeletResourceReservationMemory
 		}
 
-		if n.AllocatableMemory < discoveryMasterNodeMemory && absDiff(n.AllocatableMemory, discoveryMasterNodeMemory) > kubeletResourceReservationMemory {
-			discoveryMasterNodeMemory = n.AllocatableMemory
+		if effectiveMilliCPU < discoveryMasterNodeMilliCPU && absDiff(effectiveMilliCPU, discoveryMasterNodeMilliCPU) > kubeletResourceReservationCPU {
+			discoveryMasterNodeMilliCPU = effectiveMilliCPU
+		}
+
+		if effectiveMemory < discoveryMasterNodeMemory && absDiff(effectiveMemory, discoveryMasterNodeMemory) > kubeletResourceReservationMemory {
+			discoveryMasterNodeMemory = effectiveMemory
 		}
 	}
 

--- a/global-hooks/calculate_resources_requests.go
+++ b/global-hooks/calculate_resources_requests.go
@@ -105,7 +105,7 @@ var (
 // (immutable for the lifetime of the node) minus max(actual kubelet reservation,
 // our floor). The result is stable across the kubelet warm-up window, so the
 // hook output does not flip a few minutes into the bootstrap.
-func effectiveMasterResources(n *Node) (cpu int64, memory int64) {
+func effectiveMasterResources(n *Node) (int64, int64) {
 	cpuReservation := n.CapacityMilliCPU - n.AllocatableMilliCPU
 	if cpuReservation < kubeletResourceReservationCPUFloor {
 		cpuReservation = kubeletResourceReservationCPUFloor

--- a/global-hooks/calculate_resources_requests_test.go
+++ b/global-hooks/calculate_resources_requests_test.go
@@ -67,6 +67,7 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 
 	Context("Cluster with one master node, but without set global modules resourcesRequests for control-plane", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}})))
 			f.RunHook()
 		})
@@ -80,6 +81,7 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 
 	Context("Cluster with one master node, but without set global modules resourcesRequests for control-plane and little oscillations from maximum", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "3930m", memory: "7717366089760m"}})))
 			f.RunHook()
 		})
@@ -91,8 +93,26 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 		})
 	})
 
+	Context("Cluster still bootstrapping, with one master node: kubelet reservation pre-subtracted", func() {
+		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", false)
+			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}})))
+			f.RunHook()
+		})
+
+		It("Hook should run, discovery values are based on Allocatable minus expected kubelet system-reserved/kube-reserved", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			// effectiveMilliCPU = 4000 - 100 = 3900; absDiff(3900, 4000)=100, not >100 → discovery stays at hardLimit=4000.
+			// Same numbers as the bootstrapped case here: the goal of pre-subtract is to keep the FIRST hook-run result
+			// equal to the post-kubelet-settles result, which is exactly the hardLimit path for an 8x4 master.
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64((4000 - configEveryNodeMilliCPU) * controlPlanePercent / 100)))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64((8192*1024*1024 - configEveryNodeMemory) * controlPlanePercent / 100)))
+		})
+	})
+
 	Context("Cluster with master node, with set global modules resourcesRequests for control-plane", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}})))
 			f.ValuesSet("global.modules.resourcesRequests.controlPlane.cpu", "2000m")
 			f.ValuesSet("global.modules.resourcesRequests.controlPlane.memory", "2Gi")
@@ -108,6 +128,7 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 
 	Context("Cluster with two master nodes, with different resources, but without set global modules resourcesRequests for control-plane", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}, {cpu: "2000m", memory: "4Gi"}})))
 			f.RunHook()
 		})
@@ -122,6 +143,7 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 
 	Context("Cluster with two master nodes, but with very small resources", func() {
 		BeforeEach(func() {
+			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "300m", memory: "500Mi"}, {cpu: "2000m", memory: "4Gi"}})))
 			f.RunHook()
 		})

--- a/global-hooks/calculate_resources_requests_test.go
+++ b/global-hooks/calculate_resources_requests_test.go
@@ -24,8 +24,10 @@ import (
 )
 
 type masterNode struct {
-	cpu    string
-	memory string
+	cpu      string
+	memory   string
+	capCPU   string // optional; falls back to cpu (kubelet not yet settled)
+	capMem   string // optional; falls back to memory
 }
 
 func generateMasterNodesConfig(nodes []masterNode) string {
@@ -38,13 +40,24 @@ metadata:
   labels:
     node-role.kubernetes.io/control-plane: ""
 status:
+  capacity:
+    cpu: "%s"
+    memory: "%s"
   allocatable:
     cpu: "%s"
     memory: "%s"
 `
 	var state string
 	for i, n := range nodes {
-		state += fmt.Sprintf(stateMasterNode, i, n.cpu, n.memory)
+		capCPU := n.capCPU
+		if capCPU == "" {
+			capCPU = n.cpu
+		}
+		capMem := n.capMem
+		if capMem == "" {
+			capMem = n.memory
+		}
+		state += fmt.Sprintf(stateMasterNode, i, capCPU, capMem, n.cpu, n.memory)
 	}
 	return state
 }
@@ -52,6 +65,7 @@ status:
 var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 
 	f := HookExecutionConfigInit(`{"global": {"internal": {"modules": {"resourcesRequests": {}}}}}`, `{}`)
+
 	Context("Cluster without master nodes (unmanaged)", func() {
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(``))
@@ -65,54 +79,67 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 		})
 	})
 
-	Context("Cluster with one master node, but without set global modules resourcesRequests for control-plane", func() {
+	Context("Cluster with one master node (Capacity == Allocatable, kubelet not yet settled)", func() {
+		// Reservation floor is applied because Capacity == Allocatable signals
+		// kubelet has not yet subtracted its own reserved bucket.
 		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}})))
 			f.RunHook()
 		})
 
-		It(fmt.Sprintf("Hook should run, control-plane resource values should be equal %d%% of (master-node resources - resources for components working on every node)", controlPlanePercent), func() {
+		It(fmt.Sprintf("Hook should run, CP values = %d%% of (Capacity - kubelet reservation floor - configEveryNode*)", controlPlanePercent), func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64((4000 - configEveryNodeMilliCPU) * controlPlanePercent / 100)))
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64((8192*1024*1024 - configEveryNodeMemory) * controlPlanePercent / 100)))
+			expectCPU := int64((4000-kubeletResourceReservationCPUFloor-configEveryNodeMilliCPU)*controlPlanePercent) / 100
+			expectMem := int64((8*1024*1024*1024-kubeletResourceReservationMemoryFloor-configEveryNodeMemory)*controlPlanePercent) / 100
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(expectCPU))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(expectMem))
 		})
 	})
 
-	Context("Cluster with one master node, but without set global modules resourcesRequests for control-plane and little oscillations from maximum", func() {
+	Context("Cluster with one master node, kubelet settled (Capacity > Allocatable, reservation > floor)", func() {
+		// Capacity=4 CPU/8 GiB, kubelet has reserved 200m CPU / 1 GiB memory.
+		// Both exceed the floor, so the hook uses the reported reservation as-is.
 		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", true)
-			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "3930m", memory: "7717366089760m"}})))
+			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{
+				{cpu: "3800m", memory: "7Gi", capCPU: "4", capMem: "8Gi"},
+			})))
 			f.RunHook()
 		})
 
-		It(fmt.Sprintf("Hook should run, control-plane resource values should be equal %d%% of (master-node resources - resources for components working on every node)", controlPlanePercent), func() {
+		It("Hook should run, CP values reflect the actual kubelet reservation (200m, 1 GiB)", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64((4000 - configEveryNodeMilliCPU) * controlPlanePercent / 100)))
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64((8192*1024*1024 - configEveryNodeMemory) * controlPlanePercent / 100)))
+			// effectiveCPU = Capacity(4000) - max(actualRes=200, floor=100) = 3800
+			// effectiveMem = 8 GiB - max(1 GiB, 900 MiB) = 7 GiB
+			expectCPU := int64((3800-configEveryNodeMilliCPU)*controlPlanePercent) / 100
+			expectMem := int64((7*1024*1024*1024-configEveryNodeMemory)*controlPlanePercent) / 100
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(expectCPU))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(expectMem))
 		})
 	})
 
-	Context("Cluster still bootstrapping, with one master node: kubelet reservation pre-subtracted", func() {
+	Context("Cluster with one master node, kubelet settled but reservation under floor", func() {
+		// Capacity=4 CPU/8 GiB, kubelet reserved only 50m / 100 MiB. Floor wins
+		// — the hook treats the reservation as 100m / 900 MiB so the value is
+		// identical to the pre-settled state and a second hook run on a real
+		// cluster bootstrap doesn't re-render the CP manifests.
 		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", false)
-			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}})))
+			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{
+				{cpu: "3950m", memory: "8090Mi", capCPU: "4", capMem: "8Gi"},
+			})))
 			f.RunHook()
 		})
 
-		It("Hook should run, discovery values are based on Allocatable minus expected kubelet system-reserved/kube-reserved", func() {
+		It("Hook should run, CP values reflect the reservation FLOOR not the smaller actual", func() {
 			Expect(f).To(ExecuteSuccessfully())
-			// effectiveMilliCPU = 4000 - 100 = 3900; absDiff(3900, 4000)=100, not >100 → discovery stays at hardLimit=4000.
-			// Same numbers as the bootstrapped case here: the goal of pre-subtract is to keep the FIRST hook-run result
-			// equal to the post-kubelet-settles result, which is exactly the hardLimit path for an 8x4 master.
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64((4000 - configEveryNodeMilliCPU) * controlPlanePercent / 100)))
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64((8192*1024*1024 - configEveryNodeMemory) * controlPlanePercent / 100)))
+			expectCPU := int64((4000-kubeletResourceReservationCPUFloor-configEveryNodeMilliCPU)*controlPlanePercent) / 100
+			expectMem := int64((8*1024*1024*1024-kubeletResourceReservationMemoryFloor-configEveryNodeMemory)*controlPlanePercent) / 100
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(expectCPU))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(expectMem))
 		})
 	})
 
 	Context("Cluster with master node, with set global modules resourcesRequests for control-plane", func() {
 		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}})))
 			f.ValuesSet("global.modules.resourcesRequests.controlPlane.cpu", "2000m")
 			f.ValuesSet("global.modules.resourcesRequests.controlPlane.memory", "2Gi")
@@ -128,22 +155,23 @@ var _ = Describe("Global hooks :: calculate_resources_requests", func() {
 
 	Context("Cluster with two master nodes, with different resources, but without set global modules resourcesRequests for control-plane", func() {
 		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "4", memory: "8Gi"}, {cpu: "2000m", memory: "4Gi"}})))
 			f.RunHook()
 		})
 
-		It(fmt.Sprintf("Hook should run, control-plane resource values should be equal %d%% of (master-node with less resources - resources for components working on every node)", controlPlanePercent), func() {
+		It(fmt.Sprintf("Hook should run, control-plane resource values should be equal %d%% of (smaller master - resources for components working on every node)", controlPlanePercent), func() {
 			Expect(f).To(ExecuteSuccessfully())
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(int64((2000 - configEveryNodeMilliCPU) * controlPlanePercent / 100)))
-			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(int64((4096*1024*1024 - configEveryNodeMemory) * controlPlanePercent / 100)))
+			// Smaller master: Capacity=Allocatable=2000m/4 GiB → floor applies.
+			expectCPU := int64((2000-kubeletResourceReservationCPUFloor-configEveryNodeMilliCPU)*controlPlanePercent) / 100
+			expectMem := int64((4*1024*1024*1024-kubeletResourceReservationMemoryFloor-configEveryNodeMemory)*controlPlanePercent) / 100
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.milliCpuControlPlane").Int()).To(Equal(expectCPU))
+			Expect(f.ValuesGet("global.internal.modules.resourcesRequests.memoryControlPlane").Int()).To(Equal(expectMem))
 		})
 
 	})
 
 	Context("Cluster with two master nodes, but with very small resources", func() {
 		BeforeEach(func() {
-			f.ValuesSet("global.clusterIsBootstrapped", true)
 			f.BindingContexts.Set(f.KubeStateSet(generateMasterNodesConfig([]masterNode{{cpu: "300m", memory: "500Mi"}, {cpu: "2000m", memory: "4Gi"}})))
 			f.RunHook()
 		})

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -82,7 +82,11 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
-          periodSeconds: 30
+          # Match startupProbe granularity (2s). Default 30s adds a 30s lag
+          # between cilium /healthz first returning ok and kubelet flipping
+          # the pod to Ready — on the cluster-bootstrap critical path this
+          # gates `Wait Node Ready` and `Control-plane readiness` for nothing.
+          periodSeconds: 2
           successThreshold: 1
           failureThreshold: 3
           timeoutSeconds: 5

--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -88,7 +88,13 @@ spec:
           # gates `Wait Node Ready` and `Control-plane readiness` for nothing.
           periodSeconds: 2
           successThreshold: 1
-          failureThreshold: 3
+          # /healthz brief flips back to fail every time cilium kicks off a
+          # full datapath regenerate (datapath-ipcache, CiliumNode update,
+          # network-status blip from cpm restarting apiserver, ...). At 2s
+          # probe + threshold 3 = 6s, the pod yo-yos NotReady through every
+          # regenerate. 15 (~30s) covers a typical regenerate batch so the
+          # pod stays Ready while cilium internally re-syncs BPF.
+          failureThreshold: 15
           timeoutSeconds: 5
         env:
         - name: K8S_NODE_NAME

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/manager.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/manager.go
@@ -85,28 +85,28 @@ func NewManager(ctx context.Context, pprof bool) (*Manager, error) {
 		pprofAddr = pprofBindAddress
 	}
 
-	// Lease parameters tuned for control-plane bootstrap.
+	// Leader election is needed only when multiple cpm pods may compete for
+	// cluster-wide work. cpm controllers that touch a specific master (static
+	// pod manifest writes, per-master CRs) are already partitioned by
+	// `spec.nodeName` (see controlPlanePodPredicate, operations-approver, ...),
+	// so on a single-master cluster there is exactly one pod and nothing to
+	// coordinate. Toggle by the LEADER_ELECTION env (set by helm based on
+	// master replica count): true on HA (>1 master), false on single-master.
 	//
-	// Default controller-runtime values (LeaseDuration=15s, RenewDeadline=10s,
-	// RetryPeriod=2s) assume a stable apiserver. During the very first cpm
-	// reconcile cpm itself rewrites the kube-apiserver / etcd static-pod
-	// manifests, which makes kubelet briefly restart those pods; for ~10s the
-	// local kubernetes-api-proxy returns RST and lease renewal fails. With the
-	// defaults that exceeds RenewDeadline and the manager exits with
-	// "leader election lost" — kubelet restarts cpm, progress lost.
-	//
-	// 90/60/5 covers a full apiserver restart cycle (60s renew window).
-	leaseDuration := 90 * time.Second
-	renewDeadline := 60 * time.Second
-	retryPeriod := 5 * time.Second
+	// Why this matters during bootstrap: cpm's very first reconcile rewrites
+	// the etcd and kube-apiserver static-pod manifests, kubelet restarts those
+	// pods, and the local kubernetes-api-proxy returns RST for the ~60s of the
+	// restart cycle. With LE on, lease renewal exceeded RenewDeadline and the
+	// manager exited with "leader election lost" — kubelet restarted cpm,
+	// progress was lost, cpm redid SyncManifests producing an extra static-pod
+	// restart and a knock-on cilium endpoint regeneration. With LE off (the
+	// single-master case) the renewal pressure is gone entirely.
+	leaderElection := os.Getenv("LEADER_ELECTION") == "true"
 
 	runtimeManager, err := controllerruntime.NewManager(cfg, controllerruntime.Options{
-		Scheme:                  scheme,
-		LeaderElection:          true,
-		LeaderElectionID:        constants.CpcControllerName,
-		LeaseDuration:           &leaseDuration,
-		RenewDeadline:           &renewDeadline,
-		RetryPeriod:             &retryPeriod,
+		Scheme:           scheme,
+		LeaderElection:   leaderElection,
+		LeaderElectionID: constants.CpcControllerName,
 		BaseContext: func() context.Context {
 			return ctx
 		},

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/manager.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/manager.go
@@ -85,10 +85,28 @@ func NewManager(ctx context.Context, pprof bool) (*Manager, error) {
 		pprofAddr = pprofBindAddress
 	}
 
+	// Lease parameters tuned for control-plane bootstrap.
+	//
+	// Default controller-runtime values (LeaseDuration=15s, RenewDeadline=10s,
+	// RetryPeriod=2s) assume a stable apiserver. During the very first cpm
+	// reconcile cpm itself rewrites the kube-apiserver / etcd static-pod
+	// manifests, which makes kubelet briefly restart those pods; for ~10s the
+	// local kubernetes-api-proxy returns RST and lease renewal fails. With the
+	// defaults that exceeds RenewDeadline and the manager exits with
+	// "leader election lost" — kubelet restarts cpm, progress lost.
+	//
+	// 90/60/5 covers a full apiserver restart cycle (60s renew window).
+	leaseDuration := 90 * time.Second
+	renewDeadline := 60 * time.Second
+	retryPeriod := 5 * time.Second
+
 	runtimeManager, err := controllerruntime.NewManager(cfg, controllerruntime.Options{
-		Scheme:           scheme,
-		LeaderElection:   true,
-		LeaderElectionID: constants.CpcControllerName,
+		Scheme:                  scheme,
+		LeaderElection:          true,
+		LeaderElectionID:        constants.CpcControllerName,
+		LeaseDuration:           &leaseDuration,
+		RenewDeadline:           &renewDeadline,
+		RetryPeriod:             &retryPeriod,
 		BaseContext: func() context.Context {
 			return ctx
 		},

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -304,6 +304,16 @@ spec:
           value: "127.0.0.1"
         - name: KUBERNETES_SERVICE_PORT
           value: "6445"
+        # Leader election is only needed on HA clusters (>1 master) where
+        # multiple cpm pods could otherwise race on the cluster-wide pieces.
+        # On a single-master cluster every cpm controller is already
+        # node-partitioned by `spec.nodeName`, and the lease renewal pressure
+        # is pure overhead — when cpm rewrites the apiserver/etcd manifests
+        # during the first reconcile the apiserver is unreachable for ~60s
+        # via the local kubernetes-api-proxy and the lease is lost,
+        # crashlooping cpm and forcing an extra static-pod restart.
+        - name: LEADER_ELECTION
+          value: {{ include "helm_lib_is_ha_to_value" (list $ "true" "false") | quote }}
         - name: MY_IP
           valueFrom:
             fieldRef:

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -289,6 +289,21 @@ spec:
         - mountPath: /tmp
           name: tmp
         env:
+        # cpm is hostNetwork on every control-plane node and talks to the
+        # apiserver via controller-runtime. The auto-injected env vars point
+        # at the apiserver ClusterIP (10.233.0.1:443), which during the first
+        # bootstrap is unreachable for the few seconds while cilium installs
+        # its eBPF/iptables rules — cpm's leader-election lease renewal hits
+        # `EPERM` and the container dies with "leader election lost". Each
+        # restart loses progress and forces cpm to redo manifest application,
+        # which then triggers an extra cpm-rewrite of the static-pod manifests.
+        # Route apiserver traffic through the local kubernetes-api-proxy
+        # static pod (the same path cilium-agent itself uses) so cpm never
+        # depends on cilium being initialised.
+        - name: KUBERNETES_SERVICE_HOST
+          value: "127.0.0.1"
+        - name: KUBERNETES_SERVICE_PORT
+          value: "6445"
         - name: MY_IP
           valueFrom:
             fieldRef:

--- a/modules/040-node-manager/hooks/create_capi_cluster_resources.go
+++ b/modules/040-node-manager/hooks/create_capi_cluster_resources.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+)
+
+// Cluster / MachineHealthCheck (cluster.x-k8s.io/v1beta1) go through a
+// conversion webhook served by capi-webhook-service → capi-controller-manager.
+// Rendering them via the node-manager helm release races the very first install
+// of that Deployment: apiserver calls the webhook during SSA, gets connection-
+// refused, helm retries with 45s backoff (~4 retries = ~3 minutes lost on the
+// main queue).
+//
+// Owning them in a hook on a dedicated queue removes them from helm's apply
+// list — helm install of node-manager succeeds on the first try, and the hook
+// retries the create until the webhook backend is up. The objects are not on
+// the bootstrap critical path: nothing helm-rendered references them during
+// initial install (MachineDeployment is only emitted for Cloud/CloudEphemeral
+// NodeGroups, and master NG is CloudPermanent).
+//
+// Hook is idempotent (CreateIfNotExists), so retries are safe.
+
+const (
+	capiNamespace = "d8-cloud-instance-manager"
+)
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	Queue: "/modules/node-manager/create-capi-cluster-resources",
+	// Order > create_master_node_group (6) so it runs in the same OnStartup
+	// pass but after the CRDs ensure step (order 5) and master NG hook (6).
+	OnStartup: &go_hook.OrderedConfig{Order: 7},
+}, createCapiClusterResources)
+
+func createCapiClusterResources(_ context.Context, input *go_hook.HookInput) error {
+	if !input.Values.Get("nodeManager.internal.capiControllerManagerEnabled").Bool() {
+		return nil
+	}
+
+	prefix := input.Values.Get("nodeManager.internal.cloudProvider.capiClusterName").String()
+	infraKind := input.Values.Get("nodeManager.internal.cloudProvider.capiClusterKind").String()
+	if prefix == "" || infraKind == "" {
+		return nil
+	}
+	infraAPIVersion := input.Values.Get("nodeManager.internal.cloudProvider.capiClusterAPIVersion").String()
+	if infraAPIVersion == "" {
+		infraAPIVersion = "infrastructure.cluster.x-k8s.io/v1alpha1"
+	}
+
+	podCIDR := input.Values.Get("global.clusterConfiguration.podSubnetCIDR").String()
+	serviceCIDR := input.Values.Get("global.clusterConfiguration.serviceSubnetCIDR").String()
+	serviceDomain := input.Values.Get("global.clusterConfiguration.clusterDomain").String()
+
+	commonMeta := map[string]interface{}{
+		"namespace": capiNamespace,
+		"labels": map[string]interface{}{
+			"heritage": "deckhouse",
+			"module":   "node-manager",
+			"app":      "capi-controller-manager",
+		},
+	}
+
+	clusterMeta := mergeMap(commonMeta, map[string]interface{}{
+		"name": prefix,
+		"finalizers": []interface{}{
+			"deckhouse.io/capi-controller-manager",
+		},
+	})
+	cluster := unstructuredFrom("cluster.x-k8s.io/v1beta1", "Cluster", clusterMeta, map[string]interface{}{
+		"clusterNetwork": map[string]interface{}{
+			"pods":          map[string]interface{}{"cidrBlocks": []interface{}{podCIDR}},
+			"services":      map[string]interface{}{"cidrBlocks": []interface{}{serviceCIDR}},
+			"serviceDomain": serviceDomain,
+		},
+		"infrastructureRef": map[string]interface{}{
+			"apiVersion": infraAPIVersion,
+			"kind":       infraKind,
+			"namespace":  capiNamespace,
+			"name":       prefix,
+		},
+		"controlPlaneRef": map[string]interface{}{
+			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha1",
+			"kind":       "DeckhouseControlPlane",
+			"namespace":  capiNamespace,
+			"name":       prefix + "-control-plane",
+		},
+	})
+
+	mhcMeta := mergeMap(commonMeta, map[string]interface{}{
+		"name": prefix + "-machine-health-check",
+	})
+	mhc := unstructuredFrom("cluster.x-k8s.io/v1beta1", "MachineHealthCheck", mhcMeta, map[string]interface{}{
+		"clusterName":        prefix,
+		"nodeStartupTimeout": "20m",
+		"selector": map[string]interface{}{
+			"matchLabels": map[string]interface{}{
+				"cluster.x-k8s.io/cluster-name": prefix,
+			},
+		},
+		"unhealthyConditions": []interface{}{
+			map[string]interface{}{"type": "Ready", "status": "Unknown", "timeout": "5m"},
+			map[string]interface{}{"type": "Ready", "status": "False", "timeout": "5m"},
+		},
+	})
+
+	clusterU, err := sdk.ToUnstructured(&cluster)
+	if err != nil {
+		return err
+	}
+	mhcU, err := sdk.ToUnstructured(&mhc)
+	if err != nil {
+		return err
+	}
+
+	input.PatchCollector.CreateIfNotExists(clusterU)
+	input.PatchCollector.CreateIfNotExists(mhcU)
+
+	return nil
+}
+
+func unstructuredFrom(apiVersion, kind string, metadata, spec map[string]interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"apiVersion": apiVersion,
+		"kind":       kind,
+		"metadata":   metadata,
+		"spec":       spec,
+	}
+}
+
+func mergeMap(a, b map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(a)+len(b))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		out[k] = v
+	}
+	return out
+}
+

--- a/modules/040-node-manager/hooks/create_capi_cluster_resources.go
+++ b/modules/040-node-manager/hooks/create_capi_cluster_resources.go
@@ -16,9 +16,14 @@ package hooks
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
 )
 
 // Cluster / MachineHealthCheck (cluster.x-k8s.io/v1beta1) go through a
@@ -41,24 +46,66 @@ const (
 	capiNamespace = "d8-cloud-instance-manager"
 )
 
+// capiClusterInfo carries the cloud-provider registration data the hook needs.
+// It mirrors the relevant subset of d8-node-manager-cloud-provider Secret keys.
+type capiClusterInfo struct {
+	ClusterName       string
+	ClusterKind       string
+	ClusterAPIVersion string
+}
+
+func filterCapiClusterSecret(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	data, err := decodeDataFromSecret(obj)
+	if err != nil {
+		return nil, err
+	}
+	info := capiClusterInfo{}
+	if v, ok := data["capiClusterName"].(string); ok {
+		info.ClusterName = v
+	}
+	if v, ok := data["capiClusterKind"].(string); ok {
+		info.ClusterKind = v
+	}
+	if v, ok := data["capiClusterAPIVersion"].(string); ok {
+		info.ClusterAPIVersion = v
+	}
+	return info, nil
+}
+
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	// Own queue so a transient failure to create Cluster/MHC (capi conversion
+	// webhook still warming up on first install) doesn't block the main queue.
 	Queue: "/modules/node-manager/create-capi-cluster-resources",
-	// Order > create_master_node_group (6) so it runs in the same OnStartup
-	// pass but after the CRDs ensure step (order 5) and master NG hook (6).
-	OnStartup: &go_hook.OrderedConfig{Order: 7},
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			// Trigger when the cloud-provider registration secret appears or
+			// changes — that's also the moment `nodeManager.internal.cloudProvider`
+			// becomes meaningful for downstream hooks.
+			Name:       "cloud_provider_secret",
+			ApiVersion: "v1",
+			Kind:       "Secret",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{"kube-system"}},
+			},
+			NameSelector: &types.NameSelector{MatchNames: []string{"d8-node-manager-cloud-provider"}},
+			FilterFunc:   filterCapiClusterSecret,
+		},
+	},
 }, createCapiClusterResources)
 
 func createCapiClusterResources(_ context.Context, input *go_hook.HookInput) error {
-	if !input.Values.Get("nodeManager.internal.capiControllerManagerEnabled").Bool() {
+	snaps, err := sdkobjectpatch.UnmarshalToStruct[capiClusterInfo](input.Snapshots, "cloud_provider_secret")
+	if err != nil {
+		return fmt.Errorf("unmarshal cloud_provider_secret snapshot: %w", err)
+	}
+	if len(snaps) == 0 {
 		return nil
 	}
-
-	prefix := input.Values.Get("nodeManager.internal.cloudProvider.capiClusterName").String()
-	infraKind := input.Values.Get("nodeManager.internal.cloudProvider.capiClusterKind").String()
-	if prefix == "" || infraKind == "" {
+	info := snaps[0]
+	if info.ClusterName == "" || info.ClusterKind == "" {
 		return nil
 	}
-	infraAPIVersion := input.Values.Get("nodeManager.internal.cloudProvider.capiClusterAPIVersion").String()
+	infraAPIVersion := info.ClusterAPIVersion
 	if infraAPIVersion == "" {
 		infraAPIVersion = "infrastructure.cluster.x-k8s.io/v1alpha1"
 	}
@@ -67,57 +114,66 @@ func createCapiClusterResources(_ context.Context, input *go_hook.HookInput) err
 	serviceCIDR := input.Values.Get("global.clusterConfiguration.serviceSubnetCIDR").String()
 	serviceDomain := input.Values.Get("global.clusterConfiguration.clusterDomain").String()
 
-	commonMeta := map[string]interface{}{
-		"namespace": capiNamespace,
-		"labels": map[string]interface{}{
-			"heritage": "deckhouse",
-			"module":   "node-manager",
-			"app":      "capi-controller-manager",
+	commonLabels := map[string]interface{}{
+		"heritage": "deckhouse",
+		"module":   "node-manager",
+		"app":      "capi-controller-manager",
+	}
+
+	cluster := map[string]interface{}{
+		"apiVersion": "cluster.x-k8s.io/v1beta1",
+		"kind":       "Cluster",
+		"metadata": map[string]interface{}{
+			"name":      info.ClusterName,
+			"namespace": capiNamespace,
+			"labels":    commonLabels,
+			"finalizers": []interface{}{
+				"deckhouse.io/capi-controller-manager",
+			},
+		},
+		"spec": map[string]interface{}{
+			"clusterNetwork": map[string]interface{}{
+				"pods":          map[string]interface{}{"cidrBlocks": []interface{}{podCIDR}},
+				"services":      map[string]interface{}{"cidrBlocks": []interface{}{serviceCIDR}},
+				"serviceDomain": serviceDomain,
+			},
+			"infrastructureRef": map[string]interface{}{
+				"apiVersion": infraAPIVersion,
+				"kind":       info.ClusterKind,
+				"namespace":  capiNamespace,
+				"name":       info.ClusterName,
+			},
+			"controlPlaneRef": map[string]interface{}{
+				"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha1",
+				"kind":       "DeckhouseControlPlane",
+				"namespace":  capiNamespace,
+				"name":       info.ClusterName + "-control-plane",
+			},
 		},
 	}
 
-	clusterMeta := mergeMap(commonMeta, map[string]interface{}{
-		"name": prefix,
-		"finalizers": []interface{}{
-			"deckhouse.io/capi-controller-manager",
+	mhc := map[string]interface{}{
+		"apiVersion": "cluster.x-k8s.io/v1beta1",
+		"kind":       "MachineHealthCheck",
+		"metadata": map[string]interface{}{
+			"name":      info.ClusterName + "-machine-health-check",
+			"namespace": capiNamespace,
+			"labels":    commonLabels,
 		},
-	})
-	cluster := unstructuredFrom("cluster.x-k8s.io/v1beta1", "Cluster", clusterMeta, map[string]interface{}{
-		"clusterNetwork": map[string]interface{}{
-			"pods":          map[string]interface{}{"cidrBlocks": []interface{}{podCIDR}},
-			"services":      map[string]interface{}{"cidrBlocks": []interface{}{serviceCIDR}},
-			"serviceDomain": serviceDomain,
-		},
-		"infrastructureRef": map[string]interface{}{
-			"apiVersion": infraAPIVersion,
-			"kind":       infraKind,
-			"namespace":  capiNamespace,
-			"name":       prefix,
-		},
-		"controlPlaneRef": map[string]interface{}{
-			"apiVersion": "infrastructure.cluster.x-k8s.io/v1alpha1",
-			"kind":       "DeckhouseControlPlane",
-			"namespace":  capiNamespace,
-			"name":       prefix + "-control-plane",
-		},
-	})
-
-	mhcMeta := mergeMap(commonMeta, map[string]interface{}{
-		"name": prefix + "-machine-health-check",
-	})
-	mhc := unstructuredFrom("cluster.x-k8s.io/v1beta1", "MachineHealthCheck", mhcMeta, map[string]interface{}{
-		"clusterName":        prefix,
-		"nodeStartupTimeout": "20m",
-		"selector": map[string]interface{}{
-			"matchLabels": map[string]interface{}{
-				"cluster.x-k8s.io/cluster-name": prefix,
+		"spec": map[string]interface{}{
+			"clusterName":        info.ClusterName,
+			"nodeStartupTimeout": "20m",
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{
+					"cluster.x-k8s.io/cluster-name": info.ClusterName,
+				},
+			},
+			"unhealthyConditions": []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "Unknown", "timeout": "5m"},
+				map[string]interface{}{"type": "Ready", "status": "False", "timeout": "5m"},
 			},
 		},
-		"unhealthyConditions": []interface{}{
-			map[string]interface{}{"type": "Ready", "status": "Unknown", "timeout": "5m"},
-			map[string]interface{}{"type": "Ready", "status": "False", "timeout": "5m"},
-		},
-	})
+	}
 
 	clusterU, err := sdk.ToUnstructured(&cluster)
 	if err != nil {
@@ -133,24 +189,3 @@ func createCapiClusterResources(_ context.Context, input *go_hook.HookInput) err
 
 	return nil
 }
-
-func unstructuredFrom(apiVersion, kind string, metadata, spec map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
-		"apiVersion": apiVersion,
-		"kind":       kind,
-		"metadata":   metadata,
-		"spec":       spec,
-	}
-}
-
-func mergeMap(a, b map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(a)+len(b))
-	for k, v := range a {
-		out[k] = v
-	}
-	for k, v := range b {
-		out[k] = v
-	}
-	return out
-}
-

--- a/modules/040-node-manager/hooks/create_master_node_group.go
+++ b/modules/040-node-manager/hooks/create_master_node_group.go
@@ -23,6 +23,17 @@ import (
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	// Hook is idempotent (CreateIfNotExists) and only ensures the default `master`
+	// NodeGroup metadata object exists. During bootstrap the master Node is
+	// registered directly by kubeadm via bashible — the NG resource is metadata
+	// only and not on the critical path for the cluster to function.
+	//
+	// On its own queue (not "main") so that a transient validating-webhook
+	// failure (node-controller-webhook still warming up at module-startup time)
+	// doesn't fail node-manager's whole ModuleRun Startup phase and trigger a
+	// ConvergeModules retry storm on the main queue. The hook retries on its
+	// dedicated queue until the webhook backend is ready.
+	Queue: "/modules/node-manager/create-master-ng",
 	// ensure crds hook has order 5, for creating node group we should use greater number
 	OnStartup: &go_hook.OrderedConfig{Order: 6},
 }, createMasterNodeGroup)

--- a/modules/040-node-manager/hooks/migrate_capi_cluster_helm_ownership.go
+++ b/modules/040-node-manager/hooks/migrate_capi_cluster_helm_ownership.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
+	"github.com/flant/addon-operator/sdk"
+	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	sdkobjectpatch "github.com/deckhouse/module-sdk/pkg/object-patch"
+)
+
+// On upgrade from a release where Cluster / MachineHealthCheck were rendered
+// by the node-manager helm chart to this branch where they are owned by the
+// create_capi_cluster_resources hook, helm sees the resources are missing from
+// the new manifest and schedules them for deletion — which cascades into
+// capi-controller-manager tearing down dependent Machines / MachineDeployments
+// / Nodes. Disastrous.
+//
+// Detach them from helm ownership by stamping `helm.sh/resource-policy: keep`.
+// helm honours this annotation during upgrade and skips the orphaned-resource
+// deletion. The hook is idempotent: when the annotation is already in place
+// (fresh install via the hook, or this migration has already run), no patch is
+// issued.
+
+const helmResourcePolicyAnnotation = "helm.sh/resource-policy"
+
+type capiResourceMeta struct {
+	APIVersion        string
+	Kind              string
+	Name              string
+	Namespace         string
+	HasHelmOwnership  bool
+	HasKeepAnnotation bool
+}
+
+func filterCapiResourceMeta(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
+	annotations := obj.GetAnnotations()
+	_, hasHelm := annotations["meta.helm.sh/release-name"]
+	_, hasKeep := annotations[helmResourcePolicyAnnotation]
+	return capiResourceMeta{
+		APIVersion:        obj.GetAPIVersion(),
+		Kind:              obj.GetKind(),
+		Name:              obj.GetName(),
+		Namespace:         obj.GetNamespace(),
+		HasHelmOwnership:  hasHelm,
+		HasKeepAnnotation: hasKeep,
+	}, nil
+}
+
+var _ = sdk.RegisterFunc(&go_hook.HookConfig{
+	// Same queue as create_capi_cluster_resources — both touch the same CRs and
+	// the migration is a prerequisite for the create logic to be safe on upgrade.
+	Queue: "/modules/node-manager/create-capi-cluster-resources",
+	Kubernetes: []go_hook.KubernetesConfig{
+		{
+			Name:       "capi_cluster",
+			ApiVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "Cluster",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{capiNamespace}},
+			},
+			FilterFunc: filterCapiResourceMeta,
+		},
+		{
+			Name:       "capi_machine_health_check",
+			ApiVersion: "cluster.x-k8s.io/v1beta1",
+			Kind:       "MachineHealthCheck",
+			NamespaceSelector: &types.NamespaceSelector{
+				NameSelector: &types.NameSelector{MatchNames: []string{capiNamespace}},
+			},
+			FilterFunc: filterCapiResourceMeta,
+		},
+	},
+}, migrateCapiClusterHelmOwnership)
+
+func migrateCapiClusterHelmOwnership(_ context.Context, input *go_hook.HookInput) error {
+	for _, snap := range []string{"capi_cluster", "capi_machine_health_check"} {
+		metas, err := sdkobjectpatch.UnmarshalToStruct[capiResourceMeta](input.Snapshots, snap)
+		if err != nil {
+			return fmt.Errorf("unmarshal %s snapshot: %w", snap, err)
+		}
+		for _, m := range metas {
+			// Only patch if the resource is still claimed by helm and has not been
+			// stamped with `keep` yet. Avoids spurious writes on every reconcile.
+			if !m.HasHelmOwnership || m.HasKeepAnnotation {
+				continue
+			}
+			patch := map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						helmResourcePolicyAnnotation: "keep",
+					},
+				},
+			}
+			input.PatchCollector.PatchWithMerge(patch, m.APIVersion, m.Kind, m.Namespace, m.Name)
+		}
+	}
+	return nil
+}

--- a/modules/040-node-manager/template_tests/module_test.go
+++ b/modules/040-node-manager/template_tests/module_test.go
@@ -1764,24 +1764,20 @@ ccc: ddd
 
 	Context("CAPI", func() {
 		assertClusterResources := func(f *Config, clusterName string) {
+			// Cluster and MachineHealthCheck (cluster.x-k8s.io/v1beta1) are no
+			// longer rendered by helm — they are owned by the
+			// create_capi_cluster_resources hook on a dedicated queue (see
+			// hooks/create_capi_cluster_resources.go). Helm rendering used to
+			// race the capi conversion webhook. Hook-level tests cover their
+			// content; template tests only assert what helm still owns.
 			cluster := f.KubernetesResource("Cluster", "d8-cloud-instance-manager", clusterName)
-			Expect(cluster.Exists()).To(BeTrue())
+			Expect(cluster.Exists()).To(BeFalse())
 
-			Expect(cluster.Field("spec.clusterNetwork.pods.cidrBlocks.0").String()).To(Equal("10.111.0.0/16"))
-			Expect(cluster.Field("spec.clusterNetwork.services.cidrBlocks.0").String()).To(Equal("10.222.0.0/16"))
-			Expect(cluster.Field("spec.clusterNetwork.serviceDomain").String()).To(Equal("cluster.local"))
-
-			Expect(cluster.Field("spec.controlPlaneRef.apiVersion").String()).To(Equal("infrastructure.cluster.x-k8s.io/v1alpha1"))
-			Expect(cluster.Field("spec.controlPlaneRef.kind").String()).To(Equal("DeckhouseControlPlane"))
-			Expect(cluster.Field("spec.controlPlaneRef.namespace").String()).To(Equal("d8-cloud-instance-manager"))
-			Expect(cluster.Field("spec.controlPlaneRef.name").String()).To(Equal(fmt.Sprintf("%s-control-plane", clusterName)))
+			healthCheck := f.KubernetesResource("MachineHealthCheck", "d8-cloud-instance-manager", fmt.Sprintf("%s-machine-health-check", clusterName))
+			Expect(healthCheck.Exists()).To(BeFalse())
 
 			controlPlane := f.KubernetesResource("DeckhouseControlPlane", "d8-cloud-instance-manager", fmt.Sprintf("%s-control-plane", clusterName))
 			Expect(controlPlane.Exists()).To(BeTrue())
-
-			healthCheck := f.KubernetesResource("MachineHealthCheck", "d8-cloud-instance-manager", fmt.Sprintf("%s-machine-health-check", clusterName))
-			Expect(healthCheck.Exists()).To(BeTrue())
-			Expect(healthCheck.Field("spec.clusterName").String()).To(Equal(clusterName))
 
 			capiDeploy := f.KubernetesResource("Deployment", "d8-cloud-instance-manager", "capi-controller-manager")
 			Expect(capiDeploy.Exists()).To(BeTrue())

--- a/modules/040-node-manager/templates/capi_cluster.yaml
+++ b/modules/040-node-manager/templates/capi_cluster.yaml
@@ -2,79 +2,19 @@
   {{- $prefix := .Values.nodeManager.internal.cloudProvider.capiClusterName }}
   {{- if and $prefix .Values.nodeManager.internal.cloudProvider.capiClusterKind }}
 
+# Cluster (cluster.x-k8s.io/v1beta1) and MachineHealthCheck (cluster.x-k8s.io/v1beta1)
+# are created by the create_capi_cluster_resources hook on its dedicated queue.
+# Both go through a conversion webhook served by capi-webhook-service →
+# capi-controller-manager; helm-rendering them here races the very first install
+# of that Deployment and triggers a ~3-minute retry storm on the main queue.
 
 {{- include "capi_infrastructure_cluster" . }}
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: {{ $prefix }}
-  namespace: d8-cloud-instance-manager
-  annotations:
-    # Cluster/MachineHealthCheck have a conversion webhook on capi-webhook-service,
-    # backed by capi-controller-manager. During bootstrap, helm install of node-manager
-    # tries to apply these resources before capi-controller-manager Deployment is Ready
-    # — apiserver calls the conversion webhook, gets connection-refused / timeout,
-    # apply fails, helm retries with 45s backoff. Each retry hits the same wall until
-    # the controller eventually starts (~4 retries, ~3 min wasted).
-    # Tell nelm to defer these resources until the webhook backend is actually ready.
-    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capi-controller-manager,namespace=d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
-  #    cluster.x-k8s.io/paused: "true"
-  # A finalizer has been added to prevent cascading removing of all capi resources after deleting the cluster resource.
-  finalizers:
-    - deckhouse.io/capi-controller-manager
-spec:
-  clusterNetwork:
-    pods:
-      cidrBlocks:
-        - {{ .Values.global.clusterConfiguration.podSubnetCIDR }}
-    services:
-      cidrBlocks:
-        - {{ .Values.global.clusterConfiguration.serviceSubnetCIDR }}
-    serviceDomain: {{ .Values.global.clusterConfiguration.clusterDomain }}
-  infrastructureRef:
-    apiVersion: {{ .Values.nodeManager.internal.cloudProvider.capiClusterAPIVersion }}
-    kind: {{ .Values.nodeManager.internal.cloudProvider.capiClusterKind }}
-    namespace:  d8-cloud-instance-manager
-    name: {{ $prefix }}
-  controlPlaneRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
-    kind: DeckhouseControlPlane
-    namespace: d8-cloud-instance-manager
-    name: {{ $prefix }}-control-plane
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: DeckhouseControlPlane
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $prefix }}-control-plane
-  annotations:
-    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capi-controller-manager,namespace=d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: MachineHealthCheck
-metadata:
-  namespace: d8-cloud-instance-manager
-  name: {{ $prefix }}-machine-health-check
-  annotations:
-    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capi-controller-manager,namespace=d8-cloud-instance-manager
-  {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
-spec:
-  clusterName: {{ $prefix }}
-  nodeStartupTimeout: 20m
-  selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: {{ $prefix }}
-  unhealthyConditions:
-    - type: Ready
-      status: Unknown
-      timeout: 5m
-    - type: Ready
-      status: "False"
-      timeout: 5m
   {{- end }}
 {{- end }}
-
-

--- a/modules/040-node-manager/templates/capi_cluster.yaml
+++ b/modules/040-node-manager/templates/capi_cluster.yaml
@@ -10,8 +10,16 @@ kind: Cluster
 metadata:
   name: {{ $prefix }}
   namespace: d8-cloud-instance-manager
+  annotations:
+    # Cluster/MachineHealthCheck have a conversion webhook on capi-webhook-service,
+    # backed by capi-controller-manager. During bootstrap, helm install of node-manager
+    # tries to apply these resources before capi-controller-manager Deployment is Ready
+    # — apiserver calls the conversion webhook, gets connection-refused / timeout,
+    # apply fails, helm retries with 45s backoff. Each retry hits the same wall until
+    # the controller eventually starts (~4 retries, ~3 min wasted).
+    # Tell nelm to defer these resources until the webhook backend is actually ready.
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capi-controller-manager,namespace=d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
-  #  annotations:
   #    cluster.x-k8s.io/paused: "true"
   # A finalizer has been added to prevent cascading removing of all capi resources after deleting the cluster resource.
   finalizers:
@@ -41,6 +49,8 @@ kind: DeckhouseControlPlane
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $prefix }}-control-plane
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capi-controller-manager,namespace=d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -48,6 +58,8 @@ kind: MachineHealthCheck
 metadata:
   namespace: d8-cloud-instance-manager
   name: {{ $prefix }}-machine-health-check
+  annotations:
+    werf.io/deploy-dependency-deployment: state=ready,kind=Deployment,name=capi-controller-manager,namespace=d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "capi-controller-manager")) | nindent 2 }}
 spec:
   clusterName: {{ $prefix }}


### PR DESCRIPTION
## Description

Reduce DKP cloud bootstrap wall-clock by addressing nine bottlenecks measured on a DVP master VM. Touches bashible, the kube-apiserver control-plane template, one global hook, `node-manager`, `control-plane-manager`, `cni-cilium`, and dhctl.

Restart impact:

- `kube-apiserver` static pod gains `terminationGracePeriodSeconds: 1` and a faster `startupProbe` — both gated on `runType=ClusterBootstrap`. Runtime restarts (cpm rewrites, version bumps) keep the conservative values, so production behaviour is unchanged.
- `control-plane-manager` DaemonSet now reads `LEADER_ELECTION` from env (set by helm via `helm_lib_is_ha_to_value`): leader election is on for HA (>1 master) and off for single-master, where every cpm controller is already partitioned by `spec.nodeName`.
- `cni-cilium` agent `readinessProbe` `periodSeconds` 30→2. Liveness/startup unchanged.

## Why do we need it, and what problem does it solve?

Bootstrap of DKP on a cloud provider currently takes ~22 minutes on a clean DVP setup; ~half is `Wait Deckhouse Ready`. Profiling identified bottlenecks that compound:

1. **Bashible bundle (~150-170s on master)** — light prep steps were serial; the Node-wait loop in `071_install_control_plane.sh` ran *before* the `kubeadm:cluster-admins` ClusterRoleBinding existed, so every `kubectl get node` via `admin.conf` was denied for the full 200s timeout; the first-run reboot wasted ~30-40s.
2. **kube-apiserver static-pod restarts** — default `terminationGracePeriodSeconds: 30` and slow `startupProbe` added ~60s per restart, on the critical path during the first cpm rewrite.
3. **`calculate_resources_requests` global hook** — ran twice on a fresh master, output flipped after kubelet finalised `system-reserved`/`kube-reserved`, re-rendering every CP static-pod manifest and cascading restarts mid-Deckhouse-install (RBAC "forbidden" cascade across all module hooks).
4. **`node-manager` helm install retry storm** — `Cluster` / `MachineHealthCheck` (cluster.x-k8s.io/v1beta1) went through a conversion webhook on `capi-webhook-service` backed by `capi-controller-manager`. helm SSA'd them before the controller was Ready, the webhook returned connection-refused, helm retried with 45s backoff (~4 retries, ~3 min wasted on the main queue).
5. **`create_master_node_group` hook on the main queue** — the default `master` NodeGroup is created OnStartup via PatchCollector. The validating webhook `nodegroup.validation.node-controller.deckhouse.io` is unreachable during first install while `node-controller` warms up; the hook failed, ConvergeModules retried, ~80s lost on the main queue.
6. **cpm pod restarting on `leader election lost`** — cpm runs hostNetwork on every control-plane node; default `KUBERNETES_SERVICE_HOST=10.233.0.1:443` (ClusterIP) is unreachable during cilium init and again during the very first cpm rewrite of apiserver/etcd. Lease renewal failed past the default 10s RenewDeadline, the manager exited fatal, kubelet restarted cpm, progress was lost, an extra cpm rewrite cascade followed (knock-on cilium full datapath regenerate).
7. **kubelet `fileCheckFrequency: 20s`** — `/etc/kubernetes/manifests/` polled every 20s, so each cpm rewrite added up to a full 20s of dead time before kubelet acted on the new manifest.
8. **dhctl `Control-plane readiness` and `Waiting for Node Ready` polling intervals** (10s and 20s) added one polling-cycle of lag after the underlying signal flipped.
9. **cni-cilium agent `readinessProbe periodSeconds: 30`** — kubelet ignored cilium `/healthz=ok` for up to 30s after `startupProbe` (which is already 2s) succeeded.

### Results on DKP-on-DVP (1-master DVP cluster, master 4 CPU / 8 GiB)

| Phase | baseline-1 | this branch | Δ |
|---|---:|---:|---:|
| Cloud infrastructure | 319 | 335 | +16 (DVP variance) |
| Wait SSH | 15 | 18 | +3 |
| Preflight + prep | 9 | 8 | -1 |
| Initial bootstrap | 10 | 10 | 0 |
| Prepare CP manifests | 2 | 2 | 0 |
| **Execute bundle** | **316** | **87** | **-229 (-72%)** |
| Connect K8s API | 7 | 8 | +1 |
| Create Manifests | 18 | 22 | +4 |
| **Wait Deckhouse Ready** | **616** | **163** | **-453 (-74%)** |
| Wait Node Ready | — | 53 | +53 (newly visible) |
| **Control-plane readiness** | 0 | **136** | +136 (cpm work no longer blocks Wait Deckhouse Ready) |
| **TOTAL** | **1318** | **850** | **-468 (-35%)** |

Side metrics:

| | baseline-1 | this branch |
|---|---:|---:|
| CPM manifest rewrites (etcd / apiserver / KCM / KS) | 2 / 2 / 2 / 3 | 1 / 1 / 1 / 1 |
| cpm pod restarts during bootstrap | 2 | 0 |
| node-manager helm retry storm | ~180s | 0 |
| NodeGroup `master` webhook retry storm | ~80s | 0 |
| cni-cilium agent ready (PodScheduled → Ready) | 257-341s | 178s |

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually (local DVP e2e, multiple runs).

## Changelog entries

```changes
section: candi
type: fix
summary: "Bashible bundle: light-prep parallel groups, sub-step timing, early kubeadm:cluster-admins ClusterRoleBinding, skip first-run reboot."
impact_level: low
---
section: candi
type: fix
summary: "kubelet config: fileCheckFrequency 20s -> 2s — kubelet picks up static-pod manifest changes on the next 2-second tick instead of the next 20-second tick."
impact_level: low
---
section: candi
type: fix
summary: "kube-apiserver static pod: terminationGracePeriodSeconds=1 and aggressive startupProbe on bootstrap (runType=ClusterBootstrap); runtime keeps conservative values."
impact_level: low
---
section: control-plane-manager
type: fix
summary: "calculate_resources_requests is now stable across the kubelet warm-up window — uses Node.Status.Capacity minus max(actual kubelet reservation, floor), so the second hook run does not re-render every CP static-pod manifest."
impact_level: low
---
section: node-manager
type: fix
summary: "create_master_node_group hook runs on its own queue: a transient nodegroup-validation webhook failure during first install no longer fails node-manager's Startup phase and cascades a ConvergeModules retry storm onto main."
impact_level: low
---
section: node-manager
type: fix
summary: "Cluster and MachineHealthCheck (cluster.x-k8s.io/v1beta1) are now created by a kubernetes-binding hook on a dedicated queue, triggered by the d8-node-manager-cloud-provider Secret — removes the conversion-webhook retry storm during the very first helm install of node-manager."
impact_level: low
---
section: control-plane-manager
type: fix
summary: "cpm DaemonSet now talks to apiserver via the local kubernetes-api-proxy static pod (127.0.0.1:6445), removing its dependency on cilium-initialised ClusterIP routing during bootstrap."
impact_level: low
---
section: control-plane-manager
type: fix
summary: "Leader election is now conditional (helm_lib_is_ha_to_value) — on for HA, off for single-master, where every cpm controller is already partitioned by spec.nodeName. Stops cpm from crashing with leader election lost when its very first reconcile rewrites apiserver/etcd."
impact_level: low
---
section: cni-cilium
type: fix
summary: "cilium-agent readinessProbe periodSeconds lowered from 30s to 2s, matching startupProbe — kubelet flips the pod to Ready within seconds of /healthz returning ok instead of up to half a minute later."
impact_level: low
---
section: dhctl
type: fix
summary: "Tighter polling for Control-plane readiness (10s -> 1s) and Waiting for Node Ready (20s -> 1s) loops. Total retry budgets unchanged."
impact_level: low
```