### PR TITLE
[chore] regenerate codegen

### DIFF
--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -160,12 +160,6 @@ read:
     - cert-manager.io/issuers
     - cilium.io/ciliumclusterwidenetworkpolicies
     - cilium.io/ciliumnetworkpolicies
-    - cluster.x-k8s.io/clusters
-    - cluster.x-k8s.io/machinedeployments
-    - cluster.x-k8s.io/machinehealthchecks
-    - cluster.x-k8s.io/machinepools
-    - cluster.x-k8s.io/machines
-    - cluster.x-k8s.io/machinesets
     - config.gatekeeper.sh/configs
     - configmaps
     - connection.gatekeeper.sh/connections
@@ -187,10 +181,13 @@ read:
     - deckhouse.io/deschedulers
     - deckhouse.io/dexauthenticators
     - deckhouse.io/dexclients
+    - deckhouse.io/dvpinstanceclasses
+    - deckhouse.io/dynamixinstanceclasses
     - deckhouse.io/gcpinstanceclasses
     - deckhouse.io/huaweicloudinstanceclasses
     - deckhouse.io/hubblemonitoringconfigs
     - deckhouse.io/ingressmetrics
+    - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
@@ -211,6 +208,7 @@ read:
     - deckhouse.io/securitypolicyexceptions
     - deckhouse.io/servicemetrics
     - deckhouse.io/statefulsetmetrics
+    - deckhouse.io/vcdaffinityrules
     - deckhouse.io/vcdinstanceclasses
     - deckhouse.io/vsphereinstanceclasses
     - deckhouse.io/yandexinstanceclasses
@@ -237,24 +235,23 @@ read:
     - gateway.networking.k8s.io/tcproutes
     - gateway.networking.k8s.io/tlsroutes
     - gateway.networking.k8s.io/udproutes
+    - infrastructure.cluster.x-k8s.io/deckhouseclusters
+    - infrastructure.cluster.x-k8s.io/deckhousemachines
     - infrastructure.cluster.x-k8s.io/deckhousemachinetemplates
+    - infrastructure.cluster.x-k8s.io/dynamixclusters
+    - infrastructure.cluster.x-k8s.io/dynamixmachines
     - infrastructure.cluster.x-k8s.io/dynamixmachinetemplates
+    - infrastructure.cluster.x-k8s.io/huaweicloudclusters
+    - infrastructure.cluster.x-k8s.io/huaweicloudmachines
     - infrastructure.cluster.x-k8s.io/huaweicloudmachinetemplates
-    - infrastructure.cluster.x-k8s.io/staticmachinetemplates
+    - infrastructure.cluster.x-k8s.io/vcdclusters
+    - infrastructure.cluster.x-k8s.io/vcdclustertemplates
+    - infrastructure.cluster.x-k8s.io/vcdmachines
     - infrastructure.cluster.x-k8s.io/vcdmachinetemplates
+    - infrastructure.cluster.x-k8s.io/zvirtclusters
+    - infrastructure.cluster.x-k8s.io/zvirtmachines
     - infrastructure.cluster.x-k8s.io/zvirtmachinetemplates
     - limitranges
-    - machine.sapcloud.io/alicloudmachineclasses
-    - machine.sapcloud.io/awsmachineclasses
-    - machine.sapcloud.io/azuremachineclasses
-    - machine.sapcloud.io/gcpmachineclasses
-    - machine.sapcloud.io/machinedeployments
-    - machine.sapcloud.io/machines
-    - machine.sapcloud.io/machinesets
-    - machine.sapcloud.io/openstackmachineclasses
-    - machine.sapcloud.io/packetmachineclasses
-    - machine.sapcloud.io/vspheremachineclasses
-    - machine.sapcloud.io/yandexmachineclasses
     - metrics.k8s.io/nodes
     - metrics.k8s.io/pods
     - mutations.gatekeeper.sh/assign
@@ -326,7 +323,6 @@ read:
     - deckhouse.io/customprometheusrules
     - deckhouse.io/grafanaadditionaldatasources
     - deckhouse.io/grafanadashboarddefinitions
-    - deckhouse.io/ingressnginxcontrollers
 read-write:
     - deckhouse.io/podloggingconfigs
 write:
@@ -424,8 +420,11 @@ delete,deletecollection:
     - acme.cert-manager.io/orders
     - cert-manager.io/certificaterequests
     - cert-manager.io/challenges
+patch,update:
+    - nodes
 read:
     - deckhouse.io/ingressistiocontrollers
+    - deckhouse.io/ingressnginxcontrollers/status
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
     - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
@@ -438,7 +437,11 @@ read:
     - sailoperator.io/istios
     - sailoperator.io/ztunnels
 read-write:
+    - apps.kruise.io/daemonsets
     - deckhouse.io/downtimes
+    - deckhouse.io/ingressnginxcontrollers
+    - deckhouse.io/nodegroupconfigurations
+    - deckhouse.io/staticinstances
     - deckhouse.io/upmeterremotewrites
 write:
     - apiextensions.k8s.io/customresourcedefinitions
@@ -460,7 +463,7 @@ write:
     - deckhouse.io/grafanaadditionaldatasources
     - deckhouse.io/grafanadashboarddefinitions
     - deckhouse.io/hubblemonitoringconfigs
-    - deckhouse.io/ingressnginxcontrollers
+    - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/moduleconfigs
     - deckhouse.io/moduledocumentations
@@ -485,7 +488,7 @@ write:
 {{site.data.i18n.common.role[page.lang] | capitalize }} `ClusterAdmin` ({{site.data.i18n.common.includes_rules_from[page.lang]}} `User`, `PrivilegedUser`, `Editor`, `Admin`, `ClusterEditor`):
 
 ```text
-delete,deletecollection,patch,update:
+delete,deletecollection,get,list,patch,update,watch:
     - machine.sapcloud.io/alicloudmachineclasses
     - machine.sapcloud.io/awsmachineclasses
     - machine.sapcloud.io/azuremachineclasses
@@ -503,17 +506,50 @@ list:
     - dex.coreos.com/offlinesessionses
     - dex.coreos.com/passwords
 patch,update:
+    - deckhouse.io/vcdaffinityrules
+    - infrastructure.cluster.x-k8s.io/deckhouseclusters
+    - infrastructure.cluster.x-k8s.io/deckhousemachines
+    - infrastructure.cluster.x-k8s.io/deckhousemachinetemplates
+    - infrastructure.cluster.x-k8s.io/dynamixclusters
+    - infrastructure.cluster.x-k8s.io/dynamixmachines
+    - infrastructure.cluster.x-k8s.io/dynamixmachinetemplates
+    - infrastructure.cluster.x-k8s.io/huaweicloudclusters
+    - infrastructure.cluster.x-k8s.io/huaweicloudmachines
+    - infrastructure.cluster.x-k8s.io/huaweicloudmachinetemplates
+    - infrastructure.cluster.x-k8s.io/vcdclusters
+    - infrastructure.cluster.x-k8s.io/vcdclustertemplates
+    - infrastructure.cluster.x-k8s.io/vcdmachines
+    - infrastructure.cluster.x-k8s.io/vcdmachinetemplates
+    - infrastructure.cluster.x-k8s.io/zvirtclusters
+    - infrastructure.cluster.x-k8s.io/zvirtmachines
+    - infrastructure.cluster.x-k8s.io/zvirtmachinetemplates
     - machine.sapcloud.io/machinedeployments/scale
 proxy:
     - nodes
 read:
+    - cluster.x-k8s.io/machinedrainrules
     - control-plane.deckhouse.io/controlplaneoperations
+    - infrastructure.cluster.x-k8s.io/deckhousecontrolplanes
+    - infrastructure.cluster.x-k8s.io/staticclusters
+    - infrastructure.cluster.x-k8s.io/staticmachines
+    - nfd.k8s-sigs.io/nodefeaturegroups
+    - nfd.k8s-sigs.io/nodefeaturerules
+    - nfd.k8s-sigs.io/nodefeatures
 read-write:
+    - cluster.x-k8s.io/clusters
+    - cluster.x-k8s.io/machinedeployments
+    - cluster.x-k8s.io/machinehealthchecks
+    - cluster.x-k8s.io/machinepools
+    - cluster.x-k8s.io/machines
+    - cluster.x-k8s.io/machinesets
     - deckhouse.io/clusterauthorizationrules
     - deckhouse.io/dexproviders
     - deckhouse.io/groups
+    - deckhouse.io/nodeusers
+    - deckhouse.io/sshcredentials
     - deckhouse.io/useroperations
     - deckhouse.io/users
+    - infrastructure.cluster.x-k8s.io/staticmachinetemplates
     - nodes/configz
     - nodes/healthz
     - nodes/log
@@ -524,19 +560,15 @@ read-write:
 write:
     - cilium.io/ciliumclusterwidenetworkpolicies
     - cilium.io/ciliumnetworkpolicies
-    - cluster.x-k8s.io/clusters
-    - cluster.x-k8s.io/machinedeployments
     - cluster.x-k8s.io/machinedeployments/scale
-    - cluster.x-k8s.io/machinehealthchecks
-    - cluster.x-k8s.io/machinepools
-    - cluster.x-k8s.io/machines
-    - cluster.x-k8s.io/machinesets
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/deschedulers
+    - deckhouse.io/dvpinstanceclasses
+    - deckhouse.io/dynamixinstanceclasses
     - deckhouse.io/gcpinstanceclasses
     - deckhouse.io/huaweicloudinstanceclasses
     - deckhouse.io/ingressistiocontrollers
@@ -553,12 +585,6 @@ write:
     - deckhouse.io/zvirtinstanceclasses
     - expansion.gatekeeper.sh/expansiontemplate
     - externaldata.gatekeeper.sh/providers
-    - infrastructure.cluster.x-k8s.io/deckhousemachinetemplates
-    - infrastructure.cluster.x-k8s.io/dynamixmachinetemplates
-    - infrastructure.cluster.x-k8s.io/huaweicloudmachinetemplates
-    - infrastructure.cluster.x-k8s.io/staticmachinetemplates
-    - infrastructure.cluster.x-k8s.io/vcdmachinetemplates
-    - infrastructure.cluster.x-k8s.io/zvirtmachinetemplates
     - install.istio.io/istiooperators
     - limitranges
     - mutations.gatekeeper.sh/assign

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -169,12 +169,6 @@ read:
     - cert-manager.io/issuers
     - cilium.io/ciliumclusterwidenetworkpolicies
     - cilium.io/ciliumnetworkpolicies
-    - cluster.x-k8s.io/clusters
-    - cluster.x-k8s.io/machinedeployments
-    - cluster.x-k8s.io/machinehealthchecks
-    - cluster.x-k8s.io/machinepools
-    - cluster.x-k8s.io/machines
-    - cluster.x-k8s.io/machinesets
     - config.gatekeeper.sh/configs
     - configmaps
     - connection.gatekeeper.sh/connections
@@ -196,10 +190,13 @@ read:
     - deckhouse.io/deschedulers
     - deckhouse.io/dexauthenticators
     - deckhouse.io/dexclients
+    - deckhouse.io/dvpinstanceclasses
+    - deckhouse.io/dynamixinstanceclasses
     - deckhouse.io/gcpinstanceclasses
     - deckhouse.io/huaweicloudinstanceclasses
     - deckhouse.io/hubblemonitoringconfigs
     - deckhouse.io/ingressmetrics
+    - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
@@ -220,6 +217,7 @@ read:
     - deckhouse.io/securitypolicyexceptions
     - deckhouse.io/servicemetrics
     - deckhouse.io/statefulsetmetrics
+    - deckhouse.io/vcdaffinityrules
     - deckhouse.io/vcdinstanceclasses
     - deckhouse.io/vsphereinstanceclasses
     - deckhouse.io/yandexinstanceclasses
@@ -246,24 +244,23 @@ read:
     - gateway.networking.k8s.io/tcproutes
     - gateway.networking.k8s.io/tlsroutes
     - gateway.networking.k8s.io/udproutes
+    - infrastructure.cluster.x-k8s.io/deckhouseclusters
+    - infrastructure.cluster.x-k8s.io/deckhousemachines
     - infrastructure.cluster.x-k8s.io/deckhousemachinetemplates
+    - infrastructure.cluster.x-k8s.io/dynamixclusters
+    - infrastructure.cluster.x-k8s.io/dynamixmachines
     - infrastructure.cluster.x-k8s.io/dynamixmachinetemplates
+    - infrastructure.cluster.x-k8s.io/huaweicloudclusters
+    - infrastructure.cluster.x-k8s.io/huaweicloudmachines
     - infrastructure.cluster.x-k8s.io/huaweicloudmachinetemplates
-    - infrastructure.cluster.x-k8s.io/staticmachinetemplates
+    - infrastructure.cluster.x-k8s.io/vcdclusters
+    - infrastructure.cluster.x-k8s.io/vcdclustertemplates
+    - infrastructure.cluster.x-k8s.io/vcdmachines
     - infrastructure.cluster.x-k8s.io/vcdmachinetemplates
+    - infrastructure.cluster.x-k8s.io/zvirtclusters
+    - infrastructure.cluster.x-k8s.io/zvirtmachines
     - infrastructure.cluster.x-k8s.io/zvirtmachinetemplates
     - limitranges
-    - machine.sapcloud.io/alicloudmachineclasses
-    - machine.sapcloud.io/awsmachineclasses
-    - machine.sapcloud.io/azuremachineclasses
-    - machine.sapcloud.io/gcpmachineclasses
-    - machine.sapcloud.io/machinedeployments
-    - machine.sapcloud.io/machines
-    - machine.sapcloud.io/machinesets
-    - machine.sapcloud.io/openstackmachineclasses
-    - machine.sapcloud.io/packetmachineclasses
-    - machine.sapcloud.io/vspheremachineclasses
-    - machine.sapcloud.io/yandexmachineclasses
     - metrics.k8s.io/nodes
     - metrics.k8s.io/pods
     - mutations.gatekeeper.sh/assign
@@ -335,7 +332,6 @@ read:
     - deckhouse.io/customprometheusrules
     - deckhouse.io/grafanaadditionaldatasources
     - deckhouse.io/grafanadashboarddefinitions
-    - deckhouse.io/ingressnginxcontrollers
 read-write:
     - deckhouse.io/podloggingconfigs
 write:
@@ -433,8 +429,11 @@ delete,deletecollection:
     - acme.cert-manager.io/orders
     - cert-manager.io/certificaterequests
     - cert-manager.io/challenges
+patch,update:
+    - nodes
 read:
     - deckhouse.io/ingressistiocontrollers
+    - deckhouse.io/ingressnginxcontrollers/status
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
     - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
@@ -447,7 +446,11 @@ read:
     - sailoperator.io/istios
     - sailoperator.io/ztunnels
 read-write:
+    - apps.kruise.io/daemonsets
     - deckhouse.io/downtimes
+    - deckhouse.io/ingressnginxcontrollers
+    - deckhouse.io/nodegroupconfigurations
+    - deckhouse.io/staticinstances
     - deckhouse.io/upmeterremotewrites
 write:
     - apiextensions.k8s.io/customresourcedefinitions
@@ -469,7 +472,7 @@ write:
     - deckhouse.io/grafanaadditionaldatasources
     - deckhouse.io/grafanadashboarddefinitions
     - deckhouse.io/hubblemonitoringconfigs
-    - deckhouse.io/ingressnginxcontrollers
+    - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
     - deckhouse.io/moduleconfigs
     - deckhouse.io/moduledocumentations
@@ -494,7 +497,7 @@ write:
 {{site.data.i18n.common.role[page.lang] | capitalize }} `ClusterAdmin` ({{site.data.i18n.common.includes_rules_from[page.lang]}} `User`, `PrivilegedUser`, `Editor`, `Admin`, `ClusterEditor`):
 
 ```text
-delete,deletecollection,patch,update:
+delete,deletecollection,get,list,patch,update,watch:
     - machine.sapcloud.io/alicloudmachineclasses
     - machine.sapcloud.io/awsmachineclasses
     - machine.sapcloud.io/azuremachineclasses
@@ -512,17 +515,50 @@ list:
     - dex.coreos.com/offlinesessionses
     - dex.coreos.com/passwords
 patch,update:
+    - deckhouse.io/vcdaffinityrules
+    - infrastructure.cluster.x-k8s.io/deckhouseclusters
+    - infrastructure.cluster.x-k8s.io/deckhousemachines
+    - infrastructure.cluster.x-k8s.io/deckhousemachinetemplates
+    - infrastructure.cluster.x-k8s.io/dynamixclusters
+    - infrastructure.cluster.x-k8s.io/dynamixmachines
+    - infrastructure.cluster.x-k8s.io/dynamixmachinetemplates
+    - infrastructure.cluster.x-k8s.io/huaweicloudclusters
+    - infrastructure.cluster.x-k8s.io/huaweicloudmachines
+    - infrastructure.cluster.x-k8s.io/huaweicloudmachinetemplates
+    - infrastructure.cluster.x-k8s.io/vcdclusters
+    - infrastructure.cluster.x-k8s.io/vcdclustertemplates
+    - infrastructure.cluster.x-k8s.io/vcdmachines
+    - infrastructure.cluster.x-k8s.io/vcdmachinetemplates
+    - infrastructure.cluster.x-k8s.io/zvirtclusters
+    - infrastructure.cluster.x-k8s.io/zvirtmachines
+    - infrastructure.cluster.x-k8s.io/zvirtmachinetemplates
     - machine.sapcloud.io/machinedeployments/scale
 proxy:
     - nodes
 read:
+    - cluster.x-k8s.io/machinedrainrules
     - control-plane.deckhouse.io/controlplaneoperations
+    - infrastructure.cluster.x-k8s.io/deckhousecontrolplanes
+    - infrastructure.cluster.x-k8s.io/staticclusters
+    - infrastructure.cluster.x-k8s.io/staticmachines
+    - nfd.k8s-sigs.io/nodefeaturegroups
+    - nfd.k8s-sigs.io/nodefeaturerules
+    - nfd.k8s-sigs.io/nodefeatures
 read-write:
+    - cluster.x-k8s.io/clusters
+    - cluster.x-k8s.io/machinedeployments
+    - cluster.x-k8s.io/machinehealthchecks
+    - cluster.x-k8s.io/machinepools
+    - cluster.x-k8s.io/machines
+    - cluster.x-k8s.io/machinesets
     - deckhouse.io/clusterauthorizationrules
     - deckhouse.io/dexproviders
     - deckhouse.io/groups
+    - deckhouse.io/nodeusers
+    - deckhouse.io/sshcredentials
     - deckhouse.io/useroperations
     - deckhouse.io/users
+    - infrastructure.cluster.x-k8s.io/staticmachinetemplates
     - nodes/configz
     - nodes/healthz
     - nodes/log
@@ -533,19 +569,15 @@ read-write:
 write:
     - cilium.io/ciliumclusterwidenetworkpolicies
     - cilium.io/ciliumnetworkpolicies
-    - cluster.x-k8s.io/clusters
-    - cluster.x-k8s.io/machinedeployments
     - cluster.x-k8s.io/machinedeployments/scale
-    - cluster.x-k8s.io/machinehealthchecks
-    - cluster.x-k8s.io/machinepools
-    - cluster.x-k8s.io/machines
-    - cluster.x-k8s.io/machinesets
     - config.gatekeeper.sh/configs
     - connection.gatekeeper.sh/connections
     - constraints.gatekeeper.sh/*
     - deckhouse.io/awsinstanceclasses
     - deckhouse.io/azureinstanceclasses
     - deckhouse.io/deschedulers
+    - deckhouse.io/dvpinstanceclasses
+    - deckhouse.io/dynamixinstanceclasses
     - deckhouse.io/gcpinstanceclasses
     - deckhouse.io/huaweicloudinstanceclasses
     - deckhouse.io/ingressistiocontrollers
@@ -562,12 +594,6 @@ write:
     - deckhouse.io/zvirtinstanceclasses
     - expansion.gatekeeper.sh/expansiontemplate
     - externaldata.gatekeeper.sh/providers
-    - infrastructure.cluster.x-k8s.io/deckhousemachinetemplates
-    - infrastructure.cluster.x-k8s.io/dynamixmachinetemplates
-    - infrastructure.cluster.x-k8s.io/huaweicloudmachinetemplates
-    - infrastructure.cluster.x-k8s.io/staticmachinetemplates
-    - infrastructure.cluster.x-k8s.io/vcdmachinetemplates
-    - infrastructure.cluster.x-k8s.io/zvirtmachinetemplates
     - install.istio.io/istiooperators
     - limitranges
     - mutations.gatekeeper.sh/assign


### PR DESCRIPTION
## Description

Run make generate to update the `ClusterRole` documentation for user authorization.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Update the `ClusterRole` documentation for user authorization.
impact_level: low
```
