### PR TITLE
[webhook-handler] Fix data race and deadlock in shell-operator supervisor loop

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"flag"
@@ -26,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -57,7 +59,127 @@ const (
 	// unnecessary restarts when multiple webhooks are created in quick succession.
 	// Can be overridden via SHELL_OPERATOR_RELOAD_INTERVAL environment variable.
 	DefaultShellOperatorReloadInterval = 5 * time.Second
+
+	// shellOperatorMinBackoff is the initial delay before respawning a shell-operator
+	// process that exited quickly. The delay doubles on each consecutive fast exit up
+	// to shellOperatorMaxBackoff, preventing a tight respawn loop when shell-operator
+	// fails to start (e.g. due to a malformed hook file).
+	shellOperatorMinBackoff = 500 * time.Millisecond
+	shellOperatorMaxBackoff = 30 * time.Second
+
+	// shellOperatorStableRun is the minimum runtime after which a shell-operator exit
+	// is treated as "normal" and the backoff is reset.
+	shellOperatorStableRun = 5 * time.Second
 )
+
+// shellRunner supervises a single child shell-operator process. It owns the
+// *exec.Cmd reference and synchronises access so the reload goroutine can
+// safely signal the current child while the supervisor goroutine swaps it.
+type shellRunner struct {
+	logger *log.Logger
+
+	mu  sync.Mutex
+	cmd *exec.Cmd
+}
+
+func newShellRunner(logger *log.Logger) *shellRunner {
+	return &shellRunner{logger: logger}
+}
+
+func (r *shellRunner) setCmd(c *exec.Cmd) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cmd = c
+}
+
+func (r *shellRunner) currentCmd() *exec.Cmd {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.cmd
+}
+
+// SignalTerm sends SIGTERM to the current shell-operator child, if any.
+// It treats "process already finished" as success because the runner may have
+// observed an independent exit before the signal landed.
+func (r *shellRunner) SignalTerm() error {
+	c := r.currentCmd()
+	if c == nil || c.Process == nil {
+		return nil
+	}
+	err := c.Process.Signal(syscall.SIGTERM)
+	if err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return err
+	}
+	return nil
+}
+
+// Run starts shell-operator and respawns it whenever it exits, with
+// exponential backoff for fast crashes. It returns when ctx is cancelled.
+func (r *shellRunner) Run(ctx context.Context) {
+	backoff := shellOperatorMinBackoff
+
+	for ctx.Err() == nil {
+		c := exec.Command("./shell-operator")
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+
+		if err := c.Start(); err != nil {
+			r.logger.Error("start shell-operator",
+				slog.String("error", err.Error()),
+				slog.Duration("backoff", backoff))
+			if !sleepCtx(ctx, backoff) {
+				return
+			}
+			backoff = min(backoff*2, shellOperatorMaxBackoff)
+			continue
+		}
+
+		r.setCmd(c)
+		r.logger.Info("shell-operator started", slog.Int("pid", c.Process.Pid))
+
+		startedAt := time.Now()
+		waitErr := c.Wait()
+		ran := time.Since(startedAt)
+		r.setCmd(nil)
+
+		if waitErr != nil {
+			r.logger.Info("shell-operator exited",
+				slog.String("error", waitErr.Error()),
+				slog.Duration("ran", ran))
+		} else {
+			r.logger.Info("shell-operator exited", slog.Duration("ran", ran))
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		if ran < shellOperatorStableRun {
+			r.logger.Warn("shell-operator exited too quickly, backing off",
+				slog.Duration("backoff", backoff))
+			if !sleepCtx(ctx, backoff) {
+				return
+			}
+			backoff = min(backoff*2, shellOperatorMaxBackoff)
+			continue
+		}
+
+		backoff = shellOperatorMinBackoff
+	}
+}
+
+// sleepCtx blocks for d or until ctx is cancelled. It returns false if ctx
+// was cancelled before the timer fired.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
 
 var (
 	scheme   = runtime.NewScheme()
@@ -256,45 +378,45 @@ func main() {
 		}
 	}
 
-	var cmd *exec.Cmd
-	processExited := make(chan struct{})
+	// One signal context for the whole process: cancelling it stops the manager
+	// and tells the shell-operator supervisor to drain.
+	ctx := ctrl.SetupSignalHandler()
 
-	// go-routine that runs shell-operator and signals when it exited
+	runner := newShellRunner(logger)
+
+	// Propagate pod termination to the shell-operator child so it can exit
+	// cleanly instead of being SIGKILL'ed when the parent returns.
 	go func() {
-		for {
-			logger.Debug("running shell-operator")
-			cmd = exec.Command("./shell-operator")
-			cmd.Stdout = os.Stdout
-			cmd.Stderr = os.Stderr
-
-			err := cmd.Run()
-			if err != nil {
-				logger.Info("shell-operator exited", slog.String("error", err.Error()))
-			}
-
-			// if exited not by signal
-			if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
-				isReloadShellNeed.Store(true)
-			}
-
-			processExited <- struct{}{}
+		<-ctx.Done()
+		if err := runner.SignalTerm(); err != nil {
+			logger.Error("sigterm shell-operator on shutdown", slog.String("error", err.Error()))
 		}
 	}()
 
-	// go-routine that reloads shell-operator periodically when new hooks are registered
+	// Supervisor: keeps shell-operator alive with bounded-backoff respawns.
+	setupLog.Info("starting shell-operator supervisor")
+	go runner.Run(ctx)
+
+	// Reload trigger: periodically check if controllers asked for a reload
+	// and signal the current shell-operator. The supervisor will respawn it.
 	go func() {
-		for range time.Tick(reloadInterval) {
-			if isReloadShellNeed.Load() {
-				logger.Info("restarting shell-operator")
-
-				// TODO: what if SIGTERM don't killed shell-operator?
-				err := cmd.Process.Signal(syscall.SIGTERM)
-				if err != nil && !errors.Is(err, os.ErrProcessDone) {
-					logger.Error("sigterm shell-operator", slog.String("error", err.Error()), slog.Int("pid", cmd.Process.Pid))
+		ticker := time.NewTicker(reloadInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if !isReloadShellNeed.Load() {
+					continue
 				}
-
-				<-processExited // wait for shell-operator to exit
+				// Clear the flag first so a request that arrives between
+				// the SIGTERM and the next tick is not lost.
 				isReloadShellNeed.Store(false)
+				logger.Info("reloading shell-operator")
+				if err := runner.SignalTerm(); err != nil {
+					logger.Error("sigterm shell-operator", slog.String("error", err.Error()))
+				}
 			}
 		}
 	}()
@@ -356,7 +478,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
## Problem

After #19592 (`[webhook-handler] Handle shell-operator exit state in main loop`), the `webhook-handler` pod can get into a state where port `9681` (the conversion webhook endpoint) stops responding while the pod itself stays Running and Healthy. This causes kube-apiserver to time out when calling the conversion webhook:

```
conversion webhook for deckhouse.io/v1, Kind=DexAuthenticator failed:
Post "https://conversion-webhook-handler.d8-system.svc:443/…?timeout=30s":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Any module that watches a CRD with a registered conversion (e.g. `user-authn` watching `DexAuthenticator` v2alpha1) is blocked at startup until the webhook is reachable, which can pin the entire Deckhouse operator queue.

### Root causes in the previous implementation

1. **Data race on `cmd`.** The runner goroutine reassigned `cmd = exec.Command(…)` on each iteration while the reload goroutine read `cmd.Process.Signal(…)` / `cmd.Process.Pid` without synchronisation. Under the Go memory model this is a data race; in practice it can nil-panic in the reload goroutine, permanently preventing any further restarts while the container keeps running.

2. **Channel deadlock window on natural exit.** `processExited` was unbuffered. When shell-operator exited on its own, the runner blocked on `processExited <- struct{}{}` until the reload goroutine drained it — which only happened up to one `reloadInterval` (5 s) later. During that window shell-operator was not running, but the pod remained in the Service endpoints and every kube-apiserver TLS connection on `:9681` hung until the 30 s API-server timeout.

3. **No backoff on rapid restarts.** A malformed hook file could cause shell-operator to crash-loop with no throttle, churning connections on `:9681` continuously.

4. **`ctrl.SetupSignalHandler()` called twice.** The original code called it once at the top of `main` and again in `mgr.Start(…)`. A second call panics at runtime. This was latent but would surface as soon as the first call was refactored out.

## Fix

Introduces a `shellRunner` type that owns the `*exec.Cmd` pointer behind a `sync.Mutex` and exposes a safe `SignalTerm()` method. `Run(ctx)` replaces both goroutines:

- Uses `cmd.Start()` + `cmd.Wait()` per iteration — natural exit and SIGTERM exit are handled identically; no channel needed.
- Applies exponential backoff (500 ms → 30 s) when shell-operator exits in under 5 s, preventing tight crash loops.
- Returns when `ctx` is cancelled (pod SIGTERM) after forwarding SIGTERM to the child, so shell-operator gets a clean shutdown instead of SIGKILL.

A separate short-lived goroutine replaces the reload ticker and drains cleanly on ctx cancellation. The `isReloadShellNeed` flag is cleared *before* SIGTERM so a reload request arriving between the signal and the next tick is not dropped.

`ctrl.SetupSignalHandler()` is now called exactly once; the returned context is shared by the manager and the supervisor.


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: fix data race webhook handler
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
