### PR TITLE
[istio] Separate templates below 1.27 and fix hooks

### DIFF
--- a/modules/110-istio/hooks/discovery_istiod_health_test.go
+++ b/modules/110-istio/hooks/discovery_istiod_health_test.go
@@ -74,8 +74,8 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
   {"internal":
     { "versionMap":
      {
-        "1.33": {
-          "revision": "v1x33",
+        "1.13": {
+          "revision": "v1x13",
           "fullVersion": "1.13.55",
           "supportsAmbient": false,
           "supportsOperator": true
@@ -141,7 +141,7 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeFalse())
-			Expect(f.ValuesGet(versionMapPath).String()).To(MatchJSON(`{"1.33":{"fullVersion":"1.13.55","revision":"v1x33","imageSuffix":"","isReady":false,"supportsAmbient":false,"supportsOperator":true},"1.88":{"fullVersion":"1.88.55","revision":"v1x88","imageSuffix":"","isReady":false,"supportsAmbient":true,"supportsOperator":false}}`))
+			Expect(f.ValuesGet(versionMapPath).String()).To(MatchJSON(`{"1.13":{"fullVersion":"1.13.55","revision":"v1x13","imageSuffix":"","isReady":false,"supportsAmbient":false,"supportsOperator":true},"1.88":{"fullVersion":"1.88.55","revision":"v1x88","imageSuffix":"","isReady":false,"supportsAmbient":true,"supportsOperator":false}}`))
 		})
 	})
 
@@ -159,16 +159,16 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeTrue())
 			versionMap := f.ValuesGet(versionMapPath).Map()
-			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": false,"supportsAmbient":false,"supportsOperator":true}`))
+			Expect(versionMap["1.13"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x13","imageSuffix": "","isReady": false,"supportsAmbient":false,"supportsOperator":true}`))
 			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": true,"supportsAmbient":true,"supportsOperator":false}`))
 		})
 	})
 
 	Context("Istiod pods in `Running` phase and injector webhook with old full version", func() {
 		BeforeEach(func() {
-			f.ValuesSet("istio.internal.globalVersion", "1.33")
+			f.ValuesSet("istio.internal.globalVersion", "1.13")
 			f.BindingContexts.Set(f.KubeStateSet(podIstiodYaml(PodIstiodTemplateParams{
-				Revision: "v1x33",
+				Revision: "v1x13",
 				Phase:    "Running",
 			}) + "---" + istioSidecarInjectorGlobalWebhook))
 			f.RunHook()
@@ -178,7 +178,7 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeTrue())
 			versionMap := f.ValuesGet(versionMapPath).Map()
-			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": false,"supportsAmbient":false,"supportsOperator":true}`))
+			Expect(versionMap["1.13"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x13","imageSuffix": "","isReady": false,"supportsAmbient":false,"supportsOperator":true}`))
 			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": false,"supportsAmbient":true,"supportsOperator":false}`))
 		})
 	})
@@ -192,7 +192,7 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 					Phase:    "Running",
 				}) + "---" +
 					podIstiodYaml(PodIstiodTemplateParams{
-						Revision: "v1x33",
+						Revision: "v1x13",
 						Phase:    "Running",
 					})))
 			f.RunHook()
@@ -202,7 +202,7 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Exists()).To(BeTrue())
 			Expect(f.ValuesGet(isGlobalVersionIstiodReadyPath).Bool()).To(BeTrue())
 			versionMap := f.ValuesGet(versionMapPath).Map()
-			Expect(versionMap["1.33"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x33","imageSuffix": "","isReady": true,"supportsAmbient":false,"supportsOperator":true}`))
+			Expect(versionMap["1.13"]).To(MatchJSON(`{"fullVersion": "1.13.55","revision": "v1x13","imageSuffix": "","isReady": true,"supportsAmbient":false,"supportsOperator":true}`))
 			Expect(versionMap["1.88"]).To(MatchJSON(`{"fullVersion": "1.88.55","revision": "v1x88","imageSuffix": "","isReady": false,"supportsAmbient":true,"supportsOperator":false}`))
 		})
 	})
@@ -226,7 +226,7 @@ var _ = Describe("Istio hooks :: discovery istiod health ::", func() {
 
 	Context("Istiod pods with `Running` phase but with different revision", func() {
 		BeforeEach(func() {
-			f.ValuesSet("istio.internal.globalVersion", "1.33")
+			f.ValuesSet("istio.internal.globalVersion", "1.13")
 			f.BindingContexts.Set(f.KubeStateSet(podIstiodYaml(PodIstiodTemplateParams{
 				Revision: "v1x88",
 				Phase:    "Running",

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -106,7 +106,11 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 
 	var versionsToInstallResult = input.Values.Get("istio.internal.versionsToInstall").Array()
 	for _, versionResult := range versionsToInstallResult {
-		operatorVersionsToInstall = append(operatorVersionsToInstall, versionResult.String())
+		version := versionResult.String()
+		if !versionMap.DoesSupportOperator(version) {
+			continue
+		}
+		operatorVersionsToInstall = append(operatorVersionsToInstall, version)
 	}
 
 	for iopInfo, err := range sdkobjectpatch.SnapshotIter[IstioOperatorCrdInfo](input.Snapshots.Get("istiooperators")) {
@@ -117,6 +121,9 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 		iopVer := versionMap.GetVersionByRevision(iopInfo.Revision)
 		if !versionMap.IsRevisionSupported(iopInfo.Revision) {
 			unsupportedRevisions = append(unsupportedRevisions, iopInfo.Revision)
+			continue
+		}
+		if !versionMap.DoesSupportOperator(iopVer) {
 			continue
 		}
 		if !lib.Contains(operatorVersionsToInstall, iopVer) {
@@ -149,6 +156,9 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 			istioVer := versionMap.GetVersionByRevision(istioInfo.Revision)
 			if !versionMap.IsRevisionSupported(istioInfo.Revision) {
 				unsupportedRevisions = append(unsupportedRevisions, istioInfo.Revision)
+				continue
+			}
+			if !versionMap.DoesSupportOperator(istioVer) {
 				continue
 			}
 			if !lib.Contains(operatorVersionsToInstall, istioVer) {

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install.go
@@ -107,7 +107,7 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 	var versionsToInstallResult = input.Values.Get("istio.internal.versionsToInstall").Array()
 	for _, versionResult := range versionsToInstallResult {
 		version := versionResult.String()
-		if !versionMap.DoesSupportOperator(version) {
+		if !versionMap.DoesVersionSupportOperator(version) {
 			continue
 		}
 		operatorVersionsToInstall = append(operatorVersionsToInstall, version)
@@ -123,7 +123,7 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 			unsupportedRevisions = append(unsupportedRevisions, iopInfo.Revision)
 			continue
 		}
-		if !versionMap.DoesSupportOperator(iopVer) {
+		if !versionMap.DoesVersionSupportOperator(iopVer) {
 			continue
 		}
 		if !lib.Contains(operatorVersionsToInstall, iopVer) {
@@ -158,7 +158,7 @@ func operatorRevisionsToInstallDiscovery(_ context.Context, input *go_hook.HookI
 				unsupportedRevisions = append(unsupportedRevisions, istioInfo.Revision)
 				continue
 			}
-			if !versionMap.DoesSupportOperator(istioVer) {
+			if !versionMap.DoesVersionSupportOperator(istioVer) {
 				continue
 			}
 			if !lib.Contains(operatorVersionsToInstall, istioVer) {

--- a/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
@@ -36,8 +36,10 @@ internal:
   versionMap:
      "1.1":
         revision: "v1x1"
+        supportsOperator: true
      "1.2":
         revision: "v1x2"
+        supportsOperator: true
   versionsToInstall: ["1.1"]
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
@@ -65,14 +67,19 @@ internal:
   versionMap:
     "1.1":
         revision: "v1x1"
+        supportsOperator: true
     "1.8":
         revision: "v1x8"
+        supportsOperator: true
     "1.2":
         revision: "v1x2"
+        supportsOperator: true
     "1.3":
         revision: "v1x3"
+        supportsOperator: true
     "1.4":
         revision: "v1x4"
+        supportsOperator: true
   versionsToInstall: ["1.3", "1.4"]
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
@@ -114,14 +121,19 @@ internal:
   versionMap:
     "1.1":
         revision: "v1x1"
+        supportsOperator: true
     "1.8":
         revision: "v1x8"
+        supportsOperator: true
     "1.2":
         revision: "v1x2"
+        supportsOperator: true
     "1.3":
         revision: "v1x3"
+        supportsOperator: true
     "1.4":
         revision: "v1x4"
+        supportsOperator: true
   versionsToInstall: ["1.3", "1.4"]
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
@@ -163,14 +175,19 @@ internal:
   versionMap:
     "1.1":
         revision: "v1x1"
+        supportsOperator: true
     "1.8":
         revision: "v1x8"
+        supportsOperator: true
     "1.2":
         revision: "v1x2"
+        supportsOperator: true
     "1.3":
         revision: "v1x3"
+        supportsOperator: true
     "1.4":
         revision: "v1x4"
+        supportsOperator: true
   versionsToInstall: ["1.3", "1.4"]
 `
 			f.ValuesSetFromYaml("istio", []byte(values))
@@ -211,6 +228,67 @@ spec:
 			value, exists := requirements.GetValue(minVersionValuesKey)
 			Expect(exists).To(BeTrue())
 			Expect(value).To(BeEquivalentTo("1.2"))
+		})
+	})
+
+	Context("Operator-free versions are excluded from operatorVersionsToInstall", func() {
+		BeforeEach(func() {
+			values := `
+internal:
+  versionMap:
+    "1.25":
+        revision: "v1x25"
+        supportsOperator: true
+    "1.27":
+        revision: "v1x27"
+        supportsOperator: false
+  versionsToInstall: ["1.25", "1.27"]
+`
+			f.ValuesSetFromYaml("istio", []byte(values))
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should include only operator-supported versions", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(Equal([]string{"1.25"}))
+
+			value, exists := requirements.GetValue(minVersionValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("1.25"))
+		})
+	})
+
+	Context("Operator-free IstioOperator in cluster is ignored", func() {
+		BeforeEach(func() {
+			values := `
+internal:
+  versionMap:
+    "1.27":
+        revision: "v1x27"
+        supportsOperator: false
+  versionsToInstall: []
+`
+			f.ValuesSetFromYaml("istio", []byte(values))
+			f.BindingContexts.Set(f.KubeStateSet(`
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: v1x27
+  namespace: d8-istio
+spec:
+  revision: v1x27
+`))
+			f.RunHook()
+		})
+
+		It("Should not add operator-free version from CRD", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(BeEmpty())
+
+			_, exists := requirements.GetValue(minVersionValuesKey)
+			Expect(exists).To(BeFalse())
 		})
 	})
 })

--- a/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
+++ b/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
@@ -65,13 +65,12 @@ func (vm IstioVersionsMap) DoesSupportAmbient(fullVer string) bool {
 	return false
 }
 
-func (vm IstioVersionsMap) DoesSupportOperator(fullVer string) bool {
-	for _, istioVerInfo := range vm {
-		if istioVerInfo.FullVersion == fullVer {
-			return istioVerInfo.SupportsOperator
-		}
+func (vm IstioVersionsMap) DoesSupportOperator(version string) bool {
+	istioVerInfo, ok := vm[version]
+	if !ok {
+		return false
 	}
-	return false
+	return istioVerInfo.SupportsOperator
 }
 
 func (vm IstioVersionsMap) IsRevisionSupported(rev string) bool {

--- a/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
+++ b/modules/110-istio/hooks/lib/istio_versions/istio_versions.go
@@ -65,7 +65,16 @@ func (vm IstioVersionsMap) DoesSupportAmbient(fullVer string) bool {
 	return false
 }
 
-func (vm IstioVersionsMap) DoesSupportOperator(version string) bool {
+func (vm IstioVersionsMap) DoesSupportOperator(fullVer string) bool {
+	for _, istioVerInfo := range vm {
+		if istioVerInfo.FullVersion == fullVer {
+			return istioVerInfo.SupportsOperator
+		}
+	}
+	return false
+}
+
+func (vm IstioVersionsMap) DoesVersionSupportOperator(version string) bool {
 	istioVerInfo, ok := vm[version]
 	if !ok {
 		return false

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -75,11 +75,13 @@ const istioValues = `
           fullVersion: "1.25.2"
           imageSuffix: "V1x25x2"
           supportsAmbient: true
+          supportsOperator: true
         "1.21.6":
           revision: "v1x21x6"
           fullVersion: "1.21.6"
           imageSuffix: "V1x21x6"
           supportsAmbient: false
+          supportsOperator: true
       kialiSigningKey: "kiali"
       operatorVersionsToInstall: []
       versionsToInstall: []

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -9,6 +9,7 @@
 
 {{- range $version := .Values.istio.internal.versionsToInstall }}
   {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+  {{- if get $versionInfo "supportsOperator" }}
   {{- $revision := get $versionInfo "revision"}}
   {{- $imageSuffix := get $versionInfo "imageSuffix" }}
   {{- $fullVersion := get $versionInfo "fullVersion" }}
@@ -277,5 +278,6 @@ spec:
       - matchExpressions:
         - key: job-name
           operator: Exists
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -9,6 +9,7 @@
 
 {{- range $version := .Values.istio.internal.versionsToInstall }}
   {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+  {{- if get $versionInfo "supportsOperator" }}
   {{- $revision := get $versionInfo "revision"}}
   {{- $imageSuffix := get $versionInfo "imageSuffix" }}
   {{- $fullVersion := get $versionInfo "fullVersion" }}
@@ -259,5 +260,6 @@ spec:
       - matchExpressions:
         - key: job-name
           operator: Exists
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/mutatingwebhook-revisions.yaml
@@ -23,7 +23,7 @@
   admissionReviewVersions: ["v1"]
 {{- end }}
 
-{{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
+{{- range $version := .Values.istio.internal.versionsToInstall }}
 {{- $baseArg := (list $ $version) }}
 ---
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}

--- a/modules/110-istio/templates/control-plane/servicemonitor.yaml
+++ b/modules/110-istio/templates/control-plane/servicemonitor.yaml
@@ -1,6 +1,7 @@
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
   {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+    {{- if get $versionInfo "supportsOperator" }}
     {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -34,5 +35,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/control-plane/servicemonitor.yaml
+++ b/modules/110-istio/templates/control-plane/servicemonitor.yaml
@@ -1,7 +1,6 @@
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
-  {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
+  {{- range $version := .Values.istio.internal.versionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
-    {{- if get $versionInfo "supportsOperator" }}
     {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -35,6 +34,5 @@ spec:
     - sourceLabels: [__meta_kubernetes_endpointslice_endpoint_conditions_ready]
       regex: "true"
       action: keep
-    {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
+++ b/modules/110-istio/templates/control-plane/validatingwebhook-revisions.yaml
@@ -1,4 +1,4 @@
-{{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
+{{- range $version := .Values.istio.internal.versionsToInstall }}
 {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
 {{- $revision := get $versionInfo "revision" }}
 ---

--- a/modules/110-istio/templates/operator/configmap-lock.yaml
+++ b/modules/110-istio/templates/operator/configmap-lock.yaml
@@ -1,5 +1,6 @@
 {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
   {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+  {{- if get $versionInfo "supportsOperator" }}
   {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: v1
@@ -8,4 +9,5 @@ metadata:
   name: istio-operator-lock-{{ $revision }}
   namespace: d8-istio
   {{- include "helm_lib_module_labels" (list $ (dict "app" "operator" "revision" $revision)) | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/operator/deployment.yaml
+++ b/modules/110-istio/templates/operator/deployment.yaml
@@ -10,6 +10,7 @@ memory: 100Mi
 
 {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
   {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+  {{- if get $versionInfo "supportsOperator" }}
   {{- $fullVersion := get $versionInfo "fullVersion" }}
   {{ $imageSuffix := get $versionInfo "imageSuffix" }}
   {{- $revision := get $versionInfo "revision" }}
@@ -142,4 +143,5 @@ spec:
               path: config.properties
           name: operator-config
       {{- end }}
+  {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/operator/podmonitor.yaml
+++ b/modules/110-istio/templates/operator/podmonitor.yaml
@@ -1,6 +1,7 @@
 {{- if (.Values.global.enabledModules | has "operator-prometheus") }}
   {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+    {{- if get $versionInfo "supportsOperator" }}
     {{- $revision := get $versionInfo "revision" }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -42,5 +43,6 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_ready]
       regex: "true"
       action: keep
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/operator/rbac-for-us.yaml
+++ b/modules/110-istio/templates/operator/rbac-for-us.yaml
@@ -1,5 +1,6 @@
 {{- range $version := .Values.istio.internal.operatorVersionsToInstall }}
   {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+  {{- if get $versionInfo "supportsOperator" }}
   {{- $revision := get $versionInfo "revision" }}
   {{- $fullVersion := get $versionInfo "fullVersion" }}
 ---
@@ -536,4 +537,5 @@ roleRef:
   kind: ClusterRole
   name: d8:istio:operator-{{ $revision }}
   apiGroup: rbac.authorization.k8s.io
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

- skip operator/IOP/Sail install paths when supportsOperator is false.
- render revision webhooks from versionsToInstall; fix istiod health test revision.

## Why do we need it, and what problem does it solve?
This is a third step to introduce istio v 1.27


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Skipped operator/IOP/Sail install paths when supportsOperator is false.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
