### PR TITLE
[control-plane-manager] Allow change labels and annotations for secret d8-secret-encryption-key

### DIFF
--- a/modules/040-control-plane-manager/webhooks/validating/d8-secret-encryption-key-configuration
+++ b/modules/040-control-plane-manager/webhooks/validating/d8-secret-encryption-key-configuration
@@ -35,16 +35,43 @@ EOF
 }
 
 function __main__() {
-  # Secret kube-system/d8-secret-encryption-key cannot be deleted
-  if context::jq -e -r '.review.request.operation != "CREATE"' >/dev/null 2>&1; then
-    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
-{"allowed":false, "message":"it is forbidden to modify secret d8-secret-encryption-key"}
-EOF
+  local operation user
+  operation=$(context::jq -r '.review.request.operation')
+  user=$(context::jq -r '.review.request.userInfo.username')
 
+  if [[ "$operation" == "DELETE" ]]; then
+    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden to delete secret d8-secret-encryption-key"}
+EOF
     return 0
   fi
 
-    cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+  if [[ "$operation" == "UPDATE" ]]; then
+    # Allow changes only to labels and annotations
+    local diff
+    diff=$(context::jq -c '
+      .review.request.object as $new |
+      .review.request.oldObject as $old |
+      $new | del(.metadata.labels, .metadata.annotations, .metadata.resourceVersion, .metadata.managedFields) == ($old | del(.metadata.labels, .metadata.annotations, .metadata.resourceVersion, .metadata.managedFields))
+    ')
+
+    if [[ "$diff" == "false" ]]; then
+      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"it is forbidden to modify secret d8-secret-encryption-key (only labels and annotations are allowed to be changed)"}
+EOF
+      return 0
+    fi
+
+    # Allow label/annotation changes only for deckhouse service account
+    if [[ "$user" != "system:serviceaccount:d8-system:deckhouse" ]]; then
+      cat <<EOF > "$VALIDATING_RESPONSE_PATH"
+{"allowed":false, "message":"only system:serviceaccount:d8-system:deckhouse is allowed to modify labels and annotations of secret d8-secret-encryption-key"}
+EOF
+      return 0
+    fi
+  fi
+
+  cat <<EOF > "$VALIDATING_RESPONSE_PATH"
 {"allowed":true}
 EOF
 


### PR DESCRIPTION
## Description

The validation hook has been fixed. Changing labels and annotations is now allowed using the service account `system:serviceaccount:d8-system:deckhouse`.

## Why do we need it, and what problem does it solve?

It's currently impossible to edit labels or annotations for the d8-secret-encryption-key secret. The validation hook prevents any operations.

This may be needed for migration tools or CI.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: fix 
summary: Allow change labels and annotations for secret d8-secret-encryption-key
impact_level: default
```
