### PR TITLE
[go_lib/controlplane] add PKI/kubeconfig renewal libraries and structured expiration reports

### DIFF
--- a/go_lib/controlplane/kubeconfig/errors.go
+++ b/go_lib/controlplane/kubeconfig/errors.go
@@ -31,6 +31,16 @@ func (e *MissingError) Error() string {
 	return fmt.Sprintf("kubeconfig file %q not found", e.File)
 }
 
+// CAMissingError is returned when the signing CA certificate file is absent.
+// The client cert cannot be re-signed, so renewal is skipped.
+type CAMissingError struct {
+	CAName string
+}
+
+func (e *CAMissingError) Error() string {
+	return fmt.Sprintf("CA %q certificate not found on disk", e.CAName)
+}
+
 // CAExternalError is returned when the CA certificate exists but its private key does not (external CA scenario).
 // Renewal of the kubeconfig client cert is skipped — only the holder of the CA key can sign new leaf certificates.
 type CAExternalError struct {
@@ -42,7 +52,7 @@ func (e *CAExternalError) Error() string {
 }
 
 // CAExpiredError is returned when the CA certificate has already expired.
-// Renewal is blocked: signing with an expired CA produces certificates that fail chain validation in Kubernetes components.
+// Renewal is skipped: a client cert signed by an expired CA fails chain validation, so re-signing is pointless until the CA is rotated.
 type CAExpiredError struct {
 	CAName    string
 	ExpiredAt time.Time

--- a/go_lib/controlplane/kubeconfig/errors.go
+++ b/go_lib/controlplane/kubeconfig/errors.go
@@ -21,12 +21,13 @@ import (
 	"time"
 )
 
-// KubeconfigMissingError is returned when a kubeconfig file does not exist on disk. The caller treats this as a skippable condition.
-type KubeconfigMissingError struct {
+// MissingError is returned when a kubeconfig file does not exist on disk.
+// The caller treats this as a skippable condition.
+type MissingError struct {
 	File File
 }
 
-func (e *KubeconfigMissingError) Error() string {
+func (e *MissingError) Error() string {
 	return fmt.Sprintf("kubeconfig file %q not found", e.File)
 }
 

--- a/go_lib/controlplane/kubeconfig/errors.go
+++ b/go_lib/controlplane/kubeconfig/errors.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"fmt"
+	"time"
+)
+
+// KubeconfigMissingError is returned when a kubeconfig file does not exist on disk. The caller treats this as a skippable condition.
+type KubeconfigMissingError struct {
+	File File
+}
+
+func (e *KubeconfigMissingError) Error() string {
+	return fmt.Sprintf("kubeconfig file %q not found", e.File)
+}
+
+// CAExternalError is returned when the CA certificate exists but its private key does not (external CA scenario).
+// Renewal of the kubeconfig client cert is skipped — only the holder of the CA key can sign new leaf certificates.
+type CAExternalError struct {
+	CAName string
+}
+
+func (e *CAExternalError) Error() string {
+	return fmt.Sprintf("CA %q private key not found (external CA — renewal skipped)", e.CAName)
+}
+
+// CAExpiredError is returned when the CA certificate has already expired.
+// Renewal is blocked: signing with an expired CA produces certificates that fail chain validation in Kubernetes components.
+type CAExpiredError struct {
+	CAName    string
+	ExpiredAt time.Time
+}
+
+func (e *CAExpiredError) Error() string {
+	return fmt.Sprintf(
+		"CA %q expired at %s — renewing kubeconfig certs against an expired CA is pointless; rotate the CA first",
+		e.CAName, e.ExpiredAt.UTC().Format(time.RFC3339),
+	)
+}

--- a/go_lib/controlplane/kubeconfig/expiration.go
+++ b/go_lib/controlplane/kubeconfig/expiration.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"sort"
 	"time"
@@ -34,15 +35,48 @@ import (
 type ExpirationOption func(*expirationOptions)
 
 type expirationOptions struct {
-	kubeconfigDir    string
-	files            []File
-	ignoreReadErrors bool
+	kubeconfigDir string
+	files         []File
 }
 
 type ClientCertificateExpiration struct {
 	File     File
 	Path     string
 	NotAfter time.Time
+}
+type KubeconfigExpirationReport struct {
+	Entries []KubeconfigExpirationEntry
+}
+
+type KubeconfigExpirationEntry struct {
+	File     File
+	Path     string
+	NotAfter time.Time
+	Action   KubeconfigExpirationAction
+	Err      error
+}
+
+// KubeconfigExpirationAction describes what happened to a single kubeconfig file.
+type KubeconfigExpirationAction uint8
+
+const (
+	// KubeconfigExpirationActionRead - client cert was read successfully.
+	KubeconfigExpirationActionRead KubeconfigExpirationAction = iota
+	// KubeconfigExpirationActionSkippedMissing - kubeconfig file is absent.
+	KubeconfigExpirationActionSkippedMissing
+	// KubeconfigExpirationActionSkippedReadError - file exists but could not be parsed.
+	// The wrapped loader error is available in Entry.Err.
+	KubeconfigExpirationActionSkippedReadError
+)
+
+func (r *KubeconfigExpirationReport) add(file File, path string, notAfter time.Time, action KubeconfigExpirationAction, err error) {
+	r.Entries = append(r.Entries, KubeconfigExpirationEntry{
+		File:     file,
+		Path:     path,
+		NotAfter: notAfter,
+		Action:   action,
+		Err:      err,
+	})
 }
 
 var defaultExpirationFiles = []File{
@@ -66,36 +100,27 @@ func WithFiles(files ...File) ExpirationOption {
 	}
 }
 
-// WithIgnoreReadErrors enables partial success and returns read failures as errors.Join(...).
-func WithIgnoreReadErrors() ExpirationOption {
-	return func(o *expirationOptions) {
-		o.ignoreReadErrors = true
-	}
-}
-
-func ListClientCertificateExpirations(opts ...ExpirationOption) ([]ClientCertificateExpiration, error) {
+// ListClientCertificateExpirations enumerates the selected kubeconfig files and returns a structured report.
+func ListClientCertificateExpirations(opts ...ExpirationOption) (KubeconfigExpirationReport, error) {
 	options := newExpirationOptions(opts...)
 	files := expirationFiles(options)
 
-	result := make([]ClientCertificateExpiration, 0, len(files))
-	var errs []error
-
+	var report KubeconfigExpirationReport
 	for _, file := range files {
 		path := filepath.Join(options.kubeconfigDir, string(file))
-		expiration, err := clientCertificateExpiration(path)
-		if err != nil {
-			if !options.ignoreReadErrors {
-				return nil, err
-			}
 
-			errs = append(errs, err)
-			continue
+		exp, loadErr := clientCertificateExpiration(path)
+		switch {
+		case loadErr == nil:
+			report.add(exp.File, exp.Path, exp.NotAfter, KubeconfigExpirationActionRead, nil)
+		case errors.Is(loadErr, fs.ErrNotExist):
+			report.add(file, path, time.Time{}, KubeconfigExpirationActionSkippedMissing, nil)
+		default:
+			report.add(file, path, time.Time{}, KubeconfigExpirationActionSkippedReadError, loadErr)
 		}
-
-		result = append(result, expiration)
 	}
 
-	return result, errors.Join(errs...)
+	return report, nil
 }
 
 func GetClientCertificateExpiration(path string) (ClientCertificateExpiration, error) {

--- a/go_lib/controlplane/kubeconfig/expiration.go
+++ b/go_lib/controlplane/kubeconfig/expiration.go
@@ -54,17 +54,10 @@ type KubeconfigExpirationEntry struct {
 	Err error
 }
 
-// KubeconfigExpirationAction describes what happened to a single kubeconfig file.
-type KubeconfigExpirationAction uint8
-
-func (r *KubeconfigExpirationReport) add(file File, path string, notAfter time.Time, err error) {
+func (r *KubeconfigExpirationReport) add(exp ClientCertificateExpiration, err error) {
 	r.Entries = append(r.Entries, KubeconfigExpirationEntry{
-		ClientCertificateExpiration: ClientCertificateExpiration{
-			File:     file,
-			Path:     path,
-			NotAfter: notAfter,
-		},
-		Err: err,
+		ClientCertificateExpiration: exp,
+		Err:                         err,
 	})
 }
 
@@ -90,6 +83,7 @@ func WithFiles(files ...File) ExpirationOption {
 }
 
 // ListClientCertificateExpirations enumerates the selected kubeconfig files and returns a structured report.
+// The caller iterates report.Entries and decides per-entry what to do.
 func ListClientCertificateExpirations(opts ...ExpirationOption) KubeconfigExpirationReport {
 	options := newExpirationOptions(opts...)
 	files := expirationFiles(options)
@@ -101,11 +95,11 @@ func ListClientCertificateExpirations(opts ...ExpirationOption) KubeconfigExpira
 		exp, loadErr := clientCertificateExpiration(path)
 		switch {
 		case loadErr == nil:
-			report.add(exp.File, exp.Path, exp.NotAfter, nil)
+			report.add(exp, nil)
 		case errors.Is(loadErr, fs.ErrNotExist):
-			report.add(file, path, time.Time{}, &KubeconfigMissingError{File: file})
+			report.add(ClientCertificateExpiration{File: file, Path: path}, &MissingError{File: file})
 		default:
-			report.add(file, path, time.Time{}, loadErr)
+			report.add(ClientCertificateExpiration{File: file, Path: path}, loadErr)
 		}
 	}
 

--- a/go_lib/controlplane/kubeconfig/expiration.go
+++ b/go_lib/controlplane/kubeconfig/expiration.go
@@ -44,38 +44,27 @@ type ClientCertificateExpiration struct {
 	Path     string
 	NotAfter time.Time
 }
+
 type KubeconfigExpirationReport struct {
 	Entries []KubeconfigExpirationEntry
 }
 
 type KubeconfigExpirationEntry struct {
-	File     File
-	Path     string
-	NotAfter time.Time
-	Action   KubeconfigExpirationAction
-	Err      error
+	ClientCertificateExpiration
+	Err error
 }
 
 // KubeconfigExpirationAction describes what happened to a single kubeconfig file.
 type KubeconfigExpirationAction uint8
 
-const (
-	// KubeconfigExpirationActionRead - client cert was read successfully.
-	KubeconfigExpirationActionRead KubeconfigExpirationAction = iota
-	// KubeconfigExpirationActionSkippedMissing - kubeconfig file is absent.
-	KubeconfigExpirationActionSkippedMissing
-	// KubeconfigExpirationActionSkippedReadError - file exists but could not be parsed.
-	// The wrapped loader error is available in Entry.Err.
-	KubeconfigExpirationActionSkippedReadError
-)
-
-func (r *KubeconfigExpirationReport) add(file File, path string, notAfter time.Time, action KubeconfigExpirationAction, err error) {
+func (r *KubeconfigExpirationReport) add(file File, path string, notAfter time.Time, err error) {
 	r.Entries = append(r.Entries, KubeconfigExpirationEntry{
-		File:     file,
-		Path:     path,
-		NotAfter: notAfter,
-		Action:   action,
-		Err:      err,
+		ClientCertificateExpiration: ClientCertificateExpiration{
+			File:     file,
+			Path:     path,
+			NotAfter: notAfter,
+		},
+		Err: err,
 	})
 }
 
@@ -101,7 +90,7 @@ func WithFiles(files ...File) ExpirationOption {
 }
 
 // ListClientCertificateExpirations enumerates the selected kubeconfig files and returns a structured report.
-func ListClientCertificateExpirations(opts ...ExpirationOption) (KubeconfigExpirationReport, error) {
+func ListClientCertificateExpirations(opts ...ExpirationOption) KubeconfigExpirationReport {
 	options := newExpirationOptions(opts...)
 	files := expirationFiles(options)
 
@@ -112,15 +101,15 @@ func ListClientCertificateExpirations(opts ...ExpirationOption) (KubeconfigExpir
 		exp, loadErr := clientCertificateExpiration(path)
 		switch {
 		case loadErr == nil:
-			report.add(exp.File, exp.Path, exp.NotAfter, KubeconfigExpirationActionRead, nil)
+			report.add(exp.File, exp.Path, exp.NotAfter, nil)
 		case errors.Is(loadErr, fs.ErrNotExist):
-			report.add(file, path, time.Time{}, KubeconfigExpirationActionSkippedMissing, nil)
+			report.add(file, path, time.Time{}, &KubeconfigMissingError{File: file})
 		default:
-			report.add(file, path, time.Time{}, KubeconfigExpirationActionSkippedReadError, loadErr)
+			report.add(file, path, time.Time{}, loadErr)
 		}
 	}
 
-	return report, nil
+	return report
 }
 
 func GetClientCertificateExpiration(path string) (ClientCertificateExpiration, error) {

--- a/go_lib/controlplane/kubeconfig/expiration_test.go
+++ b/go_lib/controlplane/kubeconfig/expiration_test.go
@@ -53,44 +53,49 @@ func TestListClientCertificateExpirations_DefaultExcludesKubelet(t *testing.T) {
 		require.NoError(t, createKubeConfigFile(file, opt, &rep))
 	}
 
-	expirations, err := ListClientCertificateExpirations(WithKubeconfigDir(dir))
-	require.NoError(t, err)
+	report := ListClientCertificateExpirations(WithKubeconfigDir(dir))
 
-	require.Len(t, expirations, 4)
+	require.Len(t, report.Entries, 4)
 	assert.Equal(t, []File{Admin, ControllerManager, Scheduler, SuperAdmin}, expirationFiles(newExpirationOptions(WithKubeconfigDir(dir))))
 
-	files := make([]File, 0, len(expirations))
-	for _, expiration := range expirations {
-		files = append(files, expiration.File)
+	files := make([]File, 0, len(report.Entries))
+	for _, e := range report.Entries {
+		require.NoError(t, e.Err)
+		files = append(files, e.File)
 	}
 
 	assert.Equal(t, []File{Admin, ControllerManager, Scheduler, SuperAdmin}, files)
 	assert.NotContains(t, files, Kubelet)
 }
 
-func TestListClientCertificateExpirations_IgnoreReadErrors(t *testing.T) {
+func TestListClientCertificateExpirations_MissingEntries(t *testing.T) {
 	dir := t.TempDir()
 	opt := makeExpirationTestOptions(t, dir)
 
 	var rep KubeconfigApplyReport
 	require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
 
-	_, err := ListClientCertificateExpirations(
+	report := ListClientCertificateExpirations(
 		WithKubeconfigDir(dir),
 		WithFiles(Admin, Admin, Scheduler),
 	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), filepath.Join(dir, string(Scheduler)))
+	require.Len(t, report.Entries, 2)
 
-	expirations, err := ListClientCertificateExpirations(
-		WithKubeconfigDir(dir),
-		WithFiles(Admin, Admin, Scheduler),
-		WithIgnoreReadErrors(),
-	)
-	require.Error(t, err)
-	require.Len(t, expirations, 1)
-	assert.Equal(t, Admin, expirations[0].File)
-	assert.Contains(t, err.Error(), filepath.Join(dir, string(Scheduler)))
+	byFile := make(map[File]KubeconfigExpirationEntry, len(report.Entries))
+	for _, e := range report.Entries {
+		byFile[e.File] = e
+	}
+
+	adminEntry, ok := byFile[Admin]
+	require.True(t, ok)
+	require.NoError(t, adminEntry.Err)
+
+	schedulerEntry, ok := byFile[Scheduler]
+	require.True(t, ok)
+	var missing *MissingError
+	require.ErrorAs(t, schedulerEntry.Err, &missing)
+	assert.Equal(t, Scheduler, missing.File)
+	assert.Equal(t, filepath.Join(dir, string(Scheduler)), schedulerEntry.Path)
 }
 
 func TestGetClientCertificateExpiration_NormalizesKnownAndUnknownPaths(t *testing.T) {

--- a/go_lib/controlplane/kubeconfig/renew.go
+++ b/go_lib/controlplane/kubeconfig/renew.go
@@ -98,9 +98,9 @@ type KubeconfigRenewReport struct {
 }
 
 type KubeconfigRenewEntry struct {
-	File   File
-	Path   string
-	Action KubeconfigRenewAction
+	File File
+	Path string
+	Err  error
 }
 
 // KubeconfigRenewAction describes what happened to a single kubeconfig file.
@@ -115,11 +115,11 @@ const (
 	KubeconfigRenewActionSkippedExternalCA
 )
 
-func (r *KubeconfigRenewReport) add(file File, path string, action KubeconfigRenewAction) {
+func (r *KubeconfigRenewReport) add(file File, path string, err error) {
 	r.Entries = append(r.Entries, KubeconfigRenewEntry{
-		File:   file,
-		Path:   path,
-		Action: action,
+		File: file,
+		Path: path,
+		Err:  err,
 	})
 }
 
@@ -227,7 +227,7 @@ func RenewClientCerts(opts ...RenewOption) (KubeconfigRenewReport, error) {
 
 		err := renewClientCert(o.kubeconfigDir, o.pkiDir, info.File)
 		if err == nil {
-			report.add(info.File, path, KubeconfigRenewActionRenewed)
+			report.add(info.File, path, nil)
 			continue
 		}
 
@@ -235,9 +235,9 @@ func RenewClientCerts(opts ...RenewOption) (KubeconfigRenewReport, error) {
 		var external *CAExternalError
 		switch {
 		case errors.As(err, &missing):
-			report.add(info.File, path, KubeconfigRenewActionSkippedMissing)
+			report.add(info.File, path, missing)
 		case errors.As(err, &external):
-			report.add(info.File, path, KubeconfigRenewActionSkippedExternalCA)
+			report.add(info.File, path, external)
 		default:
 			// *CAExpiredError or any non-sentinel error is fatal.
 			return report, err

--- a/go_lib/controlplane/kubeconfig/renew.go
+++ b/go_lib/controlplane/kubeconfig/renew.go
@@ -132,11 +132,6 @@ func clientCertConfigFromX509(cert *x509.Certificate) pkiutil.CertConfig {
 
 // renewClientCert unconditionally re-signs the client certificate embedded in the given kubeconfig file.
 // All other kubeconfig fields are preserved. CA cert and key are loaded from pkiDir.
-//
-// Sentinel errors:
-//   - *MissingError — kubeconfig file absent (skippable)
-//   - *CAExternalError        — CA key absent (skippable)
-//   - *CAExpiredError         — CA cert expired (hard stop)
 func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
 	path := filepath.Join(kubeconfigDir, string(file))
 
@@ -151,7 +146,7 @@ func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
 	caCert, err := pkiutil.LoadCert(filepath.Join(pkiDir, "ca.crt"))
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("CA certificate not found in %q", pkiDir)
+			return &CAMissingError{CAName: "ca"}
 		}
 		return fmt.Errorf("load CA cert: %w", err)
 	}
@@ -196,20 +191,37 @@ func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
 	authInfo.ClientKey = ""
 	authInfo.ClientKeyData = encodedKey
 
-	return clientcmd.WriteToFile(*kubeConfig, path)
+	if err := clientcmd.WriteToFile(*kubeConfig, path); err != nil {
+		return fmt.Errorf("write kubeconfig %q: %w", file, err)
+	}
+	return nil
 }
 
 // RenewClientCert unconditionally re-signs the client certificate embedded in the given kubeconfig file.
-// Returns nil on success or one of *MissingError / *CAExternalError / *CAExpiredError to let the caller distinguish skip vs. fatal.
-// This is the low-level, single-file entry point; for renewing a batch of kubeconfig files with a structured outcome report, use RenewClientCerts.
+// All other kubeconfig fields are preserved. CA cert and key are loaded from pkiDir.
+//
+// The returned error encodes the outcome:
+//   - nil              — re-signed cleanly
+//   - *MissingError    — kubeconfig file absent (skipped)
+//   - *CAMissingError  — CA cert file absent (skipped)
+//   - *CAExternalError — CA key absent / external CA (skipped)
+//   - *CAExpiredError  — CA already expired (skipped)
+//   - any other error  — IO/permissions/signing failure (skipped)
 func RenewClientCert(file File, opts ...RenewOption) error {
 	o := newRenewOptions(opts...)
 	return renewClientCert(o.kubeconfigDir, o.pkiDir, file)
 }
 
 // RenewClientCerts iterates DefaultRenewableFiles() (or the subset chosen via WithRenewFiles) and renews each kubeconfig client certificate in turn.
-// The outcome of every file is recorded in report.Entries with Err == nil on success or a sentinel error otherwise.
-// Iteration never aborts — the caller iterates report.Entries and decides per-entry what to do.
+// All other kubeconfig fields are preserved. CA cert and key are loaded from pkiDir.
+//
+// The returned error encodes the outcome:
+//   - nil              — re-signed cleanly
+//   - *MissingError    — kubeconfig file absent (skipped)
+//   - *CAMissingError  — CA cert file absent (skipped)
+//   - *CAExternalError — CA key absent / external CA (skipped)
+//   - *CAExpiredError  — CA already expired (skipped)
+//   - any other error  — IO/permissions/signing failure (skipped)
 func RenewClientCerts(opts ...RenewOption) KubeconfigRenewReport {
 	o := newRenewOptions(opts...)
 

--- a/go_lib/controlplane/kubeconfig/renew.go
+++ b/go_lib/controlplane/kubeconfig/renew.go
@@ -32,7 +32,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
 )
 
-type FileInfo struct {
+type fileInfo struct {
 	File        File
 	Description string
 }
@@ -50,8 +50,8 @@ func FileDescription(file File) string {
 
 // defaultRenewableFiles returns the canonical list of renewable kubeconfig files.
 // The kubelet.conf entry is intentionally omitted — kubelet manages its own client certificate rotation.
-func defaultRenewableFiles() []FileInfo {
-	return []FileInfo{
+func defaultRenewableFiles() []fileInfo {
+	return []fileInfo{
 		{Admin, "certificate embedded in the kubeconfig file for the admin to use"},
 		{SuperAdmin, "certificate embedded in the kubeconfig file for the super-admin"},
 		{ControllerManager, "certificate embedded in the kubeconfig file for the controller manager to use"},
@@ -262,7 +262,7 @@ func RenewClientCerts(opts ...RenewOption) KubeconfigRenewReport {
 
 // selectFiles returns the inventory with only the given files, preserving the canonical order.
 // When files is empty, returned default inventory.
-func selectFiles(files []File) []FileInfo {
+func selectFiles(files []File) []fileInfo {
 	full := defaultRenewableFiles()
 	if len(files) == 0 {
 		return full
@@ -273,7 +273,7 @@ func selectFiles(files []File) []FileInfo {
 		wanted[f] = struct{}{}
 	}
 
-	result := make([]FileInfo, 0, len(files))
+	result := make([]fileInfo, 0, len(files))
 	for _, info := range full {
 		if _, ok := wanted[info.File]; ok {
 			result = append(result, info)

--- a/go_lib/controlplane/kubeconfig/renew.go
+++ b/go_lib/controlplane/kubeconfig/renew.go
@@ -37,9 +37,20 @@ type FileInfo struct {
 	Description string
 }
 
-// DefaultRenewableFiles returns the canonical list of renewable kubeconfig files.
+// FileDescription returns the human-readable description for the given kubeconfig file.
+// Falls back to the string representation of file when no description is found.
+func FileDescription(file File) string {
+	for _, info := range defaultRenewableFiles() {
+		if info.File == file {
+			return info.Description
+		}
+	}
+	return string(file)
+}
+
+// defaultRenewableFiles returns the canonical list of renewable kubeconfig files.
 // The kubelet.conf entry is intentionally omitted — kubelet manages its own client certificate rotation.
-func DefaultRenewableFiles() []FileInfo {
+func defaultRenewableFiles() []FileInfo {
 	return []FileInfo{
 		{Admin, "certificate embedded in the kubeconfig file for the admin to use"},
 		{SuperAdmin, "certificate embedded in the kubeconfig file for the super-admin"},
@@ -75,7 +86,7 @@ func WithRenewPKIDir(dir string) RenewOption {
 }
 
 // WithRenewFiles restricts RenewClientCerts to the provided kubeconfig files.
-// When empty, the full DefaultRenewableFiles() inventory is used.
+// When empty, the full default renewable files inventory is used.
 func WithRenewFiles(files ...File) RenewOption {
 	return func(o *renewOptions) {
 		o.files = append(o.files, files...)
@@ -225,7 +236,7 @@ func RenewClientCert(file File, opts ...RenewOption) error {
 	return renewClientCert(o.kubeconfigDir, o.pkiDir, file, o.dryRun)
 }
 
-// RenewClientCerts iterates DefaultRenewableFiles() (or the subset chosen via WithRenewFiles) and renews each kubeconfig client certificate in turn.
+// RenewClientCerts iterates the renewable kubeconfig files (or the subset chosen via WithRenewFiles) and renews each kubeconfig client certificate in turn.
 // All other kubeconfig fields are preserved. CA cert and key are loaded from pkiDir.
 //
 // The returned error encodes the outcome:
@@ -249,10 +260,10 @@ func RenewClientCerts(opts ...RenewOption) KubeconfigRenewReport {
 	return report
 }
 
-// selectFiles returns the inventory with only the given files, preserving the canonical DefaultRenewableFiles() order.
+// selectFiles returns the inventory with only the given files, preserving the canonical order.
 // When files is empty, returned default inventory.
 func selectFiles(files []File) []FileInfo {
-	full := DefaultRenewableFiles()
+	full := defaultRenewableFiles()
 	if len(files) == 0 {
 		return full
 	}

--- a/go_lib/controlplane/kubeconfig/renew.go
+++ b/go_lib/controlplane/kubeconfig/renew.go
@@ -97,23 +97,17 @@ type KubeconfigRenewReport struct {
 	Entries []KubeconfigRenewEntry
 }
 
+// KubeconfigRenewEntry is one row of KubeconfigRenewReport.
+// Err == nil means the client cert was re-signed; otherwise Err is a sentinel describing what happened:
+//   - *MissingError    when the kubeconfig file is absent (skippable)
+//   - *CAExternalError when the CA private key is absent (skippable)
+//   - *CAExpiredError  when the signing CA has expired (renewal is pointless and the kubeconfig is left untouched)
+//   - any other error (wrapped) for IO/permissions/signing failures
 type KubeconfigRenewEntry struct {
 	File File
 	Path string
 	Err  error
 }
-
-// KubeconfigRenewAction describes what happened to a single kubeconfig file.
-type KubeconfigRenewAction uint8
-
-const (
-	// KubeconfigRenewActionRenewed - certificate was renewed.
-	KubeconfigRenewActionRenewed KubeconfigRenewAction = iota
-	// KubeconfigRenewActionSkippedMissing - certificate was skipped because it was missing.
-	KubeconfigRenewActionSkippedMissing
-	// external CA scenario; the kubeconfig is left untouched.
-	KubeconfigRenewActionSkippedExternalCA
-)
 
 func (r *KubeconfigRenewReport) add(file File, path string, err error) {
 	r.Entries = append(r.Entries, KubeconfigRenewEntry{
@@ -140,7 +134,7 @@ func clientCertConfigFromX509(cert *x509.Certificate) pkiutil.CertConfig {
 // All other kubeconfig fields are preserved. CA cert and key are loaded from pkiDir.
 //
 // Sentinel errors:
-//   - *KubeconfigMissingError — kubeconfig file absent (skippable)
+//   - *MissingError — kubeconfig file absent (skippable)
 //   - *CAExternalError        — CA key absent (skippable)
 //   - *CAExpiredError         — CA cert expired (hard stop)
 func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
@@ -149,7 +143,7 @@ func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
 	oldCert, err := loadClientCertificate(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return &KubeconfigMissingError{File: file}
+			return &MissingError{File: file}
 		}
 		return err
 	}
@@ -206,7 +200,7 @@ func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
 }
 
 // RenewClientCert unconditionally re-signs the client certificate embedded in the given kubeconfig file.
-// Returns nil on success or one of *KubeconfigMissingError / *CAExternalError / *CAExpiredError to let the caller distinguish skip vs. fatal.
+// Returns nil on success or one of *MissingError / *CAExternalError / *CAExpiredError to let the caller distinguish skip vs. fatal.
 // This is the low-level, single-file entry point; for renewing a batch of kubeconfig files with a structured outcome report, use RenewClientCerts.
 func RenewClientCert(file File, opts ...RenewOption) error {
 	o := newRenewOptions(opts...)
@@ -214,9 +208,9 @@ func RenewClientCert(file File, opts ...RenewOption) error {
 }
 
 // RenewClientCerts iterates DefaultRenewableFiles() (or the subset chosen via WithRenewFiles) and renews each kubeconfig client certificate in turn.
-// On *KubeconfigMissingError or *CAExternalError: an entry is appended to the report with the corresponding skip action and iteration continues.
-// On *CAExpiredError or any other error (I/O, permissions, signing failure): iteration aborts and the partial report gathered so far is returned together with the fatal error.
-func RenewClientCerts(opts ...RenewOption) (KubeconfigRenewReport, error) {
+// The outcome of every file is recorded in report.Entries with Err == nil on success or a sentinel error otherwise.
+// Iteration never aborts — the caller iterates report.Entries and decides per-entry what to do.
+func RenewClientCerts(opts ...RenewOption) KubeconfigRenewReport {
 	o := newRenewOptions(opts...)
 
 	inventory := selectFiles(o.files)
@@ -224,27 +218,10 @@ func RenewClientCerts(opts ...RenewOption) (KubeconfigRenewReport, error) {
 	var report KubeconfigRenewReport
 	for _, info := range inventory {
 		path := filepath.Join(o.kubeconfigDir, string(info.File))
-
-		err := renewClientCert(o.kubeconfigDir, o.pkiDir, info.File)
-		if err == nil {
-			report.add(info.File, path, nil)
-			continue
-		}
-
-		var missing *KubeconfigMissingError
-		var external *CAExternalError
-		switch {
-		case errors.As(err, &missing):
-			report.add(info.File, path, missing)
-		case errors.As(err, &external):
-			report.add(info.File, path, external)
-		default:
-			// *CAExpiredError or any non-sentinel error is fatal.
-			return report, err
-		}
+		report.add(info.File, path, renewClientCert(o.kubeconfigDir, o.pkiDir, info.File))
 	}
 
-	return report, nil
+	return report
 }
 
 // selectFiles returns the inventory with only the given files, preserving the canonical DefaultRenewableFiles() order.

--- a/go_lib/controlplane/kubeconfig/renew.go
+++ b/go_lib/controlplane/kubeconfig/renew.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/client-go/tools/clientcmd"
+	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+)
+
+type FileInfo struct {
+	File        File
+	Description string
+}
+
+// DefaultRenewableFiles returns the canonical list of renewable kubeconfig files.
+// The kubelet.conf entry is intentionally omitted — kubelet manages its own client certificate rotation.
+func DefaultRenewableFiles() []FileInfo {
+	return []FileInfo{
+		{Admin, "certificate embedded in the kubeconfig file for the admin to use"},
+		{SuperAdmin, "certificate embedded in the kubeconfig file for the super-admin"},
+		{ControllerManager, "certificate embedded in the kubeconfig file for the controller manager to use"},
+		{Scheduler, "certificate embedded in the kubeconfig file for the scheduler to use"},
+	}
+}
+
+// RenewOption configures RenewClientCert and RenewClientCerts.
+type RenewOption func(*renewOptions)
+
+type renewOptions struct {
+	kubeconfigDir string
+	pkiDir        string
+	files         []File
+}
+
+// WithRenewKubeconfigDir overrides the directory containing kubeconfig files.
+// Defaults to DefaultOutDir (/etc/kubernetes).
+func WithRenewKubeconfigDir(dir string) RenewOption {
+	return func(o *renewOptions) {
+		o.kubeconfigDir = dir
+	}
+}
+
+// WithRenewPKIDir overrides the directory containing the CA cert/key used to sign the new client certificates.
+// Defaults to constants.DefaultCertificatesDir (/etc/kubernetes/pki).
+func WithRenewPKIDir(dir string) RenewOption {
+	return func(o *renewOptions) {
+		o.pkiDir = dir
+	}
+}
+
+// WithRenewFiles restricts RenewClientCerts to the provided kubeconfig files.
+// When empty, the full DefaultRenewableFiles() inventory is used.
+func WithRenewFiles(files ...File) RenewOption {
+	return func(o *renewOptions) {
+		o.files = append(o.files, files...)
+	}
+}
+
+func newRenewOptions(opts ...RenewOption) *renewOptions {
+	o := &renewOptions{
+		kubeconfigDir: DefaultOutDir,
+		pkiDir:        constants.DefaultCertificatesDir,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// KubeconfigRenewReport describes per-file outcomes of a RenewClientCerts call.
+type KubeconfigRenewReport struct {
+	Entries []KubeconfigRenewEntry
+}
+
+type KubeconfigRenewEntry struct {
+	File   File
+	Path   string
+	Action KubeconfigRenewAction
+}
+
+// KubeconfigRenewAction describes what happened to a single kubeconfig file.
+type KubeconfigRenewAction uint8
+
+const (
+	// KubeconfigRenewActionRenewed - certificate was renewed.
+	KubeconfigRenewActionRenewed KubeconfigRenewAction = iota
+	// KubeconfigRenewActionSkippedMissing - certificate was skipped because it was missing.
+	KubeconfigRenewActionSkippedMissing
+	// external CA scenario; the kubeconfig is left untouched.
+	KubeconfigRenewActionSkippedExternalCA
+)
+
+func (r *KubeconfigRenewReport) add(file File, path string, action KubeconfigRenewAction) {
+	r.Entries = append(r.Entries, KubeconfigRenewEntry{
+		File:   file,
+		Path:   path,
+		Action: action,
+	})
+}
+
+// clientCertConfigFromX509 extracts CN/Organization/Usages from the embedded client certificate.
+func clientCertConfigFromX509(cert *x509.Certificate) pkiutil.CertConfig {
+	return pkiutil.CertConfig{
+		Config: certutil.Config{
+			CommonName:   cert.Subject.CommonName,
+			Organization: cert.Subject.Organization,
+			Usages:       cert.ExtKeyUsage,
+		},
+		EncryptionAlgorithm:       pkiutil.DetectEncryptionAlgorithm(cert),
+		CertificateValidityPeriod: constants.CertificateValidityPeriod,
+	}
+}
+
+// renewClientCert unconditionally re-signs the client certificate embedded in the given kubeconfig file.
+// All other kubeconfig fields are preserved. CA cert and key are loaded from pkiDir.
+//
+// Sentinel errors:
+//   - *KubeconfigMissingError — kubeconfig file absent (skippable)
+//   - *CAExternalError        — CA key absent (skippable)
+//   - *CAExpiredError         — CA cert expired (hard stop)
+func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
+	path := filepath.Join(kubeconfigDir, string(file))
+
+	oldCert, err := loadClientCertificate(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &KubeconfigMissingError{File: file}
+		}
+		return err
+	}
+
+	caCert, err := pkiutil.LoadCert(filepath.Join(pkiDir, "ca.crt"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("CA certificate not found in %q", pkiDir)
+		}
+		return fmt.Errorf("load CA cert: %w", err)
+	}
+
+	if time.Now().After(caCert.NotAfter) {
+		return &CAExpiredError{CAName: "ca", ExpiredAt: caCert.NotAfter}
+	}
+
+	caKey, err := pkiutil.LoadKey(filepath.Join(pkiDir, "ca.key"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &CAExternalError{CAName: "ca"}
+		}
+		return fmt.Errorf("load CA key: %w", err)
+	}
+
+	cfg := clientCertConfigFromX509(oldCert)
+
+	newCert, newKey, err := pkiutil.NewCertAndKey(caCert, caKey, cfg)
+	if err != nil {
+		return fmt.Errorf("generate client cert for %q: %w", file, err)
+	}
+
+	encodedKey, err := keyutil.MarshalPrivateKeyToPEM(newKey)
+	if err != nil {
+		return fmt.Errorf("marshal private key: %w", err)
+	}
+
+	kubeConfig, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		return fmt.Errorf("load kubeconfig %q: %w", file, err)
+	}
+
+	authInfo, err := currentAuthInfo(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("kubeconfig %q: %w", file, err)
+	}
+
+	// Switch to embedded PEM and clear file-path references so clientcmd never sees both modes set after the patch (client-certificate-data and client-certificate mutually exclusive).
+	authInfo.ClientCertificate = ""
+	authInfo.ClientCertificateData = pkiutil.EncodeCertificate(newCert)
+	authInfo.ClientKey = ""
+	authInfo.ClientKeyData = encodedKey
+
+	return clientcmd.WriteToFile(*kubeConfig, path)
+}
+
+// RenewClientCert unconditionally re-signs the client certificate embedded in the given kubeconfig file.
+// Returns nil on success or one of *KubeconfigMissingError / *CAExternalError / *CAExpiredError to let the caller distinguish skip vs. fatal.
+// This is the low-level, single-file entry point; for renewing a batch of kubeconfig files with a structured outcome report, use RenewClientCerts.
+func RenewClientCert(file File, opts ...RenewOption) error {
+	o := newRenewOptions(opts...)
+	return renewClientCert(o.kubeconfigDir, o.pkiDir, file)
+}
+
+// RenewClientCerts iterates DefaultRenewableFiles() (or the subset chosen via WithRenewFiles) and renews each kubeconfig client certificate in turn.
+// On *KubeconfigMissingError or *CAExternalError: an entry is appended to the report with the corresponding skip action and iteration continues.
+// On *CAExpiredError or any other error (I/O, permissions, signing failure): iteration aborts and the partial report gathered so far is returned together with the fatal error.
+func RenewClientCerts(opts ...RenewOption) (KubeconfigRenewReport, error) {
+	o := newRenewOptions(opts...)
+
+	inventory := selectFiles(o.files)
+
+	var report KubeconfigRenewReport
+	for _, info := range inventory {
+		path := filepath.Join(o.kubeconfigDir, string(info.File))
+
+		err := renewClientCert(o.kubeconfigDir, o.pkiDir, info.File)
+		if err == nil {
+			report.add(info.File, path, KubeconfigRenewActionRenewed)
+			continue
+		}
+
+		var missing *KubeconfigMissingError
+		var external *CAExternalError
+		switch {
+		case errors.As(err, &missing):
+			report.add(info.File, path, KubeconfigRenewActionSkippedMissing)
+		case errors.As(err, &external):
+			report.add(info.File, path, KubeconfigRenewActionSkippedExternalCA)
+		default:
+			// *CAExpiredError or any non-sentinel error is fatal.
+			return report, err
+		}
+	}
+
+	return report, nil
+}
+
+// selectFiles returns the inventory with only the given files, preserving the canonical DefaultRenewableFiles() order.
+// When files is empty, returned default inventory.
+func selectFiles(files []File) []FileInfo {
+	full := DefaultRenewableFiles()
+	if len(files) == 0 {
+		return full
+	}
+
+	wanted := make(map[File]struct{}, len(files))
+	for _, f := range files {
+		wanted[f] = struct{}{}
+	}
+
+	result := make([]FileInfo, 0, len(files))
+	for _, info := range full {
+		if _, ok := wanted[info.File]; ok {
+			result = append(result, info)
+		}
+	}
+	return result
+}

--- a/go_lib/controlplane/kubeconfig/renew.go
+++ b/go_lib/controlplane/kubeconfig/renew.go
@@ -55,6 +55,7 @@ type renewOptions struct {
 	kubeconfigDir string
 	pkiDir        string
 	files         []File
+	dryRun        bool
 }
 
 // WithRenewKubeconfigDir overrides the directory containing kubeconfig files.
@@ -78,6 +79,14 @@ func WithRenewPKIDir(dir string) RenewOption {
 func WithRenewFiles(files ...File) RenewOption {
 	return func(o *renewOptions) {
 		o.files = append(o.files, files...)
+	}
+}
+
+// WithDryRun runs all renewal checks and signing in memory but skips writing the new kubeconfig to disk.
+// The returned error contract is unchanged.
+func WithDryRun() RenewOption {
+	return func(o *renewOptions) {
+		o.dryRun = true
 	}
 }
 
@@ -132,7 +141,7 @@ func clientCertConfigFromX509(cert *x509.Certificate) pkiutil.CertConfig {
 
 // renewClientCert unconditionally re-signs the client certificate embedded in the given kubeconfig file.
 // All other kubeconfig fields are preserved. CA cert and key are loaded from pkiDir.
-func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
+func renewClientCert(kubeconfigDir, pkiDir string, file File, dryRun bool) error {
 	path := filepath.Join(kubeconfigDir, string(file))
 
 	oldCert, err := loadClientCertificate(path)
@@ -191,6 +200,10 @@ func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
 	authInfo.ClientKey = ""
 	authInfo.ClientKeyData = encodedKey
 
+	if dryRun {
+		return nil
+	}
+
 	if err := clientcmd.WriteToFile(*kubeConfig, path); err != nil {
 		return fmt.Errorf("write kubeconfig %q: %w", file, err)
 	}
@@ -209,7 +222,7 @@ func renewClientCert(kubeconfigDir, pkiDir string, file File) error {
 //   - any other error  — IO/permissions/signing failure (skipped)
 func RenewClientCert(file File, opts ...RenewOption) error {
 	o := newRenewOptions(opts...)
-	return renewClientCert(o.kubeconfigDir, o.pkiDir, file)
+	return renewClientCert(o.kubeconfigDir, o.pkiDir, file, o.dryRun)
 }
 
 // RenewClientCerts iterates DefaultRenewableFiles() (or the subset chosen via WithRenewFiles) and renews each kubeconfig client certificate in turn.
@@ -230,7 +243,7 @@ func RenewClientCerts(opts ...RenewOption) KubeconfigRenewReport {
 	var report KubeconfigRenewReport
 	for _, info := range inventory {
 		path := filepath.Join(o.kubeconfigDir, string(info.File))
-		report.add(info.File, path, renewClientCert(o.kubeconfigDir, o.pkiDir, info.File))
+		report.add(info.File, path, renewClientCert(o.kubeconfigDir, o.pkiDir, info.File, o.dryRun))
 	}
 
 	return report

--- a/go_lib/controlplane/kubeconfig/renew_test.go
+++ b/go_lib/controlplane/kubeconfig/renew_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeconfig
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/util/keyutil"
+)
+
+func writePKI(t *testing.T, pkiDir string, caCert *x509.Certificate, caKey crypto.Signer) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pkiDir, "ca.crt"),
+		pkiutil.EncodeCertificate(caCert),
+		0o600,
+	))
+	if caKey != nil {
+		keyPEM, err := keyutil.MarshalPrivateKeyToPEM(caKey)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(pkiDir, "ca.key"), keyPEM, 0o600))
+	}
+}
+
+func createExpiredCACert(t *testing.T) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "expired-ca"},
+		NotBefore:             time.Now().Add(-48 * time.Hour),
+		NotAfter:              time.Now().Add(-1 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(certBytes)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func TestRenewClientCert_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	pkiDir := t.TempDir()
+
+	caCert, caKey := createCACert(t)
+
+	opt := makeExpirationTestOptions(t, dir)
+	var rep KubeconfigApplyReport
+	require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
+
+	writePKI(t, pkiDir, caCert, caKey)
+
+	origCert, err := loadClientCertificate(filepath.Join(dir, string(Admin)))
+	require.NoError(t, err)
+
+	require.NoError(t, RenewClientCert(Admin,
+		WithRenewKubeconfigDir(dir),
+		WithRenewPKIDir(pkiDir),
+	))
+
+	newCert, err := loadClientCertificate(filepath.Join(dir, string(Admin)))
+	require.NoError(t, err)
+
+	assert.Equal(t, origCert.Subject.CommonName, newCert.Subject.CommonName)
+	assert.Equal(t, origCert.Subject.Organization, newCert.Subject.Organization)
+	assert.Equal(t, origCert.ExtKeyUsage, newCert.ExtKeyUsage)
+	assert.True(t, newCert.NotAfter.After(time.Now()))
+}
+
+func TestRenewClientCert_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	pkiDir := t.TempDir()
+
+	caCert, caKey := createCACert(t)
+
+	opt := makeExpirationTestOptions(t, dir)
+	var rep KubeconfigApplyReport
+	require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
+
+	writePKI(t, pkiDir, caCert, caKey)
+
+	statBefore, err := os.Stat(filepath.Join(dir, string(Admin)))
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.NoError(t, RenewClientCert(Admin,
+		WithRenewKubeconfigDir(dir),
+		WithRenewPKIDir(pkiDir),
+		WithDryRun(),
+	))
+
+	statAfter, err := os.Stat(filepath.Join(dir, string(Admin)))
+	require.NoError(t, err)
+	assert.Equal(t, statBefore.ModTime(), statAfter.ModTime(), "dry-run must not modify the file on disk")
+}
+
+func TestRenewClientCert_ErrorSentinels(t *testing.T) {
+	tests := []struct {
+		name      string
+		setupPKI  func(t *testing.T, dir, pkiDir string)
+		setupKube func(t *testing.T, dir string)
+		wantErr   interface{ Error() string }
+	}{
+		{
+			name: "kubeconfig missing",
+			setupPKI: func(t *testing.T, _, pkiDir string) {
+				caCert, caKey := createCACert(t)
+				writePKI(t, pkiDir, caCert, caKey)
+			},
+			setupKube: func(_ *testing.T, _ string) {},
+			wantErr:   &MissingError{},
+		},
+		{
+			name:     "CA cert missing",
+			setupPKI: func(_ *testing.T, _, _ string) {},
+			setupKube: func(t *testing.T, dir string) {
+				opt := makeExpirationTestOptions(t, dir)
+				var rep KubeconfigApplyReport
+				require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
+			},
+			wantErr: &CAMissingError{},
+		},
+		{
+			name: "external CA — key absent",
+			setupPKI: func(t *testing.T, _, pkiDir string) {
+				caCert, _ := createCACert(t)
+				writePKI(t, pkiDir, caCert, nil)
+			},
+			setupKube: func(t *testing.T, dir string) {
+				opt := makeExpirationTestOptions(t, dir)
+				var rep KubeconfigApplyReport
+				require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
+			},
+			wantErr: &CAExternalError{},
+		},
+		{
+			name: "CA expired",
+			setupPKI: func(t *testing.T, _, pkiDir string) {
+				expiredCert, expiredKey := createExpiredCACert(t)
+				writePKI(t, pkiDir, expiredCert, expiredKey)
+			},
+			setupKube: func(t *testing.T, dir string) {
+				opt := makeExpirationTestOptions(t, dir)
+				var rep KubeconfigApplyReport
+				require.NoError(t, createKubeConfigFile(Admin, opt, &rep))
+			},
+			wantErr: &CAExpiredError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			pkiDir := t.TempDir()
+
+			tt.setupKube(t, dir)
+			tt.setupPKI(t, dir, pkiDir)
+
+			err := RenewClientCert(Admin,
+				WithRenewKubeconfigDir(dir),
+				WithRenewPKIDir(pkiDir),
+			)
+			require.Error(t, err)
+			assert.ErrorAs(t, err, &tt.wantErr)
+		})
+	}
+}

--- a/go_lib/controlplane/pki/errors.go
+++ b/go_lib/controlplane/pki/errors.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package pki
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // CertValidationError is returned by createRootCertIfNotExists when an existing CA
 // certificate does not satisfy the current configuration. The caller should treat
@@ -28,4 +31,31 @@ type CertValidationError struct {
 
 func (e *CertValidationError) Error() string {
 	return fmt.Sprintf("certificate %q are not valid: %s", e.BaseName, e.Reason)
+}
+
+type CertMissingError struct {
+	BaseName string
+}
+
+func (e *CertMissingError) Error() string {
+	return fmt.Sprintf("certificate %q not found on disk", e.BaseName)
+}
+
+type CAExternalError struct {
+	CAName string
+}
+
+func (e *CAExternalError) Error() string {
+	return fmt.Sprintf("CA %q private key not found (external CA — renewal skipped)", e.CAName)
+}
+
+type CAExpiredError struct {
+	CAName    string
+	ExpiredAt time.Time
+}
+
+func (e *CAExpiredError) Error() string {
+	return fmt.Sprintf("CA %q expired at %s — renewing leaf certs against an expired CA is pointless; rotate the CA first",
+		e.CAName, e.ExpiredAt.UTC().Format(time.RFC3339),
+	)
 }

--- a/go_lib/controlplane/pki/errors.go
+++ b/go_lib/controlplane/pki/errors.go
@@ -43,6 +43,18 @@ func (e *MissingError) Error() string {
 	return fmt.Sprintf("certificate %q not found on disk", e.BaseName)
 }
 
+// CAMissingError is returned when the signing CA certificate file is absent.
+// The leaf cannot be re-signed, so renewal is skipped.
+type CAMissingError struct {
+	CAName string
+}
+
+func (e *CAMissingError) Error() string {
+	return fmt.Sprintf("CA %q certificate not found on disk", e.CAName)
+}
+
+// CAExternalError is returned when the CA certificate exists but its private key does not (external CA scenario).
+// Renewal is skipped.
 type CAExternalError struct {
 	CAName string
 }
@@ -51,6 +63,8 @@ func (e *CAExternalError) Error() string {
 	return fmt.Sprintf("CA %q private key not found (external CA — renewal skipped)", e.CAName)
 }
 
+// CAExpiredError is returned when the signing CA certificate has already expired.
+// Renewal is skipped: a leaf signed by an expired CA fails chain validation, so re-signing is pointless until the CA is rotated.
 type CAExpiredError struct {
 	CAName    string
 	ExpiredAt time.Time

--- a/go_lib/controlplane/pki/errors.go
+++ b/go_lib/controlplane/pki/errors.go
@@ -33,11 +33,13 @@ func (e *CertValidationError) Error() string {
 	return fmt.Sprintf("certificate %q are not valid: %s", e.BaseName, e.Reason)
 }
 
-type CertMissingError struct {
+// MissingError is returned when a certificate file does not exist on disk.
+// The caller treats this as a skippable condition.
+type MissingError struct {
 	BaseName string
 }
 
-func (e *CertMissingError) Error() string {
+func (e *MissingError) Error() string {
 	return fmt.Sprintf("certificate %q not found on disk", e.BaseName)
 }
 

--- a/go_lib/controlplane/pki/expiration.go
+++ b/go_lib/controlplane/pki/expiration.go
@@ -95,12 +95,13 @@ func WithRootCertificates(names ...RootCertName) ExpirationOption {
 
 // ListCertificateExpirations enumerates the selected certificates and returns a structured report.
 // The caller iterates report.Entries and decides per-entry what to do.
-func ListCertificateExpirations(opts ...ExpirationOption) ExpirationReport {
+// Returned error is reserved for an invalid request — an unknown certificate name passed
+func ListCertificateExpirations(opts ...ExpirationOption) (ExpirationReport, error) {
 	options := newExpirationOptions(opts...)
 
 	inventory, err := buildCertificateInventory(options)
 	if err != nil {
-		panic(err)
+		return ExpirationReport{}, err
 	}
 
 	var report ExpirationReport
@@ -118,7 +119,7 @@ func ListCertificateExpirations(opts ...ExpirationOption) ExpirationReport {
 		}
 	}
 
-	return report
+	return report, nil
 }
 
 // skeletonExpiration builds a CertificateExpiration for failed cases:

--- a/go_lib/controlplane/pki/expiration.go
+++ b/go_lib/controlplane/pki/expiration.go
@@ -19,6 +19,7 @@ package pki
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -34,7 +35,6 @@ type expirationOptions struct {
 	certificatesDir  string
 	leafCertificates []LeafCertName
 	rootCertificates []RootCertName
-	ignoreReadErrors bool
 }
 
 type CertificateExpiration struct {
@@ -43,6 +43,45 @@ type CertificateExpiration struct {
 	NotAfter  time.Time
 	Authority RootCertName
 	IsCA      bool
+}
+
+type ExpirationReport struct {
+	Entries []ExpirationEntry
+}
+
+type ExpirationEntry struct {
+	Name      string
+	Path      string
+	NotAfter  time.Time
+	Authority RootCertName
+	IsCA      bool
+	Action    ExpirationAction
+	Err       error
+}
+
+// ExpirationAction describes what happened to a single certificate.
+type ExpirationAction uint8
+
+const (
+	// ExpirationActionRead - certificate was read successfully.
+	ExpirationActionRead ExpirationAction = iota
+	// ExpirationActionSkippedMissing - certificate file is absent on disk.
+	ExpirationActionSkippedMissing
+	// ExpirationActionSkippedReadError - file exists but could not be loaded
+	// The wrapped loader error is available in Entry.Err.
+	ExpirationActionSkippedReadError
+)
+
+func (r *ExpirationReport) add(name, path string, authority RootCertName, isCA bool, notAfter time.Time, action ExpirationAction, err error) {
+	r.Entries = append(r.Entries, ExpirationEntry{
+		Name:      name,
+		Path:      path,
+		NotAfter:  notAfter,
+		Authority: authority,
+		IsCA:      isCA,
+		Action:    action,
+		Err:       err,
+	})
 }
 
 type certificateInventoryItem struct {
@@ -72,40 +111,32 @@ func WithRootCertificates(names ...RootCertName) ExpirationOption {
 	}
 }
 
-// WithIgnoreReadErrors enables partial success and returns read failures as errors.Join(...).
-func WithIgnoreReadErrors() ExpirationOption {
-	return func(o *expirationOptions) {
-		o.ignoreReadErrors = true
-	}
-}
-
-func ListCertificateExpirations(opts ...ExpirationOption) ([]CertificateExpiration, error) {
+// ListCertificateExpirations enumerates the selected certificates and returns a structured report.
+func ListCertificateExpirations(opts ...ExpirationOption) (ExpirationReport, error) {
 	options := newExpirationOptions(opts...)
 
 	inventory, err := buildCertificateInventory(options)
 	if err != nil {
-		return nil, err
+		return ExpirationReport{}, err
 	}
 
-	result := make([]CertificateExpiration, 0, len(inventory))
-	var errs []error
-
+	var report ExpirationReport
 	for _, item := range inventory {
-		expiration, err := loadCertificateExpiration(filepath.Join(options.certificatesDir, item.relPath), item)
-		if err != nil {
-			if !options.ignoreReadErrors {
-				return nil, err
-			}
+		path := filepath.Join(options.certificatesDir, item.relPath)
+		isCA := item.authority == ""
 
-			errs = append(errs, err)
-
-			continue
+		exp, loadErr := loadCertificateExpiration(path, item)
+		switch {
+		case loadErr == nil:
+			report.add(exp.Name, exp.Path, exp.Authority, exp.IsCA, exp.NotAfter, ExpirationActionRead, nil)
+		case errors.Is(loadErr, fs.ErrNotExist):
+			report.add(item.name, path, item.authority, isCA, time.Time{}, ExpirationActionSkippedMissing, nil)
+		default:
+			report.add(item.name, path, item.authority, isCA, time.Time{}, ExpirationActionSkippedReadError, loadErr)
 		}
-
-		result = append(result, expiration)
 	}
 
-	return result, errors.Join(errs...)
+	return report, nil
 }
 
 func GetCertificateExpiration(path string) (CertificateExpiration, error) {

--- a/go_lib/controlplane/pki/expiration.go
+++ b/go_lib/controlplane/pki/expiration.go
@@ -49,38 +49,20 @@ type ExpirationReport struct {
 	Entries []ExpirationEntry
 }
 
+// ExpirationEntry is one row of ExpirationReport. The embedded
+// CertificateExpiration fields are populated when Err == nil. Otherwise Err
+// is a sentinel describing why the entry was skipped:
+//   - *MissingError when the file is absent on disk
+//   - any other error (wrapped) when the file exists but cannot be parsed
 type ExpirationEntry struct {
-	Name      string
-	Path      string
-	NotAfter  time.Time
-	Authority RootCertName
-	IsCA      bool
-	Action    ExpirationAction
-	Err       error
+	CertificateExpiration
+	Err error
 }
 
-// ExpirationAction describes what happened to a single certificate.
-type ExpirationAction uint8
-
-const (
-	// ExpirationActionRead - certificate was read successfully.
-	ExpirationActionRead ExpirationAction = iota
-	// ExpirationActionSkippedMissing - certificate file is absent on disk.
-	ExpirationActionSkippedMissing
-	// ExpirationActionSkippedReadError - file exists but could not be loaded
-	// The wrapped loader error is available in Entry.Err.
-	ExpirationActionSkippedReadError
-)
-
-func (r *ExpirationReport) add(name, path string, authority RootCertName, isCA bool, notAfter time.Time, action ExpirationAction, err error) {
+func (r *ExpirationReport) add(exp CertificateExpiration, err error) {
 	r.Entries = append(r.Entries, ExpirationEntry{
-		Name:      name,
-		Path:      path,
-		NotAfter:  notAfter,
-		Authority: authority,
-		IsCA:      isCA,
-		Action:    action,
-		Err:       err,
+		CertificateExpiration: exp,
+		Err:                   err,
 	})
 }
 
@@ -112,31 +94,42 @@ func WithRootCertificates(names ...RootCertName) ExpirationOption {
 }
 
 // ListCertificateExpirations enumerates the selected certificates and returns a structured report.
-func ListCertificateExpirations(opts ...ExpirationOption) (ExpirationReport, error) {
+// The caller iterates report.Entries and decides per-entry what to do.
+func ListCertificateExpirations(opts ...ExpirationOption) ExpirationReport {
 	options := newExpirationOptions(opts...)
 
 	inventory, err := buildCertificateInventory(options)
 	if err != nil {
-		return ExpirationReport{}, err
+		panic(err)
 	}
 
 	var report ExpirationReport
 	for _, item := range inventory {
 		path := filepath.Join(options.certificatesDir, item.relPath)
-		isCA := item.authority == ""
 
 		exp, loadErr := loadCertificateExpiration(path, item)
 		switch {
 		case loadErr == nil:
-			report.add(exp.Name, exp.Path, exp.Authority, exp.IsCA, exp.NotAfter, ExpirationActionRead, nil)
+			report.add(exp, nil)
 		case errors.Is(loadErr, fs.ErrNotExist):
-			report.add(item.name, path, item.authority, isCA, time.Time{}, ExpirationActionSkippedMissing, nil)
+			report.add(skeletonExpiration(item, path), &MissingError{BaseName: item.name})
 		default:
-			report.add(item.name, path, item.authority, isCA, time.Time{}, ExpirationActionSkippedReadError, loadErr)
+			report.add(skeletonExpiration(item, path), loadErr)
 		}
 	}
 
-	return report, nil
+	return report
+}
+
+// skeletonExpiration builds a CertificateExpiration for failed cases:
+// NotAfter is zero but Name/Path/Authority/IsCA are populated from inventory
+func skeletonExpiration(item certificateInventoryItem, path string) CertificateExpiration {
+	return CertificateExpiration{
+		Name:      item.name,
+		Path:      path,
+		Authority: item.authority,
+		IsCA:      item.authority == "",
+	}
 }
 
 func GetCertificateExpiration(path string) (CertificateExpiration, error) {

--- a/go_lib/controlplane/pki/expiration_test.go
+++ b/go_lib/controlplane/pki/expiration_test.go
@@ -42,7 +42,8 @@ func TestListCertificateExpirations_DefaultInventory(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	report := ListCertificateExpirations(WithCertificatesDir(dir))
+	report, err := ListCertificateExpirations(WithCertificatesDir(dir))
+	require.NoError(t, err)
 	require.Len(t, report.Entries, 10)
 
 	paths := make([]string, 0, len(report.Entries))
@@ -61,10 +62,11 @@ func TestListCertificateExpirations_MissingEntries(t *testing.T) {
 
 	require.NoError(t, writeCert(dir, string(CACertName), caCert))
 
-	report := ListCertificateExpirations(
+	report, err := ListCertificateExpirations(
 		WithCertificatesDir(dir),
 		WithRootCertificates(CACertName, CACertName, EtcdCACertName),
 	)
+	require.NoError(t, err)
 	require.Len(t, report.Entries, 2)
 
 	byName := make(map[string]ExpirationEntry, len(report.Entries))

--- a/go_lib/controlplane/pki/expiration_test.go
+++ b/go_lib/controlplane/pki/expiration_test.go
@@ -42,41 +42,47 @@ func TestListCertificateExpirations_DefaultInventory(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	expirations, err := ListCertificateExpirations(WithCertificatesDir(dir))
-	require.NoError(t, err)
-	require.Len(t, expirations, 10)
+	report := ListCertificateExpirations(WithCertificatesDir(dir))
+	require.Len(t, report.Entries, 10)
 
-	paths := make([]string, 0, len(expirations))
-	for _, expiration := range expirations {
-		paths = append(paths, expiration.Path)
+	paths := make([]string, 0, len(report.Entries))
+	for _, e := range report.Entries {
+		require.NoError(t, e.Err, "entry %q should have no error", e.Name)
+		paths = append(paths, e.Path)
 	}
 
 	assert.True(t, sort.StringsAreSorted(paths))
 	assert.NotContains(t, paths, filepath.Join(dir, "sa.crt"))
 }
 
-func TestListCertificateExpirations_IgnoreReadErrors(t *testing.T) {
+func TestListCertificateExpirations_MissingEntries(t *testing.T) {
 	dir := t.TempDir()
 	caCert, _ := makeTestCACert(t, "kubernetes")
 
 	require.NoError(t, writeCert(dir, string(CACertName), caCert))
 
-	_, err := ListCertificateExpirations(
+	report := ListCertificateExpirations(
 		WithCertificatesDir(dir),
 		WithRootCertificates(CACertName, CACertName, EtcdCACertName),
 	)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), filepath.Join(dir, "etcd", "ca.crt"))
+	require.Len(t, report.Entries, 2)
 
-	expirations, err := ListCertificateExpirations(
-		WithCertificatesDir(dir),
-		WithRootCertificates(CACertName, CACertName, EtcdCACertName),
-		WithIgnoreReadErrors(),
-	)
-	require.Error(t, err)
-	require.Len(t, expirations, 1)
-	assert.Equal(t, string(CACertName), expirations[0].Name)
-	assert.Contains(t, err.Error(), filepath.Join(dir, "etcd", "ca.crt"))
+	byName := make(map[string]ExpirationEntry, len(report.Entries))
+	for _, e := range report.Entries {
+		byName[e.Name] = e
+	}
+
+	caEntry, ok := byName[string(CACertName)]
+	require.True(t, ok)
+	require.NoError(t, caEntry.Err)
+	assert.True(t, caEntry.IsCA)
+
+	etcdCAEntry, ok := byName[string(EtcdCACertName)]
+	require.True(t, ok)
+	var missing *MissingError
+	require.ErrorAs(t, etcdCAEntry.Err, &missing)
+	assert.Equal(t, string(EtcdCACertName), missing.BaseName)
+	assert.Equal(t, filepath.Join(dir, "etcd", "ca.crt"), etcdCAEntry.Path)
 }
 
 func TestGetCertificateExpiration_NormalizesKnownAndUnknownPaths(t *testing.T) {

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -135,7 +135,7 @@ func renewLeafCert(pkiDir string, name LeafCertName) error {
 	caCert, err := pkiutil.LoadCert(caCertFile)
 	if err != nil {
 		if isNotExistError(err) {
-			return fmt.Errorf("CA cert %q not found", caName)
+			return &CAMissingError{CAName: string(caName)}
 		}
 		return fmt.Errorf("load CA cert %q: %w", caName, err)
 	}
@@ -170,20 +170,33 @@ func renewLeafCert(pkiDir string, name LeafCertName) error {
 	return nil
 }
 
-// RenewLeafCert renews a leaf certificate by re-signing it with the same private key.
-// All Subject/SAN/Usage/Algorithm fields are preserved from the current certificate file.
+// RenewCertificate renews a leaf certificate by re-signing it with a fresh key.
+// All Subject/SAN/Usage/Algorithm fields are preserved from the current cert.
 // The new certificate is issued with constants.CertificateValidityPeriod (1 year).
-// Sentinel errors:
-//   - *MissingError  — leaf cert file absent (skippable)
-//   - *CAExternalError   — CA key absent (skippable)
-//   - *CAExpiredError    — CA cert expired (hard stop; renewal is pointless)
+//
+// The returned error encodes the outcome:
+//   - nil              — re-signed cleanly
+//   - *MissingError    — leaf cert file absent (skipped)
+//   - *CAMissingError  — CA cert file absent (skipped)
+//   - *CAExternalError — CA key absent / external CA (skipped)
+//   - *CAExpiredError  — CA already expired (skipped)
+//   - any other error  — IO/permissions/signing failure (skipped)
 func RenewCertificate(name LeafCertName, opts ...RenewOption) error {
 	o := newRenewOptions(opts...)
 	return renewLeafCert(o.certificatesDir, name)
 }
 
-// RenewCertificates iterates the inventory (or the subset chosen via WithRenewLeafs) and renews each leaf certificate in turn.
-// Iteration never aborts — the caller iterates report.Entries and decides per-entry what to do.
+// RenewCertificates renews a batch of leaf certificates by re-signing them with a fresh key.
+// All Subject/SAN/Usage/Algorithm fields are preserved from the current cert.
+// The new certificate is issued with constants.CertificateValidityPeriod (1 year).
+//
+// The returned error encodes the outcome:
+//   - nil              — re-signed cleanly
+//   - *MissingError    — leaf cert file absent (skipped)
+//   - *CAMissingError  — CA cert file absent (skipped)
+//   - *CAExternalError — CA key absent / external CA (skipped)
+//   - *CAExpiredError  — CA already expired (skipped)
+//   - any other error  — IO/permissions/signing failure (skipped)
 func RenewCertificates(opts ...RenewOption) PKIRenewReport {
 	o := newRenewOptions(opts...)
 

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -18,7 +18,6 @@ package pki
 
 import (
 	"crypto/x509"
-	"errors"
 	"fmt"
 	"time"
 
@@ -69,32 +68,25 @@ type PKIRenewReport struct {
 	Entries []PKIRenewEntry
 }
 
-// PKIRenewEntry is one row of PKIRenewReport. Mirrors CertificateExpiration struct.
+// PKIRenewEntry is one row of PKIRenewReport.
+// Err == nil means the cert was renewed successfully; otherwise Err is a sentinel describing what happened:
+//   - *MissingError   when the leaf cert file is absent (skippable)
+//   - *CAExternalError when the CA private key is absent (skippable)
+//   - *CAExpiredError when the signing CA has expired (renewal is pointless and the cert is left untouched)
+//   - any other error (wrapped) for IO/permissions/signing failures
 type PKIRenewEntry struct {
 	Name      LeafCertName
 	Path      string
 	Authority RootCertName
-	Action    PKIRenewAction
+	Err       error
 }
 
-// PKIRenewAction describes what happened to a single leaf certificate.
-type PKIRenewAction uint8
-
-const (
-	// PKIRenewActionRenewed - certificate was renewed.
-	PKIRenewActionRenewed PKIRenewAction = iota
-	// PKIRenewActionSkippedMissing - certificate was skipped because it was missing.
-	PKIRenewActionSkippedMissing
-	// external CA scenario; the leaf is left untouched.
-	PKIRenewActionSkippedExternalCA
-)
-
-func (r *PKIRenewReport) add(name LeafCertName, path string, authority RootCertName, action PKIRenewAction) {
+func (r *PKIRenewReport) add(name LeafCertName, path string, authority RootCertName, err error) {
 	r.Entries = append(r.Entries, PKIRenewEntry{
 		Name:      name,
 		Path:      path,
 		Authority: authority,
-		Action:    action,
+		Err:       err,
 	})
 }
 
@@ -134,7 +126,7 @@ func renewLeafCert(pkiDir string, name LeafCertName) error {
 	oldCert, err := pkiutil.LoadCert(certFile)
 	if err != nil {
 		if isNotExistError(err) {
-			return &CertMissingError{BaseName: string(name)}
+			return &MissingError{BaseName: string(name)}
 		}
 		return fmt.Errorf("load cert %q: %w", name, err)
 	}
@@ -182,7 +174,7 @@ func renewLeafCert(pkiDir string, name LeafCertName) error {
 // All Subject/SAN/Usage/Algorithm fields are preserved from the current certificate file.
 // The new certificate is issued with constants.CertificateValidityPeriod (1 year).
 // Sentinel errors:
-//   - *CertMissingError  — leaf cert file absent (skippable)
+//   - *MissingError  — leaf cert file absent (skippable)
 //   - *CAExternalError   — CA key absent (skippable)
 //   - *CAExpiredError    — CA cert expired (hard stop; renewal is pointless)
 func RenewCertificate(name LeafCertName, opts ...RenewOption) error {
@@ -191,9 +183,8 @@ func RenewCertificate(name LeafCertName, opts ...RenewOption) error {
 }
 
 // RenewCertificates iterates the inventory (or the subset chosen via WithRenewLeafs) and renews each leaf certificate in turn.
-// On *CertMissingError or *CAExternalError: an entry is appended to the report with the corresponding skip action and iteration continues.
-// On *CAExpiredError or any other error (I/O, permissions, signing failure): iteration aborts and the partial report gathered so far is returned together with the fatal error.
-func RenewCertificates(opts ...RenewOption) (PKIRenewReport, error) {
+// Iteration never aborts — the caller iterates report.Entries and decides per-entry what to do.
+func RenewCertificates(opts ...RenewOption) PKIRenewReport {
 	o := newRenewOptions(opts...)
 
 	inventory := selectLeafs(o.leafCertificates)
@@ -203,30 +194,14 @@ func RenewCertificates(opts ...RenewOption) (PKIRenewReport, error) {
 		authority, _ := caForLeaf(info.Name)
 		path := certPath(o.certificatesDir, string(info.Name))
 
-		err := renewLeafCert(o.certificatesDir, info.Name)
-		if err == nil {
-			report.add(info.Name, path, authority, PKIRenewActionRenewed)
-			continue
-		}
-
-		var missingCert *CertMissingError
-		var externalCA *CAExternalError
-		switch {
-		case errors.As(err, &missingCert):
-			report.add(info.Name, path, authority, PKIRenewActionSkippedMissing)
-		case errors.As(err, &externalCA):
-			report.add(info.Name, path, authority, PKIRenewActionSkippedExternalCA)
-		default:
-			// *CAExpiredError or any non-sentinel error is fatal.
-			return report, err
-		}
+		report.add(info.Name, path, authority, renewLeafCert(o.certificatesDir, info.Name))
 	}
 
-	return report, nil
+	return report
 }
 
 // defaultLeafCertificates returns the canonical list of renewable control-plane leaf certificates.
-func defaultLeafCertificates() []LeafCertificateInfo {
+func DefaultLeafCertificates() []LeafCertificateInfo {
 	return []LeafCertificateInfo{
 		{ApiserverCertName, "certificate for serving the Kubernetes API"},
 		{ApiserverKubeletClientCertName, "certificate for the API server to connect to kubelet"},
@@ -241,7 +216,7 @@ func defaultLeafCertificates() []LeafCertificateInfo {
 // selectLeafs returns the inventory with only the given names, preserving the canonical DefaultLeafCertificates() order.
 // When names is empty, returned default inventory.
 func selectLeafs(names []LeafCertName) []LeafCertificateInfo {
-	full := defaultLeafCertificates()
+	full := DefaultLeafCertificates()
 	if len(names) == 0 {
 		return full
 	}

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -37,7 +37,7 @@ func certConfigFromX509(cert *x509.Certificate) certConfig {
 			},
 			Usages: cert.ExtKeyUsage,
 		},
-		EncryptionAlgorithm: DetectEncryptionAlgorithm(cert),
+		EncryptionAlgorithm: pkiutil.DetectEncryptionAlgorithm(cert),
 	}
 }
 

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -33,19 +33,6 @@ type LeafCertificateInfo struct {
 	Description string
 }
 
-// DefaultLeafCertificates returns the canonical list of renewable control-plane leaf certificates.
-func DefaultLeafCertificates() []LeafCertificateInfo {
-	return []LeafCertificateInfo{
-		{ApiserverCertName, "certificate for serving the Kubernetes API"},
-		{ApiserverKubeletClientCertName, "certificate for the API server to connect to kubelet"},
-		{ApiserverEtcdClientCertName, "certificate the apiserver uses to access etcd"},
-		{FrontProxyClientCertName, "certificate for the front proxy client"},
-		{EtcdServerCertName, "certificate for serving etcd"},
-		{EtcdPeerCertName, "certificate for etcd nodes to communicate with each other"},
-		{EtcdHealthcheckClientCertName, "certificate for liveness probes to healthcheck etcd"},
-	}
-}
-
 type RenewOption func(*renewOptions)
 
 type renewOptions struct {
@@ -238,10 +225,23 @@ func RenewCertificates(opts ...RenewOption) (PKIRenewReport, error) {
 	return report, nil
 }
 
+// defaultLeafCertificates returns the canonical list of renewable control-plane leaf certificates.
+func defaultLeafCertificates() []LeafCertificateInfo {
+	return []LeafCertificateInfo{
+		{ApiserverCertName, "certificate for serving the Kubernetes API"},
+		{ApiserverKubeletClientCertName, "certificate for the API server to connect to kubelet"},
+		{ApiserverEtcdClientCertName, "certificate the apiserver uses to access etcd"},
+		{FrontProxyClientCertName, "certificate for the front proxy client"},
+		{EtcdServerCertName, "certificate for serving etcd"},
+		{EtcdPeerCertName, "certificate for etcd nodes to communicate with each other"},
+		{EtcdHealthcheckClientCertName, "certificate for liveness probes to healthcheck etcd"},
+	}
+}
+
 // selectLeafs returns the inventory with only the given names, preserving the canonical DefaultLeafCertificates() order.
 // When names is empty, returned default inventory.
 func selectLeafs(names []LeafCertName) []LeafCertificateInfo {
-	full := DefaultLeafCertificates()
+	full := defaultLeafCertificates()
 	if len(names) == 0 {
 		return full
 	}

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -37,6 +37,7 @@ type RenewOption func(*renewOptions)
 type renewOptions struct {
 	certificatesDir  string
 	leafCertificates []LeafCertName
+	dryRun           bool
 }
 
 // WithRenewDir overrides the PKI directory used by Renew*.
@@ -52,6 +53,14 @@ func WithRenewDir(dir string) RenewOption {
 func WithRenewLeafs(names ...LeafCertName) RenewOption {
 	return func(o *renewOptions) {
 		o.leafCertificates = append(o.leafCertificates, names...)
+	}
+}
+
+// WithDryRun runs all renewal checks and signing in memory but skips writing the new certificate to disk.
+// The returned error contract is unchange
+func WithDryRun() RenewOption {
+	return func(o *renewOptions) {
+		o.dryRun = true
 	}
 }
 
@@ -116,7 +125,7 @@ func caForLeaf(name LeafCertName) (RootCertName, bool) {
 	return "", false
 }
 
-func renewLeafCert(pkiDir string, name LeafCertName) error {
+func renewLeafCert(pkiDir string, name LeafCertName, dryRun bool) error {
 	caName, ok := caForLeaf(name)
 	if !ok {
 		return fmt.Errorf("unknown leaf certificate %q", name)
@@ -164,6 +173,11 @@ func renewLeafCert(pkiDir string, name LeafCertName) error {
 	if err != nil {
 		return fmt.Errorf("sign cert %q: %w", name, err)
 	}
+
+	if dryRun {
+		return nil
+	}
+
 	if err := writeCertAndKey(pkiDir, string(name), newCert, newKey); err != nil {
 		return fmt.Errorf("write cert %q: %w", name, err)
 	}
@@ -183,7 +197,7 @@ func renewLeafCert(pkiDir string, name LeafCertName) error {
 //   - any other error  — IO/permissions/signing failure (skipped)
 func RenewCertificate(name LeafCertName, opts ...RenewOption) error {
 	o := newRenewOptions(opts...)
-	return renewLeafCert(o.certificatesDir, name)
+	return renewLeafCert(o.certificatesDir, name, o.dryRun)
 }
 
 // RenewCertificates renews a batch of leaf certificates by re-signing them with a fresh key.
@@ -207,7 +221,7 @@ func RenewCertificates(opts ...RenewOption) PKIRenewReport {
 		authority, _ := caForLeaf(info.Name)
 		path := certPath(o.certificatesDir, string(info.Name))
 
-		report.add(info.Name, path, authority, renewLeafCert(o.certificatesDir, info.Name))
+		report.add(info.Name, path, authority, renewLeafCert(o.certificatesDir, info.Name, o.dryRun))
 	}
 
 	return report

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -49,7 +49,7 @@ func WithRenewDir(dir string) RenewOption {
 }
 
 // WithRenewLeafs restricts RenewCertificates to the provided leaf names.
-// When empty, the full DefaultLeafCertificates() inventory is used.
+// When empty, the full default leaf certificate inventory is used.
 func WithRenewLeafs(names ...LeafCertName) RenewOption {
 	return func(o *renewOptions) {
 		o.leafCertificates = append(o.leafCertificates, names...)
@@ -227,8 +227,19 @@ func RenewCertificates(opts ...RenewOption) PKIRenewReport {
 	return report
 }
 
+// LeafDescription returns the human-readable description for the given renewable leaf certificate name.
+// Falls back to the string representation of name when no description is found.
+func LeafDescription(name LeafCertName) string {
+	for _, info := range defaultLeafCertificates() {
+		if info.Name == name {
+			return info.Description
+		}
+	}
+	return string(name)
+}
+
 // defaultLeafCertificates returns the canonical list of renewable control-plane leaf certificates.
-func DefaultLeafCertificates() []LeafCertificateInfo {
+func defaultLeafCertificates() []LeafCertificateInfo {
 	return []LeafCertificateInfo{
 		{ApiserverCertName, "certificate for serving the Kubernetes API"},
 		{ApiserverKubeletClientCertName, "certificate for the API server to connect to kubelet"},
@@ -240,10 +251,10 @@ func DefaultLeafCertificates() []LeafCertificateInfo {
 	}
 }
 
-// selectLeafs returns the inventory with only the given names, preserving the canonical DefaultLeafCertificates() order.
+// selectLeafs returns the inventory with only the given names, preserving the canonical order.
 // When names is empty, returned default inventory.
 func selectLeafs(names []LeafCertName) []LeafCertificateInfo {
-	full := DefaultLeafCertificates()
+	full := defaultLeafCertificates()
 	if len(names) == 0 {
 		return full
 	}

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -19,6 +19,7 @@ package pki
 import (
 	"crypto/x509"
 	"fmt"
+	"net"
 	"time"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -38,6 +39,7 @@ type renewOptions struct {
 	certificatesDir  string
 	leafCertificates []LeafCertName
 	dryRun           bool
+	extraIP          net.IP
 }
 
 // WithRenewDir overrides the PKI directory used by Renew*.
@@ -61,6 +63,14 @@ func WithRenewLeafs(names ...LeafCertName) RenewOption {
 func WithDryRun() RenewOption {
 	return func(o *renewOptions) {
 		o.dryRun = true
+	}
+}
+
+// WithRenewExtraIP adds an extra IP SAN to renewed serving certificates.
+// Client certificates without IP SANs are renewed unchanged.
+func WithRenewExtraIP(ip net.IP) RenewOption {
+	return func(o *renewOptions) {
+		o.extraIP = ip
 	}
 }
 
@@ -125,7 +135,9 @@ func caForLeaf(name LeafCertName) (RootCertName, bool) {
 	return "", false
 }
 
-func renewLeafCert(pkiDir string, name LeafCertName, dryRun bool) error {
+func renewLeafCert(o *renewOptions, name LeafCertName) error {
+	pkiDir := o.certificatesDir
+
 	caName, ok := caForLeaf(name)
 	if !ok {
 		return fmt.Errorf("unknown leaf certificate %q", name)
@@ -164,6 +176,10 @@ func renewLeafCert(pkiDir string, name LeafCertName, dryRun bool) error {
 	cfg := certConfigFromX509(oldCert)
 	cfg.CertificateValidityPeriod = constants.CertificateValidityPeriod
 
+	if o.extraIP != nil && len(cfg.AltNames.IPs) > 0 {
+		cfg.AltNames.IPs = append(cfg.AltNames.IPs, o.extraIP)
+	}
+
 	newKey, err := pkiutil.NewPrivateKey(cfg.EncryptionAlgorithm)
 	if err != nil {
 		return fmt.Errorf("generate new key for cert %q: %w", name, err)
@@ -174,7 +190,7 @@ func renewLeafCert(pkiDir string, name LeafCertName, dryRun bool) error {
 		return fmt.Errorf("sign cert %q: %w", name, err)
 	}
 
-	if dryRun {
+	if o.dryRun {
 		return nil
 	}
 
@@ -197,7 +213,7 @@ func renewLeafCert(pkiDir string, name LeafCertName, dryRun bool) error {
 //   - any other error  — IO/permissions/signing failure (skipped)
 func RenewCertificate(name LeafCertName, opts ...RenewOption) error {
 	o := newRenewOptions(opts...)
-	return renewLeafCert(o.certificatesDir, name, o.dryRun)
+	return renewLeafCert(o, name)
 }
 
 // RenewCertificates renews a batch of leaf certificates by re-signing them with a fresh key.
@@ -221,7 +237,7 @@ func RenewCertificates(opts ...RenewOption) PKIRenewReport {
 		authority, _ := caForLeaf(info.Name)
 		path := certPath(o.certificatesDir, string(info.Name))
 
-		report.add(info.Name, path, authority, renewLeafCert(o.certificatesDir, info.Name, o.dryRun))
+		report.add(info.Name, path, authority, renewLeafCert(o, info.Name))
 	}
 
 	return report

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -28,7 +28,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
 )
 
-type LeafCertificateInfo struct {
+type leafCertificateInfo struct {
 	Name        LeafCertName
 	Description string
 }
@@ -255,8 +255,8 @@ func LeafDescription(name LeafCertName) string {
 }
 
 // defaultLeafCertificates returns the canonical list of renewable control-plane leaf certificates.
-func defaultLeafCertificates() []LeafCertificateInfo {
-	return []LeafCertificateInfo{
+func defaultLeafCertificates() []leafCertificateInfo {
+	return []leafCertificateInfo{
 		{ApiserverCertName, "certificate for serving the Kubernetes API"},
 		{ApiserverKubeletClientCertName, "certificate for the API server to connect to kubelet"},
 		{ApiserverEtcdClientCertName, "certificate the apiserver uses to access etcd"},
@@ -269,7 +269,7 @@ func defaultLeafCertificates() []LeafCertificateInfo {
 
 // selectLeafs returns the inventory with only the given names, preserving the canonical order.
 // When names is empty, returned default inventory.
-func selectLeafs(names []LeafCertName) []LeafCertificateInfo {
+func selectLeafs(names []LeafCertName) []leafCertificateInfo {
 	full := defaultLeafCertificates()
 	if len(names) == 0 {
 		return full
@@ -280,7 +280,7 @@ func selectLeafs(names []LeafCertName) []LeafCertificateInfo {
 		wanted[n] = struct{}{}
 	}
 
-	result := make([]LeafCertificateInfo, 0, len(names))
+	result := make([]leafCertificateInfo, 0, len(names))
 	for _, info := range full {
 		if _, ok := wanted[info.Name]; ok {
 			result = append(result, info)

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto/x509"
+	"fmt"
+	"time"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func certConfigFromX509(cert *x509.Certificate) certConfig {
+	return certConfig{
+		Config: certutil.Config{
+			CommonName:   cert.Subject.CommonName,
+			Organization: cert.Subject.Organization,
+			AltNames: certutil.AltNames{
+				DNSNames: cert.DNSNames,
+				IPs:      cert.IPAddresses,
+			},
+			Usages: cert.ExtKeyUsage,
+		},
+		EncryptionAlgorithm: DetectEncryptionAlgorithm(cert),
+	}
+}
+
+func caForLeaf(name LeafCertName) (RootCertName, bool) {
+	for caName, leafNames := range defaultCertTreeScheme {
+		for _, leafName := range leafNames {
+			if leafName == name {
+				return caName, true
+			}
+		}
+	}
+	return "", false
+}
+
+// RenewLeafCert renews a leaf certificate by re-signing it with the same private key.
+// All Subject/SAN/Usage/Algorithm fields are preserved from the current certificate file.
+// The new certificate is issued with constants.CertificateValidityPeriod (1 year).
+// Sentinel errors:
+//   - *CertMissingError  — leaf cert file absent (skippable)
+//   - *CAExternalError   — CA key absent (skippable)
+//   - *CAExpiredError    — CA cert expired (hard stop; renewal is pointless)
+func RenewLeafCert(pkiDir string, name LeafCertName) error {
+	caName, ok := caForLeaf(name)
+	if !ok {
+		return fmt.Errorf("unknown leaf certificate %q", name)
+	}
+
+	certFile := certPath(pkiDir, string(name))
+	oldCert, err := pkiutil.LoadCert(certFile)
+	if err != nil {
+		if isNotExistError(err) {
+			return &CertMissingError{BaseName: string(name)}
+		}
+		return fmt.Errorf("load cert %q: %w", name, err)
+	}
+
+	caCertFile := certPath(pkiDir, string(caName))
+	caCert, err := pkiutil.LoadCert(caCertFile)
+	if err != nil {
+		if isNotExistError(err) {
+			return fmt.Errorf("CA cert %q not found", caName)
+		}
+		return fmt.Errorf("load CA cert %q: %w", caName, err)
+	}
+
+	if time.Now().After(caCert.NotAfter) {
+		return &CAExpiredError{CAName: string(caName), ExpiredAt: caCert.NotAfter}
+	}
+
+	caKey, err := pkiutil.LoadKey(keyPath(pkiDir, string(caName)))
+	if err != nil {
+		if isNotExistError(err) {
+			return &CAExternalError{CAName: string(caName)}
+		}
+		return fmt.Errorf("load CA key %q: %w", caName, err)
+	}
+
+	cfg := certConfigFromX509(oldCert)
+	cfg.CertificateValidityPeriod = constants.CertificateValidityPeriod
+
+	newKey, err := pkiutil.NewPrivateKey(cfg.EncryptionAlgorithm)
+	if err != nil {
+		return fmt.Errorf("generate new key for cert %q: %w", name, err)
+	}
+
+	newCert, err := pkiutil.NewSignedCert(cfg, newKey, caCert, caKey)
+	if err != nil {
+		return fmt.Errorf("sign cert %q: %w", name, err)
+	}
+	if err := writeCertAndKey(pkiDir, string(name), newCert, newKey); err != nil {
+		return fmt.Errorf("write cert %q: %w", name, err)
+	}
+	return nil
+}

--- a/go_lib/controlplane/pki/renew.go
+++ b/go_lib/controlplane/pki/renew.go
@@ -18,13 +18,98 @@ package pki
 
 import (
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"time"
 
+	certutil "k8s.io/client-go/util/cert"
+
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
-	certutil "k8s.io/client-go/util/cert"
 )
+
+type LeafCertificateInfo struct {
+	Name        LeafCertName
+	Description string
+}
+
+// DefaultLeafCertificates returns the canonical list of renewable control-plane leaf certificates.
+func DefaultLeafCertificates() []LeafCertificateInfo {
+	return []LeafCertificateInfo{
+		{ApiserverCertName, "certificate for serving the Kubernetes API"},
+		{ApiserverKubeletClientCertName, "certificate for the API server to connect to kubelet"},
+		{ApiserverEtcdClientCertName, "certificate the apiserver uses to access etcd"},
+		{FrontProxyClientCertName, "certificate for the front proxy client"},
+		{EtcdServerCertName, "certificate for serving etcd"},
+		{EtcdPeerCertName, "certificate for etcd nodes to communicate with each other"},
+		{EtcdHealthcheckClientCertName, "certificate for liveness probes to healthcheck etcd"},
+	}
+}
+
+type RenewOption func(*renewOptions)
+
+type renewOptions struct {
+	certificatesDir  string
+	leafCertificates []LeafCertName
+}
+
+// WithRenewDir overrides the PKI directory used by Renew*.
+// Defaults to constants.DefaultCertificatesDir (e.g. /etc/kubernetes/pki).
+func WithRenewDir(dir string) RenewOption {
+	return func(o *renewOptions) {
+		o.certificatesDir = dir
+	}
+}
+
+// WithRenewLeafs restricts RenewCertificates to the provided leaf names.
+// When empty, the full DefaultLeafCertificates() inventory is used.
+func WithRenewLeafs(names ...LeafCertName) RenewOption {
+	return func(o *renewOptions) {
+		o.leafCertificates = append(o.leafCertificates, names...)
+	}
+}
+
+func newRenewOptions(opts ...RenewOption) *renewOptions {
+	o := &renewOptions{certificatesDir: constants.DefaultCertificatesDir}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}
+
+// PKIRenewReport describes per-certificate outcomes of a RenewCertificates call.
+type PKIRenewReport struct {
+	Entries []PKIRenewEntry
+}
+
+// PKIRenewEntry is one row of PKIRenewReport. Mirrors CertificateExpiration struct.
+type PKIRenewEntry struct {
+	Name      LeafCertName
+	Path      string
+	Authority RootCertName
+	Action    PKIRenewAction
+}
+
+// PKIRenewAction describes what happened to a single leaf certificate.
+type PKIRenewAction uint8
+
+const (
+	// PKIRenewActionRenewed - certificate was renewed.
+	PKIRenewActionRenewed PKIRenewAction = iota
+	// PKIRenewActionSkippedMissing - certificate was skipped because it was missing.
+	PKIRenewActionSkippedMissing
+	// external CA scenario; the leaf is left untouched.
+	PKIRenewActionSkippedExternalCA
+)
+
+func (r *PKIRenewReport) add(name LeafCertName, path string, authority RootCertName, action PKIRenewAction) {
+	r.Entries = append(r.Entries, PKIRenewEntry{
+		Name:      name,
+		Path:      path,
+		Authority: authority,
+		Action:    action,
+	})
+}
 
 func certConfigFromX509(cert *x509.Certificate) certConfig {
 	return certConfig{
@@ -52,14 +137,7 @@ func caForLeaf(name LeafCertName) (RootCertName, bool) {
 	return "", false
 }
 
-// RenewLeafCert renews a leaf certificate by re-signing it with the same private key.
-// All Subject/SAN/Usage/Algorithm fields are preserved from the current certificate file.
-// The new certificate is issued with constants.CertificateValidityPeriod (1 year).
-// Sentinel errors:
-//   - *CertMissingError  — leaf cert file absent (skippable)
-//   - *CAExternalError   — CA key absent (skippable)
-//   - *CAExpiredError    — CA cert expired (hard stop; renewal is pointless)
-func RenewLeafCert(pkiDir string, name LeafCertName) error {
+func renewLeafCert(pkiDir string, name LeafCertName) error {
 	caName, ok := caForLeaf(name)
 	if !ok {
 		return fmt.Errorf("unknown leaf certificate %q", name)
@@ -111,4 +189,73 @@ func RenewLeafCert(pkiDir string, name LeafCertName) error {
 		return fmt.Errorf("write cert %q: %w", name, err)
 	}
 	return nil
+}
+
+// RenewLeafCert renews a leaf certificate by re-signing it with the same private key.
+// All Subject/SAN/Usage/Algorithm fields are preserved from the current certificate file.
+// The new certificate is issued with constants.CertificateValidityPeriod (1 year).
+// Sentinel errors:
+//   - *CertMissingError  — leaf cert file absent (skippable)
+//   - *CAExternalError   — CA key absent (skippable)
+//   - *CAExpiredError    — CA cert expired (hard stop; renewal is pointless)
+func RenewCertificate(name LeafCertName, opts ...RenewOption) error {
+	o := newRenewOptions(opts...)
+	return renewLeafCert(o.certificatesDir, name)
+}
+
+// RenewCertificates iterates the inventory (or the subset chosen via WithRenewLeafs) and renews each leaf certificate in turn.
+// On *CertMissingError or *CAExternalError: an entry is appended to the report with the corresponding skip action and iteration continues.
+// On *CAExpiredError or any other error (I/O, permissions, signing failure): iteration aborts and the partial report gathered so far is returned together with the fatal error.
+func RenewCertificates(opts ...RenewOption) (PKIRenewReport, error) {
+	o := newRenewOptions(opts...)
+
+	inventory := selectLeafs(o.leafCertificates)
+
+	var report PKIRenewReport
+	for _, info := range inventory {
+		authority, _ := caForLeaf(info.Name)
+		path := certPath(o.certificatesDir, string(info.Name))
+
+		err := renewLeafCert(o.certificatesDir, info.Name)
+		if err == nil {
+			report.add(info.Name, path, authority, PKIRenewActionRenewed)
+			continue
+		}
+
+		var missingCert *CertMissingError
+		var externalCA *CAExternalError
+		switch {
+		case errors.As(err, &missingCert):
+			report.add(info.Name, path, authority, PKIRenewActionSkippedMissing)
+		case errors.As(err, &externalCA):
+			report.add(info.Name, path, authority, PKIRenewActionSkippedExternalCA)
+		default:
+			// *CAExpiredError or any non-sentinel error is fatal.
+			return report, err
+		}
+	}
+
+	return report, nil
+}
+
+// selectLeafs returns the inventory with only the given names, preserving the canonical DefaultLeafCertificates() order.
+// When names is empty, returned default inventory.
+func selectLeafs(names []LeafCertName) []LeafCertificateInfo {
+	full := DefaultLeafCertificates()
+	if len(names) == 0 {
+		return full
+	}
+
+	wanted := make(map[LeafCertName]struct{}, len(names))
+	for _, n := range names {
+		wanted[n] = struct{}{}
+	}
+
+	result := make([]LeafCertificateInfo, 0, len(names))
+	for _, info := range full {
+		if _, ok := wanted[info.Name]; ok {
+			result = append(result, info)
+		}
+	}
+	return result
 }

--- a/go_lib/controlplane/pki/renew_test.go
+++ b/go_lib/controlplane/pki/renew_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pki
+
+import (
+	"crypto"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+func makeExpiredCACert(t *testing.T, commonName string) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+	key, err := pkiutil.NewPrivateKey(constants.EncryptionAlgorithmRSA2048)
+	require.NoError(t, err)
+
+	cert, err := pkiutil.NewSelfSignedCACert(pkiutil.CertConfig{
+		Config:   certutil.Config{CommonName: commonName},
+		NotAfter: time.Now().Add(-1 * time.Hour),
+	}, key)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func makeLeafCert(t *testing.T, commonName string, caCert *x509.Certificate, caKey crypto.Signer) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+	key, err := pkiutil.NewPrivateKey(constants.EncryptionAlgorithmRSA2048)
+	require.NoError(t, err)
+
+	cert, err := pkiutil.NewSignedCert(pkiutil.CertConfig{
+		Config: certutil.Config{
+			CommonName: commonName,
+			Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		},
+		CertificateValidityPeriod: constants.CertificateValidityPeriod,
+	}, key, caCert, caKey)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func TestRenewCertificate_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+
+	caCert, caKey := makeTestCACert(t, "kubernetes")
+	require.NoError(t, writeCertAndKey(dir, string(CACertName), caCert, caKey))
+
+	leafCert, leafKey := makeLeafCert(t, "kube-apiserver", caCert, caKey)
+	require.NoError(t, writeCertAndKey(dir, string(ApiserverCertName), leafCert, leafKey))
+
+	origCert, err := pkiutil.LoadCert(certPath(dir, string(ApiserverCertName)))
+	require.NoError(t, err)
+
+	require.NoError(t, RenewCertificate(ApiserverCertName, WithRenewDir(dir)))
+
+	newCert, err := pkiutil.LoadCert(certPath(dir, string(ApiserverCertName)))
+	require.NoError(t, err)
+
+	assert.Equal(t, origCert.Subject.CommonName, newCert.Subject.CommonName)
+	assert.Equal(t, origCert.Subject.Organization, newCert.Subject.Organization)
+	assert.Equal(t, origCert.ExtKeyUsage, newCert.ExtKeyUsage)
+	assert.True(t, newCert.NotAfter.After(time.Now()))
+}
+
+func TestRenewCertificate_DryRun(t *testing.T) {
+	dir := t.TempDir()
+
+	caCert, caKey := makeTestCACert(t, "kubernetes")
+	require.NoError(t, writeCertAndKey(dir, string(CACertName), caCert, caKey))
+
+	leafCert, leafKey := makeLeafCert(t, "kube-apiserver", caCert, caKey)
+	require.NoError(t, writeCertAndKey(dir, string(ApiserverCertName), leafCert, leafKey))
+
+	statBefore, err := os.Stat(certPath(dir, string(ApiserverCertName)))
+	require.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.NoError(t, RenewCertificate(ApiserverCertName, WithRenewDir(dir), WithDryRun()))
+
+	statAfter, err := os.Stat(certPath(dir, string(ApiserverCertName)))
+	require.NoError(t, err)
+	assert.Equal(t, statBefore.ModTime(), statAfter.ModTime(), "dry-run must not modify the file on disk")
+}
+
+func TestRenewCertificate_ErrorSentinels(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, dir string)
+		wantErr interface{ Error() string }
+	}{
+		{
+			name: "leaf cert missing",
+			setup: func(t *testing.T, dir string) {
+				caCert, caKey := makeTestCACert(t, "kubernetes")
+				require.NoError(t, writeCertAndKey(dir, string(CACertName), caCert, caKey))
+			},
+			wantErr: &MissingError{},
+		},
+		{
+			name: "CA cert missing",
+			setup: func(t *testing.T, dir string) {
+				caCert, caKey := makeTestCACert(t, "kubernetes")
+				leafCert, leafKey := makeLeafCert(t, "kube-apiserver", caCert, caKey)
+				require.NoError(t, writeCertAndKey(dir, string(ApiserverCertName), leafCert, leafKey))
+			},
+			wantErr: &CAMissingError{},
+		},
+		{
+			name: "external CA — key absent",
+			setup: func(t *testing.T, dir string) {
+				caCert, caKey := makeTestCACert(t, "kubernetes")
+				leafCert, leafKey := makeLeafCert(t, "kube-apiserver", caCert, caKey)
+				require.NoError(t, writeCertAndKey(dir, string(ApiserverCertName), leafCert, leafKey))
+				// Write only the CA cert, not the key.
+				require.NoError(t, writeCert(dir, string(CACertName), caCert))
+			},
+			wantErr: &CAExternalError{},
+		},
+		{
+			name: "CA expired",
+			setup: func(t *testing.T, dir string) {
+				expiredCA, expiredKey := makeExpiredCACert(t, "kubernetes")
+				freshCA, freshKey := makeTestCACert(t, "kubernetes")
+				leafCert, leafKey := makeLeafCert(t, "kube-apiserver", freshCA, freshKey)
+				require.NoError(t, writeCertAndKey(dir, string(ApiserverCertName), leafCert, leafKey))
+				require.NoError(t, writeCertAndKey(dir, string(CACertName), expiredCA, expiredKey))
+			},
+			wantErr: &CAExpiredError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tt.setup(t, dir)
+
+			err := RenewCertificate(ApiserverCertName, WithRenewDir(dir))
+			require.Error(t, err)
+			assert.ErrorAs(t, err, &tt.wantErr)
+		})
+	}
+}
+
+func TestRenewCertificates_AllDefaultLeafs(t *testing.T) {
+	dir := t.TempDir()
+
+	cas := map[RootCertName]struct {
+		cert *x509.Certificate
+		key  crypto.Signer
+	}{}
+	for _, caName := range []RootCertName{CACertName, FrontProxyCACertName, EtcdCACertName} {
+		cert, key := makeTestCACert(t, string(caName))
+		require.NoError(t, writeCertAndKey(dir, string(caName), cert, key))
+		cas[caName] = struct {
+			cert *x509.Certificate
+			key  crypto.Signer
+		}{cert, key}
+	}
+
+	for _, info := range defaultLeafCertificates() {
+		caName, ok := caForLeaf(info.Name)
+		require.True(t, ok)
+		ca := cas[caName]
+		leafCert, leafKey := makeLeafCert(t, string(info.Name), ca.cert, ca.key)
+		require.NoError(t, writeCertAndKey(dir, string(info.Name), leafCert, leafKey))
+	}
+
+	report := RenewCertificates(WithRenewDir(dir))
+
+	require.Len(t, report.Entries, len(defaultLeafCertificates()))
+	for _, entry := range report.Entries {
+		assert.NoError(t, entry.Err, "cert %s should renew without error", entry.Name)
+	}
+}
+
+func TestRenewCertificate_UnknownLeaf(t *testing.T) {
+	err := RenewCertificate(LeafCertName("not-a-real-cert"), WithRenewDir(t.TempDir()))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown leaf certificate")
+}
+
+func TestRenewCertificates_WithLeafsSubset(t *testing.T) {
+	dir := t.TempDir()
+
+	caCert, caKey := makeTestCACert(t, "kubernetes")
+	require.NoError(t, writeCertAndKey(dir, string(CACertName), caCert, caKey))
+
+	for _, name := range []LeafCertName{ApiserverCertName, ApiserverKubeletClientCertName} {
+		leafCert, leafKey := makeLeafCert(t, string(name), caCert, caKey)
+		require.NoError(t, writeCertAndKey(dir, string(name), leafCert, leafKey))
+	}
+
+	statBefore := map[LeafCertName]time.Time{}
+	for _, name := range []LeafCertName{ApiserverCertName, ApiserverKubeletClientCertName} {
+		info, err := os.Stat(certPath(dir, string(name)))
+		require.NoError(t, err)
+		statBefore[name] = info.ModTime()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	report := RenewCertificates(
+		WithRenewDir(dir),
+		WithRenewLeafs(ApiserverCertName),
+	)
+
+	require.Len(t, report.Entries, 1)
+	assert.Equal(t, ApiserverCertName, report.Entries[0].Name)
+	assert.NoError(t, report.Entries[0].Err)
+
+	info, err := os.Stat(certPath(dir, string(ApiserverCertName)))
+	require.NoError(t, err)
+	assert.True(t, info.ModTime().After(statBefore[ApiserverCertName]), "apiserver cert should have been renewed")
+
+	info, err = os.Stat(filepath.Join(dir, string(ApiserverKubeletClientCertName)+".crt"))
+	require.NoError(t, err)
+	assert.Equal(t, statBefore[ApiserverKubeletClientCertName], info.ModTime(), "apiserver-kubelet-client must not be touched")
+}

--- a/go_lib/controlplane/pki/validate.go
+++ b/go_lib/controlplane/pki/validate.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
 )
 
@@ -89,9 +88,5 @@ func certificateSubjectAndSansIsEqual(oldCert *x509.Certificate, newCertCfg cert
 }
 
 func certificateEncryptionAlgoIsEqual(oldCert *x509.Certificate, newCertCfg certConfig) bool {
-	return detectEncryptionAlgorithm(oldCert) == newCertCfg.EncryptionAlgorithm
-}
-
-func detectEncryptionAlgorithm(cert *x509.Certificate) constants.EncryptionAlgorithmType {
-	return pkiutil.DetectEncryptionAlgorithm(cert)
+	return pkiutil.DetectEncryptionAlgorithm(oldCert) == newCertCfg.EncryptionAlgorithm
 }

--- a/go_lib/controlplane/pki/validate.go
+++ b/go_lib/controlplane/pki/validate.go
@@ -17,8 +17,6 @@ limitations under the License.
 package pki
 
 import (
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"time"
@@ -95,29 +93,5 @@ func certificateEncryptionAlgoIsEqual(oldCert *x509.Certificate, newCertCfg cert
 }
 
 func detectEncryptionAlgorithm(cert *x509.Certificate) constants.EncryptionAlgorithmType {
-	return DetectEncryptionAlgorithm(cert)
-}
-
-// DetectEncryptionAlgorithm returns the EncryptionAlgorithmType corresponding to the public key of cert.
-// Returns "" for unknown key types or sizes.
-func DetectEncryptionAlgorithm(cert *x509.Certificate) constants.EncryptionAlgorithmType {
-	switch pub := cert.PublicKey.(type) {
-	case *rsa.PublicKey:
-		switch pub.N.BitLen() {
-		case 2048:
-			return constants.EncryptionAlgorithmRSA2048
-		case 3072:
-			return constants.EncryptionAlgorithmRSA3072
-		case 4096:
-			return constants.EncryptionAlgorithmRSA4096
-		}
-	case *ecdsa.PublicKey:
-		switch pub.Curve.Params().BitSize {
-		case 256:
-			return constants.EncryptionAlgorithmECDSAP256
-		case 384:
-			return constants.EncryptionAlgorithmECDSAP384
-		}
-	}
-	return ""
+	return pkiutil.DetectEncryptionAlgorithm(cert)
 }

--- a/go_lib/controlplane/pki/validate.go
+++ b/go_lib/controlplane/pki/validate.go
@@ -95,6 +95,12 @@ func certificateEncryptionAlgoIsEqual(oldCert *x509.Certificate, newCertCfg cert
 }
 
 func detectEncryptionAlgorithm(cert *x509.Certificate) constants.EncryptionAlgorithmType {
+	return DetectEncryptionAlgorithm(cert)
+}
+
+// DetectEncryptionAlgorithm returns the EncryptionAlgorithmType corresponding to the public key of cert.
+// Returns "" for unknown key types or sizes.
+func DetectEncryptionAlgorithm(cert *x509.Certificate) constants.EncryptionAlgorithmType {
 	switch pub := cert.PublicKey.(type) {
 	case *rsa.PublicKey:
 		switch pub.N.BitLen() {
@@ -113,6 +119,5 @@ func detectEncryptionAlgorithm(cert *x509.Certificate) constants.EncryptionAlgor
 			return constants.EncryptionAlgorithmECDSAP384
 		}
 	}
-
 	return ""
 }

--- a/go_lib/controlplane/util/pkiutil/validate.go
+++ b/go_lib/controlplane/util/pkiutil/validate.go
@@ -17,11 +17,39 @@ limitations under the License.
 package pkiutil
 
 import (
+	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/x509"
 	"time"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
 )
 
 // CertificateExpiresSoon returns true if cert will expire within the given threshold duration.
 func CertificateExpiresSoon(cert *x509.Certificate, threshold time.Duration) bool {
 	return time.Until(cert.NotAfter) < threshold
+}
+
+// DetectEncryptionAlgorithm returns the EncryptionAlgorithmType corresponding to the public key of cert.
+// Returns "" for unknown key types or sizes.
+func DetectEncryptionAlgorithm(cert *x509.Certificate) constants.EncryptionAlgorithmType {
+	switch pub := cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		switch pub.N.BitLen() {
+		case 2048:
+			return constants.EncryptionAlgorithmRSA2048
+		case 3072:
+			return constants.EncryptionAlgorithmRSA3072
+		case 4096:
+			return constants.EncryptionAlgorithmRSA4096
+		}
+	case *ecdsa.PublicKey:
+		switch pub.Curve.Params().BitSize {
+		case 256:
+			return constants.EncryptionAlgorithmECDSAP256
+		case 384:
+			return constants.EncryptionAlgorithmECDSAP384
+		}
+	}
+	return ""
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -41,10 +41,14 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 	var readErrs []error
 
 	if leafNames := deps.leafCertFiles(); len(leafNames) > 0 {
-		report := pki.ListCertificateExpirations(
+		report, err := pki.ListCertificateExpirations(
 			pki.WithCertificatesDir(constants.KubernetesPkiPath),
 			pki.WithLeafCertificates(leafNames...),
 		)
+		if err != nil {
+			logger.Warn("cannot list cert expirations", "error", err)
+			readErrs = append(readErrs, err)
+		}
 		for _, e := range report.Entries {
 			if e.Err != nil {
 				logger.Warn("cannot read cert expiration", "name", e.Name, "path", e.Path, "error", e.Err)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -37,29 +37,27 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 	certExpiry := make(map[string]metav1.Time)
 
 	if leafNames := deps.leafCertFiles(); len(leafNames) > 0 {
-		expirations, err := pki.ListCertificateExpirations(
+		report, err := pki.ListCertificateExpirations(
 			pki.WithCertificatesDir(constants.KubernetesPkiPath),
 			pki.WithLeafCertificates(leafNames...),
-			pki.WithIgnoreReadErrors(),
 		)
 		for _, e := range joinedErrors(err) {
 			logger.Warn("cannot read cert expiration", log.Err(e))
 		}
-		for _, exp := range expirations {
+		for _, exp := range report.Entries {
 			certExpiry[exp.Name+".crt"] = metav1.NewTime(exp.NotAfter)
 		}
 	}
 
 	if len(deps.KubeconfigFiles) > 0 {
-		expirations, err := kubeconfig.ListClientCertificateExpirations(
+		report, err := kubeconfig.ListClientCertificateExpirations(
 			kubeconfig.WithKubeconfigDir(kubeconfigDir),
 			kubeconfig.WithFiles(deps.KubeconfigFiles...),
-			kubeconfig.WithIgnoreReadErrors(),
 		)
 		for _, e := range joinedErrors(err) {
 			logger.Warn("cannot read kubeconfig cert expiration", log.Err(e))
 		}
-		for _, exp := range expirations {
+		for _, exp := range report.Entries {
 			certExpiry[string(exp.File)] = metav1.NewTime(exp.NotAfter)
 		}
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -17,6 +17,9 @@ limitations under the License.
 package controlplaneoperation
 
 import (
+	"errors"
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/kubeconfig"
@@ -28,58 +31,48 @@ import (
 )
 
 // observeCertExpirationsForStaticPod reads leaf cert and kubeconfig client cert expirations for one static pod component.
-func observeCertExpirationsForStaticPod(component controlplanev1alpha1.OperationComponent, kubeconfigDir string, logger *log.Logger) (controlplanev1alpha1.ObservedComponentState, bool) {
+func observeCertExpirationsForStaticPod(component controlplanev1alpha1.OperationComponent, kubeconfigDir string, logger *log.Logger) (controlplanev1alpha1.ObservedComponentState, bool, error) {
 	if !component.IsStaticPodComponent() {
-		return controlplanev1alpha1.ObservedComponentState{}, false
+		return controlplanev1alpha1.ObservedComponentState{}, false, nil
 	}
 	deps := componentDeps(component)
 
 	certExpiry := make(map[string]metav1.Time)
+	var readErrs []error
 
 	if leafNames := deps.leafCertFiles(); len(leafNames) > 0 {
-		report, err := pki.ListCertificateExpirations(
+		report := pki.ListCertificateExpirations(
 			pki.WithCertificatesDir(constants.KubernetesPkiPath),
 			pki.WithLeafCertificates(leafNames...),
 		)
-		for _, e := range joinedErrors(err) {
-			logger.Warn("cannot read cert expiration", log.Err(e))
-		}
-		for _, exp := range report.Entries {
-			certExpiry[exp.Name+".crt"] = metav1.NewTime(exp.NotAfter)
+		for _, e := range report.Entries {
+			if e.Err != nil {
+				logger.Warn("cannot read cert expiration", "name", e.Name, "path", e.Path, log.Err(e.Err))
+				readErrs = append(readErrs, fmt.Errorf("cert %q: %w", e.Name, e.Err))
+				continue
+			}
+			certExpiry[e.Name+".crt"] = metav1.NewTime(e.NotAfter)
 		}
 	}
 
 	if len(deps.KubeconfigFiles) > 0 {
-		report, err := kubeconfig.ListClientCertificateExpirations(
+		report := kubeconfig.ListClientCertificateExpirations(
 			kubeconfig.WithKubeconfigDir(kubeconfigDir),
 			kubeconfig.WithFiles(deps.KubeconfigFiles...),
 		)
-		for _, e := range joinedErrors(err) {
-			logger.Warn("cannot read kubeconfig cert expiration", log.Err(e))
-		}
-		for _, exp := range report.Entries {
-			certExpiry[string(exp.File)] = metav1.NewTime(exp.NotAfter)
+		for _, e := range report.Entries {
+			if e.Err != nil {
+				logger.Warn("cannot read kubeconfig cert expiration", "file", e.File, "path", e.Path, log.Err(e.Err))
+				readErrs = append(readErrs, fmt.Errorf("kubeconfig %q: %w", e.File, e.Err))
+				continue
+			}
+			certExpiry[string(e.File)] = metav1.NewTime(e.NotAfter)
 		}
 	}
 
-	if len(certExpiry) == 0 {
-		return controlplanev1alpha1.ObservedComponentState{}, true
+	state := controlplanev1alpha1.ObservedComponentState{}
+	if len(certExpiry) > 0 {
+		state.CertificatesExpirationDate = certExpiry
 	}
-	return controlplanev1alpha1.ObservedComponentState{
-		CertificatesExpirationDate: certExpiry,
-	}, true
-}
-
-// joinedErrors unwraps an errors.Join result into individual errors. If err is
-// nil it returns nil; if err is a plain (non-joined) error it is returned as a
-// single-element slice.
-func joinedErrors(err error) []error {
-	if err == nil {
-		return nil
-	}
-	type multiErr interface{ Unwrap() []error }
-	if me, ok := err.(multiErr); ok {
-		return me.Unwrap()
-	}
-	return []error{err}
+	return state, true, errors.Join(readErrs...)
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -47,7 +47,7 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 		)
 		for _, e := range report.Entries {
 			if e.Err != nil {
-				logger.Warn("cannot read cert expiration", "name", e.Name, "path", e.Path, log.Err(e.Err))
+				logger.Warn("cannot read cert expiration", "name", e.Name, "path", e.Path, "error", e.Err)
 				readErrs = append(readErrs, fmt.Errorf("cert %q: %w", e.Name, e.Err))
 				continue
 			}
@@ -62,7 +62,7 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 		)
 		for _, e := range report.Entries {
 			if e.Err != nil {
-				logger.Warn("cannot read kubeconfig cert expiration", "file", e.File, "path", e.Path, log.Err(e.Err))
+				logger.Warn("cannot read kubeconfig cert expiration", "file", e.File, "path", e.Path, "error", e.Err)
 				readErrs = append(readErrs, fmt.Errorf("kubeconfig %q: %w", e.File, e.Err))
 				continue
 			}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -283,10 +283,20 @@ type certObserveStep struct{}
 func (c *certObserveStep) Execute(_ context.Context, env *StepEnv, logger *log.Logger) (StepResult, error) {
 	kubeconfigDir := env.Node.KubeconfigDir
 	component := env.State.Raw().Spec.Component
-	observedState, ok := observeCertExpirationsForStaticPod(component, kubeconfigDir, logger)
+	observedState, ok, err := observeCertExpirationsForStaticPod(component, kubeconfigDir, logger)
 	if !ok {
 		logger.Warn("CertObserve skipped: not a static pod component")
 		return StepResult{Outcome: OutcomeCompleted}, nil
+	}
+
+	// Persist whatever was read successfully before surfacing the error
+	// the partial state is still visible in the operation status.
+	if len(observedState.CertificatesExpirationDate) > 0 {
+		env.State.SetObservedState(&observedState)
+	}
+
+	if err != nil {
+		return StepResult{}, fmt.Errorf("read certificate expirations: %w", err)
 	}
 
 	if len(observedState.CertificatesExpirationDate) == 0 {
@@ -294,7 +304,6 @@ func (c *certObserveStep) Execute(_ context.Context, env *StepEnv, logger *log.L
 		return StepResult{Outcome: OutcomeCompleted}, nil
 	}
 
-	env.State.SetObservedState(&observedState)
 	logger.Info("observed certificate expiration", slog.Int("certificates", len(observedState.CertificatesExpirationDate)))
 	return StepResult{Outcome: OutcomeCompleted}, nil
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Adds reusable renewal and expiration-report APIs under `go_lib/controlplane` and adapts `control-plane-manager` certificate observation to use them.

- introduces `pki.RenewCertificates` with per-certificate `PKIRenewReport` and `pki.RenewCertificate` for just err return, leaf filtering (`WithRenewLeafs`), optional `WithDryRun`, and typed skip/error reasons (`MissingError`, `CAMissingError`, etc.)
- on renewal, copies Subject, DNS/IP SANs, EKU, and encryption algorithm from the existing leaf cert (`certConfigFromX509`); serving certs can get an extra IP SAN via `WithRenewExtraIP` (client certs without IP SANs are unchanged)
- tightens `pki` certificate validation with a one-directional SAN subset check: every DNS/IP SAN required by the desired config must be present in the cert; extra SANs in the cert are allowed
- introduces `kubeconfig.RenewClientCerts` with `KubeconfigRenewReport` for admin/super-admin/controller-manager/scheduler client certs (kubelet excluded), preserving client cert Subject fields on re-sign
- replaces `WithIgnoreReadErrors` on expiration listing with structured `ExpirationReport` / `KubeconfigExpirationReport` entries that carry per-file `Err` (including `MissingError` for absent files)
- updates `CertObserve` in `control-plane-manager` to consume the new reports: warn per failed file, persist successfully read expirations into `ControlPlaneOperation` status, and fail the step when any targeted cert/kubeconfig could not be read
- adds unit tests for renewal and SAN validation in `pki/renew_test.go`, `pki/validate_test.go`, and `kubeconfig/renew_test.go`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Control-plane certificate renewal and expiration checks are moving out of ad-hoc / `kubeadm`-oriented code paths into `go_lib/controlplane`

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Add PKI/kubeconfig renewal libraries and structured expiration reports
impact_level: low

```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
