### PR TITLE
[docs] Update editions availability info for stronghold module

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -631,8 +631,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section.",
-        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>."
+        "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section of the Deckhouse Stronghold documentation.",
+        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a> документации Deckhouse Stronghold."
       }
     },
     "external": "true",

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -636,7 +636,7 @@
       }
     },
     "external": "true",
-    "path": "/products/stronghold/documentation/about/editions.html"
+    "path": "/modules/stronghold/"
   },
   "user-authz": {
     "editionFullyAvailable": [

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -632,7 +632,7 @@
     "editionsWithRestrictionsComments": {
       "all": {
         "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section.",
-        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>"
+        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>."
       }
     },
     "external": "true",

--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -610,7 +610,7 @@
     "external": "true",
     "path": "/modules/storage-volume-data-manager/stable/"
   },
-  "stronghold (CE)": {
+  "stronghold": {
     "editions": [
       "ce",
       "be",
@@ -620,19 +620,8 @@
       "cse-lite",
       "cse-pro"
     ],
-    "external": "true",
-    "path": "/products/stronghold/documentation/about/editions.html"
-  },
-  "stronghold (EE)": {
-    "editions": [
-      "be",
-      "se",
-      "se-plus",
-      "ee",
-      "cse-lite",
-      "cse-pro"
-    ],
     "editionsWithRestrictions": [
+      "ce",
       "be",
       "se",
       "se-plus",
@@ -642,16 +631,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A separate license is required",
-        "ru": "Требуется отдельная лицензия"
-      },
-      "cse-lite": {
-        "en": "A separate license is required for Deckhouse Stronghold CSE. There are functionality limitations",
-        "ru": "Требуется отдельная лицензия на Deckhouse Stronghold CSE. Есть ограничения функциональности"
-      },
-      "cse-pro": {
-        "en": "A separate license is required for Deckhouse Stronghold CSE. There are functionality limitations",
-        "ru": "Требуется отдельная лицензия на Deckhouse Stronghold CSE. Есть ограничения функциональности"
+        "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section.",
+        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>"
       }
     },
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -696,8 +696,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Some features are available depending on the selected license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>\"Editions\"</a> section.",
-        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>"
+        "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section.",
+        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>"
       }
     },
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -697,7 +697,7 @@
     "editionsWithRestrictionsComments": {
       "all": {
         "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section.",
-        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>"
+        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>."
       }
     },
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -696,8 +696,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section.",
-        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>."
+        "en": "Some features are available depending on the selected Deckhouse Stronghold license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>&quot;Editions&quot;</a> section of the Deckhouse Stronghold documentation.",
+        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии Deckhouse Stronghold. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a> документации Deckhouse Stronghold."
       }
     },
     "external": "true",

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -685,11 +685,8 @@
     ]
   },
   "stronghold": {
-    "commercialBadgeMessage": {
-      "en": "A separate license is required",
-      "ru": "Требуется отдельная лицензия"
-    },
     "editionsWithRestrictions": [
+      "ce",
       "be",
       "se",
       "se-plus",
@@ -699,8 +696,8 @@
     ],
     "editionsWithRestrictionsComments": {
       "all": {
-        "en": "A separate license is required",
-        "ru": "Требуется отдельная лицензия"
+        "en": "Some features are available depending on the selected license. For more details, see the <a href='/products/stronghold/documentation/about/editions/'>\"Editions\"</a> section.",
+        "ru": "Некоторые функции доступны в зависимости от выбранной лицензии. Подробнее можно ознакомиться в разделе <a href='/products/stronghold/documentation/about/editions/'>«Редакции»</a>"
       }
     },
     "external": "true",


### PR DESCRIPTION
## Description

Update editions availability info for stronghold module.

## Why do we need it, and what problem does it solve?

Users of the stronghold module may not understand why some functionality is unavailable or behaves differently when the module is connected to the product.

## Why do we need it in the patch release (if we do)?

Not necessarily. The change is informational only.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: documentation
type: feature
summary: Update editions availability info for stronghold module.
impact_level: low
```
