### PR TITLE
[tools] fix sync_terraform_versions_with_oss.sh failing with relative--repo-root

### DIFF
--- a/tools/sync_versions/sync_oss_versions.sh
+++ b/tools/sync_versions/sync_oss_versions.sh
@@ -154,6 +154,8 @@ check_requirements() {
     exit 1
   fi
 
+  REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+
   SOURCE_OSS_FILE="${REPO_ROOT}/${SOURCE_MODULE}/oss.yaml"
   TARGET_OSS_FILE="${REPO_ROOT}/${TARGET_MODULE}/oss.yaml"
 
@@ -206,14 +208,15 @@ sync_dependency_versions() {
   fi
 
   if [[ "$versions_count" != "0" ]]; then
-    yq e -i "
-      (.[] | select(.id == \"$TARGET_ID\")).versions = (
-        load(\"$SOURCE_OSS_FILE\")[] |
-        select(.id == \"$SOURCE_ID\") |
-        .versions
-      ) |
+    local tmp
+    tmp="$(mktemp)"
+    yq ea "
+      (select(fileIndex == 1) | .[] | select(.id == \"$SOURCE_ID\") | .versions) as \$v |
+      select(fileIndex == 0) |
+      (.[] | select(.id == \"$TARGET_ID\")).versions = \$v |
       del((.[] | select(.id == \"$TARGET_ID\")).version)
-    " "$TARGET_OSS_FILE"
+    " "$TARGET_OSS_FILE" "$SOURCE_OSS_FILE" > "$tmp"
+    mv "$tmp" "$TARGET_OSS_FILE"
 
     log_info "updated versions for dependency '$TARGET_ID' in '$TARGET_OSS_FILE'"
     return 0

--- a/tools/sync_versions/sync_terraform_versions_with_oss.sh
+++ b/tools/sync_versions/sync_terraform_versions_with_oss.sh
@@ -141,14 +141,13 @@ update_yaml_version() {
       del(.${PROVIDER_ID}.versions)
     " "$yaml_file"
   elif [[ "$VERSIONS_COUNT" != "0" ]]; then
-    yq e -i "
-      .${PROVIDER_ID}.versions = (
-        load(\"$OSS_FILE\")[] |
-        select(.id == \"$FULL_ID\") |
-        [.versions[].version]
-      ) |
-      del(.${PROVIDER_ID}.version)
-    " "$yaml_file"
+    local tmp
+    tmp="$(mktemp)"
+    yq ea "
+      (select(fileIndex == 1) | .[] | select(.id == \"$FULL_ID\") | [.versions[].version]) as \$v |
+      select(fileIndex == 0) | .${PROVIDER_ID}.versions = \$v | del(.${PROVIDER_ID}.version)
+    " "$yaml_file" "$OSS_FILE" > "$tmp"
+    mv "$tmp" "$yaml_file"
   else
     log_error "neither version nor versions found for $FULL_ID in $OSS_FILE"
     exit 1

--- a/tools/sync_versions/sync_terraform_versions_with_oss.sh
+++ b/tools/sync_versions/sync_terraform_versions_with_oss.sh
@@ -104,6 +104,8 @@ check_requirements() {
     exit 1
   fi
 
+  REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+
   OSS_FILE="${REPO_ROOT}/${MODULE}/oss.yaml"
   GLOBAL_TF_YAML_FILE="${REPO_ROOT}/${TF_YAML_FILE}"
   MODULE_TF_YAML_FILE="${REPO_ROOT}/${MODULE}/${TF_YAML_FILE}"


### PR DESCRIPTION
## Description
Fix `make generate` failing locally with `Error: Filename expression returned nil` from `yq`
when `sync_terraform_versions_with_oss.sh` is called with a relative `--repo-root` argument.

## Why do we need it, and what problem does it solve?
`yq`'s `load()` function does not reliably resolve relative file paths when running
in `-i` (in-place) mode. Since `go generate` passes `--repo-root ..` (relative),
`OSS_FILE` ends up as a relative path inside the `load()` expression, causing it
to return nil and abort.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: fix
summary: Fixed sync_terraform_versions_with_oss.sh failing with a relative --repo-root due to yq load() path resolution.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
