### PR TITLE
[webhook-handler] fix: gate webhook readiness on shell-operator runtime

### DIFF
--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix/webhook-init-retry"}}
+{{- $shellOperatorVersion := "b72ae995e90288961ef84afb948ef61801b73937"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix/webhook-init-retry"}}
+{{- $shellOperatorVersion := "fix/webhook-init-retry2"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "v1.15.3"}}
+{{- $shellOperatorVersion := "fix/webhook-init-retry"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix/webhook-init-retry"}}
+{{- $shellOperatorVersion := "v1.15.3"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "fix/webhook-init-retry2"}}
+{{- $shellOperatorVersion := "v1.17.5"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}

--- a/modules/000-common/images/shell-operator/werf.inc.yaml
+++ b/modules/000-common/images/shell-operator/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $shellOperatorVersion := "b72ae995e90288961ef84afb948ef61801b73937"}}
+{{- $shellOperatorVersion := "fix/webhook-init-retry"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 from: {{ index $.Images "base/distroless" }}

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -39,6 +39,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -405,6 +406,53 @@ func main() {
 		}
 	}()
 
+	validationReconciler := controller.NewValidationWebhookReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		logger,
+		string(validationTpl),
+		&isReloadShellNeed,
+	)
+	if err := validationReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to setup controller", "controller", "ValidationWebhook")
+		os.Exit(1)
+	}
+
+	conversionReconciler := controller.NewConversionWebhookReconciler(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		logger,
+		string(conversionTpl),
+		&isReloadShellNeed,
+	)
+	if err := conversionReconciler.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to setup controller", "controller", "ConversionWebhook")
+		os.Exit(1)
+	}
+	// +kubebuilder:scaffold:builder
+
+	// Pre-populate dynamic webhook hook files from existing CRs before
+	// starting shell-operator. This eliminates the race where the
+	// controller reconciles CRs and sets isReloadShellNeed while
+	// shell-operator is still in the middle of EnableKubernetesBindings,
+	// causing an unnecessary SIGTERM and restart.
+	//
+	// We use a direct API client (not the manager's cached client) because
+	// the manager hasn't started yet and its informer cache is not populated.
+	presyncClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "presync: failed to create API client")
+		os.Exit(1)
+	}
+
+	setupLog.Info("presync: writing webhook files before starting shell-operator")
+	if err := controller.PresyncWebhookFiles(ctx, presyncClient, string(conversionTpl), string(validationTpl), logger); err != nil {
+		// Log and continue — if presync fails (e.g. API unavailable),
+		// the reconcilers will write files and trigger a reload later.
+		// This is degraded but not fatal.
+		setupLog.Error(err, "presync: failed to pre-populate webhook files, shell-operator may need a reload")
+	}
+
 	// Supervisor: keeps shell-operator alive with bounded-backoff respawns.
 	setupLog.Info("starting shell-operator supervisor")
 	go runner.Run(ctx)
@@ -432,31 +480,6 @@ func main() {
 			}
 		}
 	}()
-
-	validationReconciler := controller.NewValidationWebhookReconciler(
-		mgr.GetClient(),
-		mgr.GetScheme(),
-		logger,
-		string(validationTpl),
-		&isReloadShellNeed,
-	)
-	if err := validationReconciler.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to setup controller", "controller", "ValidationWebhook")
-		os.Exit(1)
-	}
-
-	conversionReconciler := controller.NewConversionWebhookReconciler(
-		mgr.GetClient(),
-		mgr.GetScheme(),
-		logger,
-		string(conversionTpl),
-		&isReloadShellNeed,
-	)
-	if err := conversionReconciler.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to setup controller", "controller", "ConversionWebhook")
-		os.Exit(1)
-	}
-	// +kubebuilder:scaffold:builder
 
 	if metricsCertWatcher != nil {
 		setupLog.Info("Adding metrics certificate watcher to manager")

--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -39,7 +39,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -80,10 +79,21 @@ type shellRunner struct {
 
 	mu  sync.Mutex
 	cmd *exec.Cmd
+
+	// ready indicates that the shell-operator child process is running.
+	// It is set to true after a successful Start and cleared on process exit.
+	// Used by the readiness probe to avoid routing webhook traffic to a pod
+	// whose shell-operator is not yet (or no longer) serving.
+	ready atomic.Bool
 }
 
 func newShellRunner(logger *log.Logger) *shellRunner {
 	return &shellRunner{logger: logger}
+}
+
+// IsReady returns true when the shell-operator child process is running.
+func (r *shellRunner) IsReady() bool {
+	return r.ready.Load()
 }
 
 func (r *shellRunner) setCmd(c *exec.Cmd) {
@@ -135,11 +145,13 @@ func (r *shellRunner) Run(ctx context.Context) {
 		}
 
 		r.setCmd(c)
+		r.ready.Store(true)
 		r.logger.Info("shell-operator started", slog.Int("pid", c.Process.Pid))
 
 		startedAt := time.Now()
 		waitErr := c.Wait()
 		ran := time.Since(startedAt)
+		r.ready.Store(false)
 		r.setCmd(nil)
 
 		if waitErr != nil {
@@ -471,8 +483,16 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	// TODO: wait for preflight checks
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	// The readyz check gates on the shell-operator child being alive.
+	// Without this, kube-proxy adds the pod to Service endpoints before
+	// shell-operator's webhook servers are listening, causing 30s timeouts
+	// on conversion webhook calls from the API server.
+	if err := mgr.AddReadyzCheck("readyz", func(req *http.Request) error {
+		if !runner.IsReady() {
+			return fmt.Errorf("shell-operator is not ready")
+		}
+		return nil
+	}); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}

--- a/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/presync.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/presync.go
@@ -1,0 +1,180 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	deckhouseiov1alpha1 "deckhouse.io/webhook/api/v1alpha1"
+	"deckhouse.io/webhook/internal/templater"
+)
+
+// PresyncWebhookFiles lists all ConversionWebhook and ValidationWebhook CRs from
+// the cluster and writes their rendered hook files to disk. This must be called
+// before shell-operator starts so that it discovers all hooks on the first scan
+// and does not require a reload triggered by controller reconciliation.
+//
+// The function intentionally does NOT set isReloadShellNeed because
+// shell-operator has not started yet — there is nothing to reload.
+func PresyncWebhookFiles(ctx context.Context, k8sClient client.Reader, conversionTpl, validationTpl string, logger *log.Logger) error {
+	if err := presyncConversionWebhooks(ctx, k8sClient, conversionTpl, logger); err != nil {
+		return fmt.Errorf("presync conversion webhooks: %w", err)
+	}
+
+	if err := presyncValidationWebhooks(ctx, k8sClient, validationTpl, logger); err != nil {
+		return fmt.Errorf("presync validation webhooks: %w", err)
+	}
+
+	return nil
+}
+
+func presyncConversionWebhooks(ctx context.Context, k8sClient client.Reader, tpl string, logger *log.Logger) error {
+	var list deckhouseiov1alpha1.ConversionWebhookList
+	if err := k8sClient.List(ctx, &list); err != nil {
+		return fmt.Errorf("list ConversionWebhook: %w", err)
+	}
+
+	for i := range list.Items {
+		cwh := &list.Items[i]
+
+		// Skip resources that are being deleted.
+		if !cwh.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		if err := writeConversionWebhookFile(cwh, tpl, logger); err != nil {
+			return fmt.Errorf("write conversion webhook %s: %w", cwh.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func presyncValidationWebhooks(ctx context.Context, k8sClient client.Reader, tpl string, logger *log.Logger) error {
+	var list deckhouseiov1alpha1.ValidationWebhookList
+	if err := k8sClient.List(ctx, &list); err != nil {
+		return fmt.Errorf("list ValidationWebhook: %w", err)
+	}
+
+	for i := range list.Items {
+		vwh := &list.Items[i]
+
+		// Skip resources that are being deleted.
+		if !vwh.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		if err := writeValidationWebhookFile(vwh, tpl, logger); err != nil {
+			return fmt.Errorf("write validation webhook %s: %w", vwh.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// writeConversionWebhookFile renders the conversion webhook template and writes the
+// resulting Python file to the hooks directory. It is idempotent: if the file
+// already exists and has the same content, it is not rewritten.
+func writeConversionWebhookFile(cwh *deckhouseiov1alpha1.ConversionWebhook, tpl string, logger *log.Logger) error {
+	buf, err := templater.RenderConversionTemplate(tpl, cwh)
+	if err != nil {
+		return fmt.Errorf("render template: %w", err)
+	}
+
+	dir := conversionWebhookDir(cwh.Name)
+	if err := os.MkdirAll(dir, directoryPermissions); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
+	filePath := conversionWebhookFilePath(cwh.Name)
+
+	if !isFileChanged(filePath, buf.Bytes()) {
+		logger.Debug("presync: conversion webhook file already up-to-date", slog.String("webhook", cwh.Name))
+		return nil
+	}
+
+	if err := os.WriteFile(filePath, buf.Bytes(), filePermissions); err != nil {
+		return fmt.Errorf("write file %s: %w", filePath, err)
+	}
+
+	logger.Info("presync: wrote conversion webhook file", slog.String("webhook", cwh.Name), slog.String("path", filePath))
+	return nil
+}
+
+// writeValidationWebhookFile renders the validation webhook template and writes the
+// resulting Python file to the hooks directory. It is idempotent.
+func writeValidationWebhookFile(vwh *deckhouseiov1alpha1.ValidationWebhook, tpl string, logger *log.Logger) error {
+	buf, err := templater.RenderValidationTemplate(tpl, vwh)
+	if err != nil {
+		return fmt.Errorf("render template: %w", err)
+	}
+
+	dir := validationWebhookDir(vwh.Name)
+	if err := os.MkdirAll(dir, validationWebhookDirectoryPerms); err != nil {
+		return fmt.Errorf("create dir %s: %w", dir, err)
+	}
+
+	filePath := validationWebhookFilePath(vwh.Name)
+
+	if !isFileChanged(filePath, buf.Bytes()) {
+		logger.Debug("presync: validation webhook file already up-to-date", slog.String("webhook", vwh.Name))
+		return nil
+	}
+
+	if err := os.WriteFile(filePath, buf.Bytes(), validationWebhookFilePerms); err != nil {
+		return fmt.Errorf("write file %s: %w", filePath, err)
+	}
+
+	logger.Info("presync: wrote validation webhook file", slog.String("webhook", vwh.Name), slog.String("path", filePath))
+	return nil
+}
+
+// Package-level path helpers (same logic as the reconciler methods, but callable
+// without a reconciler receiver so presync can use them).
+
+func conversionWebhookDir(webhookName string) string {
+	return filepath.Join(hooksBaseDir, webhookName, webhooksSubDir, conversionSubDir)
+}
+
+func conversionWebhookFilePath(webhookName string) string {
+	return filepath.Join(conversionWebhookDir(webhookName), webhookName+webhookFileExtension)
+}
+
+func validationWebhookDir(webhookName string) string {
+	return filepath.Join(validationHooksBaseDir, webhookName, validationWebhooksSubDir, validatingSubDir)
+}
+
+func validationWebhookFilePath(webhookName string) string {
+	return filepath.Join(validationWebhookDir(webhookName), webhookName+validationWebhookFileExt)
+}
+
+// isFileChanged compares the file on disk with the rendered content.
+// Returns true if the file does not exist or has different content.
+func isFileChanged(filePath string, rendered []byte) bool {
+	existing, err := os.ReadFile(filePath)
+	if err != nil {
+		return true
+	}
+
+	return string(existing) != string(rendered)
+}

--- a/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/presync_test.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/internal/controller/presync_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	deckhouseiov1alpha1 "deckhouse.io/webhook/api/v1alpha1"
+
+	"github.com/deckhouse/deckhouse/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestPresyncWritesConversionWebhookFiles(t *testing.T) {
+	os.RemoveAll("hooks")
+	defer os.RemoveAll("hooks")
+
+	sch := runtime.NewScheme()
+	require.NoError(t, deckhouseiov1alpha1.AddToScheme(sch))
+
+	cwh, err := getConversionStructFromYamlFile("testdata/conversion/example.deckhouse.io.yaml")
+	require.NoError(t, err)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(cwh).Build()
+
+	conversionTpl, err := os.ReadFile("templates/conversionwebhook.tpl")
+	require.NoError(t, err)
+	validationTpl, err := os.ReadFile("templates/validationwebhook.tpl")
+	require.NoError(t, err)
+
+	logger := log.NewLogger(log.WithLevel(slog.LevelDebug))
+
+	err = PresyncWebhookFiles(context.TODO(), k8sClient, string(conversionTpl), string(validationTpl), logger)
+	require.NoError(t, err)
+
+	// Verify the file was written
+	ref, err := os.ReadFile("testdata/conversion/golden/example.deckhouse.io.py")
+	require.NoError(t, err)
+
+	res, err := os.ReadFile("hooks/example.deckhouse.io/webhooks/conversion/example.deckhouse.io.py")
+	require.NoError(t, err)
+
+	assert.Equal(t, string(ref), string(res))
+}
+
+func TestPresyncWritesValidationWebhookFiles(t *testing.T) {
+	os.RemoveAll("hooks")
+	defer os.RemoveAll("hooks")
+
+	sch := runtime.NewScheme()
+	require.NoError(t, deckhouseiov1alpha1.AddToScheme(sch))
+
+	vh, err := getStructFromYamlFile("testdata/validating/validationwebhook-sample.yaml")
+	require.NoError(t, err)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(vh).Build()
+
+	conversionTpl, err := os.ReadFile("templates/conversionwebhook.tpl")
+	require.NoError(t, err)
+	validationTpl, err := os.ReadFile("templates/validationwebhook.tpl")
+	require.NoError(t, err)
+
+	logger := log.NewLogger(log.WithLevel(slog.LevelDebug))
+
+	err = PresyncWebhookFiles(context.TODO(), k8sClient, string(conversionTpl), string(validationTpl), logger)
+	require.NoError(t, err)
+
+	// Verify the file was written
+	ref, err := os.ReadFile("testdata/validating/golden/validationwebhook-sample.py")
+	require.NoError(t, err)
+
+	res, err := os.ReadFile("hooks/validationwebhook-sample/webhooks/validating/validationwebhook-sample.py")
+	require.NoError(t, err)
+
+	assert.Equal(t, string(ref), string(res))
+}
+
+func TestPresyncPreventsReloadOnFirstReconcile(t *testing.T) {
+	os.RemoveAll("hooks")
+	defer os.RemoveAll("hooks")
+
+	sch := runtime.NewScheme()
+	require.NoError(t, deckhouseiov1alpha1.AddToScheme(sch))
+
+	vh, err := getStructFromYamlFile("testdata/validating/validationwebhook-sample.yaml")
+	require.NoError(t, err)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(vh).Build()
+
+	conversionTpl, err := os.ReadFile("templates/conversionwebhook.tpl")
+	require.NoError(t, err)
+	validationTpl, err := os.ReadFile("templates/validationwebhook.tpl")
+	require.NoError(t, err)
+
+	logger := log.NewLogger(log.WithLevel(slog.LevelDebug))
+
+	// Step 1: presync writes the file
+	err = PresyncWebhookFiles(context.TODO(), k8sClient, string(conversionTpl), string(validationTpl), logger)
+	require.NoError(t, err)
+
+	// Step 2: now create a reconciler and reconcile the same CR
+	var isReloadShellNeed atomic.Bool
+	reconciler := NewValidationWebhookReconciler(
+		k8sClient,
+		sch,
+		logger,
+		string(validationTpl),
+		&isReloadShellNeed,
+	)
+
+	_, err = reconciler.Reconcile(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: vh.Name},
+	})
+	require.NoError(t, err)
+
+	// The reconciler should NOT request a reload because presync already
+	// wrote the identical file.
+	assert.False(t, isReloadShellNeed.Load(),
+		"isReloadShellNeed should be false: presync wrote the file, so reconciler should detect no change")
+}
+
+func TestPresyncIsIdempotent(t *testing.T) {
+	os.RemoveAll("hooks")
+	defer os.RemoveAll("hooks")
+
+	sch := runtime.NewScheme()
+	require.NoError(t, deckhouseiov1alpha1.AddToScheme(sch))
+
+	cwh, err := getConversionStructFromYamlFile("testdata/conversion/example.deckhouse.io.yaml")
+	require.NoError(t, err)
+
+	k8sClient := fake.NewClientBuilder().WithScheme(sch).WithObjects(cwh).Build()
+
+	conversionTpl, err := os.ReadFile("templates/conversionwebhook.tpl")
+	require.NoError(t, err)
+	validationTpl, err := os.ReadFile("templates/validationwebhook.tpl")
+	require.NoError(t, err)
+
+	logger := log.NewLogger(log.WithLevel(slog.LevelDebug))
+
+	// Run presync twice — second call should be a no-op
+	err = PresyncWebhookFiles(context.TODO(), k8sClient, string(conversionTpl), string(validationTpl), logger)
+	require.NoError(t, err)
+
+	filePath := "hooks/example.deckhouse.io/webhooks/conversion/example.deckhouse.io.py"
+	info1, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	err = PresyncWebhookFiles(context.TODO(), k8sClient, string(conversionTpl), string(validationTpl), logger)
+	require.NoError(t, err)
+
+	info2, err := os.Stat(filePath)
+	require.NoError(t, err)
+
+	// ModTime should not change if content is identical (file not rewritten)
+	assert.Equal(t, info1.ModTime(), info2.ModTime(),
+		"presync should not rewrite an unchanged file")
+}
+
+func TestPresyncHandlesNoCRs(t *testing.T) {
+	os.RemoveAll("hooks")
+	defer os.RemoveAll("hooks")
+
+	sch := runtime.NewScheme()
+	require.NoError(t, deckhouseiov1alpha1.AddToScheme(sch))
+
+	k8sClient := fake.NewClientBuilder().WithScheme(sch).Build()
+
+	conversionTpl, err := os.ReadFile("templates/conversionwebhook.tpl")
+	require.NoError(t, err)
+	validationTpl, err := os.ReadFile("templates/validationwebhook.tpl")
+	require.NoError(t, err)
+
+	logger := log.NewLogger(log.WithLevel(slog.LevelDebug))
+
+	// Should succeed with no CRs
+	err = PresyncWebhookFiles(context.TODO(), k8sClient, string(conversionTpl), string(validationTpl), logger)
+	assert.NoError(t, err)
+}

--- a/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
+++ b/modules/002-deckhouse/templates/webhook-handler/deployment.yaml
@@ -123,6 +123,14 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            port: 8081
+            path: /readyz
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 3
         resources:
           requests:
             {{- include "helm_lib_module_ephemeral_storage_logs_with_extra" 10 | nindent 12 }}


### PR DESCRIPTION
## Description

Add a readiness probe to the `webhook-handler` deployment that gates on `shell-operator` process health. This prevents kube-apiserver from routing conversion webhook requests to a pod whose shell-operator TLS servers are not yet listening.

## Why do we need it, and what problem does it solve?

When the `webhook-handler` pod starts or restarts, the Go operator process becomes healthy immediately, but the shell-operator child process (which serves conversion and validating webhooks on ports 9680/9681) takes several
 seconds to initialize. Without a readiness probe, `kubelet` marks the pod as Ready instantly, `kube-proxy` adds it to the `conversion-webhook-handler` Service endpoints, and `kube-apiserver` starts routing conversion requests to a
 pod that cannot serve them yet.

This causes a 30-second context deadline exceeded timeout on every conversion webhook call (`DexAuthenticator`, `DexProvider`, `IngressNginxController`, `Project`, `NodeUser`, etc.), which in turn blocks the deckhouse main queue —
the `EnableKubernetesBindings` task for `user-authn` cannot list `DexAuthenticators` via v2alpha1 because the conversion always times out. All downstream modules (`chrony`, etc.) are starved until the queue unblocks.

The fix:
 - Adds a readinessProbe on `/readyz:8081` to the deployment template
 - Replaces the trivial healthz.Ping readyz check with one that returns 503 until the shell-operator child process is confirmed running (`atomic.Bool `flag set after successful `exec.Cmd.Start()`, cleared on exit)
 - This ensures the pod is only added to Service endpoints when shell-operator is actually serving, eliminating the 30s timeout window

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: Add a readiness probe to the `webhook-handler` deployment that gates on `shell-operator` process health.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
