### PR TITLE
user-authn: add dex patch for CVE-2026-32952

### DIFF
--- a/modules/150-user-authn/images/dex/patches/012-fix-cve.patch
+++ b/modules/150-user-authn/images/dex/patches/012-fix-cve.patch
@@ -1,0 +1,28 @@
+diff --git a/go.mod b/go.mod
+index d8e7ba5..609a615 100644
+--- a/go.mod
++++ b/go.mod
+@@ -48,7 +48,7 @@ require (
+ 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
+ 	dario.cat/mergo v1.0.1 // indirect
+ 	filippo.io/edwards25519 v1.1.1 // indirect
+-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
++	github.com/Azure/go-ntlmssp v0.1.1 // indirect
+ 	github.com/Masterminds/goutils v1.1.1 // indirect
+ 	github.com/Masterminds/semver/v3 v3.3.0 // indirect
+ 	github.com/agext/levenshtein v1.2.3 // indirect
+diff --git a/go.sum b/go.sum
+index f00fbbf..4e6d4ac 100644
+--- a/go.sum
++++ b/go.sum
+@@ -14,8 +14,8 @@ filippo.io/edwards25519 v1.1.1 h1:YpjwWWlNmGIDyXOn8zLzqiD+9TyIlPhGFG96P39uBpw=
+ filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+ github.com/AppsFlyer/go-sundheit v0.6.0 h1:d2hBvCjBSb2lUsEWGfPigr4MCOt04sxB+Rppl0yUMSk=
+ github.com/AppsFlyer/go-sundheit v0.6.0/go.mod h1:LDdBHD6tQBtmHsdW+i1GwdTt6Wqc0qazf5ZEJVTbTME=
+-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
+-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
++github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
++github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
+ github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+ github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+ github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=

--- a/modules/150-user-authn/images/dex/patches/README.md
+++ b/modules/150-user-authn/images/dex/patches/README.md
@@ -91,5 +91,8 @@ Manual unlock is performed by patching the user's `OfflineSessions` resource
 ### 011-fix-cve.patch
 
 Update Go module dependencies to fix:
-- CVE-2026-32952 (`github.com/Azure/go-ntlmssp` -> `v0.1.1`)
 - CVE-2026-29181 (`go.opentelemetry.io/otel` -> `v1.41.0`)
+
+
+### 012-fix-cve.patch
+- CVE-2026-32952 (`github.com/Azure/go-ntlmssp` -> `v0.1.1`)


### PR DESCRIPTION
## Description
Fix 
CVE-2026-32952
## Why do we need it, and what problem does it solve?
Security scanning reports `CVE-2026-32952` in `userAuthn / dex` (`usr/local/bin/dex`) due to vulnerable `github.com/Azure/go-ntlmssp`.
This change updates the dependency to a fixed version and removes the vulnerability from the Dex image.
## Why do we need it in the patch release (if we do)?
This is a security remediation and should be backported to the patch release to minimize the exposure window for existing installations.
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: user-authn
type: fix
summary: Fix CVE-2026-32952 in Dex by bumping github.com/Azure/go-ntlmssp to v0.1.1.
impact_level: default