### PR TITLE
[cloud-provider-vcd] Fix LogrAdapter panic in VCD infra-controller-manager

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager/src/internal/logr/logr.go
+++ b/ee/modules/030-cloud-provider-vcd/images/infra-controller-manager/src/internal/logr/logr.go
@@ -37,7 +37,11 @@ func (l *LogrAdapter) Info(level int, msg string, args ...any) {
 }
 
 func (l *LogrAdapter) Error(err error, msg string, _ ...any) {
-	l.logger.Error(msg, slog.String("error", err.Error()))
+	if err != nil {
+		l.logger.Error(msg, slog.String("error", err.Error()))
+	} else {
+		l.logger.Error(msg)
+	}
 }
 
 func (l *LogrAdapter) WithValues(args ...any) logr.LogSink {


### PR DESCRIPTION
## Description

Fix a panic in the VCD `infra-controller-manager` `LogrAdapter`.

The adapter currently calls `err.Error()` unconditionally in `LogrAdapter.Error()`. When `controller-runtime` / `klog` invoke `Error(nil, ...)`, the manager crashes with a nil pointer dereference and the `infra-controller-manager` pod may enter `CrashLoopBackOff`.

This change makes `LogrAdapter.Error()` nil-safe and keeps the manager running while still logging the error message. The change affects only the error logging path in `d8-cloud-provider-vcd/infra-controller-manager` and does not change reconciliation logic.

## Why do we need it, and what problem does it solve?

This fixes a real crash condition in VCD clusters.

During transient `apiserver` / `etcd` failures, `infra-controller-manager` may hit logging paths where `Error(nil, ...)` is called by upstream libraries. Because the adapter dereferences `nil`, a temporary control plane problem turns into a process crash and pod restart.

With this fix, transient API-side errors no longer cause an additional panic in the manager itself.

## Why do we need it in the patch release (if we do)?

This should be included in a patch release because the bug affects already deployed VCD clusters and can cause `infra-controller-manager` to crash on transient control plane errors. The fix is small, isolated, and reduces the risk of unnecessary restarts in production.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-vcd
type: fix
summary: Fix LogrAdapter panic in VCD infra-controller-manager
impact_level: default
```