### PR TITLE
[upmeter] fix mini e2e probe for alertmanager

### DIFF
--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/observability_rules_group.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/observability_rules_group.go
@@ -665,15 +665,15 @@ kind: ObservabilityMetricsRulesGroup
 metadata:
   labels:
     heritage: upmeter
-    upmeter-agent: %s
+    upmeter-agent: %q
     upmeter-group: monitoring-and-autoscaling
     upmeter-probe: observability-recording
-  name: %s
-  namespace: %s
+  name: %q
+  namespace: %q
 spec:
   interval: "30s"
   rules:
-  - record: %s
+  - record: %q
     expr: kube_namespace_created
 `, agentID, name, namespace, metric)
 }
@@ -685,19 +685,19 @@ kind: ObservabilityMetricsRulesGroup
 metadata:
   labels:
     heritage: upmeter
-    upmeter-agent: %s
+    upmeter-agent: %q
     upmeter-group: monitoring-and-autoscaling
     upmeter-probe: alertmanager
-  name: %s
-  namespace: %s
+  name: %q
+  namespace: %q
 spec:
   interval: "30s"
   rules:
-  - alert: %s
+  - alert: %q
     expr: kube_namespace_created > 0
     labels:
       severity: warning
-      %s: %s
+      %q: %q
     annotations:
       summary: "upmeter observability mini e2e alert"
 `, agentID, name, namespace, alertName, alertLabelKey, alertLabelValue)
@@ -710,17 +710,17 @@ kind: ObservabilityNotificationSilence
 metadata:
   labels:
     heritage: upmeter
-    upmeter-agent: %s
+    upmeter-agent: %q
     upmeter-group: monitoring-and-autoscaling
     upmeter-probe: alertmanager
-  name: %s
-  namespace: %s
+  name: %q
+  namespace: %q
 spec:
-  startsAt: "%s"
-  endsAt: "%s"
+  startsAt: %q
+  endsAt: %q
   selector:
     matchLabels:
-      %s: %s
+      %q: %q
 `,
 		agentID,
 		name,

--- a/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/observability_rules_group_test.go
+++ b/modules/500-upmeter/images/upmeter/src/pkg/probe/checker/observability_rules_group_test.go
@@ -54,6 +54,21 @@ func Test_recordingRulesGroupManifest(t *testing.T) {
 	assert.Equal(t, "kube_namespace_created", rule["expr"])
 }
 
+func Test_recordingRulesGroupManifest_numericAgentID(t *testing.T) {
+	manifest := recordingRulesGroupManifest("7798", "test-ns", "recording-rules", "upmeter_metric")
+
+	var obj map[string]interface{}
+	err := yaml.Unmarshal([]byte(manifest), &obj)
+	assert.NoError(t, err)
+
+	metadata := obj["metadata"].(map[string]interface{})
+	labels := metadata["labels"].(map[string]interface{})
+
+	value, ok := labels["upmeter-agent"].(string)
+	assert.True(t, ok, "upmeter-agent label must be a string, got %T", labels["upmeter-agent"])
+	assert.Equal(t, "7798", value)
+}
+
 func Test_alertRulesGroupManifest(t *testing.T) {
 	manifest := alertRulesGroupManifest(
 		"agent-01",
@@ -81,6 +96,78 @@ func Test_alertRulesGroupManifest(t *testing.T) {
 	assert.Equal(t, "abc-123", labels["upmeter_alert_id"])
 }
 
+func Test_alertRulesGroupManifest_numericValues(t *testing.T) {
+	manifest := alertRulesGroupManifest(
+		"7798",
+		"test-ns",
+		"alert-rules",
+		"UpmeterMiniE2E",
+		"upmeter_alert_id",
+		"123456",
+	)
+
+	var obj map[string]interface{}
+	err := yaml.Unmarshal([]byte(manifest), &obj)
+	assert.NoError(t, err)
+
+	metadata := obj["metadata"].(map[string]interface{})
+	metaLabels := metadata["labels"].(map[string]interface{})
+	agentValue, ok := metaLabels["upmeter-agent"].(string)
+	assert.True(t, ok, "upmeter-agent label must be a string, got %T", metaLabels["upmeter-agent"])
+	assert.Equal(t, "7798", agentValue)
+
+	spec := obj["spec"].(map[string]interface{})
+	rule := spec["rules"].([]interface{})[0].(map[string]interface{})
+	ruleLabels := rule["labels"].(map[string]interface{})
+	alertIDValue, ok := ruleLabels["upmeter_alert_id"].(string)
+	assert.True(t, ok, "upmeter_alert_id label must be a string, got %T", ruleLabels["upmeter_alert_id"])
+	assert.Equal(t, "123456", alertIDValue)
+}
+
+func Test_alertRulesGroupManifest_quotedKeyParsesAsBareString(t *testing.T) {
+	manifest := alertRulesGroupManifest(
+		"agent-01",
+		"test-ns",
+		"alert-rules",
+		"UpmeterMiniE2E",
+		"upmeter_alert_id",
+		"abc-123",
+	)
+
+	var obj map[string]interface{}
+	err := yaml.Unmarshal([]byte(manifest), &obj)
+	assert.NoError(t, err)
+
+	labels := obj["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["labels"].(map[string]interface{})
+
+	_, bareOK := labels["upmeter_alert_id"]
+	assert.True(t, bareOK, "label key must be parsed as bare string `upmeter_alert_id`")
+
+	_, quotedLeaked := labels[`"upmeter_alert_id"`]
+	assert.False(t, quotedLeaked, "label key must NOT contain literal quote characters")
+}
+
+func Test_alertRulesGroupManifest_specialCharsAreEscaped(t *testing.T) {
+	manifest := alertRulesGroupManifest(
+		`hash"with"quotes`,
+		"test-ns",
+		"alert-rules",
+		"UpmeterMiniE2E",
+		"upmeter_alert_id",
+		`val\nwith\backslash`,
+	)
+
+	var obj map[string]interface{}
+	err := yaml.Unmarshal([]byte(manifest), &obj)
+	assert.NoError(t, err, "manifest must be parseable YAML even with special chars in values")
+
+	metaLabels := obj["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
+	assert.Equal(t, `hash"with"quotes`, metaLabels["upmeter-agent"])
+
+	ruleLabels := obj["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["labels"].(map[string]interface{})
+	assert.Equal(t, `val\nwith\backslash`, ruleLabels["upmeter_alert_id"])
+}
+
 func Test_observabilitySilenceManifest(t *testing.T) {
 	startsAt := time.Date(2026, time.February, 27, 9, 0, 0, 0, time.UTC)
 	endsAt := startsAt.Add(10 * time.Minute)
@@ -106,6 +193,35 @@ func Test_observabilitySilenceManifest(t *testing.T) {
 	selector := spec["selector"].(map[string]interface{})
 	matchLabels := selector["matchLabels"].(map[string]interface{})
 	assert.Equal(t, "abc-123", matchLabels["upmeter_alert_id"])
+}
+
+func Test_observabilitySilenceManifest_numericValues(t *testing.T) {
+	startsAt := time.Date(2026, time.February, 27, 9, 0, 0, 0, time.UTC)
+	endsAt := startsAt.Add(10 * time.Minute)
+
+	manifest := observabilitySilenceManifest(
+		"7798",
+		"test-ns",
+		"silence-1",
+		"upmeter_alert_id",
+		"123456",
+		startsAt,
+		endsAt,
+	)
+
+	var obj map[string]interface{}
+	err := yaml.Unmarshal([]byte(manifest), &obj)
+	assert.NoError(t, err)
+
+	metaLabels := obj["metadata"].(map[string]interface{})["labels"].(map[string]interface{})
+	agentValue, ok := metaLabels["upmeter-agent"].(string)
+	assert.True(t, ok, "upmeter-agent label must be a string, got %T", metaLabels["upmeter-agent"])
+	assert.Equal(t, "7798", agentValue)
+
+	matchLabels := obj["spec"].(map[string]interface{})["selector"].(map[string]interface{})["matchLabels"].(map[string]interface{})
+	alertIDValue, ok := matchLabels["upmeter_alert_id"].(string)
+	assert.True(t, ok, "matchLabels.upmeter_alert_id must be a string, got %T", matchLabels["upmeter_alert_id"])
+	assert.Equal(t, "123456", alertIDValue)
 }
 
 func Test_isMetricPresentInPrometheusResponse(t *testing.T) {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Force-quotes all variable interpolations in the YAML manifests rendered at runtime by the upmeter `observability-rules-group-recording` and `observability-rules-group-alert` probes (`ObservabilityMetricsRulesGroup` and `ObservabilityNotificationSilence`). Previously the manifests used `%s`, which produced unquoted YAML scalars. 


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

On clusters where `NODE_NAME` produces a digits-only hash upmeter probes are permanently Down because the underlying `ObservabilityMetricsRulesGroup` manifest is rejected by the Kubernetes API on every probe cycle. End-users see persistent 0.00 availability for these components in the upmeter UI even though the underlying components are healthy.

## Why do we need it in the patch release (if we do)?

Yes, the issue is deterministic per node

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix 
summary: Quoted all variable interpolations in YAML manifests rendered by the `upmeter` observability-rules-group-recording and observability-rules-group-alert probes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
