### PR TITLE
[extended-monitoring] Always use system CA bundle in image-availability-exporter

### DIFF
--- a/modules/340-extended-monitoring/template_tests/image_availability_test.go
+++ b/modules/340-extended-monitoring/template_tests/image_availability_test.go
@@ -146,7 +146,7 @@ serviceSubnetCIDR: 10.222.0.0/16
 				Expect(hec.RenderError).ShouldNot(HaveOccurred())
 
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
-				insecureSkipVerifyArg := deploy.Field("spec.template.spec.containers.0.args.5").String()
+				insecureSkipVerifyArg := deploy.Field("spec.template.spec.containers.0.args.6").String()
 
 				Expect(insecureSkipVerifyArg).To(Equal("--skip-registry-cert-verification"))
 			})
@@ -164,7 +164,7 @@ serviceSubnetCIDR: 10.222.0.0/16
 				Expect(hec.RenderError).ShouldNot(HaveOccurred())
 
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
-				insecureSkipVerifyArg := deploy.Field("spec.template.spec.containers.0.args.5").String()
+				insecureSkipVerifyArg := deploy.Field("spec.template.spec.containers.0.args.6").String()
 
 				Expect(insecureSkipVerifyArg).To(BeEmpty())
 			})
@@ -185,7 +185,7 @@ serviceSubnetCIDR: 10.222.0.0/16
 				Expect(hec.RenderError).ShouldNot(HaveOccurred())
 
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
-				allowPlainHTTPArg := deploy.Field("spec.template.spec.containers.0.args.5").String()
+				allowPlainHTTPArg := deploy.Field("spec.template.spec.containers.0.args.6").String()
 
 				Expect(allowPlainHTTPArg).To(Equal("--allow-plain-http"))
 			})
@@ -204,7 +204,7 @@ serviceSubnetCIDR: 10.222.0.0/16
 				Expect(hec.RenderError).ShouldNot(HaveOccurred())
 
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
-				insecureSkipVerifyArg := deploy.Field("spec.template.spec.containers.0.args.5").String()
+				insecureSkipVerifyArg := deploy.Field("spec.template.spec.containers.0.args.6").String()
 
 				Expect(insecureSkipVerifyArg).To(BeEmpty())
 			})
@@ -225,7 +225,7 @@ serviceSubnetCIDR: 10.222.0.0/16
 				Expect(hec.RenderError).ShouldNot(HaveOccurred())
 
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
-				forceCheckDisabledControllers := deploy.Field("spec.template.spec.containers.0.args.5").String()
+				forceCheckDisabledControllers := deploy.Field("spec.template.spec.containers.0.args.6").String()
 
 				Expect(forceCheckDisabledControllers).To(BeEmpty())
 			})
@@ -247,7 +247,7 @@ serviceSubnetCIDR: 10.222.0.0/16
 				Expect(hec.RenderError).ShouldNot(HaveOccurred())
 
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
-				forceCheckDisabledControllers := deploy.Field("spec.template.spec.containers.0.args.5").String()
+				forceCheckDisabledControllers := deploy.Field("spec.template.spec.containers.0.args.6").String()
 
 				Expect(forceCheckDisabledControllers).To(Equal("--force-check-disabled-controllers=Deployment,DaemonSet"))
 			})
@@ -268,7 +268,7 @@ serviceSubnetCIDR: 10.222.0.0/16
 				Expect(hec.RenderError).ShouldNot(HaveOccurred())
 
 				deploy := hec.KubernetesResource("Deployment", "d8-monitoring", "image-availability-exporter")
-				forceCheckDisabledControllers := deploy.Field("spec.template.spec.containers.0.args.5").String()
+				forceCheckDisabledControllers := deploy.Field("spec.template.spec.containers.0.args.6").String()
 
 				Expect(forceCheckDisabledControllers).To(Equal("--force-check-disabled-controllers=*"))
 			})

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -82,6 +82,7 @@ spec:
         {{- if eq .Values.extendedMonitoring.imageAvailability.registry.scheme "HTTP" }}
         - --allow-plain-http
         {{- end }}
+        - --capath=/etc/ssl/certs/ca-certificates.crt
         {{- with .Values.global.modulesImages.registry.CA }}
         - --capath=/deckhouse-registry-root-ca/ca.crt
         {{- end }}

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -76,13 +76,13 @@ spec:
         {{- end }}
         - '--ignored-images={{ $ignoredImages | join "~" }}'
         - --namespace-label=extended-monitoring.deckhouse.io/enabled
+        - --capath=/etc/ssl/certs/ca-certificates.crt
         {{- with .Values.extendedMonitoring.imageAvailability.registry.tlsConfig.insecureSkipVerify }}
         - --skip-registry-cert-verification
         {{- end }}
         {{- if eq .Values.extendedMonitoring.imageAvailability.registry.scheme "HTTP" }}
         - --allow-plain-http
         {{- end }}
-        - --capath=/etc/ssl/certs/ca-certificates.crt
         {{- with .Values.global.modulesImages.registry.CA }}
         - --capath=/deckhouse-registry-root-ca/ca.crt
         {{- end }}


### PR DESCRIPTION
## Description
When `--capath` is used in the `image-availability-exporter`, the bundle provided becomes the only one server certificates are verified against. When a `registry module` is enabled and configured in `Direct` mode, the `extended-monitoring` module injects the `registry` module CA into `image-availability-exporter`. After that, the `image-availability-exporter` is unable to check images in other container registries because it cannot verify the peer using the only CA provided.
This behaviour, however, has a workaround: the `extended-monitoring` module has [it's own CA setting](https://deckhouse.io/modules/extended-monitoring/configuration.html#parameters-imageavailability-registry-tlsconfig-ca) for the `image-availability-exporter`, but the better option would be to always specify the default system CA bundle.

## Why do we need it, and what problem does it solve?
Now, if the `registry` module is configured in the `Direct` mode, `image-availability-exporter` is not able to check user payload registries. 

## Why do we need it in the patch release (if we do)?
Why not?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Enforced permanent use of the default CA bundle in `image-availability-exporter` in the `extended-monitoring` module.
impact_level: default
```