### PR TITLE
[istio] Timeout fixes for jwt token re-generation for communication between multiclusters

### DIFF
--- a/modules/110-istio/images/common-v1x21x6/patches/004-istio-multicluster_regenerate_token_timeout.patch
+++ b/modules/110-istio/images/common-v1x21x6/patches/004-istio-multicluster_regenerate_token_timeout.patch
@@ -1,0 +1,172 @@
+diff --git a/pilot/pkg/credentials/kube/multicluster.go b/pilot/pkg/credentials/kube/multicluster.go
+index 54e9b4a8a9..00ef0f0078 100644
+--- a/pilot/pkg/credentials/kube/multicluster.go
++++ b/pilot/pkg/credentials/kube/multicluster.go
+@@ -55,8 +55,10 @@ func (m *Multicluster) ClusterUpdated(cluster *multicluster.Cluster, _ <-chan st
+ 	sc := NewCredentialsController(cluster.Client)
+ 	m.m.Lock()
+ 	defer m.m.Unlock()
+-	m.deleteCluster(cluster.ID)
+-	m.addCluster(cluster, sc)
++	for _, onCredential := range m.secretHandlers {
++		sc.AddEventHandler(onCredential)
++	}
++	m.remoteKubeControllers[cluster.ID] = sc
+ }
+ 
+ func (m *Multicluster) ClusterDeleted(key cluster.ID) {
+diff --git a/pilot/pkg/serviceregistry/aggregate/controller.go b/pilot/pkg/serviceregistry/aggregate/controller.go
+index f4f91c7bba..f2d74d0f01 100644
+--- a/pilot/pkg/serviceregistry/aggregate/controller.go
++++ b/pilot/pkg/serviceregistry/aggregate/controller.go
+@@ -16,6 +16,7 @@ package aggregate
+ 
+ import (
+ 	"net/netip"
++	"reflect"
+ 	"sync"
+ 
+ 	"istio.io/istio/pilot/pkg/features"
+@@ -215,6 +216,29 @@ func (c *Controller) DeleteRegistry(clusterID cluster.ID, providerID provider.ID
+ 	log.Infof("%s registry for the cluster %s has been deleted.", providerID, clusterID)
+ }
+ 
++// Used when two registries temporarily share the same cluster ID and provider during remote-secret rotation.
++func (c *Controller) DeleteRegistryInstance(registry serviceregistry.Instance) bool {
++	if registry == nil {
++		return false
++	}
++	target := reflect.ValueOf(registry)
++	c.storeLock.Lock()
++	defer c.storeLock.Unlock()
++	for i, re := range c.registries {
++		if re == nil {
++			continue
++		}
++		cur := reflect.ValueOf(re.Instance)
++		if target.Kind() == reflect.Ptr && cur.Kind() == reflect.Ptr && target.Pointer() == cur.Pointer() {
++			c.registries = append(c.registries[:i], c.registries[i+1:]...)
++			log.Infof("registry instance %T removed from aggregate", registry)
++			return true
++		}
++	}
++	log.Warnf("registry instance %T not found in aggregate", registry)
++	return false
++}
++
+ // GetRegistries returns a copy of all registries
+ func (c *Controller) GetRegistries() []serviceregistry.Instance {
+ 	c.storeLock.RLock()
+diff --git a/pilot/pkg/serviceregistry/kube/controller/multicluster.go b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+index 9fde457cdc..fb93c427df 100644
+--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
++++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+@@ -18,6 +18,7 @@ import (
+ 	"context"
+ 	"strings"
+ 	"sync"
++	"time"
+ 
+ 	"golang.org/x/sync/errgroup"
+ 	"k8s.io/apimachinery/pkg/api/errors"
+@@ -167,16 +168,64 @@ func (m *Multicluster) ClusterAdded(cluster *multicluster.Cluster, clusterStopCh
+ // when a remote cluster is updated.
+ func (m *Multicluster) ClusterUpdated(cluster *multicluster.Cluster, stop <-chan struct{}) {
+ 	m.m.Lock()
+-	m.deleteCluster(cluster.ID)
++	if m.closing {
++		m.m.Unlock()
++		return
++	}
++	oldKC, existed := m.remoteKubeControllers[cluster.ID]
++	if !existed {
++		m.m.Unlock()
++		m.ClusterAdded(cluster, stop)
++		return
++	}
+ 	kubeController, kubeRegistry, options, configCluster := m.addCluster(cluster)
+ 	if kubeController == nil {
+-		// m.closing was true, nothing to do.
+ 		m.m.Unlock()
+ 		return
+ 	}
+ 	m.m.Unlock()
+-	// clusterStopCh is a channel that will be closed when this cluster removed.
++
++	// Register and start the new kube registry first so the mesh keeps serving traffic from the old
++	// registry until the new one has completed initial sync, then drop the old registry by instance.
+ 	m.initializeCluster(cluster, kubeController, kubeRegistry, *options, configCluster, stop)
++
++	m.waitForRemoteKubeRegistryReady(kubeRegistry, cluster.ID)
++
++	m.removeOldRemoteClusterAfterNewReady(oldKC)
++
++	if m.XDSUpdater != nil {
++		m.XDSUpdater.ConfigUpdate(&model.PushRequest{Full: true, Reason: model.NewReasonStats(model.ClusterUpdate)})
++	}
++}
++
++func (m *Multicluster) waitForRemoteKubeRegistryReady(kubeRegistry *Controller, id cluster.ID) {
++	maxWait := 15 * time.Minute
++	if features.RemoteClusterTimeout > 0 {
++		maxWait = features.RemoteClusterTimeout*3 + 60*time.Second
++	}
++	deadline := time.Now().Add(maxWait)
++	for time.Now().Before(deadline) {
++		if kubeRegistry.HasSynced() {
++			return
++		}
++		time.Sleep(50 * time.Millisecond)
++	}
++	log.Warnf("remote cluster %s: new kube registry did not report HasSynced within %v; removing old registry anyway",
++		id, maxWait)
++}
++
++func (m *Multicluster) removeOldRemoteClusterAfterNewReady(oldKC *kubeController) {
++	if oldKC.workloadEntryController != nil {
++		if !m.opts.MeshServiceController.DeleteRegistryInstance(oldKC.workloadEntryController) {
++			log.Warnf("failed to remove old WorkloadEntry registry from aggregate during cluster credential rotation")
++		}
++	}
++	if !m.opts.MeshServiceController.DeleteRegistryInstance(oldKC.Controller) {
++		log.Warnf("failed to remove old Kubernetes registry from aggregate during cluster credential rotation")
++	}
++	if err := oldKC.Cleanup(); err != nil {
++		log.Warnf("failed cleaning up old kube controller after remote cluster update: %v", err)
++	}
+ }
+ 
+ // ClusterDeleted is passed to the secret controller as a callback to be called
+diff --git a/pkg/kube/multicluster/secretcontroller.go b/pkg/kube/multicluster/secretcontroller.go
+index 4df6fcfcdc..e93662451d 100644
+--- a/pkg/kube/multicluster/secretcontroller.go
++++ b/pkg/kube/multicluster/secretcontroller.go
+@@ -253,6 +253,7 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
+ 		}
+ 
+ 		action, callback := "Adding", c.handleAdd
++		var prevCluster *Cluster
+ 		if prev := c.cs.Get(secretKey, cluster.ID(clusterID)); prev != nil {
+ 			action, callback = "Updating", c.handleUpdate
+ 			// clusterID must be unique even across multiple secrets
+@@ -261,8 +262,8 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
+ 				logger.Infof("skipping update (kubeconfig are identical)")
+ 				continue
+ 			}
+-			// stop previous remote cluster
+-			prev.Stop()
++			// Defer prev.Stop() until after ClusterUpdated has registered the replacement and removed the old registry.
++			prevCluster = prev
+ 		} else if c.cs.Contains(cluster.ID(clusterID)) {
+ 			// if the cluster has been registered before by another secret, ignore the new one.
+ 			logger.Warnf("cluster has already been registered")
+@@ -280,6 +281,9 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
+ 		logger.Infof("finished callback for cluster and starting to sync")
+ 		c.cs.Store(secretKey, remoteCluster.ID, remoteCluster)
+ 		go remoteCluster.Run()
++		if prevCluster != nil {
++			prevCluster.Stop()
++		}
+ 	}
+ 
+ 	log.Infof("Number of remote clusters: %d", c.cs.Len())

--- a/modules/110-istio/images/common-v1x21x6/patches/README.md
+++ b/modules/110-istio/images/common-v1x21x6/patches/README.md
@@ -15,6 +15,11 @@ Fix use expfmt library in pilot-agent. This library used for format metrics.
 > [!WARNING]
 > **After update istio to version 1.22.X and above need delete this patch!**
 
+## 004-istio-multicluster_regenerate_token_timeout.patch
+
+Implement graceful transition for remote multicluster secrets. To prevent connectivity gaps during secret rotation, the old secret is no longer dismissed immediately. Instead, it remains active until the new secret is processed and all associated metadata is synced.
+Adopted upstream pr https://github.com/istio/istio/pull/58567.
+
 ## 001-kiali-go-mod.patch
 
 Fix CVE

--- a/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x21x6/werf.inc.yaml
@@ -18,7 +18,7 @@ shell:
   install:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/istio.git /src/istio/
   - cd /src/istio/
-  - git apply --verbose /patches/001-istio-apply_go.patch /patches/002-istio-gomod_gosum.patch /patches/003-istio-server_fmtText.patch
+  - git apply --verbose /patches/001-istio-apply_go.patch /patches/002-istio-gomod_gosum.patch /patches/003-istio-server_fmtText.patch /patches/004-istio-multicluster_regenerate_token_timeout.patch
   - rm -rf /src/istio/.git
   - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali.git /src/kiali/
   - cd /src/kiali/

--- a/modules/110-istio/images/common-v1x25x2/patches/002-istio-multicluster-regenerate-token-timeout.patch
+++ b/modules/110-istio/images/common-v1x25x2/patches/002-istio-multicluster-regenerate-token-timeout.patch
@@ -1,0 +1,61 @@
+diff --git a/pkg/kube/multicluster/secretcontroller.go b/pkg/kube/multicluster/secretcontroller.go
+index 824ac68268..664776fcbb 100644
+--- a/pkg/kube/multicluster/secretcontroller.go
++++ b/pkg/kube/multicluster/secretcontroller.go
+@@ -258,6 +258,26 @@ func (c *Controller) createRemoteCluster(kubeConfig []byte, clusterID string) (*
+ 	}, nil
+ }
+ 
++// stopPreviousClusterAfterReplacementReady closes prev after newCluster reports initial sync (or after
++// a bounded wait), so rotating istio-remote-secret does not tear down the old kube client before the
++// replacement is usable.
++func (c *Controller) stopPreviousClusterAfterReplacementReady(newCluster, prev *Cluster, logger *log.Scope) {
++	wait := features.RemoteClusterTimeout
++	if wait == 0 {
++		wait = 2 * time.Minute
++	} else {
++		wait += 2 * time.Second
++	}
++	deadline := time.Now().Add(wait)
++	for !newCluster.HasSynced() && time.Now().Before(deadline) {
++		time.Sleep(20 * time.Millisecond)
++	}
++	if !newCluster.HasSynced() {
++		logger.Warnf("replacement cluster did not become ready within %v; stopping previous kubeconfig anyway", wait)
++	}
++	prev.Stop()
++}
++
+ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) error {
+ 	secretKey := name.String()
+ 	// First delete clusters
+@@ -277,6 +297,7 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
+ 		}
+ 
+ 		action := Add
++		var prevCluster *Cluster
+ 		if prev := c.cs.Get(secretKey, cluster.ID(clusterID)); prev != nil {
+ 			action = Update
+ 			// clusterID must be unique even across multiple secrets
+@@ -285,8 +306,8 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
+ 				logger.Infof("skipping update (kubeconfig are identical)")
+ 				continue
+ 			}
+-			// stop previous remote cluster
+-			prev.Stop()
++			// Keep the previous cluster alive until the replacement is ready.
++			prevCluster = prev
+ 		} else if c.cs.Contains(cluster.ID(clusterID)) {
+ 			// if the cluster has been registered before by another secret, ignore the new one.
+ 			logger.Warnf("cluster has already been registered")
+@@ -305,6 +326,10 @@ func (c *Controller) addSecret(name types.NamespacedName, s *corev1.Secret) erro
+ 		go func() {
+ 			remoteCluster.Run(c.meshWatcher, c.handlers, action)
+ 		}()
++		if prevCluster != nil {
++			// Do not block the work queue while waiting for replacement readiness.
++			go c.stopPreviousClusterAfterReplacementReady(remoteCluster, prevCluster, logger)
++		}
+ 	}
+ 
+ 	log.Infof("Number of remote clusters: %d", c.cs.Len())

--- a/modules/110-istio/images/common-v1x25x2/patches/README.md
+++ b/modules/110-istio/images/common-v1x25x2/patches/README.md
@@ -7,3 +7,8 @@ Fix Kiali CVE vulnerabilities
 ## 001-istio-gomod_gosum.patch
 
 Fix Istio CVE vulnerabilities
+
+## 002-istio-multicluster-regenerate-token-timeout.patch
+
+Implement graceful transition for remote multicluster secrets. To prevent connectivity gaps during secret rotation, the old secret is no longer dismissed immediately. Instead, it remains active until the new secret is processed and all associated metadata is synced.
+Adopted upstream pr https://github.com/istio/istio/pull/58567.

--- a/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x25x2/werf.inc.yaml
@@ -18,7 +18,7 @@ shell:
   install:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/istio.git /src/istio/
   - cd /src/istio/
-  - git apply --verbose /patches/001-istio-gomod_gosum.patch
+  - git apply --verbose /patches/001-istio-gomod_gosum.patch /patches/002-istio-multicluster-regenerate-token-timeout.patch
   - rm -rf /src/istio/.git
   - git clone --depth 1 --branch {{ $kialiVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/kiali.git /src/kiali/
   - cd /src/kiali/


### PR DESCRIPTION
## Description
This PR backports a fix for Istio multicluster remote-secret rotation to prevent traffic interruption during JWT/kubeconfig updates. Ref #19278

## Why do we need it, and what problem does it solve?
Before this fix, when istio-remote-secret-<cluster> was updated (for example, annual JWT regeneration), the previous remote cluster could be stopped/removed before the new one became ready.
This created a temporary gap in remote service discovery, which could manifest as ~30s disruption (including DNS/service resolution issues for multicluster traffic).
This PR removes that gap by ensuring handover is graceful:

new remote connectivity is brought up first,
old connectivity is retired only after replacement readiness.
Validation on test multicluster environments (delta/omega tests clusters) with live JWT rotation under load in sample namespace showed no outage windows (no request errors during rotation).
Measured results:
delta -> omega direction: 220/220 successful requests, 0 errors, longest_no_success_window = 0 ms, max_gap_between_success = 345.6 ms, p95 = 256.0 ms.
omega -> delta direction (isolated to remote v2 only): 260/260 successful requests, 0 errors, longest_no_success_window = 0 ms, max_gap_between_success = 350.1 ms, p95 = 288.4 ms.

## Why do we need it in the patch release (if we do)?

This fix Istio multicluster remote-secret rotation to prevent traffic interruption during JWT/kubeconfig updates

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Implement graceful metadata secret renewal for multiclusters.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
