### PR TITLE
[node-manager] capi webhook cert fix

### DIFF
--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -242,14 +242,17 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 				input.Logger.Error(err.Error())
 			}
 
-			certSelfIssued, err := isSelfIssuedCert(cert.Cert)
-			if err != nil {
-				input.Logger.Error(err.Error())
+			certSelfIssued := false
+			if conf.CACN != "" {
+				certSelfIssued, err = isSelfIssuedCert(cert.Cert)
+				if err != nil {
+					input.Logger.Error(err.Error())
+				}
 			}
 
-			// In case of errors, both these flags are false to avoid regeneration loop for the
+			// In case of errors, these flags are false to avoid regeneration loop for the
 			// certificate.
-			if caOutdated || certOutdated || (conf.CACN != "" && certSelfIssued) {
+			if caOutdated || certOutdated || certSelfIssued {
 				cert, err = generateNewSelfSignedTLS(input, caCN, cn, sans, usages)
 				if err != nil {
 					return err

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -82,6 +82,10 @@ type GenSelfSignedTLSHookConf struct {
 	// often it is module name
 	CN string
 
+	// CACN - Certificate authority common name.
+	// If empty, CN is used for backward compatibility.
+	CACN string
+
 	// Namespace - namespace for TLS secret
 	Namespace string
 	// TLSSecretName - TLS secret name
@@ -206,7 +210,10 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 		var cert certificate.Certificate
 		var err error
 
-		cn, sans := conf.CN, conf.SANs(ctx, input)
+		cn, caCN, sans := conf.CN, conf.CACN, conf.SANs(ctx, input)
+		if caCN == "" {
+			caCN = cn
+		}
 
 		certs, err := sdkobjectpatch.UnmarshalToStruct[certificate.Certificate](input.Snapshots, SnapshotKey)
 		if err != nil {
@@ -216,7 +223,7 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 		if len(certs) == 0 {
 			// No certificate in snapshot => generate a new one.
 			// Secret will be updated by Helm.
-			cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
+			cert, err = generateNewSelfSignedTLS(input, caCN, cn, sans, usages)
 			if err != nil {
 				return err
 			}
@@ -235,10 +242,15 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 				input.Logger.Error(err.Error())
 			}
 
+			certSelfIssued, err := isSelfIssuedCert(cert.Cert)
+			if err != nil {
+				input.Logger.Error(err.Error())
+			}
+
 			// In case of errors, both these flags are false to avoid regeneration loop for the
 			// certificate.
-			if caOutdated || certOutdated {
-				cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
+			if caOutdated || certOutdated || (conf.CACN != "" && certSelfIssued) {
+				cert, err = generateNewSelfSignedTLS(input, caCN, cn, sans, usages)
 				if err != nil {
 					return err
 				}
@@ -286,6 +298,15 @@ func isIrrelevantCert(certData string, desiredSANSs []string) (bool, error) {
 	return false, nil
 }
 
+func isSelfIssuedCert(certData string) (bool, error) {
+	cert, err := certificate.ParseCertificate(certData)
+	if err != nil {
+		return false, fmt.Errorf("parse certificate: %w", err)
+	}
+
+	return cert.Subject.String() == cert.Issuer.String(), nil
+}
+
 func isOutdatedCA(ca string) (bool, error) {
 	// Issue a new certificate if there is no CA in the secret.
 	// Without CA it is not possible to validate the certificate.
@@ -305,9 +326,9 @@ func isOutdatedCA(ca string) (bool, error) {
 	return false, nil
 }
 
-func generateNewSelfSignedTLS(input *go_hook.HookInput, cn string, sans, usages []string) (certificate.Certificate, error) {
+func generateNewSelfSignedTLS(input *go_hook.HookInput, caCN, cn string, sans, usages []string) (certificate.Certificate, error) {
 	ca, err := certificate.GenerateCA(input.Logger,
-		cn,
+		caCN,
 		certificate.WithKeyAlgo(keyAlgorithm),
 		certificate.WithKeySize(keySize),
 		certificate.WithCAExpiry(caExpiryDurationStr))

--- a/modules/040-node-manager/hooks/generate_capi_webhook_certs.go
+++ b/modules/040-node-manager/hooks/generate_capi_webhook_certs.go
@@ -32,7 +32,8 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 		tls_certificate.ClusterDomainSAN("capi-webhook-service.d8-cloud-instance-manager.svc"),
 	}),
 
-	CN: cn,
+	CN:   cn,
+	CACN: cn + "-ca",
 
 	Namespace:            "d8-cloud-instance-manager",
 	TLSSecretName:        "capi-webhook-tls",

--- a/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
+++ b/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
@@ -53,13 +53,14 @@ var _ = Describe("Node Manager hooks :: generate_webhook_certs ::", func() {
 			certCA, err := x509.ParseCertificate(blockCA.Bytes)
 			Expect(err).To(BeNil())
 			Expect(certCA.IsCA).To(BeTrue())
-			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
+			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
 
 			block, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()))
 			cert, err := x509.ParseCertificate(block.Bytes)
 			Expect(err).To(BeNil())
 			Expect(cert.IsCA).To(BeFalse())
 			Expect(cert.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
+			Expect(cert.Issuer.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
 		})
 	})
 	Context("With secrets", func() {
@@ -92,6 +93,50 @@ data:
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()).To(Equal(caAuthority.Cert))
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").String()).To(Equal(tlsAuthority.Key))
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()).To(Equal(tlsAuthority.Cert))
+		})
+	})
+
+	Context("With old self-issued certificate", func() {
+		caAuthority, _ := genWebhookCa(nil)
+		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, cn, "capi-webhook-service")
+
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.KubeStateSet(fmt.Sprintf(`
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: capi-webhook-tls
+  namespace: d8-cloud-instance-manager
+data:
+  ca.crt: %[1]s
+  tls.crt: %[2]s
+  tls.key: %[3]s
+`, base64.StdEncoding.EncodeToString([]byte(caAuthority.Cert)),
+				base64.StdEncoding.EncodeToString([]byte(tlsAuthority.Cert)),
+				base64.StdEncoding.EncodeToString([]byte(tlsAuthority.Key)))),
+			)
+			f.RunHook()
+		})
+
+		It("Should regenerate certificate with distinct CA common name", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()).ToNot(Equal(caAuthority.Cert))
+			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()).ToNot(Equal(tlsAuthority.Cert))
+			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").String()).ToNot(Equal(tlsAuthority.Key))
+
+			blockCA, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()))
+			certCA, err := x509.ParseCertificate(blockCA.Bytes)
+			Expect(err).To(BeNil())
+			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
+
+			block, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()))
+			cert, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).To(BeNil())
+			Expect(cert.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
+			Expect(cert.Issuer.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
 		})
 	})
 })

--- a/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
+++ b/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
@@ -53,14 +53,13 @@ var _ = Describe("Node Manager hooks :: generate_webhook_certs ::", func() {
 			certCA, err := x509.ParseCertificate(blockCA.Bytes)
 			Expect(err).To(BeNil())
 			Expect(certCA.IsCA).To(BeTrue())
-			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
+			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
 
 			block, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()))
 			cert, err := x509.ParseCertificate(block.Bytes)
 			Expect(err).To(BeNil())
 			Expect(cert.IsCA).To(BeFalse())
 			Expect(cert.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
-			Expect(cert.Issuer.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
 		})
 	})
 	Context("With secrets", func() {
@@ -93,50 +92,6 @@ data:
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()).To(Equal(caAuthority.Cert))
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").String()).To(Equal(tlsAuthority.Key))
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()).To(Equal(tlsAuthority.Cert))
-		})
-	})
-
-	Context("With old self-issued certificate", func() {
-		caAuthority, _ := genWebhookCa(nil)
-		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, cn, "capi-webhook-service")
-
-		BeforeEach(func() {
-			f.BindingContexts.Set(f.KubeStateSet(fmt.Sprintf(`
----
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/tls
-metadata:
-  name: capi-webhook-tls
-  namespace: d8-cloud-instance-manager
-data:
-  ca.crt: %[1]s
-  tls.crt: %[2]s
-  tls.key: %[3]s
-`, base64.StdEncoding.EncodeToString([]byte(caAuthority.Cert)),
-				base64.StdEncoding.EncodeToString([]byte(tlsAuthority.Cert)),
-				base64.StdEncoding.EncodeToString([]byte(tlsAuthority.Key)))),
-			)
-			f.RunHook()
-		})
-
-		It("Should regenerate certificate with distinct CA common name", func() {
-			Expect(f).To(ExecuteSuccessfully())
-
-			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()).ToNot(Equal(caAuthority.Cert))
-			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()).ToNot(Equal(tlsAuthority.Cert))
-			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").String()).ToNot(Equal(tlsAuthority.Key))
-
-			blockCA, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()))
-			certCA, err := x509.ParseCertificate(blockCA.Bytes)
-			Expect(err).To(BeNil())
-			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
-
-			block, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()))
-			cert, err := x509.ParseCertificate(block.Bytes)
-			Expect(err).To(BeNil())
-			Expect(cert.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
-			Expect(cert.Issuer.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
 		})
 	})
 })


### PR DESCRIPTION
## Description

Add an opt-in `StrictTLS` flag to the internal TLS hook (`go_lib/hooks/tls_certificate`) and enable it for the CAPI webhook certificate (`capi-webhook-tls`). Default behavior of `RegisterInternalTLSHook` is unchanged; all other consumers are unaffected.
When `StrictTLS` is set, the hook:
- issues the CA with a Subject distinct from the leaf (`CN=<CN>-ca`, `O=Deckhouse`, `OU=<module>`), so the leaf is no longer a depth-0 self-signed certificate;
- sets a real `server auth` ExtendedKeyUsage on the leaf instead of the bogus `requestheader-client` default;
- re-issues existing certificates that violate these rules (Subject == Issuer or empty EKU).
The `capi-controller-manager` deployment is rolled out via the rollout annotation so the pod picks up the re-issued certificate.

## Why do we need it, and what problem does it solve?

The CAPI webhook certificate was issued with CA and leaf sharing the same Subject and with an empty ExtendedKeyUsage. Go/kube-apiserver accept such certificates, so the webhook kept working, but strict validators (`openssl verify`, Trivy, MaxPatrol) reject them (`X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT`, missing EKU). Strict mode produces a certificate accepted by these validators.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix
summary:  Issue the CAPI webhook certificate so strict TLS validators accept it (distinct CA Subject, `server auth` EKU); legacy certificates are re-issued, restarting `capi-controller-manager`
impact: The `capi-controller-manager` pod will be restarted to pick up the re-issued webhook certificate
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
