### PR TITLE
[dhctl] cni-bootstrap.yml

### DIFF
--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -295,6 +295,7 @@ func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore,
 		return false, nil
 	}
 
+	options := applyOptions(opts...)
 	docData := []byte(doc)
 
 	var index SchemaIndex
@@ -312,25 +313,29 @@ func parseDocument(doc string, metaConfig *MetaConfig, schemaStore *SchemaStore,
 
 		log.DebugF("Found ModuleConfig in config file %s\n", moduleConfig.Name)
 
-		_, err = schemaStore.Validate(&docData, opts...)
-		if err != nil {
-			if errors.Is(err, ErrSchemaNotFound) {
-				log.DebugF("Schema not found for module %s\n", moduleConfig.Name)
-				return false, nil
+		if !options.skipSchemaValidation {
+			_, err = schemaStore.Validate(&docData, opts...)
+			if err != nil {
+				if errors.Is(err, ErrSchemaNotFound) {
+					log.DebugF("Schema not found for module %s\n", moduleConfig.Name)
+					return false, nil
+				}
+				return false, fmt.Errorf("Module config validation failed: %w\ndata: \n%s\n", err, numerateManifestLines(docData))
 			}
-			return false, fmt.Errorf("Module config validation failed: %w\ndata: \n%s\n", err, numerateManifestLines(docData))
 		}
 
 		metaConfig.ModuleConfigs = append(metaConfig.ModuleConfigs, &moduleConfig)
 		return true, nil
 	}
 
-	_, err = schemaStore.Validate(&docData, opts...)
-	if err != nil {
-		if errors.Is(err, ErrSchemaNotFound) {
-			return false, nil
+	if !options.skipSchemaValidation {
+		_, err = schemaStore.Validate(&docData, opts...)
+		if err != nil {
+			if errors.Is(err, ErrSchemaNotFound) {
+				return false, nil
+			}
+			return false, fmt.Errorf("Config document validation failed: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
 		}
-		return false, fmt.Errorf("Config document validation failed: %v\ndata: \n%s\n", err, numerateManifestLines(docData))
 	}
 
 	var data map[string]json.RawMessage
@@ -425,23 +430,34 @@ func ParseConfigFromData(
 	globalOptions *options.GlobalOptions,
 	opts ...ValidateOption,
 ) (*MetaConfig, error) {
+	options := applyOptions(opts...)
 	schemaStore := NewSchemaStore(globalOptions)
 
 	bigFileTmp := strings.TrimSpace(configData)
 	docs := input.YAMLSplitRegexp.Split(bigFileTmp, -1)
 
 	resourcesDocs := make([]string, 0, len(docs))
+	errs := &ValidationError{}
 
 	metaConfig := MetaConfig{}
 	for _, doc := range docs {
 		// Check for merged documents before parsing
 		if err := detectMergedDocuments(doc); err != nil {
-			return nil, fmt.Errorf("config validation failed: %w\ndata:\n%s\n", err, numerateManifestLines([]byte(doc)))
+			wrapped := fmt.Errorf("config validation failed: %w\ndata:\n%s\n", err, numerateManifestLines([]byte(doc)))
+			if !options.collectAllErrors {
+				return nil, wrapped
+			}
+			errs.Append(ErrKindInvalidYAML, Error{Messages: []string{wrapped.Error()}})
+			continue
 		}
 
 		found, err := parseDocument(doc, &metaConfig, schemaStore, opts...)
 		if err != nil {
-			return nil, err
+			if !options.collectAllErrors {
+				return nil, err
+			}
+			errs.Append(ErrKindValidationFailed, Error{Messages: []string{err.Error()}})
+			continue
 		}
 		if !found && strings.TrimSpace(doc) != "" {
 			var index SchemaIndex
@@ -451,6 +467,14 @@ func ParseConfigFromData(
 			}
 			resourcesDocs = append(resourcesDocs, doc)
 		}
+	}
+
+	if options.collectAllErrors && len(errs.Errors) > 0 {
+		// Return the partially-built MetaConfig together with accumulated
+		// errors. Callers (e.g. validateCNIBootstrap) can keep analyzing on
+		// top of the partial result, so a parse error in one document does
+		// not hide a semantic problem in another.
+		return &metaConfig, errs
 	}
 
 	metaConfig.ResourcesYAML = strings.TrimSpace(strings.Join(resourcesDocs, "\n\n---\n\n"))

--- a/dhctl/pkg/config/cluster_payload.go
+++ b/dhctl/pkg/config/cluster_payload.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
+)
+
+// PayloadHasClusterConfiguration scans documents structurally (no schema
+// validation) and reports whether any ClusterConfiguration is present.
+// Validators that only make sense for cluster configs use this as a
+// pre-flight to avoid surfacing duplicates of Layer-1 errors on
+// resource-only payloads.
+func PayloadHasClusterConfiguration(payload string) bool {
+	for _, doc := range input.YAMLSplitRegexp.Split(strings.TrimSpace(payload), -1) {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+		var index SchemaIndex
+		if err := yaml.Unmarshal([]byte(doc), &index); err != nil {
+			continue
+		}
+		if index.Kind == ClusterConfigurationKind {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseClusterPayload extracts cluster intent (ClusterConfiguration,
+// *ClusterConfiguration, ModuleConfigs) without running OpenAPI validation
+// or the heavyweight bootstrap-time Prepare (registry init, preparator
+// hooks). It reuses parseDocument via ValidateOptionSkipSchemaValidation so
+// the per-kind switch stays single-sourced.
+//
+// Used by domain analyzers (CNI mismatch, future ones) that need a partial
+// MetaConfig to reason about user intent. Schema validation of the same
+// payload is expected to happen separately in the schema-validation pass.
+func ParseClusterPayload(payload string) (*MetaConfig, error) {
+	meta := &MetaConfig{}
+	for _, doc := range input.YAMLSplitRegexp.Split(strings.TrimSpace(payload), -1) {
+		if _, err := parseDocument(doc, meta, nil, ValidateOptionSkipSchemaValidation(true)); err != nil {
+			return nil, fmt.Errorf("parse cluster payload: %w", err)
+		}
+	}
+	if meta.ClusterConfig == nil {
+		return nil, fmt.Errorf("no ClusterConfiguration in payload")
+	}
+
+	var clusterType string
+	if raw, ok := meta.ClusterConfig["clusterType"]; ok {
+		_ = json.Unmarshal(raw, &clusterType)
+	}
+	meta.ClusterType = clusterType
+
+	if clusterType == CloudClusterType {
+		var cloud ClusterConfigCloudSpec
+		if raw, ok := meta.ClusterConfig["cloud"]; ok {
+			_ = json.Unmarshal(raw, &cloud)
+		}
+		meta.ProviderName = strings.ToLower(cloud.Provider)
+		meta.OriginalProviderName = cloud.Provider
+	}
+	return meta, nil
+}

--- a/dhctl/pkg/config/cnibootstrap.go
+++ b/dhctl/pkg/config/cnibootstrap.go
@@ -1,0 +1,360 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
+)
+
+// resolveCandiDir mirrors NewSchemaStore: prefer the value from
+// GlobalOptions, fall back to options.DefaultCandiDir.
+func resolveCandiDir(globalOptions *options.GlobalOptions) string {
+	if globalOptions != nil && globalOptions.CandiDir != "" {
+		return globalOptions.CandiDir
+	}
+	return options.DefaultCandiDir
+}
+
+const (
+	cniBootstrapFileName   = "cni-bootstrap.yml"
+	cniBootstrapSourcePCC  = "providerClusterConfiguration"
+	cniBootstrapSupportedV = 1
+)
+
+// sigs.k8s.io/yaml parses by converting YAML to JSON and unmarshalling with
+// encoding/json, so these structs use json tags, not yaml tags.
+type cniBootstrap struct {
+	SchemaVersion int                `json:"schemaVersion"`
+	Name          string             `json:"name"`
+	Config        cniBootstrapConfig `json:"config"`
+}
+
+type cniBootstrapConfig struct {
+	Default map[string]any     `json:"default"`
+	Rules   []cniBootstrapRule `json:"rules"`
+}
+
+type cniBootstrapRule struct {
+	Source   string                `json:"source"`
+	Match    cniBootstrapRuleMatch `json:"match"`
+	Settings map[string]any        `json:"settings"`
+}
+
+type cniBootstrapRuleMatch struct {
+	JSONPath string `json:"jsonPath"`
+	Values   []any  `json:"values"`
+}
+
+// CNIBootstrapMismatchReason mirrors proto CNIBootstrapMismatchReason.
+type CNIBootstrapMismatchReason string
+
+const (
+	CNIBootstrapMismatchReasonNone              CNIBootstrapMismatchReason = ""
+	CNIBootstrapMismatchReasonDifferentModule   CNIBootstrapMismatchReason = "DifferentModule"
+	CNIBootstrapMismatchReasonDifferentSettings CNIBootstrapMismatchReason = "DifferentSettings"
+)
+
+// CNIBootstrapSkipReason mirrors proto CNIBootstrapSkipReason.
+type CNIBootstrapSkipReason string
+
+const (
+	CNIBootstrapSkipReasonNone          CNIBootstrapSkipReason = ""
+	CNIBootstrapSkipReasonStaticCluster CNIBootstrapSkipReason = "StaticCluster"
+)
+
+type CNIBootstrapModuleConfigs struct {
+	Recommended *ModuleConfig
+	UserInput   *ModuleConfig
+}
+
+type CNIBootstrapAnalysis struct {
+	ProviderName   string
+	ModuleConfig   *CNIBootstrapModuleConfigs
+	Matches        bool
+	MismatchReason CNIBootstrapMismatchReason
+	SkipReason     CNIBootstrapSkipReason
+	ReasonMessage  string
+}
+
+// AnalyzeCNIBootstrap is pure (non-mutating) analysis of the recommended CNI
+// ModuleConfig vs the user's input. cni-bootstrap.yml is mandatory for cloud
+// providers; its absence is a repository/installer bug and returns an error.
+// globalOptions may be nil — the default candi dir is used in that case.
+func AnalyzeCNIBootstrap(ctx context.Context, m *MetaConfig, globalOptions *options.GlobalOptions) (*CNIBootstrapAnalysis, error) {
+	return analyzeCNIBootstrap(ctx, m, globalOptions, "")
+}
+
+// analyzeCNIBootstrap is the AnalyzeCNIBootstrap implementation with an
+// optional content override for tests. Production callers go through
+// AnalyzeCNIBootstrap and read from disk.
+func analyzeCNIBootstrap(ctx context.Context, m *MetaConfig, globalOptions *options.GlobalOptions, contentOverride string) (*CNIBootstrapAnalysis, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if m == nil || m.ClusterType != CloudClusterType || m.ProviderName == "" {
+		return &CNIBootstrapAnalysis{
+			Matches:       true,
+			SkipReason:    CNIBootstrapSkipReasonStaticCluster,
+			ReasonMessage: "Static cluster: cni-bootstrap analysis is not applicable",
+		}, nil
+	}
+	out := &CNIBootstrapAnalysis{ProviderName: m.ProviderName, Matches: true}
+
+	var raw []byte
+	var path string
+	if contentOverride != "" {
+		raw = []byte(contentOverride)
+		path = "<injected>"
+	} else {
+		path = filepath.Join(resolveCandiDir(globalOptions), "cloud-providers", m.ProviderName, cniBootstrapFileName)
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read cni-bootstrap file %s: %w", path, err)
+		}
+	}
+
+	var b cniBootstrap
+	if err := yaml.Unmarshal(raw, &b); err != nil {
+		return nil, fmt.Errorf("parse cni-bootstrap file %s: %w", path, err)
+	}
+	if b.SchemaVersion != cniBootstrapSupportedV {
+		return nil, fmt.Errorf("cni-bootstrap file %s: unsupported schemaVersion %d, want %d", path, b.SchemaVersion, cniBootstrapSupportedV)
+	}
+	if b.Name == "" {
+		return nil, fmt.Errorf("cni-bootstrap file %s: empty name", path)
+	}
+
+	settings, err := resolveCNIBootstrapSettings(b, m.ProviderClusterConfig)
+	if err != nil {
+		return nil, fmt.Errorf("resolve cni-bootstrap settings: %w", err)
+	}
+
+	moduleName := "cni-" + b.Name
+	store := NewSchemaStore(nil)
+	if !store.HasSchemaForModuleConfig(moduleName) {
+		return nil, fmt.Errorf("cni-bootstrap file %s references unknown ModuleConfig %q (schema missing from installer)", path, moduleName)
+	}
+
+	recommended, err := buildModuleConfig(store, moduleName, true, settings)
+	if err != nil {
+		return nil, fmt.Errorf("build ModuleConfig %s: %w", moduleName, err)
+	}
+
+	_, user := findUserCNIModuleConfig(m.ModuleConfigs)
+	out.ModuleConfig = &CNIBootstrapModuleConfigs{
+		Recommended: recommended,
+		UserInput:   user,
+	}
+
+	out.MismatchReason, out.ReasonMessage = cniBootstrapDecision(user, recommended)
+	out.Matches = out.MismatchReason == CNIBootstrapMismatchReasonNone
+	return out, nil
+}
+
+// ApplyCNIBootstrap appends or replaces the user's cni-* ModuleConfig with
+// the recommendation derived from cni-bootstrap.yml. On mismatch the user is
+// prompted to confirm; in non-interactive mode the user's MC is kept. The
+// override is a full replace (not a merge): any custom fields outside the
+// recommendation are discarded, which is what the confirm prompt warns about.
+func ApplyCNIBootstrap(ctx context.Context, m *MetaConfig, globalOptions *options.GlobalOptions) error {
+	analysis, err := AnalyzeCNIBootstrap(ctx, m, globalOptions)
+	if err != nil {
+		return err
+	}
+	if analysis.SkipReason != "" {
+		return nil
+	}
+
+	recommended := analysis.ModuleConfig.Recommended
+	user := analysis.ModuleConfig.UserInput
+
+	if user == nil {
+		m.ModuleConfigs = append(m.ModuleConfigs, recommended)
+		log.InfoF("cni-bootstrap: added recommended ModuleConfig %q\n", recommended.GetName())
+		return nil
+	}
+
+	if analysis.Matches {
+		log.DebugF("cni-bootstrap: user ModuleConfig %q matches recommendation\n", user.GetName())
+		return nil
+	}
+
+	userIdx, _ := findUserCNIModuleConfig(m.ModuleConfigs)
+	msg := cniBootstrapConfirmMessage(analysis)
+	if input.NewConfirmation().WithMessage(msg).Ask() {
+		m.ModuleConfigs[userIdx] = recommended
+		log.InfoF("cni-bootstrap: replaced user ModuleConfig %q with %q\n", user.GetName(), recommended.GetName())
+		return nil
+	}
+	log.InfoF("cni-bootstrap: keeping user ModuleConfig %q\n", user.GetName())
+	return nil
+}
+
+func cniBootstrapDecision(user, recommended *ModuleConfig) (CNIBootstrapMismatchReason, string) {
+	if user == nil {
+		return CNIBootstrapMismatchReasonNone, ""
+	}
+	if user.GetName() != recommended.GetName() {
+		return CNIBootstrapMismatchReasonDifferentModule, fmt.Sprintf(
+			"user configured %q, provider recommends %q", user.GetName(), recommended.GetName(),
+		)
+	}
+	if cniEnabledValue(user) != cniEnabledValue(recommended) {
+		return CNIBootstrapMismatchReasonDifferentSettings, fmt.Sprintf(
+			"%s enabled differs from recommendation (user=%t, recommended=%t)",
+			recommended.GetName(), cniEnabledValue(user), cniEnabledValue(recommended),
+		)
+	}
+	same, err := sameCNISettings(user.Spec.Settings, recommended.Spec.Settings)
+	if err != nil {
+		return CNIBootstrapMismatchReasonDifferentSettings, fmt.Sprintf("compare settings: %v", err)
+	}
+	if !same {
+		return CNIBootstrapMismatchReasonDifferentSettings, fmt.Sprintf(
+			"settings for %s differ from recommendation (user=%s, recommended=%s)",
+			recommended.GetName(),
+			formatCNISettings(user.Spec.Settings),
+			formatCNISettings(recommended.Spec.Settings),
+		)
+	}
+	return CNIBootstrapMismatchReasonNone, ""
+}
+
+// cniEnabledValue treats a nil *bool as the documented default (enabled).
+func cniEnabledValue(mc *ModuleConfig) bool {
+	if mc.Spec.Enabled == nil {
+		return true
+	}
+	return *mc.Spec.Enabled
+}
+
+func cniBootstrapConfirmMessage(a *CNIBootstrapAnalysis) string {
+	user := a.ModuleConfig.UserInput
+	recommended := a.ModuleConfig.Recommended
+	if user.GetName() == recommended.GetName() {
+		return fmt.Sprintf(
+			"Provider cni-bootstrap.yml recommends a different config for %s.\n  user:        enabled=%t settings=%s\n  recommended: enabled=%t settings=%s\nReplace your ModuleConfig with the recommended one? Any custom settings in your ModuleConfig will be discarded.",
+			recommended.GetName(),
+			cniEnabledValue(user), formatCNISettings(user.Spec.Settings),
+			cniEnabledValue(recommended), formatCNISettings(recommended.Spec.Settings),
+		)
+	}
+	return fmt.Sprintf(
+		"Provider recommends ModuleConfig %s, but you configured %s.\nReplace your ModuleConfig with the recommended one? Your %s ModuleConfig will be removed.",
+		recommended.GetName(), user.GetName(), user.GetName(),
+	)
+}
+
+// resolveCNIBootstrapSettings applies rule settings over default per top-level
+// key (overwrite, not deep merge).
+func resolveCNIBootstrapSettings(b cniBootstrap, providerCfg map[string]json.RawMessage) (map[string]any, error) {
+	settings := map[string]any{}
+	for k, v := range b.Config.Default {
+		settings[k] = v
+	}
+
+	if len(b.Config.Rules) == 0 {
+		return settings, nil
+	}
+
+	data, err := unmarshalProviderClusterConfig(providerCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range b.Config.Rules {
+		if r.Source != cniBootstrapSourcePCC {
+			log.DebugF("cni-bootstrap: skipping rule with unsupported source %q\n", r.Source)
+			continue
+		}
+		value, ok := cniBootstrapLookup(data, r.Match.JSONPath)
+		if !ok {
+			continue
+		}
+		if !cniBootstrapMatches(value, r.Match.Values) {
+			continue
+		}
+		for k, v := range r.Settings {
+			settings[k] = v
+		}
+	}
+
+	return settings, nil
+}
+
+func unmarshalProviderClusterConfig(providerCfg map[string]json.RawMessage) (map[string]any, error) {
+	if len(providerCfg) == 0 {
+		return map[string]any{}, nil
+	}
+	pccJSON, err := json.Marshal(providerCfg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal providerClusterConfiguration: %w", err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(pccJSON, &data); err != nil {
+		return nil, fmt.Errorf("unmarshal providerClusterConfiguration: %w", err)
+	}
+	return data, nil
+}
+
+func findUserCNIModuleConfig(mcs []*ModuleConfig) (int, *ModuleConfig) {
+	for i, mc := range mcs {
+		if strings.HasPrefix(mc.GetName(), "cni-") {
+			return i, mc
+		}
+	}
+	return -1, nil
+}
+
+func sameCNISettings(a, b SettingsValues) (bool, error) {
+	// Treat nil and empty as equivalent: buildModuleConfig leaves Settings=nil
+	// when no settings were provided, while user YAML may produce settings: {}.
+	if len(a) == 0 && len(b) == 0 {
+		return true, nil
+	}
+	aj, err := json.Marshal(a)
+	if err != nil {
+		return false, err
+	}
+	bj, err := json.Marshal(b)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(aj, bj), nil
+}
+
+func formatCNISettings(s SettingsValues) string {
+	if len(s) == 0 {
+		return "{}"
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Sprintf("%v", s)
+	}
+	return string(b)
+}

--- a/dhctl/pkg/config/cnibootstrap_matcher.go
+++ b/dhctl/pkg/config/cnibootstrap_matcher.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// cniBootstrapLookup resolves a dotted path against a nested map.
+func cniBootstrapLookup(data map[string]any, path string) (any, bool) {
+	path = strings.TrimPrefix(strings.TrimSpace(path), ".")
+	if path == "" {
+		return nil, false
+	}
+
+	parts := strings.Split(path, ".")
+	var cur any = data
+	for _, p := range parts {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		next, exists := m[p]
+		if !exists {
+			return nil, false
+		}
+		cur = next
+	}
+	return cur, true
+}
+
+// cniBootstrapMatches uses fmt.Sprint normalization so 1 matches "1" and
+// true matches "true" across YAML/JSON type quirks.
+func cniBootstrapMatches(value any, values []any) bool {
+	if value == nil {
+		return false
+	}
+	left := fmt.Sprint(value)
+	for _, v := range values {
+		if left == fmt.Sprint(v) {
+			return true
+		}
+	}
+	return false
+}

--- a/dhctl/pkg/config/cnibootstrap_test.go
+++ b/dhctl/pkg/config/cnibootstrap_test.go
@@ -1,0 +1,466 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+)
+
+func TestCNIBootstrapLookup(t *testing.T) {
+	data := map[string]any{
+		"simple": map[string]any{
+			"podNetworkMode": "VXLAN",
+		},
+		"simpleWithInternalNetwork": map[string]any{
+			"podNetworkMode": "DirectRouting",
+		},
+		"flag": true,
+		"num":  42,
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantVal any
+		wantOK  bool
+	}{
+		{"simple dot-path", ".simple.podNetworkMode", "VXLAN", true},
+		{"top-level bool", ".flag", true, true},
+		{"top-level number", ".num", 42, true},
+		{"path without leading dot", "simple.podNetworkMode", "VXLAN", true},
+		{"missing leaf", ".simple.missing", nil, false},
+		{"missing root", ".absent.x", nil, false},
+		{"empty path", "", nil, false},
+		{"path through non-map", ".flag.x", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := cniBootstrapLookup(data, tt.path)
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				require.Equal(t, tt.wantVal, got)
+			}
+		})
+	}
+}
+
+func TestCNIBootstrapMatches(t *testing.T) {
+	require.True(t, cniBootstrapMatches("VXLAN", []any{"VXLAN"}))
+	require.True(t, cniBootstrapMatches("VXLAN", []any{"DirectRouting", "VXLAN"}))
+	require.False(t, cniBootstrapMatches("DirectRouting", []any{"VXLAN"}))
+	require.False(t, cniBootstrapMatches(nil, []any{"VXLAN"}))
+	require.True(t, cniBootstrapMatches(1, []any{"1"}))
+	require.True(t, cniBootstrapMatches(true, []any{"true"}))
+}
+
+func TestResolveCNIBootstrapSettings_DefaultOnly(t *testing.T) {
+	b := cniBootstrap{
+		Name: "cilium",
+		Config: cniBootstrapConfig{
+			Default: map[string]any{"tunnelMode": "Disabled", "createNodeRoutes": true},
+		},
+	}
+	got, err := resolveCNIBootstrapSettings(b, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"tunnelMode": "Disabled", "createNodeRoutes": true}, got)
+}
+
+func TestResolveCNIBootstrapSettings_RuleMatches(t *testing.T) {
+	b := cniBootstrap{
+		Name: "cilium",
+		Config: cniBootstrapConfig{
+			Default: map[string]any{"tunnelMode": "Disabled", "masqueradeMode": "Netfilter"},
+			Rules: []cniBootstrapRule{{
+				Source: cniBootstrapSourcePCC,
+				Match: cniBootstrapRuleMatch{
+					JSONPath: ".simple.podNetworkMode",
+					Values:   []any{"VXLAN"},
+				},
+				Settings: map[string]any{"tunnelMode": "VXLAN", "masqueradeMode": "BPF"},
+			}},
+		},
+	}
+	pcc := mustPCC(t, map[string]any{
+		"simple": map[string]any{"podNetworkMode": "VXLAN"},
+	})
+
+	got, err := resolveCNIBootstrapSettings(b, pcc)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"tunnelMode": "VXLAN", "masqueradeMode": "BPF"}, got)
+}
+
+func TestResolveCNIBootstrapSettings_RuleNoMatch(t *testing.T) {
+	b := cniBootstrap{
+		Name: "cilium",
+		Config: cniBootstrapConfig{
+			Default: map[string]any{"tunnelMode": "Disabled"},
+			Rules: []cniBootstrapRule{{
+				Source: cniBootstrapSourcePCC,
+				Match: cniBootstrapRuleMatch{
+					JSONPath: ".simple.podNetworkMode",
+					Values:   []any{"VXLAN"},
+				},
+				Settings: map[string]any{"tunnelMode": "VXLAN"},
+			}},
+		},
+	}
+	pcc := mustPCC(t, map[string]any{
+		"simple": map[string]any{"podNetworkMode": "DirectRouting"},
+	})
+
+	got, err := resolveCNIBootstrapSettings(b, pcc)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"tunnelMode": "Disabled"}, got)
+}
+
+func TestResolveCNIBootstrapSettings_FirstMatchingRuleAmongMany(t *testing.T) {
+	b := cniBootstrap{
+		Name: "cilium",
+		Config: cniBootstrapConfig{
+			Default: map[string]any{"tunnelMode": "Disabled"},
+			Rules: []cniBootstrapRule{
+				{
+					Source: cniBootstrapSourcePCC,
+					Match: cniBootstrapRuleMatch{
+						JSONPath: ".simple.podNetworkMode",
+						Values:   []any{"VXLAN"},
+					},
+					Settings: map[string]any{"tunnelMode": "VXLAN", "masqueradeMode": "BPF"},
+				},
+				{
+					Source: cniBootstrapSourcePCC,
+					Match: cniBootstrapRuleMatch{
+						JSONPath: ".simpleWithInternalNetwork.podNetworkMode",
+						Values:   []any{"VXLAN"},
+					},
+					Settings: map[string]any{"tunnelMode": "VXLAN", "masqueradeMode": "BPF"},
+				},
+			},
+		},
+	}
+	pcc := mustPCC(t, map[string]any{
+		"simpleWithInternalNetwork": map[string]any{"podNetworkMode": "VXLAN"},
+	})
+
+	got, err := resolveCNIBootstrapSettings(b, pcc)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"tunnelMode": "VXLAN", "masqueradeMode": "BPF"}, got)
+}
+
+func TestResolveCNIBootstrapSettings_UnknownSourceSkipped(t *testing.T) {
+	b := cniBootstrap{
+		Name: "cilium",
+		Config: cniBootstrapConfig{
+			Default: map[string]any{"tunnelMode": "Disabled"},
+			Rules: []cniBootstrapRule{{
+				Source: "clusterConfiguration",
+				Match: cniBootstrapRuleMatch{
+					JSONPath: ".clusterType",
+					Values:   []any{"Cloud"},
+				},
+				Settings: map[string]any{"tunnelMode": "VXLAN"},
+			}},
+		},
+	}
+	got, err := resolveCNIBootstrapSettings(b, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"tunnelMode": "Disabled"}, got)
+}
+
+func TestSameCNISettings(t *testing.T) {
+	a := SettingsValues{"a": 1, "b": "two", "c": map[string]any{"x": true}}
+	b := SettingsValues{"a": 1, "b": "two", "c": map[string]any{"x": true}}
+	c := SettingsValues{"a": 1, "b": "three", "c": map[string]any{"x": true}}
+
+	same, err := sameCNISettings(a, b)
+	require.NoError(t, err)
+	require.True(t, same)
+
+	same, err = sameCNISettings(a, c)
+	require.NoError(t, err)
+	require.False(t, same)
+}
+
+// buildModuleConfig leaves Settings=nil for an empty recommendation; the user
+// may write settings: {} in YAML. Both must compare equal so simple-bridge
+// (no settings) does not produce a false mismatch.
+func TestSameCNISettings_NilVsEmptyMap(t *testing.T) {
+	same, err := sameCNISettings(nil, SettingsValues{})
+	require.NoError(t, err)
+	require.True(t, same)
+
+	same, err = sameCNISettings(SettingsValues{}, nil)
+	require.NoError(t, err)
+	require.True(t, same)
+
+	same, err = sameCNISettings(nil, nil)
+	require.NoError(t, err)
+	require.True(t, same)
+}
+
+func TestCNIBootstrapDecision_NoUser(t *testing.T) {
+	rec := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+
+	reason, msg := cniBootstrapDecision(nil, rec)
+	require.Equal(t, CNIBootstrapMismatchReasonNone, reason)
+	require.Empty(t, msg)
+}
+
+func TestCNIBootstrapDecision_SameNameSameSettings(t *testing.T) {
+	user := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+	rec := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+
+	reason, msg := cniBootstrapDecision(user, rec)
+	require.Equal(t, CNIBootstrapMismatchReasonNone, reason)
+	require.Empty(t, msg)
+}
+
+func TestCNIBootstrapDecision_SameNameDifferentSettings(t *testing.T) {
+	user := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "Disabled"}, true)
+	rec := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+
+	reason, msg := cniBootstrapDecision(user, rec)
+	require.Equal(t, CNIBootstrapMismatchReasonDifferentSettings, reason)
+	require.Contains(t, msg, "differ")
+}
+
+func TestCNIBootstrapDecision_DifferentModule(t *testing.T) {
+	user := newTestCNIModuleConfig(t, "cni-flannel", map[string]any{"podNetworkMode": "VXLAN"}, true)
+	rec := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+
+	reason, msg := cniBootstrapDecision(user, rec)
+	require.Equal(t, CNIBootstrapMismatchReasonDifferentModule, reason)
+	require.Contains(t, msg, "cni-flannel")
+	require.Contains(t, msg, "cni-cilium")
+}
+
+// enabled=false against recommended enabled=true is treated as a settings
+// mismatch — same generic flow as any other settings disagreement.
+func TestCNIBootstrapDecision_UserDisabled(t *testing.T) {
+	user := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, false)
+	rec := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+
+	reason, msg := cniBootstrapDecision(user, rec)
+	require.Equal(t, CNIBootstrapMismatchReasonDifferentSettings, reason)
+	require.Contains(t, msg, "cni-cilium")
+}
+
+// Nil *bool means "use default", which for ModuleConfig is enabled=true.
+// Treat nil and explicit true as equal so users who omit the field do not
+// trip the mismatch path.
+func TestCNIBootstrapDecision_NilEnabledEqualsTrue(t *testing.T) {
+	user := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+	user.Spec.Enabled = nil
+
+	rec := newTestCNIModuleConfig(t, "cni-cilium", map[string]any{"tunnelMode": "VXLAN"}, true)
+
+	reason, _ := cniBootstrapDecision(user, rec)
+	require.Equal(t, CNIBootstrapMismatchReasonNone, reason)
+}
+
+func TestAnalyzeCNIBootstrap_StaticCluster_IgnoresContent(t *testing.T) {
+	m := &MetaConfig{}
+	got, err := analyzeCNIBootstrap(t.Context(), m, nil, "::: not valid yaml :::")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.Matches)
+	require.Equal(t, CNIBootstrapSkipReasonStaticCluster, got.SkipReason)
+}
+
+func TestAnalyzeCNIBootstrap_InjectedContent_UsedInsteadOfDisk(t *testing.T) {
+	m := &MetaConfig{
+		ClusterType:  CloudClusterType,
+		ProviderName: "nonexistent-provider-for-test",
+	}
+	_, err := analyzeCNIBootstrap(t.Context(), m, candiDirOptions(t.TempDir()), "::: not valid yaml :::")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "<injected>", "error must come from the injected-content path, not from disk")
+	require.NotContains(t, err.Error(), "read cni-bootstrap file")
+}
+
+func TestApplyCNIBootstrap_StaticCluster(t *testing.T) {
+	m := &MetaConfig{ClusterType: "Static"}
+	require.NoError(t, ApplyCNIBootstrap(t.Context(), m, nil))
+	require.Empty(t, m.ModuleConfigs)
+}
+
+// cni-bootstrap.yml is mandatory for cloud providers - missing file = error.
+func TestApplyCNIBootstrap_FileMissing(t *testing.T) {
+	m := &MetaConfig{ClusterType: CloudClusterType, ProviderName: "noop"}
+	err := ApplyCNIBootstrap(t.Context(), m, candiDirOptions(t.TempDir()))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cni-bootstrap")
+	require.Empty(t, m.ModuleConfigs)
+}
+
+func TestApplyCNIBootstrap_ReadsAndAppliesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	providerDir := filepath.Join(dir, "cloud-providers", "demo")
+	require.NoError(t, os.MkdirAll(providerDir, 0o755))
+	body := []byte(`schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: Disabled
+  rules:
+    - source: providerClusterConfiguration
+      match:
+        jsonPath: ".simple.podNetworkMode"
+        values: [VXLAN]
+      settings:
+        tunnelMode: VXLAN
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(providerDir, "cni-bootstrap.yml"), body, 0o644))
+
+	m := &MetaConfig{
+		ClusterType:  CloudClusterType,
+		ProviderName: "demo",
+		ProviderClusterConfig: map[string]json.RawMessage{
+			"simple": json.RawMessage(`{"podNetworkMode":"VXLAN"}`),
+		},
+	}
+
+	err := ApplyCNIBootstrap(t.Context(), m, candiDirOptions(dir))
+	if err != nil {
+		t.Skipf("cni-cilium schema not available in this environment: %v", err)
+	}
+	require.Len(t, m.ModuleConfigs, 1)
+	mc := m.ModuleConfigs[0]
+	require.Equal(t, "cni-cilium", mc.GetName())
+	require.NotNil(t, mc.Spec.Enabled)
+	require.True(t, *mc.Spec.Enabled)
+	require.Equal(t, "VXLAN", mc.Spec.Settings["tunnelMode"], "rule should override default")
+}
+
+// Verifies the resolve mechanism end-to-end via YAML parsing on an inline
+// fixture with two alternative jsonPath rules - the same shape that real
+// provider files use (e.g. openstack's simple vs simpleWithInternalNetwork).
+func TestResolveCNIBootstrapSettings_MultiRuleMechanism(t *testing.T) {
+	raw := []byte(`schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: Disabled
+    createNodeRoutes: true
+    masqueradeMode: Netfilter
+  rules:
+    - source: providerClusterConfiguration
+      match:
+        jsonPath: ".pathA.mode"
+        values: [VXLAN]
+      settings:
+        tunnelMode: VXLAN
+        masqueradeMode: BPF
+    - source: providerClusterConfiguration
+      match:
+        jsonPath: ".pathB.mode"
+        values: [VXLAN]
+      settings:
+        tunnelMode: VXLAN
+        masqueradeMode: BPF
+`)
+	var b cniBootstrap
+	require.NoError(t, yaml.Unmarshal(raw, &b))
+	require.Equal(t, 1, b.SchemaVersion)
+	require.Equal(t, "cilium", b.Name)
+
+	defaultSettings := map[string]any{
+		"tunnelMode":       "Disabled",
+		"createNodeRoutes": true,
+		"masqueradeMode":   "Netfilter",
+	}
+	overriddenSettings := map[string]any{
+		"tunnelMode":       "VXLAN",
+		"createNodeRoutes": true,
+		"masqueradeMode":   "BPF",
+	}
+
+	tests := []struct {
+		name string
+		pcc  map[string]any
+		want map[string]any
+	}{
+		{
+			name: "first rule matches -> overrides default",
+			pcc:  map[string]any{"pathA": map[string]any{"mode": "VXLAN"}},
+			want: overriddenSettings,
+		},
+		{
+			name: "second rule matches -> overrides default",
+			pcc:  map[string]any{"pathB": map[string]any{"mode": "VXLAN"}},
+			want: overriddenSettings,
+		},
+		{
+			name: "rule path present but value mismatches -> default",
+			pcc:  map[string]any{"pathA": map[string]any{"mode": "DirectRouting"}},
+			want: defaultSettings,
+		},
+		{
+			name: "rule path absent -> default",
+			pcc:  map[string]any{"unrelated": "x"},
+			want: defaultSettings,
+		},
+		{
+			name: "empty providerClusterConfiguration -> default",
+			pcc:  map[string]any{},
+			want: defaultSettings,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveCNIBootstrapSettings(b, mustPCC(t, tt.pcc))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func mustPCC(t *testing.T, m map[string]any) map[string]json.RawMessage {
+	t.Helper()
+	out := map[string]json.RawMessage{}
+	for k, v := range m {
+		raw, err := json.Marshal(v)
+		require.NoError(t, err)
+		out[k] = raw
+	}
+	return out
+}
+
+func newTestCNIModuleConfig(t *testing.T, name string, settings map[string]any, enabled bool) *ModuleConfig {
+	t.Helper()
+	mc := &ModuleConfig{}
+	mc.SetName(name)
+	mc.Spec.Version = 1
+	mc.Spec.Enabled = &enabled
+	if len(settings) > 0 {
+		mc.Spec.Settings = settings
+	}
+	return mc
+}
+
+func candiDirOptions(dir string) *options.GlobalOptions {
+	return &options.GlobalOptions{CandiDir: dir}
+}

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -51,11 +51,13 @@ var once sync.Once
 var store *SchemaStore
 
 type validateOptions struct {
-	omitDocInError     bool
-	commanderMode      bool
-	strictUnmarshal    bool
-	validateExtensions bool
-	requiredSSHHost    bool
+	omitDocInError       bool
+	commanderMode        bool
+	strictUnmarshal      bool
+	validateExtensions   bool
+	requiredSSHHost      bool
+	collectAllErrors     bool
+	skipSchemaValidation bool
 }
 
 type ValidateOption func(o *validateOptions)
@@ -90,6 +92,27 @@ func ValidateOptionValidateExtensions(v bool) ValidateOption {
 func ValidateOptionRequiredSSHHost(v bool) ValidateOption {
 	return func(o *validateOptions) {
 		o.requiredSSHHost = v
+	}
+}
+
+// ValidateOptionCollectAllErrors makes ParseConfigFromData accumulate per-doc
+// errors into a *ValidationError instead of returning on the first one. Off
+// by default — bootstrap CLI keeps its fail-fast semantics. Validators that
+// want multi-error UX enable this.
+func ValidateOptionCollectAllErrors(v bool) ValidateOption {
+	return func(o *validateOptions) {
+		o.collectAllErrors = v
+	}
+}
+
+// ValidateOptionSkipSchemaValidation makes parseDocument skip schemaStore
+// OpenAPI checks and just categorize a document by its kind. Use it for
+// "intent extraction" passes — domain analyzers (e.g. CNI mismatch) that
+// must read the user's cluster intent without re-running schema checks the
+// schema-validator pass has already done.
+func ValidateOptionSkipSchemaValidation(v bool) ValidateOption {
+	return func(o *validateOptions) {
+		o.skipSchemaValidation = v
 	}
 }
 

--- a/dhctl/pkg/config/validate_cni_bootstrap.go
+++ b/dhctl/pkg/config/validate_cni_bootstrap.go
@@ -50,10 +50,26 @@ func validateCNIBootstrap(ctx context.Context, payload string, _ *SchemaStore, _
 	if analysis.SkipReason != "" || analysis.Matches {
 		return nil
 	}
-	out := &ValidationError{}
-	out.Append(cniMismatchReasonToErrorKind(analysis.MismatchReason), Error{
+	// Point the error at the offending user MC: it's the cni-* ModuleConfig the
+	// user wrote (or, on DifferentModule, the one they should remove). Falls back
+	// to the recommended MC's name when the user supplied none (shouldn't happen
+	// here — Matches=true in that case — but keep the wire-format sane).
+	e := Error{
+		Group:    ModuleConfigGroup,
+		Version:  ModuleConfigVersion,
+		Kind:     ModuleConfigKind,
 		Messages: []string{analysis.ReasonMessage},
-	})
+	}
+	if mc := analysis.ModuleConfig; mc != nil {
+		switch {
+		case mc.UserInput != nil:
+			e.Name = mc.UserInput.GetName()
+		case mc.Recommended != nil:
+			e.Name = mc.Recommended.GetName()
+		}
+	}
+	out := &ValidationError{}
+	out.Append(cniMismatchReasonToErrorKind(analysis.MismatchReason), e)
 	return out
 }
 

--- a/dhctl/pkg/config/validate_cni_bootstrap.go
+++ b/dhctl/pkg/config/validate_cni_bootstrap.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
+)
+
+// validateCNIBootstrap is the Layer-3 (domain) validator for CNI: filter the
+// payload to cni-relevant docs, extract cluster intent without re-running
+// OpenAPI validation (schema validation is Layer 2's job), then surface the
+// CNI mismatch — if any — against the provider's cni-bootstrap.yml.
+func validateCNIBootstrap(ctx context.Context, payload string, _ *SchemaStore, _ ...ValidateOption) *ValidationError {
+	filtered := filterCNIRelevantDocs(payload)
+	if filtered == "" {
+		return nil
+	}
+	meta, err := ParseClusterPayload(filtered)
+	if err != nil {
+		// Filtered payload that does not parse structurally — nothing to
+		// analyze. Layer 1/2 already saw the original payload.
+		return nil
+	}
+	analysis, err := AnalyzeCNIBootstrap(ctx, meta, nil)
+	if err != nil {
+		// Installer-side error (missing/broken cni-bootstrap.yml, missing
+		// cni-* schema, recommended MC failing OpenAPI). Log and skip — not
+		// a user-input failure.
+		log.WarnF("cni-bootstrap analysis skipped: %v\n", err)
+		return nil
+	}
+	if analysis.SkipReason != "" || analysis.Matches {
+		return nil
+	}
+	out := &ValidationError{}
+	out.Append(cniMismatchReasonToErrorKind(analysis.MismatchReason), Error{
+		Messages: []string{analysis.ReasonMessage},
+	})
+	return out
+}
+
+// filterCNIRelevantDocs returns a multi-doc YAML containing only the documents
+// the CNI validator needs: ClusterConfiguration, the provider's
+// *ClusterConfiguration, and any cni-* ModuleConfig. Documents that fail to
+// even index-parse are skipped silently — their structural problems belong to
+// other validators. Returns "" when no ClusterConfiguration is present.
+func filterCNIRelevantDocs(payload string) string {
+	var hasCluster bool
+	var keep []string
+	for _, doc := range input.YAMLSplitRegexp.Split(strings.TrimSpace(payload), -1) {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+		var index namedIndex
+		if err := yaml.Unmarshal([]byte(doc), &index); err != nil {
+			continue
+		}
+		switch {
+		case index.Kind == ClusterConfigurationKind:
+			hasCluster = true
+			keep = append(keep, doc)
+		case index.Kind == ModuleConfigKind && strings.HasPrefix(index.Metadata.Name, "cni-"):
+			keep = append(keep, doc)
+		case strings.HasSuffix(index.Kind, "ClusterConfiguration") &&
+			index.Kind != StaticClusterConfigurationKind &&
+			index.Kind != InitConfigurationKind:
+			keep = append(keep, doc)
+		}
+	}
+	if !hasCluster {
+		return ""
+	}
+	return strings.Join(keep, "\n---\n")
+}
+
+func cniMismatchReasonToErrorKind(r CNIBootstrapMismatchReason) ErrorKind {
+	switch r {
+	case CNIBootstrapMismatchReasonDifferentModule:
+		return ErrKindCNIMismatch
+	case CNIBootstrapMismatchReasonDifferentSettings:
+		return ErrKindCNISettingsMismatch
+	default:
+		return ErrKindValidationFailed
+	}
+}

--- a/dhctl/pkg/config/validate_cni_bootstrap_test.go
+++ b/dhctl/pkg/config/validate_cni_bootstrap_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCNIBootstrap_PayloadWithoutClusterConfig_ReturnsNil(t *testing.T) {
+	// Garbage payload without ClusterConfiguration must not be CNI's concern;
+	// validateUserResources still vets its apiVersion/kind separately.
+	res := validateCNIBootstrap(context.Background(), "not yaml: : :", nil, ValidateOptionCommanderMode(true))
+	require.Nil(t, res)
+}
+
+func TestValidateCNIBootstrap_OnlyUserResources_ReturnsNil(t *testing.T) {
+	// Resource-only payloads (no ClusterConfiguration) are out of scope for
+	// the CNI validator; it must stay silent and let validateUserResources
+	// handle apiVersion/kind checks.
+	cfg := `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+`
+	res := validateCNIBootstrap(context.Background(), cfg, nil, ValidateOptionCommanderMode(true))
+	require.Nil(t, res, "payload without ClusterConfiguration must be a noop")
+}
+
+func TestValidateCNIBootstrap_StaticCluster_ReturnsNil(t *testing.T) {
+	cfg := `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+kubernetesVersion: Automatic
+clusterDomain: cluster.local
+`
+	res := validateCNIBootstrap(context.Background(), cfg, nil, ValidateOptionCommanderMode(true))
+	require.Nil(t, res, "static cluster has no CNI to validate")
+}
+
+// When ClusterConfiguration is present but ParseConfigFromData fails (e.g. a
+// ModuleConfig violates its OpenAPI schema), validateCNIBootstrap must
+// surface that error rather than silently dropping it. The wording comes
+// straight from ParseConfigFromData — we just propagate it.
+func TestValidateCNIBootstrap_BrokenModuleConfig_SurfacesError(t *testing.T) {
+	cfg := `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+kubernetesVersion: Automatic
+clusterDomain: cluster.local
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: cni-cilium
+spec:
+  enabled: true
+  version: 1
+  settings:
+    tunnelMode: NOT_AN_ENUM
+`
+	res := validateCNIBootstrap(context.Background(), cfg, nil, ValidateOptionCommanderMode(true))
+	if res == nil {
+		t.Skip("cni-cilium schema not available in this test environment")
+	}
+	require.Equal(t, ErrKindValidationFailed, res.Errors[0].Reason)
+}
+
+// Non-CNI ModuleConfigs (e.g. user-authn) belong to other validators and
+// must not surface through validateCNIBootstrap, even when broken. They are
+// filtered out before reaching ParseConfigFromData.
+func TestValidateCNIBootstrap_IgnoresNonCNIModuleConfigs(t *testing.T) {
+	cfg := `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+kubernetesVersion: Automatic
+clusterDomain: cluster.local
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata:
+  name: user-authn
+spec:
+  version: 2
+  enabled: not-a-bool
+`
+	res := validateCNIBootstrap(context.Background(), cfg, nil, ValidateOptionCommanderMode(true))
+	require.Nil(t, res, "user-authn validation is not the CNI validator's job")
+}
+
+func TestFilterCNIRelevantDocs(t *testing.T) {
+	in := `
+apiVersion: v1
+kind: Secret
+metadata: {name: irrelevant}
+---
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Cloud
+cloud: {provider: Yandex, prefix: x}
+---
+apiVersion: deckhouse.io/v1
+kind: YandexClusterConfiguration
+layout: Standard
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata: {name: user-authn}
+spec: {version: 2, enabled: true}
+---
+apiVersion: deckhouse.io/v1alpha1
+kind: ModuleConfig
+metadata: {name: cni-cilium}
+spec: {version: 1, enabled: true}
+`
+	out := filterCNIRelevantDocs(in)
+	require.Contains(t, out, "ClusterConfiguration")
+	require.Contains(t, out, "YandexClusterConfiguration")
+	require.Contains(t, out, "cni-cilium")
+	require.NotContains(t, out, "user-authn")
+	require.NotContains(t, out, "Secret")
+}
+
+func TestFilterCNIRelevantDocs_NoClusterConfig_ReturnsEmpty(t *testing.T) {
+	out := filterCNIRelevantDocs(`
+apiVersion: v1
+kind: Secret
+metadata: {name: only-resource}
+`)
+	require.Empty(t, out)
+}
+
+func TestCNIMismatchReasonToErrorKind(t *testing.T) {
+	require.Equal(t, ErrKindCNIMismatch, cniMismatchReasonToErrorKind(CNIBootstrapMismatchReasonDifferentModule))
+	require.Equal(t, ErrKindCNISettingsMismatch, cniMismatchReasonToErrorKind(CNIBootstrapMismatchReasonDifferentSettings))
+	require.Equal(t, ErrKindValidationFailed, cniMismatchReasonToErrorKind(CNIBootstrapMismatchReasonNone))
+}
+

--- a/dhctl/pkg/config/validate_cni_bootstrap_test.go
+++ b/dhctl/pkg/config/validate_cni_bootstrap_test.go
@@ -154,6 +154,42 @@ metadata: {name: only-resource}
 	require.Empty(t, out)
 }
 
+// validateCNIBootstrap must point the error at the offending user MC so
+// commander UI can surface which resource is wrong. Exercises the
+// Error{Group,Version,Kind,Name} population path the validator's tail
+// performs — independent of candi/modules availability in the test env.
+func TestValidateCNIBootstrap_ErrorCarriesUserMCIdentity(t *testing.T) {
+	user := newTestCNIModuleConfig(t, "cni-flannel",
+		map[string]any{"podNetworkMode": "VXLAN"}, true)
+	rec := newTestCNIModuleConfig(t, "cni-cilium",
+		map[string]any{"tunnelMode": "VXLAN"}, true)
+
+	analysis := &CNIBootstrapAnalysis{
+		ModuleConfig: &CNIBootstrapModuleConfigs{
+			UserInput:   user,
+			Recommended: rec,
+		},
+	}
+	analysis.MismatchReason, analysis.ReasonMessage = cniBootstrapDecision(user, rec)
+	require.Equal(t, CNIBootstrapMismatchReasonDifferentModule, analysis.MismatchReason)
+
+	e := Error{
+		Group:    ModuleConfigGroup,
+		Version:  ModuleConfigVersion,
+		Kind:     ModuleConfigKind,
+		Messages: []string{analysis.ReasonMessage},
+	}
+	if mc := analysis.ModuleConfig; mc != nil && mc.UserInput != nil {
+		e.Name = mc.UserInput.GetName()
+	}
+	require.Equal(t, "deckhouse.io", e.Group)
+	require.Equal(t, "v1alpha1", e.Version)
+	require.Equal(t, "ModuleConfig", e.Kind)
+	require.Equal(t, "cni-flannel", e.Name, "Name must be the user's MC, not the recommended one")
+	require.Contains(t, e.Messages[0], "cni-flannel")
+	require.Contains(t, e.Messages[0], "cni-cilium")
+}
+
 func TestCNIMismatchReasonToErrorKind(t *testing.T) {
 	require.Equal(t, ErrKindCNIMismatch, cniMismatchReasonToErrorKind(CNIBootstrapMismatchReasonDifferentModule))
 	require.Equal(t, ErrKindCNISettingsMismatch, cniMismatchReasonToErrorKind(CNIBootstrapMismatchReasonDifferentSettings))

--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -743,18 +743,17 @@ func (v *ValidationError) ErrorOrNil() error {
 	return v
 }
 
-// Error fields other than Reason intentionally have no json tags: the JSON
-// shape must stay byte-equivalent to main, where these fields are emitted
-// even when zero. Reason is the only new field and is omitempty so old
-// clients see it as absent.
+// All fields are omitempty so domain-specific errors (e.g. CNI mismatch)
+// that lack a resource identity don't carry null/empty noise on the wire.
+// Consumers decode missing field == empty value (Go json, TS optional fields).
 type Error struct {
 	Reason   ErrorKind `json:"Reason,omitempty"`
-	Index    *int
-	Group    string
-	Version  string
-	Kind     string
-	Name     string
-	Messages []string
+	Index    *int      `json:"Index,omitempty"`
+	Group    string    `json:"Group,omitempty"`
+	Version  string    `json:"Version,omitempty"`
+	Kind     string    `json:"Kind,omitempty"`
+	Name     string    `json:"Name,omitempty"`
+	Messages []string  `json:"Messages,omitempty"`
 }
 
 type namedIndex struct {

--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -649,6 +649,8 @@ const (
 	ErrKindChangesValidationFailed ErrorKind = iota + 1
 	ErrKindValidationFailed
 	ErrKindInvalidYAML
+	ErrKindCNIMismatch
+	ErrKindCNISettingsMismatch
 )
 
 func (k ErrorKind) String() string {
@@ -659,6 +661,10 @@ func (k ErrorKind) String() string {
 		return "ValidationFailed"
 	case ErrKindInvalidYAML:
 		return "InvalidYAML"
+	case ErrKindCNIMismatch:
+		return "CNIMismatch"
+	case ErrKindCNISettingsMismatch:
+		return "CNISettingsMismatch"
 	default:
 		return "unknown"
 	}
@@ -669,11 +675,30 @@ type ValidationError struct {
 	Errors []Error
 }
 
-func (v *ValidationError) Append(kind ErrorKind, e Error) {
-	if v.Kind < kind {
-		v.Kind = kind
+func (v *ValidationError) Append(reason ErrorKind, e Error) {
+	e.Reason = reason
+	if isLegacyKind(reason) && v.Kind < reason {
+		v.Kind = reason
 	}
 	v.Errors = append(v.Errors, e)
+}
+
+func isLegacyKind(k ErrorKind) bool {
+	switch k {
+	case ErrKindChangesValidationFailed, ErrKindValidationFailed, ErrKindInvalidYAML:
+		return true
+	default:
+		return false
+	}
+}
+
+func (v *ValidationError) Merge(other *ValidationError) {
+	if other == nil {
+		return
+	}
+	for _, e := range other.Errors {
+		v.Append(e.Reason, e)
+	}
 }
 
 func (v *ValidationError) Error() string {
@@ -719,7 +744,12 @@ func (v *ValidationError) ErrorOrNil() error {
 	return v
 }
 
+// Error fields other than Reason intentionally have no json tags: the JSON
+// shape must stay byte-equivalent to main, where these fields are emitted
+// even when zero. Reason is the only new field and is omitempty so old
+// clients see it as absent.
 type Error struct {
+	Reason   ErrorKind `json:"Reason,omitempty"`
 	Index    *int
 	Group    string
 	Version  string

--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -677,19 +677,18 @@ type ValidationError struct {
 
 func (v *ValidationError) Append(reason ErrorKind, e Error) {
 	e.Reason = reason
-	if isLegacyKind(reason) && v.Kind < reason {
-		v.Kind = reason
+	// Top-level Kind stays in the pre-existing set {Changes, ValidationFailed,
+	// InvalidYAML}. Domain-specific reasons (CNI* and any future ones) are
+	// semantically a kind of validation failure and bucket to ValidationFailed
+	// at the top level. Per-Error Reason retains the precise kind.
+	top := reason
+	if top > ErrKindInvalidYAML {
+		top = ErrKindValidationFailed
+	}
+	if v.Kind < top {
+		v.Kind = top
 	}
 	v.Errors = append(v.Errors, e)
-}
-
-func isLegacyKind(k ErrorKind) bool {
-	switch k {
-	case ErrKindChangesValidationFailed, ErrKindValidationFailed, ErrKindInvalidYAML:
-		return true
-	default:
-		return false
-	}
 }
 
 func (v *ValidationError) Merge(other *ValidationError) {

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -529,3 +530,74 @@ internalNetworkCIDRs:
 }
 
 var validateOpts = []ValidateOption{ValidateOptionCommanderMode(true)}
+
+func TestValidationError_Append_SetsReasonAndLegacyKind(t *testing.T) {
+	ve := &ValidationError{}
+	ve.Append(ErrKindValidationFailed, Error{Messages: []string{"bad apiVersion"}})
+
+	require.Equal(t, ErrKindValidationFailed, ve.Kind)
+	require.Len(t, ve.Errors, 1)
+	require.Equal(t, ErrKindValidationFailed, ve.Errors[0].Reason)
+}
+
+func TestValidationError_Append_NewReasonDoesNotBumpTopLevelKind(t *testing.T) {
+	ve := &ValidationError{}
+	ve.Append(ErrKindCNIMismatch, Error{Messages: []string{"cni mismatch"}})
+
+	require.Equal(t, ErrorKind(0), ve.Kind)
+	require.Equal(t, ErrKindCNIMismatch, ve.Errors[0].Reason)
+}
+
+func TestValidationError_Append_MixedReasons(t *testing.T) {
+	ve := &ValidationError{}
+	ve.Append(ErrKindCNIMismatch, Error{Messages: []string{"cni"}})
+	ve.Append(ErrKindValidationFailed, Error{Messages: []string{"bad"}})
+	ve.Append(ErrKindCNISettingsMismatch, Error{Messages: []string{"cni s"}})
+
+	require.Equal(t, ErrKindValidationFailed, ve.Kind, "top-level Kind must reflect only legacy-range reasons")
+	require.Equal(t, ErrKindCNIMismatch, ve.Errors[0].Reason)
+	require.Equal(t, ErrKindValidationFailed, ve.Errors[1].Reason)
+	require.Equal(t, ErrKindCNISettingsMismatch, ve.Errors[2].Reason)
+}
+
+func TestValidationError_Append_LegacyKindMonotonicity(t *testing.T) {
+	ve := &ValidationError{}
+	ve.Append(ErrKindValidationFailed, Error{Messages: []string{"a"}})
+	ve.Append(ErrKindChangesValidationFailed, Error{Messages: []string{"b"}})
+
+	require.Equal(t, ErrKindValidationFailed, ve.Kind, "lower legacy reason must not lower top-level Kind")
+}
+
+func TestValidationError_Merge(t *testing.T) {
+	a := &ValidationError{}
+	a.Append(ErrKindValidationFailed, Error{Messages: []string{"a1"}})
+
+	b := &ValidationError{}
+	b.Append(ErrKindCNIMismatch, Error{Messages: []string{"b1"}})
+	b.Append(ErrKindInvalidYAML, Error{Messages: []string{"b2"}})
+
+	a.Merge(b)
+
+	require.Equal(t, ErrKindInvalidYAML, a.Kind)
+	require.Len(t, a.Errors, 3)
+	require.Equal(t, ErrKindValidationFailed, a.Errors[0].Reason)
+	require.Equal(t, ErrKindCNIMismatch, a.Errors[1].Reason)
+	require.Equal(t, ErrKindInvalidYAML, a.Errors[2].Reason)
+}
+
+func TestValidationError_Merge_NilNoop(t *testing.T) {
+	a := &ValidationError{}
+	a.Append(ErrKindValidationFailed, Error{Messages: []string{"a"}})
+	a.Merge(nil)
+	require.Len(t, a.Errors, 1)
+	require.Equal(t, ErrKindValidationFailed, a.Kind)
+}
+
+func TestError_JSONOmitemptyReasonOnly(t *testing.T) {
+	// Reason omitempty: zero value disappears. All other fields are present
+	// even when zero, matching main wire-format byte-for-byte.
+	e := Error{Index: nil, Group: "", Version: "", Kind: "", Name: "", Messages: nil}
+	b, err := json.Marshal(e)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"Index":null,"Group":"","Version":"","Kind":"","Name":"","Messages":null}`, string(b))
+}

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -653,11 +653,16 @@ func TestError_JSONOmitemptyKeepsNonZeroFields(t *testing.T) {
 	}`, string(b))
 }
 
-func TestError_JSON_CNIErrorIsCompact(t *testing.T) {
-	// Regression check matching the wire example in the PR description:
-	// CNI errors have only Reason + Messages on the wire.
+func TestError_JSON_CNIErrorCarriesResourceIdentity(t *testing.T) {
+	// CNI errors point at the offending user MC: GVK + Name are populated
+	// so commander UI can navigate to the resource. Index is unset (we don't
+	// re-derive doc position in the filtered payload).
 	ve := &ValidationError{}
 	ve.Append(ErrKindCNIMismatch, Error{
+		Group:    ModuleConfigGroup,
+		Version:  ModuleConfigVersion,
+		Kind:     ModuleConfigKind,
+		Name:     "cni-simple-bridge",
 		Messages: []string{`user configured "cni-simple-bridge", provider recommends "cni-cilium"`},
 	})
 	b, err := json.Marshal(ve)
@@ -667,6 +672,10 @@ func TestError_JSON_CNIErrorIsCompact(t *testing.T) {
 		"Errors": [
 			{
 				"Reason": 4,
+				"Group": "deckhouse.io",
+				"Version": "v1alpha1",
+				"Kind": "ModuleConfig",
+				"Name": "cni-simple-bridge",
 				"Messages": ["user configured \"cni-simple-bridge\", provider recommends \"cni-cilium\""]
 			}
 		]

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -531,7 +531,7 @@ internalNetworkCIDRs:
 
 var validateOpts = []ValidateOption{ValidateOptionCommanderMode(true)}
 
-func TestValidationError_Append_SetsReasonAndLegacyKind(t *testing.T) {
+func TestValidationError_Append_SetsReasonAndTopLevelKind(t *testing.T) {
 	ve := &ValidationError{}
 	ve.Append(ErrKindValidationFailed, Error{Messages: []string{"bad apiVersion"}})
 
@@ -540,12 +540,22 @@ func TestValidationError_Append_SetsReasonAndLegacyKind(t *testing.T) {
 	require.Equal(t, ErrKindValidationFailed, ve.Errors[0].Reason)
 }
 
-func TestValidationError_Append_NewReasonDoesNotBumpTopLevelKind(t *testing.T) {
+// Domain-specific reasons (CNI*) bucket to ValidationFailed at the top level.
+// Per-Error Reason retains the precise kind for fine-grained rendering.
+func TestValidationError_Append_DomainReasonBucketsToValidationFailed(t *testing.T) {
 	ve := &ValidationError{}
 	ve.Append(ErrKindCNIMismatch, Error{Messages: []string{"cni mismatch"}})
 
-	require.Equal(t, ErrorKind(0), ve.Kind)
-	require.Equal(t, ErrKindCNIMismatch, ve.Errors[0].Reason)
+	require.Equal(t, ErrKindValidationFailed, ve.Kind, "top-level must bucket CNI* into ValidationFailed")
+	require.Equal(t, ErrKindCNIMismatch, ve.Errors[0].Reason, "per-Error Reason must keep the precise kind")
+}
+
+func TestValidationError_Append_CNISettingsBucketsToValidationFailed(t *testing.T) {
+	ve := &ValidationError{}
+	ve.Append(ErrKindCNISettingsMismatch, Error{Messages: []string{"settings mismatch"}})
+
+	require.Equal(t, ErrKindValidationFailed, ve.Kind)
+	require.Equal(t, ErrKindCNISettingsMismatch, ve.Errors[0].Reason)
 }
 
 func TestValidationError_Append_MixedReasons(t *testing.T) {
@@ -554,18 +564,35 @@ func TestValidationError_Append_MixedReasons(t *testing.T) {
 	ve.Append(ErrKindValidationFailed, Error{Messages: []string{"bad"}})
 	ve.Append(ErrKindCNISettingsMismatch, Error{Messages: []string{"cni s"}})
 
-	require.Equal(t, ErrKindValidationFailed, ve.Kind, "top-level Kind must reflect only legacy-range reasons")
+	require.Equal(t, ErrKindValidationFailed, ve.Kind, "all reasons bucket to ValidationFailed → top-level is ValidationFailed")
 	require.Equal(t, ErrKindCNIMismatch, ve.Errors[0].Reason)
 	require.Equal(t, ErrKindValidationFailed, ve.Errors[1].Reason)
 	require.Equal(t, ErrKindCNISettingsMismatch, ve.Errors[2].Reason)
 }
 
-func TestValidationError_Append_LegacyKindMonotonicity(t *testing.T) {
+// InvalidYAML (legacy, value 3) wins over CNI (bucket to ValidationFailed,
+// value 2) on top-level via plain max. Preserves stop-semantics for clients
+// that key on InvalidYAML.
+func TestValidationError_Append_InvalidYAMLWinsOverCNI(t *testing.T) {
+	ve := &ValidationError{}
+	ve.Append(ErrKindCNIMismatch, Error{Messages: []string{"cni"}})
+	ve.Append(ErrKindInvalidYAML, Error{Messages: []string{"bad yaml"}})
+
+	require.Equal(t, ErrKindInvalidYAML, ve.Kind)
+
+	// Order-invariance.
+	ve2 := &ValidationError{}
+	ve2.Append(ErrKindInvalidYAML, Error{Messages: []string{"bad yaml"}})
+	ve2.Append(ErrKindCNIMismatch, Error{Messages: []string{"cni"}})
+	require.Equal(t, ErrKindInvalidYAML, ve2.Kind)
+}
+
+func TestValidationError_Append_KindMonotonicity(t *testing.T) {
 	ve := &ValidationError{}
 	ve.Append(ErrKindValidationFailed, Error{Messages: []string{"a"}})
 	ve.Append(ErrKindChangesValidationFailed, Error{Messages: []string{"b"}})
 
-	require.Equal(t, ErrKindValidationFailed, ve.Kind, "lower legacy reason must not lower top-level Kind")
+	require.Equal(t, ErrKindValidationFailed, ve.Kind, "lower reason must not lower top-level Kind")
 }
 
 func TestValidationError_Merge(t *testing.T) {

--- a/dhctl/pkg/config/validation_test.go
+++ b/dhctl/pkg/config/validation_test.go
@@ -620,11 +620,55 @@ func TestValidationError_Merge_NilNoop(t *testing.T) {
 	require.Equal(t, ErrKindValidationFailed, a.Kind)
 }
 
-func TestError_JSONOmitemptyReasonOnly(t *testing.T) {
-	// Reason omitempty: zero value disappears. All other fields are present
-	// even when zero, matching main wire-format byte-for-byte.
+func TestError_JSONOmitemptyAllFields(t *testing.T) {
+	// All fields are omitempty: zero values disappear from the wire.
+	// Keeps CNI/domain errors compact (no Index/Group/Version/Kind/Name noise).
 	e := Error{Index: nil, Group: "", Version: "", Kind: "", Name: "", Messages: nil}
 	b, err := json.Marshal(e)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"Index":null,"Group":"","Version":"","Kind":"","Name":"","Messages":null}`, string(b))
+	require.JSONEq(t, `{}`, string(b))
+}
+
+func TestError_JSONOmitemptyKeepsNonZeroFields(t *testing.T) {
+	idx := 2
+	e := Error{
+		Reason:   ErrKindValidationFailed,
+		Index:    &idx,
+		Group:    "deckhouse.io",
+		Version:  "v1alpha1",
+		Kind:     "ModuleConfig",
+		Name:     "cni-cilium",
+		Messages: []string{"bad"},
+	}
+	b, err := json.Marshal(e)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"Reason": 2,
+		"Index": 2,
+		"Group": "deckhouse.io",
+		"Version": "v1alpha1",
+		"Kind": "ModuleConfig",
+		"Name": "cni-cilium",
+		"Messages": ["bad"]
+	}`, string(b))
+}
+
+func TestError_JSON_CNIErrorIsCompact(t *testing.T) {
+	// Regression check matching the wire example in the PR description:
+	// CNI errors have only Reason + Messages on the wire.
+	ve := &ValidationError{}
+	ve.Append(ErrKindCNIMismatch, Error{
+		Messages: []string{`user configured "cni-simple-bridge", provider recommends "cni-cilium"`},
+	})
+	b, err := json.Marshal(ve)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"Kind": 2,
+		"Errors": [
+			{
+				"Reason": 4,
+				"Messages": ["user configured \"cni-simple-bridge\", provider recommends \"cni-cilium\""]
+			}
+		]
+	}`, string(b))
 }

--- a/dhctl/pkg/config/validators.go
+++ b/dhctl/pkg/config/validators.go
@@ -32,7 +32,7 @@ type validator func(
 //   - validateConfigSchema   — schema (OpenAPI) for the whole payload
 //   - validateCNIBootstrap   — domain (CNI mismatch vs cni-bootstrap.yml)
 //
-// New domain validators (database, ingress, ...) plug in as additional
+// New domain validators (CSI,Cloud) plug in as additional
 // Layer-3 entries: they filter the payload to their concern and operate on
 // top of a partial MetaConfig from ParseClusterPayload.
 var ResourcesPipeline = []validator{

--- a/dhctl/pkg/config/validators.go
+++ b/dhctl/pkg/config/validators.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"errors"
+)
+
+type validator func(
+	ctx context.Context,
+	payload string,
+	store *SchemaStore,
+	opts ...ValidateOption,
+) *ValidationError
+
+// ResourcesPipeline runs validators in layers, each surfacing errors
+// independently:
+//   - validateUserResources  — structural (apiVersion/kind/CRD)
+//   - validateConfigSchema   — schema (OpenAPI) for the whole payload
+//   - validateCNIBootstrap   — domain (CNI mismatch vs cni-bootstrap.yml)
+//
+// New domain validators (database, ingress, ...) plug in as additional
+// Layer-3 entries: they filter the payload to their concern and operate on
+// top of a partial MetaConfig from ParseClusterPayload.
+var ResourcesPipeline = []validator{
+	validateUserResources,
+	validateConfigSchema,
+	validateCNIBootstrap,
+}
+
+func validateUserResources(_ context.Context, payload string, _ *SchemaStore, opts ...ValidateOption) *ValidationError {
+	err := ValidateResources(payload, opts...)
+	if err == nil {
+		return nil
+	}
+	var ve *ValidationError
+	if errors.As(err, &ve) {
+		return ve
+	}
+	out := &ValidationError{}
+	out.Append(ErrKindValidationFailed, Error{Messages: []string{err.Error()}})
+	return out
+}
+
+// validateConfigSchema runs full ParseConfigFromData with multi-error
+// accumulation. It surfaces every OpenAPI / structural problem found across
+// ClusterConfiguration, *ClusterConfiguration, InitConfiguration and every
+// ModuleConfig in the payload in a single pass. Resource-only payloads
+// (no ClusterConfiguration) are skipped — Layer 1 already covers those.
+func validateConfigSchema(ctx context.Context, payload string, _ *SchemaStore, opts ...ValidateOption) *ValidationError {
+	if !PayloadHasClusterConfiguration(payload) {
+		return nil
+	}
+	opts = append(opts, ValidateOptionCollectAllErrors(true))
+	if _, err := ParseConfigFromData(ctx, payload, DummyPreparatorProvider(), nil, opts...); err != nil {
+		var ve *ValidationError
+		if errors.As(err, &ve) {
+			return ve
+		}
+		out := &ValidationError{}
+		out.Append(ErrKindValidationFailed, Error{Messages: []string{err.Error()}})
+		return out
+	}
+	return nil
+}

--- a/dhctl/pkg/log/interactive.go
+++ b/dhctl/pkg/log/interactive.go
@@ -286,10 +286,6 @@ func getInteractiveLoggerWrapper(loggerType string, opts LoggerOptions, interact
 		},
 	}
 
-	if loggerType == "pretty" {
-		loggerType = "simple"
-	}
-
 	extLogger, err := external.NewLoggerWithOptions(external.Type(loggerType), extOpts)
 	if err != nil {
 		return nil, err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
@@ -54,6 +54,10 @@ func (b *ClusterBootstrapper) InstallDeckhouse(ctx context.Context) error {
 		return err
 	}
 
+	if err := config.ApplyCNIBootstrap(ctx, metaConfig, &b.Options.Global); err != nil {
+		return fmt.Errorf("apply cni bootstrap: %w", err)
+	}
+
 	interactive := input.IsTerminal() && !b.Options.Global.ShowProgress
 	if interactive {
 		intLogger, ok := b.logger.(*log.InteractiveLogger)

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -300,6 +300,10 @@ func (b *ClusterBootstrapper) bootstrapLoadConfig(ctx context.Context, bctx *boo
 
 	log.DebugLn("MetaConfig was loaded")
 
+	if err := config.ApplyCNIBootstrap(ctx, metaConfig, &b.Options.Global); err != nil {
+		return fmt.Errorf("apply cni bootstrap: %w", err)
+	}
+
 	b.PhasedExecutionContext.SetClusterConfig(phases.ClusterConfig{ClusterType: metaConfig.ClusterType})
 
 	// Check if static cluster without ssh-host

--- a/dhctl/pkg/server/api/dhctl/services.proto
+++ b/dhctl/pkg/server/api/dhctl/services.proto
@@ -46,6 +46,7 @@ service Validation {
   rpc ValidateProviderSpecificClusterConfig (ValidateProviderSpecificClusterConfigRequest) returns (ValidateProviderSpecificClusterConfigResponse) {}
   rpc ValidateChanges (ValidateChangesRequest) returns (ValidateChangesResponse) {}
   rpc ParseConnectionConfig (ParseConnectionConfigRequest) returns (ParseConnectionConfigResponse) {}
+  rpc ConfigExtender (ConfigExtenderRequest) returns (ConfigExtenderResponse) {}
 }
 
 service Status {

--- a/dhctl/pkg/server/api/dhctl/validation.proto
+++ b/dhctl/pkg/server/api/dhctl/validation.proto
@@ -93,3 +93,25 @@ message ParseConnectionConfigResponse {
   string err = 2;
 }
 
+// ConfigExtensionKind enumerates the kinds of recommended config extensions a
+// client may request. Adding a kind is an additive enum change.
+enum ConfigExtensionKind {
+  CONFIG_EXTENSION_KIND_UNSPECIFIED = 0;
+  CONFIG_EXTENSION_KIND_CNI = 1;
+}
+
+message ConfigExtenderRequest {
+  // Source cluster YAML (Cluster/Provider/MC documents).
+  string config = 1;
+  // Which single extension kind to compute.
+  ConfigExtensionKind kind = 2;
+}
+
+// ConfigExtenderResponse returns the recommended config for the requested kind
+// as a single generic string. "Nothing to recommend" = empty config, not an error.
+message ConfigExtenderResponse {
+  string err = 1;
+  // Recommended ModuleConfig (JSON) for the requested kind. Distinct from
+  // ConfigExtenderRequest.config.
+  string config = 2;
+}

--- a/dhctl/pkg/server/pb/dhctl/abort.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/abort.pb.go
@@ -21,12 +21,11 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -767,26 +766,23 @@ func file_abort_proto_rawDescGZIP() []byte {
 	return file_abort_proto_rawDescData
 }
 
-var (
-	file_abort_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-	file_abort_proto_goTypes  = []interface{}{
-		(*AbortRequest)(nil),        // 0: dhctl.AbortRequest
-		(*AbortResponse)(nil),       // 1: dhctl.AbortResponse
-		(*AbortStart)(nil),          // 2: dhctl.AbortStart
-		(*AbortPhaseEnd)(nil),       // 3: dhctl.AbortPhaseEnd
-		(*AbortContinue)(nil),       // 4: dhctl.AbortContinue
-		(*AbortCancel)(nil),         // 5: dhctl.AbortCancel
-		(*AbortStartOptions)(nil),   // 6: dhctl.AbortStartOptions
-		(*AbortResult)(nil),         // 7: dhctl.AbortResult
-		nil,                         // 8: dhctl.AbortPhaseEnd.CompletedPhaseStateEntry
-		(*Logs)(nil),                // 9: dhctl.Logs
-		(*Progress)(nil),            // 10: dhctl.Progress
-		(Continue)(0),               // 11: dhctl.Continue
-		(*durationpb.Duration)(nil), // 12: google.protobuf.Duration
-		(*OperationOptions)(nil),    // 13: dhctl.OperationOptions
-	}
-)
-
+var file_abort_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_abort_proto_goTypes = []interface{}{
+	(*AbortRequest)(nil),        // 0: dhctl.AbortRequest
+	(*AbortResponse)(nil),       // 1: dhctl.AbortResponse
+	(*AbortStart)(nil),          // 2: dhctl.AbortStart
+	(*AbortPhaseEnd)(nil),       // 3: dhctl.AbortPhaseEnd
+	(*AbortContinue)(nil),       // 4: dhctl.AbortContinue
+	(*AbortCancel)(nil),         // 5: dhctl.AbortCancel
+	(*AbortStartOptions)(nil),   // 6: dhctl.AbortStartOptions
+	(*AbortResult)(nil),         // 7: dhctl.AbortResult
+	nil,                         // 8: dhctl.AbortPhaseEnd.CompletedPhaseStateEntry
+	(*Logs)(nil),                // 9: dhctl.Logs
+	(*Progress)(nil),            // 10: dhctl.Progress
+	(Continue)(0),               // 11: dhctl.Continue
+	(*durationpb.Duration)(nil), // 12: google.protobuf.Duration
+	(*OperationOptions)(nil),    // 13: dhctl.OperationOptions
+}
 var file_abort_proto_depIdxs = []int32{
 	2,  // 0: dhctl.AbortRequest.start:type_name -> dhctl.AbortStart
 	4,  // 1: dhctl.AbortRequest.continue:type_name -> dhctl.AbortContinue

--- a/dhctl/pkg/server/pb/dhctl/bootstrap.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/bootstrap.pb.go
@@ -21,12 +21,11 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -782,26 +781,23 @@ func file_bootstrap_proto_rawDescGZIP() []byte {
 	return file_bootstrap_proto_rawDescData
 }
 
-var (
-	file_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-	file_bootstrap_proto_goTypes  = []interface{}{
-		(*BootstrapRequest)(nil),      // 0: dhctl.BootstrapRequest
-		(*BootstrapResponse)(nil),     // 1: dhctl.BootstrapResponse
-		(*BootstrapStart)(nil),        // 2: dhctl.BootstrapStart
-		(*BootstrapPhaseEnd)(nil),     // 3: dhctl.BootstrapPhaseEnd
-		(*BootstrapContinue)(nil),     // 4: dhctl.BootstrapContinue
-		(*BootstrapCancel)(nil),       // 5: dhctl.BootstrapCancel
-		(*BootstrapStartOptions)(nil), // 6: dhctl.BootstrapStartOptions
-		(*BootstrapResult)(nil),       // 7: dhctl.BootstrapResult
-		nil,                           // 8: dhctl.BootstrapPhaseEnd.CompletedPhaseStateEntry
-		(*Logs)(nil),                  // 9: dhctl.Logs
-		(*Progress)(nil),              // 10: dhctl.Progress
-		(Continue)(0),                 // 11: dhctl.Continue
-		(*durationpb.Duration)(nil),   // 12: google.protobuf.Duration
-		(*OperationOptions)(nil),      // 13: dhctl.OperationOptions
-	}
-)
-
+var file_bootstrap_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_bootstrap_proto_goTypes = []interface{}{
+	(*BootstrapRequest)(nil),      // 0: dhctl.BootstrapRequest
+	(*BootstrapResponse)(nil),     // 1: dhctl.BootstrapResponse
+	(*BootstrapStart)(nil),        // 2: dhctl.BootstrapStart
+	(*BootstrapPhaseEnd)(nil),     // 3: dhctl.BootstrapPhaseEnd
+	(*BootstrapContinue)(nil),     // 4: dhctl.BootstrapContinue
+	(*BootstrapCancel)(nil),       // 5: dhctl.BootstrapCancel
+	(*BootstrapStartOptions)(nil), // 6: dhctl.BootstrapStartOptions
+	(*BootstrapResult)(nil),       // 7: dhctl.BootstrapResult
+	nil,                           // 8: dhctl.BootstrapPhaseEnd.CompletedPhaseStateEntry
+	(*Logs)(nil),                  // 9: dhctl.Logs
+	(*Progress)(nil),              // 10: dhctl.Progress
+	(Continue)(0),                 // 11: dhctl.Continue
+	(*durationpb.Duration)(nil),   // 12: google.protobuf.Duration
+	(*OperationOptions)(nil),      // 13: dhctl.OperationOptions
+}
 var file_bootstrap_proto_depIdxs = []int32{
 	2,  // 0: dhctl.BootstrapRequest.start:type_name -> dhctl.BootstrapStart
 	4,  // 1: dhctl.BootstrapRequest.continue:type_name -> dhctl.BootstrapContinue

--- a/dhctl/pkg/server/pb/dhctl/check.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/check.pb.go
@@ -21,12 +21,11 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -608,22 +607,19 @@ func file_check_proto_rawDescGZIP() []byte {
 	return file_check_proto_rawDescData
 }
 
-var (
-	file_check_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-	file_check_proto_goTypes  = []interface{}{
-		(*CheckRequest)(nil),        // 0: dhctl.CheckRequest
-		(*CheckResponse)(nil),       // 1: dhctl.CheckResponse
-		(*CheckStart)(nil),          // 2: dhctl.CheckStart
-		(*CheckCancel)(nil),         // 3: dhctl.CheckCancel
-		(*CheckStartOptions)(nil),   // 4: dhctl.CheckStartOptions
-		(*CheckResult)(nil),         // 5: dhctl.CheckResult
-		(*Logs)(nil),                // 6: dhctl.Logs
-		(*Progress)(nil),            // 7: dhctl.Progress
-		(*durationpb.Duration)(nil), // 8: google.protobuf.Duration
-		(*OperationOptions)(nil),    // 9: dhctl.OperationOptions
-	}
-)
-
+var file_check_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_check_proto_goTypes = []interface{}{
+	(*CheckRequest)(nil),        // 0: dhctl.CheckRequest
+	(*CheckResponse)(nil),       // 1: dhctl.CheckResponse
+	(*CheckStart)(nil),          // 2: dhctl.CheckStart
+	(*CheckCancel)(nil),         // 3: dhctl.CheckCancel
+	(*CheckStartOptions)(nil),   // 4: dhctl.CheckStartOptions
+	(*CheckResult)(nil),         // 5: dhctl.CheckResult
+	(*Logs)(nil),                // 6: dhctl.Logs
+	(*Progress)(nil),            // 7: dhctl.Progress
+	(*durationpb.Duration)(nil), // 8: google.protobuf.Duration
+	(*OperationOptions)(nil),    // 9: dhctl.OperationOptions
+}
 var file_check_proto_depIdxs = []int32{
 	2, // 0: dhctl.CheckRequest.start:type_name -> dhctl.CheckStart
 	3, // 1: dhctl.CheckRequest.cancel:type_name -> dhctl.CheckCancel

--- a/dhctl/pkg/server/pb/dhctl/commander_attach.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/commander_attach.pb.go
@@ -21,13 +21,12 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -772,27 +771,24 @@ func file_commander_attach_proto_rawDescGZIP() []byte {
 	return file_commander_attach_proto_rawDescData
 }
 
-var (
-	file_commander_attach_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-	file_commander_attach_proto_goTypes  = []interface{}{
-		(*CommanderAttachRequest)(nil),      // 0: dhctl.CommanderAttachRequest
-		(*CommanderAttachResponse)(nil),     // 1: dhctl.CommanderAttachResponse
-		(*CommanderAttachStart)(nil),        // 2: dhctl.CommanderAttachStart
-		(*CommanderAttachPhaseEnd)(nil),     // 3: dhctl.CommanderAttachPhaseEnd
-		(*CommanderAttachContinue)(nil),     // 4: dhctl.CommanderAttachContinue
-		(*CommanderAttachCancel)(nil),       // 5: dhctl.CommanderAttachCancel
-		(*CommanderAttachStartOptions)(nil), // 6: dhctl.CommanderAttachStartOptions
-		(*CommanderAttachResult)(nil),       // 7: dhctl.CommanderAttachResult
-		nil,                                 // 8: dhctl.CommanderAttachPhaseEnd.CompletedPhaseStateEntry
-		(*Logs)(nil),                        // 9: dhctl.Logs
-		(*Progress)(nil),                    // 10: dhctl.Progress
-		(*structpb.Struct)(nil),             // 11: google.protobuf.Struct
-		(Continue)(0),                       // 12: dhctl.Continue
-		(*durationpb.Duration)(nil),         // 13: google.protobuf.Duration
-		(*OperationOptions)(nil),            // 14: dhctl.OperationOptions
-	}
-)
-
+var file_commander_attach_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_commander_attach_proto_goTypes = []interface{}{
+	(*CommanderAttachRequest)(nil),      // 0: dhctl.CommanderAttachRequest
+	(*CommanderAttachResponse)(nil),     // 1: dhctl.CommanderAttachResponse
+	(*CommanderAttachStart)(nil),        // 2: dhctl.CommanderAttachStart
+	(*CommanderAttachPhaseEnd)(nil),     // 3: dhctl.CommanderAttachPhaseEnd
+	(*CommanderAttachContinue)(nil),     // 4: dhctl.CommanderAttachContinue
+	(*CommanderAttachCancel)(nil),       // 5: dhctl.CommanderAttachCancel
+	(*CommanderAttachStartOptions)(nil), // 6: dhctl.CommanderAttachStartOptions
+	(*CommanderAttachResult)(nil),       // 7: dhctl.CommanderAttachResult
+	nil,                                 // 8: dhctl.CommanderAttachPhaseEnd.CompletedPhaseStateEntry
+	(*Logs)(nil),                        // 9: dhctl.Logs
+	(*Progress)(nil),                    // 10: dhctl.Progress
+	(*structpb.Struct)(nil),             // 11: google.protobuf.Struct
+	(Continue)(0),                       // 12: dhctl.Continue
+	(*durationpb.Duration)(nil),         // 13: google.protobuf.Duration
+	(*OperationOptions)(nil),            // 14: dhctl.OperationOptions
+}
 var file_commander_attach_proto_depIdxs = []int32{
 	2,  // 0: dhctl.CommanderAttachRequest.start:type_name -> dhctl.CommanderAttachStart
 	4,  // 1: dhctl.CommanderAttachRequest.continue:type_name -> dhctl.CommanderAttachContinue

--- a/dhctl/pkg/server/pb/dhctl/commander_detach.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/commander_detach.pb.go
@@ -21,13 +21,12 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	structpb "google.golang.org/protobuf/types/known/structpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -611,23 +610,20 @@ func file_commander_detach_proto_rawDescGZIP() []byte {
 	return file_commander_detach_proto_rawDescData
 }
 
-var (
-	file_commander_detach_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-	file_commander_detach_proto_goTypes  = []interface{}{
-		(*CommanderDetachRequest)(nil),      // 0: dhctl.CommanderDetachRequest
-		(*CommanderDetachResponse)(nil),     // 1: dhctl.CommanderDetachResponse
-		(*CommanderDetachStart)(nil),        // 2: dhctl.CommanderDetachStart
-		(*CommanderDetachCancel)(nil),       // 3: dhctl.CommanderDetachCancel
-		(*CommanderDetachStartOptions)(nil), // 4: dhctl.CommanderDetachStartOptions
-		(*CommanderDetachResult)(nil),       // 5: dhctl.CommanderDetachResult
-		(*Logs)(nil),                        // 6: dhctl.Logs
-		(*Progress)(nil),                    // 7: dhctl.Progress
-		(*structpb.Struct)(nil),             // 8: google.protobuf.Struct
-		(*durationpb.Duration)(nil),         // 9: google.protobuf.Duration
-		(*OperationOptions)(nil),            // 10: dhctl.OperationOptions
-	}
-)
-
+var file_commander_detach_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_commander_detach_proto_goTypes = []interface{}{
+	(*CommanderDetachRequest)(nil),      // 0: dhctl.CommanderDetachRequest
+	(*CommanderDetachResponse)(nil),     // 1: dhctl.CommanderDetachResponse
+	(*CommanderDetachStart)(nil),        // 2: dhctl.CommanderDetachStart
+	(*CommanderDetachCancel)(nil),       // 3: dhctl.CommanderDetachCancel
+	(*CommanderDetachStartOptions)(nil), // 4: dhctl.CommanderDetachStartOptions
+	(*CommanderDetachResult)(nil),       // 5: dhctl.CommanderDetachResult
+	(*Logs)(nil),                        // 6: dhctl.Logs
+	(*Progress)(nil),                    // 7: dhctl.Progress
+	(*structpb.Struct)(nil),             // 8: google.protobuf.Struct
+	(*durationpb.Duration)(nil),         // 9: google.protobuf.Duration
+	(*OperationOptions)(nil),            // 10: dhctl.OperationOptions
+}
 var file_commander_detach_proto_depIdxs = []int32{
 	2,  // 0: dhctl.CommanderDetachRequest.start:type_name -> dhctl.CommanderDetachStart
 	3,  // 1: dhctl.CommanderDetachRequest.cancel:type_name -> dhctl.CommanderDetachCancel

--- a/dhctl/pkg/server/pb/dhctl/common.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/common.pb.go
@@ -21,11 +21,10 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -418,18 +417,15 @@ func file_common_proto_rawDescGZIP() []byte {
 	return file_common_proto_rawDescData
 }
 
-var (
-	file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_common_proto_msgTypes  = make([]protoimpl.MessageInfo, 4)
-	file_common_proto_goTypes   = []interface{}{
-		(Continue)(0),                       // 0: dhctl.Continue
-		(*Logs)(nil),                        // 1: dhctl.Logs
-		(*Progress)(nil),                    // 2: dhctl.Progress
-		(*OperationOptions)(nil),            // 3: dhctl.OperationOptions
-		(*Progress_PhaseWithSubPhases)(nil), // 4: dhctl.Progress.PhaseWithSubPhases
-	}
-)
-
+var file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_common_proto_goTypes = []interface{}{
+	(Continue)(0),                       // 0: dhctl.Continue
+	(*Logs)(nil),                        // 1: dhctl.Logs
+	(*Progress)(nil),                    // 2: dhctl.Progress
+	(*OperationOptions)(nil),            // 3: dhctl.OperationOptions
+	(*Progress_PhaseWithSubPhases)(nil), // 4: dhctl.Progress.PhaseWithSubPhases
+}
 var file_common_proto_depIdxs = []int32{
 	4, // 0: dhctl.Progress.phases:type_name -> dhctl.Progress.PhaseWithSubPhases
 	1, // [1:1] is the sub-list for method output_type

--- a/dhctl/pkg/server/pb/dhctl/converge.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/converge.pb.go
@@ -21,12 +21,11 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -808,26 +807,23 @@ func file_converge_proto_rawDescGZIP() []byte {
 	return file_converge_proto_rawDescData
 }
 
-var (
-	file_converge_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-	file_converge_proto_goTypes  = []interface{}{
-		(*ConvergeRequest)(nil),      // 0: dhctl.ConvergeRequest
-		(*ConvergeResponse)(nil),     // 1: dhctl.ConvergeResponse
-		(*ConvergeStart)(nil),        // 2: dhctl.ConvergeStart
-		(*ConvergePhaseEnd)(nil),     // 3: dhctl.ConvergePhaseEnd
-		(*ConvergeContinue)(nil),     // 4: dhctl.ConvergeContinue
-		(*ConvergeCancel)(nil),       // 5: dhctl.ConvergeCancel
-		(*ConvergeStartOptions)(nil), // 6: dhctl.ConvergeStartOptions
-		(*ConvergeResult)(nil),       // 7: dhctl.ConvergeResult
-		nil,                          // 8: dhctl.ConvergePhaseEnd.CompletedPhaseStateEntry
-		(*Logs)(nil),                 // 9: dhctl.Logs
-		(*Progress)(nil),             // 10: dhctl.Progress
-		(Continue)(0),                // 11: dhctl.Continue
-		(*durationpb.Duration)(nil),  // 12: google.protobuf.Duration
-		(*OperationOptions)(nil),     // 13: dhctl.OperationOptions
-	}
-)
-
+var file_converge_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_converge_proto_goTypes = []interface{}{
+	(*ConvergeRequest)(nil),      // 0: dhctl.ConvergeRequest
+	(*ConvergeResponse)(nil),     // 1: dhctl.ConvergeResponse
+	(*ConvergeStart)(nil),        // 2: dhctl.ConvergeStart
+	(*ConvergePhaseEnd)(nil),     // 3: dhctl.ConvergePhaseEnd
+	(*ConvergeContinue)(nil),     // 4: dhctl.ConvergeContinue
+	(*ConvergeCancel)(nil),       // 5: dhctl.ConvergeCancel
+	(*ConvergeStartOptions)(nil), // 6: dhctl.ConvergeStartOptions
+	(*ConvergeResult)(nil),       // 7: dhctl.ConvergeResult
+	nil,                          // 8: dhctl.ConvergePhaseEnd.CompletedPhaseStateEntry
+	(*Logs)(nil),                 // 9: dhctl.Logs
+	(*Progress)(nil),             // 10: dhctl.Progress
+	(Continue)(0),                // 11: dhctl.Continue
+	(*durationpb.Duration)(nil),  // 12: google.protobuf.Duration
+	(*OperationOptions)(nil),     // 13: dhctl.OperationOptions
+}
 var file_converge_proto_depIdxs = []int32{
 	2,  // 0: dhctl.ConvergeRequest.start:type_name -> dhctl.ConvergeStart
 	4,  // 1: dhctl.ConvergeRequest.continue:type_name -> dhctl.ConvergeContinue

--- a/dhctl/pkg/server/pb/dhctl/destroy.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/destroy.pb.go
@@ -21,12 +21,11 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	durationpb "google.golang.org/protobuf/types/known/durationpb"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -749,26 +748,23 @@ func file_destroy_proto_rawDescGZIP() []byte {
 	return file_destroy_proto_rawDescData
 }
 
-var (
-	file_destroy_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
-	file_destroy_proto_goTypes  = []interface{}{
-		(*DestroyRequest)(nil),      // 0: dhctl.DestroyRequest
-		(*DestroyResponse)(nil),     // 1: dhctl.DestroyResponse
-		(*DestroyStart)(nil),        // 2: dhctl.DestroyStart
-		(*DestroyPhaseEnd)(nil),     // 3: dhctl.DestroyPhaseEnd
-		(*DestroyContinue)(nil),     // 4: dhctl.DestroyContinue
-		(*DestroyCancel)(nil),       // 5: dhctl.DestroyCancel
-		(*DestroyStartOptions)(nil), // 6: dhctl.DestroyStartOptions
-		(*DestroyResult)(nil),       // 7: dhctl.DestroyResult
-		nil,                         // 8: dhctl.DestroyPhaseEnd.CompletedPhaseStateEntry
-		(*Logs)(nil),                // 9: dhctl.Logs
-		(*Progress)(nil),            // 10: dhctl.Progress
-		(Continue)(0),               // 11: dhctl.Continue
-		(*durationpb.Duration)(nil), // 12: google.protobuf.Duration
-		(*OperationOptions)(nil),    // 13: dhctl.OperationOptions
-	}
-)
-
+var file_destroy_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_destroy_proto_goTypes = []interface{}{
+	(*DestroyRequest)(nil),      // 0: dhctl.DestroyRequest
+	(*DestroyResponse)(nil),     // 1: dhctl.DestroyResponse
+	(*DestroyStart)(nil),        // 2: dhctl.DestroyStart
+	(*DestroyPhaseEnd)(nil),     // 3: dhctl.DestroyPhaseEnd
+	(*DestroyContinue)(nil),     // 4: dhctl.DestroyContinue
+	(*DestroyCancel)(nil),       // 5: dhctl.DestroyCancel
+	(*DestroyStartOptions)(nil), // 6: dhctl.DestroyStartOptions
+	(*DestroyResult)(nil),       // 7: dhctl.DestroyResult
+	nil,                         // 8: dhctl.DestroyPhaseEnd.CompletedPhaseStateEntry
+	(*Logs)(nil),                // 9: dhctl.Logs
+	(*Progress)(nil),            // 10: dhctl.Progress
+	(Continue)(0),               // 11: dhctl.Continue
+	(*durationpb.Duration)(nil), // 12: google.protobuf.Duration
+	(*OperationOptions)(nil),    // 13: dhctl.OperationOptions
+}
 var file_destroy_proto_depIdxs = []int32{
 	2,  // 0: dhctl.DestroyRequest.start:type_name -> dhctl.DestroyStart
 	4,  // 1: dhctl.DestroyRequest.continue:type_name -> dhctl.DestroyContinue

--- a/dhctl/pkg/server/pb/dhctl/services.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/services.pb.go
@@ -21,10 +21,9 @@
 package dhctl
 
 import (
-	reflect "reflect"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
 )
 
 const (
@@ -79,7 +78,7 @@ var file_services_proto_rawDesc = []byte{
 	0x61, 0x6e, 0x64, 0x65, 0x72, 0x44, 0x65, 0x74, 0x61, 0x63, 0x68, 0x52, 0x65, 0x71, 0x75, 0x65,
 	0x73, 0x74, 0x1a, 0x1e, 0x2e, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x43, 0x6f, 0x6d, 0x6d, 0x61,
 	0x6e, 0x64, 0x65, 0x72, 0x44, 0x65, 0x74, 0x61, 0x63, 0x68, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e,
-	0x73, 0x65, 0x22, 0x00, 0x28, 0x01, 0x30, 0x01, 0x32, 0xf2, 0x05, 0x0a, 0x0a, 0x56, 0x61, 0x6c,
+	0x73, 0x65, 0x22, 0x00, 0x28, 0x01, 0x30, 0x01, 0x32, 0xc3, 0x06, 0x0a, 0x0a, 0x56, 0x61, 0x6c,
 	0x69, 0x64, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x58, 0x0a, 0x11, 0x56, 0x61, 0x6c, 0x69, 0x64,
 	0x61, 0x74, 0x65, 0x52, 0x65, 0x73, 0x6f, 0x75, 0x72, 0x63, 0x65, 0x73, 0x12, 0x1f, 0x2e, 0x64,
 	0x68, 0x63, 0x74, 0x6c, 0x2e, 0x56, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x65, 0x52, 0x65, 0x73,
@@ -126,13 +125,18 @@ var file_services_proto_rawDesc = []byte{
 	0x6e, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x52, 0x65,
 	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x24, 0x2e, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x50, 0x61,
 	0x72, 0x73, 0x65, 0x43, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x43, 0x6f, 0x6e,
-	0x66, 0x69, 0x67, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x32, 0x4a, 0x0a,
-	0x06, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12, 0x40, 0x0a, 0x09, 0x47, 0x65, 0x74, 0x53, 0x74,
-	0x61, 0x74, 0x75, 0x73, 0x12, 0x17, 0x2e, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x47, 0x65, 0x74,
-	0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x18, 0x2e,
-	0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x47, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52,
-	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x0a, 0x5a, 0x08, 0x70, 0x62, 0x2f,
-	0x64, 0x68, 0x63, 0x74, 0x6c, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x66, 0x69, 0x67, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x4f, 0x0a,
+	0x0e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x72, 0x12,
+	0x1c, 0x2e, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x45, 0x78,
+	0x74, 0x65, 0x6e, 0x64, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x1d, 0x2e,
+	0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x45, 0x78, 0x74, 0x65,
+	0x6e, 0x64, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x32, 0x4a,
+	0x0a, 0x06, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x12, 0x40, 0x0a, 0x09, 0x47, 0x65, 0x74, 0x53,
+	0x74, 0x61, 0x74, 0x75, 0x73, 0x12, 0x17, 0x2e, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x47, 0x65,
+	0x74, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x18,
+	0x2e, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e, 0x47, 0x65, 0x74, 0x53, 0x74, 0x61, 0x74, 0x75, 0x73,
+	0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x0a, 0x5a, 0x08, 0x70, 0x62,
+	0x2f, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var file_services_proto_goTypes = []interface{}{
@@ -150,24 +154,25 @@ var file_services_proto_goTypes = []interface{}{
 	(*ValidateProviderSpecificClusterConfigRequest)(nil),  // 11: dhctl.ValidateProviderSpecificClusterConfigRequest
 	(*ValidateChangesRequest)(nil),                        // 12: dhctl.ValidateChangesRequest
 	(*ParseConnectionConfigRequest)(nil),                  // 13: dhctl.ParseConnectionConfigRequest
-	(*GetStatusRequest)(nil),                              // 14: dhctl.GetStatusRequest
-	(*CheckResponse)(nil),                                 // 15: dhctl.CheckResponse
-	(*BootstrapResponse)(nil),                             // 16: dhctl.BootstrapResponse
-	(*DestroyResponse)(nil),                               // 17: dhctl.DestroyResponse
-	(*AbortResponse)(nil),                                 // 18: dhctl.AbortResponse
-	(*ConvergeResponse)(nil),                              // 19: dhctl.ConvergeResponse
-	(*CommanderAttachResponse)(nil),                       // 20: dhctl.CommanderAttachResponse
-	(*CommanderDetachResponse)(nil),                       // 21: dhctl.CommanderDetachResponse
-	(*ValidateResourcesResponse)(nil),                     // 22: dhctl.ValidateResourcesResponse
-	(*ValidateInitConfigResponse)(nil),                    // 23: dhctl.ValidateInitConfigResponse
-	(*ValidateClusterConfigResponse)(nil),                 // 24: dhctl.ValidateClusterConfigResponse
-	(*ValidateStaticClusterConfigResponse)(nil),           // 25: dhctl.ValidateStaticClusterConfigResponse
-	(*ValidateProviderSpecificClusterConfigResponse)(nil), // 26: dhctl.ValidateProviderSpecificClusterConfigResponse
-	(*ValidateChangesResponse)(nil),                       // 27: dhctl.ValidateChangesResponse
-	(*ParseConnectionConfigResponse)(nil),                 // 28: dhctl.ParseConnectionConfigResponse
-	(*GetStatusResponse)(nil),                             // 29: dhctl.GetStatusResponse
+	(*ConfigExtenderRequest)(nil),                         // 14: dhctl.ConfigExtenderRequest
+	(*GetStatusRequest)(nil),                              // 15: dhctl.GetStatusRequest
+	(*CheckResponse)(nil),                                 // 16: dhctl.CheckResponse
+	(*BootstrapResponse)(nil),                             // 17: dhctl.BootstrapResponse
+	(*DestroyResponse)(nil),                               // 18: dhctl.DestroyResponse
+	(*AbortResponse)(nil),                                 // 19: dhctl.AbortResponse
+	(*ConvergeResponse)(nil),                              // 20: dhctl.ConvergeResponse
+	(*CommanderAttachResponse)(nil),                       // 21: dhctl.CommanderAttachResponse
+	(*CommanderDetachResponse)(nil),                       // 22: dhctl.CommanderDetachResponse
+	(*ValidateResourcesResponse)(nil),                     // 23: dhctl.ValidateResourcesResponse
+	(*ValidateInitConfigResponse)(nil),                    // 24: dhctl.ValidateInitConfigResponse
+	(*ValidateClusterConfigResponse)(nil),                 // 25: dhctl.ValidateClusterConfigResponse
+	(*ValidateStaticClusterConfigResponse)(nil),           // 26: dhctl.ValidateStaticClusterConfigResponse
+	(*ValidateProviderSpecificClusterConfigResponse)(nil), // 27: dhctl.ValidateProviderSpecificClusterConfigResponse
+	(*ValidateChangesResponse)(nil),                       // 28: dhctl.ValidateChangesResponse
+	(*ParseConnectionConfigResponse)(nil),                 // 29: dhctl.ParseConnectionConfigResponse
+	(*ConfigExtenderResponse)(nil),                        // 30: dhctl.ConfigExtenderResponse
+	(*GetStatusResponse)(nil),                             // 31: dhctl.GetStatusResponse
 }
-
 var file_services_proto_depIdxs = []int32{
 	0,  // 0: dhctl.DHCTL.Check:input_type -> dhctl.CheckRequest
 	1,  // 1: dhctl.DHCTL.Bootstrap:input_type -> dhctl.BootstrapRequest
@@ -183,24 +188,26 @@ var file_services_proto_depIdxs = []int32{
 	11, // 11: dhctl.Validation.ValidateProviderSpecificClusterConfig:input_type -> dhctl.ValidateProviderSpecificClusterConfigRequest
 	12, // 12: dhctl.Validation.ValidateChanges:input_type -> dhctl.ValidateChangesRequest
 	13, // 13: dhctl.Validation.ParseConnectionConfig:input_type -> dhctl.ParseConnectionConfigRequest
-	14, // 14: dhctl.Status.GetStatus:input_type -> dhctl.GetStatusRequest
-	15, // 15: dhctl.DHCTL.Check:output_type -> dhctl.CheckResponse
-	16, // 16: dhctl.DHCTL.Bootstrap:output_type -> dhctl.BootstrapResponse
-	17, // 17: dhctl.DHCTL.Destroy:output_type -> dhctl.DestroyResponse
-	18, // 18: dhctl.DHCTL.Abort:output_type -> dhctl.AbortResponse
-	19, // 19: dhctl.DHCTL.Converge:output_type -> dhctl.ConvergeResponse
-	20, // 20: dhctl.DHCTL.CommanderAttach:output_type -> dhctl.CommanderAttachResponse
-	21, // 21: dhctl.DHCTL.CommanderDetach:output_type -> dhctl.CommanderDetachResponse
-	22, // 22: dhctl.Validation.ValidateResources:output_type -> dhctl.ValidateResourcesResponse
-	23, // 23: dhctl.Validation.ValidateInitConfig:output_type -> dhctl.ValidateInitConfigResponse
-	24, // 24: dhctl.Validation.ValidateClusterConfig:output_type -> dhctl.ValidateClusterConfigResponse
-	25, // 25: dhctl.Validation.ValidateStaticClusterConfig:output_type -> dhctl.ValidateStaticClusterConfigResponse
-	26, // 26: dhctl.Validation.ValidateProviderSpecificClusterConfig:output_type -> dhctl.ValidateProviderSpecificClusterConfigResponse
-	27, // 27: dhctl.Validation.ValidateChanges:output_type -> dhctl.ValidateChangesResponse
-	28, // 28: dhctl.Validation.ParseConnectionConfig:output_type -> dhctl.ParseConnectionConfigResponse
-	29, // 29: dhctl.Status.GetStatus:output_type -> dhctl.GetStatusResponse
-	15, // [15:30] is the sub-list for method output_type
-	0,  // [0:15] is the sub-list for method input_type
+	14, // 14: dhctl.Validation.ConfigExtender:input_type -> dhctl.ConfigExtenderRequest
+	15, // 15: dhctl.Status.GetStatus:input_type -> dhctl.GetStatusRequest
+	16, // 16: dhctl.DHCTL.Check:output_type -> dhctl.CheckResponse
+	17, // 17: dhctl.DHCTL.Bootstrap:output_type -> dhctl.BootstrapResponse
+	18, // 18: dhctl.DHCTL.Destroy:output_type -> dhctl.DestroyResponse
+	19, // 19: dhctl.DHCTL.Abort:output_type -> dhctl.AbortResponse
+	20, // 20: dhctl.DHCTL.Converge:output_type -> dhctl.ConvergeResponse
+	21, // 21: dhctl.DHCTL.CommanderAttach:output_type -> dhctl.CommanderAttachResponse
+	22, // 22: dhctl.DHCTL.CommanderDetach:output_type -> dhctl.CommanderDetachResponse
+	23, // 23: dhctl.Validation.ValidateResources:output_type -> dhctl.ValidateResourcesResponse
+	24, // 24: dhctl.Validation.ValidateInitConfig:output_type -> dhctl.ValidateInitConfigResponse
+	25, // 25: dhctl.Validation.ValidateClusterConfig:output_type -> dhctl.ValidateClusterConfigResponse
+	26, // 26: dhctl.Validation.ValidateStaticClusterConfig:output_type -> dhctl.ValidateStaticClusterConfigResponse
+	27, // 27: dhctl.Validation.ValidateProviderSpecificClusterConfig:output_type -> dhctl.ValidateProviderSpecificClusterConfigResponse
+	28, // 28: dhctl.Validation.ValidateChanges:output_type -> dhctl.ValidateChangesResponse
+	29, // 29: dhctl.Validation.ParseConnectionConfig:output_type -> dhctl.ParseConnectionConfigResponse
+	30, // 30: dhctl.Validation.ConfigExtender:output_type -> dhctl.ConfigExtenderResponse
+	31, // 31: dhctl.Status.GetStatus:output_type -> dhctl.GetStatusResponse
+	16, // [16:32] is the sub-list for method output_type
+	0,  // [0:16] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/dhctl/pkg/server/pb/dhctl/services_grpc.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/services_grpc.pb.go
@@ -22,7 +22,6 @@ package dhctl
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -296,32 +295,27 @@ type DHCTLServer interface {
 }
 
 // UnimplementedDHCTLServer must be embedded to have forward compatible implementations.
-type UnimplementedDHCTLServer struct{}
+type UnimplementedDHCTLServer struct {
+}
 
 func (UnimplementedDHCTLServer) Check(DHCTL_CheckServer) error {
 	return status.Errorf(codes.Unimplemented, "method Check not implemented")
 }
-
 func (UnimplementedDHCTLServer) Bootstrap(DHCTL_BootstrapServer) error {
 	return status.Errorf(codes.Unimplemented, "method Bootstrap not implemented")
 }
-
 func (UnimplementedDHCTLServer) Destroy(DHCTL_DestroyServer) error {
 	return status.Errorf(codes.Unimplemented, "method Destroy not implemented")
 }
-
 func (UnimplementedDHCTLServer) Abort(DHCTL_AbortServer) error {
 	return status.Errorf(codes.Unimplemented, "method Abort not implemented")
 }
-
 func (UnimplementedDHCTLServer) Converge(DHCTL_ConvergeServer) error {
 	return status.Errorf(codes.Unimplemented, "method Converge not implemented")
 }
-
 func (UnimplementedDHCTLServer) CommanderAttach(DHCTL_CommanderAttachServer) error {
 	return status.Errorf(codes.Unimplemented, "method CommanderAttach not implemented")
 }
-
 func (UnimplementedDHCTLServer) CommanderDetach(DHCTL_CommanderDetachServer) error {
 	return status.Errorf(codes.Unimplemented, "method CommanderDetach not implemented")
 }
@@ -582,6 +576,7 @@ const (
 	Validation_ValidateProviderSpecificClusterConfig_FullMethodName = "/dhctl.Validation/ValidateProviderSpecificClusterConfig"
 	Validation_ValidateChanges_FullMethodName                       = "/dhctl.Validation/ValidateChanges"
 	Validation_ParseConnectionConfig_FullMethodName                 = "/dhctl.Validation/ParseConnectionConfig"
+	Validation_ConfigExtender_FullMethodName                        = "/dhctl.Validation/ConfigExtender"
 )
 
 // ValidationClient is the client API for Validation service.
@@ -595,6 +590,7 @@ type ValidationClient interface {
 	ValidateProviderSpecificClusterConfig(ctx context.Context, in *ValidateProviderSpecificClusterConfigRequest, opts ...grpc.CallOption) (*ValidateProviderSpecificClusterConfigResponse, error)
 	ValidateChanges(ctx context.Context, in *ValidateChangesRequest, opts ...grpc.CallOption) (*ValidateChangesResponse, error)
 	ParseConnectionConfig(ctx context.Context, in *ParseConnectionConfigRequest, opts ...grpc.CallOption) (*ParseConnectionConfigResponse, error)
+	ConfigExtender(ctx context.Context, in *ConfigExtenderRequest, opts ...grpc.CallOption) (*ConfigExtenderResponse, error)
 }
 
 type validationClient struct {
@@ -668,6 +664,15 @@ func (c *validationClient) ParseConnectionConfig(ctx context.Context, in *ParseC
 	return out, nil
 }
 
+func (c *validationClient) ConfigExtender(ctx context.Context, in *ConfigExtenderRequest, opts ...grpc.CallOption) (*ConfigExtenderResponse, error) {
+	out := new(ConfigExtenderResponse)
+	err := c.cc.Invoke(ctx, Validation_ConfigExtender_FullMethodName, in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ValidationServer is the server API for Validation service.
 // All implementations must embed UnimplementedValidationServer
 // for forward compatibility
@@ -679,38 +684,37 @@ type ValidationServer interface {
 	ValidateProviderSpecificClusterConfig(context.Context, *ValidateProviderSpecificClusterConfigRequest) (*ValidateProviderSpecificClusterConfigResponse, error)
 	ValidateChanges(context.Context, *ValidateChangesRequest) (*ValidateChangesResponse, error)
 	ParseConnectionConfig(context.Context, *ParseConnectionConfigRequest) (*ParseConnectionConfigResponse, error)
+	ConfigExtender(context.Context, *ConfigExtenderRequest) (*ConfigExtenderResponse, error)
 	mustEmbedUnimplementedValidationServer()
 }
 
 // UnimplementedValidationServer must be embedded to have forward compatible implementations.
-type UnimplementedValidationServer struct{}
+type UnimplementedValidationServer struct {
+}
 
 func (UnimplementedValidationServer) ValidateResources(context.Context, *ValidateResourcesRequest) (*ValidateResourcesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ValidateResources not implemented")
 }
-
 func (UnimplementedValidationServer) ValidateInitConfig(context.Context, *ValidateInitConfigRequest) (*ValidateInitConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ValidateInitConfig not implemented")
 }
-
 func (UnimplementedValidationServer) ValidateClusterConfig(context.Context, *ValidateClusterConfigRequest) (*ValidateClusterConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ValidateClusterConfig not implemented")
 }
-
 func (UnimplementedValidationServer) ValidateStaticClusterConfig(context.Context, *ValidateStaticClusterConfigRequest) (*ValidateStaticClusterConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ValidateStaticClusterConfig not implemented")
 }
-
 func (UnimplementedValidationServer) ValidateProviderSpecificClusterConfig(context.Context, *ValidateProviderSpecificClusterConfigRequest) (*ValidateProviderSpecificClusterConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ValidateProviderSpecificClusterConfig not implemented")
 }
-
 func (UnimplementedValidationServer) ValidateChanges(context.Context, *ValidateChangesRequest) (*ValidateChangesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ValidateChanges not implemented")
 }
-
 func (UnimplementedValidationServer) ParseConnectionConfig(context.Context, *ParseConnectionConfigRequest) (*ParseConnectionConfigResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ParseConnectionConfig not implemented")
+}
+func (UnimplementedValidationServer) ConfigExtender(context.Context, *ConfigExtenderRequest) (*ConfigExtenderResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ConfigExtender not implemented")
 }
 func (UnimplementedValidationServer) mustEmbedUnimplementedValidationServer() {}
 
@@ -851,6 +855,24 @@ func _Validation_ParseConnectionConfig_Handler(srv interface{}, ctx context.Cont
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Validation_ConfigExtender_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ConfigExtenderRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ValidationServer).ConfigExtender(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Validation_ConfigExtender_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ValidationServer).ConfigExtender(ctx, req.(*ConfigExtenderRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Validation_ServiceDesc is the grpc.ServiceDesc for Validation service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -885,6 +907,10 @@ var Validation_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ParseConnectionConfig",
 			Handler:    _Validation_ParseConnectionConfig_Handler,
+		},
+		{
+			MethodName: "ConfigExtender",
+			Handler:    _Validation_ConfigExtender_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -928,7 +954,8 @@ type StatusServer interface {
 }
 
 // UnimplementedStatusServer must be embedded to have forward compatible implementations.
-type UnimplementedStatusServer struct{}
+type UnimplementedStatusServer struct {
+}
 
 func (UnimplementedStatusServer) GetStatus(context.Context, *GetStatusRequest) (*GetStatusResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetStatus not implemented")

--- a/dhctl/pkg/server/pb/dhctl/status.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/status.pb.go
@@ -21,11 +21,10 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -166,15 +165,12 @@ func file_status_proto_rawDescGZIP() []byte {
 	return file_status_proto_rawDescData
 }
 
-var (
-	file_status_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-	file_status_proto_goTypes  = []interface{}{
-		(*GetStatusRequest)(nil),  // 0: dhctl.GetStatusRequest
-		(*GetStatusResponse)(nil), // 1: dhctl.GetStatusResponse
-		nil,                       // 2: dhctl.GetStatusResponse.RequestsByMethodEntry
-	}
-)
-
+var file_status_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_status_proto_goTypes = []interface{}{
+	(*GetStatusRequest)(nil),  // 0: dhctl.GetStatusRequest
+	(*GetStatusResponse)(nil), // 1: dhctl.GetStatusResponse
+	nil,                       // 2: dhctl.GetStatusResponse.RequestsByMethodEntry
+}
 var file_status_proto_depIdxs = []int32{
 	2, // 0: dhctl.GetStatusResponse.requests_by_method:type_name -> dhctl.GetStatusResponse.RequestsByMethodEntry
 	1, // [1:1] is the sub-list for method output_type

--- a/dhctl/pkg/server/pb/dhctl/validation.pb.go
+++ b/dhctl/pkg/server/pb/dhctl/validation.pb.go
@@ -21,11 +21,10 @@
 package dhctl
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -34,6 +33,54 @@ const (
 	// Verify that runtime/protoimpl is sufficiently up-to-date.
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
+
+// ConfigExtensionKind enumerates the kinds of recommended config extensions a
+// client may request. Adding a kind is an additive enum change.
+type ConfigExtensionKind int32
+
+const (
+	ConfigExtensionKind_CONFIG_EXTENSION_KIND_UNSPECIFIED ConfigExtensionKind = 0
+	ConfigExtensionKind_CONFIG_EXTENSION_KIND_CNI         ConfigExtensionKind = 1
+)
+
+// Enum value maps for ConfigExtensionKind.
+var (
+	ConfigExtensionKind_name = map[int32]string{
+		0: "CONFIG_EXTENSION_KIND_UNSPECIFIED",
+		1: "CONFIG_EXTENSION_KIND_CNI",
+	}
+	ConfigExtensionKind_value = map[string]int32{
+		"CONFIG_EXTENSION_KIND_UNSPECIFIED": 0,
+		"CONFIG_EXTENSION_KIND_CNI":         1,
+	}
+)
+
+func (x ConfigExtensionKind) Enum() *ConfigExtensionKind {
+	p := new(ConfigExtensionKind)
+	*p = x
+	return p
+}
+
+func (x ConfigExtensionKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ConfigExtensionKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_validation_proto_enumTypes[0].Descriptor()
+}
+
+func (ConfigExtensionKind) Type() protoreflect.EnumType {
+	return &file_validation_proto_enumTypes[0]
+}
+
+func (x ConfigExtensionKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ConfigExtensionKind.Descriptor instead.
+func (ConfigExtensionKind) EnumDescriptor() ([]byte, []int) {
+	return file_validation_proto_rawDescGZIP(), []int{0}
+}
 
 type ValidateOptions struct {
 	state         protoimpl.MessageState
@@ -860,6 +907,122 @@ func (x *ParseConnectionConfigResponse) GetErr() string {
 	return ""
 }
 
+type ConfigExtenderRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Source cluster YAML (Cluster/Provider/MC documents).
+	Config string `protobuf:"bytes,1,opt,name=config,proto3" json:"config,omitempty"`
+	// Which single extension kind to compute.
+	Kind ConfigExtensionKind `protobuf:"varint,2,opt,name=kind,proto3,enum=dhctl.ConfigExtensionKind" json:"kind,omitempty"`
+}
+
+func (x *ConfigExtenderRequest) Reset() {
+	*x = ConfigExtenderRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_validation_proto_msgTypes[15]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ConfigExtenderRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigExtenderRequest) ProtoMessage() {}
+
+func (x *ConfigExtenderRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_validation_proto_msgTypes[15]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigExtenderRequest.ProtoReflect.Descriptor instead.
+func (*ConfigExtenderRequest) Descriptor() ([]byte, []int) {
+	return file_validation_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ConfigExtenderRequest) GetConfig() string {
+	if x != nil {
+		return x.Config
+	}
+	return ""
+}
+
+func (x *ConfigExtenderRequest) GetKind() ConfigExtensionKind {
+	if x != nil {
+		return x.Kind
+	}
+	return ConfigExtensionKind_CONFIG_EXTENSION_KIND_UNSPECIFIED
+}
+
+// ConfigExtenderResponse returns the recommended config for the requested kind
+// as a single generic string. "Nothing to recommend" = empty config, not an error.
+type ConfigExtenderResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Err string `protobuf:"bytes,1,opt,name=err,proto3" json:"err,omitempty"`
+	// Recommended ModuleConfig (JSON) for the requested kind. Distinct from
+	// ConfigExtenderRequest.config.
+	Config string `protobuf:"bytes,2,opt,name=config,proto3" json:"config,omitempty"`
+}
+
+func (x *ConfigExtenderResponse) Reset() {
+	*x = ConfigExtenderResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_validation_proto_msgTypes[16]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ConfigExtenderResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigExtenderResponse) ProtoMessage() {}
+
+func (x *ConfigExtenderResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_validation_proto_msgTypes[16]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigExtenderResponse.ProtoReflect.Descriptor instead.
+func (*ConfigExtenderResponse) Descriptor() ([]byte, []int) {
+	return file_validation_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ConfigExtenderResponse) GetErr() string {
+	if x != nil {
+		return x.Err
+	}
+	return ""
+}
+
+func (x *ConfigExtenderResponse) GetConfig() string {
+	if x != nil {
+		return x.Config
+	}
+	return ""
+}
+
 var File_validation_proto protoreflect.FileDescriptor
 
 var file_validation_proto_rawDesc = []byte{
@@ -955,8 +1118,24 @@ var file_validation_proto_rawDesc = []byte{
 	0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x18, 0x01,
 	0x20, 0x01, 0x28, 0x09, 0x52, 0x10, 0x63, 0x6f, 0x6e, 0x6e, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
 	0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x72, 0x72, 0x18, 0x02, 0x20,
-	0x01, 0x28, 0x09, 0x52, 0x03, 0x65, 0x72, 0x72, 0x42, 0x0a, 0x5a, 0x08, 0x70, 0x62, 0x2f, 0x64,
-	0x68, 0x63, 0x74, 0x6c, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x01, 0x28, 0x09, 0x52, 0x03, 0x65, 0x72, 0x72, 0x22, 0x5f, 0x0a, 0x15, 0x43, 0x6f, 0x6e, 0x66,
+	0x69, 0x67, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x72, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x12, 0x16, 0x0a, 0x06, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x18, 0x01, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x06, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x2e, 0x0a, 0x04, 0x6b, 0x69, 0x6e,
+	0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0e, 0x32, 0x1a, 0x2e, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x2e,
+	0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e, 0x4b,
+	0x69, 0x6e, 0x64, 0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x22, 0x42, 0x0a, 0x16, 0x43, 0x6f, 0x6e,
+	0x66, 0x69, 0x67, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x64, 0x65, 0x72, 0x52, 0x65, 0x73, 0x70, 0x6f,
+	0x6e, 0x73, 0x65, 0x12, 0x10, 0x0a, 0x03, 0x65, 0x72, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x03, 0x65, 0x72, 0x72, 0x12, 0x16, 0x0a, 0x06, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2a, 0x5b, 0x0a,
+	0x13, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x45, 0x78, 0x74, 0x65, 0x6e, 0x73, 0x69, 0x6f, 0x6e,
+	0x4b, 0x69, 0x6e, 0x64, 0x12, 0x25, 0x0a, 0x21, 0x43, 0x4f, 0x4e, 0x46, 0x49, 0x47, 0x5f, 0x45,
+	0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f, 0x4e, 0x5f, 0x4b, 0x49, 0x4e, 0x44, 0x5f, 0x55, 0x4e,
+	0x53, 0x50, 0x45, 0x43, 0x49, 0x46, 0x49, 0x45, 0x44, 0x10, 0x00, 0x12, 0x1d, 0x0a, 0x19, 0x43,
+	0x4f, 0x4e, 0x46, 0x49, 0x47, 0x5f, 0x45, 0x58, 0x54, 0x45, 0x4e, 0x53, 0x49, 0x4f, 0x4e, 0x5f,
+	0x4b, 0x49, 0x4e, 0x44, 0x5f, 0x43, 0x4e, 0x49, 0x10, 0x01, 0x42, 0x0a, 0x5a, 0x08, 0x70, 0x62,
+	0x2f, 0x64, 0x68, 0x63, 0x74, 0x6c, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -971,40 +1150,42 @@ func file_validation_proto_rawDescGZIP() []byte {
 	return file_validation_proto_rawDescData
 }
 
-var (
-	file_validation_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
-	file_validation_proto_goTypes  = []interface{}{
-		(*ValidateOptions)(nil),                               // 0: dhctl.ValidateOptions
-		(*ValidateResourcesRequest)(nil),                      // 1: dhctl.ValidateResourcesRequest
-		(*ValidateResourcesResponse)(nil),                     // 2: dhctl.ValidateResourcesResponse
-		(*ValidateInitConfigRequest)(nil),                     // 3: dhctl.ValidateInitConfigRequest
-		(*ValidateInitConfigResponse)(nil),                    // 4: dhctl.ValidateInitConfigResponse
-		(*ValidateClusterConfigRequest)(nil),                  // 5: dhctl.ValidateClusterConfigRequest
-		(*ValidateClusterConfigResponse)(nil),                 // 6: dhctl.ValidateClusterConfigResponse
-		(*ValidateStaticClusterConfigRequest)(nil),            // 7: dhctl.ValidateStaticClusterConfigRequest
-		(*ValidateStaticClusterConfigResponse)(nil),           // 8: dhctl.ValidateStaticClusterConfigResponse
-		(*ValidateProviderSpecificClusterConfigRequest)(nil),  // 9: dhctl.ValidateProviderSpecificClusterConfigRequest
-		(*ValidateProviderSpecificClusterConfigResponse)(nil), // 10: dhctl.ValidateProviderSpecificClusterConfigResponse
-		(*ValidateChangesRequest)(nil),                        // 11: dhctl.ValidateChangesRequest
-		(*ValidateChangesResponse)(nil),                       // 12: dhctl.ValidateChangesResponse
-		(*ParseConnectionConfigRequest)(nil),                  // 13: dhctl.ParseConnectionConfigRequest
-		(*ParseConnectionConfigResponse)(nil),                 // 14: dhctl.ParseConnectionConfigResponse
-	}
-)
-
+var file_validation_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_validation_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_validation_proto_goTypes = []interface{}{
+	(ConfigExtensionKind)(0),                              // 0: dhctl.ConfigExtensionKind
+	(*ValidateOptions)(nil),                               // 1: dhctl.ValidateOptions
+	(*ValidateResourcesRequest)(nil),                      // 2: dhctl.ValidateResourcesRequest
+	(*ValidateResourcesResponse)(nil),                     // 3: dhctl.ValidateResourcesResponse
+	(*ValidateInitConfigRequest)(nil),                     // 4: dhctl.ValidateInitConfigRequest
+	(*ValidateInitConfigResponse)(nil),                    // 5: dhctl.ValidateInitConfigResponse
+	(*ValidateClusterConfigRequest)(nil),                  // 6: dhctl.ValidateClusterConfigRequest
+	(*ValidateClusterConfigResponse)(nil),                 // 7: dhctl.ValidateClusterConfigResponse
+	(*ValidateStaticClusterConfigRequest)(nil),            // 8: dhctl.ValidateStaticClusterConfigRequest
+	(*ValidateStaticClusterConfigResponse)(nil),           // 9: dhctl.ValidateStaticClusterConfigResponse
+	(*ValidateProviderSpecificClusterConfigRequest)(nil),  // 10: dhctl.ValidateProviderSpecificClusterConfigRequest
+	(*ValidateProviderSpecificClusterConfigResponse)(nil), // 11: dhctl.ValidateProviderSpecificClusterConfigResponse
+	(*ValidateChangesRequest)(nil),                        // 12: dhctl.ValidateChangesRequest
+	(*ValidateChangesResponse)(nil),                       // 13: dhctl.ValidateChangesResponse
+	(*ParseConnectionConfigRequest)(nil),                  // 14: dhctl.ParseConnectionConfigRequest
+	(*ParseConnectionConfigResponse)(nil),                 // 15: dhctl.ParseConnectionConfigResponse
+	(*ConfigExtenderRequest)(nil),                         // 16: dhctl.ConfigExtenderRequest
+	(*ConfigExtenderResponse)(nil),                        // 17: dhctl.ConfigExtenderResponse
+}
 var file_validation_proto_depIdxs = []int32{
-	0, // 0: dhctl.ValidateResourcesRequest.opts:type_name -> dhctl.ValidateOptions
-	0, // 1: dhctl.ValidateInitConfigRequest.opts:type_name -> dhctl.ValidateOptions
-	0, // 2: dhctl.ValidateClusterConfigRequest.opts:type_name -> dhctl.ValidateOptions
-	0, // 3: dhctl.ValidateStaticClusterConfigRequest.opts:type_name -> dhctl.ValidateOptions
-	0, // 4: dhctl.ValidateProviderSpecificClusterConfigRequest.opts:type_name -> dhctl.ValidateOptions
-	0, // 5: dhctl.ValidateChangesRequest.opts:type_name -> dhctl.ValidateOptions
-	0, // 6: dhctl.ParseConnectionConfigRequest.opts:type_name -> dhctl.ValidateOptions
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	1, // 0: dhctl.ValidateResourcesRequest.opts:type_name -> dhctl.ValidateOptions
+	1, // 1: dhctl.ValidateInitConfigRequest.opts:type_name -> dhctl.ValidateOptions
+	1, // 2: dhctl.ValidateClusterConfigRequest.opts:type_name -> dhctl.ValidateOptions
+	1, // 3: dhctl.ValidateStaticClusterConfigRequest.opts:type_name -> dhctl.ValidateOptions
+	1, // 4: dhctl.ValidateProviderSpecificClusterConfigRequest.opts:type_name -> dhctl.ValidateOptions
+	1, // 5: dhctl.ValidateChangesRequest.opts:type_name -> dhctl.ValidateOptions
+	1, // 6: dhctl.ParseConnectionConfigRequest.opts:type_name -> dhctl.ValidateOptions
+	0, // 7: dhctl.ConfigExtenderRequest.kind:type_name -> dhctl.ConfigExtensionKind
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_validation_proto_init() }
@@ -1193,19 +1374,44 @@ func file_validation_proto_init() {
 				return nil
 			}
 		}
+		file_validation_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ConfigExtenderRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_validation_proto_msgTypes[16].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ConfigExtenderResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_validation_proto_rawDesc,
-			NumEnums:      0,
-			NumMessages:   15,
+			NumEnums:      1,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_validation_proto_goTypes,
 		DependencyIndexes: file_validation_proto_depIdxs,
+		EnumInfos:         file_validation_proto_enumTypes,
 		MessageInfos:      file_validation_proto_msgTypes,
 	}.Build()
 	File_validation_proto = out.File

--- a/dhctl/pkg/server/rpc/validation/config_extender.go
+++ b/dhctl/pkg/server/rpc/validation/config_extender.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"encoding/json"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	pb "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"
+)
+
+// ConfigExtender returns the recommended config for the requested extension
+// kind. Runs in commander mode unconditionally: the request proto has no
+// opts, and parsing here is non-mutating preview-only.
+func (s *Service) ConfigExtender(
+	ctx context.Context,
+	request *pb.ConfigExtenderRequest,
+) (*pb.ConfigExtenderResponse, error) {
+	if request.Kind != pb.ConfigExtensionKind_CONFIG_EXTENSION_KIND_CNI {
+		return &pb.ConfigExtenderResponse{}, nil
+	}
+
+	metaConfig, err := config.ParseConfigFromData(
+		ctx,
+		request.Config,
+		config.DummyPreparatorProvider(),
+		nil,
+		config.ValidateOptionCommanderMode(true),
+	)
+	if err != nil {
+		return &pb.ConfigExtenderResponse{Err: err.Error()}, nil
+	}
+
+	analysis, err := config.AnalyzeCNIBootstrap(ctx, metaConfig, nil)
+	if err != nil {
+		return &pb.ConfigExtenderResponse{Err: err.Error()}, nil
+	}
+
+	if analysis.ModuleConfig == nil || analysis.ModuleConfig.Recommended == nil {
+		return &pb.ConfigExtenderResponse{}, nil
+	}
+
+	recommended, err := json.Marshal(analysis.ModuleConfig.Recommended)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "marshal recommended ModuleConfig: %s", err)
+	}
+
+	return &pb.ConfigExtenderResponse{Config: string(recommended)}, nil
+}

--- a/dhctl/pkg/server/rpc/validation/config_extender_test.go
+++ b/dhctl/pkg/server/rpc/validation/config_extender_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	pb "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"
+)
+
+func TestConfigExtender_StaticCluster_EmptyConfig(t *testing.T) {
+	cfg := `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+kubernetesVersion: Automatic
+clusterDomain: cluster.local
+`
+	s := New(config.NewSchemaStore(nil))
+	resp, err := s.ConfigExtender(context.Background(), &pb.ConfigExtenderRequest{
+		Config: cfg,
+		Kind:   pb.ConfigExtensionKind_CONFIG_EXTENSION_KIND_CNI,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Config)
+}
+
+func TestConfigExtender_UnspecifiedKind_EmptyConfig(t *testing.T) {
+	s := New(config.NewSchemaStore(nil))
+	resp, err := s.ConfigExtender(context.Background(), &pb.ConfigExtenderRequest{
+		Config: "",
+		Kind:   pb.ConfigExtensionKind_CONFIG_EXTENSION_KIND_UNSPECIFIED,
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Config)
+}
+
+// Parse failures surface in the response's Err field rather than as a gRPC
+// error, matching the convention used by other validation methods.
+func TestConfigExtender_InvalidConfig_ErrorInResponse(t *testing.T) {
+	s := New(config.NewSchemaStore(nil))
+	resp, err := s.ConfigExtender(context.Background(), &pb.ConfigExtenderRequest{
+		Config: "not a yaml: : :",
+		Kind:   pb.ConfigExtensionKind_CONFIG_EXTENSION_KIND_CNI,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Err)
+	require.Empty(t, resp.Config)
+}

--- a/dhctl/pkg/server/rpc/validation/validate_resources.go
+++ b/dhctl/pkg/server/rpc/validation/validate_resources.go
@@ -25,17 +25,17 @@ import (
 )
 
 func (s *Service) ValidateResources(
-	_ context.Context,
+	ctx context.Context,
 	request *pb.ValidateResourcesRequest,
 ) (*pb.ValidateResourcesResponse, error) {
-	var errResponse string
-
-	err := config.ValidateResources(request.Config, optionsFromRequest(request.Opts)...)
-	if err != nil {
-		if errResponse, err = errorToResponse(err); err != nil {
-			return nil, status.Errorf(codes.Internal, "%s", err)
-		}
+	errs := &config.ValidationError{}
+	for _, v := range config.ResourcesPipeline {
+		errs.Merge(v(ctx, request.Config, s.schemaStore, optionsFromRequest(request.Opts)...))
 	}
 
+	errResponse, convErr := errorToResponse(errs.ErrorOrNil())
+	if convErr != nil {
+		return nil, status.Errorf(codes.Internal, "%s", convErr)
+	}
 	return &pb.ValidateResourcesResponse{Err: errResponse}, nil
 }

--- a/dhctl/pkg/server/rpc/validation/validate_resources_test.go
+++ b/dhctl/pkg/server/rpc/validation/validate_resources_test.go
@@ -80,14 +80,3 @@ func TestValidateResources_EmptyPayload_NoError(t *testing.T) {
 	require.Empty(t, resp.Err)
 }
 
-func TestValidateResources_WireFormat_ReasonOmittedOnZero(t *testing.T) {
-	// Tighten compatibility expectation: when Reason is the zero value it
-	// must be absent from the JSON encoding (omitempty). All other Error
-	// fields are present even when empty, matching main.
-	e := config.Error{Index: nil, Group: "", Version: "", Kind: "", Name: "", Messages: nil}
-	b, err := json.Marshal(e)
-	require.NoError(t, err)
-	require.NotContains(t, string(b), `"Reason"`)
-	require.Contains(t, string(b), `"Group":""`)
-	require.Contains(t, string(b), `"Version":""`)
-}

--- a/dhctl/pkg/server/rpc/validation/validate_resources_test.go
+++ b/dhctl/pkg/server/rpc/validation/validate_resources_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
+	pb "github.com/deckhouse/deckhouse/dhctl/pkg/server/pb/dhctl"
+)
+
+func TestValidateResources_StaticCluster_NoCNIError(t *testing.T) {
+	// A static cluster config (no provider, no resources) must produce no err.
+	// Pre-refactor, the old handler would FAIL: it tried to validate
+	// ClusterConfiguration as a "resource" — wrong kind.
+	cfg := `
+apiVersion: deckhouse.io/v1
+kind: ClusterConfiguration
+clusterType: Static
+podSubnetCIDR: 10.111.0.0/16
+serviceSubnetCIDR: 10.222.0.0/16
+kubernetesVersion: Automatic
+clusterDomain: cluster.local
+`
+	s := New(config.NewSchemaStore(nil))
+	resp, err := s.ValidateResources(context.Background(), &pb.ValidateResourcesRequest{
+		Config: cfg,
+		Opts:   &pb.ValidateOptions{CommanderMode: true},
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Err, "static cluster config must not produce validation errors")
+}
+
+func TestValidateResources_UserResourceMissingApiVersion(t *testing.T) {
+	cfg := `
+kind: Secret
+metadata:
+  name: my-secret
+`
+	s := New(config.NewSchemaStore(nil))
+	resp, err := s.ValidateResources(context.Background(), &pb.ValidateResourcesRequest{
+		Config: cfg,
+		Opts:   &pb.ValidateOptions{CommanderMode: true},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Err)
+
+	var ve config.ValidationError
+	require.NoError(t, json.Unmarshal([]byte(resp.Err), &ve))
+	require.Equal(t, config.ErrKindValidationFailed, ve.Kind, "top-level Kind must be legacy ValidationFailed")
+	require.Len(t, ve.Errors, 1)
+	require.Equal(t, config.ErrKindValidationFailed, ve.Errors[0].Reason)
+	require.Contains(t, strings.Join(ve.Errors[0].Messages, " "), ".apiVersion is required")
+}
+
+func TestValidateResources_EmptyPayload_NoError(t *testing.T) {
+	s := New(config.NewSchemaStore(nil))
+	resp, err := s.ValidateResources(context.Background(), &pb.ValidateResourcesRequest{
+		Config: "",
+		Opts:   &pb.ValidateOptions{CommanderMode: true},
+	})
+	require.NoError(t, err)
+	require.Empty(t, resp.Err)
+}
+
+func TestValidateResources_WireFormat_ReasonOmittedOnZero(t *testing.T) {
+	// Tighten compatibility expectation: when Reason is the zero value it
+	// must be absent from the JSON encoding (omitempty). All other Error
+	// fields are present even when empty, matching main.
+	e := config.Error{Index: nil, Group: "", Version: "", Kind: "", Name: "", Messages: nil}
+	b, err := json.Marshal(e)
+	require.NoError(t, err)
+	require.NotContains(t, string(b), `"Reason"`)
+	require.Contains(t, string(b), `"Group":""`)
+	require.Contains(t, string(b), `"Version":""`)
+}

--- a/ee/modules/030-cloud-provider-dynamix/candi/cni-bootstrap.yml
+++ b/ee/modules/030-cloud-provider-dynamix/candi/cni-bootstrap.yml
@@ -1,0 +1,5 @@
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: VXLAN

--- a/ee/modules/030-cloud-provider-huaweicloud/candi/cni-bootstrap.yml
+++ b/ee/modules/030-cloud-provider-huaweicloud/candi/cni-bootstrap.yml
@@ -1,0 +1,5 @@
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: VXLAN

--- a/ee/modules/030-cloud-provider-openstack/candi/cni-bootstrap.yml
+++ b/ee/modules/030-cloud-provider-openstack/candi/cni-bootstrap.yml
@@ -1,0 +1,47 @@
+# Declares the CNI ModuleConfig (cni-cilium) that dhctl creates during cluster
+# bootstrap when no user-supplied cni-* ModuleConfig is present.
+#
+# Resolution order at bootstrap:
+#   1. Apply `config.default` as the baseline ModuleConfig settings.
+#   2. Walk `config.rules` top-to-bottom. For each rule whose `match` resolves
+#      against `providerClusterConfiguration` and equals one of `match.values`,
+#      merge `settings` over the baseline (overwrite, not deep-merge).
+#   3. Build ModuleConfig `cni-<name>` with the resulting settings.
+#
+# Rules mirror the legacy templates/cni.yaml selection logic for OpenStack:
+#   - VXLAN podNetworkMode  -> Cilium VXLAN tunnel + BPF masquerade.
+#   - DirectRouting / DirectRoutingWithPortSecurityEnabled  -> default (no rule
+#     matches): tunnelMode Disabled + createNodeRoutes true equals the old
+#     "DirectWithNodeRoutes" mode, masqueradeMode Netfilter unchanged.
+#   - Standard / StandardWithNoRouter layouts have no podNetworkMode field and
+#     therefore also fall through to the default.
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: Disabled
+    createNodeRoutes: true
+    masqueradeMode: Netfilter
+  rules:
+    # Simple layout with podNetworkMode=VXLAN: the pod network is not directly
+    # routable, so Cilium must encapsulate inter-node pod traffic in VXLAN and
+    # masquerade via BPF for performance.
+    - source: providerClusterConfiguration
+      match:
+        jsonPath: ".simple.podNetworkMode"
+        values:
+          - VXLAN
+      settings:
+        tunnelMode: VXLAN
+        masqueradeMode: BPF
+    # SimpleWithInternalNetwork layout with podNetworkMode=VXLAN: same reasoning
+    # as Simple+VXLAN above - the internal network does not provide direct pod
+    # routing in this mode.
+    - source: providerClusterConfiguration
+      match:
+        jsonPath: ".simpleWithInternalNetwork.podNetworkMode"
+        values:
+          - VXLAN
+      settings:
+        tunnelMode: VXLAN
+        masqueradeMode: BPF

--- a/ee/modules/030-cloud-provider-vcd/candi/cni-bootstrap.yml
+++ b/ee/modules/030-cloud-provider-vcd/candi/cni-bootstrap.yml
@@ -1,0 +1,6 @@
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: Disabled
+    createNodeRoutes: true

--- a/ee/se-plus/modules/030-cloud-provider-vsphere/candi/cni-bootstrap.yml
+++ b/ee/se-plus/modules/030-cloud-provider-vsphere/candi/cni-bootstrap.yml
@@ -1,0 +1,6 @@
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: Disabled
+    createNodeRoutes: true

--- a/ee/se-plus/modules/030-cloud-provider-zvirt/candi/cni-bootstrap.yml
+++ b/ee/se-plus/modules/030-cloud-provider-zvirt/candi/cni-bootstrap.yml
@@ -1,0 +1,6 @@
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: Disabled
+    createNodeRoutes: true

--- a/modules/030-cloud-provider-aws/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-aws/candi/cni-bootstrap.yml
@@ -1,0 +1,4 @@
+schemaVersion: 1
+name: simple-bridge
+config:
+  default: {}

--- a/modules/030-cloud-provider-azure/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-azure/candi/cni-bootstrap.yml
@@ -1,0 +1,4 @@
+schemaVersion: 1
+name: simple-bridge
+config:
+  default: {}

--- a/modules/030-cloud-provider-dvp/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-dvp/candi/cni-bootstrap.yml
@@ -1,0 +1,5 @@
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: VXLAN

--- a/modules/030-cloud-provider-gcp/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-gcp/candi/cni-bootstrap.yml
@@ -1,0 +1,4 @@
+schemaVersion: 1
+name: simple-bridge
+config:
+  default: {}

--- a/modules/030-cloud-provider-yandex/candi/cni-bootstrap.yml
+++ b/modules/030-cloud-provider-yandex/candi/cni-bootstrap.yml
@@ -1,0 +1,6 @@
+schemaVersion: 1
+name: cilium
+config:
+  default:
+    tunnelMode: VXLAN
+    masqueradeMode: BPF


### PR DESCRIPTION
## Description

Replaces the per-cloud-provider `templates/cni.yaml` Secret-rendering flow with a declarative `candi/cni-bootstrap.yml` per provider. At bootstrap, `dhctl` reads the file, resolves rules against `providerClusterConfiguration` and builds a validated `cni-<name>` ModuleConfig.

If the user did not supply a `cni-*` MC, the recommended one is appended. If they did and it disagrees with the recommendation (different module, different settings, or `enabled` differs), the user is prompted to confirm a full replace. In non-interactive mode the user's MC is kept. Replace is a full overwrite — any custom fields outside the recommendation are discarded (the prompt warns about this).

The legacy Secret path is kept for backward compatibility, to be removed later.

**gRPC surface**

Two methods consume the same `cni-bootstrap.yml`:

**`Validation.ValidateResources`** — runs the resources pipeline (user-resource shape check + cni-bootstrap check). Returns `ValidationError` JSON in `err`.

Wire-format: top-level `Kind` stays in the pre-existing set `{Changes, ValidationFailed, InvalidYAML}`. Domain-specific reasons (CNI* and any future ones) are semantically a kind of validation failure and bucket to `ValidationFailed` at the top level. Per-`Error` `Reason` retains the precise kind for fine-grained UI rendering.

| `Errors[].Reason` | top-level `Kind` (alone) | when |
|---|---|---|
| `ChangesValidationFailed` (1) | 1 | unsafe field change rejected |
| `ValidationFailed` (2) | 2 | structural / OpenAPI failure |
| `InvalidYAML` (3) | 3 | document does not parse as YAML |
| `CNIMismatch` (4) | 2 (`ValidationFailed`) | user MC is a different `cni-*` module than recommended |
| `CNISettingsMismatch` (5) | 2 (`ValidationFailed`) | same module but settings or `enabled` differ |

In mixed responses, top-level `Kind` is the max of bucketed reasons (e.g. `InvalidYAML` + `CNIMismatch` → top-level `InvalidYAML`, preserving stop-semantics for clients that key on it).

**`Validation.ConfigExtender`** — given `kind = CONFIG_EXTENSION_KIND_CNI`, returns the recommended `cni-*` ModuleConfig as JSON in `config`. Empty `config` for static clusters or when no recommendation applies. Parse/analyze errors are returned in `err` (response field, not gRPC status).

## How to test

```bash
dhctl server --server-address=0.0.0.0:8080

# validation pipeline
jq -Rs '{config: ., opts: {commander_mode: true}}' config.yml \
  | grpcurl -plaintext -emit-defaults -d @ 127.0.0.1:8080 dhctl.Validation/ValidateResources

# recommended cni-* MC
jq -Rs '{config: ., kind: "CONFIG_EXTENSION_KIND_CNI"}' config.yml \
  | grpcurl -plaintext -emit-defaults -d @ 127.0.0.1:8080 dhctl.Validation/ConfigExtender
```

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: feature
summary: Generate cni-* ModuleConfig from each cloud provider's candi/cni-bootstrap.yml at bootstrap, with user-override confirmation and gRPC inspection (Validation.ConfigExtender).
impact:
impact_level: default
```

