### PR TITLE
[cloud-provider-dvp] fix vmBDA retry loop, sentinel errors, disk cleanup hangs and orphaned-disk handling

### DIFF
--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -560,6 +560,10 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 	for _, disk := range disksToDelete {
 		logger.Info("Removing VirtualDisk", "disk_name", disk)
 		if err = r.DVP.DiskService.RemoveDiskByName(ctx, disk); err != nil {
+			if errors.Is(err, dvpapi.ErrNotFound) {
+				logger.Info("VirtualDisk already gone, skipping", "disk_name", disk)
+				continue
+			}
 			if errors.Is(err, context.DeadlineExceeded) {
 				logger.Error(err, "VirtualDisk deletion timed out, marking as orphaned and continuing",
 					"disk_name", disk,
@@ -568,7 +572,7 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 					dvpMachine.Annotations = make(map[string]string)
 				}
 				h := sha1.Sum([]byte(disk)) //nolint:gosec
-				key := fmt.Sprintf("%s%x", OrphanedDiskAnnotationPrefix, h[:4])
+				key := fmt.Sprintf("%s%x", OrphanedDiskAnnotationPrefix, h[:8])
 				dvpMachine.Annotations[key] = disk
 				continue
 			}

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -60,6 +60,8 @@ const (
 	OrphanedVMAnnotation = "dvp.deckhouse.io/orphaned-vm"
 	// OrphanedVMTimestampAnnotation records when VM became orphaned
 	OrphanedVMTimestampAnnotation = "dvp.deckhouse.io/orphaned-vm-timestamp"
+	// OrphanedDiskAnnotationPrefix is the prefix for annotations marking timed-out disk deletions
+	OrphanedDiskAnnotationPrefix = "dvp.deckhouse.io/orphaned-disk-"
 )
 
 type ownedResourceCreator struct {
@@ -564,7 +566,7 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 				if dvpMachine.Annotations == nil {
 					dvpMachine.Annotations = make(map[string]string)
 				}
-				dvpMachine.Annotations["dvp.deckhouse.io/orphaned-disk-"+disk] = time.Now().Format(time.RFC3339)
+				dvpMachine.Annotations[OrphanedDiskAnnotationPrefix+disk] = time.Now().Format(time.RFC3339)
 				continue
 			}
 			merr = multierror.Append(merr, fmt.Errorf("delete VirtualDisk %s: %w", disk, err))

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -584,7 +584,7 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 		}
 	}
 	if len(orphanedDisks) > 0 {
-		logger.Error(nil, "VirtualDisks timed out and were not deleted — manual cleanup required in parent DVP cluster",
+		logger.Info("VirtualDisks timed out and were not deleted — manual cleanup required in parent DVP cluster",
 			"orphaned_disks", orphanedDisks,
 		)
 	}

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"context"
+	"crypto/sha1" //nolint:gosec
 	"errors"
 	"fmt"
 	"strings"
@@ -566,7 +567,9 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 				if dvpMachine.Annotations == nil {
 					dvpMachine.Annotations = make(map[string]string)
 				}
-				dvpMachine.Annotations[OrphanedDiskAnnotationPrefix+disk] = time.Now().Format(time.RFC3339)
+				h := sha1.Sum([]byte(disk)) //nolint:gosec
+				key := fmt.Sprintf("%s%x", OrphanedDiskAnnotationPrefix, h[:4])
+				dvpMachine.Annotations[key] = disk
 				continue
 			}
 			merr = multierror.Append(merr, fmt.Errorf("delete VirtualDisk %s: %w", disk, err))
@@ -578,9 +581,9 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 	}
 
 	var orphanedDisks []string
-	for k := range dvpMachine.Annotations {
+	for k, v := range dvpMachine.Annotations {
 		if strings.HasPrefix(k, OrphanedDiskAnnotationPrefix) {
-			orphanedDisks = append(orphanedDisks, strings.TrimPrefix(k, OrphanedDiskAnnotationPrefix))
+			orphanedDisks = append(orphanedDisks, v)
 		}
 	}
 	if len(orphanedDisks) > 0 {

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -577,6 +577,18 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 		return ctrl.Result{}, fmt.Errorf("delete VirtualDisks: %w", err)
 	}
 
+	var orphanedDisks []string
+	for k := range dvpMachine.Annotations {
+		if strings.HasPrefix(k, OrphanedDiskAnnotationPrefix) {
+			orphanedDisks = append(orphanedDisks, strings.TrimPrefix(k, OrphanedDiskAnnotationPrefix))
+		}
+	}
+	if len(orphanedDisks) > 0 {
+		logger.Error(nil, "VirtualDisks timed out and were not deleted — manual cleanup required in parent DVP cluster",
+			"orphaned_disks", orphanedDisks,
+		)
+	}
+
 	controllerutil.RemoveFinalizer(dvpMachine, infrastructurev1a1.MachineFinalizer)
 
 	if vmDeletionFailed {

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -1186,7 +1186,7 @@ func (r *DeckhouseMachineReconciler) migrateDiskStorageClassIfNeeded(
 ) (bool, error) {
 	disk, err := r.DVP.DiskService.GetDiskByName(ctx, diskName)
 	if err != nil {
-		if errors.Is(err, cloudprovider.DiskNotFound) {
+		if errors.Is(err, dvpapi.ErrNotFound) || errors.Is(err, cloudprovider.DiskNotFound) {
 			if required {
 				return false, fmt.Errorf("disk %q not found", diskName)
 			}
@@ -1237,7 +1237,7 @@ func (r *DeckhouseMachineReconciler) migrateDiskStorageClassIfNeeded(
 		return true, nil
 	case diskSCStepApplyPatch:
 		if _, err := r.DVP.DiskService.GetStorageClass(ctx, desiredStorageClass); err != nil {
-			if errors.Is(err, cloudprovider.DiskNotFound) {
+			if errors.Is(err, dvpapi.ErrNotFound) || errors.Is(err, cloudprovider.DiskNotFound) {
 				return false, fmt.Errorf("storage class %q not found", desiredStorageClass)
 			}
 			return false, err

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -557,6 +557,16 @@ func (r *DeckhouseMachineReconciler) reconcileDeleteOperation(
 	for _, disk := range disksToDelete {
 		logger.Info("Removing VirtualDisk", "disk_name", disk)
 		if err = r.DVP.DiskService.RemoveDiskByName(ctx, disk); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				logger.Error(err, "VirtualDisk deletion timed out, marking as orphaned and continuing",
+					"disk_name", disk,
+				)
+				if dvpMachine.Annotations == nil {
+					dvpMachine.Annotations = make(map[string]string)
+				}
+				dvpMachine.Annotations["dvp.deckhouse.io/orphaned-disk-"+disk] = time.Now().Format(time.RFC3339)
+				continue
+			}
 			merr = multierror.Append(merr, fmt.Errorf("delete VirtualDisk %s: %w", disk, err))
 		}
 	}

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller_test.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller_test.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller_test.go
@@ -35,14 +35,31 @@ import (
 )
 
 var _ = Describe("DeckhouseMachine Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
+	Context("When reconciling a resource that does not exist", func() {
+		It("should return no error (idempotent not-found)", func() {
+			controllerReconciler := &DeckhouseMachineReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
 
-		ctx := context.Background()
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "nonexistent-machine",
+					Namespace: "default",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
+		})
+	})
+
+	Context("When reconciling a resource that has no owner Machine", func() {
+		const resourceName = "test-resource"
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: "default",
 		}
 		deckhousemachine := &infrastructurev1alpha1.DeckhouseMachine{}
 
@@ -55,14 +72,12 @@ var _ = Describe("DeckhouseMachine Controller", func() {
 						Name:      resourceName,
 						Namespace: "default",
 					},
-					// TODO(user): Specify other spec details if needed.
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
 			resource := &infrastructurev1alpha1.DeckhouseMachine{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
@@ -70,19 +85,24 @@ var _ = Describe("DeckhouseMachine Controller", func() {
 			By("Cleanup the specific resource instance DeckhouseMachine")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
-		It("should successfully reconcile the resource", func() {
+
+		It("should return no error and not add a finalizer when owner Machine is absent", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &DeckhouseMachineReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+			result, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			Expect(result.Requeue).To(BeFalse())
+
+			// No owner Machine → controller must not add the MachineFinalizer.
+			fetched := &infrastructurev1alpha1.DeckhouseMachine{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, fetched)).To(Succeed())
+			Expect(fetched.Finalizers).NotTo(ContainElement(infrastructurev1alpha1.MachineFinalizer))
 		})
 	})
 })

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -390,7 +390,6 @@ func (c *ComputeService) getVMBDA(ctx context.Context, diskName string, vmHostna
 	return &vmbdas.Items[0], nil
 }
 
-
 func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, clusterUUID, vmHostname, name string, userData []byte, vmName string, vmUID types.UID) error {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -181,35 +181,21 @@ func (c *ComputeService) DeleteVM(ctx context.Context, name string) error {
 	return nil
 }
 
-func (c *ComputeService) GetDisksForDetachAndDelete(ctx context.Context, vm *v1alpha2.VirtualMachine, detachDisks bool) ([]string, []string, error) {
+func (c *ComputeService) GetDisksForDetachAndDelete(_ context.Context, vm *v1alpha2.VirtualMachine, detachDisks bool) ([]string, []string, error) {
 	disksToDetach := make([]string, 0)
 	disksToDelete := make([]string, 0)
-	vmHostname, err := c.GetVMHostname(vm)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	vmbdas, err := c.listVMBDAByHostname(ctx, vmHostname)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	vmbdasMap := make(map[string]struct{})
-
-	for _, vdbda := range vmbdas {
-		vmbdasMap[vdbda.Spec.BlockDeviceRef.Name] = struct{}{}
-	}
 
 	for _, device := range vm.Status.BlockDeviceRefs {
-		if !device.Attached || device.Kind != v1alpha2.DiskDevice {
+		if device.Kind != v1alpha2.DiskDevice {
 			continue
 		}
-		if _, ok := vmbdasMap[device.Name]; !ok || !detachDisks {
-			disksToDelete = append(disksToDelete, device.Name)
+		if device.Hotplugged {
+			if detachDisks {
+				disksToDetach = append(disksToDetach, device.Name)
+			}
 			continue
 		}
-
-		disksToDetach = append(disksToDetach, device.Name)
+		disksToDelete = append(disksToDelete, device.Name)
 	}
 
 	return disksToDetach, disksToDelete, nil

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -283,16 +283,19 @@ func (c *ComputeService) AttachDiskToVM(ctx context.Context, diskName string, vm
 		return err
 	}
 
+	vmBDAName := fmt.Sprintf("vmbda-%s-%s", diskName, vmHostname)
+
 	vmbda, err := c.getVMBDA(ctx, diskName, vmHostname)
 	if vmbda != nil && err == nil {
-		return nil
+		// vmBDA already exists but may be InProgress — wait for it instead of returning OK prematurely.
+		waitCtx, cancel := context.WithTimeout(ctx, DefaultDiskAttachTimeout)
+		defer cancel()
+		return c.WaitDiskAttaching(waitCtx, vmBDAName)
 	}
 
 	if err != nil && !errors.Is(err, ErrNotFound) {
 		return err
 	}
-
-	vmBDAName := fmt.Sprintf("vmbda-%s-%s", diskName, vmHostname)
 
 	vmbda = &v1alpha2.VirtualMachineBlockDeviceAttachment{
 		TypeMeta: metav1.TypeMeta{
@@ -332,12 +335,9 @@ func (c *ComputeService) AttachDiskToVM(ctx context.Context, diskName string, vm
 		return err
 	}
 
-	err = c.WaitDiskAttaching(ctx, vmBDAName)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	attachCtx, cancel := context.WithTimeout(ctx, DefaultDiskAttachTimeout)
+	defer cancel()
+	return c.WaitDiskAttaching(attachCtx, vmBDAName)
 }
 
 func (c *ComputeService) DetachDiskFromVM(ctx context.Context, diskName string, vmName string) error {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -390,23 +390,6 @@ func (c *ComputeService) getVMBDA(ctx context.Context, diskName string, vmHostna
 	return &vmbdas.Items[0], nil
 }
 
-func (c *ComputeService) listVMBDAByHostname(ctx context.Context, vmHostname string) ([]v1alpha2.VirtualMachineBlockDeviceAttachment, error) {
-	selector, err := labels.Parse(fmt.Sprintf("%s=%s", attachmentMachineNameLabel, vmHostname))
-	if err != nil {
-		return nil, err
-	}
-
-	var vmbdas v1alpha2.VirtualMachineBlockDeviceAttachmentList
-	err = c.client.List(ctx, &vmbdas, &client.ListOptions{
-		LabelSelector: selector,
-		Namespace:     c.namespace,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return vmbdas.Items, nil
-}
 
 func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, clusterUUID, vmHostname, name string, userData []byte, vmName string, vmUID types.UID) error {
 	s := &corev1.Secret{

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -48,6 +48,8 @@ const (
 const (
 	// DefaultVMDeletionTimeout is the maximum time to wait for VM deletion
 	DefaultVMDeletionTimeout = 10 * time.Minute
+	// DefaultDiskAttachTimeout is the maximum time to wait for a VirtualDisk to attach to a VM
+	DefaultDiskAttachTimeout = 10 * time.Minute
 )
 
 type ComputeService struct {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -40,6 +40,9 @@ const (
 	attachmentDiskNameLabel    = "virtualMachineDiskName"
 	attachmentMachineNameLabel = "virtualMachineName"
 	DVPLoadBalancerLabelPrefix = "dvp.deckhouse.io/"
+
+	DeckhouseManagedByLabelKey   = "deckhouse.io/managed-by"
+	DeckhouseManagedByLabelValue = "deckhouse"
 )
 
 const (
@@ -390,13 +393,20 @@ func (c *ComputeService) getVMBDA(ctx context.Context, diskName string, vmHostna
 	return &vmbdas.Items[0], nil
 }
 
+func isDeckhouseManagedSecret(secret *corev1.Secret) bool {
+	if secret.Labels == nil {
+		return false
+	}
+	return secret.Labels[DeckhouseManagedByLabelKey] == DeckhouseManagedByLabelValue
+}
+
 func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, clusterUUID, vmHostname, name string, userData []byte, vmName string, vmUID types.UID) error {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: c.namespace,
 			Labels: map[string]string{
-				"deckhouse.io/managed-by":       "deckhouse",
+				DeckhouseManagedByLabelKey:      DeckhouseManagedByLabelValue,
 				"dvp.deckhouse.io/cluster-uuid": clusterUUID,
 				"dvp.deckhouse.io/hostname":     vmHostname,
 			},
@@ -413,21 +423,32 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 		StringData: map[string]string{"userData": string(userData)},
 	}
 
-	// Try to create, if already exists then update
-	if _, err := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
-			// Secret already exists, update it instead
-			existing, getErr := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
-			if getErr != nil {
-				return fmt.Errorf("get existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, getErr)
-			}
-			existing.StringData = map[string]string{"userData": string(userData)}
-			if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
-				return fmt.Errorf("update '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
-			}
-			return nil
-		}
+	_, err := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !k8serrors.IsAlreadyExists(err) {
 		return fmt.Errorf("create '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, err)
+	}
+
+	// Secret already exists — load it and decide whether we may update userData.
+	existing, getErr := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return fmt.Errorf("get existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, getErr)
+	}
+
+	// Not managed by Deckhouse (legacy or user-created): keep as-is and continue reconcile.
+	if !isDeckhouseManagedSecret(existing) {
+		klog.Warningf(
+			"cloud-init secret %s/%s already exists without %s=%s; leaving unchanged and continuing with existing userData",
+			c.namespace, name, DeckhouseManagedByLabelKey, DeckhouseManagedByLabelValue,
+		)
+		return nil
+	}
+
+	existing.StringData = map[string]string{"userData": string(userData)}
+	if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
+		return fmt.Errorf("update '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
 	}
 	return nil
 }

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -197,7 +197,6 @@ func (d *DiskService) GetDiskByName(ctx context.Context, diskName string) (*v1al
 
 const (
 	DefaultDiskDeletionTimeout = 5 * time.Minute
-	DefaultDiskAttachTimeout   = 10 * time.Minute
 )
 
 func (d *DiskService) RemoveDiskByName(ctx context.Context, diskName string) error {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -19,6 +19,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"time"
 
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	cloudprovider "k8s.io/cloud-provider"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
@@ -59,7 +59,7 @@ func (d *DiskService) ListDisksByName(ctx context.Context, diskName string) (*v1
 
 	if err := d.client.List(ctx, &virtualDiskList, opts); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, cloudprovider.DiskNotFound
+			return nil, ErrNotFound
 		}
 		return nil, err
 	}
@@ -189,11 +189,13 @@ func (d *DiskService) GetDiskByName(ctx context.Context, diskName string) (*v1al
 		return nil, fmt.Errorf("found more than one disk with the name %s, please contanct the DVP admin to check the name duplication", diskName)
 	}
 	if len(disks.Items) == 0 {
-		return nil, cloudprovider.DiskNotFound
+		return nil, ErrNotFound
 	}
 
 	return &disks.Items[0], nil
 }
+
+const DefaultDiskDeletionTimeout = 5 * time.Minute
 
 func (d *DiskService) RemoveDiskByName(ctx context.Context, diskName string) error {
 	disk, err := d.GetDiskByName(ctx, diskName)
@@ -201,17 +203,13 @@ func (d *DiskService) RemoveDiskByName(ctx context.Context, diskName string) err
 		return err
 	}
 
-	err = d.client.Delete(ctx, disk)
-	if err != nil {
+	if err = d.client.Delete(ctx, disk); err != nil {
 		return err
 	}
 
-	err = d.WaitDiskDeletion(ctx, diskName)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	deleteCtx, cancel := context.WithTimeout(ctx, DefaultDiskDeletionTimeout)
+	defer cancel()
+	return d.WaitDiskDeletion(deleteCtx, diskName)
 }
 
 func (d *DiskService) ResizeDisk(ctx context.Context, diskName string, newSize string) error {
@@ -259,7 +257,7 @@ func (d *DiskService) GetStorageClassList(ctx context.Context) (*storagev1.Stora
 	storageClassList, err := d.clientset.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, cloudprovider.DiskNotFound
+			return nil, ErrNotFound
 		}
 		return nil, err
 	}
@@ -270,7 +268,7 @@ func (d *DiskService) GetStorageClass(ctx context.Context, name string) (*storag
 	storageClass, err := d.clientset.StorageV1().StorageClasses().Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, cloudprovider.DiskNotFound
+			return nil, ErrNotFound
 		}
 		return nil, err
 	}

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -195,7 +195,10 @@ func (d *DiskService) GetDiskByName(ctx context.Context, diskName string) (*v1al
 	return &disks.Items[0], nil
 }
 
-const DefaultDiskDeletionTimeout = 5 * time.Minute
+const (
+	DefaultDiskDeletionTimeout = 5 * time.Minute
+	DefaultDiskAttachTimeout   = 10 * time.Minute
+)
 
 func (d *DiskService) RemoveDiskByName(ctx context.Context, diskName string) error {
 	disk, err := d.GetDiskByName(ctx, diskName)

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -20,6 +20,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	dvpapi "dvp-common/api"
 
@@ -235,14 +236,24 @@ func (c *ControllerService) ControllerPublishVolume(
 	}
 
 	if exists {
-		klog.Errorf("Publish requested but vmBDA exists for disk=%s vm=%s and is not Attached yet; retry later",
-			diskName, vmHostname,
-		)
-		return nil, status.Errorf(
-			codes.Aborted,
-			"Publish requested but vmBDA exists for disk=%s vm=%s and is not Attached yet; retry later",
-			diskName, vmHostname,
-		)
+		vmBDAName := fmt.Sprintf("vmbda-%s-%s", diskName, vmHostname)
+		klog.Infof("Publish: vmBDA %s exists but not Attached yet, waiting", vmBDAName)
+		waitErr := c.dvpCloudAPI.ComputeService.WaitDiskAttaching(ctx, vmBDAName)
+		if waitErr != nil {
+			if errors.Is(waitErr, context.DeadlineExceeded) {
+				return nil, status.Errorf(codes.DeadlineExceeded,
+					"Publish: timeout waiting for vmBDA attachment: disk=%s vm=%s",
+					diskName, vmHostname,
+				)
+			}
+			klog.Errorf("Publish: vmBDA %s failed (%v), cleaning up for retry", vmBDAName, waitErr)
+			_ = c.dvpCloudAPI.ComputeService.DetachDiskFromVM(ctx, diskName, vmHostname)
+			return nil, status.Errorf(codes.Internal,
+				"Publish: vmBDA failed, cleaned up, retry: disk=%s vm=%s: %v",
+				diskName, vmHostname, waitErr,
+			)
+		}
+		return &csi.ControllerPublishVolumeResponse{}, nil
 	}
 
 	err = c.dvpCloudAPI.ComputeService.AttachDiskToVM(ctx, diskName, vmHostname)
@@ -289,14 +300,6 @@ func (c *ControllerService) getDiskAttachState(
 	}
 
 	attached := vmbda.Status.Phase == v1alpha2.BlockDeviceAttachmentPhaseAttached
-
-	if vmbda.Status.Phase == v1alpha2.BlockDeviceAttachmentPhaseFailed {
-		return true, attached, status.Errorf(
-			codes.FailedPrecondition,
-			"vmBDA %s is Failed for disk=%s vm=%s",
-			vmbda.Name, diskName, vmHostname,
-		)
-	}
 
 	return true, attached, nil
 }

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -188,7 +188,7 @@ func (c *ControllerService) DeleteVolume(
 
 	_, err := c.dvpCloudAPI.DiskService.GetDiskByName(ctx, diskName)
 	if err != nil {
-		if errors.Is(err, dvpapi.ErrNotFound) {
+		if errors.Is(err, dvpapi.ErrNotFound) || errors.Is(err, cloudprovider.DiskNotFound) {
 			return &csi.DeleteVolumeResponse{}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "error from parent DVP cluster while finding disk %v by id: %v", diskName, err)
@@ -396,7 +396,7 @@ func (c *ControllerService) ControllerExpandVolume(ctx context.Context, req *csi
 
 	disk, err := c.dvpCloudAPI.DiskService.GetDiskByName(ctx, volumeName)
 	if err != nil {
-		if errors.Is(err, dvpapi.ErrNotFound) {
+		if errors.Is(err, dvpapi.ErrNotFound) || errors.Is(err, cloudprovider.DiskNotFound) {
 			return nil, status.Errorf(codes.NotFound, "disk %v wasn't found", volumeName)
 		}
 		return nil, status.Errorf(codes.Internal, "error from parent DVP cluster while finding disk %v: %v", volumeName, err)

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -238,7 +238,9 @@ func (c *ControllerService) ControllerPublishVolume(
 	if exists {
 		vmBDAName := fmt.Sprintf("vmbda-%s-%s", diskName, vmHostname)
 		klog.Infof("Publish: vmBDA %s exists but not Attached yet, waiting", vmBDAName)
-		waitErr := c.dvpCloudAPI.ComputeService.WaitDiskAttaching(ctx, vmBDAName)
+		waitCtx, cancel := context.WithTimeout(ctx, dvpapi.DefaultDiskAttachTimeout)
+		defer cancel()
+		waitErr := c.dvpCloudAPI.ComputeService.WaitDiskAttaching(waitCtx, vmBDAName)
 		if waitErr != nil {
 			if errors.Is(waitErr, context.DeadlineExceeded) {
 				return nil, status.Errorf(codes.DeadlineExceeded,
@@ -247,7 +249,9 @@ func (c *ControllerService) ControllerPublishVolume(
 				)
 			}
 			klog.Errorf("Publish: vmBDA %s failed (%v), cleaning up for retry", vmBDAName, waitErr)
-			_ = c.dvpCloudAPI.ComputeService.DetachDiskFromVM(ctx, diskName, vmHostname)
+			if detachErr := c.dvpCloudAPI.ComputeService.DetachDiskFromVM(ctx, diskName, vmHostname); detachErr != nil {
+				klog.Errorf("Publish: failed to cleanup vmBDA %s: %v", vmBDAName, detachErr)
+			}
 			return nil, status.Errorf(codes.Internal,
 				"Publish: vmBDA failed, cleaned up, retry: disk=%s vm=%s: %v",
 				diskName, vmHostname, waitErr,


### PR DESCRIPTION
## Description
Fixes a chain of bugs in the DVP cloud provider stack (CSI driver, dvp-common API, CAPI machine controller) discovered during a production incident when migrating from static to dynamic nodes in a nested DVP cluster.

No restarts of critical cluster components required. Changes affect only the DVP CSI driver and CAPI machine controller pods running in the management cluster.
## Why do we need it, and what problem does it solve?
During migration from static to dynamic nodes in a nested DVP cluster, a chain of bugs caused all new PVC mounts to stop working for 21+ hours.

**CSI ControllerPublishVolume returned `Aborted` for an in-progress vmBDA**
kubelet retried with exponential backoff — x1580 times in 21 hours — and eventually gave up, so newly provisioned PVCs could not be mounted.
Fix: block and wait for the vmBDA to reach `Attached`; on `Failed` vmBDA — clean up and return `Internal` so kubelet retries with a clean slate; propagate `DeadlineExceeded` correctly. Added explicit 10-minute timeout on `WaitDiskAttaching` symmetrically in both the `exists` branch and the new-vmBDA creation path in `AttachDiskToVM`.

**CSI getDiskAttachState returned `FailedPrecondition` for a Failed vmBDA**
kubelet does not retry `FailedPrecondition`, leaving the volume permanently unmounted with no automatic recovery.
Fix: remove the `FailedPrecondition` branch; ownership of the Failed-vmBDA cleanup path moves to `ControllerPublishVolume`.

**AttachDiskToVM returned success for an in-progress vmBDA**
If a vmBDA already existed but had not yet reached `Attached`, `AttachDiskToVM` returned `nil` immediately, allowing CSI to report success before the disk was actually attached.
Fix: if vmBDA exists but is not `Attached`, wait for attachment (with timeout) instead of returning early.

**Sentinel mismatch in DeleteVolume**
`GetDiskByName` returned `cloudprovider.DiskNotFound` but `DeleteVolume` checked `dvpapi.ErrNotFound`, so deleting a non-existent disk returned `codes.Internal` instead of idempotent success, leaving PersistentVolumes stuck in `Released` forever.
Fix: replace `cloudprovider.DiskNotFound` with `ErrNotFound` throughout `disk.go`.

**GetDisksForDetachAndDelete misclassified disks**
Used vmBDA list + stale `device.Attached` filter that skipped InProgress disks, preventing their cleanup on machine deletion.
Fix: use `device.Hotplugged` from `vm.Status.BlockDeviceRefs` directly; removed dependency on `listVMBDAByHostname`.

**RemoveDiskByName called WaitDiskDeletion without a timeout**
If a VirtualDisk got stuck (e.g. due to a leaked hp-pod holding the PVC finalizer), machine deletion in CAPI hung forever.
Fix: bound the wait with `context.WithTimeout(ctx, 5*time.Minute)`.

**CAPI reconcileDeleteOperation blocked machine deletion on stuck disk**
When disk deletion timed out, reconcile returned an error and the DeckhouseMachine could never be deleted.
Fix: on `context.DeadlineExceeded` from disk deletion, annotate the machine with `dvp.deckhouse.io/orphaned-disk-<name>`, log the orphaned disk list before finalizer removal, and continue so the finalizer is eventually removed.

**CreateCloudInitProvisioningSecret overwrote non-Deckhouse secrets**
If a cloud-init secret with the same name already existed but was not created by Deckhouse (no `deckhouse.io/managed-by=deckhouse` label), the controller silently overwrote its userData.
Fix: check the label before updating; if not managed by Deckhouse — leave the secret unchanged and continue reconcile.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: fix CSI vmBDA retry loop that caused x1580 retries and blocked new PVC mounts on static→dynamic node migration
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
