### PR TITLE
[cloud-provider-dvp] skip update of non-deckhouse cloud-init secrets on conflict

### DIFF
--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/compute.go
@@ -40,6 +40,9 @@ const (
 	attachmentDiskNameLabel    = "virtualMachineDiskName"
 	attachmentMachineNameLabel = "virtualMachineName"
 	DVPLoadBalancerLabelPrefix = "dvp.deckhouse.io/"
+
+	DeckhouseManagedByLabelKey   = "deckhouse.io/managed-by"
+	DeckhouseManagedByLabelValue = "deckhouse"
 )
 
 const (
@@ -422,13 +425,20 @@ func (c *ComputeService) listVMBDAByHostname(ctx context.Context, vmHostname str
 	return vmbdas.Items, nil
 }
 
+func isDeckhouseManagedSecret(secret *corev1.Secret) bool {
+	if secret.Labels == nil {
+		return false
+	}
+	return secret.Labels[DeckhouseManagedByLabelKey] == DeckhouseManagedByLabelValue
+}
+
 func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, clusterUUID, vmHostname, name string, userData []byte, vmName string, vmUID types.UID) error {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: c.namespace,
 			Labels: map[string]string{
-				"deckhouse.io/managed-by":       "deckhouse",
+				DeckhouseManagedByLabelKey:      DeckhouseManagedByLabelValue,
 				"dvp.deckhouse.io/cluster-uuid": clusterUUID,
 				"dvp.deckhouse.io/hostname":     vmHostname,
 			},
@@ -445,21 +455,32 @@ func (c *ComputeService) CreateCloudInitProvisioningSecret(ctx context.Context, 
 		StringData: map[string]string{"userData": string(userData)},
 	}
 
-	// Try to create, if already exists then update
-	if _, err := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{}); err != nil {
-		if k8serrors.IsAlreadyExists(err) {
-			// Secret already exists, update it instead
-			existing, getErr := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
-			if getErr != nil {
-				return fmt.Errorf("get existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, getErr)
-			}
-			existing.StringData = map[string]string{"userData": string(userData)}
-			if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
-				return fmt.Errorf("update '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
-			}
-			return nil
-		}
+	_, err := c.clientset.CoreV1().Secrets(c.namespace).Create(ctx, s, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !k8serrors.IsAlreadyExists(err) {
 		return fmt.Errorf("create '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, err)
+	}
+
+	// Secret already exists — load it and decide whether we may update userData.
+	existing, getErr := c.clientset.CoreV1().Secrets(c.namespace).Get(ctx, name, metav1.GetOptions{})
+	if getErr != nil {
+		return fmt.Errorf("get existing '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, getErr)
+	}
+
+	// Not managed by Deckhouse (legacy or user-created): keep as-is and continue reconcile.
+	if !isDeckhouseManagedSecret(existing) {
+		klog.Warningf(
+			"cloud-init secret %s/%s already exists without %s=%s; leaving unchanged and continuing with existing userData",
+			c.namespace, name, DeckhouseManagedByLabelKey, DeckhouseManagedByLabelValue,
+		)
+		return nil
+	}
+
+	existing.StringData = map[string]string{"userData": string(userData)}
+	if _, updateErr := c.clientset.CoreV1().Secrets(c.namespace).Update(ctx, existing, metav1.UpdateOptions{}); updateErr != nil {
+		return fmt.Errorf("update '%s[%s]' secret: %w", name, v1alpha2.SecretTypeCloudInit, updateErr)
 	}
 	return nil
 }


### PR DESCRIPTION
## Description
Refined CreateCloudInitProvisioningSecret in cloud-provider-dvp (dvp-common/api/compute.go):

- Replaced nested if branches with early returns when handling AlreadyExists.
- On conflict, update userData only if the existing secret has deckhouse.io/managed-by=deckhouse.
- If the secret exists but is not Deckhouse-managed (legacy object or user-created), log a warning, leave the secret unchanged, and return success so reconcile can continue with the existing cloud-init.

No changes to cluster-wide control-plane components. After module upgrade, capdvp-controller-manager will pick up the new logic on its usual rollout.

## Why do we need it, and what problem does it solve?
When a cloud-init provisioning secret already exists, the controller always overwrites it on the next reconcile. That is correct for Deckhouse-owned secrets left from a failed provisioning attempt, but unsafe for secrets without deckhouse.io/managed-by=deckhouse (manual or legacy objects with the same name).

This change:

- Keeps idempotent updates for Deckhouse-managed secrets (fixes repeated secret already exists flows for our own orphans).
- Avoids silently overwriting foreign secrets.
- Does not fail reconcile when a non-managed secret is present — only warns and continues with existing userData.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Update existing cloud-init secrets on conflict only when they are marked as Deckhouse-managed.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
