### PR TITLE
[istio] Migrate images to distroless

### DIFF
--- a/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x25x2/werf.inc.yaml
@@ -13,7 +13,7 @@
 # Based on https://github.com/istio/istio/blob/1.25.2/docker/Dockerfile.base
 #      and https://github.com/istio/istio/blob/1.25.2/pilot/docker/Dockerfile.proxyv2
 image: {{ .ModuleName }}/{{ .ImageName }}
-fromImage: common/alt-p11
+fromImage: common/distroless
 import:
 - image: {{ .ModuleName }}/common-{{ $istioImageVersion }}-src-artifact
   add: /src/istio/tools/packaging/common/envoy_bootstrap.json
@@ -33,6 +33,18 @@ import:
   owner: 1337
   group: 1337
   after: setup
+- image: libs/glibc-v2.41
+  add: /lib64/libc.so.6
+  to: /lib64/libc.so.6
+  before: install
+- image: libs/glibc-v2.41
+  add: /lib64/libm.so.6
+  to: /lib64/libm.so.6
+  before: install
+- image: libs/glibc-v2.41
+  add: /lib64/ld-linux-x86-64.so.2
+  to: /lib64/ld-linux-x86-64.so.2
+  before: install
 - image: {{ .ModuleName }}/{{ .ImageName }}-binaries-artifact
   add: /relocate
   to: /
@@ -54,20 +66,12 @@ import:
   before: setup
 git:
 {{- include "image mount points" . }}
-shell:
-  beforeInstall:
-  {{- include "alt packages proxy" . | nindent 2 }}
-  - apt-get install -y ca-certificates
-  - update-ca-trust
-  - apt-get clean
-  - rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
-  install:
-  - useradd -m --uid 1337 istio-proxy
-  - echo istio-proxy ALL=NOPASSWD:ALL | tee -a /etc/sudoers
 imageSpec:
   config:
     user: "1337:1337"
-    env: { "ISTIO_META_ISTIO_PROXY_SHA": "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489", "ISTIO_META_ISTIO_VERSION": "{{ $istioVersion }}" }
+    env:
+      ISTIO_META_ISTIO_PROXY_SHA: "istio-proxy:78bd2d9b284978e170a49cd13decd5f952544489"
+      ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     workingDir: "/"
     entrypoint: ["/usr/local/bin/pilot-agent"]
 ---

--- a/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -1,7 +1,7 @@
 {{- $istioVersion := "1.25.2" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
-fromImage: common/alt-p11
+fromImage: common/distroless
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
     add: /src/ztunnel/bin/ztunnel
@@ -10,7 +10,8 @@ import:
 imageSpec:
   config:
     user: "1337:1337"
-    env: { "ISTIO_META_ISTIO_VERSION": "{{ $istioVersion }}" }
+    env:
+      ISTIO_META_ISTIO_VERSION: {{ $istioVersion }}
     entrypoint: ["/usr/local/bin/ztunnel"]
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact
@@ -20,6 +21,28 @@ import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src/ztunnel
   to: /src/ztunnel
+  owner: 1337
+  group: 1337
+  before: install
+- image: libs/glibc-v2.41
+  add: /lib64/libc.so.6
+  to: /lib64/libc.so.6
+  before: install
+- image: libs/glibc-v2.41
+  add: /lib64/libm.so.6
+  to: /lib64/libm.so.6
+  before: install
+- image: libs/glibc-v2.41
+  add: /lib64/ld-linux-x86-64.so.2
+  to: /lib64/ld-linux-x86-64.so.2
+  before: install
+- image: libs/xz-v5.8.1
+  add: /usr/lib/libc.so
+  to: /lib64/libc.so
+  before: install
+- image: tools/gcc-gnu-releases/gcc-14.2.0
+  add: /usr/lib/libgcc_s.so.1
+  to: /lib64/libgcc_s.so.1
   before: install
 shell:
   beforeInstall:
@@ -39,11 +62,8 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
 fromImage: common/src-artifact
 final: false
-secrets:
-- id: SOURCE_REPO
-  value: {{ .SOURCE_REPO }}
-shell:
-  install:
-  - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/ztunnel.git /src/ztunnel
-  - rm -rf /src/ztunnel/.git
+git:
+- url: {{ .SOURCE_REPO }}/istio/ztunnel
+  tag: {{ $istioVersion }}
+  to: /src/ztunnel
 ---

--- a/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
+++ b/modules/110-istio/images/ztunnel-v1x25x2/werf.inc.yaml
@@ -24,26 +24,6 @@ import:
   owner: 1337
   group: 1337
   before: install
-- image: libs/glibc-v2.41
-  add: /lib64/libc.so.6
-  to: /lib64/libc.so.6
-  before: install
-- image: libs/glibc-v2.41
-  add: /lib64/libm.so.6
-  to: /lib64/libm.so.6
-  before: install
-- image: libs/glibc-v2.41
-  add: /lib64/ld-linux-x86-64.so.2
-  to: /lib64/ld-linux-x86-64.so.2
-  before: install
-- image: libs/xz-v5.8.1
-  add: /usr/lib/libc.so
-  to: /lib64/libc.so
-  before: install
-- image: tools/gcc-gnu-releases/gcc-14.2.0
-  add: /usr/lib/libgcc_s.so.1
-  to: /lib64/libgcc_s.so.1
-  before: install
 shell:
   beforeInstall:
   {{- include "alt packages proxy" . | nindent 2 }}


### PR DESCRIPTION
## Description

Migrate Istio proxyv2 and ztunnel images for Istio 1.25.2 from `common/alt-p11` base to `common/distroless`.

## Why do we need it, and what problem does it solve?

Using a distroless base image significantly reduces the number of packages, binaries, and libraries present in the final container images. This minimizes the attack surface for potential vulnerabilities and aligns with security best practices for production container images.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: chore
summary: Migrate proxyv2 and ztunnel images to distroless base.
impact_level: low
```