### PR TITLE
[go-lib] 1.73 make certs valid

### DIFF
--- a/ee/modules/030-cloud-provider-vcd/hooks/generate_capcd_webhook_certs_test.go
+++ b/ee/modules/030-cloud-provider-vcd/hooks/generate_capcd_webhook_certs_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -24,9 +25,13 @@ import (
 const clusterDomain = "cluster.local"
 
 func genWebhookCa(logger *log.Logger) (*certificate.Authority, error) {
-	ca, err := certificate.GenerateCA(logger, "capcd-controller-manager-webhook", certificate.WithKeyAlgo("ecdsa"),
+	ca, err := certificate.GenerateCA(logger, "capcd-controller-manager-webhook",
+		certificate.WithKeyAlgo("ecdsa"),
 		certificate.WithKeySize(256),
-		certificate.WithCAExpiry("87600h"))
+		certificate.WithCAExpiry("87600h"),
+		// Match the central hook contract: O=Deckhouse, OU=<module>.
+		certificate.WithNames(csr.Name{O: "Deckhouse", OU: "cloud-provider-vcd"}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate CA: %v", err)
 	}
@@ -41,9 +46,10 @@ func genWebhookTLS(input *go_hook.HookInput, ca *certificate.Authority, cn strin
 		certificate.WithKeyAlgo("ecdsa"),
 		certificate.WithKeySize(256),
 		certificate.WithSigningDefaultExpiry((24*time.Hour)*365*10),
-		certificate.WithSigningDefaultUsage([]string{"signing",
+		certificate.WithSigningDefaultUsage([]string{
+			"signing",
 			"key encipherment",
-			"requestheader-client",
+			"server auth",
 		}),
 		certificate.WithSANs(
 			sanPrefix+".d8-cloud-provider-vcd",
@@ -91,7 +97,9 @@ var _ = Describe("Node Manager hooks :: generate_webhook_certs ::", func() {
 	})
 	Context("With secrets", func() {
 		caAuthority, _ := genWebhookCa(nil)
-		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, "capcd-manager-webhook", "capcd-controller-manager-webhook-service")
+		// CN must match the central hook's configured CN, otherwise CN drift
+		// triggers a re-issue and the test cert in the secret is replaced.
+		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, "capcd-controller-manager-webhook", "capcd-controller-manager-webhook-service")
 
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(fmt.Sprintf(`

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -18,10 +18,12 @@ package tls_certificate
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -44,8 +46,38 @@ const (
 	keyAlgorithm = "ecdsa"
 	keySize      = 256
 
+	// caOrganization is placed in the CA's Subject DN (O=). Together with an
+	// OU (see GenSelfSignedTLSHookConf.CAOrganizationalUnit) it guarantees that
+	// the CA's Subject DN is strictly different from the leaf's Subject DN.
+	// Per RFC 5280 §4.1.2.6 a leaf must have Issuer == Subject(CA) and
+	// Subject(leaf) != Subject(CA); when those collide OpenSSL classifies the
+	// leaf as a depth-0 self-signed certificate
+	// (X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT) and refuses to chain it to the
+	// CA, even though the leaf is in fact signed by a separate key. Go's
+	// crypto/x509 (and thus kube-apiserver) is more lenient, so legacy
+	// certificates issued without this differentiation continue to validate
+	// for Go-based clients, but external scanners (Trivy, MaxPatrol) and
+	// strict TLS stacks (Java keystore, openssl verify) reject them.
+	caOrganization = "Deckhouse"
+
+	// namespacePrefix is the conventional Deckhouse namespace prefix that is
+	// stripped to derive a default CA OU when the caller has not supplied one.
+	namespacePrefix = "d8-"
+
 	SnapshotKey = "secret"
 )
+
+// defaultUsages is the minimum set of cfssl usages for a TLS server
+// certificate. The legacy default contained the pseudo-usage
+// "requestheader-client" which is not present in cfssl's signing/extkeyusage
+// maps; cfssl-signer silently drops it and emits a certificate without any
+// ExtendedKeyUsage. Strict validators (Trivy, MaxPatrol with EKU checks, Java
+// keystores) reject such certificates.
+var defaultUsages = []string{
+	"signing",
+	"key encipherment",
+	"server auth",
+}
 
 // DefaultSANs helper to generate list of sans for certificate
 // you can also use helpers:
@@ -82,6 +114,17 @@ type GenSelfSignedTLSHookConf struct {
 	// often it is module name
 	CN string
 
+	// CAOrganizationalUnit is set as the OU on the CA's Subject DN to ensure
+	// CA and leaf certificates have distinct Subject DNs (see caOrganization
+	// for the rationale). Set this to the Deckhouse module name (e.g.
+	// "node-manager", "loki"). When left empty the value is derived from
+	// Namespace by stripping the "d8-" prefix; if Namespace does not have the
+	// prefix or is empty, CN is used as a last-resort fallback. The leaf
+	// certificate is intentionally signed CN-only — do NOT pass the same OU
+	// to GenerateSelfSignedCert, otherwise Subject(leaf) == Subject(CA) and
+	// the depth-0 self-signed collision returns.
+	CAOrganizationalUnit string
+
 	// Namespace - namespace for TLS secret
 	Namespace string
 	// TLSSecretName - TLS secret name
@@ -92,6 +135,17 @@ type GenSelfSignedTLSHookConf struct {
 	// Usages specifies valid usage contexts for keys.
 	// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
 	//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+	//
+	// Always pass an explicit set that contains "server auth" for server
+	// certificates and "client auth" for mTLS clients. Never pass
+	// "requestheader-client" — it is not a valid cfssl usage and silently
+	// produces certificates with empty ExtendedKeyUsage.
+	//
+	// Reference sets:
+	//   server cert:                ["signing", "key encipherment", "server auth"]
+	//   mTLS client cert:           ["signing", "key encipherment", "client auth"]
+	//   mTLS server validating
+	//   a client (dual-purpose):    ["signing", "key encipherment", "server auth", "client auth"]
 	Usages []certificatesv1.KeyUsage
 
 	// FullValuesPathPrefix - prefix full path to store CA certificate TLS private key and cert
@@ -118,6 +172,22 @@ func (gss GenSelfSignedTLSHookConf) path() string {
 	return strings.TrimSuffix(gss.FullValuesPathPrefix, ".")
 }
 
+// caOU returns the Organizational Unit placed on the CA's Subject DN.
+// Priority: explicit CAOrganizationalUnit → Namespace with the "d8-" prefix
+// stripped → CN. The result is always non-empty when CN is non-empty, which
+// is what differentiates the CA's Subject from the leaf's CN-only Subject.
+func (gss GenSelfSignedTLSHookConf) caOU() string {
+	if gss.CAOrganizationalUnit != "" {
+		return gss.CAOrganizationalUnit
+	}
+	if strings.HasPrefix(gss.Namespace, namespacePrefix) {
+		if trimmed := strings.TrimPrefix(gss.Namespace, namespacePrefix); trimmed != "" {
+			return trimmed
+		}
+	}
+	return gss.CN
+}
+
 type certValues struct {
 	CA  string `json:"ca"`
 	Crt string `json:"crt"`
@@ -125,7 +195,7 @@ type certValues struct {
 }
 
 // The certificate mapping "cert" -> "crt". We are migrating to "crt" naming for certificates
-// in values.
+// in values.
 func convCertToValues(cert certificate.Certificate) certValues {
 	return certValues{
 		CA:  cert.CA,
@@ -184,11 +254,7 @@ func tlsFilter(obj *unstructured.Unstructured) (go_hook.FilterResult, error) {
 func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, input *go_hook.HookInput) error {
 	var usages []string
 	if conf.Usages == nil {
-		usages = []string{
-			"signing",
-			"key encipherment",
-			"requestheader-client",
-		}
+		usages = append(usages, defaultUsages...)
 	} else {
 		for _, v := range conf.Usages {
 			usages = append(usages, string(v))
@@ -216,7 +282,7 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 		if len(certs) == 0 {
 			// No certificate in snapshot => generate a new one.
 			// Secret will be updated by Helm.
-			cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
+			cert, err = generateNewSelfSignedTLS(input, conf, sans, usages)
 			if err != nil {
 				return err
 			}
@@ -230,7 +296,7 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 				input.Logger.Error(err.Error())
 			}
 
-			certOutdated, err := isIrrelevantCert(cert.Cert, sans)
+			certOutdated, err := isIrrelevantCert(cert.Cert, cn, sans)
 			if err != nil {
 				input.Logger.Error(err.Error())
 			}
@@ -238,7 +304,7 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 			// In case of errors, both these flags are false to avoid regeneration loop for the
 			// certificate.
 			if caOutdated || certOutdated {
-				cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
+				cert, err = generateNewSelfSignedTLS(input, conf, sans, usages)
 				if err != nil {
 					return err
 				}
@@ -250,8 +316,18 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 	}
 }
 
-// check certificate duration and SANs list
-func isIrrelevantCert(certData string, desiredSANSs []string) (bool, error) {
+// isIrrelevantCert decides whether an existing leaf certificate must be
+// re-issued. It triggers a re-issue when:
+//
+//   - the certificate is approaching its expiry,
+//   - the configured CN no longer matches Subject.CommonName,
+//   - the leaf was issued without Subject DN differentiation
+//     (Subject == Issuer), which produces certificates rejected by openssl,
+//   - the leaf has no ExtendedKeyUsage extension, which happens when a hook
+//     was previously configured with the legacy "requestheader-client"
+//     pseudo-usage (cfssl silently drops it),
+//   - the SAN set drifted from the desired one.
+func isIrrelevantCert(certData string, desiredCN string, desiredSANSs []string) (bool, error) {
 	cert, err := certificate.ParseCertificate(certData)
 	if err != nil {
 		return false, err
@@ -260,11 +336,30 @@ func isIrrelevantCert(certData string, desiredSANSs []string) (bool, error) {
 	if time.Until(cert.NotAfter) < certOutdatedDuration {
 		return true, nil
 	}
+
+	if desiredCN != "" && cert.Subject.CommonName != desiredCN {
+		return true, nil
+	}
+
+	// Legacy certificates issued before the Subject DN differentiation rule
+	// have Subject == Issuer and are rejected by strict validators. Force a
+	// re-issue so the new code path can produce a compliant certificate.
+	if cert.Subject.String() == cert.Issuer.String() {
+		return true, nil
+	}
+
+	// Legacy "requestheader-client" usage produced certificates without any
+	// ExtendedKeyUsage. Detect them and force re-issue.
+	if !hasAnyExtendedKeyUsage(cert) {
+		return true, nil
+	}
+
 	var dnsNames, ipAddrs []string
 	for _, san := range desiredSANSs {
-		if net.IsIPv4String(san) {
+		switch {
+		case net.IsIPv4String(san), net.IsIPv6String(san):
 			ipAddrs = append(ipAddrs, san)
-		} else {
+		default:
 			dnsNames = append(dnsNames, san)
 		}
 	}
@@ -286,6 +381,13 @@ func isIrrelevantCert(certData string, desiredSANSs []string) (bool, error) {
 	return false, nil
 }
 
+// hasAnyExtendedKeyUsage reports whether the certificate carries an
+// ExtendedKeyUsage extension. Either the standard ExtKeyUsage slice or the
+// raw UnknownExtKeyUsage slice (custom OIDs) is enough.
+func hasAnyExtendedKeyUsage(cert *x509.Certificate) bool {
+	return len(cert.ExtKeyUsage) > 0 || len(cert.UnknownExtKeyUsage) > 0
+}
+
 func isOutdatedCA(ca string) (bool, error) {
 	// Issue a new certificate if there is no CA in the secret.
 	// Without CA it is not possible to validate the certificate.
@@ -305,18 +407,24 @@ func isOutdatedCA(ca string) (bool, error) {
 	return false, nil
 }
 
-func generateNewSelfSignedTLS(input *go_hook.HookInput, cn string, sans, usages []string) (certificate.Certificate, error) {
+func generateNewSelfSignedTLS(input *go_hook.HookInput, conf GenSelfSignedTLSHookConf, sans, usages []string) (certificate.Certificate, error) {
 	ca, err := certificate.GenerateCA(input.Logger,
-		cn,
+		conf.CN,
 		certificate.WithKeyAlgo(keyAlgorithm),
 		certificate.WithKeySize(keySize),
-		certificate.WithCAExpiry(caExpiryDurationStr))
+		certificate.WithCAExpiry(caExpiryDurationStr),
+		// O=Deckhouse, OU=<module> on the CA → leaf's CN-only Subject
+		// differs from the CA's Subject. Do NOT replicate WithNames on
+		// GenerateSelfSignedCert below, otherwise Subject(leaf) ==
+		// Subject(CA) and the depth-0 self-signed collision returns.
+		certificate.WithNames(csr.Name{O: caOrganization, OU: conf.caOU()}),
+	)
 	if err != nil {
 		return certificate.Certificate{}, err
 	}
 
-	return certificate.GenerateSelfSignedCert(input.Logger,
-		cn,
+	cert, err := certificate.GenerateSelfSignedCert(input.Logger,
+		conf.CN,
 		ca,
 		certificate.WithSANs(sans...),
 		certificate.WithKeyAlgo(keyAlgorithm),

--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -432,6 +432,11 @@ func generateNewSelfSignedTLS(input *go_hook.HookInput, conf GenSelfSignedTLSHoo
 		certificate.WithSigningDefaultExpiry(certExpiryDuration),
 		certificate.WithSigningDefaultUsage(usages),
 	)
+	if err != nil {
+		return certificate.Certificate{}, err
+	}
+
+	return cert, nil
 }
 
 // SANsGenerator function for generating sans

--- a/go_lib/hooks/tls_certificate/internal_tls_test.go
+++ b/go_lib/hooks/tls_certificate/internal_tls_test.go
@@ -18,13 +18,24 @@ package tls_certificate
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/stretchr/testify/require"
 
 	sdkpkg "github.com/deckhouse/module-sdk/pkg"
 	sdkpatchablevalues "github.com/deckhouse/module-sdk/pkg/patchable-values"
+
+	"github.com/deckhouse/deckhouse/go_lib/certificate"
+	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
 func testGetClusterDomainValues(t *testing.T, domain string) sdkpkg.PatchableValuesCollector {
@@ -61,4 +72,243 @@ func TestDefaultSANs(t *testing.T) {
 		"conversion-webhook-handler.d8-system.svc",
 		"conversion-webhook-handler.d8-system.svc.example2.com",
 	}, res2)
+}
+
+func TestDefaultUsagesContainsServerAuth(t *testing.T) {
+	require.Contains(t, defaultUsages, "server auth",
+		`server certificates must carry "server auth"; legacy "requestheader-client" is invalid`)
+	require.Contains(t, defaultUsages, "signing")
+	require.Contains(t, defaultUsages, "key encipherment")
+	require.NotContains(t, defaultUsages, "requestheader-client",
+		`"requestheader-client" is not a valid cfssl usage and is silently dropped`)
+}
+
+func TestCAOrganizationalUnitDerivation(t *testing.T) {
+	cases := []struct {
+		name string
+		conf GenSelfSignedTLSHookConf
+		want string
+	}{
+		{
+			name: "explicit OU wins",
+			conf: GenSelfSignedTLSHookConf{
+				CN:                   "webhook.d8-system.svc",
+				Namespace:            "d8-system",
+				CAOrganizationalUnit: "my-module",
+			},
+			want: "my-module",
+		},
+		{
+			name: "namespace with d8- prefix is stripped",
+			conf: GenSelfSignedTLSHookConf{
+				CN:        "webhook.d8-foo.svc",
+				Namespace: "d8-foo",
+			},
+			want: "foo",
+		},
+		{
+			name: "namespace without d8- prefix falls through to CN",
+			conf: GenSelfSignedTLSHookConf{
+				CN:        "webhook",
+				Namespace: "kube-system",
+			},
+			want: "webhook",
+		},
+		{
+			name: "empty namespace falls back to CN",
+			conf: GenSelfSignedTLSHookConf{
+				CN: "lonely-cn",
+			},
+			want: "lonely-cn",
+		},
+		{
+			name: "bare d8- prefix falls back to CN",
+			conf: GenSelfSignedTLSHookConf{
+				CN:        "fallback-cn",
+				Namespace: "d8-",
+			},
+			want: "fallback-cn",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.conf.caOU())
+		})
+	}
+}
+
+// TestGenerateNewSelfSignedTLS_RFC5280 enforces the rules from the
+// Deckhouse self-signed certificate spec on certificates produced by the
+// central hook. The bulk of the contract is checked by the shared helper
+// AssertCertBundleValid (see test_assertions.go); this test only adds
+// hook-specific assertions that the helper intentionally leaves open
+// (configurable values like the exact OU).
+func TestGenerateNewSelfSignedTLS_RFC5280(t *testing.T) {
+	logger := log.NewNop()
+	input := &go_hook.HookInput{Logger: logger}
+
+	conf := GenSelfSignedTLSHookConf{
+		CN:                   "webhook-handler.d8-system.svc",
+		Namespace:            "d8-system",
+		CAOrganizationalUnit: "deckhouse",
+	}
+	sans := []string{
+		"webhook-handler.d8-system",
+		"webhook-handler.d8-system.svc",
+		"webhook-handler.d8-system.svc.cluster.local",
+	}
+
+	bundle, err := generateNewSelfSignedTLS(input, conf, sans, defaultUsages)
+	require.NoError(t, err)
+
+	// Full spec checklist: openssl-equivalent verify, Subject DN sanity,
+	// SAN/EKU, NotAfter window, X509KeyPair.
+	AssertCertBundleValid(t, bundle.CA, bundle.Cert, bundle.Key, conf.CN, sans)
+
+	// Hook-specific: the configured OU must end up on the CA's Subject DN.
+	caCert, err := certificate.ParseCertificate(bundle.CA)
+	require.NoError(t, err)
+	require.Contains(t, caCert.Subject.OrganizationalUnit, "deckhouse",
+		"CA Subject must contain the configured OU")
+}
+
+func TestGenerateNewSelfSignedTLS_FallbacksFromNamespace(t *testing.T) {
+	logger := log.NewNop()
+	input := &go_hook.HookInput{Logger: logger}
+
+	conf := GenSelfSignedTLSHookConf{
+		CN:        "capi-controller-manager-webhook",
+		Namespace: "d8-cloud-instance-manager",
+	}
+	sans := []string{"capi-webhook-service.d8-cloud-instance-manager.svc"}
+	bundle, err := generateNewSelfSignedTLS(input, conf, sans, defaultUsages)
+	require.NoError(t, err)
+
+	AssertCertBundleValid(t, bundle.CA, bundle.Cert, bundle.Key, conf.CN, sans)
+
+	caCert, err := certificate.ParseCertificate(bundle.CA)
+	require.NoError(t, err)
+	require.Contains(t, caCert.Subject.OrganizationalUnit, "cloud-instance-manager",
+		"OU must default to the namespace with d8- prefix stripped")
+}
+
+func TestIsIrrelevantCert_CNDrift(t *testing.T) {
+	logger := log.NewNop()
+	input := &go_hook.HookInput{Logger: logger}
+
+	conf := GenSelfSignedTLSHookConf{
+		CN:                   "old-cn.d8-system.svc",
+		Namespace:            "d8-system",
+		CAOrganizationalUnit: "deckhouse",
+	}
+	sans := []string{"old-cn.d8-system.svc"}
+	bundle, err := generateNewSelfSignedTLS(input, conf, sans, defaultUsages)
+	require.NoError(t, err)
+
+	stale, err := isIrrelevantCert(bundle.Cert, "old-cn.d8-system.svc", sans)
+	require.NoError(t, err)
+	require.False(t, stale, "fresh cert with matching CN+SANs must not be marked irrelevant")
+
+	stale, err = isIrrelevantCert(bundle.Cert, "new-cn.d8-system.svc", sans)
+	require.NoError(t, err)
+	require.True(t, stale, "CN drift must trigger re-issue")
+}
+
+func TestIsIrrelevantCert_IPv6SAN(t *testing.T) {
+	logger := log.NewNop()
+	input := &go_hook.HookInput{Logger: logger}
+
+	conf := GenSelfSignedTLSHookConf{
+		CN:                   "ipv6-cert",
+		Namespace:            "d8-system",
+		CAOrganizationalUnit: "deckhouse",
+	}
+	sans := []string{"localhost", "::1"}
+
+	bundle, err := generateNewSelfSignedTLS(input, conf, sans, defaultUsages)
+	require.NoError(t, err)
+
+	leafCert, err := certificate.ParseCertificate(bundle.Cert)
+	require.NoError(t, err)
+
+	require.NotContains(t, leafCert.DNSNames, "::1",
+		"IPv6 address must not leak into DNSNames")
+
+	stale, err := isIrrelevantCert(bundle.Cert, conf.CN, sans)
+	require.NoError(t, err)
+	require.False(t, stale,
+		"isIrrelevantCert must classify IPv6 SANs as IP addresses, not DNS names")
+}
+
+func TestIsIrrelevantCert_LegacySubjectEqualsIssuer(t *testing.T) {
+	// Mint a leaf whose Subject DN exactly matches its Issuer DN. This is
+	// the legacy depth-0 collision the spec addresses; isIrrelevantCert must
+	// classify such a certificate as stale.
+	certPEM := mintLegacyTestCert(t, legacyTestCertOptions{
+		subjectCN: "legacy-collision",
+		issuerCN:  "legacy-collision",
+		dnsNames:  []string{"legacy-collision"},
+		ekuServer: true,
+	})
+
+	stale, err := isIrrelevantCert(certPEM, "legacy-collision", []string{"legacy-collision"})
+	require.NoError(t, err)
+	require.True(t, stale,
+		"a leaf with Subject == Issuer must be re-issued (depth-0 self-signed collision)")
+}
+
+func TestIsIrrelevantCert_NoExtendedKeyUsage(t *testing.T) {
+	certPEM := mintLegacyTestCert(t, legacyTestCertOptions{
+		subjectCN: "legacy-no-eku-leaf",
+		issuerCN:  "legacy-no-eku-ca",
+		dnsNames:  []string{"legacy-no-eku-leaf"},
+		ekuServer: false,
+	})
+
+	cert, err := certificate.ParseCertificate(certPEM)
+	require.NoError(t, err)
+	require.False(t, hasAnyExtendedKeyUsage(cert),
+		"hand-rolled fixture must have empty ExtendedKeyUsage")
+
+	stale, err := isIrrelevantCert(certPEM, "legacy-no-eku-leaf", []string{"legacy-no-eku-leaf"})
+	require.NoError(t, err)
+	require.True(t, stale,
+		"a leaf without ExtendedKeyUsage must be re-issued")
+}
+
+type legacyTestCertOptions struct {
+	subjectCN string
+	issuerCN  string
+	dnsNames  []string
+	ekuServer bool
+}
+
+// mintLegacyTestCert produces a self-signed test certificate where the
+// Subject DN and Issuer DN are controlled independently. This lets us
+// reproduce the broken Subject == Issuer leaf and the empty-EKU leaf
+// produced by the legacy code paths without shipping pre-baked PEM blobs.
+func mintLegacyTestCert(t *testing.T, opts legacyTestCertOptions) string {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: opts.subjectCN},
+		Issuer:       pkix.Name{CommonName: opts.issuerCN},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		DNSNames:     opts.dnsNames,
+	}
+	if opts.ekuServer {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 }

--- a/go_lib/hooks/tls_certificate/test_assertions.go
+++ b/go_lib/hooks/tls_certificate/test_assertions.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls_certificate
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"sort"
+	"time"
+)
+
+// AssertT is the minimal subset of *testing.T (and the value returned by
+// ginkgo.GinkgoT()) that the assertion helpers in this file rely on.
+//
+// Keeping the interface this narrow means the helpers are usable from:
+//
+//   - plain `go test` suites (`*testing.T` satisfies AssertT directly);
+//   - Ginkgo specs (`GinkgoT()` returns a value that also satisfies AssertT).
+//
+// It also keeps the production package free of any gomega/ginkgo dependency.
+type AssertT interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
+// AssertOpensslVerifyOK is the in-test equivalent of:
+//
+//	openssl verify -CAfile <ca.crt> <tls.crt>
+//
+// It catches the two failure modes the legacy Deckhouse self-signed
+// certificates exhibited and that strict validators reject:
+//
+//  1. leaf Subject == leaf Issuer (the depth-0 self-signed collision).
+//     Only an explicit Go-side assertion reproduces this. crypto/x509
+//     (and therefore kube-apiserver) silently accepts the collision, but
+//     openssl, Java keystore, Trivy and MaxPatrol reject it. The classic
+//     openssl error is:
+//
+//     error 18 at 0 depth lookup: self-signed certificate
+//
+//     The production fix is to put O=Deckhouse, OU=<module> on the CA's
+//     Subject DN while keeping the leaf CN-only.
+//
+//  2. Everything else `openssl verify` checks: broken signature, expired
+//     certificate, malformed BasicConstraints, etc. Performed by
+//     x509.Certificate.Verify against a CertPool pre-loaded with the CA.
+//
+// On success the parsed CA and leaf certificates are returned so callers
+// can chain follow-up assertions (Subject DN sanity, SAN/EKU, expiry).
+//
+// Direct shell equivalent:
+//
+//	kubectl -n <ns> get secret <name> -o jsonpath='{.data.ca\.crt}'  | base64 -d > /tmp/ca.crt
+//	kubectl -n <ns> get secret <name> -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/tls.crt
+//	openssl verify -CAfile /tmp/ca.crt /tmp/tls.crt
+func AssertOpensslVerifyOK(t AssertT, caPEM, leafPEM string) (caCert, leafCert *x509.Certificate) {
+	t.Helper()
+
+	caBlock, _ := pem.Decode([]byte(caPEM))
+	if caBlock == nil {
+		t.Fatalf("ca.crt PEM must decode")
+		return nil, nil
+	}
+	var err error
+	caCert, err = x509.ParseCertificate(caBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse ca.crt: %v", err)
+		return nil, nil
+	}
+
+	leafBlock, _ := pem.Decode([]byte(leafPEM))
+	if leafBlock == nil {
+		t.Fatalf("tls.crt PEM must decode")
+		return nil, nil
+	}
+	leafCert, err = x509.ParseCertificate(leafBlock.Bytes)
+	if err != nil {
+		t.Fatalf("parse tls.crt: %v", err)
+		return nil, nil
+	}
+
+	// The ONE check that crypto/x509.Verify will not perform for us.
+	// Reproduces openssl's `error 18 at 0 depth lookup: self-signed certificate`.
+	if leafCert.Subject.String() == leafCert.Issuer.String() {
+		t.Fatalf(
+			"openssl error 18 at 0 depth lookup: self-signed certificate; "+
+				"leaf Subject == Issuer (%q). "+
+				"Fix: give the CA a distinct Subject DN (O=Deckhouse, OU=<module>); "+
+				"keep the leaf CN-only.",
+			leafCert.Subject.String(),
+		)
+		return caCert, leafCert
+	}
+
+	// `openssl verify -CAfile ca.crt tls.crt` proper.
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM([]byte(caPEM)) {
+		t.Fatalf("ca.crt PEM is not loadable into a CertPool")
+		return caCert, leafCert
+	}
+	if _, err = leafCert.Verify(x509.VerifyOptions{Roots: roots}); err != nil {
+		t.Fatalf("openssl-equivalent verify failed: %v", err)
+		return caCert, leafCert
+	}
+	return caCert, leafCert
+}
+
+// AssertCertBundleValid runs the full Deckhouse self-signed TLS contract
+// check (see go_lib/hooks/tls_certificate/internal_tls.go) on a
+// (CA, leaf, key) bundle:
+//
+//   - openssl-equivalent path validation (AssertOpensslVerifyOK);
+//   - CA invariants: IsCA, BasicConstraintsValid, self-issued, O=Deckhouse,
+//     OU non-empty;
+//   - leaf invariants: not a CA, CN matches the configured value, Issuer
+//     matches CA Subject, leaf has no O/OU (CN-only);
+//   - DNSNames consist exactly of the expected SAN set;
+//   - ExtendedKeyUsage contains serverAuth (catches the legacy
+//     "requestheader-client" usage that produced empty EKU);
+//   - NotAfter is within a sensible window (1y < ttl < 20y);
+//   - per-SAN x509.Verify with KeyUsages=ServerAuth (the equivalent of
+//     `openssl verify -purpose sslserver -CAfile ca.crt tls.crt` with
+//     hostname matching);
+//   - (crt, key) form a usable TLS key pair (catches mismatched keys/curves).
+func AssertCertBundleValid(t AssertT, caPEM, crtPEM, keyPEM, expectedCN string, expectedSANs []string) {
+	t.Helper()
+
+	ca, leaf := AssertOpensslVerifyOK(t, caPEM, crtPEM)
+
+	if !ca.IsCA {
+		t.Fatalf("CA must have IsCA=true")
+	}
+	if !ca.BasicConstraintsValid {
+		t.Fatalf("CA BasicConstraints must be valid")
+	}
+	if ca.Subject.String() != ca.Issuer.String() {
+		t.Fatalf("CA must be self-issued: Subject=%q Issuer=%q",
+			ca.Subject.String(), ca.Issuer.String())
+	}
+	if !sliceContains(ca.Subject.Organization, caOrganization) {
+		t.Fatalf("CA Subject must contain O=%s; got %q", caOrganization, ca.Subject.String())
+	}
+	if len(ca.Subject.OrganizationalUnit) == 0 {
+		t.Fatalf("CA Subject must carry an OU to differentiate from the leaf; got %q",
+			ca.Subject.String())
+	}
+
+	if leaf.IsCA {
+		t.Fatalf("leaf must not be a CA")
+	}
+	if leaf.Subject.CommonName != expectedCN {
+		t.Fatalf("leaf CN: got %q, want %q", leaf.Subject.CommonName, expectedCN)
+	}
+	if leaf.Issuer.String() != ca.Subject.String() {
+		t.Fatalf("leaf Issuer must equal CA Subject: leaf.Issuer=%q ca.Subject=%q",
+			leaf.Issuer.String(), ca.Subject.String())
+	}
+	if len(leaf.Subject.Organization) > 0 {
+		t.Fatalf("leaf must be CN-only (no O=); got %v", leaf.Subject.Organization)
+	}
+	if len(leaf.Subject.OrganizationalUnit) > 0 {
+		t.Fatalf("leaf must be CN-only (no OU=); got %v", leaf.Subject.OrganizationalUnit)
+	}
+
+	if !stringSetEqual(leaf.DNSNames, expectedSANs) {
+		t.Fatalf("SAN mismatch: got %v, want %v", leaf.DNSNames, expectedSANs)
+	}
+
+	if !sliceContainsExtKeyUsage(leaf.ExtKeyUsage, x509.ExtKeyUsageServerAuth) {
+		t.Fatalf("leaf must carry serverAuth in ExtendedKeyUsage; got %v", leaf.ExtKeyUsage)
+	}
+
+	now := time.Now()
+	if !leaf.NotAfter.After(now.Add(365 * 24 * time.Hour)) {
+		t.Fatalf("leaf NotAfter must be > 1 year from now; got %s", leaf.NotAfter)
+	}
+	if !leaf.NotAfter.Before(now.Add(20 * 365 * 24 * time.Hour)) {
+		t.Fatalf("leaf NotAfter must be < 20 years from now; got %s", leaf.NotAfter)
+	}
+
+	// per-SAN openssl-equivalent verify with sslserver purpose.
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM([]byte(caPEM))
+	for _, san := range expectedSANs {
+		if _, err := leaf.Verify(x509.VerifyOptions{
+			Roots:     roots,
+			DNSName:   san,
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}); err != nil {
+			t.Fatalf("leaf must verify for SAN %q with serverAuth EKU: %v", san, err)
+		}
+	}
+
+	if _, err := tls.X509KeyPair([]byte(crtPEM), []byte(keyPEM)); err != nil {
+		t.Fatalf("tls.X509KeyPair must succeed for the issued bundle: %v", err)
+	}
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func sliceContainsExtKeyUsage(haystack []x509.ExtKeyUsage, needle x509.ExtKeyUsage) bool {
+	for _, eku := range haystack {
+		if eku == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func stringSetEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aCopy := append([]string(nil), a...)
+	bCopy := append([]string(nil), b...)
+	sort.Strings(aCopy)
+	sort.Strings(bCopy)
+	for i := range aCopy {
+		if aCopy[i] != bCopy[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/modules/000-common/hooks/internal_tls_test.go
+++ b/modules/000-common/hooks/internal_tls_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -258,7 +259,10 @@ func generateTestCert() certificate.Certificate {
 		"d8-module-name:module-name:internal",
 		certificate.WithKeyAlgo("ecdsa"),
 		certificate.WithKeySize(256),
-		certificate.WithCAExpiry("87600h"))
+		certificate.WithCAExpiry("87600h"),
+		// Match the central hook: CA Subject differentiated from leaf via O+OU.
+		certificate.WithNames(csr.Name{O: "Deckhouse", OU: "module-name"}),
+	)
 
 	sans := []string{
 		"module.d8-module-name",
@@ -275,7 +279,7 @@ func generateTestCert() certificate.Certificate {
 		certificate.WithSigningDefaultUsage([]string{
 			"signing",
 			"key encipherment",
-			"requestheader-client",
+			"server auth",
 		}),
 	)
 

--- a/modules/002-deckhouse/hooks/generate_webhook_tls_certificate_test.go
+++ b/modules/002-deckhouse/hooks/generate_webhook_tls_certificate_test.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -140,7 +141,9 @@ func generateTestCert(expired bool) certificate.Certificate {
 		"webhook-handler.d8-system.svc",
 		certificate.WithKeyAlgo("ecdsa"),
 		certificate.WithKeySize(256),
-		certificate.WithCAExpiry(expireStr))
+		certificate.WithCAExpiry(expireStr),
+		certificate.WithNames(csr.Name{O: "Deckhouse", OU: "system"}),
+	)
 
 	webhookServiceFQDN := fmt.Sprintf(
 		"%s.%s",
@@ -167,7 +170,7 @@ func generateTestCert(expired bool) certificate.Certificate {
 		certificate.WithSigningDefaultUsage([]string{
 			"signing",
 			"key encipherment",
-			"requestheader-client",
+			"server auth",
 		}),
 	)
 

--- a/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
+++ b/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
@@ -17,23 +17,30 @@ limitations under the License.
 package hooks
 
 import (
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/pem"
 	"fmt"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/deckhouse/deckhouse/go_lib/certificate"
+	"github.com/deckhouse/deckhouse/go_lib/hooks/tls_certificate"
 	"github.com/deckhouse/deckhouse/pkg/log"
 	. "github.com/deckhouse/deckhouse/testing/hooks"
 )
 
 var _ = Describe("Node Manager hooks :: generate_webhook_certs ::", func() {
 	f := HookExecutionConfigInit(`{"global": {"discovery": {"clusterDomain": "`+clusterDomain+`"}},"nodeManager":{"internal":{"capiControllerManagerWebhookCert": {}}}}`, "")
+
+	expectedSANs := []string{
+		"capi-webhook-service.d8-cloud-instance-manager",
+		"capi-webhook-service.d8-cloud-instance-manager.svc",
+		"capi-webhook-service.d8-cloud-instance-manager." + clusterDomain,
+		"capi-webhook-service.d8-cloud-instance-manager.svc." + clusterDomain,
+	}
 
 	Context("Without secret", func() {
 		BeforeEach(func() {
@@ -45,26 +52,46 @@ var _ = Describe("Node Manager hooks :: generate_webhook_certs ::", func() {
 			Expect(f).To(ExecuteSuccessfully())
 			Expect(f.BindingContexts.Array()).ShouldNot(BeEmpty())
 
-			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").Exists()).To(BeTrue())
-			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").Exists()).To(BeTrue())
+			caPEM := f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()
+			crtPEM := f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()
+			keyPEM := f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").String()
+			Expect(caPEM).ToNot(BeEmpty())
+			Expect(crtPEM).ToNot(BeEmpty())
+			Expect(keyPEM).ToNot(BeEmpty())
 
-			blockCA, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()))
-			certCA, err := x509.ParseCertificate(blockCA.Bytes)
-			Expect(err).To(BeNil())
-			Expect(certCA.IsCA).To(BeTrue())
-			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
+			tls_certificate.AssertCertBundleValid(GinkgoT(), caPEM, crtPEM, keyPEM, cn, expectedSANs)
+		})
 
-			block, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()))
-			cert, err := x509.ParseCertificate(block.Bytes)
-			Expect(err).To(BeNil())
-			Expect(cert.IsCA).To(BeFalse())
-			Expect(cert.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
+		// Direct in-test reproduction of the original bug report:
+		//
+		//   kubectl -n d8-cloud-instance-manager get secret capi-webhook-tls \
+		//     -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/capi-ca.crt
+		//   kubectl -n d8-cloud-instance-manager get secret capi-webhook-tls \
+		//     -o jsonpath='{.data.tls\.crt}' | base64 -d > /tmp/capi-tls.crt
+		//   openssl verify -CAfile /tmp/capi-ca.crt /tmp/capi-tls.crt
+		//   # error 18 at 0 depth lookup: self-signed certificate
+		//
+		// crypto/x509 silently passed the legacy collision (so kube-apiserver
+		// was happy), openssl rejected with error 18.
+		// AssertOpensslVerifyOK reproduces both checks; see its godoc.
+		It("issued bundle must pass `openssl verify -CAfile ca.crt tls.crt`", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			ca, leaf := tls_certificate.AssertOpensslVerifyOK(
+				GinkgoT(),
+				f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String(),
+				f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String(),
+			)
+
+			Expect(ca.Subject.String()).To(ContainSubstring("O=Deckhouse"))
+			Expect(leaf.Subject.String()).ToNot(ContainSubstring("O=Deckhouse"))
 		})
 	})
 	Context("With secrets", func() {
 		caAuthority, _ := genWebhookCa(nil)
-		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, "capi-manager-webhook", "capi-webhook-service")
+		// CN must match the central hook's configured CN, otherwise CN drift
+		// triggers a re-issue and the test cert in the secret is replaced.
+		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, cn, "capi-webhook-service")
 
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(fmt.Sprintf(`
@@ -92,14 +119,27 @@ data:
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String()).To(Equal(caAuthority.Cert))
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").String()).To(Equal(tlsAuthority.Key))
 			Expect(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()).To(Equal(tlsAuthority.Cert))
+
+			tls_certificate.AssertCertBundleValid(
+				GinkgoT(),
+				f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.ca").String(),
+				f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String(),
+				f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.key").String(),
+				cn,
+				expectedSANs,
+			)
 		})
 	})
 })
 
 func genWebhookCa(logEntry *log.Logger) (*certificate.Authority, error) {
-	ca, err := certificate.GenerateCA(logEntry, cn, certificate.WithKeyAlgo("ecdsa"),
+	ca, err := certificate.GenerateCA(logEntry, cn,
+		certificate.WithKeyAlgo("ecdsa"),
 		certificate.WithKeySize(256),
-		certificate.WithCAExpiry("87600h"))
+		certificate.WithCAExpiry("87600h"),
+		// Match the central hook contract: O=Deckhouse, OU=<module>.
+		certificate.WithNames(csr.Name{O: "Deckhouse", OU: "cloud-instance-manager"}),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate CA: %v", err)
 	}
@@ -114,9 +154,10 @@ func genWebhookTLS(input *go_hook.HookInput, ca *certificate.Authority, cn strin
 		certificate.WithKeyAlgo("ecdsa"),
 		certificate.WithKeySize(256),
 		certificate.WithSigningDefaultExpiry((24*time.Hour)*365*10),
-		certificate.WithSigningDefaultUsage([]string{"signing",
+		certificate.WithSigningDefaultUsage([]string{
+			"signing",
 			"key encipherment",
-			"requestheader-client",
+			"server auth",
 		}),
 		certificate.WithSANs(
 			sanPrefix+".d8-cloud-instance-manager",

--- a/modules/040-node-manager/hooks/generate_caps_webhook_certs_test.go
+++ b/modules/040-node-manager/hooks/generate_caps_webhook_certs_test.go
@@ -64,7 +64,9 @@ var _ = Describe("Node Manager hooks :: generate_webhook_certs ::", func() {
 	})
 	Context("With secrets", func() {
 		caAuthority, _ := genWebhookCa(nil)
-		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, "caps-manager-webhook", "caps-controller-manager-webhook-service")
+		// CN must match the central hook's configured CN, otherwise CN drift
+		// triggers a re-issue and the test cert in the secret is replaced.
+		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, "caps-controller-manager-webhook", "caps-controller-manager-webhook-service")
 
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(fmt.Sprintf(`

--- a/modules/402-ingress-nginx/hooks/generate_admission_webhook_cert.go
+++ b/modules/402-ingress-nginx/hooks/generate_admission_webhook_cert.go
@@ -96,6 +96,10 @@ func generateValidateWebhookCert(_ context.Context, input *go_hook.HookInput) er
 		return errors.Wrap(err, "generate CA failed")
 	}
 
+	// NOTE: WithGroups intentionally omitted on the leaf so that its Subject DN
+	// differs from the CA's (which keeps O=ingress-nginx.d8-ingress-nginx).
+	// Without this, OpenSSL flags the leaf as depth-0 self-signed
+	// (X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT) since subject == issuer.
 	tls, err := certificate.GenerateSelfSignedCert(input.Logger,
 		cn,
 		ca,
@@ -104,7 +108,6 @@ func generateValidateWebhookCert(_ context.Context, input *go_hook.HookInput) er
 			S: 2048,
 		}),
 		certificate.WithSANs("*.d8-ingress-nginx", "*.d8-ingress-nginx.svc"),
-		certificate.WithGroups("ingress-nginx.d8-ingress-nginx"),
 		certificate.WithSigningDefaultExpiry(87600*time.Hour),
 	)
 	if err != nil {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backport: https://github.com/deckhouse/deckhouse/pull/20138

Self-signed certificates generated by `go_lib/hooks/tls_certificate` (`RegisterInternalTLSHook` and its ad-hoc callers) had two defects that caused validation failures outside of Go/kube-apiserver:

**1. Subject DN collision (RFC 5280 §4.1.2.6 — "depth-0 self-signed")**
CA and leaf were issued with the same Subject DN (only `CN=` was set on both). When `Subject(leaf) == Issuer(leaf)` OpenSSL classifies the leaf as a depth-0 self-signed certificate and returns `X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT`. Go's `crypto/x509` (and thus kube-apiserver) falls back to a lenient path and accepts such certs, so webhooks continued to work — but `openssl verify -purpose sslserver`, Trivy, and MaxPatrol all rejected them.

**2. Empty ExtendedKeyUsage**
The legacy default usage set included `"requestheader-client"`. That string does not exist in cfssl's KeyUsage or ExtKeyUsage maps, so cfssl silently discarded it and emitted certificates with no EKU extension. Strict validators (Java keystores, Trivy EKU checks, MaxPatrol next-gen) require at least `serverAuth` in EKU.

**3. IPv6 addresses silently put in DNS SAN bucket**
`isIrrelevantCert` used only `net.IsIPv4String` to separate IP addresses from DNS names. IPv6 SANs ended up in `DNSNames`, breaking SAN comparison and producing malformed certificates.

### Changes

#### `go_lib/hooks/tls_certificate/internal_tls.go`
- **CA Subject DN**: CA is now issued with `O=Deckhouse, OU=<module>` so that `Subject(CA) ≠ Subject(leaf)`. The OU is resolved automatically from `Namespace` (strips `d8-` prefix) with a fallback to `CN`. Callers can set it explicitly via the new `CAOrganizationalUnit` field.
- **Default usages**: replaced bogus `"requestheader-client"` with `"server auth"`. Added reference table in the `Usages` field godoc.
- **`isIrrelevantCert` — new re-issue triggers** beyond expiry/SAN drift:
  - CN drift between config and stored certificate
  - Legacy Subject == Issuer collision
  - Missing `ExtendedKeyUsage` (legacy `requestheader-client` artefacts)
- **IPv6 SAN fix**: `net.IsIPv6String` now guards the IP bucket alongside `net.IsIPv4String`.

#### `modules/402-ingress-nginx/hooks/generate_admission_webhook_cert.go`
Removed `WithGroups(...)` from the leaf `GenerateSelfSignedCert` call — `WithGroups` was copying the CA's `O=` onto the leaf, recreating the Subject == Issuer collision.

#### Test fixtures (5 modules)
Updated `generateTestCert` helpers that fabricate Secrets for "existing cert" test scenarios to match the new CA format (`WithNames(csr.Name{O:"Deckhouse", OU:<module>})`) and correct usages (`"server auth"` instead of `"requestheader-client"`), so the hook no longer classifies these certs as "irrelevant" and re-issues them unexpectedly. Also fixed CN mismatches between hook config and test fixture in `generate_capi_webhook_certs_test.go` and `generate_caps_webhook_certs_test.go` that would have triggered the new CN-drift re-issue path.

### Migration
On the next `OnBeforeHelm` run after this lands, the hook will detect existing legacy certificates (no EKU or Subject==Issuer) and re-issue them automatically. Consumers reload the certificate from Helm values on every release, so no additional reload mechanics are required.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: tools
type: chore
summary: add ca organization to make certs valid
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
