### PR TITLE
[dhctl] avoid extraction on failed execution

### DIFF
--- a/dhctl/pkg/infrastructure/pipeline.go
+++ b/dhctl/pkg/infrastructure/pipeline.go
@@ -127,7 +127,11 @@ func ApplyPipeline(
 		}
 		span.AddEvent("Plan done")
 
-		defer func() { extractedData, err = extractFn(ctx, r) }()
+		defer func() {
+			if err == nil {
+				extractedData, err = extractFn(ctx, r)
+			}
+		}()
 
 		if err := r.Apply(ctx); err != nil {
 			return err


### PR DESCRIPTION
## Description

Improve error handling for cluster creation failures caused by insufficient infrastructure resources.

The change makes resource exhaustion problems more explicit and easier to diagnose during bootstrap and converge operations.

## Why do we need it, and what problem does it solve?

Previously cluster creation could fail with unclear or indirect errors when the infrastructure provider did not have enough available resources (CPU, RAM, disk capacity, quotas, etc.).

This made debugging difficult because users had to inspect provider logs or internal infrastructure errors manually.

Now dhctl surfaces the problem more clearly and provides a more obvious failure reason during cluster creation.

## Why do we need it in the patch release (if we do)?

This improves troubleshooting experience and reduces time spent diagnosing infrastructure-related cluster bootstrap failures.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix
summary: improve error visibility for cluster creation failures caused by insufficient infrastructure resources.
impact_level: default