### PR TITLE
[docs] Hybrid cluster guide in DVP

### DIFF
--- a/docs/documentation/_data/sidebars/main.yml
+++ b/docs/documentation/_data/sidebars/main.yml
@@ -390,9 +390,25 @@ entries:
                             ru: Интеграция со службами zVirt
                           url: /admin/integrations/virtualization/zvirt/services.html
                 - title:
-                    en: Hybrid cluster
-                    ru: Гибридный кластер
-                  url: /admin/integrations/hybrid/overview.html
+                    en: Hybrid clusters
+                    ru: Гибридные кластеры
+                  folders:
+                    - title:
+                        en: Overview
+                        ru: Обзор
+                      url: /admin/integrations/hybrid/overview.html
+                    - title:
+                        en: Hybrid cluster with Yandex Cloud
+                        ru: Гибридный кластер с Yandex Cloud
+                      url: /admin/integrations/hybrid/yandex-hybrid.html
+                    - title:
+                        en: Hybrid cluster with VCD
+                        ru: Гибридный кластер с VCD
+                      url: /admin/integrations/hybrid/vcd-hybrid.html
+                    - title:
+                        en: Hybrid cluster with vSphere
+                        ru: Гибридный кластер с vSphere
+                      url: /admin/integrations/hybrid/vsphere-hybrid.html
             - title:
                 en: High reliability and availability
                 ru: Высокая надежность и доступность

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/DVP_HYBRID_RU.md
@@ -1,0 +1,546 @@
+---
+title: Гибридный кластер с DVP
+permalink: ru/admin/integrations/hybrid/dvp-hybrid.html
+lang: ru
+---
+
+Далее описан процесс добавления worker-узлов из Deckhouse Virtualization Platform (DVP) в существующий статический кластер DKP.
+
+Для интеграции с DVP используется модуль [`cloud-provider-dvp`](/modules/cloud-provider-dvp/). Он обеспечивает взаимодействие DKP с API кластера DVP, создание виртуальных машин, подключение созданных ВМ к существующему Kubernetes-кластеру и управление жизненным циклом worker-узлов через механизмы Cluster API.
+
+В этом разделе описано автоматическое создание worker-узлов в DVP. В этом сценарии DKP самостоятельно создаёт виртуальные машины в указанном неймспейсе DVP и подключает их к существующему кластеру через механизмы Cluster API. Параметры ВМ задаются ресурсом [DVPInstanceClass](/modules/cloud-provider-dvp/cr.html#dvpinstanceclass), а требуемое количество узлов и зоны размещения — ресурсом [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом `CloudEphemeral`.
+
+## Предварительные требования
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Кластер создан с параметром [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype).
+- Между сетью статических узлов кластера DKP и сетью виртуальных машин в DVP настроена сетевая связность.
+- Создаваемые в DVP worker-узлы имеют доступ к Kubernetes API подключаемого DKP-кластера, DNS и необходимым адресам согласно разделам [Сетевое взаимодействие](../../../../reference/network_interaction.html) и [Настройка сетевых политик](../../configuration/network/policy/configuration.html).
+- Выполнены требования из раздела [Подготовка окружения](/modules/cloud-provider-dvp/environment.html):
+  - создан ServiceAccount для доступа к API DVP;
+  - назначены необходимые права доступа;
+  - сгенерирован kubeconfig для подключения к API DVP;
+  - подготовлен неймспейс, в котором будут создаваться виртуальные машины и диски.
+- В DVP доступен образ ОС Linux с поддержкой `cloud-init`, например `ubuntu-24-04-lts`.
+- В DVP доступен подходящий VirtualMachineClass, например `amd-epyc-gen-3`.
+- В DVP доступен StorageClass для корневых дисков виртуальных машин, например `replicated`.
+- Если используется шаблон виртуальной машины, убедитесь, что он содержит только один диск.
+- Из кластера DKP доступен Kubernetes API кластера DVP.
+- При использовании Cilium с туннелированием трафика подов выбран режим [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode), соответствующий сетевой связности между площадками.
+
+{% alert level="warning" %}
+В параметрах DVPInstanceClass используются ресурсы кластера DVP: VirtualMachineClass, ClusterVirtualImage, VirtualImage, VirtualDisk и StorageClass из DVP, а не из подключаемого DKP-кластера.
+{% endalert %}
+
+## Добавление автоматически создаваемых узлов
+
+1. На машине администратора, где настроен доступ к кластеру DVP, подготовьте kubeconfig для доступа модуля `cloud-provider-dvp` к API DVP.
+
+   Выполните шаги из раздела [Подготовка окружения](/modules/cloud-provider-dvp/environment.html) и закодируйте полученный kubeconfig в Base64:
+
+   ```shell
+   export DVP_PROVIDER_KUBECONFIG="./kubeconfig"
+   export DVP_KUBECONFIG_B64="$(base64 -w0 ${DVP_PROVIDER_KUBECONFIG})"
+   ```
+
+1. Задайте пространство имён DVP, в котором будут создаваться виртуальные машины и диски:
+
+   ```shell
+   export DVP_NAMESPACE="<DVP_NAMESPACE>"
+   ```
+
+1. Определите зону DVP, в которой будут создаваться worker-узлы.
+
+   Выполните команду в кластере DVP под пользователем, у которого есть права на просмотр узлов:
+
+   ```shell
+   d8 k get nodes -L topology.kubernetes.io/region,topology.kubernetes.io/zone
+   ```
+
+   Если в DVP не настроены отдельные топологические зоны, используйте зону `default`.
+
+   {% alert level="warning" %}
+   Значение зоны в ModuleConfig и NodeGroup должно совпадать с доступной зоной DVP. Не указывайте произвольные значения, например `zone-a` или `zone-b`, если такие зоны не настроены в DVP.
+   {% endalert %}
+
+1. Создайте файл, например `cloud-provider-dvp-mc.yaml`, с конфигурацией модуля `cloud-provider-dvp`:
+
+   ```shell
+   cat > cloud-provider-dvp-mc.yaml <<EOF
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-dvp
+   spec:
+     enabled: true
+     version: 1
+     settings:
+       provider:
+         kubeconfigDataBase64: ${DVP_KUBECONFIG_B64}
+         namespace: ${DVP_NAMESPACE}
+       zones:
+         - <ZONE_NAME>
+   EOF
+   ```
+
+   Где:
+
+   - `provider.kubeconfigDataBase64` — kubeconfig для доступа к API DVP в кодировке Base64;
+   - `provider.namespace` — неймспейс DVP, в котором будут создаваться виртуальные машины и диски;
+   - `zones` — список зон DVP, в которых разрешено создавать worker-узлы.
+
+1. Примените ModuleConfig:
+
+   ```shell
+   d8 k apply -f cloud-provider-dvp-mc.yaml
+   ```
+
+1. Дождитесь включения модуля `cloud-provider-dvp`:
+
+   ```shell
+   d8 k get moduleconfig cloud-provider-dvp
+   d8 k get module cloud-provider-dvp -o wide
+   d8 k -n d8-cloud-provider-dvp get pods -o wide
+   ```
+
+   Модуль должен перейти в состояние `Ready`, а поды в неймспейсе `d8-cloud-provider-dvp` — в состояние `Running`.
+
+1. Убедитесь, что модуль `node-manager` находится в состоянии `Ready`:
+
+   ```shell
+   d8 k get module node-manager -o wide
+   ```
+
+   Если модуль находится в состоянии Error, проверьте, что в ModuleConfig и NodeGroup указаны доступные зоны DVP.
+
+1. Убедитесь, что в кластере появился ресурс DVPInstanceClass:
+
+   ```shell
+   d8 k get crd dvpinstanceclasses.deckhouse.io
+   ```
+
+1. На машине администратора, где настроен доступ к кластеру DVP, проверьте доступные классы виртуальных машин, образы и StorageClass:
+
+   ```shell
+   d8 k --kubeconfig ${DVP_PROVIDER_KUBECONFIG} get virtualmachineclasses
+   d8 k --kubeconfig ${DVP_PROVIDER_KUBECONFIG} get clustervirtualimages
+   d8 k --kubeconfig ${DVP_PROVIDER_KUBECONFIG} get storageclasses
+   ```
+
+   Используйте полученные значения при создании DVPInstanceClass.
+
+1. Создайте файл, например `dvp-instanceclass-nodegroup.yaml`, с ресурсами DVPInstanceClass и NodeGroup:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: DVPInstanceClass
+   metadata:
+     name: dvp-worker
+   spec:
+     virtualMachine:
+       cpu:
+         cores: 3
+         coreFraction: 20%
+       memory:
+         size: 6Gi
+       virtualMachineClassName: <VIRTUAL_MACHINE_CLASS_NAME>
+       bootloader: EFI
+     rootDisk:
+       size: 15Gi
+       storageClass: <STORAGE_CLASS_NAME>
+       image:
+         kind: ClusterVirtualImage
+         name: <CLUSTER_VIRTUAL_IMAGE_NAME>
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: dvp-worker
+   spec:
+     nodeType: CloudEphemeral
+     cloudInstances:
+       classReference:
+         kind: DVPInstanceClass
+         name: dvp-worker
+       minPerZone: 1
+       maxPerZone: 1
+       zones:
+         - <ZONE_NAME>
+   ```
+
+   Где:
+
+   - `virtualMachineClassName` — имя VirtualMachineClass в DVP, например `amd-epyc-gen-3`;
+   - `rootDisk.storageClass` — имя StorageClass в DVP, например `replicated`;
+   - `rootDisk.image.kind` — тип источника образа. Для кластерного образа используйте `ClusterVirtualImage`;
+   - `rootDisk.image.name` — имя образа ОС в DVP, например `ubuntu-24-04-lts`;
+   - `cloudInstances.zones` — зона DVP, в которой будет создан worker-узел. Значение должно входить в список `zones` из ModuleConfig.
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f dvp-instanceclass-nodegroup.yaml
+   ```
+
+   После применения DKP начнёт создавать виртуальную машину в DVP и подключать её к кластеру как worker-узел.
+
+1. Проверьте состояние NodeGroup:
+
+   ```shell
+   d8 k get nodegroup dvp-worker -o wide
+   d8 k describe nodegroup dvp-worker
+   ```
+
+1. Проверьте появление нового узла в DKP-кластере:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                              STATUS   ROLES                  AGE   VERSION    INTERNAL-IP
+   dvp-hybrid-master-0               Ready    control-plane,master   1h    v1.33.10   10.12.0.69
+   dvp-worker-c75a75c1-twqp4-bjpvl   Ready    dvp-worker             10m   v1.33.10   10.12.3.15
+   ```
+
+## Добавление вручную созданных узлов через CAPS
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-dvp`](/modules/cloud-provider-dvp/) включён и настроен.
+- Компоненты модуля `cloud-provider-dvp` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-dvp get pods -o wide
+  ```
+
+- В DVP создана виртуальная машина, которая будет подключена к кластеру.
+- Виртуальная машина подключена к сети DVP, используемой для гибридной интеграции с кластером.
+- IP-адрес виртуальной машины входит в диапазон, указанный в [`internalNetworkCIDRs`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#staticclusterconfiguration-internalnetworkcidrs).
+- Имя виртуальной машины в DVP совпадает с hostname внутри операционной системы.
+- На виртуальной машине есть административный SSH-доступ для первичной настройки пользователя, под которым CAPS будет подключаться к узлу, либо такой пользователь уже создан заранее.
+- Пользователь для подключения по SSH может выполнять команды через `sudo` без ввода пароля.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+1. На master-узле задайте переменные для создаваемой NodeGroup и подключаемой виртуальной машины:
+
+   ```shell
+   export NODE_GROUP="dvp-caps"
+   export NODE_NAME="dvp-worker-caps"
+   export NODE_SSH_IP="<NODE_IP>"
+   export CAPS_USER="caps"
+   ```
+
+   Где:
+
+   - `NODE_GROUP` — имя NodeGroup, в которую будет добавлен узел;
+   - `NODE_NAME` — имя подключаемого узла. Оно должно совпадать с hostname внутри операционной системы и именем ВМ в DVP;
+   - `NODE_SSH_IP` — IP-адрес виртуальной машины, доступный по SSH;
+   - `CAPS_USER` — пользователь, под которым CAPS будет подключаться к виртуальной машине.
+
+1. На master-узле создайте NodeGroup:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     nodeType: Static
+     staticInstances:
+       count: 1
+       labelSelector:
+         matchLabels:
+           role: ${NODE_GROUP}
+   EOF
+   ```
+
+   В этом сценарии используется `nodeType: Static`, потому что виртуальная машина уже создана вручную, а CAPS будет только подключать и настраивать её по SSH.
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME       TYPE     READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   dvp-caps   Static   0       0       0                                                               1m    True
+   ```
+
+1. На master-узле сгенерируйте SSH-ключ, который CAPS будет использовать для подключения к виртуальной машине:
+
+   ```shell
+   ssh-keygen -t ed25519 \
+     -f /dev/shm/${NODE_GROUP}-id \
+     -C "" \
+     -N ""
+   ```
+
+   {% alert level="info" %}
+   Ключ создаётся с пустой парольной фразой, так как CAPS должен использовать его автоматически.
+   {% endalert %}
+
+1. На master-узле создайте ресурс [SSHCredentials](/modules/node-manager/cr.html#sshcredentials):
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: SSHCredentials
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     user: ${CAPS_USER}
+     privateSSHKey: "$(base64 -w0 /dev/shm/${NODE_GROUP}-id)"
+   EOF
+   ```
+
+   Ресурс SSHCredentials хранит имя пользователя и приватный SSH-ключ, с помощью которых CAPS будет подключаться к виртуальной машине.
+
+1. Убедитесь, что ресурс SSHCredentials создан:
+
+   ```shell
+   d8 k get sshcredentials
+   d8 k describe sshcredentials ${NODE_GROUP}
+   ```
+
+1. На master-узле выведите публичную часть SSH-ключа:
+
+   ```shell
+   cat /dev/shm/${NODE_GROUP}-id.pub
+   ```
+
+   Этот ключ понадобится на следующем шаге для настройки пользователя на подключаемой виртуальной машине.
+
+1. На подключаемой виртуальной машине создайте пользователя, под которым CAPS будет выполнять настройку узла. Выполните команды на подключаемой виртуальной машине, указав публичный SSH-ключ, полученный на предыдущем шаге:
+
+   ```shell
+   export CAPS_USER="caps"
+   export KEY='<SSH_PUBLIC_KEY>'
+
+   useradd -m -s /bin/bash ${CAPS_USER}
+   usermod -aG sudo ${CAPS_USER}
+
+   echo "${CAPS_USER} ALL=(ALL) NOPASSWD: ALL" | EDITOR='tee -a' visudo
+
+   mkdir -p /home/${CAPS_USER}/.ssh
+   echo "${KEY}" > /home/${CAPS_USER}/.ssh/authorized_keys
+
+   chown -R ${CAPS_USER}:${CAPS_USER} /home/${CAPS_USER}
+   chmod 700 /home/${CAPS_USER}/.ssh
+   chmod 600 /home/${CAPS_USER}/.ssh/authorized_keys
+   ```
+
+   {% alert level="info" %}
+   Значение `KEY` необходимо указывать в кавычках, так как публичный SSH-ключ содержит пробелы.
+   {% endalert %}
+
+   {% alert level="info" %}
+   Для операционных систем семейства Astra Linux при использовании модуля мандатного контроля целостности Parsec дополнительно задайте максимальный уровень целостности для пользователя:
+
+   ```shell
+   pdpl-user -i 63 ${CAPS_USER}
+   ```
+
+   {% endalert %}
+
+1. На master-узле проверьте, что CAPS-пользователь может подключиться к виртуальной машине по SSH и выполнять команды через `sudo` без пароля:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'hostname; sudo -n true; echo OK'
+   ```
+
+   В выводе должно быть имя узла и строка `OK`.
+
+1. На master-узле создайте ресурс [StaticInstance](/modules/node-manager/cr.html#staticinstance) для подключаемой виртуальной машины:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: StaticInstance
+   metadata:
+     name: ${NODE_NAME}
+     labels:
+       role: ${NODE_GROUP}
+   spec:
+     address: "${NODE_SSH_IP}"
+     credentialsRef:
+       kind: SSHCredentials
+       name: ${NODE_GROUP}
+   EOF
+   ```
+
+   Где:
+
+   - `metadata.name` — имя подключаемого узла;
+   - `metadata.labels.role` — лейбл, по которому NodeGroup выбирает этот StaticInstance;
+   - `spec.address` — IP-адрес виртуальной машины, доступный по SSH;
+   - `spec.credentialsRef.name` — имя созданного ранее ресурса SSHCredentials.
+
+1. Проверьте состояние StaticInstance:
+
+   ```shell
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+   ```
+
+1. Дождитесь подключения узла и проверьте его состояние:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                 STATUS   ROLES                  AGE   VERSION    INTERNAL-IP
+   dvp-hybrid-master-0  Ready    control-plane,master   1h    v1.33.12   10.12.0.69
+   dvp-worker-caps      Ready    dvp-caps               5m    v1.33.12   10.12.3.88
+   ```
+
+1. При сбоях подключения проверьте состояние NodeGroup, StaticInstance, Instance, Machine и события в кластере:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+
+   d8 k get instances -o wide
+
+   d8 k -n d8-cloud-instance-manager get \
+     machines.cluster.x-k8s.io,\
+   staticmachines.infrastructure.cluster.x-k8s.io \
+     -o wide
+
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+   Если StaticInstance остаётся в состоянии `Bootstrapping`, проверьте логи bootstrap на подключаемой виртуальной машине:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'sudo tail -n 120 /var/log/d8/bashible/bootstrap.log'
+   ```
+
+   Если в логах есть ошибка `Failed to discover node_ip that matches internalNetworkCIDRs`, проверьте, что IP-адрес виртуальной машины входит в `internalNetworkCIDRs`.
+
+## Добавление вручную созданных узлов через bootstrap-скрипт
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-dvp`](/modules/cloud-provider-dvp/) включён и настроен.
+- Компоненты модуля `cloud-provider-dvp` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-dvp get pods -o wide
+  ```
+
+- В DVP создана виртуальная машина, которая будет подключена к кластеру.
+- Виртуальная машина подключена к сети DVP, используемой для гибридной интеграции с кластером.
+- IP-адрес виртуальной машины входит в диапазон, указанный в [`internalNetworkCIDRs`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#staticclusterconfiguration-internalnetworkcidrs).
+- Имя виртуальной машины в DVP совпадает с hostname внутри операционной системы.
+- На виртуальной машине есть SSH-доступ для копирования и запуска bootstrap-скрипта.
+- Пользователь для подключения по SSH может выполнять команды через `sudo` без ввода пароля.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+1. Создайте файл, например `cloud-static-nodegroup.yaml`, с ресурсом NodeGroup и типом узлов CloudStatic:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: cloud-static
+   spec:
+     nodeType: CloudStatic
+   ```
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f cloud-static-nodegroup.yaml
+   ```
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup cloud-static
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME           TYPE          READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   cloud-static   CloudStatic   0       0       0                                                               1m    True
+   ```
+
+1. Получите bootstrap-скрипт для созданной NodeGroup:
+
+   ```shell
+   NODE_GROUP=cloud-static
+
+   d8 k -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} \
+     -o jsonpath='{.data.bootstrap\.sh}' > bootstrap.b64
+   ```
+
+1. Скопируйте bootstrap-скрипт на подключаемую виртуальную машину:
+
+   ```shell
+   scp bootstrap.b64 <USER>@<NODE_IP>:/tmp/bootstrap.b64
+   ```
+
+1. Подключитесь к виртуальной машине по SSH:
+
+   ```shell
+   ssh <USER>@<NODE_IP>
+   ```
+
+1. На виртуальной машине декодируйте bootstrap-скрипт, назначьте права и запустите его:
+
+   ```shell
+   base64 -d /tmp/bootstrap.b64 > /tmp/bootstrap.sh
+   chmod +x /tmp/bootstrap.sh
+
+   sudo bash /tmp/bootstrap.sh
+   ```
+
+   После запуска bootstrap-скрипт установит необходимые компоненты, настроит container runtime, kubelet и подключит узел к кластеру.
+
+1. На master-узле проверьте появление нового узла:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                   STATUS   ROLES                  AGE   VERSION    INTERNAL-IP
+   dvp-hybrid-master-0    Ready    control-plane,master   1h    v1.33.12   10.12.0.69
+   cloud-static-worker-0  Ready    cloud-static           5m    v1.33.12   10.12.3.88
+   ```
+
+1. При сбоях подключения проверьте состояние NodeGroup, события и логи bootstrap на подключаемой виртуальной машине:
+
+   ```shell
+   d8 k get nodegroup cloud-static
+   d8 k describe nodegroup cloud-static
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+   На подключаемой виртуальной машине:
+
+   ```shell
+   sudo tail -n 120 /var/log/d8/bashible/bootstrap.log
+   ```
+
+   Если в логах есть ошибка `Failed to discover node_ip that matches internalNetworkCIDRs`, проверьте, что IP-адрес виртуальной машины входит в `internalNetworkCIDRs`.

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW.md
@@ -3,319 +3,57 @@ title: Hybrid integrations
 permalink: en/admin/integrations/hybrid/overview.html
 ---
 
-Deckhouse Kubernetes Platform (DKP) can use cloud provider resources to expand the capacity of static clusters.
-Currently, integration is supported with [OpenStack](../public/openstack/connection-and-authorization.html), [Yandex Cloud](../public/yandex/authorization.html), and [VMware vCloud Director (VCD)](../virtualization/vcd/connection-and-authorization.html).
+A hybrid cluster is a DKP cluster in which the control plane and base worker nodes are placed in your own infrastructure, while additional worker nodes are connected from an external cloud or virtualization environment, for example from Yandex Cloud, VMware Cloud Director, or VMware vSphere.
 
-A hybrid cluster is a Kubernetes cluster that combines bare-metal nodes with nodes running on vSphere or OpenStack.
-To create such a cluster, an L2 network must be available between all nodes.
+This approach allows you to extend an existing static cluster without creating a separate Kubernetes cluster: increase compute capacity, place part of the workloads in external infrastructure, or gradually migrate services there. For applications, a single Kubernetes control plane is preserved: a common API, common resources, and unified mechanisms for scheduling, monitoring, updating, and operations.
 
-{% alert level="info" %}
-The Deckhouse Kubernetes Platform allows to set a prefix for the names of CloudEphemeral nodes added to a hybrid cluster with Static master nodes.
-To do this, use the [`instancePrefix`](/modules/node-manager/configuration.html#parameters-instanceprefix) parameter of the `node-manager` module. The prefix specified in the parameter will be added to the name of all CloudEphemeral nodes added to the cluster. It is not possible to set a prefix for a specific NodeGroup.
-{% endalert %}
+Hybrid integration is performed on the basis of an already deployed static DKP cluster — a cluster with the [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype) parameter. In such a cluster, the control plane and base worker nodes are placed in your own infrastructure. Then the corresponding cloud provider module is enabled, through which DKP receives information about the external infrastructure and can create or connect additional worker nodes.
 
-## Hybrid cluster with Yandex Cloud
+Depending on the provider, nodes can be added automatically through the cloud API or by manually connecting pre-created virtual machines: using the DKP bootstrap script or Cluster API Provider Static (CAPS).
 
-The following section describes how to create a hybrid cluster that combines static (bare-metal) nodes and cloud nodes in Yandex Cloud using Deckhouse Kubernetes Platform (DKP).
+The general principles of hybrid integration are described on this page. The procedure for preparing the infrastructure and adding worker nodes depends on the provider being used and is provided in separate guides:
 
-### Prerequisites for Yandex Cloud
+- [Yandex Cloud](./yandex-hybrid.html)
+- [VMware Cloud Director](./vcd-hybrid.html)
+- [VMware vSphere](./vsphere-hybrid.html)
 
-- A working cluster with the parameter `clusterType: Static`.
-- The CNI controller switched to VXLAN mode. For details, refer to the [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode) parameter.
-- Configured network connectivity between the static cluster node network and VCD (either at L2 level, or at L3 level with port access according to the [required network policies for DKP operation](../../configuration/network/policy/configuration.html)).
+## Node group types
 
-### Adding automatically created nodes in Yandex Cloud
+DKP uses different node group types for hybrid scenarios:
 
-1. Create a Service Account in the required Yandex Cloud folder:
+- [`Static`](../../../../architecture/cluster-and-infrastructure/node-management/static-nodes.html) — nodes that are created and maintained by the user; also used in scenarios involving connection through CAPS.
+- [`CloudEphemeral`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-ephemeral-nodes.html) — nodes that DKP creates and deletes automatically through the provider API.
+- [`CloudStatic`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-static-nodes.html) — nodes that are created by the user in external infrastructure and then connected to the cluster.
+- `Hybrid` — the NodeGroup type used in the scenario for connecting manually created cloud nodes in Yandex Cloud.
 
-   - Assign the `editor` role.
-   - Provide access to the used VPC with the `vpc.admin` role.
+## Node addition methods
 
-1. Create the `d8-provider-cluster-configuration` secret with the required data. Example `cloud-provider-cluster-configuration.yaml`:
+Worker nodes from external infrastructure can be connected in several ways:
 
-   ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: YandexClusterConfiguration
-   layout: WithoutNAT
-   masterNodeGroup:
-     replicas: 1
-     instanceClass:
-       cores: 4
-       memory: 8192
-       imageID: fd80bm0rh4rkepi5ksdi
-       diskSizeGB: 100
-       platform: standard-v3
-       externalIPAddresses:
-       - "Auto"
-   nodeNetworkCIDR: 10.160.0.0/16
-   existingNetworkID: empty
-   provider:
-     cloudID: CLOUD_ID
-     folderID: FOLDER_ID
-     serviceAccountJSON: '{"id":"ajevk1dp8f9...--END PRIVATE KEY-----\n"}'
-   sshPublicKey: <SSH_PUBLIC_KEY>
-   ```
+- **Automatic node creation**. DKP creates virtual machines through the provider API. VM parameters are described by the `*InstanceClass` resource, while the required number of nodes and placement zones are described by the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource.
+- **Connecting manually created nodes through CAPS**. A virtual machine is created by the user in advance, and DKP connects to it over SSH through Cluster API Provider Static and configures the node. This uses the [NodeGroup](/modules/node-manager/cr.html#nodegroup), [SSHCredentials](/modules/node-manager/cr.html#sshcredentials), and [StaticInstance](/modules/node-manager/cr.html#staticinstance) resources.
+- **Connecting manually created nodes through a bootstrap script**. A virtual machine is created by the user in advance, after which the DKP bootstrap script is run on it to connect the node to the cluster.
 
-   Parameter descriptions:
-   - `nodeNetworkCIDR` — CIDR of the network covering all node subnets in Yandex Cloud.
-   - `cloudID` — Your cloud ID.
-   - `folderID` — Your folder ID.
-   - `serviceAccountJSON` — The Service Account in JSON format.
-   - `sshPublicKey` — Public SSH key for deployed machines.
+This section describes the general network requirements for hybrid clusters. Provider-specific requirements for networks, virtual machine templates, credentials, placement parameters, and node addition methods are provided in separate guides for [Yandex Cloud](./yandex-hybrid.html), [VCD](./vcd-hybrid.html), and [vSphere](./vsphere-hybrid.html).
 
-     Values in `masterNodeGroup` are irrelevant since master nodes are not created.
+## General network requirements
 
-1. Fill in `data.cloud-provider-discovery-data.json` in the same secret. Example:
+Bidirectional network connectivity sufficient for DKP and Kubernetes components to operate must be configured between the cluster’s static nodes and nodes placed in external infrastructure.
 
-   ```yaml
-   {
-     "apiVersion": "deckhouse.io/v1",
-     "defaultLbTargetGroupNetworkId": "empty",
-     "internalNetworkIDs": [
-       "<NETWORK-ID>"
-     ],
-     "kind": "YandexCloudDiscoveryData",
-     "monitoringAPIKey": "",
-     "region": "ru-central1",
-     "routeTableID": "empty",
-     "shouldAssignPublicIPAddress": false,
-     "zoneToSubnetIdMap": {
-       "ru-central1-a": "<A-SUBNET-ID>",
-       "ru-central1-b": "<B-SUBNET-ID>", 
-       "ru-central1-d": "<D-SUBNET-ID>"
-     },
-     "zones": [
-       "ru-central1-a",
-       "ru-central1-b",
-      "ru-central1-d"
-     ]
-   }
-   ```
+Connected nodes must have access to the Kubernetes API, DNS, and the required external service addresses, including the container registry. In the reverse direction, the control plane and cluster system components must have access to the connected nodes for kubelet, network components, monitoring, and Kubernetes service operations.
 
-    Parameter descriptions:
-    - `internalNetworkIDs` — List of network IDs in Yandex Cloud providing internal node connectivity.
-    - `zoneToSubnetIdMap` — Zone-to-subnet mapping (one subnet per zone).
-    - `shouldAssignPublicIPAddress: true` — Assigns public IPs to created nodes if required. For zones without subnets, can be set to `empty`.
+DKP components that interact with external infrastructure must have access to the API of the corresponding provider.
 
-1. Encode the above files (YandexClusterConfiguration and YandexCloudDiscoveryData) in Base64, then insert them into the `cloud-provider-cluster-configuration.yaml` and `cloud-provider-discovery-data.json` fields in the secret.
+The full list of connections is provided in the [Network interaction](../../../../reference/network_interaction.html) section, and access restriction recommendations are provided in the [Network policy configuration](../../configuration/network/policy/configuration.html) section.
 
-   ```yaml
-   apiVersion: v1
-   data:
-     cloud-provider-cluster-configuration.yaml: <YANDEXCLUSTERCONFIGURATION_BASE64_ENCODED>
-     cloud-provider-discovery-data.json: <YANDEXCLOUDDISCOVERYDATA-BASE64-ENCODED>
-   kind: Secret
-   metadata:
-     labels:
-       heritage: deckhouse
-       name: d8-provider-cluster-configuration
-     name: d8-provider-cluster-configuration
-     namespace: kube-system
-   type: Opaque
-   ---
-   apiVersion: deckhouse.io/v1alpha1
-   kind: ModuleConfig
-   metadata:
-     name: cloud-provider-yandex
-   spec:
-     version: 1
-     enabled: true
-     settings:
-       storageClass:
-         default: network-ssd
-   ```
+It is also recommended to check:
 
-1. Remove the `ValidatingAdmissionPolicyBinding` object to avoid conflicts:
+- routing between the networks of static and connected nodes in both directions
+- availability of the Kubernetes API for connected nodes
+- availability of connected nodes from the control plane and cluster system components
+- availability of DNS servers and allowed external addresses
+- availability of the container registry and other external services required for downloading images and packages
+- the same MTU value along the entire network path, especially when using tunnels
+- traffic encapsulation parameters when using Cilium, including [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode), if traffic filtering is applied between sites
 
-   ```shell
-   d8 k delete validatingadmissionpolicybindings.admissionregistration.k8s.io heritage-label-objects.deckhouse.io
-   ```
-
-1. Apply the manifests in the cluster.
-
-1. Wait for the `cloud-provider-yandex` module activation and CRD creation:
-
-   ```shell
-   d8 k get mc cloud-provider-yandex
-   d8 k get crd yandexinstanceclasses
-   ```
-
-1. Create and apply NodeGroup and YandexInstanceClass manifests:
-
-   ```yaml
-   ---
-   apiVersion: deckhouse.io/v1alpha1
-   kind: NodeGroup
-   metadata:
-     name: worker
-   spec:
-     nodeType: Cloud
-     cloudInstances:
-       classReference:
-         kind: YandexInstanceClass
-         name: worker
-       minPerZone: 1
-       maxPerZone: 3
-       zones:
-         - ru-central1-d
-   ---
-   apiVersion: deckhouse.io/v1alpha1
-   kind: YandexInstanceClass
-   metadata:
-     name: worker
-   spec:
-     cores: 4
-     memory: 8192
-     diskSizeGB: 50
-     diskType: network-ssd
-     mainSubnet: <YOUR-SUBNET-ID>
-   ```
-
-   The `mainSubnet` parameter must contain the subnet ID from Yandex Cloud that is used for interconnection with your infrastructure (L2 connectivity with static node groups).
-
-   After applying the manifests, the provisioning of virtual machines in Yandex Cloud managed by the `node-manager` module will begin.
-
-1. Check the `machine-controller-manager` logs for troubleshooting:
-
-   ```shell
-   d8 k -n d8-cloud-provider-yandex get machine
-   d8 k -n d8-cloud-provider-yandex get machineset
-   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager
-   ```
-
-## Hybrid cluster with VCD
-
-This section describes the process of creating a hybrid cluster that combines static (bare-metal) nodes and cloud nodes in VMware vCloud Director (VCD) using Deckhouse Kubernetes Platform (DKP).
-
-### Prerequisites for VCD
-
-Before you begin, ensure the following conditions are met:
-
-- **Infrastructure**:
-  - A bare-metal DKP cluster is installed.
-  - A tenant is configured in VCD [with allocated resources](../virtualization/vcd/connection-and-authorization.html).
-  - Configured network connectivity between the static cluster node network and VCD (either at L2 level, or at L3 level with port access according to the [required network policies for DKP operation](../../configuration/network/policy/configuration.html)).
-  - A working network is configured in VCD with DHCP enabled.
-  - A user with a static password and VCD administrator privileges has been created.
-
-- **Software settings**:
-  - The CNI controller is switched to VXLAN mode. More details — [`tunnelMode` configuration](/modules/cni-cilium/configuration.html#parameters-tunnelmode).
-  - A [list of required VCD resources](../virtualization/vcd/connection-and-authorization.html) is prepared (VDC, VAPP, templates, policies, etc.).
-
-### Adding automatically created nodes in VCD
-
-1. 1. Create a file, for example `cloud-provider-vcd-mc.yaml`, with a ModuleConfig resource:
-
-   ```yaml
-   apiVersion: deckhouse.io/v1alpha1
-   kind: ModuleConfig
-   metadata:
-     name: cloud-provider-vcd
-   spec:
-     version: 1
-     enabled: true
-     settings:
-       mainNetwork: <NETWORK_NAME>
-       organization: <ORGANIZATION>
-       virtualDataCenter: <VDC_NAME>
-       virtualApplicationName: <VAPP_NAME>
-       sshPublicKey: <SSH_PUBLIC_KEY>
-       provider:
-         server: <API_URL>
-         username: <USER_NAME>
-         password: <PASSWORD>
-         apiToken: <API_TOKEN>
-         insecure: false
-   ```
-
-   Where:
-   - `mainNetwork` — the name of the network where cloud nodes will be deployed in your VCD cluster.
-   - `organization` — the name of your VCD organization.
-   - `virtualDataCenter` — the name of the virtual data center.
-   - `virtualApplicationName` — the name of the vApp where nodes will be created (e.g., `dkp-vcd-app`).
-   - `sshPublicKey` — the SSH public key for node access.
-   - `provider.server` — the API URL of your VCD instance.
-   - `provider.username` — the name of the static user that will be used to interact with VCD.
-   - `provider.password` — the password of a user with administrator privileges in VCD.
-   - `provider.insecure` — set to `true` if VCD uses a self-signed TLS certificate.
-
-   If a token is used for authentication, specify `apiToken` instead of `username` and `password`:
-
-   ```yaml
-   provider:
-     server: <API_URL>
-     apiToken: <API_TOKEN>
-     username: ""
-     password: ""
-     insecure: false
-   ```
-
-1. Apply the ModuleConfig:
-
-   ```shell
-   d8 k apply -f cloud-provider-vcd-mc.yaml
-   d8 k get mc cloud-provider-vcd
-   ```
-
-1. Make sure all pods in the `d8-cloud-provider-vcd` namespace are in the `Running` state:
-
-   ```shell
-   d8 k get pods -n d8-cloud-provider-vcd
-   ```
-
-1. Make sure StorageClasses for VCD have been created in the cluster:
-
-   ```shell
-   d8 k get sc
-   ```
-
-1. Create a file, for example `vcd-instanceclass-nodegroup.yaml` with the [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass) and [NodeGroup](/modules/node-manager/cr.html#nodegroup) resources:
-
-   ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: VCDInstanceClass
-   metadata:
-     name: worker
-   spec:
-     rootDiskSizeGb: 50
-     sizingPolicy: <SIZING_POLICY>
-     storageProfile: <STORAGE_PROFILE>
-     template: <VAPP_TEMPLATE>
-   ---
-   apiVersion: deckhouse.io/v1
-   kind: NodeGroup
-   metadata:
-     name: worker
-   spec:
-     nodeType: CloudEphemeral
-     cloudInstances:
-       classReference:
-         kind: VCDInstanceClass
-         name: worker
-       maxPerZone: 2
-       minPerZone: 1
-     nodeTemplate:
-       labels:
-         node-role/worker: ""
-   ```
-
-1. Apply the manifest:
-
-   ```shell
-   d8 k apply -f vcd-instanceclass-nodegroup.yaml
-   ```
-
-   After the manifest is applied, DKP will start creating virtual machines in VCD managed by the `node-manager` module.
-
-1. Make sure the required number of nodes has appeared in the cluster:
-
-   ```shell
-   d8 k get nodes -o wide
-   ```
-
-1. If VM creation fails, check the Machine and MachineSet objects and the machine-controller-manager logs:
-
-   ```shell
-   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
-   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
-   ```
+Specific requirements for networks, subnets, virtual machine templates, credentials, and additional parameters depend on the infrastructure provider being used and are provided in the "Prerequisites" section for the corresponding provider.

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/OVERVIEW_RU.md
@@ -1,319 +1,60 @@
 ---
-title: Гибридная интеграция
+title: Гибридные кластеры
 permalink: ru/admin/integrations/hybrid/overview.html
 lang: ru
 ---
 
-Deckhouse Kubernetes Platform (DKP) имеет возможность использовать ресурсы облачных провайдеров для расширения ресурсов статических кластеров. В данный момент поддерживается интеграция с облаками на базе [OpenStack](../public/openstack/connection-and-authorization.html), [Yandex Cloud](../public/yandex/authorization.html) и [VMware vCloud Director (VCD)](../virtualization/vcd/connection-and-authorization.html).
+Гибридный кластер — это кластер DKP, в котором control plane и базовые worker-узлы размещаются в собственной инфраструктуре, а дополнительные worker-узлы подключаются из внешнего облака или среды виртуализации, например из Yandex Cloud, VMware Cloud Director или VMware vSphere.
 
-Гибридный кластер представляет собой объединенные в один кластер bare-metal-узлы и узлы провайдера. Для создания такого кластера необходимо наличие L2-сети между всеми узлами кластера.
+Такой подход позволяет расширять существующий статический кластер без создания отдельного Kubernetes-кластера: увеличивать вычислительные мощности, размещать часть рабочих нагрузок во внешней инфраструктуре или постепенно переносить туда сервисы. Для приложений при этом сохраняется единая плоскость управления Kubernetes: общий API, единые ресурсы, единые механизмы планирования, мониторинга, обновления и эксплуатации.
 
-{% alert level="info" %}
-В Deckhouse Kubernetes Platform есть возможность задавать префикс для имени CloudEphemeral-узлов, добавляемых в гибридный кластер c master-узлами типа Static.
-Для этого используйте параметр [`instancePrefix`](/modules/node-manager/configuration.html#parameters-instanceprefix) модуля `node-manager`. Префикс, указанный в параметре, будет добавляться к имени всех добавляемых в кластер узлов типа CloudEphemeral. Задать префикс для определенной NodeGroup нельзя.
-{% endalert %}
+Гибридная интеграция выполняется на базе уже развёрнутого статического кластера DKP — кластера с параметром [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype). В таком кластере control plane и базовые worker-узлы размещаются в собственной инфраструктуре. Затем включается модуль соответствующего облачного провайдера, через который DKP получает информацию о внешней инфраструктуре и может создавать или подключать дополнительные worker-узлы.
 
-## Гибридный кластер с Yandex Cloud
+В зависимости от провайдера узлы можно добавлять автоматически через API облака или подключать заранее созданные виртуальные машины вручную: через bootstrap-скрипт DKP либо через Cluster API Provider Static (CAPS).
 
-Далее описан процесс создания гибридного кластера, объединяющего статические (bare-metal) узлы и облачные узлы в Yandex Cloud с использованием Deckhouse Kubernetes Platform (DKP).
+Общие принципы гибридной интеграции описаны на этой странице. Порядок подготовки инфраструктуры и добавления worker-узлов зависит от используемого провайдера и приведён в отдельных инструкциях:
 
-### Предварительные требования для Yandex Cloud
+- [Yandex Cloud](./yandex-hybrid.html);
+- [VMware Cloud Director](./vcd-hybrid.html);
+- [VMware vSphere](./vsphere-hybrid.html).
 
-- Рабочий кластер с параметром `clusterType: Static`.
-- Контроллер CNI переведён в режим VXLAN. Подробнее — [настройка `tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode).
-- Настроенная сетевая связность между Yandex Cloud и сетью узлов статического кластера согласно [необходимым сетевым политикам для работы DKP](../../configuration/network/policy/configuration.html).
+## Типы групп узлов
 
-### Добавление автоматически создаваемых узлов в Yandex Cloud
+В DKP для гибридных сценариев используются разные типы групп узлов:
 
-1. Создайте Service Account в нужном каталоге Yandex Cloud:
+- [`Static`](../../../../architecture/cluster-and-infrastructure/node-management/static-nodes.html) — узлы, которые создаются и обслуживаются пользователем; также используются в сценариях подключения через CAPS.
+- [`CloudEphemeral`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-ephemeral-nodes.html) — узлы, которые DKP создаёт и удаляет автоматически через API провайдера.
+- [`CloudStatic`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-static-nodes.html) — узлы, которые создаются пользователем во внешней инфраструктуре и затем подключаются к кластеру.
+- `Hybrid` — тип NodeGroup, используемый в сценарии подключения вручную созданных облачных узлов в Yandex Cloud.
 
-   - Назначьте роль `editor`.
-   - Предоставьте доступ к используемой VPC с ролью `vpc.admin`.
+## Способы добавления узлов
 
-1. Создайте секрет `d8-provider-cluster-configuration` с нужными данными. Пример содержимого `cloud-provider-cluster-configuration.yaml`:
+Подключение worker-узлов из внешней инфраструктуры может выполняться несколькими способами:
 
-   ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: YandexClusterConfiguration
-   layout: WithoutNAT
-   masterNodeGroup:
-     replicas: 1
-     instanceClass:
-       cores: 4
-       memory: 8192
-       imageID: fd80bm0rh4rkepi5ksdi
-       diskSizeGB: 100
-       platform: standard-v3
-       externalIPAddresses:
-       - "Auto"
-   nodeNetworkCIDR: 10.160.0.0/16
-   existingNetworkID: empty
-   provider:
-     cloudID: CLOUD_ID
-     folderID: FOLDER_ID
-     serviceAccountJSON: '{"id":"ajevk1dp8f9...--END PRIVATE KEY-----\n"}'
-   sshPublicKey: <SSH_PUBLIC_KEY>
-   ```
+- **Автоматическое создание узлов**. DKP создаёт виртуальные машины через API провайдера. Параметры ВМ описываются ресурсом `*InstanceClass`, а требуемое количество узлов и зоны размещения — ресурсом [NodeGroup](/modules/node-manager/cr.html#nodegroup).
+- **Подключение вручную созданных узлов через CAPS**. Виртуальная машина создаётся пользователем заранее, а DKP подключается к ней по SSH через Cluster API Provider Static и выполняет настройку узла. Для этого используются ресурсы [NodeGroup](/modules/node-manager/cr.html#nodegroup), [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) и [StaticInstance](/modules/node-manager/cr.html#staticinstance).
+- **Подключение вручную созданных узлов через bootstrap-скрипт**. Виртуальная машина создаётся пользователем заранее, после чего на ней запускается bootstrap-скрипт DKP для подключения узла к кластеру.
 
-   Значения параметров:
-   - `nodeNetworkCIDR` — CIDR сети, который включает адреса всех используемых подсетей узлов в Yandex Cloud;
-   - `cloudID` — ID вашего облака;
-   - `folderID` — ID каталога;
-   - `serviceAccountJSON` — service account в каталоге, выгруженный в формате JSON;
-   - `sshPublicKey` — публичный ключ, который будет добавлен на разворачиваемые машины.
+В этом разделе описаны общие сетевые требования для гибридных кластеров. Провайдер-специфичные требования к сетям, шаблонам виртуальных машин, учётным данным, параметрам размещения и способам добавления узлов приведены в отдельных инструкциях для [Yandex Cloud](./yandex-hybrid.html), [VCD](./vcd-hybrid.html) и [vSphere](./vsphere-hybrid.html).
 
-     Значения в `masterNodeGroup` не имеют значения, так как master-узлы не разворачиваются.
+## Общие сетевые требования
 
-1. Заполните значения для файла `data.cloud-provider-discovery-data.json` в этом же секрете. Пример:
+Между статическими узлами кластера и узлами, размещёнными во внешней инфраструктуре, должна быть настроена двусторонняя сетевая связность, достаточная для работы компонентов DKP и Kubernetes.
 
-   ```yaml
-   {
-     "apiVersion": "deckhouse.io/v1",
-     "defaultLbTargetGroupNetworkId": "empty",
-     "internalNetworkIDs": [
-       "<NETWORK-ID>"
-     ],
-     "kind": "YandexCloudDiscoveryData",
-     "monitoringAPIKey": "",
-     "region": "ru-central1",
-     "routeTableID": "empty",
-     "shouldAssignPublicIPAddress": false,
-     "zoneToSubnetIdMap": {
-       "ru-central1-a": "<A-SUBNET-ID>",
-       "ru-central1-b": "<B-SUBNET-ID>", 
-       "ru-central1-d": "<D-SUBNET-ID>"
-     },
-     "zones": [
-       "ru-central1-a",
-       "ru-central1-b",
-      "ru-central1-d"
-     ]
-   }
-   ```
+Подключаемые узлы должны иметь доступ к Kubernetes API, DNS и необходимым адресам внешних сервисов, включая container registry. В обратном направлении control plane и системные компоненты кластера должны иметь доступ к подключаемым узлам для работы kubelet, сетевых компонентов, мониторинга и служебных операций Kubernetes.
 
-    Значения параметров:
-    - `internalNetworkIDs` — список ID сетей в Yandex Cloud, через которые обеспечивается внутренняя связность между узлами.
-    - `zoneToSubnetIdMap` — отображение зон на соответствующие подсети внутри указанных сетей (по одной подсети на зону).
-    - `shouldAssignPublicIPAddress: true` — указывает, требуется ли назначать публичные IP-адреса для создаваемых узлов. Для зон, в которых подсети отсутствуют, допустимо использовать значение `empty`.
+Компоненты DKP, взаимодействующие с внешней инфраструктурой, должны иметь доступ к API соответствующего провайдера.
 
-1. Закодируйте полученные выше файлы YandexClusterConfiguration и YandexCloudDiscoveryData в формат Base64. Затем вставьте закодированные строки в поля `cloud-provider-cluster-configuration.yaml` и `cloud-provider-discovery-data.json` секрета, как показано в примере ниже:
+Полный перечень соединений приведён в разделе [«Сетевое взаимодействие»](../../../../reference/network_interaction.html), а рекомендации по ограничениям доступа — в разделе [«Настройка сетевых политик»](../../configuration/network/policy/configuration.html).
 
-   ```yaml
-   apiVersion: v1
-   data:
-     cloud-provider-cluster-configuration.yaml: <YANDEXCLUSTERCONFIGURATION_BASE64_ENCODED>
-     cloud-provider-discovery-data.json: <YANDEXCLOUDDISCOVERYDATA-BASE64-ENCODED>
-   kind: Secret
-   metadata:
-     labels:
-       heritage: deckhouse
-       name: d8-provider-cluster-configuration
-     name: d8-provider-cluster-configuration
-     namespace: kube-system
-   type: Opaque
-   ---
-   apiVersion: deckhouse.io/v1alpha1
-   kind: ModuleConfig
-   metadata:
-     name: cloud-provider-yandex
-   spec:
-     version: 1
-     enabled: true
-     settings:
-       storageClass:
-         default: network-ssd
-   ```
+Дополнительно рекомендуется проверить:
 
-1. Удалите объект `ValidatingAdmissionPolicyBinding`, чтобы избежать конфликтов:
+- маршрутизацию между сетями статических и подключаемых узлов в обоих направлениях;
+- доступность Kubernetes API для подключаемых узлов;
+- доступность подключаемых узлов со стороны control plane и системных компонентов кластера;
+- доступность DNS-серверов и разрешённых внешних адресов;
+- доступность container registry и других внешних сервисов, необходимых для загрузки образов и пакетов;
+- одинаковое значение MTU на всём сетевом пути, особенно при использовании туннелей;
+- параметры инкапсуляции трафика при использовании Cilium, включая [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode), если между площадками применяется фильтрация трафика.
 
-   ```shell
-   d8 k delete validatingadmissionpolicybindings.admissionregistration.k8s.io heritage-label-objects.deckhouse.io
-   ```
-
-1. Примените два созданных на предыдущем шаге манифеста в кластере.
-
-1. После применения дождитесь активации модуля `cloud-provider-yandex` и появления CRD yandexinstanceclasses:
-
-   ```shell
-   d8 k get mc cloud-provider-yandex
-   d8 k get crd yandexinstanceclasses
-   ```
-
-1. Внесите необходимые значения в приведённые ниже манифесты и примените их в кластере. Пример:
-
-   ```yaml
-   ---
-   apiVersion: deckhouse.io/v1alpha1
-   kind: NodeGroup
-   metadata:
-     name: worker
-   spec:
-     nodeType: Cloud
-     cloudInstances:
-       classReference:
-         kind: YandexInstanceClass
-         name: worker
-       minPerZone: 1
-       maxPerZone: 3
-       zones:
-         - ru-central1-d
-   ---
-   apiVersion: deckhouse.io/v1alpha1
-   kind: YandexInstanceClass
-   metadata:
-     name: worker
-   spec:
-     cores: 4
-     memory: 8192
-     diskSizeGB: 50
-     diskType: network-ssd
-     mainSubnet: <YOUR-SUBNET-ID>
-   ```
-
-   Параметр `mainSubnet` должен содержать ID подсети из Yandex Cloud, которая используется для связи с вашей инфраструктурой (L2-связность с группами статических узлов).
-
-   После применения манифестов начнётся заказ виртуальных машин в Yandex Cloud, управляемых модулем `node-manager`.
-
-1. Для диагностики состояния и поиска возможных проблем проверьте логи `machine-controller-manager`:
-
-   ```shell
-   d8 k -n d8-cloud-provider-yandex get machine
-   d8 k -n d8-cloud-provider-yandex get machineset
-   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager
-   ```
-
-## Гибридный кластер с VCD
-
-Далее описан процесс создания гибридного кластера, объединяющего статические (bare-metal) узлы и облачные узлы в VMware vCloud Director (VCD) с использованием Deckhouse Kubernetes Platform (DKP).
-
-### Предварительные требования для VCD
-
-Перед началом убедитесь, что выполнены следующие условия:
-
-- **Инфраструктура**:
-  - Установлен bare-metal кластер DKP.
-  - Настроен тенант в VCD [с выделенными ресурсами](../virtualization/vcd/connection-and-authorization.html).
-  - Настроена сетевая связанность между сетью узлов статического кластера и VCD (на уровне L2, либо на уровне L3 с доступами по портам согласно [необходимым сетевым политикам для работы DKP](../../configuration/network/policy/configuration.html)).
-  - Настроена рабочая сеть в VCD с включённым DHCP-сервером.
-  - Создан пользователь со статичным паролем и правами администратора VCD.
-
-- **Настройки ПО**:
-  - Контроллер CNI переведён в режим VXLAN. Подробнее — [настройка `tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode).
-  - Подготовлен [список необходимых ресурсов VCD](../virtualization/vcd/connection-and-authorization.html) (VDC, VAPP, шаблоны, политики и т.д.).
-
-### Добавление автоматически создаваемых узлов в VCD
-
-1. Создайте файл, например, `cloud-provider-vcd-mc.yaml` с ресурсом ModuleConfig:
-
-   ```yaml
-   apiVersion: deckhouse.io/v1alpha1
-   kind: ModuleConfig
-   metadata:
-     name: cloud-provider-vcd
-   spec:
-     version: 1
-     enabled: true
-     settings:
-       mainNetwork: <NETWORK_NAME>
-       organization: <ORGANIZATION>
-       virtualDataCenter: <VDC_NAME>
-       virtualApplicationName: <VAPP_NAME>
-       sshPublicKey: <SSH_PUBLIC_KEY>
-       provider:
-         server: <API_URL>
-         username: <USER_NAME>
-         password: <PASSWORD>
-         insecure: false
-   ```
-
-   Где:
-   - `mainNetwork` — имя сети, в которой будут размещаться облачные узлы в кластере VCD.
-   - `organization` — название вашей организации в VCD.
-   - `virtualDataCenter` — имя виртуального дата-центра.
-   - `virtualApplicationName` — имя vApp, где будут создаваться узлы (например, `dkp-vcd-app`).
-   - `sshPublicKey` — публичный SSH-ключ для доступа к узлам.
-   - `provider.server` — URL-адрес API вашего VCD.
-   - `provider.username` — имя статического пользователя, от имени которого будет происходить взаимодействие с VCD.
-   - `provider.password` — пароль пользователя с правами администратора в VCD.
-   - `provider.insecure` — установите значение `true`, если VCD использует самоподписанный TLS-сертификат.
-
-   Если для аутентификации используется токен, вместо `username` и `password` укажите `apiToken`:
-
-   ```yaml
-   provider:
-     server: <API_URL>
-     apiToken: <API_TOKEN>
-     username: ""
-     password: ""
-     insecure: false
-   ```
-
-1. Примените ModuleConfig:
-
-   ```shell
-   d8 k apply -f cloud-provider-vcd-mc.yaml
-   d8 k get mc cloud-provider-vcd
-   ```
-
-1. Убедитесь, что все поды в пространстве имён `d8-cloud-provider-vcd` находятся в состоянии `Running`:
-
-   ```shell
-   d8 k get pods -n d8-cloud-provider-vcd
-   ```
-
-1. Убедитесь, что в кластере созданы StorageClass для VCD:
-
-   ```shell
-   d8 k get sc
-   ```
-
-1. Создайте файл, например, `vcd-instanceclass-nodegroup.yaml` с ресурсами [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass) и [NodeGroup](/modules/node-manager/cr.html#nodegroup):
-
-   ```yaml
-   apiVersion: deckhouse.io/v1
-   kind: VCDInstanceClass
-   metadata:
-     name: worker
-   spec:
-     rootDiskSizeGb: 50
-     sizingPolicy: <SIZING_POLICY>
-     storageProfile: <STORAGE_PROFILE>
-     template: <VAPP_TEMPLATE>
-   ---
-   apiVersion: deckhouse.io/v1
-   kind: NodeGroup
-   metadata:
-     name: worker
-   spec:
-     nodeType: CloudEphemeral
-     cloudInstances:
-       classReference:
-         kind: VCDInstanceClass
-         name: worker
-       maxPerZone: 2
-       minPerZone: 1
-     nodeTemplate:
-       labels:
-         node-role/worker: ""
-   ```
-
-1. Примените манифест:
-
-   ```shell
-   d8 k apply -f vcd-instanceclass-nodegroup.yaml
-   ```
-
-   После применения манифеста DKP начнёт создавать виртуальные машины в VCD, управляемые модулем `node-manager`.
-
-1. Убедитесь, что в кластере появилось требуемое количество узлов:
-
-   ```shell
-   d8 k get nodes -o wide
-   ```
-
-1. При сбоях создания ВМ проверьте объекты Machine, MachineSet и логи machine-controller-manager:
-
-   ```shell
-   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
-   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
-   ```
+Конкретные требования к сетям, подсетям, шаблонам виртуальных машин, учётным данным и дополнительным параметрам зависят от используемого провайдера инфраструктуры и приведены в разделе «Предварительные требования» для соответствующего провайдера.

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID.md
@@ -1,0 +1,475 @@
+---
+title: Hybrid cluster with VCD
+permalink: en/admin/integrations/hybrid/vcd-hybrid.html
+---
+
+The following describes the process of adding worker nodes from VMware Cloud Director (VCD) to an existing static DKP cluster.
+
+Integration with VCD uses the [`cloud-provider-vcd`](/modules/cloud-provider-vcd/) module. It provides interaction between DKP and VMware Cloud Director, creation and deletion of virtual machines, retrieval of information about the VCD infrastructure, and integration with StorageClass and other provider capabilities.
+
+This section describes three ways to add worker nodes:
+
+- **Automatic node creation in VCD**. DKP creates virtual machines through the VCD API. VM parameters are defined by the [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass) resource, and the required number of nodes is defined by the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource with the [`CloudEphemeral`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-ephemeral-nodes.html) type.
+- **Connecting manually created nodes through CAPS**. A virtual machine is created by the user in advance, and DKP connects to it over SSH through Cluster API Provider Static. This uses the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource with the `Static` type, as well as the [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) and [StaticInstance](/modules/node-manager/cr.html#staticinstance) resources.
+- **Connecting manually created nodes through a bootstrap script**. A virtual machine is created by the user in advance and connected to the cluster using the DKP bootstrap script. This scenario uses the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource with the [`CloudStatic`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-static-nodes.html) type.
+
+## Prerequisites for VCD
+
+Before you begin, make sure that the following conditions are met:
+
+- The cluster was created with the [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype) parameter.
+- Network connectivity is configured between the network of static nodes and the network of virtual machines in VCD.
+- VCD nodes added to the cluster have access to the Kubernetes API, DNS, and the required addresses according to the [Network interaction](../../../../reference/network_interaction.html) and [Network policy configuration](../../configuration/network/policy/configuration.html) sections.
+- The requirements from the [Connection and authorization in VMware vCloud Director](../virtualization/vcd/connection-and-authorization.html) section are met:
+  - a tenant with allocated resources is configured in VCD
+  - a VCD account with a static password and administrator permissions is prepared
+  - a working network with an enabled DHCP server is configured in VCD
+  - the required VCD resources are prepared: VDC, vApp, templates, policies, and other parameters
+- When using Cilium with pod traffic tunneling, the [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode) mode is selected according to the network connectivity between sites.
+
+## Adding automatically created nodes
+
+1. Create a file, for example `cloud-provider-vcd-mc.yaml`, with a ModuleConfig resource:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-vcd
+   spec:
+     version: 1
+     enabled: true
+     settings:
+       mainNetwork: <NETWORK_NAME>
+       organization: <ORGANIZATION>
+       virtualDataCenter: <VDC_NAME>
+       virtualApplicationName: <VAPP_NAME>
+       sshPublicKey: <SSH_PUBLIC_KEY>
+       provider:
+         server: <API_URL>
+         username: <USER_NAME>
+         password: <PASSWORD>
+         insecure: false
+   ```
+
+   Where:
+
+   - `mainNetwork` — the name of the network where cloud nodes will be placed in VCD
+   - `organization` — the Organization name in VCD
+   - `virtualDataCenter` — the Virtual Data Center name in VCD
+   - `virtualApplicationName` — the name of the vApp where nodes will be created, for example `dkp-vcd-app`
+   - `sshPublicKey` — the public SSH key for accessing the nodes
+   - `provider.server` — the VCD API URL
+   - `provider.username` — the VCD username
+   - `provider.password` — the VCD user password
+   - `provider.insecure` — set to `true` if VCD uses a self-signed TLS certificate
+
+   If a token is used for authentication, specify `apiToken` instead of `username` and `password`:
+
+   ```yaml
+   provider:
+     server: <API_URL>
+     apiToken: <API_TOKEN>
+     username: ""
+     password: ""
+     insecure: false
+   ```
+
+1. Apply the ModuleConfig:
+
+   ```shell
+   d8 k apply -f cloud-provider-vcd-mc.yaml
+   d8 k get mc cloud-provider-vcd
+   ```
+
+1. Make sure that all pods in the `d8-cloud-provider-vcd` namespace are in the `Running` state:
+
+   ```shell
+   d8 k get pods -n d8-cloud-provider-vcd
+   ```
+
+1. Make sure that StorageClasses for VCD have been created in the cluster:
+
+   ```shell
+   d8 k get sc
+   ```
+
+1. Create a file, for example `vcd-instanceclass-nodegroup.yaml`, with the [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass) and [NodeGroup](/modules/node-manager/cr.html#nodegroup) resources:
+
+   ```yaml
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: VCDInstanceClass
+   metadata:
+     name: worker
+   spec:
+     rootDiskSizeGb: 50
+     sizingPolicy: <SIZING_POLICY>
+     storageProfile: <STORAGE_PROFILE>
+     template: <VAPP_TEMPLATE>
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: worker
+   spec:
+     nodeType: CloudEphemeral
+     cloudInstances:
+       classReference:
+         kind: VCDInstanceClass
+         name: worker
+       maxPerZone: 2
+       minPerZone: 1
+     nodeTemplate:
+       labels:
+         node-role/worker: ""
+   ```
+
+1. Apply the manifest:
+
+   ```shell
+   d8 k apply -f vcd-instanceclass-nodegroup.yaml
+   ```
+
+   After the manifest is applied, DKP will start creating virtual machines in VCD managed by the `node-manager` module.
+
+1. Make sure that the required number of nodes has appeared in the cluster:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+1. If VM creation fails, check the Machine and MachineSet objects and the machine-controller-manager logs:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```
+
+## Adding manually created nodes through CAPS
+
+Before you begin, make sure that the following conditions are met:
+
+- The [`cloud-provider-vcd`](/modules/cloud-provider-vcd/) module is enabled and configured.
+- The `cloud-provider-vcd` module components are in the `Running` state:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vcd get pods -o wide
+  ```
+
+- StorageClasses for VCD have been created in the cluster:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- A virtual machine that will be connected to the cluster has been created in VCD.
+- The virtual machine name in VCD matches the hostname inside the operating system.
+- The following value is set in the VM advanced parameters in VCD:
+
+  ```text
+  disk.EnableUUID = 1
+  ```
+
+- The virtual machine is connected to the VCD network used as the main network for the cluster's cloud nodes. Usually, this is the network specified in the [`mainNetwork`](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass-v1-spec-mainnetwork) parameter of the `cloud-provider-vcd` configuration or in the VCDInstanceClass being used.
+- The virtual machine has administrative SSH access for initial configuration of the user that CAPS will use to connect to the node, or such a user has already been created in advance.
+- The SSH user can run commands through `sudo` without entering a password.
+- The virtual machine has the required base packages installed for the supported OS. For RED OS, install `which` and the package manager in advance if they are missing.
+
+1. On the master node, set the variables for the NodeGroup being created and the virtual machine being connected:
+
+   ```shell
+   export NODE_GROUP="vcd-caps"
+   export NODE_NAME="vcd-worker-caps"
+   export NODE_SSH_IP="<NODE_IP>"
+   export CAPS_USER="caps"
+   ```
+
+   Where:
+
+   - `NODE_GROUP` — the name of the NodeGroup to which the node will be added;
+   - `NODE_NAME` — the name of the node being connected. It must match the hostname inside the operating system and the VM name in VCD;
+   - `NODE_SSH_IP` — the IP address of the virtual machine available over SSH;
+   - `CAPS_USER` — the user that CAPS will use to connect to the virtual machine.
+
+1. On the master node, create a NodeGroup:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     nodeType: Static
+     staticInstances:
+       count: 1
+       labelSelector:
+         matchLabels:
+           role: ${NODE_GROUP}
+   EOF
+   ```
+
+   This scenario uses `nodeType: Static` because the virtual machine has already been created manually, and CAPS will only connect to it over SSH and configure it.
+
+1. Make sure that the NodeGroup has been created and synchronized:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME       TYPE     READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   vcd-caps   Static   0       0       0                                                               1m    True
+   ```
+
+1. On the master node, generate the SSH key that CAPS will use to connect to the virtual machine:
+
+   ```shell
+   ssh-keygen -t ed25519 \
+     -f /dev/shm/${NODE_GROUP}-id \
+     -C "" \
+     -N ""
+   ```
+
+   {% alert level="info" %}
+   The key is created with an empty passphrase because CAPS must use it automatically.
+   {% endalert %}  
+
+1. On the master node, create an [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) resource:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: SSHCredentials
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     user: ${CAPS_USER}
+     privateSSHKey: "$(base64 -w0 /dev/shm/${NODE_GROUP}-id)"
+   EOF
+   ```
+
+   The SSHCredentials resource stores the username and private SSH key that CAPS will use to connect to the virtual machine.
+
+1. Make sure that the SSHCredentials resource has been created:
+
+   ```shell
+   d8 k get sshcredentials
+   d8 k describe sshcredentials ${NODE_GROUP}
+   ```
+
+1. On the master node, print the public part of the SSH key:
+
+   ```shell
+   cat /dev/shm/${NODE_GROUP}-id.pub
+   ```
+
+   This key will be needed in the next step to configure the user on the virtual machine being connected.
+
+1. On the virtual machine being connected, create the user that CAPS will use to configure the node. Run the commands on the virtual machine being connected, specifying the public SSH key obtained in the previous step:
+
+   ```shell
+   export CAPS_USER="caps"
+   export KEY='<SSH_PUBLIC_KEY>'
+
+   useradd -m -s /bin/bash ${CAPS_USER}
+   usermod -aG sudo ${CAPS_USER}
+
+   echo "${CAPS_USER} ALL=(ALL) NOPASSWD: ALL" | EDITOR='tee -a' visudo
+
+   mkdir -p /home/${CAPS_USER}/.ssh
+   echo "${KEY}" > /home/${CAPS_USER}/.ssh/authorized_keys
+
+   chown -R ${CAPS_USER}:${CAPS_USER} /home/${CAPS_USER}
+   chmod 700 /home/${CAPS_USER}/.ssh
+   chmod 600 /home/${CAPS_USER}/.ssh/authorized_keys
+   ```
+
+   {% alert level="info" %}
+   The `KEY` value must be specified in quotes because the public SSH key contains spaces.
+   {% endalert %}
+
+   {% alert level="info" %}
+   For operating systems of the Astra Linux family, when using the Parsec mandatory integrity control module, additionally set the maximum integrity level for the user:
+
+   ```shell
+   pdpl-user -i 63 ${CAPS_USER}
+   ```
+
+   {% endalert %}
+
+1. On the master node, check that the CAPS user can connect to the virtual machine over SSH and run commands through `sudo` without a password:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'hostname; sudo -n true; echo OK'
+   ```
+
+   The output must contain the node name and the `OK` line.  
+
+1. On the master node, create a [StaticInstance](/modules/node-manager/cr.html#staticinstance) resource for the virtual machine being connected:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: StaticInstance
+   metadata:
+     name: ${NODE_NAME}
+     labels:
+       role: ${NODE_GROUP}
+   spec:
+     address: "${NODE_SSH_IP}"
+     credentialsRef:
+       kind: SSHCredentials
+       name: ${NODE_GROUP}
+   EOF
+   ```
+
+   Where:
+
+   - `metadata.name` — the name of the node being connected
+   - `metadata.labels.role` — the label by which NodeGroup selects this StaticInstance
+   - `spec.address` — the IP address of the virtual machine available over SSH
+   - `spec.credentialsRef.name` — the name of the SSHCredentials resource created earlier
+
+1. Check the StaticInstance status:
+
+   ```shell
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+   ```
+
+1. Wait for the node to connect and check its status:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME             STATUS   ROLES      AGE   VERSION    INTERNAL-IP      EXTERNAL-IP
+   static-master-0  Ready    master     1h    v1.33.10   192.168.240.138  <none>
+   vcd-worker-caps  Ready    vcd-caps   5m    v1.33.10   192.168.240.151  <none>
+   ```
+
+1. If connection fails, check the NodeGroup, StaticInstance, Machine status, and cluster events:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+
+   d8 k -n d8-cloud-instance-manager get machines,machinesets,machinedeployments -o wide
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Adding manually created nodes through a bootstrap script
+
+Before you begin, make sure that the following conditions are met:
+
+- The [`cloud-provider-vcd`](/modules/cloud-provider-vcd/) module is enabled and configured.
+- The `cloud-provider-vcd` module components are in the `Running` state:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vcd get pods -o wide
+  ```
+
+- StorageClasses for VCD have been created in the cluster:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- A virtual machine that will be connected to the cluster has been created in VCD.
+- The virtual machine name in VCD matches the hostname inside the operating system.
+- The following value is set in the VM advanced parameters in VCD:
+
+  ```text
+  disk.EnableUUID = 1
+  ```
+
+- The virtual machine is connected to the VCD network used as the main network for the cluster's cloud nodes. Usually, this is the network specified in the [`mainNetwork`](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass-v1-spec-mainnetwork) parameter of the `cloud-provider-vcd` configuration or in the VCDInstanceClass being used.
+- The virtual machine has the required base packages installed for the supported OS. For RED OS, install `which` and the package manager in advance if they are missing.
+
+1. Create a file, for example `cloud-static-nodegroup.yaml`, with a NodeGroup resource and the CloudStatic node type:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: cloud-static
+   spec:
+     nodeType: CloudStatic
+   ```
+
+1. Apply the manifest:
+
+   ```shell
+   d8 k apply -f cloud-static-nodegroup.yaml
+   ```
+
+1. Make sure that the NodeGroup has been created and synchronized:
+
+   ```shell
+   d8 k get nodegroup cloud-static
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME           TYPE          READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   cloud-static   CloudStatic   0       0       0                                                               1m    True
+   ```
+
+1. Get the bootstrap script for the created NodeGroup:
+
+   ```shell
+   NODE_GROUP=cloud-static
+
+   d8 k -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} \
+     -o jsonpath='{.data.bootstrap\.sh}' > bootstrap.b64
+   ```
+
+1. Copy the bootstrap script to the virtual machine being connected:
+
+   ```shell
+   scp bootstrap.b64 <USER>@<NODE_IP>:/tmp/bootstrap.b64
+   ```
+
+1. Connect to the virtual machine over SSH:
+
+   ```shell
+   ssh <USER>@<NODE_IP>
+   ```
+
+1. On the virtual machine, set permissions and run the bootstrap script:
+
+   ```shell
+   base64 -d /tmp/bootstrap.b64 > /tmp/bootstrap.sh
+   chmod +x /tmp/bootstrap.sh
+
+   sudo bash /tmp/bootstrap.sh
+   ```
+
+   After the bootstrap script is started, it will install the required components, configure the container runtime and kubelet, and connect the node to the cluster.
+
+1. On the master node, check that the new node has appeared:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME                       STATUS   ROLES          AGE   VERSION    INTERNAL-IP
+   static-master-0            Ready    master         1h    v1.33.10   192.168.240.138
+   cloud-static-worker-0      Ready    cloud-static   5m    v1.33.10   192.168.240.151
+   ```

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/VCD_HYBRID_RU.md
@@ -1,0 +1,475 @@
+---
+title: Гибридный кластер с VCD
+permalink: ru/admin/integrations/hybrid/vcd-hybrid.html
+lang: ru
+---
+
+Далее описан процесс добавления worker-узлов из VMware Cloud Director (VCD) в существующий статический кластер DKP.
+
+Для интеграции с VCD используется модуль [`cloud-provider-vcd`](/modules/cloud-provider-vcd/). Он обеспечивает взаимодействие DKP с VMware Cloud Director, создание и удаление виртуальных машин, получение информации об инфраструктуре VCD, а также интеграцию со StorageClass и другими возможностями провайдера.
+
+В разделе описаны три способа добавления worker-узлов:
+
+- **Автоматическое создание узлов в VCD**. DKP создаёт виртуальные машины через API VCD. Параметры ВМ задаются ресурсом [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass), а требуемое количество узлов — ресурсом [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом [`CloudEphemeral`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-ephemeral-nodes.html).
+- **Подключение вручную созданных узлов через CAPS**. Виртуальная машина создаётся пользователем заранее, а DKP подключается к ней по SSH через Cluster API Provider Static. Для этого используются ресурс [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом `Static`, а также ресурсы [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) и [StaticInstance](/modules/node-manager/cr.html#staticinstance).
+- **Подключение вручную созданных узлов через bootstrap-скрипт**. Виртуальная машина создаётся пользователем заранее и подключается к кластеру с помощью bootstrap-скрипта DKP. Для такого сценария используется [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом [`CloudStatic`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-static-nodes.html).
+
+## Предварительные требования для VCD
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Кластер создан с параметром [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype).
+- Между сетью статических узлов и сетью виртуальных машин в VCD настроена сетевая связность.
+- Узлы VCD, добавляемые в кластер, имеют доступ к Kubernetes API, DNS и необходимым адресам согласно разделам [Сетевое взаимодействие](../../../../reference/network_interaction.html) и [Настройка сетевых политик](../../configuration/network/policy/configuration.html).
+- Выполнены требования из раздела [Подключение и авторизация в VMware vCloud Director](../virtualization/vcd/connection-and-authorization.html):
+  - настроен тенант в VCD с выделенными ресурсами;
+  - подготовлена учётная запись VCD со статичным паролем и правами администратора;
+  - настроена рабочая сеть в VCD с включённым DHCP-сервером;
+  - подготовлены необходимые ресурсы VCD: VDC, vApp, шаблоны, политики и другие параметры.
+- При использовании Cilium с туннелированием трафика подов выбран режим [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode), соответствующий сетевой связности между площадками.
+
+## Добавление автоматически создаваемых узлов
+
+1. Создайте файл, например, `cloud-provider-vcd-mc.yaml` с ресурсом ModuleConfig:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-vcd
+   spec:
+     version: 1
+     enabled: true
+     settings:
+       mainNetwork: <NETWORK_NAME>
+       organization: <ORGANIZATION>
+       virtualDataCenter: <VDC_NAME>
+       virtualApplicationName: <VAPP_NAME>
+       sshPublicKey: <SSH_PUBLIC_KEY>
+       provider:
+         server: <API_URL>
+         username: <USER_NAME>
+         password: <PASSWORD>
+         insecure: false
+   ```
+
+   Где:
+   - `mainNetwork` — имя сети, в которой будут размещаться облачные узлы в VCD;
+   - `organization` — имя Organization в VCD;
+   - `virtualDataCenter` — имя Virtual Data Center в VCD;
+   - `virtualApplicationName` — имя vApp, где будут создаваться узлы, например `dkp-vcd-app`;
+   - `sshPublicKey` — публичный SSH-ключ для доступа к узлам;
+   - `provider.server` — URL-адрес API VCD;
+   - `provider.username` — имя пользователя VCD;
+   - `provider.password` — пароль пользователя VCD;
+   - `provider.insecure` — установите значение `true`, если VCD использует самоподписанный TLS-сертификат.
+
+   Если для аутентификации используется токен, вместо `username` и `password` укажите `apiToken`:
+
+   ```yaml
+   provider:
+     server: <API_URL>
+     apiToken: <API_TOKEN>
+     username: ""
+     password: ""
+     insecure: false
+   ```
+
+1. Примените ModuleConfig:
+
+   ```shell
+   d8 k apply -f cloud-provider-vcd-mc.yaml
+   d8 k get mc cloud-provider-vcd
+   ```
+
+1. Убедитесь, что все поды в неймспейсе `d8-cloud-provider-vcd` находятся в состоянии `Running`:
+
+   ```shell
+   d8 k get pods -n d8-cloud-provider-vcd
+   ```
+
+1. Убедитесь, что в кластере созданы StorageClass для VCD:
+
+   ```shell
+   d8 k get sc
+   ```
+
+1. Создайте файл, например, `vcd-instanceclass-nodegroup.yaml` с ресурсами [VCDInstanceClass](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass) и [NodeGroup](/modules/node-manager/cr.html#nodegroup):
+
+   ```yaml
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: VCDInstanceClass
+   metadata:
+     name: worker
+   spec:
+     rootDiskSizeGb: 50
+     sizingPolicy: <SIZING_POLICY>
+     storageProfile: <STORAGE_PROFILE>
+     template: <VAPP_TEMPLATE>
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: worker
+   spec:
+     nodeType: CloudEphemeral
+     cloudInstances:
+       classReference:
+         kind: VCDInstanceClass
+         name: worker
+       maxPerZone: 2
+       minPerZone: 1
+     nodeTemplate:
+       labels:
+         node-role/worker: ""
+   ```
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f vcd-instanceclass-nodegroup.yaml
+   ```
+
+   После применения манифеста DKP начнёт создавать виртуальные машины в VCD, управляемые модулем `node-manager`.
+
+1. Убедитесь, что в кластере появилось требуемое количество узлов:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+1. При сбоях создания ВМ проверьте объекты Machine, MachineSet и логи machine-controller-manager:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```
+
+## Добавление вручную созданных узлов через CAPS
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-vcd`](/modules/cloud-provider-vcd/) включён и настроен.
+- Компоненты модуля `cloud-provider-vcd` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vcd get pods -o wide
+  ```
+
+- В кластере созданы StorageClass для VCD:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- В VCD создана виртуальная машина, которая будет подключена к кластеру.
+- Имя виртуальной машины в VCD совпадает с hostname внутри операционной системы.
+- В дополнительных параметрах ВМ в VCD задано значение:
+
+  ```text
+  disk.EnableUUID = 1
+  ```
+
+- Виртуальная машина подключена к сети VCD, используемой как основная сеть для облачных узлов кластера. Обычно это сеть, указанная в параметре [`mainNetwork`](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass-v1-spec-mainnetwork) конфигурации `cloud-provider-vcd` или в используемом VCDInstanceClass.
+- На виртуальной машине есть административный SSH-доступ для первичной настройки пользователя, под которым CAPS будет подключаться к узлу, либо такой пользователь уже создан заранее.
+- Пользователь для подключения по SSH может выполнять команды через `sudo` без ввода пароля.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+1. На master-узле задайте переменные для создаваемой NodeGroup и подключаемой виртуальной машины:
+
+   ```shell
+   export NODE_GROUP="vcd-caps"
+   export NODE_NAME="vcd-worker-caps"
+   export NODE_SSH_IP="<NODE_IP>"
+   export CAPS_USER="caps"
+   ```
+
+   Где:
+
+   - `NODE_GROUP` — имя NodeGroup, в которую будет добавлен узел;
+   - `NODE_NAME` — имя подключаемого узла. Оно должно совпадать с hostname внутри операционной системы и именем ВМ в VCD;
+   - `NODE_SSH_IP` — IP-адрес виртуальной машины, доступный по SSH;
+   - `CAPS_USER` — пользователь, под которым CAPS будет подключаться к виртуальной машине.
+
+1. На master-узле создайте NodeGroup:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     nodeType: Static
+     staticInstances:
+       count: 1
+       labelSelector:
+         matchLabels:
+           role: ${NODE_GROUP}
+   EOF
+   ```
+
+   В этом сценарии используется `nodeType: Static`, потому что виртуальная машина уже создана вручную, а CAPS будет только подключать и настраивать её по SSH.
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME       TYPE     READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   vcd-caps   Static   0       0       0                                                               1m    True
+   ```
+
+1. На master-узле сгенерируйте SSH-ключ, который CAPS будет использовать для подключения к виртуальной машине:
+
+   ```shell
+   ssh-keygen -t ed25519 \
+     -f /dev/shm/${NODE_GROUP}-id \
+     -C "" \
+     -N ""
+   ```
+
+   {% alert level="info" %}
+   Ключ создаётся с пустой парольной фразой, так как CAPS должен использовать его автоматически.
+   {% endalert %}  
+
+1. На master-узле создайте ресурс [SSHCredentials](/modules/node-manager/cr.html#sshcredentials):
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: SSHCredentials
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     user: ${CAPS_USER}
+     privateSSHKey: "$(base64 -w0 /dev/shm/${NODE_GROUP}-id)"
+   EOF
+   ```
+
+   Ресурс SSHCredentials хранит имя пользователя и приватный SSH-ключ, с помощью которых CAPS будет подключаться к виртуальной машине.
+
+1. Убедитесь, что ресурс SSHCredentials создан:
+
+   ```shell
+   d8 k get sshcredentials
+   d8 k describe sshcredentials ${NODE_GROUP}
+   ```
+
+1. На master-узле выведите публичную часть SSH-ключа:
+
+   ```shell
+   cat /dev/shm/${NODE_GROUP}-id.pub
+   ```
+
+   Этот ключ понадобится на следующем шаге для настройки пользователя на подключаемой виртуальной машине.
+
+1. На подключаемой виртуальной машине создайте пользователя, под которым CAPS будет выполнять настройку узла. Выполните команды на подключаемой виртуальной машине, указав публичный SSH-ключ, полученный на предыдущем шаге:
+
+   ```shell
+   export CAPS_USER="caps"
+   export KEY='<SSH_PUBLIC_KEY>'
+
+   useradd -m -s /bin/bash ${CAPS_USER}
+   usermod -aG sudo ${CAPS_USER}
+
+   echo "${CAPS_USER} ALL=(ALL) NOPASSWD: ALL" | EDITOR='tee -a' visudo
+
+   mkdir -p /home/${CAPS_USER}/.ssh
+   echo "${KEY}" > /home/${CAPS_USER}/.ssh/authorized_keys
+
+   chown -R ${CAPS_USER}:${CAPS_USER} /home/${CAPS_USER}
+   chmod 700 /home/${CAPS_USER}/.ssh
+   chmod 600 /home/${CAPS_USER}/.ssh/authorized_keys
+   ```
+
+   {% alert level="info" %}
+   Значение `KEY` необходимо указывать в кавычках, так как публичный SSH-ключ содержит пробелы.
+   {% endalert %}
+
+   {% alert level="info" %}
+   Для операционных систем семейства Astra Linux при использовании модуля мандатного контроля целостности Parsec дополнительно задайте максимальный уровень целостности для пользователя:
+
+   ```shell
+   pdpl-user -i 63 ${CAPS_USER}
+   ```
+
+   {% endalert %}
+
+1. На master-узле проверьте, что CAPS-пользователь может подключиться к виртуальной машине по SSH и выполнять команды через `sudo` без пароля:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'hostname; sudo -n true; echo OK'
+   ```
+
+   В выводе должно быть имя узла и строка `OK`.  
+
+1. На master-узле создайте ресурс [StaticInstance](/modules/node-manager/cr.html#staticinstance) для подключаемой виртуальной машины:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: StaticInstance
+   metadata:
+     name: ${NODE_NAME}
+     labels:
+       role: ${NODE_GROUP}
+   spec:
+     address: "${NODE_SSH_IP}"
+     credentialsRef:
+       kind: SSHCredentials
+       name: ${NODE_GROUP}
+   EOF
+   ```
+
+   Где:
+
+   - `metadata.name` — имя подключаемого узла;
+   - `metadata.labels.role` — лейбл, по которому NodeGroup выбирает этот StaticInstance;
+   - `spec.address` — IP-адрес виртуальной машины, доступный по SSH;
+   - `spec.credentialsRef.name` — имя созданного ранее ресурса SSHCredentials.
+
+1. Проверьте состояние StaticInstance:
+
+   ```shell
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+   ```
+
+1. Дождитесь подключения узла и проверьте его состояние:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME             STATUS   ROLES      AGE   VERSION    INTERNAL-IP      EXTERNAL-IP
+   static-master-0  Ready    master     1h    v1.33.10   192.168.240.138  <none>
+   vcd-worker-caps  Ready    vcd-caps   5m    v1.33.10   192.168.240.151  <none>
+   ```
+
+1. При сбоях подключения проверьте состояние NodeGroup, StaticInstance, Machine и события в кластере:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+
+   d8 k -n d8-cloud-instance-manager get machines,machinesets,machinedeployments -o wide
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Добавление вручную созданных узлов через bootstrap-скрипт
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-vcd`](/modules/cloud-provider-vcd/) включён и настроен.
+- Компоненты модуля `cloud-provider-vcd` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vcd get pods -o wide
+  ```
+
+- В кластере созданы StorageClass для VCD:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- В VCD создана виртуальная машина, которая будет подключена к кластеру.
+- Имя виртуальной машины в VCD совпадает с hostname внутри операционной системы.
+- В дополнительных параметрах ВМ в VCD задано значение:
+
+  ```text
+  disk.EnableUUID = 1
+  ```
+
+- Виртуальная машина подключена к сети VCD, используемой как основная сеть для облачных узлов кластера. Обычно это сеть, указанная в параметре [`mainNetwork`](/modules/cloud-provider-vcd/cr.html#vcdinstanceclass-v1-spec-mainnetwork) конфигурации `cloud-provider-vcd` или в используемом VCDInstanceClass.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+1. Создайте файл, например `cloud-static-nodegroup.yaml`, с ресурсом NodeGroup и типом узлов CloudStatic:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: cloud-static
+   spec:
+     nodeType: CloudStatic
+   ```
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f cloud-static-nodegroup.yaml
+   ```
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup cloud-static
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME           TYPE          READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   cloud-static   CloudStatic   0       0       0                                                               1m    True
+   ```
+
+1. Получите bootstrap-скрипт для созданной NodeGroup:
+
+   ```shell
+   NODE_GROUP=cloud-static
+
+   d8 k -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} \
+     -o jsonpath='{.data.bootstrap\.sh}' > bootstrap.b64
+   ```
+
+1. Скопируйте bootstrap-скрипт на подключаемую виртуальную машину:
+
+   ```shell
+   scp bootstrap.b64 <USER>@<NODE_IP>:/tmp/bootstrap.b64
+   ```
+
+1. Подключитесь к виртуальной машине по SSH:
+
+   ```shell
+   ssh <USER>@<NODE_IP>
+   ```
+
+1. На виртуальной машине назначьте права и запустите bootstrap-скрипт:
+
+   ```shell
+   base64 -d /tmp/bootstrap.b64 > /tmp/bootstrap.sh
+   chmod +x /tmp/bootstrap.sh
+
+   sudo bash /tmp/bootstrap.sh
+   ```
+
+   После запуска bootstrap-скрипт установит необходимые компоненты, настроит container runtime, kubelet и подключит узел к кластеру.
+
+1. На master-узле проверьте появление нового узла:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                       STATUS   ROLES          AGE   VERSION    INTERNAL-IP
+   static-master-0            Ready    master         1h    v1.33.10   192.168.240.138
+   cloud-static-worker-0      Ready    cloud-static   5m    v1.33.10   192.168.240.151
+   ```

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/VSPHERE_HYBRID.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/VSPHERE_HYBRID.md
@@ -1,0 +1,579 @@
+---
+title: Hybrid cluster with vSphere
+permalink: en/admin/integrations/hybrid/vsphere-hybrid.html
+---
+
+The following describes the process of adding worker nodes from vSphere to an existing static DKP cluster.
+
+Integration with vSphere uses the [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/) module. It provides interaction between DKP and vCenter, retrieval of information about virtual machines, work with placement parameters, and integration with vSphere infrastructure capabilities.
+
+This section describes three ways to add worker nodes:
+
+- **Automatic node creation in vSphere**. DKP creates virtual machines through the vSphere API. VM parameters are defined by the [VsphereInstanceClass](/modules/cloud-provider-vsphere/cr.html#vsphereinstanceclass) resource, and the required number of nodes and placement zones are defined by the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource with the [`CloudEphemeral`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-ephemeral-nodes.html) type.
+- **Connecting manually created nodes through CAPS**. A virtual machine is created by the user in advance, and DKP connects to it over SSH through Cluster API Provider Static. This uses NodeGroup resources with the `Static` type, as well as SSHCredentials and StaticInstance resources.
+- **Connecting manually created nodes through a bootstrap script**. A virtual machine is created by the user in advance and connected to the cluster using the DKP bootstrap script. This scenario uses the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource with the [`CloudStatic`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-static-nodes.html) type.
+
+## Prerequisites for vSphere
+
+Before you begin, make sure that the following conditions are met:
+
+- The cluster was created with the [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype) parameter.
+- Network connectivity is configured between the network of static nodes and the network of virtual machines in vSphere.
+- vSphere nodes added to the cluster have access to the Kubernetes API, DNS, and the required addresses according to the [Network interaction](../../../../reference/network_interaction.html) and [Network policy configuration](../../configuration/network/policy/configuration.html) sections.
+- The requirements from the [Connection and authorization in VMware vSphere](../virtualization/vsphere/authorization.html) section are met:
+  - access to vCenter is configured
+  - a vSphere account with the required privileges is prepared
+  - a virtual machine template is prepared
+  - networks, Datastore, region tags, and zone tags are configured
+- When using Cilium with pod traffic tunneling, the [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode) mode is selected according to the network connectivity between sites.
+
+## Adding automatically created nodes
+
+To connect an already running static cluster to vCenter, use the [ModuleConfig](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#moduleconfig) resource of the [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/) module.
+
+In the `spec.settings` parameter, specify access parameters for vCenter, network settings, region and zone tags, and SSH keys that will be added to the created virtual machines.
+
+An example configuration and description of the available parameters are provided in the [module examples](/modules/cloud-provider-vsphere/examples.html) and in the [Configuration of the `cloud-provider-vsphere` module](/modules/cloud-provider-vsphere/configuration.html) section.
+
+1. Create a file, for example `vsphere-mc.yaml`, with ModuleConfig for the [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/) module:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-vsphere
+   spec:
+     version: 2
+     enabled: true
+     settings:
+       host: "<VCENTER_FQDN>"
+       username: "<USERNAME@DOMAIN.LOCAL>"
+       password: "<PASSWORD>"
+       insecure: true
+       vmFolderPath: "<FOLDER_PATH_UNDER_DATACENTER>"
+       regionTagCategory: "<TAG_CATEGORY_FOR_REGION>"
+       zoneTagCategory: "<TAG_CATEGORY_FOR_ZONE>"
+       region: "<REGION_TAG_NAME_ON_DATACENTER>"
+       zones:
+         - "<ZONE_TAG_NAME_ON_CLUSTER>"
+       internalNetworkNames:
+         - "<PORT_GROUP_NAME_FOR_INTERNAL_IP>"
+       sshKeys:
+         - "<SSH_PUBLIC_KEY_ONE_LINE>"
+   ```
+
+   Parameter values:
+
+   - `host` — vCenter address
+   - `username`, `password` — vSphere user credentials
+   - `insecure` — disables verification of the vCenter TLS certificate
+   - `vmFolderPath` — the folder where virtual machines will be created
+   - `regionTagCategory`, `zoneTagCategory` — region and zone tag categories
+   - `region` — region tag
+   - `zones` — list of zones where nodes can be created
+   - `internalNetworkNames` — list of vSphere networks for connecting created nodes
+   - `sshKeys` — public SSH keys that will be added to the created virtual machines
+
+1. Apply the module configuration:
+
+   ```shell
+   d8 k apply -f vsphere-mc.yaml
+   ```
+
+1. Wait for the `cloud-provider-vsphere` module to become ready:
+
+   ```shell
+   d8 k get moduleconfig cloud-provider-vsphere
+   d8 k get pods -n d8-cloud-provider-vsphere -o wide
+   ```
+
+1. Create a file, for example `vsphere-instance.yaml`, with the [VsphereInstanceClass](/modules/cloud-provider-vsphere/cr.html#vsphereinstanceclass) and [NodeGroup](/modules/node-manager/cr.html#nodegroup) resources with the `nodeType: CloudEphemeral` value:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: VsphereInstanceClass
+   metadata:
+     name: ephemeral
+   spec:
+     numCPUs: 2
+     memory: 4096
+     rootDiskSize: 40
+     template: "<PATH_TO_TEMPLATE_FROM_DATACENTER>"
+     mainNetwork: "<PORT_GROUP_NAME>"
+     datastore: "<DATASTORE_OR_FOLDER/DATASTORE>"
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ephemeral
+   spec:
+     nodeType: CloudEphemeral
+     cloudInstances:
+       classReference:
+         kind: VsphereInstanceClass
+         name: ephemeral
+       maxPerZone: 1
+       minPerZone: 1
+       zones:
+         - "<ZONE_TAG_NAME_ON_CLUSTER>"
+     disruptions:
+       approvalMode: Automatic
+   ```
+
+   Where:
+
+   - [VsphereInstanceClass](/modules/cloud-provider-vsphere/cr.html#vsphereinstanceclass) describes the parameters of the virtual machine that will be created in vSphere;
+   - [NodeGroup](/modules/node-manager/cr.html#nodegroup) describes the node group that DKP must maintain in the cluster;
+   - `nodeType: CloudEphemeral` means that nodes will be created automatically through the cloud provider;
+   - `cloudInstances.classReference` points to VsphereInstanceClass;
+   - `cloudInstances.zones` must contain zones from the `zones` list in ModuleConfig.
+
+1. Apply the manifest:
+
+   ```shell
+   d8 k apply -f vsphere-instance.yaml
+   ```
+
+   After the manifest is applied, DKP will start creating a virtual machine in vSphere. After the VM boots, kubelet will connect to the Kubernetes API, and the new node will appear in the cluster.
+
+1. Check the node status:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME                             STATUS   ROLES                  AGE   VERSION
+   static-master-0                  Ready    control-plane,master   1h    v1.33.10
+   ephemeral-1ca02a5b-7588b-k89dc   Ready    ephemeral              10m   v1.33.10
+   ```
+
+1. If VM creation fails, check the Machine and MachineSet objects and the machine-controller-manager logs:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```
+
+   Also check the cluster events:
+
+   ```shell
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Adding manually created nodes through CAPS
+
+Before you begin, make sure that the following conditions are met:
+
+- The [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/) module is enabled and configured.
+- The `cloud-provider-vsphere` module components are in the `Running` state:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vsphere get pods -o wide
+  ```
+
+- StorageClasses for vSphere have been created in the cluster:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- A virtual machine that will be connected to the cluster has been created in vSphere.
+- The virtual machine name in vSphere, the local-hostname value in the metadata, and the hostname inside the operating system match.
+- The following parameter is set in the VM advanced parameters in vSphere:
+
+  ```text
+  disk.EnableUUID = TRUE
+  ```
+
+- The virtual machine is connected to the network specified in the [`internalNetworkNames`](/modules/cloud-provider-vsphere/cluster_configuration.html#vsphereclusterconfiguration-internalnetworknames) parameter of the `cloud-provider-vsphere` module configuration.
+- The virtual machine has administrative SSH access for initial configuration of the user that CAPS will use to connect to the node, or such a user has already been created in advance.
+- The SSH user can run commands through `sudo` without entering a password.
+- The virtual machine has the required base packages installed for the supported OS. For RED OS, install `which` and the package manager in advance if they are missing.
+
+{% offtopic title="Passing metadata to a VM through vSphere..." %}
+For preliminary virtual machine configuration, you can use cloud-init through vSphere metadata. For example, metadata can be used to configure the hostname, network, and SSH keys.
+
+In this case, set the following VM advanced parameters:
+
+```text
+guestinfo.metadata = <BASE64_ENCODED_METADATA>
+guestinfo.metadata.encoding = base64
+```
+
+Example `metadata.json` file:
+
+```json
+{
+  "instance-id": "vsphere-worker-caps",
+  "local-hostname": "vsphere-worker-caps",
+  "public-keys-data": "<SSH_PUBLIC_KEY>",
+  "network": {
+    "version": 2,
+    "ethernets": {
+      "id0": {
+        "match": {
+          "driver": "vmxnet3"
+        },
+        "set-name": "ens192",
+        "dhcp4": true
+      }
+    }
+  }
+}
+```
+
+Where:
+
+- `instance-id` — virtual machine identifier;
+- `local-hostname` — node hostname inside the operating system;
+- `public-keys-data` — public SSH key for accessing the virtual machine;
+- `network` — network settings that will be applied inside the virtual machine.
+
+To get the value for the `guestinfo.metadata` parameter, run:
+
+```shell
+METADATA_B64="$(base64 -w0 metadata.json)"
+echo "$METADATA_B64"
+```
+
+Using `guestinfo.metadata` is not a mandatory CAPS requirement. The main requirement is that by the time the StaticInstance resource is created, the virtual machine is available over SSH, has the correct hostname, and the connection user can run commands through `sudo` without a password.
+{% endofftopic %}
+
+1. On the master node, set the variables for the NodeGroup being created and the virtual machine being connected:
+
+   ```shell
+   export NODE_GROUP="vsphere-caps"
+   export NODE_NAME="vsphere-worker-caps"
+   export NODE_SSH_IP="<NODE_IP>"
+   export CAPS_USER="caps"
+   ```
+
+   Where:
+
+   - `NODE_GROUP` — the name of the NodeGroup to which the node will be added
+   - `NODE_NAME` — the name of the node being connected. It must match the hostname inside the operating system and the VM name in vSphere
+   - `NODE_SSH_IP` — the IP address of the virtual machine available over SSH
+   - `CAPS_USER` — the user that CAPS will use to connect to the virtual machine
+
+1. On the master node, create a NodeGroup:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     nodeType: Static
+     staticInstances:
+       count: 1
+       labelSelector:
+         matchLabels:
+           role: ${NODE_GROUP}
+   EOF
+   ```
+
+   This scenario uses `nodeType: Static` because the virtual machine has already been created manually, and CAPS will only connect to it over SSH and configure it.
+
+1. Make sure that the NodeGroup has been created and synchronized:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME           TYPE     READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   vsphere-caps   Static   0       0       0                                                               1m    True
+   ```
+
+1. On the master node, generate the SSH key that CAPS will use to connect to the virtual machine:
+
+   ```shell
+   ssh-keygen -t ed25519 \
+     -f /dev/shm/${NODE_GROUP}-id \
+     -C "" \
+     -N ""
+   ```
+
+   {% alert level="info" %}
+   The key is created with an empty passphrase because CAPS must use it automatically.
+   {% endalert %}
+
+1. On the master node, create an [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) resource:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: SSHCredentials
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     user: ${CAPS_USER}
+     privateSSHKey: "$(base64 -w0 /dev/shm/${NODE_GROUP}-id)"
+   EOF
+   ```
+
+   The SSHCredentials resource stores the username and private SSH key that CAPS will use to connect to the virtual machine.
+
+1. Make sure that the SSHCredentials resource has been created:
+
+   ```shell
+   d8 k get sshcredentials
+   d8 k describe sshcredentials ${NODE_GROUP}
+   ```
+
+1. On the master node, print the public part of the SSH key:
+
+   ```shell
+   cat /dev/shm/${NODE_GROUP}-id.pub
+   ```
+
+   This key will be needed in the next step to configure the user on the virtual machine being connected.
+
+1. On the virtual machine being connected, create the user that CAPS will use to configure the node. Run the commands on the virtual machine being connected, specifying the public SSH key obtained in the previous step:
+
+   ```shell
+   export CAPS_USER="caps"
+   export KEY='<SSH_PUBLIC_KEY>'
+
+   useradd -m -s /bin/bash ${CAPS_USER}
+   usermod -aG sudo ${CAPS_USER}
+
+   echo "${CAPS_USER} ALL=(ALL) NOPASSWD: ALL" | EDITOR='tee -a' visudo
+
+   mkdir -p /home/${CAPS_USER}/.ssh
+   echo "${KEY}" > /home/${CAPS_USER}/.ssh/authorized_keys
+
+   chown -R ${CAPS_USER}:${CAPS_USER} /home/${CAPS_USER}
+   chmod 700 /home/${CAPS_USER}/.ssh
+   chmod 600 /home/${CAPS_USER}/.ssh/authorized_keys
+   ```
+
+   {% alert level="info" %}
+   The `KEY` value must be specified in quotes because the public SSH key contains spaces.
+   {% endalert %}
+
+   {% alert level="info" %}
+   For operating systems of the Astra Linux family, when using the Parsec mandatory integrity control module, additionally set the maximum integrity level for the user:
+
+   ```shell
+   pdpl-user -i 63 ${CAPS_USER}
+   ```
+
+   {% endalert %}
+
+1. On the master node, check that the CAPS user can connect to the virtual machine over SSH and run commands through `sudo` without a password:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'hostname; sudo -n true; echo OK'
+   ```
+
+   The output must contain the node name and the `OK` line.
+
+1. On the master node, create a [StaticInstance](/modules/node-manager/cr.html#staticinstance) resource for the virtual machine being connected:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: StaticInstance
+   metadata:
+     name: ${NODE_NAME}
+     labels:
+       role: ${NODE_GROUP}
+   spec:
+     address: "${NODE_SSH_IP}"
+     credentialsRef:
+       kind: SSHCredentials
+       name: ${NODE_GROUP}
+   EOF
+   ```
+
+   Where:
+
+   - `metadata.name` — the name of the node being connected
+   - `metadata.labels.role` — the label by which NodeGroup selects this StaticInstance
+   - `spec.address` — the IP address of the virtual machine available over SSH
+   - `spec.credentialsRef.name` — the name of the SSHCredentials resource created earlier
+
+1. Check the StaticInstance status:
+
+   ```shell
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+   ```
+
+1. Wait for the node to connect and check its status:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME                    STATUS   ROLES          AGE   VERSION    INTERNAL-IP      EXTERNAL-IP
+   static-master-0         Ready    master         1h    v1.33.10   192.168.240.135  <none>
+   vsphere-worker-caps     Ready    vsphere-caps   5m    v1.33.10   192.168.240.152  <none>
+   ```
+
+1. If connection fails, check the NodeGroup, StaticInstance, Machine status, and cluster events:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+
+   d8 k -n d8-cloud-instance-manager get machines,machinesets,machinedeployments -o wide
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Adding manually created nodes through a bootstrap script
+
+Before you begin, make sure that the following conditions are met:
+
+- The [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/) module is enabled and configured.
+- The `cloud-provider-vsphere` module components are in the `Running` state:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vsphere get pods -o wide
+  ```
+
+- StorageClasses for vSphere have been created in the cluster:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- A virtual machine that will be connected to the cluster has been created in vSphere.
+- The virtual machine name in vSphere matches the hostname inside the operating system.
+- The following parameters are set in the VM advanced parameters in vSphere:
+
+  ```text
+  disk.EnableUUID = TRUE
+  guestinfo.metadata = <BASE64_ENCODED_METADATA>
+  guestinfo.metadata.encoding = base64
+  ```
+
+  The `guestinfo.metadata` parameter must contain the metadata configuration encoded in Base64. Example `metadata.json` file:
+
+  ```json
+  {
+     "instance-id": "cloud-static-worker-0",
+     "local-hostname": "cloud-static-worker-0",
+     "public-keys-data": "<SSH_PUBLIC_KEY>",
+     "network": {
+       "version": 2,
+       "ethernets": {
+         "id0": {
+           "match": {
+             "driver": "vmxnet3"
+           },
+           "set-name": "ens192",
+           "dhcp4": true
+         }
+       }
+     }
+   }
+  ```
+
+  Where:
+
+  - `instance-id` — virtual machine identifier
+  - `local-hostname` — node hostname inside the operating system
+  - `public-keys-data` — public SSH key for accessing the virtual machine
+  - `network` — network settings that will be applied inside the virtual machine
+
+  To get the value for the `guestinfo.metadata` parameter, run:
+
+  ```shell
+  METADATA_B64="$(base64 -w0 metadata.json)"
+  echo "$METADATA_B64"
+  ```
+
+- The virtual machine is connected to the network specified in the [`internalNetworkNames`](/modules/cloud-provider-vsphere/cluster_configuration.html#vsphereclusterconfiguration-internalnetworknames) parameter of the `cloud-provider-vsphere` module configuration.
+- The virtual machine has the required base packages installed for the supported OS. For RED OS, install `which` and the package manager in advance if they are missing.
+
+1. Create a file, for example `cloud-static-nodegroup.yaml`, with a NodeGroup resource and the CloudStatic node type:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: cloud-static
+   spec:
+     nodeType: CloudStatic
+   ```
+
+1. Apply the manifest:
+
+   ```shell
+   d8 k apply -f cloud-static-nodegroup.yaml
+   ```
+
+1. Make sure that the NodeGroup has been created and synchronized:
+
+   ```shell
+   d8 k get nodegroup cloud-static
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME           TYPE          READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   cloud-static   CloudStatic   0       0       0                                                               1m    True
+   ```
+
+1. Get the bootstrap script for the created NodeGroup:
+
+   ```shell
+   NODE_GROUP=cloud-static
+
+   d8 k -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} \
+     -o jsonpath='{.data.bootstrap\.sh}' > bootstrap.b64
+   ```
+
+1. Copy the bootstrap script to the virtual machine being connected:
+
+   ```shell
+   scp bootstrap.b64 <USER>@<NODE_IP>:/tmp/bootstrap.b64
+   ```
+
+1. Connect to the virtual machine over SSH:
+
+   ```shell
+   ssh <USER>@<NODE_IP>
+   ```
+
+1. On the virtual machine, set permissions and run the bootstrap script:
+
+   ```shell
+   base64 -d /tmp/bootstrap.b64 > /tmp/bootstrap.sh
+   chmod +x /tmp/bootstrap.sh
+
+   sudo bash /tmp/bootstrap.sh
+   ```
+
+   After the bootstrap script is started, it will install the required components, configure the container runtime and kubelet, and connect the node to the cluster.
+
+1. On the master node, check that the new node has appeared:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME                       STATUS   ROLES          AGE   VERSION    INTERNAL-IP
+   static-master-0            Ready    master         1h    v1.33.10   192.168.240.135
+   cloud-static-worker-0      Ready    cloud-static   5m    v1.33.10   192.168.240.152
+   ```

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/VSPHERE_HYBRID_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/VSPHERE_HYBRID_RU.md
@@ -1,0 +1,580 @@
+---
+title: Гибридный кластер с vSphere
+permalink: ru/admin/integrations/hybrid/vsphere-hybrid.html
+lang: ru
+---
+
+Далее описан процесс добавления worker-узлов из vSphere в существующий статический кластер DKP.
+
+Для интеграции с vSphere используется модуль [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/). Он обеспечивает взаимодействие DKP с vCenter, получение информации о виртуальных машинах, работу с параметрами размещения и интеграцию с инфраструктурными возможностями vSphere.
+
+В разделе описаны три способа добавления worker-узлов:
+
+- **Автоматическое создание узлов в vSphere**. DKP создаёт виртуальные машины через API vSphere. Параметры ВМ задаются ресурсом [VsphereInstanceClass](/modules/cloud-provider-vsphere/cr.html#vsphereinstanceclass), а требуемое количество узлов и зоны размещения — ресурсом [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом [`CloudEphemeral`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-ephemeral-nodes.html).
+- **Подключение вручную созданных узлов через CAPS**. Виртуальная машина создаётся пользователем заранее, а DKP подключается к ней по SSH через Cluster API Provider Static. Для этого используются ресурсы NodeGroup с типом `Static`, а также ресурсы SSHCredentials и StaticInstance.
+- **Подключение вручную созданных узлов через bootstrap-скрипт**. Виртуальная машина создаётся пользователем заранее и подключается к кластеру с помощью bootstrap-скрипта DKP. Для такого сценария используется [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом [`CloudStatic`](../../../../architecture/cluster-and-infrastructure/node-management/cloud-static-nodes.html).
+
+## Предварительные требования для vSphere
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Кластер создан с параметром [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype).
+- Между сетью статических узлов и сетью виртуальных машин во vSphere настроена сетевая связность.
+- Узлы vSphere, добавляемые в кластер, имеют доступ к Kubernetes API, DNS и необходимым адресам согласно разделам [Сетевое взаимодействие](../../../../reference/network_interaction.html) и [Настройка сетевых политик](../../configuration/network/policy/configuration.html).
+- Выполнены требования из раздела [Подключение и авторизация в VMware vSphere](../virtualization/vsphere/authorization.html):
+  - настроен доступ к vCenter;
+  - подготовлена учётная запись vSphere с необходимыми привилегиями;
+  - подготовлен шаблон виртуальной машины;
+  - настроены сети, Datastore, теги регионов и зон.
+- При использовании Cilium с туннелированием трафика подов выбран режим [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode), соответствующий сетевой связности между площадками.
+
+## Добавление автоматически создаваемых узлов
+
+Для подключения уже работающего статического кластера к vCenter используйте ресурс [ModuleConfig](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#moduleconfig) модуля [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/).
+
+В параметре `spec.settings` укажите параметры доступа к vCenter, сетевые настройки, теги региона и зоны, а также SSH-ключи, которые будут добавлены на создаваемые виртуальные машины.
+
+Пример конфигурации и описание доступных параметров приведены в [примерах модуля](/modules/cloud-provider-vsphere/examples.html) и в разделе [Конфигурация модуля `cloud-provider-vsphere`](/modules/cloud-provider-vsphere/configuration.html).
+
+1. Создайте файл, например `vsphere-mc.yaml`, с ModuleConfig для модуля [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/):
+
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-vsphere
+   spec:
+     version: 2
+     enabled: true
+     settings:
+       host: "<VCENTER_FQDN>"
+       username: "<USERNAME@DOMAIN.LOCAL>"
+       password: "<PASSWORD>"
+       insecure: true
+       vmFolderPath: "<FOLDER_PATH_UNDER_DATACENTER>"
+       regionTagCategory: "<TAG_CATEGORY_FOR_REGION>"
+       zoneTagCategory: "<TAG_CATEGORY_FOR_ZONE>"
+       region: "<REGION_TAG_NAME_ON_DATACENTER>"
+       zones:
+         - "<ZONE_TAG_NAME_ON_CLUSTER>"
+       internalNetworkNames:
+         - "<PORT_GROUP_NAME_FOR_INTERNAL_IP>"
+       sshKeys:
+         - "<SSH_PUBLIC_KEY_ONE_LINE>"
+   ```
+
+   Значения параметров:
+
+   - `host` — адрес vCenter;
+   - `username`, `password` — учётные данные пользователя vSphere;
+   - `insecure` — отключение проверки TLS-сертификата vCenter;
+   - `vmFolderPath` — папка, в которой будут создаваться виртуальные машины;
+   - `regionTagCategory`, `zoneTagCategory` — категории тегов региона и зоны;
+   - `region` — тег региона;
+   - `zones` — список зон, в которых можно создавать узлы;
+   - `internalNetworkNames` — список сетей vSphere для подключения создаваемых узлов;
+   - `sshKeys` — публичные SSH-ключи, которые будут добавлены на создаваемые виртуальные машины.
+
+1. Примените конфигурацию модуля:
+
+   ```shell
+   d8 k apply -f vsphere-mc.yaml
+   ```
+
+1. Дождитесь готовности модуля `cloud-provider-vsphere`:
+
+   ```shell
+   d8 k get moduleconfig cloud-provider-vsphere
+   d8 k get pods -n d8-cloud-provider-vsphere -o wide
+   ```
+
+1. Создайте файл, например `vsphere-instance.yaml`, c ресурсами [VsphereInstanceClass](/modules/cloud-provider-vsphere/cr.html#vsphereinstanceclass) и [NodeGroup](/modules/node-manager/cr.html#nodegroup) со значением `nodeType: CloudEphemeral`:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: VsphereInstanceClass
+   metadata:
+     name: ephemeral
+   spec:
+     numCPUs: 2
+     memory: 4096
+     rootDiskSize: 40
+     template: "<PATH_TO_TEMPLATE_FROM_DATACENTER>"
+     mainNetwork: "<PORT_GROUP_NAME>"
+     datastore: "<DATASTORE_OR_FOLDER/DATASTORE>"
+   ---
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ephemeral
+   spec:
+     nodeType: CloudEphemeral
+     cloudInstances:
+       classReference:
+         kind: VsphereInstanceClass
+         name: ephemeral
+       maxPerZone: 1
+       minPerZone: 1
+       zones:
+         - "<ZONE_TAG_NAME_ON_CLUSTER>"
+     disruptions:
+       approvalMode: Automatic
+   ```
+
+   Где:
+
+   - [VsphereInstanceClass](/modules/cloud-provider-vsphere/cr.html#vsphereinstanceclass) описывает параметры виртуальной машины, которая будет создана во vSphere;
+   - [NodeGroup](/modules/node-manager/cr.html#nodegroup) описывает группу узлов, которую DKP должен поддерживать в кластере;
+   - `nodeType: CloudEphemeral` означает, что узлы будут создаваться автоматически через облачный провайдер;
+   - `cloudInstances.classReference` указывает на VsphereInstanceClass;
+   - `cloudInstances.zones` должен содержать зоны из списка `zones` в ModuleConfig.
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f vsphere-instance.yaml
+   ```
+
+   После применения манифеста DKP начнёт создавать виртуальную машину во vSphere. После загрузки ВМ kubelet подключится к Kubernetes API, и новый узел появится в кластере.
+
+1. Проверьте состояние узлов:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                             STATUS   ROLES                  AGE   VERSION
+   static-master-0                  Ready    control-plane,master   1h    v1.33.10
+   ephemeral-1ca02a5b-7588b-k89dc   Ready    ephemeral              10m   v1.33.10
+   ```
+
+1. При сбоях создания ВМ проверьте объекты Machine, MachineSet и логи machine-controller-manager:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinesets,machines -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```
+
+   Также проверьте события в кластере:
+
+   ```shell
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Добавление вручную созданных узлов через CAPS
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/) включён и настроен.
+- Компоненты модуля `cloud-provider-vsphere` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vsphere get pods -o wide
+  ```
+
+- В кластере созданы StorageClass для vSphere:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- В vSphere создана виртуальная машина, которая будет подключена к кластеру.
+- Имя виртуальной машины в vSphere, значение local-hostname в метаданных и hostname внутри операционной системы совпадают.
+- В дополнительных параметрах ВМ в vSphere задан параметр:
+
+  ```text
+  disk.EnableUUID = TRUE
+  ```
+
+- Виртуальная машина подключена к сети, указанной в параметре [`internalNetworkNames`](/modules/cloud-provider-vsphere/cluster_configuration.html#vsphereclusterconfiguration-internalnetworknames) конфигурации модуля `cloud-provider-vsphere`.
+- На виртуальной машине есть административный SSH-доступ для первичной настройки пользователя, под которым CAPS будет подключаться к узлу, либо такой пользователь уже создан заранее.
+- Пользователь для подключения по SSH может выполнять команды через `sudo` без ввода пароля.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+{% offtopic title="Передача метаданных в ВМ через vSphere..." %}
+Для предварительной настройки виртуальной машины можно использовать cloud-init через метаданные vSphere. Например, метаданные можно использовать для настройки hostname, сети и SSH-ключей.
+
+В этом случае задайте в дополнительных параметрах ВМ:
+
+```text
+guestinfo.metadata = <BASE64_ENCODED_METADATA>
+guestinfo.metadata.encoding = base64
+```
+
+Пример файла `metadata.json`:
+
+```json
+{
+  "instance-id": "vsphere-worker-caps",
+  "local-hostname": "vsphere-worker-caps",
+  "public-keys-data": "<SSH_PUBLIC_KEY>",
+  "network": {
+    "version": 2,
+    "ethernets": {
+      "id0": {
+        "match": {
+          "driver": "vmxnet3"
+        },
+        "set-name": "ens192",
+        "dhcp4": true
+      }
+    }
+  }
+}
+```
+
+Где:
+
+- `instance-id` — идентификатор виртуальной машины;
+- `local-hostname` — hostname узла внутри операционной системы;
+- `public-keys-data` — публичный SSH-ключ для доступа к виртуальной машине;
+- `network` — сетевые настройки, которые будут применены внутри виртуальной машины.
+
+Чтобы получить значение для параметра `guestinfo.metadata`, выполните:
+
+```shell
+METADATA_B64="$(base64 -w0 metadata.json)"
+echo "$METADATA_B64"
+```
+
+Использование `guestinfo.metadata` не является обязательным требованием CAPS. Главное, чтобы к моменту создания ресурса StaticInstance виртуальная машина была доступна по SSH, имела корректный hostname и пользователь для подключения мог выполнять команды через `sudo` без пароля.
+{% endofftopic %}
+
+1. На master-узле задайте переменные для создаваемой NodeGroup и подключаемой виртуальной машины:
+
+   ```shell
+   export NODE_GROUP="vsphere-caps"
+   export NODE_NAME="vsphere-worker-caps"
+   export NODE_SSH_IP="<NODE_IP>"
+   export CAPS_USER="caps"
+   ```
+
+   Где:
+
+   - `NODE_GROUP` — имя NodeGroup, в которую будет добавлен узел;
+   - `NODE_NAME` — имя подключаемого узла. Оно должно совпадать с hostname внутри операционной системы и именем ВМ в vSphere;
+   - `NODE_SSH_IP` — IP-адрес виртуальной машины, доступный по SSH;
+   - `CAPS_USER` — пользователь, под которым CAPS будет подключаться к виртуальной машине.
+
+1. На master-узле создайте NodeGroup:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     nodeType: Static
+     staticInstances:
+       count: 1
+       labelSelector:
+         matchLabels:
+           role: ${NODE_GROUP}
+   EOF
+   ```
+
+   В этом сценарии используется `nodeType: Static`, потому что виртуальная машина уже создана вручную, а CAPS будет только подключать и настраивать её по SSH.
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME           TYPE     READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   vsphere-caps   Static   0       0       0                                                               1m    True
+   ```
+
+1. На master-узле сгенерируйте SSH-ключ, который CAPS будет использовать для подключения к виртуальной машине:
+
+   ```shell
+   ssh-keygen -t ed25519 \
+     -f /dev/shm/${NODE_GROUP}-id \
+     -C "" \
+     -N ""
+   ```
+
+   {% alert level="info" %}
+   Ключ создаётся с пустой парольной фразой, так как CAPS должен использовать его автоматически.
+   {% endalert %}
+
+1. На master-узле создайте ресурс [SSHCredentials](/modules/node-manager/cr.html#sshcredentials):
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: SSHCredentials
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     user: ${CAPS_USER}
+     privateSSHKey: "$(base64 -w0 /dev/shm/${NODE_GROUP}-id)"
+   EOF
+   ```
+
+   Ресурс SSHCredentials хранит имя пользователя и приватный SSH-ключ, с помощью которых CAPS будет подключаться к виртуальной машине.
+
+1. Убедитесь, что ресурс SSHCredentials создан:
+
+   ```shell
+   d8 k get sshcredentials
+   d8 k describe sshcredentials ${NODE_GROUP}
+   ```
+
+1. На master-узле выведите публичную часть SSH-ключа:
+
+   ```shell
+   cat /dev/shm/${NODE_GROUP}-id.pub
+   ```
+
+   Этот ключ понадобится на следующем шаге для настройки пользователя на подключаемой виртуальной машине.
+
+1. На подключаемой виртуальной машине создайте пользователя, под которым CAPS будет выполнять настройку узла. Выполните команды на подключаемой виртуальной машине, указав публичный SSH-ключ, полученный на предыдущем шаге:
+
+   ```shell
+   export CAPS_USER="caps"
+   export KEY='<SSH_PUBLIC_KEY>'
+
+   useradd -m -s /bin/bash ${CAPS_USER}
+   usermod -aG sudo ${CAPS_USER}
+
+   echo "${CAPS_USER} ALL=(ALL) NOPASSWD: ALL" | EDITOR='tee -a' visudo
+
+   mkdir -p /home/${CAPS_USER}/.ssh
+   echo "${KEY}" > /home/${CAPS_USER}/.ssh/authorized_keys
+
+   chown -R ${CAPS_USER}:${CAPS_USER} /home/${CAPS_USER}
+   chmod 700 /home/${CAPS_USER}/.ssh
+   chmod 600 /home/${CAPS_USER}/.ssh/authorized_keys
+   ```
+
+   {% alert level="info" %}
+   Значение `KEY` необходимо указывать в кавычках, так как публичный SSH-ключ содержит пробелы.
+   {% endalert %}
+
+   {% alert level="info" %}
+   Для операционных систем семейства Astra Linux при использовании модуля мандатного контроля целостности Parsec дополнительно задайте максимальный уровень целостности для пользователя:
+
+   ```shell
+   pdpl-user -i 63 ${CAPS_USER}
+   ```
+
+   {% endalert %}
+
+1. На master-узле проверьте, что CAPS-пользователь может подключиться к виртуальной машине по SSH и выполнять команды через `sudo` без пароля:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'hostname; sudo -n true; echo OK'
+   ```
+
+   В выводе должно быть имя узла и строка `OK`.
+
+1. На master-узле создайте ресурс [StaticInstance](/modules/node-manager/cr.html#staticinstance) для подключаемой виртуальной машины:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: StaticInstance
+   metadata:
+     name: ${NODE_NAME}
+     labels:
+       role: ${NODE_GROUP}
+   spec:
+     address: "${NODE_SSH_IP}"
+     credentialsRef:
+       kind: SSHCredentials
+       name: ${NODE_GROUP}
+   EOF
+   ```
+
+   Где:
+
+   - `metadata.name` — имя подключаемого узла;
+   - `metadata.labels.role` — лейбл, по которому NodeGroup выбирает этот StaticInstance;
+   - `spec.address` — IP-адрес виртуальной машины, доступный по SSH;
+   - `spec.credentialsRef.name` — имя созданного ранее ресурса SSHCredentials.
+
+1. Проверьте состояние StaticInstance:
+
+   ```shell
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+   ```
+
+1. Дождитесь подключения узла и проверьте его состояние:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                    STATUS   ROLES          AGE   VERSION    INTERNAL-IP      EXTERNAL-IP
+   static-master-0         Ready    master         1h    v1.33.10   192.168.240.135  <none>
+   vsphere-worker-caps     Ready    vsphere-caps   5m    v1.33.10   192.168.240.152  <none>
+   ```
+
+1. При сбоях подключения проверьте состояние NodeGroup, StaticInstance, Machine и события в кластере:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+
+   d8 k -n d8-cloud-instance-manager get machines,machinesets,machinedeployments -o wide
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Добавление вручную созданных узлов через bootstrap-скрипт
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-vsphere`](/modules/cloud-provider-vsphere/) включён и настроен.
+- Компоненты модуля `cloud-provider-vsphere` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-vsphere get pods -o wide
+  ```
+
+- В кластере созданы StorageClass для vSphere:
+  
+  ```shell
+  d8 k get sc
+  ```
+
+- В vSphere создана виртуальная машина, которая будет подключена к кластеру.
+- Имя виртуальной машины в vSphere совпадает с hostname внутри операционной системы.
+- В дополнительных параметрах ВМ в vSphere заданы параметры:
+
+  ```text
+  disk.EnableUUID = TRUE
+  guestinfo.metadata = <BASE64_ENCODED_METADATA>
+  guestinfo.metadata.encoding = base64
+  ```
+
+  Параметр `guestinfo.metadata` должен содержать конфигурацию метаданных, закодированных в Base64. Пример файла `metadata.json`:
+
+  ```json
+  {
+     "instance-id": "cloud-static-worker-0",
+     "local-hostname": "cloud-static-worker-0",
+     "public-keys-data": "<SSH_PUBLIC_KEY>",
+     "network": {
+       "version": 2,
+       "ethernets": {
+         "id0": {
+           "match": {
+             "driver": "vmxnet3"
+           },
+           "set-name": "ens192",
+           "dhcp4": true
+         }
+       }
+     }
+   }
+  ```
+
+  Где:
+
+  - `instance-id` — идентификатор виртуальной машины;
+  - `local-hostname` — hostname узла внутри операционной системы;
+  - `public-keys-data` — публичный SSH-ключ для доступа к виртуальной машине;
+  - `network` — сетевые настройки, которые будут применены внутри виртуальной машины.
+
+  Чтобы получить значение для параметра `guestinfo.metadata`, выполните:
+
+  ```shell
+  METADATA_B64="$(base64 -w0 metadata.json)"
+  echo "$METADATA_B64"
+  ```
+
+- Виртуальная машина подключена к сети, указанной в параметре [`internalNetworkNames`](/modules/cloud-provider-vsphere/cluster_configuration.html#vsphereclusterconfiguration-internalnetworknames) конфигурации модуля `cloud-provider-vsphere`.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+1. Создайте файл, например `cloud-static-nodegroup.yaml`, с ресурсом NodeGroup и типом узлов CloudStatic:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: cloud-static
+   spec:
+     nodeType: CloudStatic
+   ```
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f cloud-static-nodegroup.yaml
+   ```
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup cloud-static
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME           TYPE          READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   cloud-static   CloudStatic   0       0       0                                                               1m    True
+   ```
+
+1. Получите bootstrap-скрипт для созданной NodeGroup:
+
+   ```shell
+   NODE_GROUP=cloud-static
+
+   d8 k -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} \
+     -o jsonpath='{.data.bootstrap\.sh}' > bootstrap.b64
+   ```
+
+1. Скопируйте bootstrap-скрипт на подключаемую виртуальную машину:
+
+   ```shell
+   scp bootstrap.b64 <USER>@<NODE_IP>:/tmp/bootstrap.b64
+   ```
+
+1. Подключитесь к виртуальной машине по SSH:
+
+   ```shell
+   ssh <USER>@<NODE_IP>
+   ```
+
+1. На виртуальной машине назначьте права и запустите bootstrap-скрипт:
+
+   ```shell
+   base64 -d /tmp/bootstrap.b64 > /tmp/bootstrap.sh
+   chmod +x /tmp/bootstrap.sh
+
+   sudo bash /tmp/bootstrap.sh
+   ```
+
+   После запуска bootstrap-скрипт установит необходимые компоненты, настроит container runtime, kubelet и подключит узел к кластеру.
+
+1. На master-узле проверьте появление нового узла:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                       STATUS   ROLES          AGE   VERSION    INTERNAL-IP
+   static-master-0            Ready    master         1h    v1.33.10   192.168.240.135
+   cloud-static-worker-0      Ready    cloud-static   5m    v1.33.10   192.168.240.152
+   ```

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/YANDEX_HYBRID.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/YANDEX_HYBRID.md
@@ -1,0 +1,706 @@
+---
+title:  Hybrid cluster with Yandex Cloud
+permalink: en/admin/integrations/hybrid/yandex-hybrid.html
+---
+
+The following describes the process of adding worker nodes from Yandex Cloud to an existing static DKP cluster.
+
+Integration with Yandex Cloud uses the [`cloud-provider-yandex`](/modules/cloud-provider-yandex/) module. It provides interaction between DKP and the Yandex Cloud API, retrieval of information about cloud infrastructure, creation of virtual machines, work with network parameters, and connection of nodes to an existing cluster.
+
+This section describes three ways to add worker nodes:
+
+- **Automatic node creation in Yandex Cloud**. DKP creates virtual machines through the Yandex Cloud API. VM parameters are defined by the [YandexInstanceClass](/modules/cloud-provider-yandex/cr.html#yandexinstanceclass) resource, and the required number of nodes and placement zones are defined by the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource with the `Cloud` type.
+- **Connecting manually created nodes through CAPS**. A virtual machine is created by the user in advance, and DKP connects to it over SSH through Cluster API Provider Static. This uses the [NodeGroup](/modules/node-manager/cr.html#nodegroup) resource with the `Static` type, as well as the [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) and [StaticInstance](/modules/node-manager/cr.html#staticinstance) resources.
+- **Connecting manually created nodes through a bootstrap script**. A virtual machine is created by the user in advance and connected to the cluster using the DKP bootstrap script. This scenario uses [NodeGroup](/modules/node-manager/cr.html#nodegroup) with the `Hybrid` type.
+
+## Prerequisites
+
+Before you begin, make sure that the following conditions are met:
+
+- The cluster was created with the [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype) parameter.
+- Network connectivity is configured between the network of static nodes and the Yandex Cloud VPC.
+- Yandex Cloud nodes added to the cluster have access to the Kubernetes API, DNS, and the required addresses according to the [Network interaction](../../../../reference/network_interaction.html) and [Network policy configuration](../../configuration/network/policy/configuration.html) sections.
+- The requirements from the [Authorization in Yandex Cloud](../public/yandex/authorization.html) section are met:
+  - a service account is prepared;
+  - a folder where resources will be created is selected;
+  - the required roles and access to the VPC being used are configured.
+- When using Cilium with pod traffic tunneling, the [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode) mode is selected according to the network connectivity between sites.
+
+## Adding automatically created nodes
+
+To run the preparation commands, you need the [Yandex Cloud CLI](https://yandex.cloud/ru/docs/cli/) (`yc`). You can use it on the administrator's workstation. The `yc` CLI is not required on the cluster master node: only the prepared manifests need to be applied in the cluster.
+
+1. Prepare the cloud, folder, network, subnet, and zone identifiers where worker nodes will be created:
+
+   ```shell
+   export CLOUD_ID="<CLOUD_ID>"
+   export FOLDER_ID="<FOLDER_ID>"
+   export NETWORK_ID="<NETWORK_ID>"
+   export SUBNET_ID="<SUBNET_ID>"
+   export ZONE="ru-central1-a"
+   ```
+
+   You can get the values using the Yandex Cloud CLI:
+
+   ```shell
+   yc resource-manager cloud list
+   yc resource-manager folder list
+   yc vpc network list --folder-id "$FOLDER_ID"
+   yc vpc subnet list --folder-id "$FOLDER_ID"
+   ```
+
+   Where:
+
+   - `CLOUD_ID` — Yandex Cloud cloud ID
+   - `FOLDER_ID` — ID of the folder where resources will be created
+   - `NETWORK_ID` — VPC network ID
+   - `SUBNET_ID` — ID of the subnet where worker nodes will be created
+   - `ZONE` — availability zone corresponding to the selected subnet
+
+   For details, see [Authorization in Yandex Cloud](../public/yandex/authorization.html)
+
+1. Create a Service Account in the required Yandex Cloud folder and assign permissions to it:
+
+   ```shell
+   yc iam service-account create \
+     --name dkp-hybrid \
+     --folder-id "$FOLDER_ID"
+
+   export SA_ID="$(yc iam service-account get \
+     --name dkp-hybrid \
+     --folder-id "$FOLDER_ID" \
+     --format json | jq -r .id)"
+
+   yc resource-manager folder add-access-binding "$FOLDER_ID" \
+     --role editor \
+     --subject "serviceAccount:${SA_ID}"
+
+   yc resource-manager folder add-access-binding "$FOLDER_ID" \
+     --role vpc.admin \
+     --subject "serviceAccount:${SA_ID}"
+   ```
+
+   The `editor` role is required for creating and managing cloud resources, and `vpc.admin` is required for working with VPC network resources.
+
+1. Create a Service Account key and save it to a JSON file:
+
+   ```shell
+   yc iam key create \
+     --service-account-id "$SA_ID" \
+     --output dkp-hybrid-sa-key.json
+   ```
+
+   Prepare the `serviceAccountJSON` value in a single-line format:
+
+   ```shell
+   export SERVICE_ACCOUNT_JSON="$(jq -c . dkp-hybrid-sa-key.json)"
+   ```
+
+1. Prepare the public SSH key that will be added to the created worker nodes:
+
+   ```shell
+   export SSH_PUBLIC_KEY="$(cat ~/.ssh/id_rsa.pub)"
+   ```
+
+   If another key is used, specify its path instead of `~/.ssh/id_rsa.pub`.
+
+   {% alert level="warning" %}
+   The `sshPublicKey` parameter must contain the administrator's public SSH key, not the public key from the Service Account JSON file.
+   {% endalert %}
+
+1. Get the ID of the operating system image from which virtual machines will be created:
+
+   ```shell
+   export IMAGE_ID="$(yc compute image get-latest-from-family ubuntu-2404-lts \
+     --folder-id standard-images \
+     --format json | jq -r .id)"
+   ```
+
+   {% alert level="warning" %}
+   The `imageID` parameter is the OS image ID in Yandex Cloud. Do not use the ID of an existing virtual machine or the Service Account key ID in this field.
+   {% endalert %}
+
+1. Specify the CIDR of the network where Yandex Cloud nodes will be placed:
+
+   ```shell
+   export NODE_NETWORK_CIDR="<NODE_NETWORK_CIDR>"
+   ```
+
+   `NODE_NETWORK_CIDR` is a CIDR that includes the internal IP addresses of Yandex Cloud nodes. For a single zone, it usually matches the CIDR of the selected subnet. For example, if worker nodes are created in the `10.128.0.0/24` subnet, specify `10.128.0.0/24`. You can get the subnet CIDR using the command:
+
+   ```shell
+   yc vpc subnet list --folder-id "$FOLDER_ID"
+   ```
+
+1. Create a file, for example `cloud-provider-cluster-configuration.yaml`, with the provider configuration:
+
+   ```shell
+   cat > cloud-provider-cluster-configuration.yaml <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: YandexClusterConfiguration
+   layout: WithoutNAT
+   masterNodeGroup:
+     replicas: 1
+     instanceClass:
+       cores: 4
+       memory: 8192
+       imageID: ${IMAGE_ID}
+       diskSizeGB: 100
+       platform: standard-v3
+       externalIPAddresses:
+         - "Auto"
+   nodeNetworkCIDR: ${NODE_NETWORK_CIDR}
+   existingNetworkID: empty
+   provider:
+     cloudID: ${CLOUD_ID}
+     folderID: ${FOLDER_ID}
+     serviceAccountJSON: '${SERVICE_ACCOUNT_JSON}'
+   sshPublicKey: '${SSH_PUBLIC_KEY}'
+   EOF
+   ```
+
+   Where:
+
+   - `nodeNetworkCIDR` — CIDR of the network that includes the addresses of the subnets used for Yandex Cloud nodes
+   - `imageID` — OS image ID for the created virtual machines
+   - `cloudID` — Yandex Cloud cloud ID
+   - `folderID` — Yandex Cloud folder ID
+   - `serviceAccountJSON` — Service Account JSON key in a single-line format
+   - `sshPublicKey` — public SSH key for accessing the created nodes
+
+   {% alert level="info" %}
+   In a hybrid scenario, when the control plane is already deployed as a static cluster, the `masterNodeGroup` section does not create master nodes in Yandex Cloud, but remains part of the provider configuration.
+   {% endalert %}
+
+1. Create a file, for example `cloud-provider-discovery-data.json`, with Yandex Cloud discovery data:
+
+   ```shell
+   cat > cloud-provider-discovery-data.json <<EOF
+   {
+     "apiVersion": "deckhouse.io/v1",
+     "defaultLbTargetGroupNetworkId": "empty",
+     "internalNetworkIDs": [
+       "${NETWORK_ID}"
+     ],
+     "kind": "YandexCloudDiscoveryData",
+     "monitoringAPIKey": "",
+     "region": "ru-central1",
+     "routeTableID": "empty",
+     "shouldAssignPublicIPAddress": false,
+     "zoneToSubnetIdMap": {
+       "${ZONE}": "${SUBNET_ID}"
+     },
+     "zones": [
+       "${ZONE}"
+     ]
+   }
+   EOF
+   ```
+
+   Where:
+
+   - `internalNetworkIDs` — list of Yandex Cloud network IDs that provide internal connectivity between nodes
+   - `zoneToSubnetIdMap` — mapping between an availability zone and the subnet where nodes will be created
+   - `zones` — list of zones available for node creation
+   - `shouldAssignPublicIPAddress` — controls assignment of public IP addresses to the created nodes
+
+   {% alert level="warning" %}
+   If the `shouldAssignPublicIPAddress` parameter is set to `false`, the created nodes will not have a public IP address. In this case, the nodes must have access to the registry and external services through a NAT Gateway, NAT instance, proxy, or another egress mechanism. For zones where subnets are missing, the `empty` value can be used.
+   {% endalert %}
+
+1. Encode the `cloud-provider-cluster-configuration.yaml` and `cloud-provider-discovery-data.json` files in Base64:
+
+   ```shell
+   export CLUSTER_CONFIGURATION_B64="$(base64 -w0 cloud-provider-cluster-configuration.yaml)"
+   export DISCOVERY_DATA_B64="$(base64 -w0 cloud-provider-discovery-data.json)"
+   ```
+
+1. Create a manifest with the `d8-provider-cluster-configuration` secret and ModuleConfig for the `cloud-provider-yandex` module:
+
+   ```shell
+   cat > yandex-provider-secret-and-mc.yaml <<EOF
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     labels:
+       heritage: deckhouse
+       name: d8-provider-cluster-configuration
+     name: d8-provider-cluster-configuration
+     namespace: kube-system
+   type: Opaque
+   data:
+     cloud-provider-cluster-configuration.yaml: ${CLUSTER_CONFIGURATION_B64}
+     cloud-provider-discovery-data.json: ${DISCOVERY_DATA_B64}
+   ---
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-yandex
+   spec:
+     version: 1
+     enabled: true
+     settings:
+       storageClass:
+         default: network-ssd
+   EOF
+   ```
+
+1. Copy the `yandex-provider-secret-and-mc.yaml` file to the cluster master node. Before applying it, delete the ValidatingAdmissionPolicyBinding object if it prevents creating objects with the `heritage: deckhouse` label:
+
+   ```shell
+   d8 k delete validatingadmissionpolicybindings.admissionregistration.k8s.io \
+     heritage-label-objects.deckhouse.io \
+     --ignore-not-found
+   ```
+
+   Apply the manifest:
+
+   ```shell
+   d8 k apply -f yandex-provider-secret-and-mc.yaml
+   ```
+
+1. Wait for the `cloud-provider-yandex` module to be enabled and for the YandexInstanceClass resource to appear:
+
+   ```shell
+   d8 k get moduleconfig cloud-provider-yandex
+   d8 k get crd yandexinstanceclasses.deckhouse.io
+   d8 k -n d8-cloud-provider-yandex get pods -o wide
+   ```
+
+1. Create a file, for example `yandex-instanceclass-nodegroup.yaml`, with the YandexInstanceClass and NodeGroup resources:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: YandexInstanceClass
+   metadata:
+     name: yc-worker
+   spec:
+     cores: 4
+     memory: 8192
+     diskSizeGB: 50
+     diskType: network-ssd
+     mainSubnet: <SUBNET_ID>
+   ---
+   apiVersion: deckhouse.io/v1alpha1
+   kind: NodeGroup
+   metadata:
+     name: yc-worker
+   spec:
+     nodeType: Cloud
+     cloudInstances:
+       classReference:
+         kind: YandexInstanceClass
+         name: yc-worker
+       minPerZone: 1
+       maxPerZone: 1
+       zones:
+         - ru-central1-a
+   ```
+
+   Where:
+
+   - YandexInstanceClass describes the parameters of the virtual machine that will be created in Yandex Cloud
+   - `mainSubnet` — ID of the subnet from which the created worker nodes must have access to the cluster's static nodes
+   - NodeGroup describes the node group that DKP must maintain in the cluster
+   - `nodeType: Cloud` means that nodes will be created automatically through the cloud provider
+   - `cloudInstances.zones` must contain zones from the `zones` list in `cloud-provider-discovery-data.json`
+
+1. Apply the manifest:
+
+   ```shell
+   d8 k apply -f yandex-instanceclass-nodegroup.yaml
+   ```
+
+   After applying the manifest, DKP will start creating a virtual machine in Yandex Cloud through machine-controller-manager.
+
+1. Check that the node has appeared in the cluster:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME                                 STATUS   ROLES                  AGE   VERSION    INTERNAL-IP
+   static-master-0                      Ready    control-plane,master   1h    v1.33.10   10.128.0.15
+   yc-worker-f3564dca-7fc59-s2w5d       Ready    yc-worker              10m   v1.33.10   10.128.0.21
+   ```
+
+1. To diagnose the status and find possible issues, check the machine-controller-manager logs:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinedeployments.machine.sapcloud.io -o wide
+   d8 k -n d8-cloud-instance-manager get machinesets.machine.sapcloud.io -o wide
+   d8 k -n d8-cloud-instance-manager get machines.machine.sapcloud.io -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```
+
+## Adding manually created nodes through CAPS
+
+Before you begin, make sure that the following conditions are met:
+
+- The [`cloud-provider-yandex`](/modules/cloud-provider-yandex/) module is enabled and configured.
+- The `cloud-provider-yandex` module components are in the `Running` state:
+
+  ```shell
+  d8 k -n d8-cloud-provider-yandex get pods -o wide
+  ```
+
+- A virtual machine that will be connected to the cluster has been created in Yandex Cloud.
+- The virtual machine is connected to the Yandex Cloud network and subnet used for hybrid integration with the cluster.
+- The internal IP address of the virtual machine is within the address range used for Yandex Cloud nodes.
+- The virtual machine name in Yandex Cloud matches the hostname inside the operating system.
+- The virtual machine has the required base packages installed for the supported OS. For RED OS, install `which` and the package manager in advance if they are missing.
+
+1. On the master node, set the variables for the NodeGroup being created and the virtual machine being connected:
+
+   ```shell
+   export NODE_GROUP="yc-caps"
+   export NODE_NAME="yandex-worker-hybrid-caps"
+   export NODE_SSH_IP="<NODE_PUBLIC_OR_INTERNAL_IP>"
+   export CAPS_USER="caps"
+   ```
+
+   Where:
+
+   - `NODE_GROUP` — the name of the NodeGroup to which the node will be added
+   - `NODE_NAME` — the name of the node being connected
+   - `NODE_SSH_IP` — the IP address of the virtual machine available over SSH
+   - `CAPS_USER` — the user that CAPS will use to connect to the virtual machine
+
+1. On the master node, create a NodeGroup:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     nodeType: Static
+     staticInstances:
+       count: 1
+       labelSelector:
+         matchLabels:
+           role: ${NODE_GROUP}
+   EOF
+   ```
+
+   This scenario uses `nodeType: Static` because the node has already been created manually, and CAPS will only connect to it over SSH and configure it.
+
+1. Make sure that the NodeGroup has been created and synchronized:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME      TYPE     READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   yc-caps   Static   0       0       0                                                               1m    True
+   ```
+
+1. On the master node, generate the SSH key that CAPS will use to connect to the virtual machine:
+
+   ```shell
+   ssh-keygen -t ed25519 \
+     -f /dev/shm/${NODE_GROUP}-id \
+     -C "" \
+     -N ""
+   ```
+
+   {% alert level="info" %}
+   The key is created with an empty passphrase because CAPS must use it automatically.
+   {% endalert %}
+
+1. On the master node, create an [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) resource:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: SSHCredentials
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     user: ${CAPS_USER}
+     privateSSHKey: "$(base64 -w0 /dev/shm/${NODE_GROUP}-id)"
+   EOF
+   ```
+
+   The SSHCredentials resource stores the username and private SSH key that CAPS will use to connect to the virtual machine.
+
+1. Make sure that the SSHCredentials resource has been created:
+
+   ```shell
+   d8 k get sshcredentials
+   d8 k describe sshcredentials ${NODE_GROUP}
+   ```
+
+1. On the master node, print the public part of the SSH key:
+
+   ```shell
+   cat /dev/shm/${NODE_GROUP}-id.pub
+   ```
+
+   This key will be needed in the next step to configure the user on the virtual machine being connected.
+
+1. On the virtual machine being connected, create the user that CAPS will use to configure the node. Run the commands on the virtual machine being connected, specifying the public SSH key obtained in the previous step:
+
+   ```shell
+   export CAPS_USER="caps"
+   export KEY='<SSH_PUBLIC_KEY>'
+
+   useradd -m -s /bin/bash ${CAPS_USER}
+   usermod -aG sudo ${CAPS_USER}
+
+   echo "${CAPS_USER} ALL=(ALL) NOPASSWD: ALL" | EDITOR='tee -a' visudo
+
+   mkdir -p /home/${CAPS_USER}/.ssh
+   echo "${KEY}" > /home/${CAPS_USER}/.ssh/authorized_keys
+
+   chown -R ${CAPS_USER}:${CAPS_USER} /home/${CAPS_USER}
+   chmod 700 /home/${CAPS_USER}/.ssh
+   chmod 600 /home/${CAPS_USER}/.ssh/authorized_keys
+   ```
+
+   {% alert level="info" %}
+   The `KEY` value must be specified in quotes because the public SSH key contains spaces.
+   {% endalert %}
+
+   {% alert level="info" %}
+   For operating systems of the Astra Linux family, when using the Parsec mandatory integrity control module, additionally set the maximum integrity level for the user:
+
+   ```shell
+   pdpl-user -i 63 ${CAPS_USER}
+   ```
+
+   {% endalert %}
+
+1. On the master node, check that the CAPS user can connect to the virtual machine over SSH and run commands through `sudo` without a password:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'hostname; sudo -n true; echo OK'
+   ```
+
+   The output must contain the node name and the `OK` line.
+
+1. On the master node, create a [StaticInstance](/modules/node-manager/cr.html#staticinstance) resource for the virtual machine being connected:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: StaticInstance
+   metadata:
+     name: ${NODE_NAME}
+     labels:
+       role: ${NODE_GROUP}
+   spec:
+     address: "${NODE_SSH_IP}"
+     credentialsRef:
+       kind: SSHCredentials
+       name: ${NODE_GROUP}
+   EOF
+   ```
+
+   Where:
+
+   - `metadata.name` — the name of the node being connected
+   - `metadata.labels.role` — the label by which NodeGroup selects this StaticInstance
+   - `spec.address` — the IP address of the virtual machine available over SSH
+   - `spec.credentialsRef.name` — the name of the SSHCredentials resource created earlier
+
+1. Check the StaticInstance status:
+
+   ```shell
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+   ```
+
+1. Wait for the node to connect and check its status:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME                         STATUS   ROLES     AGE   VERSION    INTERNAL-IP   EXTERNAL-IP
+   static-master-0              Ready    master    1h    v1.33.10   10.128.0.15   <none>
+   yandex-worker-hybrid-caps    Ready    yc-caps   5m    v1.33.10   10.128.0.29   <none>
+   ```
+
+1. If connection fails, check the NodeGroup, StaticInstance, Machine status, and cluster events:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+
+   d8 k -n d8-cloud-instance-manager get machines,machinesets,machinedeployments -o wide
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Adding manually created nodes through a bootstrap script
+
+Before you begin, make sure that the following conditions are met:
+
+- The [`cloud-provider-yandex`](/modules/cloud-provider-yandex/) module is enabled and configured.
+- The `cloud-provider-yandex` module components are in the `Running` state:
+
+  ```shell
+  d8 k -n d8-cloud-provider-yandex get pods -o wide
+  ```
+
+- A virtual machine that will be connected to the cluster has been created in Yandex Cloud.
+- The virtual machine is connected to the Yandex Cloud network and subnet used for hybrid integration with the cluster.
+- The internal IP address of the virtual machine is within the address range used for Yandex Cloud nodes.
+- The virtual machine name in Yandex Cloud matches the hostname inside the operating system.
+- The virtual machine has the required base packages installed for the supported OS. For RED OS, install `which` and the package manager in advance if they are missing.
+
+1. Check the virtual machine metadata in Yandex Cloud.
+
+   The VM metadata must have `cloud-init` configured with the user that will be used for SSH connection.
+
+   Example metadata:
+
+   ```yaml
+   #cloud-config
+   datasource:
+     Ec2:
+       strict_id: false
+   ssh_pwauth: no
+   users:
+     - name: <USER>
+       sudo: ALL=(ALL) NOPASSWD:ALL
+       shell: /bin/bash
+       ssh_authorized_keys:
+         - <SSH_PUBLIC_KEY>
+   ```
+
+   Where:
+
+   - `<USER>` — the username for SSH access to the virtual machine
+   - `<SSH_PUBLIC_KEY>` — the administrator's public SSH key
+
+1. On the master node, create a file, for example `yandex-manual-nodegroup.yaml`, with a NodeGroup resource:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: yc-manual
+   spec:
+     nodeType: Hybrid
+   ```
+
+   {% alert level="info" %}
+   For manually created Yandex Cloud nodes, use the `nodeType: Hybrid` value. In the NodeGroup status, such a group may be displayed as `CloudStatic`.
+   {% endalert %}
+
+1. Apply the manifest:
+
+   ```shell
+   d8 k apply -f yandex-manual-nodegroup.yaml
+   ```
+
+1. Make sure that the NodeGroup has been created and synchronized:
+
+   ```shell
+   d8 k get nodegroup yc-manual
+   d8 k describe nodegroup yc-manual
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME        TYPE          READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   yc-manual   CloudStatic   0       0       0                                                               1m    True
+   ```
+
+1. On the master node, get the bootstrap script for the created NodeGroup:
+
+   ```shell
+   NODE_GROUP=yc-manual
+
+   d8 k -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} \
+     -o jsonpath='{.data.bootstrap\.sh}' > ${NODE_GROUP}-bootstrap.b64
+   ```
+
+1. On the master node, check that the file contains the Base64 data of the bootstrap script:
+
+   ```shell
+   head -c 80 ${NODE_GROUP}-bootstrap.b64
+   echo
+   base64 -d ${NODE_GROUP}-bootstrap.b64 | head -n 5
+   ```
+
+   The decoded content must start with a bash script:
+
+   ```shell
+   #!/bin/bash
+   ```
+
+   {% alert level="info" %}
+   To copy and run the bootstrap script, use the user specified in the VM metadata.
+   {% endalert %}
+
+1. Copy the bootstrap script to the VM being connected. If SSH access to the VM is available from the master node, run the following on the master node:
+
+   ```shell
+   scp ${NODE_GROUP}-bootstrap.b64 <USER>@<NODE_PUBLIC_OR_INTERNAL_IP>:/tmp/bootstrap.b64
+   ```
+
+   If SSH access to the VM is available only from the administrator's workstation, first copy the file from the master node to the workstation, and then from the workstation to the VM:
+
+   ```shell
+   scp <MASTER_USER>@<MASTER_IP>:/root/${NODE_GROUP}-bootstrap.b64 ./bootstrap.b64
+   scp ./bootstrap.b64 <USER>@<NODE_PUBLIC_OR_INTERNAL_IP>:/tmp/bootstrap.b64
+   ```
+
+   Where:
+
+   - `<MASTER_USER>` — the user for SSH access to the master node
+   - `<MASTER_IP>` — the IP address of the master node
+   - `<USER>` — the user on the VM being connected
+   - `<NODE_PUBLIC_OR_INTERNAL_IP>` — the public or internal IP address of the VM being connected
+
+1. On the VM being connected, decode the bootstrap script, set permissions, and run it:
+
+   ```shell
+   base64 -d /tmp/bootstrap.b64 > /tmp/bootstrap.sh
+   chmod +x /tmp/bootstrap.sh
+
+   sudo bash /tmp/bootstrap.sh
+   ```
+
+   After the bootstrap script is started, it will install the required components, configure the container runtime and kubelet, and connect the node to the cluster.
+
+1. On the master node, check that the new node has appeared:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Example expected output:
+
+   ```console
+   NAME                    STATUS   ROLES       AGE   VERSION    INTERNAL-IP   EXTERNAL-IP
+   static-master-0         Ready    master      1h    v1.33.10   10.128.0.15   <none>
+   yandex-worker-hybrid    Ready    yc-manual   5m    v1.33.10   10.128.0.17   <PUBLIC_IP>
+   ```
+
+1. If connection fails, check the NodeGroup status, events, and component logs:
+
+   ```shell
+   d8 k get nodegroup yc-manual
+   d8 k describe nodegroup yc-manual
+   d8 k describe node yandex-worker-hybrid
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```

--- a/docs/documentation/pages/admin/configuration/integrations/hybrid/YANDEX_HYBRID_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/hybrid/YANDEX_HYBRID_RU.md
@@ -1,0 +1,707 @@
+---
+title: Гибридный кластер с Yandex Cloud
+permalink: ru/admin/integrations/hybrid/yandex-hybrid.html
+lang: ru
+---
+
+Далее описан процесс добавления worker-узлов из Yandex Cloud в существующий статический кластер DKP.
+
+Для интеграции с Yandex Cloud используется модуль [`cloud-provider-yandex`](/modules/cloud-provider-yandex/). Он обеспечивает взаимодействие DKP с API Yandex Cloud, получение информации об облачной инфраструктуре, создание виртуальных машин, работу с сетевыми параметрами и подключение узлов к существующему кластеру.
+
+В разделе описаны три способа добавления worker-узлов:
+
+- **Автоматическое создание узлов в Yandex Cloud**. DKP создаёт виртуальные машины через API Yandex Cloud. Параметры ВМ задаются ресурсом [YandexInstanceClass](/modules/cloud-provider-yandex/cr.html#yandexinstanceclass), а требуемое количество узлов и зоны размещения — ресурсом [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом `Cloud`.
+- **Подключение вручную созданных узлов через CAPS**. Виртуальная машина создаётся пользователем заранее, а DKP подключается к ней по SSH через Cluster API Provider Static. Для этого используются ресурс [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом `Static`, а также ресурсы [SSHCredentials](/modules/node-manager/cr.html#sshcredentials) и [StaticInstance](/modules/node-manager/cr.html#staticinstance).
+- **Подключение вручную созданных узлов через bootstrap-скрипт**. Виртуальная машина создаётся пользователем заранее и подключается к кластеру с помощью bootstrap-скрипта DKP. Для такого сценария используется [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом `Hybrid`.
+
+## Предварительные требования
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Кластер создан с параметром [`clusterType: Static`](/products/kubernetes-platform/documentation/v1/reference/api/cr.html#clusterconfiguration-clustertype).
+- Между сетью статических узлов и VPC Yandex Cloud настроена сетевая связность.
+- Узлы Yandex Cloud, добавляемые в кластер, имеют доступ к Kubernetes API, DNS и необходимым адресам согласно разделам [Сетевое взаимодействие](../../../../reference/network_interaction.html) и [Настройка сетевых политик](../../configuration/network/policy/configuration.html).
+- Выполнены требования из раздела [Авторизация в Yandex Cloud](../public/yandex/authorization.html):
+  - подготовлен сервисный аккаунт;
+  - выбран каталог, в котором будут создаваться ресурсы;
+  - настроены необходимые роли и доступ к используемой VPC.
+- При использовании Cilium с туннелированием трафика подов выбран режим [`tunnelMode`](/modules/cni-cilium/configuration.html#parameters-tunnelmode), соответствующий сетевой связности между площадками.
+
+## Добавление автоматически создаваемых узлов
+
+Для выполнения подготовительных команд нужен [Yandex Cloud CLI](https://yandex.cloud/ru/docs/cli/) (`yc`). Его можно использовать на рабочей машине администратора. На master-узле кластера `yc` не требуется: в кластере нужно применить только подготовленные манифесты.
+
+1. Подготовьте идентификаторы облака, каталога, сети, подсети и зоны, где будут создаваться worker-узлы:
+
+   ```shell
+   export CLOUD_ID="<CLOUD_ID>"
+   export FOLDER_ID="<FOLDER_ID>"
+   export NETWORK_ID="<NETWORK_ID>"
+   export SUBNET_ID="<SUBNET_ID>"
+   export ZONE="ru-central1-a"
+   ```
+
+   Получить значения можно через Yandex Cloud CLI:
+
+   ```shell
+   yc resource-manager cloud list
+   yc resource-manager folder list
+   yc vpc network list --folder-id "$FOLDER_ID"
+   yc vpc subnet list --folder-id "$FOLDER_ID"
+   ```
+
+   Где:
+
+   - `CLOUD_ID` — ID облака Yandex Cloud;
+   - `FOLDER_ID` — ID каталога, в котором будут создаваться ресурсы;
+   - `NETWORK_ID` — ID VPC-сети;
+   - `SUBNET_ID` — ID подсети, в которой будут создаваться worker-узлы;
+   - `ZONE` — зона доступности, соответствующая выбранной подсети.
+
+   Подробнее в разделе [Авторизация в Yandex Cloud](../public/yandex/authorization.html)
+
+1. Создайте Service Account в нужном каталоге Yandex Cloud и назначьте ему права:
+
+   ```shell
+   yc iam service-account create \
+     --name dkp-hybrid \
+     --folder-id "$FOLDER_ID"
+
+   export SA_ID="$(yc iam service-account get \
+     --name dkp-hybrid \
+     --folder-id "$FOLDER_ID" \
+     --format json | jq -r .id)"
+
+   yc resource-manager folder add-access-binding "$FOLDER_ID" \
+     --role editor \
+     --subject "serviceAccount:${SA_ID}"
+
+   yc resource-manager folder add-access-binding "$FOLDER_ID" \
+     --role vpc.admin \
+     --subject "serviceAccount:${SA_ID}"
+   ```
+
+   Роль `editor` нужна для создания и управления облачными ресурсами, а `vpc.admin` — для работы с сетевыми ресурсами VPC.
+
+1. Создайте ключ Service Account и сохраните его в JSON-файл:
+
+   ```shell
+   yc iam key create \
+     --service-account-id "$SA_ID" \
+     --output dkp-hybrid-sa-key.json
+   ```
+
+   Подготовьте значение `serviceAccountJSON` в однострочном формате:
+
+   ```shell
+   export SERVICE_ACCOUNT_JSON="$(jq -c . dkp-hybrid-sa-key.json)"
+   ```
+
+1. Подготовьте публичный SSH-ключ, который будет добавлен на создаваемые worker-узлы:
+
+   ```shell
+   export SSH_PUBLIC_KEY="$(cat ~/.ssh/id_rsa.pub)"
+   ```
+
+   Если используется другой ключ, укажите путь к нему вместо `~/.ssh/id_rsa.pub`.
+
+   {% alert level="warning" %}
+   В параметре `sshPublicKey` нужно передавать публичный SSH-ключ администратора, а не публичный ключ из JSON-файла Service Account.
+   {% endalert %}
+
+1. Получите ID образа операционной системы, из которого будут создаваться виртуальные машины:
+
+   ```shell
+   export IMAGE_ID="$(yc compute image get-latest-from-family ubuntu-2404-lts \
+     --folder-id standard-images \
+     --format json | jq -r .id)"
+   ```
+
+   {% alert level="warning" %}
+   Параметр `imageID` — это ID образа ОС в Yandex Cloud. Не используйте в этом поле ID существующей виртуальной машины или ID ключа Service Account.
+   {% endalert %}
+
+1. Укажите CIDR сети, в которой будут размещаться узлы Yandex Cloud:
+
+   ```shell
+   export NODE_NETWORK_CIDR="<NODE_NETWORK_CIDR>"
+   ```
+
+   `NODE_NETWORK_CIDR` — CIDR, включающий внутренние IP-адреса узлов Yandex Cloud. Для одной зоны обычно совпадает с CIDR выбранной подсети. Например, если worker-узлы создаются в подсети `10.128.0.0/24`, укажите `10.128.0.0/24`. Узнать CIDR подсети можно командой:
+
+   ```shell
+   yc vpc subnet list --folder-id "$FOLDER_ID"
+   ```
+
+1. Создайте файл, например `cloud-provider-cluster-configuration.yaml` с конфигурацией провайдера:
+
+   ```shell
+   cat > cloud-provider-cluster-configuration.yaml <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: YandexClusterConfiguration
+   layout: WithoutNAT
+   masterNodeGroup:
+     replicas: 1
+     instanceClass:
+       cores: 4
+       memory: 8192
+       imageID: ${IMAGE_ID}
+       diskSizeGB: 100
+       platform: standard-v3
+       externalIPAddresses:
+         - "Auto"
+   nodeNetworkCIDR: ${NODE_NETWORK_CIDR}
+   existingNetworkID: empty
+   provider:
+     cloudID: ${CLOUD_ID}
+     folderID: ${FOLDER_ID}
+     serviceAccountJSON: '${SERVICE_ACCOUNT_JSON}'
+   sshPublicKey: '${SSH_PUBLIC_KEY}'
+   EOF
+   ```
+
+   Где:
+
+   - `nodeNetworkCIDR` — CIDR сети, который включает адреса подсетей, используемых для узлов Yandex Cloud;
+   - `imageID` — ID образа ОС для создаваемых виртуальных машин;
+   - `cloudID` — ID облака Yandex Cloud;
+   - `folderID` — ID каталога Yandex Cloud;
+   - `serviceAccountJSON` — JSON-ключ Service Account в однострочном формате;
+   - `sshPublicKey` — публичный SSH-ключ для доступа к создаваемым узлам.
+
+   {% alert level="info" %}
+   В гибридном сценарии, когда control plane уже развёрнут как статический кластер, секция `masterNodeGroup` не приводит к созданию master-узлов в Yandex Cloud, но остаётся частью конфигурации провайдера.
+   {% endalert %}
+
+1. Создайте файл, например `cloud-provider-discovery-data.json` с discovery-данными Yandex Cloud:
+
+   ```shell
+   cat > cloud-provider-discovery-data.json <<EOF
+   {
+     "apiVersion": "deckhouse.io/v1",
+     "defaultLbTargetGroupNetworkId": "empty",
+     "internalNetworkIDs": [
+       "${NETWORK_ID}"
+     ],
+     "kind": "YandexCloudDiscoveryData",
+     "monitoringAPIKey": "",
+     "region": "ru-central1",
+     "routeTableID": "empty",
+     "shouldAssignPublicIPAddress": false,
+     "zoneToSubnetIdMap": {
+       "${ZONE}": "${SUBNET_ID}"
+     },
+     "zones": [
+       "${ZONE}"
+     ]
+   }
+   EOF
+   ```
+
+   Где:
+
+   - `internalNetworkIDs` — список ID сетей Yandex Cloud, через которые обеспечивается внутренняя связность между узлами;
+   - `zoneToSubnetIdMap` — соответствие зоны доступности и подсети, в которой будут создаваться узлы;
+   - `zones` — список зон, доступных для создания узлов;
+   - `shouldAssignPublicIPAddress` — управляет назначением публичных IP-адресов создаваемым узлам.
+
+   {% alert level="warning" %}
+   Если параметр `shouldAssignPublicIPAddress` установлен в `false`, у создаваемых узлов не будет публичного IP-адреса. В этом случае узлы должны иметь доступ к registry и внешним сервисам через NAT Gateway, NAT-инстанс, proxy или другой egress-механизм. Для зон, в которых подсети отсутствуют, допустимо использовать значение `empty`.
+   {% endalert %}
+
+1. Закодируйте файлы `cloud-provider-cluster-configuration.yaml` и `cloud-provider-discovery-data.json` в Base64:
+
+   ```shell
+   export CLUSTER_CONFIGURATION_B64="$(base64 -w0 cloud-provider-cluster-configuration.yaml)"
+   export DISCOVERY_DATA_B64="$(base64 -w0 cloud-provider-discovery-data.json)"
+   ```
+
+1. Создайте манифест с секретом `d8-provider-cluster-configuration` и ModuleConfig для модуля `cloud-provider-yandex`:
+
+   ```shell
+   cat > yandex-provider-secret-and-mc.yaml <<EOF
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     labels:
+       heritage: deckhouse
+       name: d8-provider-cluster-configuration
+     name: d8-provider-cluster-configuration
+     namespace: kube-system
+   type: Opaque
+   data:
+     cloud-provider-cluster-configuration.yaml: ${CLUSTER_CONFIGURATION_B64}
+     cloud-provider-discovery-data.json: ${DISCOVERY_DATA_B64}
+   ---
+   apiVersion: deckhouse.io/v1alpha1
+   kind: ModuleConfig
+   metadata:
+     name: cloud-provider-yandex
+   spec:
+     version: 1
+     enabled: true
+     settings:
+       storageClass:
+         default: network-ssd
+   EOF
+   ```
+
+1. Скопируйте файл `yandex-provider-secret-and-mc.yaml` на master-узел кластера. Перед применением удалите объект ValidatingAdmissionPolicyBinding, если он запрещает создание объектов с лейблом `heritage: deckhouse`:
+
+   ```shell
+   d8 k delete validatingadmissionpolicybindings.admissionregistration.k8s.io \
+     heritage-label-objects.deckhouse.io \
+     --ignore-not-found
+   ```
+
+   Примените манифест:
+
+   ```shell
+   d8 k apply -f yandex-provider-secret-and-mc.yaml
+   ```
+
+1. Дождитесь включения модуля `cloud-provider-yandex` и появления ресурса YandexInstanceClass:
+
+   ```shell
+   d8 k get moduleconfig cloud-provider-yandex
+   d8 k get crd yandexinstanceclasses.deckhouse.io
+   d8 k -n d8-cloud-provider-yandex get pods -o wide
+   ```
+
+1. Создайте файл, например `yandex-instanceclass-nodegroup.yaml` с ресурсами YandexInstanceClass и NodeGroup:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1alpha1
+   kind: YandexInstanceClass
+   metadata:
+     name: yc-worker
+   spec:
+     cores: 4
+     memory: 8192
+     diskSizeGB: 50
+     diskType: network-ssd
+     mainSubnet: <SUBNET_ID>
+   ---
+   apiVersion: deckhouse.io/v1alpha1
+   kind: NodeGroup
+   metadata:
+     name: yc-worker
+   spec:
+     nodeType: Cloud
+     cloudInstances:
+       classReference:
+         kind: YandexInstanceClass
+         name: yc-worker
+       minPerZone: 1
+       maxPerZone: 1
+       zones:
+         - ru-central1-a
+   ```
+
+   Где:
+
+   - YandexInstanceClass описывает параметры виртуальной машины, которая будет создана в Yandex Cloud;
+   - `mainSubnet` — ID подсети, из которой создаваемые worker-узлы должны иметь доступ к статическим узлам кластера;
+   - NodeGroup описывает группу узлов, которую DKP должен поддерживать в кластере;
+   - `nodeType: Cloud` означает, что узлы будут создаваться автоматически через облачного провайдера;
+   - `cloudInstances.zones` должен содержать зоны из списка `zones` в `cloud-provider-discovery-data.json`.
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f yandex-instanceclass-nodegroup.yaml
+   ```
+
+   После применения DKP начнёт создавать виртуальную машину в Yandex Cloud через machine-controller-manager.
+
+1. Проверьте появление узла в кластере:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                                 STATUS   ROLES                  AGE   VERSION    INTERNAL-IP
+   static-master-0                      Ready    control-plane,master   1h    v1.33.10   10.128.0.15
+   yc-worker-f3564dca-7fc59-s2w5d       Ready    yc-worker              10m   v1.33.10   10.128.0.21
+   ```
+
+1. Для диагностики состояния и поиска возможных проблем проверьте логи machine-controller-manager:
+
+   ```shell
+   d8 k -n d8-cloud-instance-manager get machinedeployments.machine.sapcloud.io -o wide
+   d8 k -n d8-cloud-instance-manager get machinesets.machine.sapcloud.io -o wide
+   d8 k -n d8-cloud-instance-manager get machines.machine.sapcloud.io -o wide
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```
+
+## Добавление вручную созданных узлов через CAPS
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-yandex`](/modules/cloud-provider-yandex/) включён и настроен.
+- Компоненты модуля `cloud-provider-yandex` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-yandex get pods -o wide
+  ```
+
+- В Yandex Cloud создана виртуальная машина, которая будет подключена к кластеру.
+- Виртуальная машина подключена к сети и подсети Yandex Cloud, используемым для гибридной интеграции с кластером.
+- Внутренний IP-адрес виртуальной машины входит в диапазон адресов, используемый для облачных узлов Yandex Cloud.
+- Имя виртуальной машины в Yandex Cloud совпадает с hostname внутри операционной системы.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+1. На master-узле задайте переменные для создаваемой NodeGroup и подключаемой виртуальной машины:
+
+   ```shell
+   export NODE_GROUP="yc-caps"
+   export NODE_NAME="yandex-worker-hybrid-caps"
+   export NODE_SSH_IP="<NODE_PUBLIC_OR_INTERNAL_IP>"
+   export CAPS_USER="caps"
+   ```
+
+   Где:
+
+   - `NODE_GROUP` — имя NodeGroup, в которую будет добавлен узел;
+   - `NODE_NAME` — имя подключаемого узла;
+   - `NODE_SSH_IP` — IP-адрес виртуальной машины, доступный по SSH;
+   - `CAPS_USER` — пользователь, под которым CAPS будет подключаться к виртуальной машине.
+
+1. На master-узле создайте NodeGroup:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     nodeType: Static
+     staticInstances:
+       count: 1
+       labelSelector:
+         matchLabels:
+           role: ${NODE_GROUP}
+   EOF
+   ```
+
+   В этом сценарии используется `nodeType: Static`, потому что узел уже создан вручную, а CAPS будет только подключать и настраивать его по SSH.
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME      TYPE     READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   yc-caps   Static   0       0       0                                                               1m    True
+   ```
+
+1. На master-узле сгенерируйте SSH-ключ, который CAPS будет использовать для подключения к виртуальной машине:
+
+   ```shell
+   ssh-keygen -t ed25519 \
+     -f /dev/shm/${NODE_GROUP}-id \
+     -C "" \
+     -N ""
+   ```
+
+   {% alert level="info" %}
+   Ключ создаётся с пустой парольной фразой, так как CAPS должен использовать его автоматически.
+   {% endalert %}
+
+1. На master-узле создайте ресурс [SSHCredentials](/modules/node-manager/cr.html#sshcredentials):
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: SSHCredentials
+   metadata:
+     name: ${NODE_GROUP}
+   spec:
+     user: ${CAPS_USER}
+     privateSSHKey: "$(base64 -w0 /dev/shm/${NODE_GROUP}-id)"
+   EOF
+   ```
+
+   Ресурс SSHCredentials хранит имя пользователя и приватный SSH-ключ, с помощью которых CAPS будет подключаться к виртуальной машине.
+
+1. Убедитесь, что ресурс SSHCredentials создан:
+
+   ```shell
+   d8 k get sshcredentials
+   d8 k describe sshcredentials ${NODE_GROUP}
+   ```
+
+1. На master-узле выведите публичную часть SSH-ключа:
+
+   ```shell
+   cat /dev/shm/${NODE_GROUP}-id.pub
+   ```
+
+   Этот ключ понадобится на следующем шаге для настройки пользователя на подключаемой виртуальной машине.
+
+1. На подключаемой виртуальной машине создайте пользователя, под которым CAPS будет выполнять настройку узла. Выполните команды на подключаемой виртуальной машине, указав публичный SSH-ключ, полученный на предыдущем шаге:
+
+   ```shell
+   export CAPS_USER="caps"
+   export KEY='<SSH_PUBLIC_KEY>'
+
+   useradd -m -s /bin/bash ${CAPS_USER}
+   usermod -aG sudo ${CAPS_USER}
+
+   echo "${CAPS_USER} ALL=(ALL) NOPASSWD: ALL" | EDITOR='tee -a' visudo
+
+   mkdir -p /home/${CAPS_USER}/.ssh
+   echo "${KEY}" > /home/${CAPS_USER}/.ssh/authorized_keys
+
+   chown -R ${CAPS_USER}:${CAPS_USER} /home/${CAPS_USER}
+   chmod 700 /home/${CAPS_USER}/.ssh
+   chmod 600 /home/${CAPS_USER}/.ssh/authorized_keys
+   ```
+
+   {% alert level="info" %}
+   Значение `KEY` необходимо указывать в кавычках, так как публичный SSH-ключ содержит пробелы.
+   {% endalert %}
+
+   {% alert level="info" %}
+   Для операционных систем семейства Astra Linux при использовании модуля мандатного контроля целостности Parsec дополнительно задайте максимальный уровень целостности для пользователя:
+
+   ```shell
+   pdpl-user -i 63 ${CAPS_USER}
+   ```
+
+   {% endalert %}
+
+1. На master-узле проверьте, что CAPS-пользователь может подключиться к виртуальной машине по SSH и выполнять команды через `sudo` без пароля:
+
+   ```shell
+   ssh -i /dev/shm/${NODE_GROUP}-id ${CAPS_USER}@${NODE_SSH_IP} \
+     'hostname; sudo -n true; echo OK'
+   ```
+
+   В выводе должно быть имя узла и строка `OK`.
+
+1. На master-узле создайте ресурс [StaticInstance](/modules/node-manager/cr.html#staticinstance) для подключаемой виртуальной машины:
+
+   ```shell
+   d8 k apply -f - <<EOF
+   apiVersion: deckhouse.io/v1alpha2
+   kind: StaticInstance
+   metadata:
+     name: ${NODE_NAME}
+     labels:
+       role: ${NODE_GROUP}
+   spec:
+     address: "${NODE_SSH_IP}"
+     credentialsRef:
+       kind: SSHCredentials
+       name: ${NODE_GROUP}
+   EOF
+   ```
+
+   Где:
+
+   - `metadata.name` — имя подключаемого узла;
+   - `metadata.labels.role` — лейбл, по которому NodeGroup выбирает этот StaticInstance;
+   - `spec.address` — IP-адрес виртуальной машины, доступный по SSH;
+   - `spec.credentialsRef.name` — имя созданного ранее ресурса SSHCredentials.
+
+1. Проверьте состояние StaticInstance:
+
+   ```shell
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+   ```
+
+1. Дождитесь подключения узла и проверьте его состояние:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                         STATUS   ROLES     AGE   VERSION    INTERNAL-IP   EXTERNAL-IP
+   static-master-0              Ready    master    1h    v1.33.10   10.128.0.15   <none>
+   yandex-worker-hybrid-caps    Ready    yc-caps   5m    v1.33.10   10.128.0.29   <none>
+   ```
+
+1. При сбоях подключения проверьте состояние NodeGroup, StaticInstance, Machine и события в кластере:
+
+   ```shell
+   d8 k get nodegroup ${NODE_GROUP}
+   d8 k describe nodegroup ${NODE_GROUP}
+
+   d8 k get staticinstances
+   d8 k describe staticinstance ${NODE_NAME}
+
+   d8 k -n d8-cloud-instance-manager get machines,machinesets,machinedeployments -o wide
+   d8 k get events -A --sort-by=.lastTimestamp | tail -n 100
+   ```
+
+## Добавление вручную созданных узлов через bootstrap-скрипт
+
+Перед началом убедитесь, что выполнены следующие условия:
+
+- Модуль [`cloud-provider-yandex`](/modules/cloud-provider-yandex/) включён и настроен.
+- Компоненты модуля `cloud-provider-yandex` находятся в состоянии `Running`:
+
+  ```shell
+  d8 k -n d8-cloud-provider-yandex get pods -o wide
+  ```
+
+- В Yandex Cloud создана виртуальная машина, которая будет подключена к кластеру.
+- Виртуальная машина подключена к сети и подсети Yandex Cloud, используемым для гибридной интеграции с кластером.
+- Внутренний IP-адрес виртуальной машины входит в диапазон адресов, используемый для облачных узлов Yandex Cloud.
+- Имя виртуальной машины в Yandex Cloud совпадает с hostname внутри операционной системы.
+- На виртуальной машине установлены необходимые базовые пакеты для поддерживаемой ОС. Для РЕД ОС заранее установите `which` и пакетный менеджер, если они отсутствуют.
+
+1. Проверьте метаданные виртуальной машины в Yandex Cloud.
+
+   В метаданных ВМ должен быть настроен `cloud-init` с пользователем, через которого будет выполняться подключение по SSH.
+
+   Пример метаданных:
+
+   ```yaml
+   #cloud-config
+   datasource:
+     Ec2:
+       strict_id: false
+   ssh_pwauth: no
+   users:
+     - name: <USER>
+       sudo: ALL=(ALL) NOPASSWD:ALL
+       shell: /bin/bash
+       ssh_authorized_keys:
+         - <SSH_PUBLIC_KEY>
+   ```
+
+   Где:
+
+   - `<USER>` — имя пользователя для SSH-доступа к виртуальной машине;
+   - `<SSH_PUBLIC_KEY>` — публичный SSH-ключ администратора.
+
+1. На master-узле создайте файл, например `yandex-manual-nodegroup.yaml`, с ресурсом NodeGroup:
+
+   ```yaml
+   apiVersion: deckhouse.io/v1
+   kind: NodeGroup
+   metadata:
+     name: yc-manual
+   spec:
+     nodeType: Hybrid
+   ```
+
+   {% alert level="info" %}
+   Для вручную создаваемых узлов Yandex Cloud используется значение `nodeType: Hybrid`. В статусе NodeGroup такая группа может отображаться как `CloudStatic`.
+   {% endalert %}
+
+1. Примените манифест:
+
+   ```shell
+   d8 k apply -f yandex-manual-nodegroup.yaml
+   ```
+
+1. Убедитесь, что NodeGroup создана и синхронизирована:
+
+   ```shell
+   d8 k get nodegroup yc-manual
+   d8 k describe nodegroup yc-manual
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME        TYPE          READY   NODES   UPTODATE   INSTANCES   DESIRED   MIN   MAX   STANDBY   STATUS   AGE   SYNCED
+   yc-manual   CloudStatic   0       0       0                                                               1m    True
+   ```
+
+1. На master-узле получите bootstrap-скрипт для созданной NodeGroup:
+
+   ```shell
+   NODE_GROUP=yc-manual
+
+   d8 k -n d8-cloud-instance-manager get secret manual-bootstrap-for-${NODE_GROUP} \
+     -o jsonpath='{.data.bootstrap\.sh}' > ${NODE_GROUP}-bootstrap.b64
+   ```
+
+1. На master-узле проверьте, что файл содержит Base64-данные bootstrap-скрипта:
+
+   ```shell
+   head -c 80 ${NODE_GROUP}-bootstrap.b64
+   echo
+   base64 -d ${NODE_GROUP}-bootstrap.b64 | head -n 5
+   ```
+
+   В начале декодированного содержимого должен быть bash-скрипт:
+
+   ```shell
+   #!/bin/bash
+   ```
+
+   {% alert level="info" %}
+   Для копирования и запуска bootstrap-скрипта используйте пользователя, указанного в метаданных ВМ.
+   {% endalert %}
+
+1. Скопируйте bootstrap-скрипт на подключаемую ВМ. Если SSH-доступ к ВМ есть с master-узла, выполните на master-узле:
+
+   ```shell
+   scp ${NODE_GROUP}-bootstrap.b64 <USER>@<NODE_PUBLIC_OR_INTERNAL_IP>:/tmp/bootstrap.b64
+   ```
+
+   Если SSH-доступ к ВМ есть только с рабочей машины администратора, сначала скопируйте файл с master-узла на рабочую машину, а затем с рабочей машины на ВМ:
+
+   ```shell
+   scp <MASTER_USER>@<MASTER_IP>:/root/${NODE_GROUP}-bootstrap.b64 ./bootstrap.b64
+   scp ./bootstrap.b64 <USER>@<NODE_PUBLIC_OR_INTERNAL_IP>:/tmp/bootstrap.b64
+   ```
+
+   Где:
+
+   - `<MASTER_USER>` — пользователь для SSH-доступа к master-узлу;
+   - `<MASTER_IP>` — IP-адрес master-узла;
+   - `<USER>` — пользователь на подключаемой ВМ;
+   - `<NODE_PUBLIC_OR_INTERNAL_IP>` — публичный или внутренний IP-адрес подключаемой ВМ.
+
+1. На подключаемой ВМ декодируйте bootstrap-скрипт, назначьте права и запустите его:
+
+   ```shell
+   base64 -d /tmp/bootstrap.b64 > /tmp/bootstrap.sh
+   chmod +x /tmp/bootstrap.sh
+
+   sudo bash /tmp/bootstrap.sh
+   ```
+
+   После запуска bootstrap-скрипт установит необходимые компоненты, настроит container runtime, kubelet и подключит узел к кластеру.
+
+1. На master-узле проверьте появление нового узла:
+
+   ```shell
+   d8 k get nodes -o wide
+   ```
+
+   Пример ожидаемого результата:
+
+   ```console
+   NAME                    STATUS   ROLES       AGE   VERSION    INTERNAL-IP   EXTERNAL-IP
+   static-master-0         Ready    master      1h    v1.33.10   10.128.0.15   <none>
+   yandex-worker-hybrid    Ready    yc-manual   5m    v1.33.10   10.128.0.17   <PUBLIC_IP>
+   ```
+
+1. При сбоях подключения проверьте состояние NodeGroup, события и логи компонентов:
+
+   ```shell
+   d8 k get nodegroup yc-manual
+   d8 k describe nodegroup yc-manual
+   d8 k describe node yandex-worker-hybrid
+   d8 k -n d8-cloud-instance-manager logs deploy/machine-controller-manager --tail=200
+   ```


### PR DESCRIPTION
## Description
Added hybrid cluster guide in DVP.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Added hybrid cluster guide in DVP.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
