### PR TITLE
[cloud-provider-dvp] Fix craetion of LBs and SWHCs with ExternalTrafficPolicy: Cluster

### DIFF
--- a/modules/030-cloud-provider-dvp/openapi/values.yaml
+++ b/modules/030-cloud-provider-dvp/openapi/values.yaml
@@ -480,19 +480,6 @@ properties:
             required:
               - kubeconfigDataBase64
               - namespace
-      discoveryData:
-        type: object
-        default: {}
-        additionalProperties: false
-        properties:
-          loadBalancer:
-            type: object
-            additionalProperties: false
-            description: Parameters for the load balancer.
-            properties:
-              enabled:
-                type: boolean
-                description: Whether the load balancer feature is enabled.
       providerDiscoveryData:
         type: object
         additionalProperties: false

--- a/modules/030-cloud-provider-dvp/template_tests/module_test.go
+++ b/modules/030-cloud-provider-dvp/template_tests/module_test.go
@@ -67,9 +67,6 @@ const globalValues = `
 
 const moduleValuesA = `
 internal:
-  discoveryData:
-    loadBalancer:
-      enabled: false
   providerClusterConfiguration:
     apiVersion: deckhouse.io/v1
     kind: DVPClusterConfiguration
@@ -185,6 +182,8 @@ var _ = Describe("Module :: cloud-provider-dvp :: helm template ::", func() {
 			Expect(ccmDeployment.Exists()).To(BeTrue())
 			Expect(ccmDeployment.Field("spec.template.spec.hostNetwork").Bool()).To(BeTrue())
 			Expect(ccmDeployment.Field("spec.template.spec.dnsPolicy").String()).To(Equal("Default"))
+			Expect(ccmDeployment.Field(`spec.template.spec.containers.0.args`).String()).
+				To(ContainSubstring(`--controllers=cloud-node,cloud-node-lifecycle,service-lb-controller`))
 
 			ccmVPA := f.KubernetesResource("VerticalPodAutoscaler", moduleNamespace, "cloud-controller-manager")
 			Expect(ccmVPA.Exists()).To(BeTrue())
@@ -286,5 +285,6 @@ var _ = Describe("Module :: cloud-provider-dvp :: helm template ::", func() {
 			providerSpecificBashibleBootstrapSecret := f.KubernetesResource("Secret", "kube-system", fmt.Sprintf("d8-cloud-provider-%s-bashible-bootstrap", providerID))
 			Expect(providerSpecificBashibleBootstrapSecret.Exists()).To(BeFalse())
 		})
+
 	})
 })

--- a/modules/030-cloud-provider-dvp/templates/cloud-controller-manager/deployment.yaml
+++ b/modules/030-cloud-provider-dvp/templates/cloud-controller-manager/deployment.yaml
@@ -32,14 +32,7 @@ checksum/config: {{ include (print $.Template.BasePath "/cloud-controller-manage
       key: namespace
 {{- end -}}
 
-{{- $ccmEnabledControllers := "cloud-node,cloud-node-lifecycle" -}}
-{{- if hasKey .Values.cloudProviderDvp.internal.discoveryData "loadBalancer" -}}
-  {{- if hasKey .Values.cloudProviderDvp.internal.discoveryData.loadBalancer "enabled" -}}
-    {{- if .Values.cloudProviderDvp.internal.discoveryData.loadBalancer.enabled -}}
-      {{- $ccmEnabledControllers = printf "%s,service-lb-controller" $ccmEnabledControllers -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
+{{- $ccmEnabledControllers := "cloud-node,cloud-node-lifecycle,service-lb-controller" -}}
 
 {{- $ccmConfig := dict -}}
 {{- $_ := set $ccmConfig "fullname" "cloud-controller-manager" -}}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Restores correct service-lb-controller enablement in cloud-provider-dvp so LoadBalancer Services are handled by CCM again.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
After a regression, service-lb-controller was no longer started, so newly created LoadBalancer Services stayed in Pending and no parent LB was created.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Restored correct service-lb-controller enablement in cloud-provider-dvp.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
