### PR TITLE
[node-manager] Generate `serializedLabels` with merged user and system labels; prioritize system labels

### DIFF
--- a/modules/040-node-manager/hooks/get_crds.go
+++ b/modules/040-node-manager/hooks/get_crds.go
@@ -658,11 +658,14 @@ func calculateUpdateEpoch(ts int64, clusterUUID string, nodeGroupName string) st
 }
 
 func serializeLabels(info NodeGroupCrdInfo) string {
-	if len(info.Spec.NodeTemplate.Labels) == 0 {
-		return ""
+	merged := make(map[string]string, len(info.Spec.NodeTemplate.Labels)+3)
+	for k, v := range info.Spec.NodeTemplate.Labels {
+		merged[k] = v
 	}
-
-	return labels.FormatLabels(info.Spec.NodeTemplate.Labels)
+	merged["node.deckhouse.io/group"] = info.Name
+	merged["node.deckhouse.io/type"] = string(info.Spec.NodeType)
+	merged["node-role.kubernetes.io/"+info.Name] = ""
+	return labels.FormatLabels(merged)
 }
 
 func serializeTaints(info NodeGroupCrdInfo) string {

--- a/modules/040-node-manager/hooks/get_crds_test.go
+++ b/modules/040-node-manager/hooks/get_crds_test.go
@@ -388,7 +388,7 @@ metadata:
 					},
 					"topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper1=,node.deckhouse.io/group=proper1,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.31",
@@ -424,7 +424,7 @@ metadata:
 					"cri": {
                       "type": "Containerd"
                     },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper2=,node.deckhouse.io/group=proper2,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "name": "proper2",
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
@@ -478,7 +478,7 @@ metadata:
                       },
 			          "topologyManager": {}
                     },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/cp1=,node.deckhouse.io/group=cp1,node.deckhouse.io/type=CloudPermanent",
                     "serializedTaints": "",
                     "name": "cp1",
                     "nodeType": "CloudPermanent",
@@ -506,7 +506,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper1=,node.deckhouse.io/group=proper1,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.31",
@@ -537,7 +537,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper2=,node.deckhouse.io/group=proper2,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.31",
@@ -561,7 +561,7 @@ metadata:
 			          },
 			          "topologyManager": {}
 		            },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/static1=,node.deckhouse.io/group=static1,node.deckhouse.io/type=Static",
                     "serializedTaints": "",
                     "name": "static1",
                     "nodeType": "Static",
@@ -608,7 +608,7 @@ metadata:
 			         },
 			         "topologyManager": {}
 		            },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/cp1=,node.deckhouse.io/group=cp1,node.deckhouse.io/type=CloudPermanent",
                     "serializedTaints": "",
                     "manualRolloutID": "",
                     "name": "cp1",
@@ -637,7 +637,7 @@ metadata:
 					   },
 					   "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper1=,node.deckhouse.io/group=proper1,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.31",
@@ -668,7 +668,7 @@ metadata:
 					   },
 					   "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper2=,node.deckhouse.io/group=proper2,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.31",
@@ -691,7 +691,7 @@ metadata:
                      },
 			         "topologyManager": {}
 		            },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/static1=,node.deckhouse.io/group=static1,node.deckhouse.io/type=Static",
                     "serializedTaints": "",
                     "manualRolloutID": "",
                     "name": "static1",
@@ -746,7 +746,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper1=,node.deckhouse.io/group=proper1,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.31",
@@ -777,7 +777,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper2=,node.deckhouse.io/group=proper2,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
 				    "manualRolloutID": "",
                     "kubernetesVersion": "1.31",
@@ -868,7 +868,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper1=,node.deckhouse.io/group=proper1,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
                     "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  },
@@ -899,7 +899,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper2=,node.deckhouse.io/group=proper2,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  }
@@ -1002,7 +1002,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper1=,node.deckhouse.io/group=proper1,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
                     "updateEpoch": "` + calculateEpoch("proper1", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  },
@@ -1033,7 +1033,7 @@ metadata:
 					  },
 					  "topologyManager": {}
 				    },
-                    "serializedLabels": "",
+                    "serializedLabels": "node-role.kubernetes.io/proper2=,node.deckhouse.io/group=proper2,node.deckhouse.io/type=CloudEphemeral",
                     "serializedTaints": "",
                     "updateEpoch": "` + calculateEpoch("proper2", f.ValuesGet("global.discovery.clusterUUID").String()) + `"
 				  }
@@ -1464,11 +1464,11 @@ spec:
 				f.RunHook()
 			})
 
-			It("Should set empty serializedLabels and serializedTaints", func() {
+			It("Should set system labels in serializedLabels and empty serializedTaints", func() {
 				Expect(f).To(ExecuteSuccessfully())
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").Exists()).To(BeTrue())
-				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal(""))
+				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal("node-role.kubernetes.io/test=,node.deckhouse.io/group=test,node.deckhouse.io/type=CloudEphemeral"))
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").Exists()).To(BeTrue())
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").String()).To(Equal(""))
@@ -1502,11 +1502,11 @@ spec:
 				f.RunHook()
 			})
 
-			It("Should set serializedLabels in desired format and empty serializedTaints", func() {
+			It("Should set serializedLabels with user and system labels, and empty serializedTaints", func() {
 				Expect(f).To(ExecuteSuccessfully())
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").Exists()).To(BeTrue())
-				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal("app=warp-drive-ai,environment=production"))
+				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal("app=warp-drive-ai,environment=production,node-role.kubernetes.io/test=,node.deckhouse.io/group=test,node.deckhouse.io/type=CloudEphemeral"))
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").Exists()).To(BeTrue())
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").String()).To(Equal(""))
@@ -1546,11 +1546,11 @@ spec:
 				f.RunHook()
 			})
 
-			It("Should set serializedTaints in desired format and empty serializedLabels", func() {
+			It("Should set serializedTaints in desired format and system-only serializedLabels", func() {
 				Expect(f).To(ExecuteSuccessfully())
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").Exists()).To(BeTrue())
-				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal(""))
+				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal("node-role.kubernetes.io/test=,node.deckhouse.io/group=test,node.deckhouse.io/type=CloudEphemeral"))
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").Exists()).To(BeTrue())
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").String()).To(Equal("b=v:NoExecute,a,d:NoExecute,c=v1:"))
@@ -1622,14 +1622,81 @@ spec:
 				f.RunHook()
 			})
 
-			It("Should set serializedLabels and serializedTaints in desired format", func() {
+			It("Should set serializedLabels with user and system labels, and serializedTaints in desired format", func() {
 				Expect(f).To(ExecuteSuccessfully())
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").Exists()).To(BeTrue())
-				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal("app=warp-drive-ai,environment=production"))
+				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()).To(Equal("app=warp-drive-ai,environment=production,node-role.kubernetes.io/test=,node.deckhouse.io/group=test,node.deckhouse.io/type=CloudEphemeral"))
 
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").Exists()).To(BeTrue())
 				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedTaints").String()).To(Equal("b=v:NoExecute,a,d:NoExecute,c=v1:"))
+			})
+		})
+
+		Context("User label with same key as system label node.deckhouse.io/group", func() {
+			BeforeEach(func() {
+				ng := `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: infra
+spec:
+  nodeType: CloudEphemeral
+  nodeTemplate:
+    labels:
+      node.deckhouse.io/group: custom-override
+  cloudInstances:
+    classReference:
+      kind: D8TestInstanceClass
+      name: proper1
+    zones: [a,b]
+`
+				f.BindingContexts.Set(f.KubeStateSet(ng + stateICProper))
+				setK8sVersionAsClusterConfig(f, "1.31")
+				f.ValuesSet("global.discovery.kubernetesVersion", "1.31.0")
+				f.ValuesSet("global.discovery.kubernetesVersions.0", "1.31.0")
+				f.RunHook()
+			})
+
+			It("System label should take precedence over user-defined value", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").Exists()).To(BeTrue())
+				serialized := f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()
+				Expect(serialized).To(ContainSubstring("node.deckhouse.io/group=infra"))
+				Expect(serialized).NotTo(ContainSubstring("node.deckhouse.io/group=custom-override"))
+				Expect(serialized).To(ContainSubstring("node-role.kubernetes.io/infra="))
+				Expect(serialized).To(ContainSubstring("node.deckhouse.io/type=CloudEphemeral"))
+			})
+		})
+
+		Context("NG with nodeType Static", func() {
+			BeforeEach(func() {
+				ng := `
+---
+apiVersion: deckhouse.io/v1
+kind: NodeGroup
+metadata:
+  name: db-nodes
+spec:
+  nodeType: Static
+`
+				f.BindingContexts.Set(f.KubeStateSet(ng))
+				setK8sVersionAsClusterConfig(f, "1.31")
+				f.ValuesSet("global.discovery.kubernetesVersion", "1.31.0")
+				f.ValuesSet("global.discovery.kubernetesVersions.0", "1.31.0")
+				f.RunHook()
+			})
+
+			It("serializedLabels should reflect nodeType Static", func() {
+				Expect(f).To(ExecuteSuccessfully())
+
+				Expect(f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").Exists()).To(BeTrue())
+				serialized := f.ValuesGet("nodeManager.internal.nodeGroups.0.serializedLabels").String()
+				Expect(serialized).To(ContainSubstring("node.deckhouse.io/group=db-nodes"))
+				Expect(serialized).To(ContainSubstring("node.deckhouse.io/type=Static"))
+				Expect(serialized).To(ContainSubstring("node-role.kubernetes.io/db-nodes="))
 			})
 		})
 	})


### PR DESCRIPTION
## Description
Fix serializeLabels() in hooks/get_crds.go to include Deckhouse system labels (node.deckhouse.io/group, node.deckhouse.io/type, node-role.kubernetes.io/<ng-name>) in the capacity.cluster-autoscaler.kubernetes.io/labels annotation on CAPI MachineDeployment resources.

Previously, serializeLabels() only serialized user-defined labels from NodeGroup.spec.nodeTemplate.labels. System labels that are applied later by kubelet (--node-labels) and node-controller were not included. This caused cluster-autoscaler's CAPI provider to build an incomplete template node during scale-from-zero simulation, failing to match pods that use system labels in their nodeSelector.

This change does not affect MCM-based cloud providers (Yandex, AWS, GCP, Azure, OpenStack, vSphere) — they already have system labels hardcoded in the MCM MachineDeployment template. It only affects CAPI-based providers (DVP, VCD, zVirt, Dynamix, HuaweiCloud).

No restarts of critical cluster components are triggered. The change only updates metadata.annotations on CAPI MachineDeployment objects — CAPI controller does not react to annotation changes, so no VMs are recreated.

## Why do we need it, and what problem does it solve?

On CAPI-based clusters (DVP, VCD, zVirt, Dynamix, HuaweiCloud), scale-from-zero does not work when a pending pod uses nodeSelector: node.deckhouse.io/group: <ng-name> — the standard Deckhouse pattern for targeting a specific NodeGroup, also recommended in [managed-postgres admin guide](https://deckhouse.ru/modules/managed-postgres/alpha/admin_guide.html) as the nodeSelector example for PostgresClass.

The cluster-autoscaler CAPI provider reads node labels for its template node exclusively from the capacity.cluster-autoscaler.kubernetes.io/labels annotation on MachineDeployment. Since system labels (node.deckhouse.io/group, node.deckhouse.io/type, node-role.kubernetes.io/<ng>) were missing from this annotation, the CA scheduler simulator rejected the pod with predicate "NodeAffinity" didn't pass, and the event NotTriggerScaleUp: max node group size reached was emitted.

On MCM-based clusters the same configuration works correctly because the MCM MachineDeployment template (_machine_deployment.tpl) explicitly includes these system labels in spec.template.spec.nodeTemplate.metadata.labels.

This fix aligns CAPI provider behavior with MCM, ensuring consistent scale-from-zero across all cloud providers.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Include system labels in CAPI MachineDeployment capacity annotation for correct scale-from-zero behavior
impact: On CAPI-based clusters (DVP, VCD, zVirt, Dynamix, HuaweiCloud), scale-from-zero now correctly handles pods with nodeSelector targeting system labels (node.deckhouse.io/group, node.deckhouse.io/type, node-role.kubernetes.io/<ng-name>). Previously such pods remained Pending indefinitely when NodeGroup had minPerZone=0. No user action required — the fix is applied automatically on upgrade.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
