### PR TITLE
[ci] Fix separate tests build for 1.75

### DIFF
--- a/.werf/werf-test.yaml
+++ b/.werf/werf-test.yaml
@@ -43,10 +43,6 @@ git:
   {{ .Files.Get (printf "tools/build_includes/candi-cloud-providers-%s.yaml" .Env) }}
   {{ .Files.Get (printf "tools/build_includes/candi-%s.yaml" .Env) }}
 import:
-- image: deckhouse-controller-artifact
-  add: /out/deckhouse-controller
-  to: /usr/bin/deckhouse-controller
-  after: setup
 - image: tools/jq
   add: /usr/bin/jq
   to: /usr/bin/jq
@@ -94,11 +90,9 @@ import:
   add: /{{ .TF.gcp.artifactBinary }}
   to: /dhctl-tests/plugins/registry.terraform.io/{{ .TF.gcp.namespace }}/{{ .TF.gcp.type }}/{{ $.TF.gcp.version }}/linux_amd64/{{ .TF.gcp.destinationBinary }}
   before: setup
-- image: images-digests
-  add: /images_digests.json
-  to: /deckhouse/modules/images_digests.json
-  after: setup
-- image: images-digests
-  add: /images_digests.json
-  to: /deckhouse/modules/040-node-manager/images_digests.json
-  after: setup
+# NB: the `images-digests` image is intentionally NOT imported here.
+# It carries a werf `dependencies:` block over every module image, so
+# importing it forces a full deckhouse image build. Without the baked-in
+# images_digests.json, testing/library/utils.go falls back to the dummy
+# DefaultImagesDigests (tools/images_tags) — the path designed for
+# template/matrix tests.


### PR DESCRIPTION
## Description
Fix separate tests build for 1.75.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix separate tests build.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
