### PR TITLE
update lib_helm to fix csi vpa

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.71.12
-digest: sha256:d31472c1e41b17d01873101fe5bfc4a8d41210399b0738e05f6cea5449829130
-generated: "2026-05-19T16:56:44.321773+07:00"
+  version: 1.72.0
+digest: sha256:f726180e4e40570dbeb4ed1cf000fe1a971458e68272a246745ce8c00ccf2e36
+generated: "2026-05-25T13:33:58.23687+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.71.12"
+    version: "1.72.0"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.71.12
+version: 1.72.0

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_controller.tpl
@@ -150,7 +150,7 @@ spec:
     kind: Deployment
     name: {{ $fullname }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     - containerName: "provisioner"

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_csi_node.tpl
@@ -56,7 +56,7 @@ spec:
     kind: DaemonSet
     name: {{ $fullname }}
   updatePolicy:
-    updateMode: "Auto"
+    updateMode: "InPlaceOrRecreate"
   resourcePolicy:
     containerPolicies:
     {{- if $additionalNodeVPA }}


### PR DESCRIPTION
## Description

Bump `deckhouse_lib_helm` from `1.71.12` to `1.72.0` ([lib-helm#194](https://github.com/deckhouse/lib-helm/pull/194)) to replace deprecated `updateMode: "Auto"` with `updateMode: "InPlaceOrRecreate"` in CSI `VerticalPodAutoscaler` templates.

All modules that render CSI via `helm_lib_csi_controller_manifests` / `helm_lib_csi_node_manifests` (e.g. `cloud-provider-aws`, `cloud-provider-azure`, `cloud-provider-dvp`, `cloud-provider-yandex`, OpenStack, vSphere, and other cloud/CSI modules) pick up this change on the next Helm reconcile. No per-module template edits are required.

This PR does **not** change ingress, control plane, Prometheus, or other critical components directly. CSI controller/node pods may be updated by VPA according to the new mode when recommendations change; behavior is aligned with other platform VPAs that already use `InPlaceOrRecreate`.

## Why do we need it, and what problem does it solve?

Since Vertical Pod Autoscaler 1.5.0, `updateMode: "Auto"` is [deprecated](https://github.com/kubernetes/autoscaler/issues/8424) and produces API warnings on every apply/upgrade:

```
Warning: UpdateMode "Auto" is deprecated and will be removed in a future API version.
Use explicit update modes like "Recreate", "Initial", or "InPlaceOrRecreate" instead.
```

For cloud-provider modules with CSI and VPA enabled, Helm emits **two** such warnings per reconcile (CSI controller + CSI node VPAs), which clutters Deckhouse/module logs and will break once `Auto` is removed from the API.

`InPlaceOrRecreate` is the recommended replacement: VPA tries an in-place resize when the cluster supports it, otherwise recreates the pod — effectively the same operational model as legacy `Auto` (which mapped to recreate-only behavior). See rationale in [lib-helm#194](https://github.com/deckhouse/lib-helm/pull/194).

## Why do we need it in the patch release (if we do)?

Not necessarily. This bumps `lib-helm` by a **minor** version (`1.71.x` → `1.72.0`). Per [helm_lib README](https://github.com/deckhouse/deckhouse/blob/main/helm_lib/README.md), new minor releases should not be backported to an already-released Deckhouse line; use a patch release of `lib-helm` on the release branch if a backport is required.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: "Replace deprecated VPA `updateMode` `Auto` with `InPlaceOrRecreate` for CSI controller and node VPAs."
impact: "Cloud-provider and other modules using CSI helm_lib templates no longer trigger VPA deprecation warnings on upgrade. Existing CSI VPAs are updated to `InPlaceOrRecreate` on the next reconcile."
impact_level: low
```