### PR TITLE
[cloud-provider-dvp] Use WaitForFirstConsumer binding mode instead of inheriting from parent cluster

### DIFF
--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -41,8 +41,9 @@ import (
 )
 
 const (
-	stableDefaultAnnotation = "storageclass.kubernetes.io/is-default-class"
-	betaDefaultAnnotation   = "storageclass.beta.kubernetes.io/is-default-class"
+	stableDefaultAnnotation  = "storageclass.kubernetes.io/is-default-class"
+	betaDefaultAnnotation    = "storageclass.beta.kubernetes.io/is-default-class"
+	desiredVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -114,6 +115,7 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 			if err != nil {
 				return fmt.Errorf("failed to iterate over 'storage_classes' snapshots: %v", err)
 			}
+			ensureCompatibleStorageClass(input, &storageClassSnapshot)
 			storageClasses = append(storageClasses, storageClassToStorageClassValue(&storageClassSnapshot))
 		}
 		input.Logger.Info("Found DVP storage classes using StorageClass snapshots: %v", storageClasses)
@@ -176,6 +178,8 @@ func handleDiscoveryDataStorageClasses(
 			return fmt.Errorf("failed to iterate over 'storage_classes' snapshots: %v", err)
 		}
 
+		ensureCompatibleStorageClass(input, &sc)
+
 		if _, ok := dvpstorageClass[sc.Name]; !ok {
 			storageClasses = append(storageClasses, storageClassToStorageClassValue(&sc))
 		}
@@ -197,7 +201,7 @@ func handleDiscoveryDataStorageClasses(
 		sc := storageClass{
 			Name:                 name,
 			DVPStorageClass:      sc.Name,
-			VolumeBindingMode:    sc.VolumeBindingMode,
+			VolumeBindingMode:    string(desiredVolumeBindingMode),
 			ReclaimPolicy:        sc.ReclaimPolicy,
 			AllowVolumeExpansion: sc.AllowVolumeExpansion,
 			IsDefault:            sc.IsDefault,
@@ -267,11 +271,6 @@ type storageClass struct {
 }
 
 func storageClassToStorageClassValue(sc *storagev1.StorageClass) storageClass {
-	volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
-	if sc.VolumeBindingMode != nil {
-		volumeBindingMode = *sc.VolumeBindingMode
-	}
-
 	reclaimPolicy := corev1.PersistentVolumeReclaimDelete
 	if sc.ReclaimPolicy != nil {
 		reclaimPolicy = *sc.ReclaimPolicy
@@ -294,9 +293,21 @@ func storageClassToStorageClassValue(sc *storagev1.StorageClass) storageClass {
 	return storageClass{
 		Name:                 sc.Name,
 		DVPStorageClass:      sc.Parameters["dvpStorageClass"],
-		VolumeBindingMode:    string(volumeBindingMode),
+		VolumeBindingMode:    string(desiredVolumeBindingMode),
 		ReclaimPolicy:        string(reclaimPolicy),
 		AllowVolumeExpansion: allowVolumeExpansion,
 		IsDefault:            isDefault,
 	}
+}
+
+func ensureCompatibleStorageClass(input *go_hook.HookInput, sc *storagev1.StorageClass) {
+	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == desiredVolumeBindingMode {
+		return
+	}
+
+	input.Logger.Info(
+		"Deleting storageclass because volumeBindingMode must be WaitForFirstConsumer.",
+		slog.String("storage_class", sc.Name),
+	)
+	input.PatchCollector.Delete("storage.k8s.io/v1", "StorageClass", "", sc.Name)
 }

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -43,7 +43,7 @@ import (
 const (
 	stableDefaultAnnotation  = "storageclass.kubernetes.io/is-default-class"
 	betaDefaultAnnotation    = "storageclass.beta.kubernetes.io/is-default-class"
-	desiredVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+	defaultVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -201,7 +201,7 @@ func handleDiscoveryDataStorageClasses(
 		sc := storageClass{
 			Name:                 name,
 			DVPStorageClass:      sc.Name,
-			VolumeBindingMode:    string(desiredVolumeBindingMode),
+			VolumeBindingMode:    string(defaultVolumeBindingMode),
 			ReclaimPolicy:        sc.ReclaimPolicy,
 			AllowVolumeExpansion: sc.AllowVolumeExpansion,
 			IsDefault:            sc.IsDefault,
@@ -293,7 +293,7 @@ func storageClassToStorageClassValue(sc *storagev1.StorageClass) storageClass {
 	return storageClass{
 		Name:                 sc.Name,
 		DVPStorageClass:      sc.Parameters["dvpStorageClass"],
-		VolumeBindingMode:    string(desiredVolumeBindingMode),
+		VolumeBindingMode:    string(defaultVolumeBindingMode),
 		ReclaimPolicy:        string(reclaimPolicy),
 		AllowVolumeExpansion: allowVolumeExpansion,
 		IsDefault:            isDefault,
@@ -301,7 +301,7 @@ func storageClassToStorageClassValue(sc *storagev1.StorageClass) storageClass {
 }
 
 func deleteOldStorageClass(input *go_hook.HookInput, sc *storagev1.StorageClass) {
-	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == desiredVolumeBindingMode {
+	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == defaultVolumeBindingMode {
 		return
 	}
 

--- a/modules/030-cloud-provider-dvp/hooks/discover.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover.go
@@ -115,7 +115,7 @@ func handleCloudProviderDiscoveryDataSecret(_ context.Context, input *go_hook.Ho
 			if err != nil {
 				return fmt.Errorf("failed to iterate over 'storage_classes' snapshots: %v", err)
 			}
-			ensureCompatibleStorageClass(input, &storageClassSnapshot)
+			deleteOldStorageClass(input, &storageClassSnapshot)
 			storageClasses = append(storageClasses, storageClassToStorageClassValue(&storageClassSnapshot))
 		}
 		input.Logger.Info("Found DVP storage classes using StorageClass snapshots: %v", storageClasses)
@@ -178,7 +178,7 @@ func handleDiscoveryDataStorageClasses(
 			return fmt.Errorf("failed to iterate over 'storage_classes' snapshots: %v", err)
 		}
 
-		ensureCompatibleStorageClass(input, &sc)
+		deleteOldStorageClass(input, &sc)
 
 		if _, ok := dvpstorageClass[sc.Name]; !ok {
 			storageClasses = append(storageClasses, storageClassToStorageClassValue(&sc))
@@ -300,13 +300,13 @@ func storageClassToStorageClassValue(sc *storagev1.StorageClass) storageClass {
 	}
 }
 
-func ensureCompatibleStorageClass(input *go_hook.HookInput, sc *storagev1.StorageClass) {
+func deleteOldStorageClass(input *go_hook.HookInput, sc *storagev1.StorageClass) {
 	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode == desiredVolumeBindingMode {
 		return
 	}
 
 	input.Logger.Info(
-		"Deleting storageclass because volumeBindingMode must be WaitForFirstConsumer.",
+		"Deleting storage class because volumeBindingMode must be WaitForFirstConsumer.",
 		slog.String("storage_class", sc.Name),
 	)
 	input.PatchCollector.Delete("storage.k8s.io/v1", "StorageClass", "", sc.Name)

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -342,7 +342,7 @@ data:
 			storageClass{
 				Name:                 "replicated",
 				DVPStorageClass:      "replicated",
-				VolumeBindingMode:    string(desiredVolumeBindingMode),
+				VolumeBindingMode:    string(defaultVolumeBindingMode),
 				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
 				AllowVolumeExpansion: false,
 				IsDefault:            false,
@@ -365,7 +365,7 @@ data:
 			storageClass{
 				Name:                 "stable-default",
 				DVPStorageClass:      "stable-default",
-				VolumeBindingMode:    string(desiredVolumeBindingMode),
+				VolumeBindingMode:    string(defaultVolumeBindingMode),
 				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimRetain),
 				AllowVolumeExpansion: true,
 				IsDefault:            true,
@@ -386,7 +386,7 @@ data:
 			storageClass{
 				Name:                 "beta-default",
 				DVPStorageClass:      "beta-default",
-				VolumeBindingMode:    string(desiredVolumeBindingMode),
+				VolumeBindingMode:    string(defaultVolumeBindingMode),
 				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
 				AllowVolumeExpansion: false,
 				IsDefault:            true,

--- a/modules/030-cloud-provider-dvp/hooks/discover_test.go
+++ b/modules/030-cloud-provider-dvp/hooks/discover_test.go
@@ -1,0 +1,400 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hooks
+
+import (
+	"encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/deckhouse/deckhouse/testing/hooks"
+)
+
+var _ = Describe("Modules :: cloud-provider-dvp :: hooks :: discover ::", func() {
+	const initValues = `
+cloudProviderDvp:
+  internal: {}
+`
+
+	const initValuesWithExclude = `
+cloudProviderDvp:
+  storageClass:
+    exclude:
+    - excluded-.*
+  internal:
+    defaultStorageClass: stale-default
+`
+
+	storageClassesOnly := `
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: replicated
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.dvp.deckhouse.io
+parameters:
+  dvpStorageClass: replicated
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: Immediate
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: secondary
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+provisioner: csi.dvp.deckhouse.io
+parameters:
+  dvpStorageClass: secondary
+reclaimPolicy: Retain
+allowVolumeExpansion: false
+volumeBindingMode: WaitForFirstConsumer
+`
+
+	discoveryData := `
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "DVPCloudDiscoveryData",
+  "zones": ["default"],
+  "storageClasses": [
+    {
+      "name": "replicated",
+      "volumeBindingMode": "Immediate",
+      "reclaimPolicy": "Delete",
+      "allowVolumeExpansion": true,
+      "isEnabled": true,
+      "isDefault": true
+    },
+    {
+      "name": "Excluded Fast",
+      "volumeBindingMode": "Immediate",
+      "reclaimPolicy": "Retain",
+      "allowVolumeExpansion": false,
+      "isEnabled": true,
+      "isDefault": false
+    },
+    {
+      "name": "Disabled",
+      "volumeBindingMode": "Immediate",
+      "reclaimPolicy": "Delete",
+      "allowVolumeExpansion": false,
+      "isEnabled": false,
+      "isDefault": false
+    }
+  ]
+}
+`
+
+	discoverySecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cloud-provider-discovery-data
+  namespace: kube-system
+data:
+  "discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(discoveryData)))
+
+	existingStorageClass := `
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: replicated
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: csi.dvp.deckhouse.io
+parameters:
+  dvpStorageClass: replicated
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: Immediate
+`
+
+	existingRetainedStorageClass := `
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: retained
+  labels:
+    heritage: deckhouse
+    module: cloud-provider-dvp
+provisioner: csi.dvp.deckhouse.io
+parameters:
+  dvpStorageClass: retained
+reclaimPolicy: Retain
+allowVolumeExpansion: false
+volumeBindingMode: WaitForFirstConsumer
+`
+
+	Context("When cluster state is empty", func() {
+		f := HookExecutionConfigInit(initValues, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should succeed and leave internal values empty", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").String()).To(BeEmpty())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("When only managed StorageClass snapshots are present", func() {
+		f := HookExecutionConfigInit(initValues, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateBeforeHelmContext(), f.KubeStateSet(storageClassesOnly))
+			f.RunHook()
+		})
+
+		It("Should discover storage classes from snapshots and normalize volumeBindingMode", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
+    "name": "replicated",
+    "dvpStorageClass": "replicated",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Delete",
+    "allowVolumeExpansion": true,
+    "isDefault": true
+  },
+  {
+    "name": "secondary",
+    "dvpStorageClass": "secondary",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Retain",
+    "allowVolumeExpansion": false,
+    "isDefault": false
+  }
+]
+`))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").String()).To(Equal("replicated"))
+			Expect(f.KubernetesGlobalResource("StorageClass", "replicated").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("StorageClass", "secondary").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When discovery data and managed StorageClasses are present", func() {
+		f := HookExecutionConfigInit(initValuesWithExclude, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(
+				f.GenerateBeforeHelmContext(),
+				f.KubeStateSet(discoverySecret+existingStorageClass+existingRetainedStorageClass),
+			)
+			f.RunHook()
+		})
+
+		It("Should merge discovery data with snapshots, apply excludes and keep only enabled classes", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData.apiVersion").String()).To(Equal("deckhouse.io/v1"))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData.kind").String()).To(Equal("DVPCloudDiscoveryData"))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.providerDiscoveryData.zones").String()).To(MatchJSON(`["default"]`))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.storageClasses").String()).To(MatchJSON(`
+[
+  {
+    "name": "replicated",
+    "dvpStorageClass": "replicated",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Delete",
+    "allowVolumeExpansion": true,
+    "isDefault": true
+  },
+  {
+    "name": "retained",
+    "dvpStorageClass": "retained",
+    "volumeBindingMode": "WaitForFirstConsumer",
+    "reclaimPolicy": "Retain",
+    "allowVolumeExpansion": false,
+    "isDefault": false
+  }
+]
+`))
+			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").String()).To(Equal("replicated"))
+			Expect(f.KubernetesGlobalResource("StorageClass", "replicated").Exists()).To(BeFalse())
+			Expect(f.KubernetesGlobalResource("StorageClass", "retained").Exists()).To(BeTrue())
+		})
+	})
+
+	Context("When no discovered class is marked as default", func() {
+		nonDefaultDiscoveryData := `
+{
+  "apiVersion": "deckhouse.io/v1",
+  "kind": "DVPCloudDiscoveryData",
+  "zones": ["default"],
+  "storageClasses": [
+    {
+      "name": "replicated",
+      "volumeBindingMode": "Immediate",
+      "reclaimPolicy": "Delete",
+      "allowVolumeExpansion": true,
+      "isEnabled": true,
+      "isDefault": false
+    }
+  ]
+}
+`
+		nonDefaultDiscoverySecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cloud-provider-discovery-data
+  namespace: kube-system
+data:
+  "discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(nonDefaultDiscoveryData)))
+
+		f := HookExecutionConfigInit(initValuesWithExclude, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(
+				f.GenerateBeforeHelmContext(),
+				f.KubeStateSet(nonDefaultDiscoverySecret),
+			)
+			f.RunHook()
+		})
+
+		It("Should remove stale defaultStorageClass", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("cloudProviderDvp.internal.defaultStorageClass").Exists()).To(BeFalse())
+		})
+	})
+
+	Context("When discovery data secret contains invalid payload", func() {
+		invalidDiscoverySecret := fmt.Sprintf(`
+apiVersion: v1
+kind: Secret
+metadata:
+  name: d8-cloud-provider-discovery-data
+  namespace: kube-system
+data:
+  "discovery-data.json": %s
+`, base64.StdEncoding.EncodeToString([]byte(`{"apiVersion":"deckhouse.io/v1","kind":"DVPCloudDiscoveryData","storageClasses":"broken"}`)))
+
+		f := HookExecutionConfigInit(initValues, `{}`)
+		BeforeEach(func() {
+			f.BindingContexts.Set(
+				f.GenerateBeforeHelmContext(),
+				f.KubeStateSet(invalidDiscoverySecret),
+			)
+			f.RunHook()
+		})
+
+		It("Should fail validation", func() {
+			Expect(f).To(Not(ExecuteSuccessfully()))
+		})
+	})
+
+	DescribeTable("getStorageClassName",
+		func(input, expected string) {
+			Expect(getStorageClassName(input)).To(Equal(expected))
+		},
+		Entry("keeps valid name", "replicated", "replicated"),
+		Entry("normalizes spaces and case", "Excluded Fast", "excluded-fast"),
+		Entry("removes invalid symbols and trims ends", "-Xx__$()? -foo-", "xx--foo"),
+		Entry("trims dots and dashes", ".. YY fast SSD-foo.-", "yy-fast-ssd-foo"),
+	)
+
+	DescribeTable("storageClassToStorageClassValue",
+		func(input *storagev1.StorageClass, expected storageClass) {
+			Expect(storageClassToStorageClassValue(input)).To(Equal(expected))
+		},
+		Entry("uses defaults for nil optional fields",
+			&storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "replicated",
+				},
+				Parameters: map[string]string{
+					"dvpStorageClass": "replicated",
+				},
+			},
+			storageClass{
+				Name:                 "replicated",
+				DVPStorageClass:      "replicated",
+				VolumeBindingMode:    string(desiredVolumeBindingMode),
+				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
+				AllowVolumeExpansion: false,
+				IsDefault:            false,
+			},
+		),
+		Entry("reads stable default annotation and optional fields",
+			&storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "stable-default",
+					Annotations: map[string]string{
+						stableDefaultAnnotation: "TrUe",
+					},
+				},
+				Parameters: map[string]string{
+					"dvpStorageClass": "stable-default",
+				},
+				ReclaimPolicy:        ptrTo(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: ptrTo(true),
+			},
+			storageClass{
+				Name:                 "stable-default",
+				DVPStorageClass:      "stable-default",
+				VolumeBindingMode:    string(desiredVolumeBindingMode),
+				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimRetain),
+				AllowVolumeExpansion: true,
+				IsDefault:            true,
+			},
+		),
+		Entry("reads beta default annotation",
+			&storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "beta-default",
+					Annotations: map[string]string{
+						betaDefaultAnnotation: "true",
+					},
+				},
+				Parameters: map[string]string{
+					"dvpStorageClass": "beta-default",
+				},
+			},
+			storageClass{
+				Name:                 "beta-default",
+				DVPStorageClass:      "beta-default",
+				VolumeBindingMode:    string(desiredVolumeBindingMode),
+				ReclaimPolicy:        string(corev1.PersistentVolumeReclaimDelete),
+				AllowVolumeExpansion: false,
+				IsDefault:            true,
+			},
+		),
+	)
+})
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
@@ -36,9 +36,10 @@ import (
 )
 
 const (
-	stableDefaultAnnotation = "storageclass.kubernetes.io/is-default-class"
-	betaDefaultAnnotation   = "storageclass.beta.kubernetes.io/is-default-class"
-	skipSCAnnotation        = "cloud-provider.deckhouse.io/skip-storage-class"
+	stableDefaultAnnotation  = "storageclass.kubernetes.io/is-default-class"
+	betaDefaultAnnotation    = "storageclass.beta.kubernetes.io/is-default-class"
+	skipSCAnnotation         = "cloud-provider.deckhouse.io/skip-storage-class"
+	desiredVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 )
 
 type CloudConfig struct {
@@ -155,11 +156,6 @@ func mergeStorageDomains(
 	result := []cloudDataV1.DVPStorageClass{}
 	cloudSdsMap := make(map[string]cloudDataV1.DVPStorageClass)
 	for _, sc := range cloudSds {
-		volumeBindingMode := storagev1.VolumeBindingWaitForFirstConsumer
-		if sc.VolumeBindingMode != nil {
-			volumeBindingMode = *sc.VolumeBindingMode
-		}
-
 		reclaimPolicy := corev1.PersistentVolumeReclaimDelete
 		if sc.ReclaimPolicy != nil {
 			reclaimPolicy = *sc.ReclaimPolicy
@@ -172,7 +168,7 @@ func mergeStorageDomains(
 
 		cloudSdsMap[sc.Name] = cloudDataV1.DVPStorageClass{
 			Name:                 sc.Name,
-			VolumeBindingMode:    string(volumeBindingMode),
+			VolumeBindingMode:    string(desiredVolumeBindingMode),
 			ReclaimPolicy:        string(reclaimPolicy),
 			AllowVolumeExpansion: allowVolumeExpansion,
 			IsEnabled:            true,

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer.go
@@ -39,7 +39,7 @@ const (
 	stableDefaultAnnotation  = "storageclass.kubernetes.io/is-default-class"
 	betaDefaultAnnotation    = "storageclass.beta.kubernetes.io/is-default-class"
 	skipSCAnnotation         = "cloud-provider.deckhouse.io/skip-storage-class"
-	desiredVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
+	defaultVolumeBindingMode = storagev1.VolumeBindingWaitForFirstConsumer
 )
 
 type CloudConfig struct {
@@ -168,7 +168,7 @@ func mergeStorageDomains(
 
 		cloudSdsMap[sc.Name] = cloudDataV1.DVPStorageClass{
 			Name:                 sc.Name,
-			VolumeBindingMode:    string(desiredVolumeBindingMode),
+			VolumeBindingMode:    string(defaultVolumeBindingMode),
 			ReclaimPolicy:        string(reclaimPolicy),
 			AllowVolumeExpansion: allowVolumeExpansion,
 			IsEnabled:            true,

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer_test.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer_test.go
+++ b/modules/030-cloud-provider-dvp/images/cloud-data-discoverer/src/discoverer_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cloudDataV1 "github.com/deckhouse/deckhouse/go_lib/cloud-data/apis/v1"
+)
+
+func TestMergeStorageDomainsAlwaysUsesWaitForFirstConsumer(t *testing.T) {
+	immediate := storagev1.VolumeBindingImmediate
+	deletePolicy := corev1.PersistentVolumeReclaimDelete
+	allowVolumeExpansion := true
+
+	result := mergeStorageDomains([]cloudDataV1.DVPStorageClass{
+		{
+			Name:                 "legacy",
+			VolumeBindingMode:    "Immediate",
+			ReclaimPolicy:        "Retain",
+			AllowVolumeExpansion: false,
+			IsEnabled:            true,
+			IsDefault:            true,
+		},
+	}, []storagev1.StorageClass{
+		{
+			ObjectMeta:           newObjectMeta("replicated", map[string]string{stableDefaultAnnotation: "true"}),
+			VolumeBindingMode:    &immediate,
+			ReclaimPolicy:        &deletePolicy,
+			AllowVolumeExpansion: &allowVolumeExpansion,
+		},
+		{
+			ObjectMeta:        newObjectMeta("skipped", map[string]string{skipSCAnnotation: "TRUE"}),
+			ReclaimPolicy:     &deletePolicy,
+			VolumeBindingMode: &immediate,
+		},
+	})
+
+	if len(result) != 3 {
+		t.Fatalf("expected three storage classes, got %d", len(result))
+	}
+
+	if result[0].Name != "legacy" || result[1].Name != "replicated" || result[2].Name != "skipped" {
+		t.Fatalf("expected sorted storage classes [legacy replicated skipped], got [%s %s %s]", result[0].Name, result[1].Name, result[2].Name)
+	}
+
+	if result[0].VolumeBindingMode != "Immediate" {
+		t.Fatalf("expected stored storage class to preserve existing volumeBindingMode, got %q", result[0].VolumeBindingMode)
+	}
+
+	if result[0].IsDefault {
+		t.Fatalf("expected stored-only storage class default flag to be reset")
+	}
+
+	if result[1].VolumeBindingMode != string(storagev1.VolumeBindingWaitForFirstConsumer) {
+		t.Fatalf("expected volumeBindingMode %q, got %q", storagev1.VolumeBindingWaitForFirstConsumer, result[1].VolumeBindingMode)
+	}
+
+	if result[1].ReclaimPolicy != string(deletePolicy) {
+		t.Fatalf("expected reclaimPolicy %q, got %q", deletePolicy, result[1].ReclaimPolicy)
+	}
+
+	if result[1].AllowVolumeExpansion != allowVolumeExpansion {
+		t.Fatalf("expected allowVolumeExpansion %t, got %t", allowVolumeExpansion, result[1].AllowVolumeExpansion)
+	}
+
+	if !result[1].IsEnabled || !result[1].IsDefault {
+		t.Fatalf("expected replicated storage class to be enabled and default, got enabled=%t default=%t", result[1].IsEnabled, result[1].IsDefault)
+	}
+
+	if result[2].VolumeBindingMode != string(storagev1.VolumeBindingWaitForFirstConsumer) {
+		t.Fatalf("expected skipped storage class volumeBindingMode %q, got %q", storagev1.VolumeBindingWaitForFirstConsumer, result[2].VolumeBindingMode)
+	}
+
+	if result[2].IsEnabled {
+		t.Fatalf("expected skipped storage class to be disabled")
+	}
+
+	if result[2].IsDefault {
+		t.Fatalf("expected skipped storage class to not be default")
+	}
+}
+
+func TestMergeStorageDomainsSupportsBetaDefaultAnnotation(t *testing.T) {
+	result := mergeStorageDomains(nil, []storagev1.StorageClass{
+		{
+			ObjectMeta: newObjectMeta("beta-default", map[string]string{
+				betaDefaultAnnotation: "TrUe",
+			}),
+		},
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected one storage class, got %d", len(result))
+	}
+
+	if !result[0].IsDefault {
+		t.Fatalf("expected storage class with beta default annotation to be default")
+	}
+}
+
+func TestMergeStorageDomainsUsesDefaultsForNilFieldsAndSkipsStoredDuplicates(t *testing.T) {
+	result := mergeStorageDomains([]cloudDataV1.DVPStorageClass{
+		{
+			Name:                 "duplicated",
+			VolumeBindingMode:    "Immediate",
+			ReclaimPolicy:        "Retain",
+			AllowVolumeExpansion: true,
+			IsEnabled:            false,
+			IsDefault:            true,
+		},
+		{
+			Name:                 "stored-only",
+			VolumeBindingMode:    "Immediate",
+			ReclaimPolicy:        "Retain",
+			AllowVolumeExpansion: true,
+			IsEnabled:            true,
+			IsDefault:            true,
+		},
+	}, []storagev1.StorageClass{
+		{
+			ObjectMeta: newObjectMeta("duplicated", nil),
+		},
+	})
+
+	if len(result) != 2 {
+		t.Fatalf("expected two storage classes, got %d", len(result))
+	}
+
+	if result[0].Name != "duplicated" || result[1].Name != "stored-only" {
+		t.Fatalf("unexpected storage class order: [%s %s]", result[0].Name, result[1].Name)
+	}
+
+	if result[0].ReclaimPolicy != string(corev1.PersistentVolumeReclaimDelete) {
+		t.Fatalf("expected default reclaim policy %q, got %q", corev1.PersistentVolumeReclaimDelete, result[0].ReclaimPolicy)
+	}
+
+	if result[0].AllowVolumeExpansion {
+		t.Fatalf("expected allowVolumeExpansion to default to false")
+	}
+
+	if result[0].IsDefault {
+		t.Fatalf("expected discovered storage class without annotations to not be default")
+	}
+
+	if result[1].Name != "stored-only" {
+		t.Fatalf("expected stored-only storage class to be preserved")
+	}
+}
+
+func newObjectMeta(name string, annotations map[string]string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:        name,
+		Annotations: annotations,
+	}
+}


### PR DESCRIPTION
## Description

Stop copying `volumeBindingMode` from the parent DVP cluster into child-cluster `StorageClass` objects and always use `WaitForFirstConsumer` instead. This also recreates an existing Deckhouse-managed child-cluster `StorageClass` when it still uses an incompatible binding mode, so upgrades no longer fail on the immutable `volumeBindingMode` field.

## Why do we need it, and what problem does it solve?

Changing the parent cluster replicated storage class to `Immediate` caused `cloud-provider-dvp` to render the same mode in child clusters. If a child cluster already had the same `StorageClass` with `WaitForFirstConsumer`, Helm upgrade failed with `StorageClass.storage.k8s.io "<name>" is invalid: volumeBindingMode: Invalid value: "Immediate": field is immutable`, which blocked rollouts and left queues stuck in affected nested clusters.

This change decouples child-cluster storage behavior from the parent cluster and keeps child-cluster `StorageClass` objects stable by always rendering `WaitForFirstConsumer`. It also handles already-created incompatible classes during upgrade by deleting the managed `StorageClass` before Helm reapplies it.

## Why do we need it in the patch release (if we do)?

This should be backported because the bug can break upgrades and reconciliation in existing child clusters after a parent-cluster storage class change. The failure is operationally disruptive and was discussed as an ASAP fix for affected environments.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cloud-provider-dvp
type: fix
summary: Always use WaitForFirstConsumer for child-cluster DVP StorageClasses and recreate incompatible managed classes during upgrade.
impact_level: default
```