### PR TITLE
[cloud-provider-dvp] make cloud-init secret creation idempotent

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -38,6 +38,9 @@ const (
 	attachmentDiskNameLabel    = "virtualMachineDiskName"
 	attachmentMachineNameLabel = "virtualMachineName"
 	DVPLoadBalancerLabelPrefix = "dvp.deckhouse.io/"
+
+	DeckhouseManagedByLabelKey   = "deckhouse.io/managed-by"
+	DeckhouseManagedByLabelValue = "deckhouse"
 )
 
 type ComputeService struct {
@@ -401,22 +404,40 @@ func (c *ComputeService) listVMBDAByHostname(ctx context.Context, vmHostname str
 	return vmbdas.Items, nil
 }
 
+func (c *ComputeService) isDeckhouseManagedCloudInitSecret(secret *corev1.Secret) bool {
+	if secret.Labels == nil {
+		return false
+	}
+	return secret.Labels[DeckhouseManagedByLabelKey] == DeckhouseManagedByLabelValue
+}
+
 func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, name string, userData []byte) error {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: c.namespace,
+			Labels: map[string]string{
+				DeckhouseManagedByLabelKey: DeckhouseManagedByLabelValue,
+			},
 		},
 		Type:       v1alpha2.SecretTypeCloudInit,
 		StringData: map[string]string{"userData": string(userData)},
 	}
 
-	// Try to create; if the secret already exists, update its cloud-init payload.
+	// Try to create; if the secret already exists, update only when it is managed by Deckhouse.
 	if _, err := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{}); err != nil {
 		if k8serrors.IsAlreadyExists(err) {
 			existing, getErr := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
 			if getErr != nil {
 				return fmt.Errorf("get existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, getErr)
+			}
+
+			if !c.isDeckhouseManagedCloudInitSecret(existing) {
+				klog.Warningf(
+					"cloud-init secret %s/%s already exists and is not managed by Deckhouse (%s=%s); leaving it unchanged and continuing with existing userData",
+					c.namespace, name, DeckhouseManagedByLabelKey, DeckhouseManagedByLabelValue,
+				)
+				return nil
 			}
 
 			existing.StringData = map[string]string{"userData": string(userData)}

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -411,7 +411,22 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 		StringData: map[string]string{"userData": string(userData)},
 	}
 
+	// Try to create; if the secret already exists, update its cloud-init payload.
 	if _, err := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{}); err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			existing, getErr := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
+			if getErr != nil {
+				return fmt.Errorf("get existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, getErr)
+			}
+
+			existing.StringData = map[string]string{"userData": string(userData)}
+			if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
+				return fmt.Errorf("update '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
+			}
+
+			return nil
+		}
+
 		return fmt.Errorf("create '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, err)
 	}
 	return nil


### PR DESCRIPTION
## Description
Make DVP cloud-init secret creation idempotent in `dvp-common`.
Instead of failing when the provisioning secret already exists, the controller now updates the existing secret payload and continues reconciliation. This prevents repeated machine provisioning attempts from getting stuck on `secret already exists` errors in the parent DVP cluster.

## Why do we need it, and what problem does it solve?
In some failed or partially cleaned up reconciliation flows, the cloud-init provisioning secret may remain in the parent DVP cluster after the previous machine creation attempt.
On the next reconcile, `capdvp-controller-manager` tries to create the same secret again and fails with:
`Cannot create cloud-init provisioning secret: secret already exists`
As a result, the `DeckhouseMachine` cannot finish provisioning, the corresponding `Machine` remains without a working VM/Node, and remediation loops may start creating replacement machines while the root cause remains unresolved.
This change makes cloud-init secret creation idempotent by handling the `AlreadyExists` case and updating the secret contents instead of failing.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: make DVP cloud-init provisioning secret creation idempotent to avoid `secret already exists` reconciliation failures
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
