### PR TITLE
[ingress-nginx] fix activating modsecurity crs along with isolatedprocess validation

### DIFF
--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -881,7 +881,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 mount:
 - from: tmp_dir
-  to: /tmp
+  to: /tmp_dir
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -881,9 +881,7 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 mount:
 - from: tmp_dir
-  to: /cp
-- from: tmp_dir
-  to: /setcap
+  to: /tmp
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -960,23 +958,23 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /setcap/
+  to: /tmp/setcap
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /cp/
+  to: /tmp/cp
   before: install
 shell:
   install:
-  - /cp/cp -alf /chroot/bin/. /bin/
-  - /setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /tmp/cp -alf /chroot/bin/. /bin/
+  - /tmp/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /tmp/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /tmp/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /tmp/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /tmp/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /tmp/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /tmp/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /tmp/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -880,8 +880,10 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 mount:
-- from: build_dir
-  to: /apps
+- from: tmp_dir
+  to: /apps/cp
+- from: tmp_dir
+  to: /apps/setcap
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -958,23 +960,23 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /apps/
+  to: /apps/setcap/
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /apps/
+  to: /apps/cp/
   before: install
 shell:
   install:
-  - /apps/cp -alf /chroot/bin/. /bin/
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /apps/cp/cp -alf /chroot/bin/. /bin/
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /apps/setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /apps/setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -879,6 +879,9 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
+mount:
+- from: build_dir
+  to: /apps
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -949,9 +952,7 @@ import:
   group: "0"
   includePaths:
   - usr/bin/test
-  - usr/bin/chroot
   - usr/bin/cat
-  - usr/bin/cp
   - usr/bin/tail
   before: install
 {{- include "image mount points" . }}
@@ -959,9 +960,12 @@ import:
   add: /usr/sbin/setcap
   to: /apps/setcap
   before: install
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin/cp
+  to: /apps/cp
 shell:
   install:
-  - /usr/bin/cp -alf /chroot/bin/. /bin/
+  - /apps/cp -alf /chroot/bin/. /bin/
   - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -881,9 +881,9 @@ image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 mount:
 - from: tmp_dir
-  to: /apps/cp
+  to: /cp
 - from: tmp_dir
-  to: /apps/setcap
+  to: /setcap
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -960,23 +960,23 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /apps/setcap/
+  to: /setcap/
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /apps/cp/
+  to: /cp/
   before: install
 shell:
   install:
-  - /apps/cp/cp -alf /chroot/bin/. /bin/
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /cp/cp -alf /chroot/bin/. /bin/
+  - /setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -883,6 +883,14 @@ mount:
 - from: tmp_dir
   to: /tmp_dir
 import:
+- from: {{ index $.Images "tools/libcap" }}
+  add: /usr/sbin/setcap
+  to: /tmp_dir/setcap
+  before: install
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin/cp
+  to: /tmp_dir/cp
+  before: install
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
   to: /
@@ -956,25 +964,17 @@ import:
   - usr/bin/tail
   before: install
 {{- include "image mount points" . }}
-- from: {{ index $.Images "tools/libcap" }}
-  add: /usr/sbin/setcap
-  to: /tmp/setcap
-  before: install
-- from: {{ index $.Images "tools/coreutils" }}
-  add: /usr/bin/cp
-  to: /tmp/cp
-  before: install
 shell:
   install:
-  - /tmp/cp -alf /chroot/bin/. /bin/
-  - /tmp/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /tmp/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /tmp/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /tmp/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /tmp/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /tmp/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /tmp/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /tmp/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /tmp_dir/cp -alf /chroot/bin/. /bin/
+  - /tmp_dir/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /tmp_dir/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /tmp_dir/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /tmp_dir/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /tmp_dir/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /tmp_dir/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /tmp_dir/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /tmp_dir/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -35,6 +35,22 @@
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 from: {{ index $.Images "builder/src" }}
 final: false
+mount:
+- from: build_dir
+  to: /extra_apps
+import:
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin/cp
+  to: /tools/cp
+  owner: "0"
+  group: "0"
+  before: install
+- from: {{ index $.Images "tools/libcap" }}
+  add: /usr/sbin/setcap
+  to: /tools/setcap
+  before: install
+  owner: "0"
+  group: "0"
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/patches
   to: /patches
@@ -56,6 +72,8 @@ secrets:
   value: {{ .SOURCE_REPO }}
 shell:
   install:
+  # copy extra tools
+  - cp -av /tools/* /extra_apps
   - mkdir -p /src
   - cd /src
   - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git
@@ -67,7 +85,7 @@ shell:
   #
   - mkdir -p /src/nginx-deps
   - git clone -b {{ $nginxDepsBranch }} $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx-deps.git /src/nginx-deps
-    # Dependency for opentelemetry-cpp (source: opentelemetry-cpp/cmake/nlohmann-json.cmakee)
+  # Dependency for opentelemetry-cpp (source: opentelemetry-cpp/cmake/nlohmann-json.cmakee)
   - mkdir -p /src/nginx-deps/opentelemetry-cpp/third_party/nlohmann-json
   - git clone -b {{ $nlohmannJsonBranch }} $(cat /run/secrets/SOURCE_REPO)/nlohmann/json.git /src/nginx-deps/opentelemetry-cpp/third_party/nlohmann-json
   # Remove directory for fix CVE
@@ -880,17 +898,9 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 mount:
-- from: tmp_dir
-  to: /tmp_dir
+- from: build_dir
+  to: /extra_apps
 import:
-- from: {{ index $.Images "tools/libcap" }}
-  add: /usr/sbin/setcap
-  to: /tmp_dir/setcap
-  before: install
-- from: {{ index $.Images "tools/coreutils" }}
-  add: /usr/bin/cp
-  to: /tmp_dir/cp
-  before: install
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
   to: /
@@ -966,15 +976,15 @@ import:
 {{- include "image mount points" . }}
 shell:
   install:
-  - /tmp_dir/cp -alf /chroot/bin/. /bin/
-  - /tmp_dir/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /tmp_dir/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /tmp_dir/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /tmp_dir/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /tmp_dir/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /tmp_dir/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /tmp_dir/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /tmp_dir/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /extra_apps/cp -alf /chroot/bin/. /bin/
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /extra_apps/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /extra_apps/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -74,6 +74,7 @@ shell:
   install:
   # copy extra tools
   - cp -av /tools/* /extra_apps
+  #
   - mkdir -p /src
   - cd /src
   - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -958,11 +958,11 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /apps/setcap
+  to: /apps/
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /apps/cp
+  to: /apps/
   before: install
 shell:
   install:

--- a/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-12/werf.inc.yaml
@@ -963,6 +963,7 @@ import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
   to: /apps/cp
+  before: install
 shell:
   install:
   - /apps/cp -alf /chroot/bin/. /bin/

--- a/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
@@ -884,8 +884,10 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 mount:
-- from: build_dir
-  to: /apps
+- from: tmp_dir
+  to: /apps/cp
+- from: tmp_dir
+  to: /apps/setcap
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -967,24 +969,24 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /apps/
+  to: /apps/setcap/
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /apps/
+  to: /apps/cp/
   before: install
 shell:
   install:
-  - /apps/cp -alf /chroot/. /validation-chroot/
-  - /apps/cp -alf /chroot/bin/. /bin/
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /apps/cp/cp -alf /chroot/. /validation-chroot/
+  - /apps/cp/cp -alf /chroot/bin/. /bin/
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /apps/setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /apps/setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
@@ -54,8 +54,27 @@ git:
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
+mount:
+- from: build_dir
+  to: /extra_apps
+import:
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin/cp
+  to: /tools/cp
+  owner: "0"
+  group: "0"
+  before: install
+- from: {{ index $.Images "tools/libcap" }}
+  add: /usr/sbin/setcap
+  to: /tools/setcap
+  before: install
+  owner: "0"
+  group: "0"
 shell:
   install:
+  # copy extra tools
+  - cp -av /tools/* /extra_apps
+  #
   - mkdir -p /src
   - cd /src
   - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git
@@ -883,11 +902,6 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
-mount:
-- from: tmp_dir
-  to: /apps/cp
-- from: tmp_dir
-  to: /apps/setcap
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -967,26 +981,21 @@ import:
   - usr/bin/tail
   before: install
 {{- include "image mount points" . }}
-- from: {{ index $.Images "tools/libcap" }}
-  add: /usr/sbin/setcap
-  to: /apps/setcap/
-  before: install
-- from: {{ index $.Images "tools/coreutils" }}
-  add: /usr/bin/cp
-  to: /apps/cp/
-  before: install
+mount:
+- from: build_dir
+  to: /extra_apps
 shell:
   install:
-  - /apps/cp/cp -alf /chroot/. /validation-chroot/
-  - /apps/cp/cp -alf /chroot/bin/. /bin/
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /extra_apps/cp -alf /chroot/. /validation-chroot/
+  - /extra_apps/cp -alf /chroot/bin/. /bin/
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /extra_apps/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /extra_apps/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
@@ -972,6 +972,7 @@ import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
   to: /apps/cp
+  before: install
 shell:
   install:
   - /apps/cp -alf /chroot/. /validation-chroot/

--- a/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
@@ -883,6 +883,9 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
+mount:
+- from: build_dir
+  to: /apps
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -958,9 +961,7 @@ import:
   group: "0"
   includePaths:
   - usr/bin/test
-  - usr/bin/chroot
   - usr/bin/cat
-  - usr/bin/cp
   - usr/bin/tail
   before: install
 {{- include "image mount points" . }}
@@ -968,10 +969,13 @@ import:
   add: /usr/sbin/setcap
   to: /apps/setcap
   before: install
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin/cp
+  to: /apps/cp
 shell:
   install:
-  - /usr/bin/cp -alf /chroot/. /validation-chroot/
-  - /usr/bin/cp -alf /chroot/bin/. /bin/
+  - /apps/cp -alf /chroot/. /validation-chroot/
+  - /apps/cp -alf /chroot/bin/. /bin/
   - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare

--- a/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-14/werf.inc.yaml
@@ -967,11 +967,11 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /apps/setcap
+  to: /apps/
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /apps/cp
+  to: /apps/
   before: install
 shell:
   install:

--- a/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
@@ -956,6 +956,7 @@ import:
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
   to: /apps/cp
+  before: install
 shell:
   install:
   - /apps/cp -alf /chroot/bin/. /bin/

--- a/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
@@ -867,6 +867,9 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
+mount:
+- from: build_dir
+  to: /apps
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -942,9 +945,7 @@ import:
   group: "0"
   includePaths:
   - usr/bin/test
-  - usr/bin/chroot
   - usr/bin/cat
-  - usr/bin/cp
   - usr/bin/tail
   before: install
 {{- include "image mount points" . }}
@@ -952,10 +953,13 @@ import:
   add: /usr/sbin/setcap
   to: /apps/setcap
   before: install
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin/cp
+  to: /apps/cp
 shell:
   install:
-  - /usr/bin/cp -alf /chroot/bin/. /bin/
-  - /usr/bin/cp -alf /chroot/. /validation-chroot/
+  - /apps/cp -alf /chroot/bin/. /bin/
+  - /apps/cp -alf /chroot/. /validation-chroot/
   - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
   - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare

--- a/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
@@ -54,8 +54,27 @@ git:
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
+mount:
+- from: build_dir
+  to: /extra_apps
+import:
+- from: {{ index $.Images "tools/coreutils" }}
+  add: /usr/bin/cp
+  to: /tools/cp
+  owner: "0"
+  group: "0"
+  before: install
+- from: {{ index $.Images "tools/libcap" }}
+  add: /usr/sbin/setcap
+  to: /tools/setcap
+  before: install
+  owner: "0"
+  group: "0"
 shell:
   install:
+  # copy extra tools
+  - cp -av /tools/* /extra_apps
+  #
   - mkdir -p /src
   - cd /src
   - git clone --branch {{ $controllerBranch }} --depth 1 $(cat /run/secrets/SOURCE_REPO)/kubernetes/ingress-nginx.git
@@ -867,11 +886,6 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
-mount:
-- from: tmp_dir
-  to: /apps/cp
-- from: tmp_dir
-  to: /apps/setcap
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -951,26 +965,21 @@ import:
   - usr/bin/tail
   before: install
 {{- include "image mount points" . }}
-- from: {{ index $.Images "tools/libcap" }}
-  add: /usr/sbin/setcap
-  to: /apps/setcap/
-  before: install
-- from: {{ index $.Images "tools/coreutils" }}
-  add: /usr/bin/cp
-  to: /apps/cp/
-  before: install
+mount:
+- from: build_dir
+  to: /extra_apps
 shell:
   install:
-  - /apps/cp/cp -alf /chroot/bin/. /bin/
-  - /apps/cp/cp -alf /chroot/. /validation-chroot/
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /extra_apps/cp -alf /chroot/. /validation-chroot/
+  - /extra_apps/cp -alf /chroot/bin/. /bin/
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /extra_apps/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /extra_apps/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /extra_apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /extra_apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
@@ -951,11 +951,11 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /apps/setcap
+  to: /apps/
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /apps/cp
+  to: /apps/
   before: install
 shell:
   install:

--- a/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
+++ b/modules/402-ingress-nginx/images/controller-1-15/werf.inc.yaml
@@ -868,8 +868,10 @@ shell:
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}
 mount:
-- from: build_dir
-  to: /apps
+- from: tmp_dir
+  to: /apps/cp
+- from: tmp_dir
+  to: /apps/setcap
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-chroot-artifact
   add: /
@@ -951,24 +953,24 @@ import:
 {{- include "image mount points" . }}
 - from: {{ index $.Images "tools/libcap" }}
   add: /usr/sbin/setcap
-  to: /apps/
+  to: /apps/setcap/
   before: install
 - from: {{ index $.Images "tools/coreutils" }}
   add: /usr/bin/cp
-  to: /apps/
+  to: /apps/cp/
   before: install
 shell:
   install:
-  - /apps/cp -alf /chroot/bin/. /bin/
-  - /apps/cp -alf /chroot/. /validation-chroot/
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
-  - /apps/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
-  - /apps/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
-  - /apps/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /apps/cp/cp -alf /chroot/bin/. /bin/
+  - /apps/cp/cp -alf /chroot/. /validation-chroot/
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /nginx-ingress-controller
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/unshare
+  - /apps/setcap/setcap    cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /apps/setcap/setcap -v cap_net_bind_service=+ep /chroot/usr/local/nginx/sbin/nginx
+  - /apps/setcap/setcap    cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
+  - /apps/setcap/setcap -v cap_sys_chroot,cap_net_bind_service=+ep /usr/bin/dumb-init
 imageSpec:
   config:
     workingDir: /chroot/etc/nginx

--- a/modules/402-ingress-nginx/images/sandbox/README.md
+++ b/modules/402-ingress-nginx/images/sandbox/README.md
@@ -20,4 +20,4 @@ The child mode then:
 
 `/validation-chroot` is prepared in controller images as a hardlinked copy of `/chroot`. 
 
-`SANDBOX_DEBUG=true` enables sandbox tracing, and `SANDBOX_DEBUG_CRASH_ON_DENY=true` additionally converts any deny into immediate sandbox termination.
+`SANDBOX_DEBUG=true` enables verbose syscall tracing. For unknown syscalls (for example `getpgid`), debug mode **soft-bans** the call (returns `EACCES` to the traced process) and logs `deny syscall="…" (soft-ban)`. Without debug, the same policy **kills** the traced process and logs `deny syscall="…" (kill)`, which surfaces as `Disallowed Syscall`. Use `SANDBOX_DEBUG_CRASH_ON_DENY=true` to force kill on any file/syscall deny while debugging.

--- a/modules/402-ingress-nginx/images/sandbox/src/cmd/constants.go
+++ b/modules/402-ingress-nginx/images/sandbox/src/cmd/constants.go
@@ -88,11 +88,35 @@ var sandboxExtraReadBase = []string{
 	"/etc/ingress-controller/auth/",
 	"/etc/ingress-controller/geoip/",
 	"/etc/ingress-controller/telemetry/",
-	"/bin/sh", // for modsecurity
+	"/bin/sh",                          // for modsecurity
+	"/usr/local/sbin/sh",               // for modsecurity
+	"/usr/local/bin/sh",                // for modsecurity
+	"/usr/sbin/sh",                     // for modsecurity
+	"/usr/bin/sh",                      // for modsecurity
+	"/sbin/sh",                         // for modsecurity
+	"/iis-errors.data",                 // for modsecurity
+	"java-classes.data",                // for modsecurity
+	"java-code-leakages.data",          // for modsecurity
+	"java-errors.data",                 // for modsecurity
+	"lfi-os-files.data",                // for modsecurity
+	"php-config-directives.data",       // for modsecurity
+	"php-errors-pl2.data",              // for modsecurity
+	"php-errors.data",                  // for modsecurity
+	"php-function-names-933150.data",   // for modsecurity
+	"php-function-names-933151.data",   // for modsecurity
+	"php-variables.data",               // for modsecurity
+	"restricted-files.data",            // for modsecurity
+	"restricted-upload.data",           // for modsecurity
+	"scanners-user-agents.data",        // for modsecurity
+	"sql-errors.data",                  // for modsecurity
+	"ssrf.data",                        // for modsecurity
+	"unix-shell.data",                  // for modsecurity
+	"web-shells-php.data",              // for modsecurity
+	"windows-powershell-commands.data", // for modsecurity
 	"/lib/",
 	"/usr/lib/",
 	"/usr/local/lib/",
-	"/unicode.mapping",
+	"/unicode.mapping", // for modsecurity
 	"/usr/local/modsecurity/lib/",
 	"/modules_mount/etc/nginx/modules/otel/",
 	"/chroot/*",            // allow only top-level files in /chroot (not recursive into /chroot/<dir>/...) for modsecurity "/chroot/unicode.mapping", "/chroot/scanners-user-agents.data" etc ...

--- a/modules/402-ingress-nginx/images/sandbox/src/cmd/constants.go
+++ b/modules/402-ingress-nginx/images/sandbox/src/cmd/constants.go
@@ -46,6 +46,7 @@ var sandboxExtraAllowSyscalls = []string{
 	"geteuid",
 	"getegid",
 	"getppid",
+	"getpgid",
 	"uname",
 	"wait4",
 	"poll",

--- a/modules/402-ingress-nginx/images/sandbox/src/cmd/constants_test.go
+++ b/modules/402-ingress-nginx/images/sandbox/src/cmd/constants_test.go
@@ -28,6 +28,7 @@ func TestGetSandboxExtraReadIncludesValidationChrootAndConfig(t *testing.T) {
 	for _, want := range []string{
 		"/validation-chroot/*",
 		"/usr/local/nginx/sbin/nginx",
+		"/usr/local/sbin/sh",
 		configPath,
 	} {
 		if !slices.Contains(got, want) {

--- a/modules/402-ingress-nginx/images/sandbox/src/cmd/trace_handler.go
+++ b/modules/402-ingress-nginx/images/sandbox/src/cmd/trace_handler.go
@@ -138,9 +138,13 @@ func (h *sandboxTraceHandler) Handle(ctx *ptracer.Context) ptracer.TraceAction {
 		if h.Unsafe && action == ptracer.TraceKill {
 			action = ptracer.TraceBan
 		}
-		if !h.ShowDetails && action == ptracer.TraceBan {
-			log.Printf("deny syscall=%q", syscallName)
-			action = ptracer.TraceKill
+		if action == ptracer.TraceBan {
+			if h.ShowDetails {
+				log.Printf("deny syscall=%q (soft-ban)", syscallName)
+			} else {
+				log.Printf("deny syscall=%q (kill)", syscallName)
+				action = ptracer.TraceKill
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fixes activating modsecurity CRS rules when the controller is running with IsolatedProcess validation.
Also, provides extra debug logs in debug mode.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

It allows using modsecurity CRS along with IsolatedProcess validation.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed activating modsecurity CRS rules when the Ingress NGINX Controller is running with IsolatedProcess validation.
impact: All Ingress NGINX Controller pods will be restarted.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
