### PR TITLE
[feat] security restrictions in monitoring

### DIFF
--- a/helm_lib/charts/deckhouse_lib_helm/README.md
+++ b/helm_lib/charts/deckhouse_lib_helm/README.md
@@ -101,9 +101,11 @@
 | [helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_nobody_with_writable_fs) |
 | [helm_lib_module_pod_security_context_run_as_user_deckhouse](#helm_lib_module_pod_security_context_run_as_user_deckhouse) |
 | [helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs](#helm_lib_module_pod_security_context_run_as_user_deckhouse_with_writable_fs) |
+| [helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default](#helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default) |
 | [helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted](#helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted) |
 | [helm_lib_module_container_security_context_pss_restricted_flexible](#helm_lib_module_container_security_context_pss_restricted_flexible) |
 | [helm_lib_module_pod_security_context_run_as_user_root](#helm_lib_module_pod_security_context_run_as_user_root) |
+| [helm_lib_module_pod_security_context_run_as_user_root_runtime_default](#helm_lib_module_pod_security_context_run_as_user_root_runtime_default) |
 | [helm_lib_module_pod_security_context_runtime_default](#helm_lib_module_pod_security_context_runtime_default) |
 | [helm_lib_module_container_security_context_not_allow_privilege_escalation](#helm_lib_module_container_security_context_not_allow_privilege_escalation) |
 | [helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux](#helm_lib_module_container_security_context_read_only_root_filesystem_with_selinux) |
@@ -1227,6 +1229,19 @@ list:
 -  Template context with .Values, .Chart, etc 
 
 
+### helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default
+
+ returns PodSecurityContext parameters for Pod with user and group "deckhouse" plus seccomp profile RuntimeDefault 
+
+#### Usage
+
+`{{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
+
+
 ### helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted
 
  returns SecurityContext parameters for Container with user and group "deckhouse" plus minimal required settings to comply with the Restricted mode of the Pod Security Standards 
@@ -1263,6 +1278,19 @@ list:
 #### Usage
 
 `{{ include "helm_lib_module_pod_security_context_run_as_user_root" . }} `
+
+#### Arguments
+
+-  Template context with .Values, .Chart, etc 
+
+
+### helm_lib_module_pod_security_context_run_as_user_root_runtime_default
+
+ returns PodSecurityContext parameters for Pod with user and group 0 plus seccomp profile RuntimeDefault 
+
+#### Usage
+
+`{{ include "helm_lib_module_pod_security_context_run_as_user_root_runtime_default" . }} `
 
 #### Arguments
 

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_init_container.tpl
@@ -16,6 +16,13 @@
     readOnlyRootFilesystem: true
     runAsUser: 0
     runAsGroup: 0
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - CHOWN
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - name: {{ $volume_name }}
     mountPath: /tmp/data
@@ -41,6 +48,13 @@
     readOnlyRootFilesystem: true
     runAsUser: 0
     runAsGroup: 0
+    capabilities:
+      drop:
+        - ALL
+      add:
+        - CHOWN
+    seccompProfile:
+      type: RuntimeDefault
   volumeMounts:
   - name: {{ $volume_name }}
     mountPath: /tmp/data

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_security_context.tpl
@@ -52,6 +52,18 @@ securityContext:
   fsGroup: 64535
 {{- end }}
 
+{{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default" . }} */ -}}
+{{- /* returns PodSecurityContext parameters for Pod with user and group "deckhouse" plus seccomp profile RuntimeDefault */ -}}
+{{- define "helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default" -}}
+{{- /* Template context with .Values, .Chart, etc */ -}}
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 64535
+  runAsGroup: 64535
+  seccompProfile:
+    type: RuntimeDefault
+{{- end }}
+
 {{- /* Usage: {{ include "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" . }} */ -}}
 {{- /* returns SecurityContext parameters for Container with user and group "deckhouse" plus minimal required settings to comply with the Restricted mode of the Pod Security Standards */ -}}
 {{- define "helm_lib_module_container_security_context_run_as_user_deckhouse_pss_restricted" -}}
@@ -123,6 +135,18 @@ securityContext:
   runAsNonRoot: false
   runAsUser: 0
   runAsGroup: 0
+{{- end }}
+
+{{- /* Usage: {{ include "helm_lib_module_pod_security_context_run_as_user_root_runtime_default" . }} */ -}}
+{{- /* returns PodSecurityContext parameters for Pod with user and group 0 plus seccomp profile RuntimeDefault */ -}}
+{{- define "helm_lib_module_pod_security_context_run_as_user_root_runtime_default" -}}
+{{- /* Template context with .Values, .Chart, etc */ -}}
+securityContext:
+  runAsNonRoot: false
+  runAsUser: 0
+  runAsGroup: 0
+  seccompProfile:
+    type: RuntimeDefault
 {{- end }}
 
 {{- /* Usage: {{ include "helm_lib_module_pod_security_context_runtime_default" . }} */ -}}

--- a/modules/002-deckhouse/template_tests/module_test.go
+++ b/modules/002-deckhouse/template_tests/module_test.go
@@ -75,6 +75,28 @@ modules:
   placement: {}
 `
 
+	globalValuesWithAdmissionPolicyEngine = `
+deckhouseVersion: test
+enabledModules: ["vertical-pod-autoscaler", "prometheus", "operator-prometheus", "admission-policy-engine", "admission-policy-engine-crd"]
+clusterConfiguration:
+  apiVersion: deckhouse.io/v1
+  kind: ClusterConfiguration
+  clusterDomain: cluster.local
+  clusterType: Static
+  kubernetesVersion: "Automatic"
+  podSubnetCIDR: 10.111.0.0/16
+  podSubnetNodeCIDRPrefix: "24"
+  serviceSubnetCIDR: 10.222.0.0/16
+discovery:
+  clusterMasterCount: 3
+  prometheusScrapeInterval: 30
+  kubernetesVersion: "1.31.0"
+  d8SpecificNodeCountByRole:
+    system: 1
+modules:
+  placement: {}
+`
+
 	clusterIsBootstrapped = `
 clusterIsBootstrapped: true
 `
@@ -257,6 +279,40 @@ var _ = Describe("Module :: deckhouse :: helm template ::", func() {
 				"#(name==\"KUBERNETES_SERVICE_PORT\").value",
 			).String()
 			Expect(servicePort).To(Equal("6443"))
+		})
+	})
+
+	Context("d8-monitoring namespace security labels without admission-policy-engine", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForDeckhouseNode)
+			f.HelmRender()
+		})
+
+		It("must render restricted policy and skip security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-monitoring")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("d8-monitoring namespace security labels with admission-policy-engine", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValuesWithAdmissionPolicyEngine)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("deckhouse", moduleValuesForDeckhouseNode)
+			f.HelmRender()
+		})
+
+		It("must render restricted policy and security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-monitoring")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").String()).To(Equal("true"))
 		})
 	})
 })

--- a/modules/002-deckhouse/templates/namespace.yaml
+++ b/modules/002-deckhouse/templates/namespace.yaml
@@ -5,7 +5,17 @@ metadata:
   name: d8-monitoring
   annotations:
     helm.sh/resource-policy: keep
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/monitor-watcher-enabled" "true" "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true" "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true")) | nindent 2 }}
+  {{- $monitoringNamespaceLabels := dict
+    "prometheus.deckhouse.io/monitor-watcher-enabled" "true"
+    "extended-monitoring.deckhouse.io/enabled" ""
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "prometheus.deckhouse.io/scrape-configs-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+  }}
+  {{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+    {{- $_ := set $monitoringNamespaceLabels "security.deckhouse.io/enable-security-policy-check" "true" }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list . $monitoringNamespaceLabels) | nindent 2 }}
 ---
 apiVersion: v1
 kind: Namespace

--- a/modules/200-operator-prometheus/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/200-operator-prometheus/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: operator-prometheus :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	Context("without admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["operator-prometheus"]
+modules:
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("must render restricted namespace label and skip security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-operator-prometheus")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").Exists()).To(BeFalse())
+		})
+
+		It("must not render SecurityPolicyException resources or exception pod labels", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			operatorDeployment := f.KubernetesResource("Deployment", "d8-operator-prometheus", "prometheus-operator")
+			Expect(operatorDeployment.Exists()).To(BeTrue())
+			Expect(operatorDeployment.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-operator-prometheus", "prometheus-operator").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("with admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["operator-prometheus", "admission-policy-engine", "admission-policy-engine-crd"]
+modules:
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("must render restricted namespace label and security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-operator-prometheus")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").String()).To(Equal("true"))
+		})
+
+		It("must keep workload without exceptions", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			operatorDeployment := f.KubernetesResource("Deployment", "d8-operator-prometheus", "prometheus-operator")
+			Expect(operatorDeployment.Exists()).To(BeTrue())
+			Expect(operatorDeployment.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-operator-prometheus", "prometheus-operator").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/200-operator-prometheus/template_tests/package_test.go
+++ b/modules/200-operator-prometheus/template_tests/package_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/200-operator-prometheus/templates/namespace.yaml
+++ b/modules/200-operator-prometheus/templates/namespace.yaml
@@ -1,16 +1,16 @@
-{{- define "labels" }}
-extended-monitoring.deckhouse.io/enabled: ""
-prometheus.deckhouse.io/rules-watcher-enabled: "true"
-security.deckhouse.io/pod-policy: "restricted"
-{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
-security.deckhouse.io/enable-security-policy-check: "true"
-{{- end }}
-{{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-operator-prometheus
-  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
+  {{- $namespaceLabels := dict
+    "extended-monitoring.deckhouse.io/enabled" ""
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+  }}
+  {{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+    {{- $_ := set $namespaceLabels "security.deckhouse.io/enable-security-policy-check" "true" }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list . $namespaceLabels) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-operator-prometheus") }}

--- a/modules/200-operator-prometheus/templates/namespace.yaml
+++ b/modules/200-operator-prometheus/templates/namespace.yaml
@@ -1,8 +1,16 @@
+{{- define "labels" }}
+extended-monitoring.deckhouse.io/enabled: ""
+prometheus.deckhouse.io/rules-watcher-enabled: "true"
+security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-operator-prometheus
-  {{- include "helm_lib_module_labels" (list . (dict "extended-monitoring.deckhouse.io/enabled" "" "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . "d8-operator-prometheus") }}

--- a/modules/300-prometheus/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/300-prometheus/template_tests/admission_policy_engine_compatibility_test.go
@@ -106,4 +106,40 @@ scrapeInterval: 30s
 		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "trickster").Exists()).To(BeFalse())
 		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "aggregating-proxy").Exists()).To(BeFalse())
 	})
+
+	It("if rendered, the prometheus-main prompptool init container must be restricted-PSS compliant", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		prometheusMain := f.KubernetesResource("Prometheus", "d8-monitoring", "main")
+		if !prometheusMain.Exists() {
+			Skip("Prometheus/main CR not rendered in this test setup")
+		}
+
+		initContainers := prometheusMain.Field("spec.initContainers").Array()
+		if len(initContainers) == 0 {
+			Skip("no initContainers rendered (prompp digests likely absent in test fixtures)")
+		}
+
+		found := false
+		for _, c := range initContainers {
+			if c.Get("name").String() != "prompptool" {
+				continue
+			}
+			found = true
+			drops := c.Get("securityContext.capabilities.drop").Array()
+			dropStrings := make([]string, 0, len(drops))
+			for _, d := range drops {
+				dropStrings = append(dropStrings, d.String())
+			}
+			Expect(dropStrings).To(ContainElement("ALL"),
+				"prompptool init container must drop ALL capabilities for d8-monitoring restricted PSS")
+			Expect(c.Get("securityContext.allowPrivilegeEscalation").Bool()).To(BeFalse(),
+				"prompptool init container must set allowPrivilegeEscalation:false")
+			Expect(c.Get("securityContext.runAsNonRoot").Bool()).To(BeTrue(),
+				"prompptool init container must runAsNonRoot:true")
+			Expect(c.Get("securityContext.seccompProfile.type").String()).To(Equal("RuntimeDefault"),
+				"prompptool init container must set seccompProfile.type=RuntimeDefault")
+		}
+		Expect(found).To(BeTrue(), "expected to find prompptool init container in Prometheus/main spec")
+	})
 })

--- a/modules/300-prometheus/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/300-prometheus/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: prometheus :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", `
+enabledModules: ["vertical-pod-autoscaler", "prometheus", "admission-policy-engine", "admission-policy-engine-crd"]
+modules:
+  https:
+    mode: CustomCertificate
+  publicDomainTemplate: "%s.example.com"
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+`)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+		f.ValuesSetFromYaml("prometheus", `
+auth: {}
+vpa: {}
+grafana: {}
+https:
+  mode: CustomCertificate
+internal:
+  customCertificateData:
+    tls.crt: |
+      -----BEGIN CERTIFICATE-----
+      TEST
+      -----END CERTIFICATE-----
+    tls.key: |
+      -----BEGIN PRIVATE KEY-----
+      TEST
+      -----END PRIVATE KEY-----
+  alertmanagers:
+    byAddress: []
+    byService: []
+    internal: []
+  auth: {}
+  deployDexAuthenticator: true
+  grafana:
+    enabled: true
+    additionalDatasources: []
+    alertsChannelsConfig:
+      notifiers: []
+  prometheusAPIClientTLS: {}
+  prometheusLongterm:
+    diskSizeGigabytes: 40
+    effectiveStorageClass: ceph-ssd
+    retentionGigabytes: 32
+  prometheusMain:
+    diskSizeGigabytes: 35
+    effectiveStorageClass: default
+    retentionGigabytes: 28
+  prometheusScraperIstioMTLS: {}
+  prometheusScraperTLS: {}
+  remoteWrite: []
+  vpa:
+    longtermMaxCPU: 2933m
+    longtermMaxMemory: 2200Mi
+    maxCPU: 8800m
+    maxMemory: 6600Mi
+longtermMaxDiskSizeGigabytes: 300
+longtermRetentionDays: 0
+longtermScrapeInterval: 5m
+mainMaxDiskSizeGigabytes: 300
+retentionDays: 15
+scrapeInterval: 30s
+`)
+		f.HelmRender()
+	})
+
+	It("must not render SecurityPolicyException resources or exception pod labels", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		grafanaDeployment := f.KubernetesResource("Deployment", "d8-monitoring", "grafana-v10")
+		Expect(grafanaDeployment.Exists()).To(BeTrue())
+		Expect(grafanaDeployment.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+
+		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "grafana-v10").Exists()).To(BeFalse())
+		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "alerts-receiver").Exists()).To(BeFalse())
+		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "trickster").Exists()).To(BeFalse())
+		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "aggregating-proxy").Exists()).To(BeFalse())
+	})
+})

--- a/modules/300-prometheus/templates/prometheus/_helpers.tpl
+++ b/modules/300-prometheus/templates/prometheus/_helpers.tpl
@@ -25,7 +25,17 @@ initContainers:
   - name: {{ $volume }}
     mountPath: /prometheus
     subPath: prometheus-db
-  {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" $ctx | nindent 2 }}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 64535
+    runAsGroup: 64535
+    seccompProfile:
+      type: RuntimeDefault
   resources:
     requests:
       {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 6 }}

--- a/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
@@ -40,6 +40,7 @@ discovery:
 		f.ValuesSet("global.modulesImages", GetModulesImages())
 		f.ValuesSetFromYaml("prometheusMetricsAdapter", `
 internal:
+  customMetrics: {}
   adapterCert:
     ca: test-ca
     crt: test-crt

--- a/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
@@ -34,6 +34,10 @@ modules:
 discovery:
   prometheusScrapeInterval: 30
   clusterDomain: cluster.local
+  clusterMasterCount: 1
+  d8SpecificNodeCountByRole:
+    master: 1
+    system: 1
   extensionAPIServerAuthenticationRequestheaderClientCA: test-ca
   apiVersions:
     - deckhouse.io/v1alpha1/SecurityPolicyException

--- a/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
@@ -34,6 +34,7 @@ modules:
 discovery:
   prometheusScrapeInterval: 30
   clusterDomain: cluster.local
+  extensionAPIServerAuthenticationRequestheaderClientCA: test-ca
   apiVersions:
     - deckhouse.io/v1alpha1/SecurityPolicyException
 `)

--- a/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/301-prometheus-metrics-adapter/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: prometheus-metrics-adapter :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", `
+enabledModules: ["prometheus-metrics-adapter", "admission-policy-engine", "admission-policy-engine-crd"]
+modules:
+  placement: {}
+discovery:
+  prometheusScrapeInterval: 30
+  clusterDomain: cluster.local
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+		f.ValuesSetFromYaml("prometheusMetricsAdapter", `
+internal:
+  adapterCert:
+    ca: test-ca
+    crt: test-crt
+    key: test-key
+`)
+		f.HelmRender()
+	})
+
+	It("must not render SecurityPolicyException resources or exception pod labels", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		adapterDeployment := f.KubernetesResource("Deployment", "d8-monitoring", "prometheus-metrics-adapter")
+		Expect(adapterDeployment.Exists()).To(BeTrue())
+		Expect(adapterDeployment.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+
+		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "prometheus-metrics-adapter").Exists()).To(BeFalse())
+	})
+})

--- a/modules/301-prometheus-metrics-adapter/template_tests/package_test.go
+++ b/modules/301-prometheus-metrics-adapter/template_tests/package_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/340-monitoring-kubernetes-control-plane/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-kubernetes-control-plane/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: monitoring-kubernetes-control-plane :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	Context("without admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["monitoring-kubernetes-control-plane", "control-plane-manager"]
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("must not render SPE and exception label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "control-plane-proxy")
+			Expect(daemonSet.Exists()).To(BeTrue())
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "control-plane-proxy").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("with admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["monitoring-kubernetes-control-plane", "control-plane-manager", "admission-policy-engine", "admission-policy-engine-crd"]
+discovery:
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.HelmRender()
+		})
+
+		It("must render SPE and exception label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "control-plane-proxy")
+			Expect(daemonSet.Exists()).To(BeTrue())
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("control-plane-proxy"))
+
+			securityPolicyException := f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "control-plane-proxy")
+			Expect(securityPolicyException.Exists()).To(BeTrue())
+			Expect(securityPolicyException.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
+		})
+	})
+})

--- a/modules/340-monitoring-kubernetes-control-plane/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-kubernetes-control-plane/template_tests/admission_policy_engine_compatibility_test.go
@@ -77,5 +77,36 @@ discovery:
 			Expect(securityPolicyException.Exists()).To(BeTrue())
 			Expect(securityPolicyException.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
 		})
+
+		It("must drop ALL capabilities on every container in control-plane-proxy DaemonSet", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			ds := f.KubernetesResource("DaemonSet", "d8-monitoring", "control-plane-proxy")
+			Expect(ds.Exists()).To(BeTrue())
+
+			for _, c := range ds.Field("spec.template.spec.initContainers").Array() {
+				name := c.Get("name").String()
+				drops := c.Get("securityContext.capabilities.drop").Array()
+				dropStrings := make([]string, 0, len(drops))
+				for _, d := range drops {
+					dropStrings = append(dropStrings, d.String())
+				}
+				Expect(dropStrings).To(ContainElement("ALL"),
+					"initContainer %q must drop ALL capabilities under restricted PSS", name)
+			}
+
+			containers := ds.Field("spec.template.spec.containers").Array()
+			Expect(containers).ToNot(BeEmpty())
+			for _, c := range containers {
+				name := c.Get("name").String()
+				drops := c.Get("securityContext.capabilities.drop").Array()
+				dropStrings := make([]string, 0, len(drops))
+				for _, d := range drops {
+					dropStrings = append(dropStrings, d.String())
+				}
+				Expect(dropStrings).To(ContainElement("ALL"),
+					"container %q must drop ALL capabilities under restricted PSS", name)
+			}
+		})
 	})
 })

--- a/modules/340-monitoring-kubernetes-control-plane/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-kubernetes-control-plane/template_tests/admission_policy_engine_compatibility_test.go
@@ -30,6 +30,11 @@ var _ = Describe("Module :: monitoring-kubernetes-control-plane :: admission-pol
 		BeforeEach(func() {
 			f.ValuesSetFromYaml("global", `
 enabledModules: ["monitoring-kubernetes-control-plane", "control-plane-manager"]
+discovery:
+  clusterMasterCount: 0
+  d8SpecificNodeCountByRole:
+    master: 0
+    system: 1
 `)
 			f.ValuesSet("global.modulesImages", GetModulesImages())
 			f.HelmRender()
@@ -50,6 +55,10 @@ enabledModules: ["monitoring-kubernetes-control-plane", "control-plane-manager"]
 			f.ValuesSetFromYaml("global", `
 enabledModules: ["monitoring-kubernetes-control-plane", "control-plane-manager", "admission-policy-engine", "admission-policy-engine-crd"]
 discovery:
+  clusterMasterCount: 0
+  d8SpecificNodeCountByRole:
+    master: 0
+    system: 1
   apiVersions:
     - deckhouse.io/v1alpha1/SecurityPolicyException
 `)

--- a/modules/340-monitoring-kubernetes-control-plane/template_tests/package_test.go
+++ b/modules/340-monitoring-kubernetes-control-plane/template_tests/package_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/daemonset.yaml
@@ -2,6 +2,7 @@
 cpu: 10m
 memory: 15Mi
 {{- end }}
+{{- $securityPolicyExceptionEnabled := and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -42,6 +43,9 @@ spec:
     metadata:
       labels:
         app: control-plane-proxy
+        {{- if $securityPolicyExceptionEnabled }}
+        security.deckhouse.io/security-policy-exception: control-plane-proxy
+        {{- end }}
     spec:
       serviceAccountName: control-plane-proxy
       automountServiceAccountToken: true

--- a/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/security-policy-exception.yaml
+++ b/modules/340-monitoring-kubernetes-control-plane/templates/control-plane-proxy/security-policy-exception.yaml
@@ -1,0 +1,21 @@
+{{- if and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: control-plane-proxy
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "control-plane-proxy")) | nindent 2 }}
+spec:
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          control-plane-proxy scrapes local control-plane components via host network namespace.
+    hostPorts:
+      - port: 4209
+        protocol: TCP
+        metadata:
+          description: HTTPS endpoint exposed via kube-rbac-proxy.
+{{- end }}

--- a/modules/340-monitoring-kubernetes/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-kubernetes/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const monitoringKubernetesCompatibilityValues = `
+oomKillsExporterEnabled: true
+internal:
+  clusterDNSImplementation: coredns
+  vpa:
+    kubeStateMetricsMaxCPU: "115m"
+    kubeStateMetricsMaxMemory: "180Mi"
+`
+
+var _ = Describe("Module :: monitoring-kubernetes :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	Context("without admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["monitoring-kubernetes"]
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("monitoringKubernetes", monitoringKubernetesCompatibilityValues)
+			f.HelmRender()
+		})
+
+		It("must not render SPE and exception labels", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			nodeExporterDaemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "node-exporter")
+			Expect(nodeExporterDaemonSet.Exists()).To(BeTrue())
+			Expect(nodeExporterDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "node-exporter").Exists()).To(BeFalse())
+
+			oomKillsDaemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "oom-kills-exporter")
+			Expect(oomKillsDaemonSet.Exists()).To(BeTrue())
+			Expect(oomKillsDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "oom-kills-exporter").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("with admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["monitoring-kubernetes", "admission-policy-engine", "admission-policy-engine-crd"]
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("monitoringKubernetes", monitoringKubernetesCompatibilityValues)
+			f.HelmRender()
+		})
+
+		It("must render SPE and exception labels for daemonsets requiring host access", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			nodeExporterDaemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "node-exporter")
+			Expect(nodeExporterDaemonSet.Exists()).To(BeTrue())
+			Expect(nodeExporterDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("node-exporter"))
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "node-exporter").Exists()).To(BeTrue())
+
+			oomKillsDaemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "oom-kills-exporter")
+			Expect(oomKillsDaemonSet.Exists()).To(BeTrue())
+			Expect(oomKillsDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("oom-kills-exporter"))
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "oom-kills-exporter").Exists()).To(BeTrue())
+		})
+
+		It("must keep kube-state-metrics without exception", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			kubeStateMetricsDeployment := f.KubernetesResource("Deployment", "d8-monitoring", "kube-state-metrics")
+			Expect(kubeStateMetricsDeployment.Exists()).To(BeTrue())
+			Expect(kubeStateMetricsDeployment.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "kube-state-metrics").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/340-monitoring-kubernetes/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-kubernetes/template_tests/admission_policy_engine_compatibility_test.go
@@ -92,6 +92,39 @@ discovery:
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "oom-kills-exporter").Exists()).To(BeTrue())
 		})
 
+		It("must drop ALL capabilities on every container in node-exporter and oom-kills-exporter DaemonSets", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			for _, dsName := range []string{"node-exporter", "oom-kills-exporter"} {
+				ds := f.KubernetesResource("DaemonSet", "d8-monitoring", dsName)
+				Expect(ds.Exists()).To(BeTrue(), "DaemonSet %q must exist", dsName)
+
+				for _, c := range ds.Field("spec.template.spec.initContainers").Array() {
+					name := c.Get("name").String()
+					drops := c.Get("securityContext.capabilities.drop").Array()
+					dropStrings := make([]string, 0, len(drops))
+					for _, d := range drops {
+						dropStrings = append(dropStrings, d.String())
+					}
+					Expect(dropStrings).To(ContainElement("ALL"),
+						"DS %q initContainer %q must drop ALL capabilities under restricted PSS", dsName, name)
+				}
+
+				containers := ds.Field("spec.template.spec.containers").Array()
+				Expect(containers).ToNot(BeEmpty(), "DS %q must have containers", dsName)
+				for _, c := range containers {
+					name := c.Get("name").String()
+					drops := c.Get("securityContext.capabilities.drop").Array()
+					dropStrings := make([]string, 0, len(drops))
+					for _, d := range drops {
+						dropStrings = append(dropStrings, d.String())
+					}
+					Expect(dropStrings).To(ContainElement("ALL"),
+						"DS %q container %q must drop ALL capabilities under restricted PSS", dsName, name)
+				}
+			}
+		})
+
 		It("must keep kube-state-metrics without exception", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 

--- a/modules/340-monitoring-kubernetes/template_tests/package_test.go
+++ b/modules/340-monitoring-kubernetes/template_tests/package_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/daemonset.yaml
@@ -6,6 +6,7 @@ memory: 25Mi
 cpu: 10m
 memory: 25Mi
 {{- end }}
+{{- $securityPolicyExceptionEnabled := and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -57,6 +58,9 @@ spec:
     metadata:
       labels:
         app: node-exporter
+        {{- if $securityPolicyExceptionEnabled }}
+        security.deckhouse.io/security-policy-exception: node-exporter
+        {{- end }}
       name: node-exporter
       annotations:
         container.apparmor.security.beta.kubernetes.io/node-exporter: "unconfined"
@@ -126,7 +130,7 @@ spec:
 {{- end }}
       - image: {{ include "helm_lib_module_image" (list . "kubeletEvictionThresholdsExporter") }}
         name: kubelet-eviction-thresholds-exporter
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         env:
         - name: MY_NODE_NAME
           valueFrom:

--- a/modules/340-monitoring-kubernetes/templates/node-exporter/security-policy-exception.yaml
+++ b/modules/340-monitoring-kubernetes/templates/node-exporter/security-policy-exception.yaml
@@ -1,0 +1,63 @@
+{{- if and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: node-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "node-exporter")) | nindent 2 }}
+spec:
+  securityContext:
+    capabilities:
+      allowedValues:
+        add:
+          - SYS_TIME
+        drop:
+          - ALL
+      metadata:
+        description: |
+          node-exporter requires SYS_TIME capability for NTP checks.
+    appArmorProfile:
+      allowedValues:
+        - unconfined
+      metadata:
+        description: |
+          node-exporter and kubelet-eviction-thresholds-exporter require unconfined AppArmor profile.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          node-exporter runs in host network namespace to expose node metrics endpoint.
+    hostPID:
+      allowedValue: true
+      metadata:
+        description: |
+          node-exporter reads host process information.
+    hostPorts:
+      - port: 4206
+        protocol: TCP
+        metadata:
+          description: HTTPS endpoint exposed via kube-rbac-proxy.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          node-exporter requires hostPath mounts for host filesystem and textfile collectors.
+    hostPath:
+      allowedValues:
+        - path: /var/run/node-exporter-textfile
+          readOnly: true
+          metadata:
+            description: Read node-exporter textfile metrics.
+        - path: /
+          readOnly: true
+          metadata:
+            description: Read host root filesystem for collectors.
+        - path: /etc/containerd
+          readOnly: false
+          metadata:
+            description: Access containerd configuration for eviction thresholds exporter.
+{{- end }}

--- a/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
@@ -2,6 +2,7 @@
 cpu: 1m
 memory: 20Mi
 {{- end }}
+{{- $securityPolicyExceptionEnabled := and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
 {{- if .Values.monitoringKubernetes.oomKillsExporterEnabled }}
   {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -47,13 +48,21 @@ spec:
     metadata:
       labels:
         app: oom-kills-exporter
+        {{- if $securityPolicyExceptionEnabled }}
+        security.deckhouse.io/security-policy-exception: oom-kills-exporter
+        {{- end }}
       name: oom-kills-exporter
     spec:
       serviceAccountName: oom-kills-exporter
       automountServiceAccountToken: true
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - image: {{ include "helm_lib_module_image" (list . "oomKillsExporter") }}
         name: oom-kills-exporter
@@ -96,7 +105,7 @@ spec:
             {{- include "oom_kills_exporter_resources" . | nindent 12 }}
 {{- end }}
       - name: kube-rbac-proxy
-        {{- include "helm_lib_module_container_security_context_read_only_root_filesystem" . | nindent 8 }}
+        {{- include "helm_lib_module_container_security_context_pss_restricted_flexible" dict | nindent 8 }}
         image: {{ include "helm_lib_module_common_image" (list . "kubeRbacProxy") }}
         args:
         - "--secure-listen-address=$(KUBE_RBAC_PROXY_LISTEN_ADDRESS):8443"

--- a/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
@@ -57,12 +57,7 @@ spec:
       automountServiceAccountToken: true
       {{- include "helm_lib_priority_class" (tuple . "system-node-critical") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      securityContext:
-        runAsNonRoot: false
-        runAsUser: 0
-        runAsGroup: 0
-        seccompProfile:
-          type: RuntimeDefault
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root_runtime_default" . | nindent 6 }}
       containers:
       - image: {{ include "helm_lib_module_image" (list . "oomKillsExporter") }}
         name: oom-kills-exporter

--- a/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
+++ b/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/daemonset.yaml
@@ -61,7 +61,12 @@ spec:
       containers:
       - image: {{ include "helm_lib_module_image" (list . "oomKillsExporter") }}
         name: oom-kills-exporter
-        {{- include "helm_lib_module_container_security_context_privileged_read_only_root_filesystem" . | nindent 8 }}
+        securityContext:
+          privileged: true
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         args:
           - -logtostderr
           - -v=2

--- a/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/security-policy-exception.yaml
+++ b/modules/340-monitoring-kubernetes/templates/oom-kills-exporter/security-policy-exception.yaml
@@ -1,0 +1,45 @@
+{{- if and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) .Values.monitoringKubernetes.oomKillsExporterEnabled }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: oom-kills-exporter
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "oom-kills-exporter")) | nindent 2 }}
+spec:
+  securityContext:
+    privileged:
+      allowedValue: true
+      metadata:
+        description: |
+          oom-kills-exporter requires privileged access to read kernel OOM notifications.
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          Root user is required for privileged OOM event collection.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Privileged container cannot run as non-root.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Privileged mode implies privilege escalation allowance.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          oom-kills-exporter requires hostPath access to /dev/kmsg.
+    hostPath:
+      allowedValues:
+        - path: /dev/kmsg
+          readOnly: true
+          metadata:
+            description: Read kernel OOM messages from host /dev/kmsg.
+{{- end }}

--- a/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
@@ -80,9 +80,47 @@ discovery:
 - 0
 `))
 			Expect(pseBase.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
-			Expect(pseBase.Field("spec.securityContext.allowPrivilegeEscalation.allowedValue").Bool()).To(BeTrue())
+			Expect(pseBase.Field("spec.securityContext.allowPrivilegeEscalation.allowedValue").Exists()).To(BeFalse(),
+				"allowPrivilegeEscalation:true must not be whitelisted by the SPE; the init container is expected to set allowPrivilegeEscalation:false")
 
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping-root-init").Exists()).To(BeFalse())
+		})
+
+		It("must drop ALL capabilities on every container in the DaemonSet (restricted PSS compliance)", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "monitoring-ping")
+			Expect(daemonSet.Exists()).To(BeTrue())
+
+			initContainers := daemonSet.Field("spec.template.spec.initContainers").Array()
+			Expect(initContainers).ToNot(BeEmpty())
+			for _, c := range initContainers {
+				name := c.Get("name").String()
+				drops := c.Get("securityContext.capabilities.drop").Array()
+				dropStrings := make([]string, 0, len(drops))
+				for _, d := range drops {
+					dropStrings = append(dropStrings, d.String())
+				}
+				Expect(dropStrings).To(ContainElement("ALL"),
+					"initContainer %q must drop ALL capabilities under restricted PSS", name)
+				Expect(c.Get("securityContext.allowPrivilegeEscalation").Bool()).To(BeFalse(),
+					"initContainer %q must set allowPrivilegeEscalation:false", name)
+				Expect(c.Get("securityContext.seccompProfile.type").String()).To(Equal("RuntimeDefault"),
+					"initContainer %q must set seccompProfile.type=RuntimeDefault", name)
+			}
+
+			containers := daemonSet.Field("spec.template.spec.containers").Array()
+			Expect(containers).ToNot(BeEmpty())
+			for _, c := range containers {
+				name := c.Get("name").String()
+				drops := c.Get("securityContext.capabilities.drop").Array()
+				dropStrings := make([]string, 0, len(drops))
+				for _, d := range drops {
+					dropStrings = append(dropStrings, d.String())
+				}
+				Expect(dropStrings).To(ContainElement("ALL"),
+					"container %q must drop ALL capabilities under restricted PSS", name)
+			}
 		})
 	})
 })

--- a/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const monitoringPingCompatibilityValues = `
+internal:
+  clusterTargets:
+    - name: test-target
+      ipAddress: 10.0.0.1
+`
+
+var _ = Describe("Module :: monitoring-ping :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	Context("without admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["monitoring-ping", "monitoring-kubernetes"]
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("monitoringPing", monitoringPingCompatibilityValues)
+			f.HelmRender()
+		})
+
+		It("must not render SPE and exception label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "monitoring-ping")
+			Expect(daemonSet.Exists()).To(BeTrue())
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("with admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["monitoring-ping", "monitoring-kubernetes", "admission-policy-engine", "admission-policy-engine-crd"]
+discovery:
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("monitoringPing", monitoringPingCompatibilityValues)
+			f.HelmRender()
+		})
+
+		It("must render SPE and exception label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "monitoring-ping")
+			Expect(daemonSet.Exists()).To(BeTrue())
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("monitoring-ping"))
+
+			securityPolicyException := f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping")
+			Expect(securityPolicyException.Exists()).To(BeTrue())
+			Expect(securityPolicyException.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
+		})
+	})
+})

--- a/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
@@ -43,15 +43,13 @@ enabledModules: ["monitoring-ping", "monitoring-kubernetes"]
 			f.HelmRender()
 		})
 
-		It("must not render SPE pair and exception labels", func() {
+		It("must not render SPE and exception label", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "monitoring-ping")
 			Expect(daemonSet.Exists()).To(BeTrue())
 			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
-			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/monitoring-ping-clean-node-exporter-stale").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping-root-init").Exists()).To(BeFalse())
 		})
 	})
 
@@ -68,26 +66,23 @@ discovery:
 			f.HelmRender()
 		})
 
-		It("must render SPE pair and pod-wide + per-container exception labels", func() {
+		It("must render a single merged SPE and pod-wide exception label", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "monitoring-ping")
 			Expect(daemonSet.Exists()).To(BeTrue())
 			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("monitoring-ping"))
-			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/monitoring-ping-clean-node-exporter-stale").String()).To(Equal("monitoring-ping-root-init"))
 
 			pseBase := f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping")
 			Expect(pseBase.Exists()).To(BeTrue())
 			Expect(pseBase.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
-			Expect(pseBase.Field("spec.securityContext.runAsUser").Exists()).To(BeFalse())
-			Expect(pseBase.Field("spec.securityContext.runAsNonRoot").Exists()).To(BeFalse())
-
-			pseInit := f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping-root-init")
-			Expect(pseInit.Exists()).To(BeTrue())
-			Expect(pseInit.Field("spec.securityContext.runAsUser.allowedValues").String()).To(MatchYAML(`
+			Expect(pseBase.Field("spec.securityContext.runAsUser.allowedValues").String()).To(MatchYAML(`
 - 0
 `))
-			Expect(pseInit.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
+			Expect(pseBase.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
+			Expect(pseBase.Field("spec.securityContext.allowPrivilegeEscalation.allowedValue").Bool()).To(BeTrue())
+
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping-root-init").Exists()).To(BeFalse())
 		})
 	})
 })

--- a/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/340-monitoring-ping/template_tests/admission_policy_engine_compatibility_test.go
@@ -43,13 +43,15 @@ enabledModules: ["monitoring-ping", "monitoring-kubernetes"]
 			f.HelmRender()
 		})
 
-		It("must not render SPE and exception label", func() {
+		It("must not render SPE pair and exception labels", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "monitoring-ping")
 			Expect(daemonSet.Exists()).To(BeTrue())
 			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/monitoring-ping-clean-node-exporter-stale").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping-root-init").Exists()).To(BeFalse())
 		})
 	})
 
@@ -66,16 +68,26 @@ discovery:
 			f.HelmRender()
 		})
 
-		It("must render SPE and exception label", func() {
+		It("must render SPE pair and pod-wide + per-container exception labels", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			daemonSet := f.KubernetesResource("DaemonSet", "d8-monitoring", "monitoring-ping")
 			Expect(daemonSet.Exists()).To(BeTrue())
 			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("monitoring-ping"))
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/monitoring-ping-clean-node-exporter-stale").String()).To(Equal("monitoring-ping-root-init"))
 
-			securityPolicyException := f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping")
-			Expect(securityPolicyException.Exists()).To(BeTrue())
-			Expect(securityPolicyException.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
+			pseBase := f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping")
+			Expect(pseBase.Exists()).To(BeTrue())
+			Expect(pseBase.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
+			Expect(pseBase.Field("spec.securityContext.runAsUser").Exists()).To(BeFalse())
+			Expect(pseBase.Field("spec.securityContext.runAsNonRoot").Exists()).To(BeFalse())
+
+			pseInit := f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "monitoring-ping-root-init")
+			Expect(pseInit.Exists()).To(BeTrue())
+			Expect(pseInit.Field("spec.securityContext.runAsUser.allowedValues").String()).To(MatchYAML(`
+- 0
+`))
+			Expect(pseInit.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
 		})
 	})
 })

--- a/modules/340-monitoring-ping/template_tests/package_test.go
+++ b/modules/340-monitoring-ping/template_tests/package_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -66,10 +66,16 @@ spec:
         args:
           - "--cleanup-node-exporter-metrics=true"
         securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
           readOnlyRootFilesystem: true
           runAsGroup: 0
           runAsNonRoot: false
           runAsUser: 0
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts: # TODO remove volumes in future, need for clean staled metrics
           - name: textfile
             mountPath: /node-exporter-textfile

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -50,6 +50,7 @@ spec:
         app: monitoring-ping
         {{- if $securityPolicyExceptionEnabled }}
         security.deckhouse.io/security-policy-exception: monitoring-ping
+        security.deckhouse.io/security-policy-exception/monitoring-ping-clean-node-exporter-stale: monitoring-ping-root-init
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 0
@@ -57,12 +58,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 64535
-        runAsGroup: 64535
-        seccompProfile:
-          type: RuntimeDefault
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default" . | nindent 6 }}
       automountServiceAccountToken: true
       serviceAccountName: monitoring-ping
       initContainers:

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -2,6 +2,7 @@
 cpu: 25m
 memory: 25Mi
 {{- end }}
+{{- $securityPolicyExceptionEnabled := and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -47,13 +48,21 @@ spec:
       labels:
         name: monitoring-ping
         app: monitoring-ping
+        {{- if $securityPolicyExceptionEnabled }}
+        security.deckhouse.io/security-policy-exception: monitoring-ping
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 0
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 64535
+        runAsGroup: 64535
+        seccompProfile:
+          type: RuntimeDefault
       automountServiceAccountToken: true
       serviceAccountName: monitoring-ping
       initContainers:

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -50,7 +50,6 @@ spec:
         app: monitoring-ping
         {{- if $securityPolicyExceptionEnabled }}
         security.deckhouse.io/security-policy-exception: monitoring-ping
-        security.deckhouse.io/security-policy-exception/monitoring-ping-clean-node-exporter-stale: monitoring-ping-root-init
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 0

--- a/modules/340-monitoring-ping/templates/daemonset.yaml
+++ b/modules/340-monitoring-ping/templates/daemonset.yaml
@@ -68,6 +68,8 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
+            add:
+              - NET_RAW
             drop:
               - ALL
           readOnlyRootFilesystem: true

--- a/modules/340-monitoring-ping/templates/security-policy-exception.yaml
+++ b/modules/340-monitoring-ping/templates/security-policy-exception.yaml
@@ -19,11 +19,6 @@ spec:
       metadata:
         description: |
           Root execution is required for the cleanup init container.
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          Default runtime behavior for the root cleanup init container.
     capabilities:
       allowedValues:
         add:

--- a/modules/340-monitoring-ping/templates/security-policy-exception.yaml
+++ b/modules/340-monitoring-ping/templates/security-policy-exception.yaml
@@ -8,22 +8,6 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "monitoring-ping")) | nindent 2 }}
 spec:
   securityContext:
-    runAsUser:
-      allowedValues:
-        - 0
-      metadata:
-        description: |
-          The cleanup init container runs as root to remove stale host textfile metrics.
-    runAsNonRoot:
-      allowedValue: false
-      metadata:
-        description: |
-          Root execution is required for the cleanup init container.
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          Default runtime behavior for the root cleanup init container.
     capabilities:
       allowedValues:
         add:
@@ -32,7 +16,7 @@ spec:
           - ALL
       metadata:
         description: |
-          NET_RAW capability is required for ICMP probe operations.
+          NET_RAW capability is required by the monitoring-ping container for ICMP probe operations.
   network:
     hostNetwork:
       allowedValue: true
@@ -57,4 +41,29 @@ spec:
           readOnly: false
           metadata:
             description: Shared textfile directory with node-exporter.
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: monitoring-ping-root-init
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "monitoring-ping")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          The cleanup init container runs as root to remove stale host textfile metrics.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Root execution is required for the cleanup init container.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Default runtime behavior for the root cleanup init container.
 {{- end }}

--- a/modules/340-monitoring-ping/templates/security-policy-exception.yaml
+++ b/modules/340-monitoring-ping/templates/security-policy-exception.yaml
@@ -1,0 +1,60 @@
+{{- if and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: monitoring-ping
+  namespace: d8-monitoring
+  {{- include "helm_lib_module_labels" (list . (dict "app" "monitoring-ping")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          The cleanup init container runs as root to remove stale host textfile metrics.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Root execution is required for the cleanup init container.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Default runtime behavior for the root cleanup init container.
+    capabilities:
+      allowedValues:
+        add:
+          - NET_RAW
+        drop:
+          - ALL
+      metadata:
+        description: |
+          NET_RAW capability is required for ICMP probe operations.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          monitoring-ping uses host network namespace for node-to-node ICMP probing.
+    hostPorts:
+      - port: 4289
+        protocol: TCP
+        metadata:
+          description: HTTPS endpoint exposed via kube-rbac-proxy.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          monitoring-ping requires hostPath mount for node-exporter textfile cleanup.
+    hostPath:
+      allowedValues:
+        - path: /var/run/node-exporter-textfile
+          readOnly: false
+          metadata:
+            description: Shared textfile directory with node-exporter.
+{{- end }}

--- a/modules/340-monitoring-ping/templates/security-policy-exception.yaml
+++ b/modules/340-monitoring-ping/templates/security-policy-exception.yaml
@@ -8,6 +8,22 @@ metadata:
   {{- include "helm_lib_module_labels" (list . (dict "app" "monitoring-ping")) | nindent 2 }}
 spec:
   securityContext:
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          The cleanup init container runs as root to remove stale host textfile metrics.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Root execution is required for the cleanup init container.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Default runtime behavior for the root cleanup init container.
     capabilities:
       allowedValues:
         add:
@@ -41,29 +57,4 @@ spec:
           readOnly: false
           metadata:
             description: Shared textfile directory with node-exporter.
----
-apiVersion: deckhouse.io/v1alpha1
-kind: SecurityPolicyException
-metadata:
-  name: monitoring-ping-root-init
-  namespace: d8-monitoring
-  {{- include "helm_lib_module_labels" (list . (dict "app" "monitoring-ping")) | nindent 2 }}
-spec:
-  securityContext:
-    runAsUser:
-      allowedValues:
-        - 0
-      metadata:
-        description: |
-          The cleanup init container runs as root to remove stale host textfile metrics.
-    runAsNonRoot:
-      allowedValue: false
-      metadata:
-        description: |
-          Root execution is required for the cleanup init container.
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          Default runtime behavior for the root cleanup init container.
 {{- end }}

--- a/modules/460-log-shipper/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/460-log-shipper/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const logShipperCompatibilityValues = `
+debug: false
+internal:
+  activated: true
+resourcesRequests:
+  mode: Static
+  static:
+    cpu: 5m
+    memory: 4Mi
+  vpa:
+    cpu:
+      max: 500m
+      min: 50m
+    memory:
+      max: 2048Mi
+      min: 64Mi
+    mode: Initial
+`
+
+var _ = Describe("Module :: log-shipper :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig("")
+
+	Context("without admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["log-shipper", "vertical-pod-autoscaler"]
+discovery:
+  kubernetesVersion: "1.31.14"
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("logShipper", logShipperCompatibilityValues)
+			f.HelmRender()
+		})
+
+		It("must render restricted namespace label and skip security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-log-shipper")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").Exists()).To(BeFalse())
+		})
+
+		It("must not render SPE and exception label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-log-shipper", "log-shipper-agent")
+			Expect(daemonSet.Exists()).To(BeTrue())
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-log-shipper", "log-shipper-agent").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("with admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", `
+enabledModules: ["log-shipper", "vertical-pod-autoscaler", "admission-policy-engine", "admission-policy-engine-crd"]
+discovery:
+  kubernetesVersion: "1.31.14"
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("logShipper", logShipperCompatibilityValues)
+			f.HelmRender()
+		})
+
+		It("must render restricted namespace label and security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-log-shipper")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").String()).To(Equal("true"))
+		})
+
+		It("must render SPE and exception label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-log-shipper", "log-shipper-agent")
+			Expect(daemonSet.Exists()).To(BeTrue())
+			Expect(daemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("log-shipper-agent"))
+
+			securityPolicyException := f.KubernetesResource("SecurityPolicyException", "d8-log-shipper", "log-shipper-agent")
+			Expect(securityPolicyException.Exists()).To(BeTrue())
+			Expect(securityPolicyException.Field("spec.securityContext.runAsUser.allowedValues").String()).To(MatchYAML(`
+- 0
+`))
+			Expect(securityPolicyException.Field("spec.volumes.types.allowedValues").String()).To(MatchYAML(`
+- hostPath
+`))
+		})
+	})
+})

--- a/modules/460-log-shipper/templates/daemonset.yaml
+++ b/modules/460-log-shipper/templates/daemonset.yaml
@@ -2,6 +2,7 @@
 cpu: 10m
 memory: 15Mi
 {{- end }}
+{{- $securityPolicyExceptionEnabled := and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
 
 {{- if .Values.logShipper.internal.activated }}
   {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
@@ -42,6 +43,9 @@ spec:
     metadata:
       labels:
         app: log-shipper-agent
+        {{- if $securityPolicyExceptionEnabled }}
+        security.deckhouse.io/security-policy-exception: log-shipper-agent
+        {{- end }}
       annotations:
         # TODO(nabokihms): why do we need this if we have dynamic config reloading feature?
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -62,7 +66,12 @@ spec:
         {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- end }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      {{- include "helm_lib_module_pod_security_context_run_as_user_root" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: vector
           {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}

--- a/modules/460-log-shipper/templates/daemonset.yaml
+++ b/modules/460-log-shipper/templates/daemonset.yaml
@@ -66,12 +66,7 @@ spec:
         {{- include "helm_lib_tolerations" (tuple . "any-node") | nindent 6 }}
       {{- end }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      securityContext:
-        runAsNonRoot: false
-        runAsUser: 0
-        runAsGroup: 0
-        seccompProfile:
-          type: RuntimeDefault
+      {{- include "helm_lib_module_pod_security_context_run_as_user_root_runtime_default" . | nindent 6 }}
       containers:
         - name: vector
           {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all" . | nindent 10 }}

--- a/modules/460-log-shipper/templates/namespace.yaml
+++ b/modules/460-log-shipper/templates/namespace.yaml
@@ -1,15 +1,16 @@
-{{- define "labels" }}
-prometheus.deckhouse.io/rules-watcher-enabled: "true"
-security.deckhouse.io/pod-policy: "restricted"
-{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
-security.deckhouse.io/enable-security-policy-check: "true"
-{{- end }}
-{{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
+  {{- $namespaceLabels := dict
+    "app" $.Chart.Name
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+  }}
+  {{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+    {{- $_ := set $namespaceLabels "security.deckhouse.io/enable-security-policy-check" "true" }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list . $namespaceLabels) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/460-log-shipper/templates/namespace.yaml
+++ b/modules/460-log-shipper/templates/namespace.yaml
@@ -1,8 +1,15 @@
+{{- define "labels" }}
+prometheus.deckhouse.io/rules-watcher-enabled: "true"
+security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ $.Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" $.Chart.Name "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/460-log-shipper/templates/security-policy-exception.yaml
+++ b/modules/460-log-shipper/templates/security-policy-exception.yaml
@@ -1,0 +1,47 @@
+{{- if and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: log-shipper-agent
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "log-shipper-agent")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          The log-shipper DaemonSet runs as root to read node logs from host-mounted paths.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Root execution is required for host-level log collection.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          The log-shipper DaemonSet needs hostPath mounts for node log files and local state.
+    hostPath:
+      allowedValues:
+        - path: /var/log/
+          readOnly: true
+          metadata:
+            description: Read host logs.
+        - path: /var/lib/
+          readOnly: true
+          metadata:
+            description: Read container runtime metadata used in log enrichment.
+        - path: /mnt/vector-data
+          readOnly: false
+          metadata:
+            description: Persist vector local state on the node.
+        - path: /etc/localtime
+          readOnly: true
+          metadata:
+            description: Read node timezone settings.
+{{- end }}

--- a/modules/462-loki/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/462-loki/template_tests/admission_policy_engine_compatibility_test.go
@@ -40,6 +40,14 @@ discovery:
 		f.ValuesSet("global.modulesImages", GetModulesImages())
 		f.ValuesSetFromYaml("loki", `
 lokiConfig: {}
+internal:
+  cleanupThreshold: 0
+  stsStorageSize: 0
+  pvcSize: 0
+  kubeRbacProxyTLS:
+    cert: test-cert
+    key: test-key
+    ca: test-ca
 `)
 		f.HelmRender()
 	})

--- a/modules/462-loki/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/462-loki/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+var _ = Describe("Module :: loki :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	BeforeEach(func() {
+		f.ValuesSetFromYaml("global", `
+enabledModules: ["loki", "admission-policy-engine", "admission-policy-engine-crd"]
+modules:
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`)
+		f.ValuesSet("global.modulesImages", GetModulesImages())
+		f.HelmRender()
+	})
+
+	It("must not render SecurityPolicyException resources or exception pod labels", func() {
+		Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+		lokiStatefulSet := f.KubernetesResource("StatefulSet", "d8-monitoring", "loki")
+		Expect(lokiStatefulSet.Exists()).To(BeTrue())
+		Expect(lokiStatefulSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+
+		Expect(f.KubernetesResource("SecurityPolicyException", "d8-monitoring", "loki").Exists()).To(BeFalse())
+	})
+})

--- a/modules/462-loki/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/462-loki/template_tests/admission_policy_engine_compatibility_test.go
@@ -38,6 +38,9 @@ discovery:
     - deckhouse.io/v1alpha1/SecurityPolicyException
 `)
 		f.ValuesSet("global.modulesImages", GetModulesImages())
+		f.ValuesSetFromYaml("loki", `
+lokiConfig: {}
+`)
 		f.HelmRender()
 	})
 

--- a/modules/462-loki/template_tests/package_test.go
+++ b/modules/462-loki/template_tests/package_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "")
+}

--- a/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
@@ -99,13 +99,15 @@ var _ = Describe("Module :: upmeter :: admission-policy-engine compatibility", f
 			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").Exists()).To(BeFalse())
 		})
 
-		It("must not render SPE and exception labels", func() {
+		It("must not render SPE pair and exception labels", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			agentDaemonSet := f.KubernetesResource("DaemonSet", "d8-upmeter", "upmeter-agent")
 			Expect(agentDaemonSet.Exists()).To(BeTrue())
 			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/chown-volume-data").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent-chown-init").Exists()).To(BeFalse())
 		})
 	})
 
@@ -126,13 +128,26 @@ var _ = Describe("Module :: upmeter :: admission-policy-engine compatibility", f
 			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").String()).To(Equal("true"))
 		})
 
-		It("must render SPE and exception label only for upmeter-agent", func() {
+		It("must render SPE pair and pod-wide + per-container exception labels for upmeter-agent only", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			agentDaemonSet := f.KubernetesResource("DaemonSet", "d8-upmeter", "upmeter-agent")
 			Expect(agentDaemonSet.Exists()).To(BeTrue())
 			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("upmeter-agent"))
-			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent").Exists()).To(BeTrue())
+			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/chown-volume-data").String()).To(Equal("upmeter-agent-chown-init"))
+
+			pseBase := f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent")
+			Expect(pseBase.Exists()).To(BeTrue())
+			Expect(pseBase.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
+			Expect(pseBase.Field("spec.securityContext.runAsUser").Exists()).To(BeFalse())
+			Expect(pseBase.Field("spec.securityContext.runAsNonRoot").Exists()).To(BeFalse())
+
+			pseInit := f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent-chown-init")
+			Expect(pseInit.Exists()).To(BeTrue())
+			Expect(pseInit.Field("spec.securityContext.runAsUser.allowedValues").String()).To(MatchYAML(`
+- 0
+`))
+			Expect(pseInit.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
 
 			upmeterStatefulSet := f.KubernetesResource("StatefulSet", "d8-upmeter", "upmeter")
 			Expect(upmeterStatefulSet.Exists()).To(BeTrue())

--- a/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
@@ -99,15 +99,13 @@ var _ = Describe("Module :: upmeter :: admission-policy-engine compatibility", f
 			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").Exists()).To(BeFalse())
 		})
 
-		It("must not render SPE pair and exception labels", func() {
+		It("must not render SPE and exception label", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			agentDaemonSet := f.KubernetesResource("DaemonSet", "d8-upmeter", "upmeter-agent")
 			Expect(agentDaemonSet.Exists()).To(BeTrue())
 			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
-			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/chown-volume-data").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent").Exists()).To(BeFalse())
-			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent-chown-init").Exists()).To(BeFalse())
 		})
 	})
 
@@ -128,26 +126,23 @@ var _ = Describe("Module :: upmeter :: admission-policy-engine compatibility", f
 			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").String()).To(Equal("true"))
 		})
 
-		It("must render SPE pair and pod-wide + per-container exception labels for upmeter-agent only", func() {
+		It("must render a single merged SPE and pod-wide exception label for upmeter-agent only", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			agentDaemonSet := f.KubernetesResource("DaemonSet", "d8-upmeter", "upmeter-agent")
 			Expect(agentDaemonSet.Exists()).To(BeTrue())
 			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("upmeter-agent"))
-			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception/chown-volume-data").String()).To(Equal("upmeter-agent-chown-init"))
 
 			pseBase := f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent")
 			Expect(pseBase.Exists()).To(BeTrue())
 			Expect(pseBase.Field("spec.network.hostNetwork.allowedValue").Bool()).To(BeTrue())
-			Expect(pseBase.Field("spec.securityContext.runAsUser").Exists()).To(BeFalse())
-			Expect(pseBase.Field("spec.securityContext.runAsNonRoot").Exists()).To(BeFalse())
-
-			pseInit := f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent-chown-init")
-			Expect(pseInit.Exists()).To(BeTrue())
-			Expect(pseInit.Field("spec.securityContext.runAsUser.allowedValues").String()).To(MatchYAML(`
+			Expect(pseBase.Field("spec.securityContext.runAsUser.allowedValues").String()).To(MatchYAML(`
 - 0
 `))
-			Expect(pseInit.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
+			Expect(pseBase.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
+			Expect(pseBase.Field("spec.securityContext.allowPrivilegeEscalation.allowedValue").Bool()).To(BeTrue())
+
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent-chown-init").Exists()).To(BeFalse())
 
 			upmeterStatefulSet := f.KubernetesResource("StatefulSet", "d8-upmeter", "upmeter")
 			Expect(upmeterStatefulSet.Exists()).To(BeTrue())

--- a/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package template_tests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/deckhouse/deckhouse/testing/helm"
+)
+
+const upmeterGlobalValuesNoAPE = `
+clusterConfiguration:
+  apiVersion: deckhouse.io/v1
+  cloud:
+    prefix: myprefix
+    provider: OpenStack
+  clusterDomain: cluster.local
+  clusterType: "Cloud"
+  defaultCRI: Containerd
+  kind: ClusterConfiguration
+  kubernetesVersion: "1.31"
+  podSubnetCIDR: 10.111.0.0/16
+  podSubnetNodeCIDRPrefix: "24"
+  serviceSubnetCIDR: 10.222.0.0/16
+enabledModules: ["vertical-pod-autoscaler", "upmeter"]
+modules:
+  https:
+    mode: CustomCertificate
+  publicDomainTemplate: "%s.example.com"
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+  kubernetesVersion: 1.16.15
+`
+
+const upmeterGlobalValuesWithAPE = `
+clusterConfiguration:
+  apiVersion: deckhouse.io/v1
+  cloud:
+    prefix: myprefix
+    provider: OpenStack
+  clusterDomain: cluster.local
+  clusterType: "Cloud"
+  defaultCRI: Containerd
+  kind: ClusterConfiguration
+  kubernetesVersion: "1.31"
+  podSubnetCIDR: 10.111.0.0/16
+  podSubnetNodeCIDRPrefix: "24"
+  serviceSubnetCIDR: 10.222.0.0/16
+enabledModules: ["vertical-pod-autoscaler", "upmeter", "admission-policy-engine", "admission-policy-engine-crd"]
+modules:
+  https:
+    mode: CustomCertificate
+  publicDomainTemplate: "%s.example.com"
+  placement: {}
+discovery:
+  d8SpecificNodeCountByRole:
+    system: 1
+    master: 1
+  kubernetesVersion: 1.16.15
+  apiVersions:
+    - deckhouse.io/v1alpha1/SecurityPolicyException
+`
+
+var _ = Describe("Module :: upmeter :: admission-policy-engine compatibility", func() {
+	f := SetupHelmConfig(``)
+
+	Context("without admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", upmeterGlobalValuesNoAPE)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("upmeter", customCertificatePresent)
+			f.HelmRender()
+		})
+
+		It("must render restricted namespace label and skip security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-upmeter")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").Exists()).To(BeFalse())
+		})
+
+		It("must not render SPE and exception labels", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			agentDaemonSet := f.KubernetesResource("DaemonSet", "d8-upmeter", "upmeter-agent")
+			Expect(agentDaemonSet.Exists()).To(BeTrue())
+			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("with admission-policy-engine-crd", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", upmeterGlobalValuesWithAPE)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("upmeter", customCertificatePresent)
+			f.HelmRender()
+		})
+
+		It("must render restricted namespace label and security-check label", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			namespace := f.KubernetesGlobalResource("Namespace", "d8-upmeter")
+			Expect(namespace.Exists()).To(BeTrue())
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/pod-policy").String()).To(Equal("restricted"))
+			Expect(namespace.Field("metadata.labels.security\\.deckhouse\\.io/enable-security-policy-check").String()).To(Equal("true"))
+		})
+
+		It("must render SPE and exception label only for upmeter-agent", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			agentDaemonSet := f.KubernetesResource("DaemonSet", "d8-upmeter", "upmeter-agent")
+			Expect(agentDaemonSet.Exists()).To(BeTrue())
+			Expect(agentDaemonSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").String()).To(Equal("upmeter-agent"))
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent").Exists()).To(BeTrue())
+
+			upmeterStatefulSet := f.KubernetesResource("StatefulSet", "d8-upmeter", "upmeter")
+			Expect(upmeterStatefulSet.Exists()).To(BeTrue())
+			Expect(upmeterStatefulSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter").Exists()).To(BeFalse())
+		})
+	})
+})

--- a/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
+++ b/modules/500-upmeter/template_tests/admission_policy_engine_compatibility_test.go
@@ -141,6 +141,12 @@ var _ = Describe("Module :: upmeter :: admission-policy-engine compatibility", f
 `))
 			Expect(pseBase.Field("spec.securityContext.runAsNonRoot.allowedValue").Bool()).To(BeFalse())
 			Expect(pseBase.Field("spec.securityContext.allowPrivilegeEscalation.allowedValue").Bool()).To(BeTrue())
+			Expect(pseBase.Field("spec.securityContext.capabilities.allowedValues.add").String()).To(MatchYAML(`
+- CHOWN
+`))
+			Expect(pseBase.Field("spec.securityContext.capabilities.allowedValues.drop").String()).To(MatchYAML(`
+- ALL
+`))
 
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter-agent-chown-init").Exists()).To(BeFalse())
 
@@ -148,6 +154,45 @@ var _ = Describe("Module :: upmeter :: admission-policy-engine compatibility", f
 			Expect(upmeterStatefulSet.Exists()).To(BeTrue())
 			Expect(upmeterStatefulSet.Field("spec.template.metadata.labels.security\\.deckhouse\\.io/security-policy-exception").Exists()).To(BeFalse())
 			Expect(f.KubernetesResource("SecurityPolicyException", "d8-upmeter", "upmeter").Exists()).To(BeFalse())
+		})
+
+		It("must drop ALL capabilities on every container in the upmeter-agent DaemonSet (restricted PSS compliance)", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			daemonSet := f.KubernetesResource("DaemonSet", "d8-upmeter", "upmeter-agent")
+			Expect(daemonSet.Exists()).To(BeTrue())
+
+			initContainers := daemonSet.Field("spec.template.spec.initContainers").Array()
+			Expect(initContainers).ToNot(BeEmpty())
+			for _, c := range initContainers {
+				name := c.Get("name").String()
+				drops := c.Get("securityContext.capabilities.drop").Array()
+				dropStrings := make([]string, 0, len(drops))
+				for _, d := range drops {
+					dropStrings = append(dropStrings, d.String())
+				}
+				Expect(dropStrings).To(ContainElement("ALL"),
+					"initContainer %q must drop ALL capabilities under restricted PSS", name)
+			}
+
+			containers := daemonSet.Field("spec.template.spec.containers").Array()
+			Expect(containers).ToNot(BeEmpty())
+			for _, c := range containers {
+				name := c.Get("name").String()
+				drops := c.Get("securityContext.capabilities.drop").Array()
+				dropStrings := make([]string, 0, len(drops))
+				for _, d := range drops {
+					dropStrings = append(dropStrings, d.String())
+				}
+				Expect(dropStrings).To(ContainElement("ALL"),
+					"container %q must drop ALL capabilities under restricted PSS", name)
+			}
+
+			chownInit := daemonSet.Field("spec.template.spec.initContainers.#(name==\"chown-volume-data\")")
+			Expect(chownInit.Exists()).To(BeTrue())
+			Expect(chownInit.Get("securityContext.capabilities.add").String()).To(MatchYAML(`
+- CHOWN
+`))
 		})
 	})
 })

--- a/modules/500-upmeter/templates/namespace.yaml
+++ b/modules/500-upmeter/templates/namespace.yaml
@@ -1,15 +1,15 @@
-{{- define "labels" }}
-prometheus.deckhouse.io/rules-watcher-enabled: "true"
-security.deckhouse.io/pod-policy: "restricted"
-{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
-security.deckhouse.io/enable-security-policy-check: "true"
-{{- end }}
-{{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
+  {{- $namespaceLabels := dict
+    "prometheus.deckhouse.io/rules-watcher-enabled" "true"
+    "security.deckhouse.io/pod-policy" "restricted"
+  }}
+  {{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+    {{- $_ := set $namespaceLabels "security.deckhouse.io/enable-security-policy-check" "true" }}
+  {{- end }}
+  {{- include "helm_lib_module_labels" (list . $namespaceLabels) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/500-upmeter/templates/namespace.yaml
+++ b/modules/500-upmeter/templates/namespace.yaml
@@ -1,8 +1,15 @@
+{{- define "labels" }}
+prometheus.deckhouse.io/rules-watcher-enabled: "true"
+security.deckhouse.io/pod-policy: "restricted"
+{{- if .Values.global.enabledModules | has "admission-policy-engine-crd" }}
+security.deckhouse.io/enable-security-policy-check: "true"
+{{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "prometheus.deckhouse.io/rules-watcher-enabled" "true")) | nindent 2 }}
+  {{- include "helm_lib_module_labels" (list . (fromYaml (include "labels" .))) | nindent 2 }}
 ---
 {{- include "helm_lib_kube_rbac_proxy_ca_certificate" (list . (printf "d8-%s" .Chart.Name)) }}

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -47,7 +47,6 @@ spec:
         app: upmeter-agent
         {{- if $securityPolicyExceptionEnabled }}
         security.deckhouse.io/security-policy-exception: upmeter-agent
-        security.deckhouse.io/security-policy-exception/chown-volume-data: upmeter-agent-chown-init
         {{- end }}
     spec:
       imagePullSecrets:

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -47,6 +47,7 @@ spec:
         app: upmeter-agent
         {{- if $securityPolicyExceptionEnabled }}
         security.deckhouse.io/security-policy-exception: upmeter-agent
+        security.deckhouse.io/security-policy-exception/chown-volume-data: upmeter-agent-chown-init
         {{- end }}
     spec:
       imagePullSecrets:
@@ -57,12 +58,7 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 64535
-        runAsGroup: 64535
-        seccompProfile:
-          type: RuntimeDefault
+      {{- include "helm_lib_module_pod_security_context_run_as_user_deckhouse_runtime_default" . | nindent 6 }}
       volumes:
       - name: data
         hostPath:

--- a/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/daemonset.yaml
@@ -2,6 +2,7 @@
 cpu: 20m
 memory: 20Mi
 {{- end }}
+{{- $securityPolicyExceptionEnabled := and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
 
 {{- if (.Values.global.enabledModules | has "vertical-pod-autoscaler") }}
 ---
@@ -44,6 +45,9 @@ spec:
     metadata:
       labels:
         app: upmeter-agent
+        {{- if $securityPolicyExceptionEnabled }}
+        security.deckhouse.io/security-policy-exception: upmeter-agent
+        {{- end }}
     spec:
       imagePullSecrets:
         - name: deckhouse-registry
@@ -53,7 +57,12 @@ spec:
       {{- include "helm_lib_node_selector" (tuple . "master") | nindent 6 }}
       {{- include "helm_lib_tolerations" (tuple . "wildcard") | nindent 6 }}
       {{- include "helm_lib_priority_class" (tuple . "cluster-medium") | nindent 6 }}
-      {{ include "helm_lib_module_pod_security_context_run_as_user_deckhouse" . | nindent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 64535
+        runAsGroup: 64535
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: data
         hostPath:

--- a/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
@@ -7,23 +7,6 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "upmeter")) | nindent 2 }}
 spec:
-  securityContext:
-    runAsUser:
-      allowedValues:
-        - 0
-      metadata:
-        description: |
-          The chown init container runs as root to initialize ownership on the hostPath data directory.
-    runAsNonRoot:
-      allowedValue: false
-      metadata:
-        description: |
-          Root execution is required only for the volume ownership bootstrap init container.
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          Default container runtime behavior for the root init container is required.
   network:
     hostNetwork:
       allowedValue: true
@@ -43,4 +26,29 @@ spec:
           readOnly: false
           metadata:
             description: Node-local persistent storage for upmeter-agent.
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: upmeter-agent-chown-init
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "upmeter")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          The chown init container runs as root to initialize ownership on the hostPath data directory.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Root execution is required only for the volume ownership bootstrap init container.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Default container runtime behavior for the root init container is required.
 {{- end }}

--- a/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
@@ -7,6 +7,23 @@ metadata:
   namespace: d8-{{ .Chart.Name }}
   {{- include "helm_lib_module_labels" (list . (dict "app" "upmeter")) | nindent 2 }}
 spec:
+  securityContext:
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          The chown init container runs as root to initialize ownership on the hostPath data directory.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Root execution is required only for the volume ownership bootstrap init container.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Default container runtime behavior for the root init container is required.
   network:
     hostNetwork:
       allowedValue: true
@@ -26,29 +43,4 @@ spec:
           readOnly: false
           metadata:
             description: Node-local persistent storage for upmeter-agent.
----
-apiVersion: deckhouse.io/v1alpha1
-kind: SecurityPolicyException
-metadata:
-  name: upmeter-agent-chown-init
-  namespace: d8-{{ .Chart.Name }}
-  {{- include "helm_lib_module_labels" (list . (dict "app" "upmeter")) | nindent 2 }}
-spec:
-  securityContext:
-    runAsUser:
-      allowedValues:
-        - 0
-      metadata:
-        description: |
-          The chown init container runs as root to initialize ownership on the hostPath data directory.
-    runAsNonRoot:
-      allowedValue: false
-      metadata:
-        description: |
-          Root execution is required only for the volume ownership bootstrap init container.
-    allowPrivilegeEscalation:
-      allowedValue: true
-      metadata:
-        description: |
-          Default container runtime behavior for the root init container is required.
 {{- end }}

--- a/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
@@ -1,0 +1,46 @@
+{{- if and (.Values.global.enabledModules | has "admission-policy-engine-crd") (or (.Values.global.discovery.apiVersions | has "deckhouse.io/v1alpha1/SecurityPolicyException") (.Capabilities.APIVersions.Has "deckhouse.io/v1alpha1/SecurityPolicyException")) }}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: SecurityPolicyException
+metadata:
+  name: upmeter-agent
+  namespace: d8-{{ .Chart.Name }}
+  {{- include "helm_lib_module_labels" (list . (dict "app" "upmeter")) | nindent 2 }}
+spec:
+  securityContext:
+    runAsUser:
+      allowedValues:
+        - 0
+      metadata:
+        description: |
+          The chown init container runs as root to initialize ownership on the hostPath data directory.
+    runAsNonRoot:
+      allowedValue: false
+      metadata:
+        description: |
+          Root execution is required only for the volume ownership bootstrap init container.
+    allowPrivilegeEscalation:
+      allowedValue: true
+      metadata:
+        description: |
+          Default container runtime behavior for the root init container is required.
+  network:
+    hostNetwork:
+      allowedValue: true
+      metadata:
+        description: |
+          The upmeter-agent DaemonSet uses host networking.
+  volumes:
+    types:
+      allowedValues:
+        - hostPath
+      metadata:
+        description: |
+          The upmeter-agent DaemonSet stores state in a hostPath volume.
+    hostPath:
+      allowedValues:
+        - path: /var/lib/upmeter/agent
+          readOnly: false
+          metadata:
+            description: Node-local persistent storage for upmeter-agent.
+{{- end }}

--- a/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
+++ b/modules/500-upmeter/templates/upmeter-agent/security-policy-exception.yaml
@@ -24,6 +24,15 @@ spec:
       metadata:
         description: |
           Default container runtime behavior for the root init container is required.
+    capabilities:
+      allowedValues:
+        add:
+          - CHOWN
+        drop:
+          - ALL
+      metadata:
+        description: |
+          The chown init container needs CAP_CHOWN to set ownership on the hostPath data directory; all other capabilities are dropped.
   network:
     hostNetwork:
       allowedValue: true


### PR DESCRIPTION
## Description

### Why do we need it, and what problem does it solve?

This PR adds compatibility for monitoring and logging modules with restrictive AdmissionPolicyEngine security policies. It introduces required `SecurityPolicyException` resources for daemonsets, updates related namespace manifests, and adds template tests to validate policy-engine compatibility.

### Why do we need it in the patch release (if we do)?

## Checklist

- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-kubernetes
type: feature
summary: Add SecurityPolicyException and restricted-compatible securityContext for node-exporter and oom-kills-exporter.
impact_level: default
---
section: monitoring-kubernetes-control-plane
type: feature
summary: Add SecurityPolicyException for control-plane-proxy.
impact_level: default
---
section: monitoring-ping
type: feature
summary: Add SecurityPolicyException and restricted-compatible securityContext for monitoring-ping DaemonSet.
impact_level: default
---
section: log-shipper
type: feature
summary: Add SecurityPolicyException and restricted-compatible securityContext for log-shipper DaemonSet.
impact_level: default
---
section: upmeter
type: feature
summary: Add SecurityPolicyException and restricted-compatible securityContext for upmeter-agent DaemonSet.
impact_level: default
```