### PR TITLE
[chore] make metrics label consistent

### DIFF
--- a/deckhouse-controller/internal/metrics/labels.go
+++ b/deckhouse-controller/internal/metrics/labels.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metrics provides centralized metric label key constants for deckhouse-controller.
+// All metric label keys are defined here to ensure consistency and prevent typos.
+package metrics
+
+const (
+	// ============================================================================
+	// Common Label Keys
+	// ============================================================================
+
+	// LabelModule is the label key for the module name.
+	LabelModule = "module"
+
+	// LabelSource is the label key for the module source name.
+	LabelSource = "source"
+
+	// LabelVersion is the label key for the release or module version.
+	LabelVersion = "version"
+
+	// LabelError is the label key for an error message.
+	LabelError = "error"
+
+	// LabelName is the label key for a generic resource name.
+	LabelName = "name"
+
+	// ============================================================================
+	// Module Controller Label Keys
+	// ============================================================================
+
+	// LabelModuleRelease is the label key for the module release name.
+	LabelModuleRelease = "moduleRelease"
+
+	// LabelRegistry is the label key for the registry URL.
+	LabelRegistry = "registry"
+
+	// LabelActualVersion is the label key for the currently deployed version.
+	LabelActualVersion = "actualVersion"
+
+	// ============================================================================
+	// Release Controller Label Keys
+	// ============================================================================
+
+	// LabelDeployingRelease is the label key for the name of the release being deployed.
+	LabelDeployingRelease = "deployingRelease"
+
+	// ============================================================================
+	// Release Info Metric Label Keys
+	// Used in the d8_release_info and d8_module_release_info metrics.
+	// ============================================================================
+
+	// LabelManualApprovalRequired indicates whether manual approval is required.
+	LabelManualApprovalRequired = "manualApproval"
+
+	// LabelDisruptionApprovalRequired indicates whether disruption approval is required.
+	LabelDisruptionApprovalRequired = "disruptionApproval"
+
+	// LabelRequirementsNotMet indicates whether release requirements are not met.
+	LabelRequirementsNotMet = "requirementsNotMet"
+
+	// LabelReleaseQueueDepth is the label key for the release queue depth.
+	LabelReleaseQueueDepth = "releaseQueueDepth"
+
+	// LabelMajorReleaseDepth is the label key for the major release queue depth.
+	LabelMajorReleaseDepth = "majorReleaseDepth"
+
+	// LabelMajorReleaseName is the label key for the major release name.
+	LabelMajorReleaseName = "majorReleaseName"
+
+	// LabelFromToName is the label key for the from-to release name in step-by-step updates.
+	LabelFromToName = "fromToName"
+
+	// LabelNotificationNotSent indicates whether an update notification has not been sent.
+	LabelNotificationNotSent = "notificationNotSent"
+)

--- a/deckhouse-controller/internal/metrics/metrics.go
+++ b/deckhouse-controller/internal/metrics/metrics.go
@@ -100,9 +100,9 @@ func ModuleReleaseMetricsGroupName(moduleName, version string) string {
 // This ensures consistent label usage across the codebase and matches the registered metric labels.
 func ModuleConfigurationErrorLabels(moduleName, version, errorMsg string) map[string]string {
 	return map[string]string{
-		"module":  moduleName,
-		"version": version,
-		"error":   errorMsg,
+		LabelModule:  moduleName,
+		LabelVersion: version,
+		LabelError:   errorMsg,
 	}
 }
 
@@ -133,7 +133,7 @@ func RegisterDeckhouseControllerMetrics(metricStorage metricsstorage.Storage) er
 // including experimental modules, migrations, and deprecation tracking.
 func RegisterModuleManagerMetrics(metricStorage metricsstorage.Storage) error {
 	// Register module manager metrics
-	moduleLabels := []string{"module"}
+	moduleLabels := []string{LabelModule}
 
 	// Register experimental modules allowed metric (global setting)
 	_, err := metricStorage.RegisterGauge(
@@ -220,7 +220,7 @@ func RegisterDeckhouseReleaseMetrics(metricStorage metricsstorage.Storage) error
 
 	// Register update status gauges
 	// These gauges are managed via grouped metrics and are set during release operations
-	releaseLabels := []string{"deployingRelease"}
+	releaseLabels := []string{LabelDeployingRelease}
 
 	_, err = metricStorage.RegisterGauge(
 		D8IsUpdating,
@@ -247,8 +247,8 @@ func RegisterDeckhouseReleaseMetrics(metricStorage metricsstorage.Storage) error
 // including config, source, and release controller metrics.
 func RegisterModuleControllerMetrics(metricStorage metricsstorage.Storage) error {
 	// Define common labels for module controller metrics
-	moduleLabels := []string{"module", "source"}
-	configLabels := []string{"module"}
+	moduleLabels := []string{LabelModule, LabelSource}
+	configLabels := []string{LabelModule}
 
 	// Register counter for module operations
 	// Note: These metrics use deckhouse_ placeholder which is replaced by metrics storage
@@ -282,7 +282,7 @@ func RegisterModuleControllerMetrics(metricStorage metricsstorage.Storage) error
 
 	// ModuleConfigurationError uses different labels than other module metrics
 	// because it tracks configuration errors per module version, not per source
-	moduleConfigErrorLabels := []string{"module", "version", "error"}
+	moduleConfigErrorLabels := []string{LabelModule, LabelVersion, LabelError}
 	_, err = metricStorage.RegisterGauge(
 		ModuleConfigurationError,
 		moduleConfigErrorLabels,

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_module_config.go
@@ -106,7 +106,7 @@ func moduleConfigValidationHandler(
 					return rejectResult("delete the ModulePullOverride before deleting the module config")
 				}
 
-				metricStorage.GaugeSet(metrics.D8ModuleConfigAllowedToDisable, 0, map[string]string{"module": cfg.GetName()})
+				metricStorage.GaugeSet(metrics.D8ModuleConfigAllowedToDisable, 0, map[string]string{metrics.LabelModule: cfg.GetName()})
 				// if module is already disabled - we don't need to warn user about disabling module
 				return allowResult(nil)
 			}
@@ -268,7 +268,7 @@ func moduleConfigValidationHandler(
 			warnings = append(warnings, res.Warning)
 		}
 
-		metricStorage.GaugeSet(metrics.D8ModuleConfigAllowedToDisable, allowedToDisableMetric, map[string]string{"module": cfg.GetName()})
+		metricStorage.GaugeSet(metrics.D8ModuleConfigAllowedToDisable, allowedToDisableMetric, map[string]string{metrics.LabelModule: cfg.GetName()})
 
 		module, err := moduleStorage.GetModuleByName(cfg.Name)
 		if err != nil {

--- a/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/check_release.go
@@ -513,7 +513,7 @@ func (f *DeckhouseReleaseFetcher) ensureReleases(
 	}
 
 	metricLabels := map[string]string{
-		"version": releaseForUpdate.GetVersion().Original(),
+		metrics.LabelVersion: releaseForUpdate.GetVersion().Original(),
 	}
 
 	vers, err := f.getNewVersions(ctx, actual.GetVersion(), newSemver)

--- a/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
+++ b/deckhouse-controller/pkg/controller/deckhouse-release/controller.go
@@ -494,16 +494,16 @@ func (r *deckhouseReleaseReconciler) pendingReleaseReconcile(ctx context.Context
 
 	metricLabels := releaseUpdater.NewReleaseMetricLabels(dr)
 	defer func() {
-		metricLabels[releaseUpdater.MajorReleaseDepth] = strconv.Itoa(task.QueueDepth.GetMajorReleaseDepth())
-		if metricLabels[releaseUpdater.ManualApprovalRequired] == "true" {
-			metricLabels[releaseUpdater.ReleaseQueueDepth] = strconv.Itoa(task.QueueDepth.GetReleaseQueueDepth())
+		metricLabels[metrics.LabelMajorReleaseDepth] = strconv.Itoa(task.QueueDepth.GetMajorReleaseDepth())
+		if metricLabels[metrics.LabelManualApprovalRequired] == "true" {
+			metricLabels[metrics.LabelReleaseQueueDepth] = strconv.Itoa(task.QueueDepth.GetReleaseQueueDepth())
 		}
 		r.metricsUpdater.UpdateReleaseMetric(dr.GetName(), metricLabels)
 	}()
 
 	reasons := checker.MetRequirements(ctx, dr)
 	if len(reasons) > 0 {
-		metricLabels.SetTrue(releaseUpdater.RequirementsNotMet)
+		metricLabels.SetTrue(metrics.LabelRequirementsNotMet)
 		msgs := make([]string, 0, len(reasons))
 		for _, reason := range reasons {
 			msgs = append(msgs, reason.Message)
@@ -658,7 +658,7 @@ func (r *deckhouseReleaseReconciler) DeployTimeCalculate(ctx context.Context, dr
 	checker := releaseUpdater.NewPreApplyChecker(dus, r.logger)
 	reasons := checker.MetRequirements(ctx, &dr)
 	if len(reasons) > 0 {
-		metricLabels.SetTrue(releaseUpdater.DisruptionApprovalRequired)
+		metricLabels.SetTrue(metrics.LabelDisruptionApprovalRequired)
 
 		msgs := make([]string, 0, len(reasons))
 		for _, reason := range reasons {
@@ -1120,7 +1120,7 @@ func (r *deckhouseReleaseReconciler) reconcileDeployedRelease(ctx context.Contex
 	}
 
 	if dr.GetIsUpdating() {
-		r.metricStorage.Grouped().GaugeSet(metrics.D8Updating, metrics.D8IsUpdating, 1, map[string]string{"deployingRelease": dr.GetName()})
+		r.metricStorage.Grouped().GaugeSet(metrics.D8Updating, metrics.D8IsUpdating, 1, map[string]string{metrics.LabelDeployingRelease: dr.GetName()})
 
 		return ctrl.Result{RequeueAfter: defaultCheckInterval}, nil
 	}

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -307,10 +307,10 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 
 		// Reset deprecated and experimental metrics when module is disabled
 		if module.IsDeprecated() {
-			r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 0.0, map[string]string{"module": moduleConfig.GetName()})
+			r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 0.0, map[string]string{metrics.LabelModule: moduleConfig.GetName()})
 		}
 		if module.IsExperimental() {
-			r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 0.0, map[string]string{"module": moduleConfig.GetName()})
+			r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 0.0, map[string]string{metrics.LabelModule: moduleConfig.GetName()})
 		}
 
 		// skip disabled modules
@@ -326,11 +326,11 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 	}
 
 	if module.IsExperimental() {
-		r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 1.0, map[string]string{"module": moduleConfig.GetName()})
+		r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 1.0, map[string]string{metrics.LabelModule: moduleConfig.GetName()})
 	}
 
 	if module.IsDeprecated() {
-		r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 1.0, map[string]string{"module": moduleConfig.GetName()})
+		r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 1.0, map[string]string{metrics.LabelModule: moduleConfig.GetName()})
 	}
 
 	if err := r.addFinalizer(ctx, moduleConfig); err != nil {
@@ -387,7 +387,7 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 			}
 			// fire alert at Conflict
 			r.metricStorage.Grouped().GaugeSet(metricGroup, metrics.D8ModuleAtConflict, 1.0, map[string]string{
-				"moduleName": module.Name,
+				"module": module.Name,
 			})
 		}
 	}
@@ -420,8 +420,8 @@ func (r *reconciler) deleteModuleConfig(ctx context.Context, moduleConfig *v1alp
 	metricGroup = fmt.Sprintf(metrics.ModuleConflictMetricGroupTemplate, moduleConfig.Name)
 	r.metricStorage.Grouped().ExpireGroupMetrics(metricGroup)
 
-	r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 0.0, map[string]string{"module": moduleConfig.GetName()})
-	r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 0.0, map[string]string{"module": moduleConfig.GetName()})
+	r.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModuleIsEnabled), 0.0, map[string]string{metrics.LabelModule: moduleConfig.GetName()})
+	r.metricStorage.GaugeSet(telemetry.WrapName(metrics.DeprecatedModuleIsEnabled), 0.0, map[string]string{metrics.LabelModule: moduleConfig.GetName()})
 
 	module := new(v1alpha1.Module)
 	if err := r.client.Get(ctx, client.ObjectKey{Name: moduleConfig.Name}, module); err != nil {

--- a/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/source/module_release_fetcher.go
@@ -232,9 +232,9 @@ func (f *ModuleReleaseFetcher) ensureReleases(
 	defer span.End()
 
 	metricLabels := map[string]string{
-		"module":   f.moduleName,
-		"version":  f.targetReleaseMeta.ModuleVersion,
-		"registry": f.source.Spec.Registry.Repo,
+		metrics.LabelModule:   f.moduleName,
+		metrics.LabelVersion:  f.targetReleaseMeta.ModuleVersion,
+		metrics.LabelRegistry: f.source.Spec.Registry.Repo,
 	}
 
 	logger := f.logger.With(
@@ -275,7 +275,7 @@ func (f *ModuleReleaseFetcher) ensureReleases(
 
 	// create release if deployed release and new release are in updating sequence
 	actual := releaseForUpdate
-	metricLabels["actual_version"] = "v" + actual.GetVersion().String()
+	metricLabels[metrics.LabelActualVersion] = "v" + actual.GetVersion().String()
 	if isUpdatingSequence(actual.GetVersion(), newSemver) {
 		logger.Debug("from deployed")
 
@@ -376,7 +376,7 @@ func (f *ModuleReleaseFetcher) ensureReleases(
 		if ensureErr != nil {
 			err = errors.Join(err, ensureErr)
 
-			metricLabels["version"] = "v" + ver.String()
+			metricLabels[metrics.LabelVersion] = "v" + ver.String()
 
 			if errors.Is(ensureErr, ErrModuleIsCorrupted) {
 				f.metricStorage.Grouped().GaugeSet(f.metricGroupName, metrics.D8ModuleUpdatingModuleIsNotValid, 1, metricLabels)

--- a/deckhouse-controller/pkg/helpers/deckhouse_settings.go
+++ b/deckhouse-controller/pkg/helpers/deckhouse_settings.go
@@ -90,7 +90,7 @@ func (c *DeckhouseSettingsContainer) Set(settings *DeckhouseSettings) {
 		allowExperimentalModules = 1.
 	}
 
-	c.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModulesAreAllowedMetricName), allowExperimentalModules, map[string]string{"module": "deckhouse-controller"})
+	c.metricStorage.GaugeSet(telemetry.WrapName(metrics.ExperimentalModulesAreAllowedMetricName), allowExperimentalModules, map[string]string{metrics.LabelModule: "deckhouse-controller"})
 }
 
 func (c *DeckhouseSettingsContainer) Get() *DeckhouseSettings {

--- a/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/deploy_time_checker.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/metrics"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha2"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
@@ -135,7 +136,7 @@ func (c *DeployTimeService) checkNotify(dtr *DeployTimeResult, release v1alpha1.
 func (c *DeployTimeService) processManualApproved(dtr *DeployTimeResult, release v1alpha1.Release, metricLabels MetricLabels) {
 	c.logger.Info("release is waiting for manual approval", slog.String("name", release.GetName()))
 
-	metricLabels.SetTrue(ManualApprovalRequired)
+	metricLabels.SetTrue(metrics.LabelManualApprovalRequired)
 
 	dtr.ReleaseApplyTime = c.now
 	dtr.Reason = manualApprovalRequiredReason

--- a/deckhouse-controller/pkg/releaseupdater/metrics.go
+++ b/deckhouse-controller/pkg/releaseupdater/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package releaseupdater
 
 import (
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/metrics"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	metricsstorage "github.com/deckhouse/deckhouse/pkg/metrics-storage"
 )
@@ -47,34 +48,23 @@ func (mu *MetricsUpdater) PurgeReleaseMetric(name string) {
 
 type MetricLabels map[string]string
 
-const (
-	ManualApprovalRequired     = "manualApproval"
-	DisruptionApprovalRequired = "disruptionApproval"
-	RequirementsNotMet         = "requirementsNotMet"
-	ReleaseQueueDepth          = "releaseQueueDepth"
-	MajorReleaseDepth          = "majorReleaseDepth"
-	MajorReleaseName           = "majorReleaseName"
-	FromToName                 = "fromToName"
-	NotificationNotSent        = "notificationNotSent"
-)
-
 func NewReleaseMetricLabels(release v1alpha1.Release) MetricLabels {
 	labels := make(MetricLabels, 9)
 
-	labels["name"] = release.GetName()
+	labels[metrics.LabelName] = release.GetName()
 
-	labels.SetFalse(ManualApprovalRequired)
-	labels.SetFalse(DisruptionApprovalRequired)
-	labels.SetFalse(RequirementsNotMet)
-	labels.SetFalse(NotificationNotSent)
+	labels.SetFalse(metrics.LabelManualApprovalRequired)
+	labels.SetFalse(metrics.LabelDisruptionApprovalRequired)
+	labels.SetFalse(metrics.LabelRequirementsNotMet)
+	labels.SetFalse(metrics.LabelNotificationNotSent)
 
-	labels[ReleaseQueueDepth] = "nil"
-	labels[MajorReleaseDepth] = "nil"
-	labels[MajorReleaseName] = "nil"
-	labels[FromToName] = "nil"
+	labels[metrics.LabelReleaseQueueDepth] = "nil"
+	labels[metrics.LabelMajorReleaseDepth] = "nil"
+	labels[metrics.LabelMajorReleaseName] = "nil"
+	labels[metrics.LabelFromToName] = "nil"
 
 	if _, ok := release.(*v1alpha1.ModuleRelease); ok {
-		labels["moduleName"] = release.GetModuleName()
+		labels[metrics.LabelModule] = release.GetModuleName()
 	}
 
 	return labels

--- a/deckhouse-controller/pkg/releaseupdater/release_notifier.go
+++ b/deckhouse-controller/pkg/releaseupdater/release_notifier.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deckhouse/deckhouse/deckhouse-controller/internal/metrics"
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/go_lib/libapi"
 )
@@ -72,11 +73,11 @@ func (u *ReleaseNotifier) SendPatchReleaseNotification(ctx context.Context, rele
 	}
 
 	if !u.settings.NotificationConfig.IsEmpty() && u.settings.NotificationConfig.ReleaseType == ReleaseTypeAll {
-		metricLabels.SetFalse(NotificationNotSent)
+		metricLabels.SetFalse(metrics.LabelNotificationNotSent)
 
 		err := u.sendReleaseNotification(ctx, release, applyTime)
 		if err != nil {
-			metricLabels.SetTrue(NotificationNotSent)
+			metricLabels.SetTrue(metrics.LabelNotificationNotSent)
 			return fmt.Errorf("send release notification: %w", err)
 		}
 	}
@@ -89,11 +90,11 @@ func (u *ReleaseNotifier) SendMinorReleaseNotification(ctx context.Context, rele
 	}
 
 	if !u.settings.NotificationConfig.IsEmpty() {
-		metricLabels.SetFalse(NotificationNotSent)
+		metricLabels.SetFalse(metrics.LabelNotificationNotSent)
 
 		err := u.sendReleaseNotification(ctx, release, applyTime)
 		if err != nil {
-			metricLabels.SetTrue(NotificationNotSent)
+			metricLabels.SetTrue(metrics.LabelNotificationNotSent)
 			return fmt.Errorf("send release notification: %w", err)
 		}
 	}

--- a/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
+++ b/deckhouse-controller/pkg/releaseupdater/requirements_checker.go
@@ -499,6 +499,6 @@ func (c *migratedModulesCheck) setMigratedModuleNotFoundAlert(moduleName string)
 		metrics.MigratedModuleNotFoundMetricName,
 		1,
 		map[string]string{
-			"module_name": moduleName,
+			metrics.LabelModule: moduleName,
 		})
 }

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -1115,17 +1115,17 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        The module update policy for {{ $labels.module_release }} is missing.
+        The module update policy for {{ $labels.moduleRelease }} is missing.
 
         To resolve this issue, remove the label from the module release using the following command:
 
         ```bash
-        d8 k label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-
+        d8 k label mr {{ $labels.moduleRelease }} modules.deckhouse.io/update-policy-
         ```
 
         A new suitable policy will be detected automatically.
       summary: |
-        Module update policy not found for {{ $labels.module_release }}.
+        Module update policy not found for {{ $labels.moduleRelease }}.
       severity: "5"
       markupFormat: markdown
     - name: D8DeckhouseModuleValidationError
@@ -2291,13 +2291,13 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.moduleName }}` is running {{ $labels.majorReleaseDepth }} major versions behind on major version releases.
+        Module `{{ $labels.module }}` is running {{ $labels.majorReleaseDepth }} major versions behind on major version releases.
         Major version updates may contain breaking changes and require immediate attention and careful planning.
 
         To check the module releases status, run the following command:
 
         ```bash
-        d8 k get mr -l module={{ $labels.moduleName }}
+        d8 k get mr -l module={{ $labels.module }}
         ```{{ if ne $labels.majorReleaseName "nil" }}{{ if ne $labels.fromToName "nil" }}
 
         This major release has from-to version constraints that must be met before applying the update.
@@ -2315,7 +2315,7 @@ alerts:
         d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```{{ end }}
       summary: |
-        Module {{ $labels.moduleName }} is running {{ $labels.majorReleaseDepth }} major versions behind.
+        Module {{ $labels.module }} is running {{ $labels.majorReleaseDepth }} major versions behind.
       severity: "9"
       markupFormat: markdown
     - name: D8NeedDecreaseEtcdQuotaBackendBytes
@@ -3882,7 +3882,7 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.module_name }}` specified in DeckhouseRelease was moved to external source and not found in any available ModuleSource registry. DeckhouseRelease will be lock until found module in any available ModuleSource.
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to external source and not found in any available ModuleSource registry. DeckhouseRelease will be lock until found module in any available ModuleSource.
 
         This may indicate:
         - The module source registry is not properly configured.
@@ -3908,7 +3908,7 @@ alerts:
         d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
-        Migrated module {{ $labels.module_name }} not found in registry.
+        Migrated module {{ $labels.module }} not found in registry.
       severity: "6"
       markupFormat: markdown
     - name: DeckhouseModuleUpdatingFailedBrokenSequence
@@ -3919,7 +3919,7 @@ alerts:
       description: |
         The '{{ $labels.module }}' Module update has failed.
 
-        Current version: {{ $labels.actual_version }}.
+        Current version: {{ $labels.actualVersion }}.
         Desired version: {{ $labels.version }}.
 
         Attempt to download interim releases failed.
@@ -3927,7 +3927,7 @@ alerts:
         Possible reasons:
          - The necessary versions of the Module image is not available in the registry.
 
-        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' Module image between {{ $labels.actual_version }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
+        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' Module image between {{ $labels.actualVersion }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
       summary: |
         Module update has failed. Updating sequence is broken.
       severity: "4"
@@ -3956,12 +3956,12 @@ alerts:
       module: prometheus
       edition: ce
       description: |
-        The Deckhouse module `{{ $labels.module_name }}` is using `emptyDir` as its storage.
+        The Deckhouse module `{{ $labels.module }}` is using `emptyDir` as its storage.
 
         If the associated Pod is removed from the node for any reason, the data in the `emptyDir` is deleted permanently.
         Consider using persistent storage if data durability is critical for the module.
       summary: |
-        Deckhouse module {{ $labels.module_name }} is using emptyDir for storage.
+        Deckhouse module {{ $labels.module }} is using emptyDir for storage.
       severity: "9"
       markupFormat: markdown
     - name: DeckhouseReleaseDisruptionApprovalRequired
@@ -5250,11 +5250,11 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Deckhouse has detected conflicting sources for the {{ $labels.moduleName }} module.
+        Deckhouse has detected conflicting sources for the {{ $labels.module }} module.
 
         To resolve this issue, specify the correct source in the module configuration.
       summary: |
-        Conflict detected for module {{ $labels.moduleName }}.
+        Conflict detected for module {{ $labels.module }}.
       severity: "4"
       markupFormat: markdown
     - name: ModuleConfigDeprecated
@@ -5296,12 +5296,12 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |-
-        Deckhouse has detected that the module `{{ $labels.moduleName }}` is using the deprecated update policy `{{ $labels.updatePolicy }}`. The `v1alpha1` policy has a selector that no longer functions.
+        Deckhouse has detected that the module `{{ $labels.module }}` is using the deprecated update policy `{{ $labels.updatePolicy }}`. The `v1alpha1` policy has a selector that no longer functions.
 
         To specify the update policy in the module configuration, run the following command:
 
         ```bash
-        d8 k patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
+        d8 k patch moduleconfig {{ $labels.module }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
         After resolving all alerts related to the update policy `{{ $labels.updatePolicy }}`, clear the selector by running the following command:
@@ -5310,7 +5310,7 @@ alerts:
         d8 k patch moduleupdatepolicies.v1alpha1.deckhouse.io {{ $labels.updatePolicy }} --type='json' -p='[{"op": "replace", "path": "/spec/moduleReleaseSelector/labelSelector/matchLabels", "value": {"": ""}}]'
         ```
       summary: |
-        Module {{ $labels.moduleName }} is matched by the deprecated update policy {{ $labels.updatePolicy }}.
+        Module {{ $labels.module }} is matched by the deprecated update policy {{ $labels.updatePolicy }}.
       severity: "4"
       markupFormat: markdown
     - name: ModuleIsDeprecated
@@ -5330,15 +5330,15 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.moduleName }}` is running in maintenance mode. In this mode, its state is not reconciled, which prevents configuration or hook changes from being applied automatically.
+        Module `{{ $labels.module }}` is running in maintenance mode. In this mode, its state is not reconciled, which prevents configuration or hook changes from being applied automatically.
 
         To switch the module back to normal mode, edit the corresponding ModuleConfig resource with the following command:
 
         ```bash
-        d8 k patch moduleconfig {{ $labels.moduleName }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
+        d8 k patch moduleconfig {{ $labels.module }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
         ```
       summary: |
-        Module {{ $labels.moduleName }} is running in maintenance mode.
+        Module {{ $labels.module }} is running in maintenance mode.
       severity: "6"
       markupFormat: markdown
     - name: ModuleReleaseIsBlockedByRequirements
@@ -5347,7 +5347,7 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        A new release for module `{{ $labels.moduleName }}` has been blocked because it doesn't meet the required conditions.
+        A new release for module `{{ $labels.module }}` has been blocked because it doesn't meet the required conditions.
 
         To check the requirements, run the following command:
 
@@ -5355,7 +5355,7 @@ alerts:
         d8 k  get mr {{ $labels.name }} -o json | jq .spec.requirements
         ```
       summary: |
-        A new release for module {{ $labels.moduleName }} has been blocked due to unmet requirements.
+        A new release for module {{ $labels.module }} has been blocked due to unmet requirements.
       severity: "6"
       markupFormat: markdown
     - name: ModuleReleaseIsOutdated
@@ -5364,7 +5364,7 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.moduleName }}` is running {{ $labels.versionLag }} or more minor versions behind the latest available release.
+        Module `{{ $labels.module }}` is running {{ $labels.versionLag }} or more minor versions behind the latest available release.
         This module is significantly outdated and may have compatibility issues.
 
         To approve the module release update, run the following command:
@@ -5373,7 +5373,7 @@ alerts:
         d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
-        Module {{ $labels.moduleName }} is {{ $labels.versionLag }} or more minor versions behind the latest available release.
+        Module {{ $labels.module }} is {{ $labels.versionLag }} or more minor versions behind the latest available release.
       severity: "5"
       markupFormat: markdown
     - name: ModuleReleaseIsOutdated
@@ -5382,7 +5382,7 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.moduleName }}` is running 2 minor versions behind the latest available release.
+        Module `{{ $labels.module }}` is running 2 minor versions behind the latest available release.
         Updating is recommended to maintain compatibility and access to latest features.
 
         To approve the module release update, run the following command:
@@ -5391,7 +5391,7 @@ alerts:
         d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
-        Module {{ $labels.moduleName }} is 2 minor versions behind the latest available release.
+        Module {{ $labels.module }} is 2 minor versions behind the latest available release.
       severity: "7"
       markupFormat: markdown
     - name: ModuleReleaseIsOutdated
@@ -5400,7 +5400,7 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        Module `{{ $labels.moduleName }}` is running 1 minor version behind the latest available release.
+        Module `{{ $labels.module }}` is running 1 minor version behind the latest available release.
         Consider updating to maintain compatibility and security.
 
         To approve the module release update, run the following command:
@@ -5409,7 +5409,7 @@ alerts:
         d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
-        Module {{ $labels.moduleName }} is 1 minor version behind the latest available release.
+        Module {{ $labels.module }} is 1 minor version behind the latest available release.
       severity: "9"
       markupFormat: markdown
     - name: ModuleReleaseIsWaitingManualApproval
@@ -5418,7 +5418,7 @@ alerts:
       module: monitoring-deckhouse
       edition: ce
       description: |
-        A new release for module `{{ $labels.moduleName }}` is available but requires manual approval before it can be applied.
+        A new release for module `{{ $labels.module }}` is available but requires manual approval before it can be applied.
 
         To approve the module release, run the following command:
 
@@ -5426,7 +5426,7 @@ alerts:
         d8 k annotate mr {{ $labels.name }} modules.deckhouse.io/approved="true"
         ```
       summary: |
-        A new release for module {{ $labels.moduleName }} is awaiting manual approval.
+        A new release for module {{ $labels.module }} is awaiting manual approval.
       severity: "6"
       markupFormat: markdown
     - name: NATInstanceWithDeprecatedAvailabilityZone

--- a/docs/documentation/_plugins/custom_filters.rb
+++ b/docs/documentation/_plugins/custom_filters.rb
@@ -90,6 +90,7 @@ module Jekyll
               gsub(/{{\s*\$labels\.module_name\s*\}\}/m,'MODULE_NAME').
               gsub(/{{\s*\$labels\.moduleName\s*\}\}/m,'MODULE_NAME').
               gsub(/{{\s*\$labels\.module_release\s*\}\}/m,'MODULE_RELEASE').
+              gsub(/{{\s*\$labels\.moduleRelease\s*\}\}/m,'MODULE_RELEASE').
               gsub(/{{\s*\$labels\.mountpoint\s*\}\}/m,'MOUNTPOINT').
               gsub(/{{\s*\$labels\.multicluster_name\s*\}\}/m,'MULTICLUSTER_NAME').
               gsub(/{{\s*\$labels\.namespace\s*\}\}/m,'NAMESPACE').

--- a/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
+++ b/modules/300-prometheus/monitoring/prometheus-rules/emptydir.yaml
@@ -12,9 +12,9 @@
       plk_protocol_version: "1"
       plk_create_group_if_not_exists__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDirGroup,prometheus=deckhouse,kubernetes=~kubernetes
       plk_group_for__deckhouse_module_use_empty_dir: DeckhouseModuleUseEmptyDirGroup,prometheus=deckhouse,kubernetes=~kubernetes
-      summary: Deckhouse module {{ $labels.module_name }} is using emptyDir for storage.
+      summary: Deckhouse module {{ $labels.module }} is using emptyDir for storage.
       description: |
-        The Deckhouse module `{{ $labels.module_name }}` is using `emptyDir` as its storage.
+        The Deckhouse module `{{ $labels.module }}` is using `emptyDir` as its storage.
         
         If the associated Pod is removed from the node for any reason, the data in the `emptyDir` is deleted permanently.
         Consider using persistent storage if data durability is critical for the module.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/alerting.yaml
@@ -139,7 +139,7 @@
         ```
 
   - alert: ModuleReleaseIsWaitingManualApproval
-    expr: sum by (name, moduleName) (d8_module_release_info{manualApproval="true"} * on(moduleName) group_left sum by (moduleName) (deckhouse_mm_module_info{enabled="true"}))
+    expr: sum by (name, module) (d8_module_release_info{manualApproval="true"} * on(module) group_left sum by (module) (deckhouse_mm_module_info{enabled="true"}))
     labels:
       severity_level: "6"
     annotations:
@@ -147,9 +147,9 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name"
       summary: |
-        A new release for module `{{ $labels.moduleName }}` is awaiting manual approval.
+        A new release for module `{{ $labels.module }}` is awaiting manual approval.
       description: |
-        A new release for module `{{ $labels.moduleName }}` is available but requires manual approval before it can be applied.
+        A new release for module `{{ $labels.module }}` is available but requires manual approval before it can be applied.
 
         To approve the module release, run the following command:
 
@@ -158,7 +158,7 @@
         ```
 
   - alert: ModuleReleaseIsOutdated
-    expr: sum by (name, moduleName) (d8_module_release_info{manualApproval="true", releaseQueueDepth="1"} * on(moduleName) group_left deckhouse_mm_module_info{enabled="true"})
+    expr: sum by (name, module) (d8_module_release_info{manualApproval="true", releaseQueueDepth="1"} * on(module) group_left deckhouse_mm_module_info{enabled="true"})
     labels:
       severity_level: "9"
       d8_module: deckhouse
@@ -169,9 +169,9 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name"
       summary: |
-        Module `{{ $labels.moduleName }}` is 1 minor version behind the latest available release.
+        Module `{{ $labels.module }}` is 1 minor version behind the latest available release.
       description: |
-        Module `{{ $labels.moduleName }}` is running 1 minor version behind the latest available release.
+        Module `{{ $labels.module }}` is running 1 minor version behind the latest available release.
         Consider updating to maintain compatibility and security.
 
         To approve the module release update, run the following command:
@@ -181,7 +181,7 @@
         ```
 
   - alert: ModuleReleaseIsOutdated
-    expr: sum by (name, moduleName) (d8_module_release_info{manualApproval="true", releaseQueueDepth="2"} * on(moduleName) group_left deckhouse_mm_module_info{enabled="true"})
+    expr: sum by (name, module) (d8_module_release_info{manualApproval="true", releaseQueueDepth="2"} * on(module) group_left deckhouse_mm_module_info{enabled="true"})
     labels:
       severity_level: "7"
       d8_module: deckhouse
@@ -192,9 +192,9 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name"
       summary: |
-        Module `{{ $labels.moduleName }}` is 2 minor versions behind the latest available release.
+        Module `{{ $labels.module }}` is 2 minor versions behind the latest available release.
       description: |
-        Module `{{ $labels.moduleName }}` is running 2 minor versions behind the latest available release.
+        Module `{{ $labels.module }}` is running 2 minor versions behind the latest available release.
         Updating is recommended to maintain compatibility and access to latest features.
 
         To approve the module release update, run the following command:
@@ -204,9 +204,9 @@
         ```
 
   - alert: ModuleReleaseIsOutdated
-    expr: sum by (name, moduleName) (d8_module_release_info{manualApproval="true"} * on(moduleName) group_left deckhouse_mm_module_info{enabled="true"})
-      and on(name, moduleName) sum by (name, moduleName) (d8_module_release_info{releaseQueueDepth!="nil"})
-      and on(name, moduleName) sum by (name, moduleName) (d8_module_release_info{releaseQueueDepth!="1", releaseQueueDepth!="2"})
+    expr: sum by (name, module) (d8_module_release_info{manualApproval="true"} * on(module) group_left deckhouse_mm_module_info{enabled="true"})
+      and on(name, module) sum by (name, module) (d8_module_release_info{releaseQueueDepth!="nil"})
+      and on(name, module) sum by (name, module) (d8_module_release_info{releaseQueueDepth!="1", releaseQueueDepth!="2"})
     labels:
       severity_level: "5"
       d8_module: deckhouse
@@ -217,9 +217,9 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name"
       summary: |
-        Module `{{ $labels.moduleName }}` is {{ $labels.versionLag }} or more minor versions behind the latest available release.
+        Module `{{ $labels.module }}` is {{ $labels.versionLag }} or more minor versions behind the latest available release.
       description: |
-        Module `{{ $labels.moduleName }}` is running {{ $labels.versionLag }} or more minor versions behind the latest available release.
+        Module `{{ $labels.module }}` is running {{ $labels.versionLag }} or more minor versions behind the latest available release.
         This module is significantly outdated and may have compatibility issues.
 
         To approve the module release update, run the following command:
@@ -229,7 +229,7 @@
         ```
 
   - alert: ModuleIsInMaintenanceMode
-    expr: sum(deckhouse_mm_module_maintenance{state="NoResourceReconciliation"}) by (moduleName) > 0
+    expr: sum(deckhouse_mm_module_maintenance{state="NoResourceReconciliation"}) by (module) > 0
     labels:
       severity_level: "6"
     annotations:
@@ -237,14 +237,14 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name"
       summary: |
-        Module `{{ $labels.moduleName }}` is running in maintenance mode.
+        Module `{{ $labels.module }}` is running in maintenance mode.
       description: |
-        Module `{{ $labels.moduleName }}` is running in maintenance mode. In this mode, its state is not reconciled, which prevents configuration or hook changes from being applied automatically.
+        Module `{{ $labels.module }}` is running in maintenance mode. In this mode, its state is not reconciled, which prevents configuration or hook changes from being applied automatically.
 
         To switch the module back to normal mode, edit the corresponding ModuleConfig resource with the following command:
 
         ```bash
-        d8 k patch moduleconfig {{ $labels.moduleName }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
+        d8 k patch moduleconfig {{ $labels.module }} --type=json -p='[{"op": "remove", "path": "/spec/maintenance"}]'
         ```
 
   - alert: DeckhouseReleaseNotificationNotSent
@@ -269,7 +269,7 @@
         ```
 
   - alert: ModuleReleaseIsBlockedByRequirements
-    expr: sum by (name, moduleName) (d8_module_release_info{requirementsNotMet="true"} * on(moduleName) group_left sum by (moduleName) (deckhouse_mm_module_info{enabled="true"}))
+    expr: sum by (name, module) (d8_module_release_info{requirementsNotMet="true"} * on(module) group_left sum by (module) (deckhouse_mm_module_info{enabled="true"}))
     labels:
       severity_level: "6"
     annotations:
@@ -277,9 +277,9 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name"
       summary: |
-        A new release for module `{{ $labels.moduleName }}` has been blocked due to unmet requirements.
+        A new release for module `{{ $labels.module }}` has been blocked due to unmet requirements.
       description: |
-        A new release for module `{{ $labels.moduleName }}` has been blocked because it doesn't meet the required conditions.
+        A new release for module `{{ $labels.module }}` has been blocked because it doesn't meet the required conditions.
 
         To check the requirements, run the following command:
 
@@ -314,16 +314,16 @@
         ```
 
   - alert: ModuleAtConflict
-    expr: max by (moduleName) (d8_module_at_conflict) >= 1
+    expr: max by (module) (d8_module_at_conflict) >= 1
     labels:
       severity_level: "4"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       summary: |
-        Conflict detected for module {{ $labels.moduleName }}.
+        Conflict detected for module {{ $labels.module }}.
       description: |
-        Deckhouse has detected conflicting sources for the {{ $labels.moduleName }} module.
+        Deckhouse has detected conflicting sources for the {{ $labels.module }} module.
 
         To resolve this issue, specify the correct source in the module configuration.
 
@@ -342,21 +342,21 @@
         To resolve this issue, update ModuleConfig `{{ $labels.name }}` to the latest version.
 
   - alert: ModuleHasDeprecatedUpdatePolicy
-    expr: max by (moduleName, updatePolicy) (d8_deprecated_update_policy) >= 1
+    expr: max by (module, updatePolicy) (d8_deprecated_update_policy) >= 1
     labels:
       severity_level: "4"
     annotations:
       plk_markup_format: "markdown"
       plk_protocol_version: "1"
       summary: |
-        Module `{{ $labels.moduleName }}` is matched by the deprecated update policy `{{ $labels.updatePolicy }}`.
+        Module `{{ $labels.module }}` is matched by the deprecated update policy `{{ $labels.updatePolicy }}`.
       description: |-
-        Deckhouse has detected that the module `{{ $labels.moduleName }}` is using the deprecated update policy `{{ $labels.updatePolicy }}`. The `v1alpha1` policy has a selector that no longer functions.
+        Deckhouse has detected that the module `{{ $labels.module }}` is using the deprecated update policy `{{ $labels.updatePolicy }}`. The `v1alpha1` policy has a selector that no longer functions.
 
         To specify the update policy in the module configuration, run the following command:
 
         ```bash
-        d8 k patch moduleconfig {{ $labels.moduleName }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
+        d8 k patch moduleconfig {{ $labels.module }} --type='json' -p='[{"op": "add", "path": "/spec/updatePolicy", "value": "{{ $labels.updatePolicy }}"}]'
         ```
 
         After resolving all alerts related to the update policy `{{ $labels.updatePolicy }}`, clear the selector by running the following command:
@@ -389,7 +389,7 @@
         Deckhouse memory usage is too high.
 
   - alert: D8ModuleOutdatedByMajorVersion
-    expr: sum by (name, moduleName, majorReleaseName, fromToName) (d8_module_release_info{majorReleaseDepth!~"(nil|0)", majorReleaseName!="nil"} * on(moduleName) group_left deckhouse_mm_module_info{enabled="true"})
+    expr: sum by (name, module, majorReleaseName, fromToName) (d8_module_release_info{majorReleaseDepth!~"(nil|0)", majorReleaseName!="nil"} * on(module) group_left deckhouse_mm_module_info{enabled="true"})
     labels:
       severity_level: "9"
       d8_module: deckhouse
@@ -400,15 +400,15 @@
       plk_protocol_version: "1"
       plk_ignore_labels: "name,majorReleaseName,fromToName"
       summary: |
-        Module `{{ $labels.moduleName }}` is running {{ $labels.majorReleaseDepth }} major versions behind.
+        Module `{{ $labels.module }}` is running {{ $labels.majorReleaseDepth }} major versions behind.
       description: |
-        Module `{{ $labels.moduleName }}` is running {{ $labels.majorReleaseDepth }} major versions behind on major version releases.
+        Module `{{ $labels.module }}` is running {{ $labels.majorReleaseDepth }} major versions behind on major version releases.
         Major version updates may contain breaking changes and require immediate attention and careful planning.
 
         To check the module releases status, run the following command:
 
         ```bash
-        d8 k get mr -l module={{ $labels.moduleName }}
+        d8 k get mr -l module={{ $labels.module }}
         ```{{ if ne $labels.majorReleaseName "nil" }}{{ if ne $labels.fromToName "nil" }}
 
         This major release has from-to version constraints that must be met before applying the update.

--- a/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/340-monitoring-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -431,7 +431,7 @@
         To resolve this issue, ensure that the next version of the Deckhouse image is available in the registry.
 
   - alert: DeckhouseModuleUpdatingFailedBrokenSequence
-    expr: max by(module, registry, actual_version, version) (d8_module_updating_broken_sequence) > 0
+    expr: max by(module, registry, actualVersion, version) (d8_module_updating_broken_sequence) > 0
     labels:
       severity_level: "4"
       tier: cluster
@@ -443,7 +443,7 @@
       description: |
         The '{{ $labels.module }}' Module update has failed.
 
-        Current version: {{ $labels.actual_version }}.
+        Current version: {{ $labels.actualVersion }}.
         Desired version: {{ $labels.version }}.
 
         Attempt to download interim releases failed.
@@ -451,7 +451,7 @@
         Possible reasons:
          - The necessary versions of the Module image is not available in the registry.
 
-        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' Module image between {{ $labels.actual_version }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
+        To resolve this issue, ensure that all minor versions of the '{{ $labels.module }}' Module image between {{ $labels.actualVersion }} and {{ $labels.version }} is available in the registry '{{ $labels.registry }}'.
 
   - alert: DeckhouseModuleUpdatingFailedModuleIsNotValid
     expr: max by(module, registry, version) (d8_module_updating_module_is_not_valid) > 0
@@ -534,14 +534,14 @@
     annotations:
       plk_markup_format: markdown
       plk_protocol_version: "1"
-      summary: Module update policy not found for `{{ $labels.module_release }}`.
+      summary: Module update policy not found for `{{ $labels.moduleRelease }}`.
       description: |
-        The module update policy for {{ $labels.module_release }} is missing.
+        The module update policy for {{ $labels.moduleRelease }} is missing.
 
         To resolve this issue, remove the label from the module release using the following command:
         
         ```bash
-        d8 k label mr {{ $labels.module_release }} modules.deckhouse.io/update-policy-
+        d8 k label mr {{ $labels.moduleRelease }} modules.deckhouse.io/update-policy-
         ```
 
         A new suitable policy will be detected automatically.
@@ -579,10 +579,10 @@
       plk_markup_format: "markdown"
       plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_labels_as_annotations: "module_name"
-      summary: Migrated module {{ $labels.module_name }} not found in registry.
+      plk_labels_as_annotations: "module"
+      summary: Migrated module {{ $labels.module }} not found in registry.
       description: |
-        Module `{{ $labels.module_name }}` specified in DeckhouseRelease was moved to external source and not found in any available ModuleSource registry. DeckhouseRelease will be lock until found module in any available ModuleSource.
+        Module `{{ $labels.module }}` specified in DeckhouseRelease was moved to external source and not found in any available ModuleSource registry. DeckhouseRelease will be lock until found module in any available ModuleSource.
         
         This may indicate:
         - The module source registry is not properly configured.


### PR DESCRIPTION
## Description

Backport of #18130 to release-1.75.

Starting from Deckhouse v1.75.1 (which bumped addon-operator from v1.19.0 → v1.19.7), the `deckhouse_mm_module_info` metric changed its module label name from `moduleName` to `module`. At the same time, `d8_module_release_info` and all Prometheus alert expressions in `monitoring-deckhouse` still referenced `moduleName`. This label mismatch silently broke the join, causing all module-related alerts to never fire:

- `ModuleReleaseIsWaitingManualApproval`
- `ModuleReleaseIsOutdated` (all severity levels)
- `ModuleReleaseIsBlockedByRequirements`
- `ModuleIsInMaintenanceMode`
- `D8ModuleOutdatedByMajorVersion`

The fix centralises all metric label key constants in a new `deckhouse-controller/internal/metrics/labels.go` and updates every consumer to use `module` consistently throughout — both in the Go code that emits `d8_module_release_info` and in the PromQL expressions in `alerting.yaml`.

## Why do we need it, and what problem does it solve?

Module-related alerts have been silently broken on all 1.75.x clusters since v1.75.1. For example, a `ModuleRelease` stuck in `Pending` with `manualApproval` for 60+ days produces no alert, leaving operators unaware that an update is waiting. The root cause is a label rename in addon-operator that was only addressed in `main` (v1.76.0) but never backported.

## Why do we need it in the patch release?

All module-release alerts (`ModuleReleaseIsWaitingManualApproval`, `ModuleReleaseIsOutdated`, `ModuleReleaseIsBlockedByRequirements`, `ModuleIsInMaintenanceMode`, `D8ModuleOutdatedByMajorVersion`) are non-functional on every 1.75.x cluster. Users silently miss critical signals about pending module updates and maintenance states.

## Checklist
- [x] The code is covered by unit tests.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-deckhouse
type: fix
summary: Fix module-release alerts (`ModuleReleaseIsWaitingManualApproval`, `ModuleReleaseIsOutdated`, `ModuleReleaseIsBlockedByRequirements`, `ModuleIsInMaintenanceMode`, `D8ModuleOutdatedByMajorVersion`) that never fired on 1.75.x clusters due to a `moduleName`→`module` label mismatch introduced when addon-operator was bumped to v1.19.7 in v1.75.1.
```