### PR TITLE
[bootstrap] yet another speedup DKP cloud bootstrap

### DIFF
--- a/candi/bashible/bashbooster/63_kube_curl.sh
+++ b/candi/bashible/bashbooster/63_kube_curl.sh
@@ -12,12 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bb-curl-helper-extract-admin-certs() {
-  local admin_conf="/etc/kubernetes/admin.conf"
-  local cert_file="${TMPDIR}/bb-kube-admin-cert.pem"
-  local key_file="${TMPDIR}/bb-kube-admin-key.pem"
+bb-curl-helper-extract-client-certs() {
+  local kubeconfig="$1"
+  local cert_file="$2"
+  local key_file="$3"
 
-  awk '/client-certificate-data:/{print $2}' "$admin_conf" | base64 -d > "$cert_file"
-  awk '/client-key-data:/{print $2}' "$admin_conf" | base64 -d > "$key_file"
+  awk '/client-certificate-data:/{print $2}' "$kubeconfig" | base64 -d > "$cert_file"
+  awk '/client-key-data:/{print $2}' "$kubeconfig" | base64 -d > "$key_file"
   chmod 600 "$cert_file" "$key_file"
+}
+
+bb-curl-helper-extract-admin-certs() {
+  bb-curl-helper-extract-client-certs \
+    "/etc/kubernetes/admin.conf" \
+    "${TMPDIR}/bb-kube-admin-cert.pem" \
+    "${TMPDIR}/bb-kube-admin-key.pem"
+}
+
+bb-curl-helper-extract-super-admin-certs() {
+  bb-curl-helper-extract-client-certs \
+    "/etc/kubernetes/super-admin.conf" \
+    "${TMPDIR}/bb-kube-super-admin-cert.pem" \
+    "${TMPDIR}/bb-kube-super-admin-key.pem"
 }

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -44,11 +44,17 @@ bb-curl-kube() {
   local kubeconfig="/etc/kubernetes/kubelet.conf"
   local -a auth_args=(--cacert /etc/kubernetes/pki/ca.crt --cert /var/lib/kubelet/pki/kubelet-client-current.pem)
 
-  # If auth type is overridden (admin-cert for cluster-bootstrap), use those creds.
-  if [[ "${BB_KUBE_AUTH_TYPE:-}" == "admin-cert" ]]; then
-    auth_args=(--cacert /etc/kubernetes/pki/ca.crt --cert "${TMPDIR}/bb-kube-admin-cert.pem" --key "${TMPDIR}/bb-kube-admin-key.pem")
-    kubeconfig="/etc/kubernetes/admin.conf"
-  fi
+  # If auth type is overridden for cluster-bootstrap flows, use those creds.
+  case "${BB_KUBE_AUTH_TYPE:-}" in
+    admin-cert)
+      auth_args=(--cacert /etc/kubernetes/pki/ca.crt --cert "${TMPDIR}/bb-kube-admin-cert.pem" --key "${TMPDIR}/bb-kube-admin-key.pem")
+      kubeconfig="/etc/kubernetes/admin.conf"
+      ;;
+    super-admin-cert)
+      auth_args=(--cacert /etc/kubernetes/pki/ca.crt --cert "${TMPDIR}/bb-kube-super-admin-cert.pem" --key "${TMPDIR}/bb-kube-super-admin-key.pem")
+      kubeconfig="/etc/kubernetes/super-admin.conf"
+      ;;
+  esac
 
   if [[ -z "${BB_KUBE_APISERVER_URL:-}" ]]; then
     local kube_server

--- a/candi/bashible/common-steps/all/001_prefetch_registry_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/001_prefetch_registry_packages.sh.tpl
@@ -47,6 +47,7 @@ if ! command -v rpp-get >/dev/null 2>&1; then
 fi
 
 unit="rpp-prefetch.service"
+env_file="/run/rpp-prefetch.env"
 
 # Idempotency:
 #   - active           → already running, leave it
@@ -66,31 +67,45 @@ case "$(systemctl is-active $unit 2>/dev/null || true)" in
     ;;
 esac
 
+# systemd-run launches a transient system service with a clean environment, so
+# persist the RPP auth/context explicitly for the background fetch. Keep the
+# token out of the unit definition by sourcing a root-only env file at runtime.
+if ! (umask 077 && : > "$env_file"); then
+  bb-log-warning "failed to create $env_file; skip prefetch — 007 will fetch inline"
+  return 0 2>/dev/null || exit 0
+fi
+
+for var in PACKAGES_PROXY_ADDRESSES PACKAGES_PROXY_TOKEN PACKAGES_PROXY_KUBE_APISERVER_ENDPOINTS; do
+  if [[ -n "${!var-}" ]]; then
+    printf 'export %s=%q\n' "$var" "${!var}" >>"$env_file"
+  fi
+done
+
 if ! systemd-run \
     --unit="$unit" \
     --description="Prefetch deckhouse registry packages (parallel with bashible system prep)" \
     --collect \
-    /bin/bash -c "rpp-get fetch \
-      \"kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) | toString }}\" \
-      \"kubelet:{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) | toString }}\" \
-      \"containerd:{{ index .images.registrypackages $containerd }}\" \
-      \"crictl:{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}\" \
-      \"toml-merge:{{ .images.registrypackages.tomlMerge01 }}\" \
+    /bin/bash -c ". \"$env_file\" && exec /opt/deckhouse/bin/rpp-get fetch \
       \"d8:{{ .images.registrypackages.d8 }}\" \
-      \"pause:{{ .images.registrypackages.pause }}\" \
-      \"kubernetes-api-proxy:{{ .images.registrypackages.kubernetesApiProxy }}\" \
-      \"registry-proxy:{{ .images.registrypackages.registryProxy }}\" \
-      \"jq:{{ .images.registrypackages.jq171 }}\" \
       \"yq:{{ .images.registrypackages.yq4471 }}\" \
       \"curl:{{ .images.registrypackages.d8Curl891 }}\" \
-      \"which:{{ .images.registrypackages.which223 }}\" \
-      \"virt-what:{{ .images.registrypackages.virtWhat125 }}\" \
-      \"socat:{{ .images.registrypackages.socat1734 }}\" \
       \"e2fsprogs:{{ .images.registrypackages.e2fsprogs1472 }}\" \
       \"iptables:{{ .images.registrypackages.iptables189 }}\" \
-      \"growpart:{{ .images.registrypackages.growpart033 }}\" \
+      \"socat:{{ .images.registrypackages.socat1734 }}\" \
+      \"jq:{{ .images.registrypackages.jq171 }}\" \
+      \"nfs-mount:{{- .images.registrypackages.nfsMount282 }}\" \
       \"lsblk:{{- index .images.registrypackages "lsblk2402" }}\" \
-      \"nfs-mount:{{- .images.registrypackages.nfsMount282 }}\"" \
+      \"which:{{ .images.registrypackages.which223 }}\" \
+      \"growpart:{{ .images.registrypackages.growpart033 }}\" \
+      \"virt-what:{{ .images.registrypackages.virtWhat125 }}\" \
+      \"containerd:{{ index .images.registrypackages $containerd }}\" \
+      \"kubernetes-cni:{{ index .images.registrypackages (printf "kubernetesCni%s" $kubernetesCniVersion) | toString }}\" \
+      \"kubelet:{{ index .images.registrypackages (printf "kubelet%s" $kubernetesVersion) | toString }}\" \
+      \"crictl:{{ index .images.registrypackages (printf "crictl%s" (.kubernetesVersion | replace "." "")) | toString }}\" \
+      \"registry-proxy:{{ .images.registrypackages.registryProxy }}\" \
+      \"kubernetes-api-proxy:{{ .images.registrypackages.kubernetesApiProxy }}\" \
+      \"toml-merge:{{ .images.registrypackages.tomlMerge01 }}\" \
+      \"pause:{{ .images.registrypackages.pause }}\"" \
     >/dev/null 2>&1; then
   bb-log-warning "systemd-run failed to launch $unit; 007 will fetch inline"
   return 0 2>/dev/null || exit 0

--- a/candi/bashible/common-steps/all/001_waiting_approval_annotations.sh.tpl
+++ b/candi/bashible/common-steps/all/001_waiting_approval_annotations.sh.tpl
@@ -42,7 +42,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   done
 
   bb-log-info "Waiting for update.node.deckhouse.io/approved= annotation on our Node..."
-  approval_command="d8 k annotate node $(bb-d8-node-name) update.node.deckhouse.io/approved="
+  approval_command="kubectl annotate node $(bb-d8-node-name) update.node.deckhouse.io/approved="
   waiting_approval_message="Steps are waiting for approval to start. Deckhouse is performing a rolling update. If you want to force an update, use: ${approval_command}"
   waiting_approval_status_set="no"
   attempt=0

--- a/candi/bashible/common-steps/all/003_disable_unattended_upgrades.sh.tpl
+++ b/candi/bashible/common-steps/all/003_disable_unattended_upgrades.sh.tpl
@@ -13,12 +13,17 @@
 # limitations under the License.
 # bashible: parallel-group=light-prep
 
-if ! systemctl list-unit-files unattended-upgrades.service >/dev/null 2>&1; then
-  exit 0
+# Neutralise unattended-upgrades without waiting on /var/lib/dpkg/lock: config off + mask + async stop. No-op on non-apt or non-systemd systems.
+units="unattended-upgrades.service apt-daily.timer apt-daily-upgrade.timer apt-daily.service apt-daily-upgrade.service"
+
+if [ -d /etc/apt/apt.conf.d ]; then
+  bb-sync-file /etc/apt/apt.conf.d/20auto-upgrades - << "EOF"
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
 fi
 
-if systemctl is-enabled --quiet unattended-upgrades ; then
-  systemctl disable --now unattended-upgrades
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl mask --quiet $units >/dev/null 2>&1 || true
+  systemctl stop --no-block $units >/dev/null 2>&1 || true
 fi
-
-bb-apt-remove unattended-upgrades

--- a/candi/bashible/common-steps/all/004_install_mandatory_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/004_install_mandatory_packages.sh.tpl
@@ -22,14 +22,19 @@ __sec() {
   __sec_start=$now
 }
 
-# Per-step prefetch wait: all 12 packages below are prefetched in the background by
+# Per-step prefetch wait: the packages below are prefetched in the background by
 # step 001_prefetch_registry_packages.sh (systemd unit `rpp-prefetch.service`). We
 # wait for each archive to land before calling `rpp-get install`, so install becomes
 # a fast local-extract instead of a serial HTTP download.
 #
 # If any wait times out (or the prefetch unit died) the `|| true` ensures we still
 # fall through to `rpp-get install`, which will fetch the missing archive itself.
-bb-rpp-wait-fetched "d8" "{{ .images.registrypackages.d8 }}" || true
+#
+# `d8` is intentionally NOT installed here — it's the largest registrypackage and
+# nothing between this step and 062 needs it. Its wait + install are deferred to
+# step 062 (`d8 completion bash` is the first real use). The 001 prefetch keeps
+# downloading d8 in parallel, so by the time 062 runs the archive is on disk and
+# only the (still synchronous) unpack happens then.
 bb-rpp-wait-fetched "jq" "{{ .images.registrypackages.jq171 }}" || true
 bb-rpp-wait-fetched "yq" "{{ .images.registrypackages.yq4471 }}" || true
 bb-rpp-wait-fetched "curl" "{{ .images.registrypackages.d8Curl891 }}" || true
@@ -43,5 +48,5 @@ bb-rpp-wait-fetched "lsblk" "{{- index .images.registrypackages "lsblk2402" }}" 
 bb-rpp-wait-fetched "nfs-mount" "{{- .images.registrypackages.nfsMount282 }}" || true
 __sec wait_prefetch
 
-rpp-get install "d8:{{ .images.registrypackages.d8 }}" "jq:{{ .images.registrypackages.jq171 }}" "yq:{{ .images.registrypackages.yq4471 }}" "curl:{{ .images.registrypackages.d8Curl891 }}" "which:{{ .images.registrypackages.which223 }}" "virt-what:{{ .images.registrypackages.virtWhat125 }}" "socat:{{ .images.registrypackages.socat1734 }}" "e2fsprogs:{{ .images.registrypackages.e2fsprogs1472 }}" "iptables:{{ .images.registrypackages.iptables189 }}" "growpart:{{ .images.registrypackages.growpart033 }}" "lsblk:{{- index .images.registrypackages "lsblk2402" }}" "nfs-mount:{{- .images.registrypackages.nfsMount282 }}"
+rpp-get install "jq:{{ .images.registrypackages.jq171 }}" "yq:{{ .images.registrypackages.yq4471 }}" "curl:{{ .images.registrypackages.d8Curl891 }}" "which:{{ .images.registrypackages.which223 }}" "virt-what:{{ .images.registrypackages.virtWhat125 }}" "socat:{{ .images.registrypackages.socat1734 }}" "e2fsprogs:{{ .images.registrypackages.e2fsprogs1472 }}" "iptables:{{ .images.registrypackages.iptables189 }}" "growpart:{{ .images.registrypackages.growpart033 }}" "lsblk:{{- index .images.registrypackages "lsblk2402" }}" "nfs-mount:{{- .images.registrypackages.nfsMount282 }}"
 __sec rpp_install

--- a/candi/bashible/common-steps/all/035_prefetch_node_images.sh.tpl
+++ b/candi/bashible/common-steps/all/035_prefetch_node_images.sh.tpl
@@ -14,43 +14,22 @@
 
 # Master-only background image prefetch.
 #
-# Fires a transient systemd unit `ctr-prefetch.service` right after containerd is
-# configured and restarted (030-033) and the local images are imported (034). The
-# unit pulls a curated set of images in parallel via `ctr pull` so that by the time
-# kubelet starts scheduling pods, the bulk of cold-start images is already in the
-# containerd content store.
+# Right after containerd is configured (030-033) and local images are imported (034),
+# fires a transient systemd unit that pulls a curated set of images in parallel via
+# `crictl pull`. By the time kubelet starts scheduling pods, most cold-start images are
+# already in the containerd image store. Using crictl (the CRI image service) means the
+# pull path, registry auth and mirror config are exactly the ones kubelet itself uses —
+# no --hosts-dir, no manual namespace.
 #
-# Image whitelist (order = start-priority; xargs -P workers pick lines top-to-bottom,
-# so earlier sections get scheduled first):
-#    0. deckhouse-controller (tag-based ref: `<imagesBase>:<tag>`). Injected by
-#       dhctl as `.deckhouseImageRef` and built from the same source the
-#       bootstrap Deployment uses for `params.Registry`
-#       (DeckhouseInstaller.GetInclusterImage(true)). Prefetching it here means
-#       kubelet's IfNotPresent pull of the bootstrap pod finds the ~200 MiB
-#       image already in containerd. Skipped when the ref is unavailable.
-#    1. deckhouse/*
-#    2. cniCilium/*
-#    3. common/coredns
-#    4. controlPlaneManager: etcd + kubeApiserver/kubeControllerManager/kubeScheduler/
-#                            controlPlaneManager for the current kubernetes version
-#    5. nodeManager/* (filtered: skip nvidia*, nodeFeatureDiscovery, non-current
-#                      clusterAutoscaler<N>)
-#    6. cloudProvider<Provider>/*
-#    7. common: kubeRbacProxy, iptablesWrapper, init, shellOperator, distroless
-#    8. kubeProxy: kubeProxy<N>, iptablesWrapperInit, initContainer
-#    9. common csi-sidecars for current k8s: csiExternalProvisioner<N>, csiExternalAttacher<N>,
-#       csiExternalResizer<N>, csiExternalSnapshotter<N>, csiLivenessprobe<N>,
-#       csiNodeDriverRegistrar<N>
-#   10. common misc: checkKernelVersion, cniMigrationInitChecker, vxlanOffloadingFixer
-#   11. chrony/*
-#   12. registryPackagesProxy/*
-#   13. monitoringKubernetes/*
-#   14. kubeDns/*
+# The list is rendered below in start-priority order (xargs -P workers take lines
+# top-to-bottom): deckhouse-controller (tag-based `.deckhouseImageRef`, ~200 MiB, the
+# bootstrap pod's own image), deckhouse/*, cniCilium/*, coredns, controlPlaneManager,
+# nodeManager (minus nvidia*/nodeFeatureDiscovery/stale clusterAutoscaler), current
+# cloudProvider/*, common runtime bits, kubeProxy, csi-sidecars, common misc, then
+# chrony/*, registryPackagesProxy/*, monitoringKubernetes/* and kubeDns/*.
 #
-# Each line: "<section>/<imageKey> <ref>" — pull_one splits on the first space.
-#
-# This is fire-and-forget: failures never block bashible. If the unit dies, times out,
-# or some image cannot be pulled, kubelet will fetch it later as usual.
+# Each line is "<section>/<imageKey> <ref>"; pull_one splits on the first space.
+# Fire-and-forget: failures never block bashible; kubelet fetches anything missing later.
 
 {{- if and (eq .nodeGroup.name "master") (or (eq .cri "Containerd") (eq .cri "ContainerdV2")) }}
 
@@ -67,187 +46,139 @@ case "$(systemctl is-system-running 2>/dev/null || true)" in
     ;;
 esac
 
-if ! command -v ctr >/dev/null 2>&1; then
-  bb-log-warning "ctr not available; skip image prefetch"
+if ! command -v crictl >/dev/null 2>&1; then
+  bb-log-warning "crictl not available; skip image prefetch"
   return 0 2>/dev/null || exit 0
 fi
 
 unit="ctr-prefetch.service"
 
-case "$(systemctl is-active $unit 2>/dev/null || true)" in
+case "$(systemctl is-active "$unit" 2>/dev/null || true)" in
   active|activating)
     bb-log-info "$unit already running; nothing to do"
     return 0 2>/dev/null || exit 0
     ;;
-  failed)
-    systemctl reset-failed $unit >/dev/null 2>&1 || true
-    ;;
-  inactive|"")
-    systemctl stop $unit >/dev/null 2>&1 || true
-    systemctl reset-failed $unit >/dev/null 2>&1 || true
-    ;;
 esac
-
-# Render the prefetch list straight into a file via a quoted heredoc — no bash array
-# literal, no go-template trim acrobatics. The quoted EOF (single-quoted PREFETCH_EOF)
-# disables bash expansion; go-template still substitutes its actions as it produces
-# the file.
-list_file="/run/ctr-prefetch.list"
-umask 077
-{{- $k8s := .kubernetesVersion | toString | replace "." "" }}
-{{- $cpmNames := list "etcd"
-    (printf "controlPlaneManager%s" $k8s)
-    (printf "kubeApiserver%s" $k8s)
-    (printf "kubeControllerManager%s" $k8s)
-    (printf "kubeScheduler%s" $k8s) }}
-{{- $commonRest := list "kubeRbacProxy" "iptablesWrapper" "init" "shellOperator" "distroless" }}
-cat > "$list_file" <<'PREFETCH_EOF'
-{{- with .deckhouseImageRef }}
-deckhouse/controller {{ . }}
-{{- end }}
-{{- range $name, $digest := (index $.images "deckhouse" | default dict) }}
-deckhouse/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- range $name, $digest := (index $.images "cniCilium" | default dict) }}
-cniCilium/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- with index ($.images.common | default dict) "coredns" }}
-common/coredns {{ $.registry.imagesBase }}@{{ . }}
-{{- end }}
-{{- range $name := $cpmNames }}
-{{- $digest := index ($.images.controlPlaneManager | default dict) $name }}
-{{- if $digest }}
-controlPlaneManager/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- end }}
-{{- $caCurrent := printf "clusterAutoscaler%s" $k8s }}
-{{- range $name, $digest := (index $.images "nodeManager" | default dict) }}
-{{- if not (hasPrefix "nvidia" $name) }}
-{{- if ne $name "nodeFeatureDiscovery" }}
-{{- if or (not (hasPrefix "clusterAutoscaler" $name)) (eq $name $caCurrent) }}
-nodeManager/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- if .provider }}
-{{- $cpSection := printf "cloudProvider%s" (.provider | title) }}
-{{- range $name, $digest := (index $.images $cpSection | default dict) }}
-{{ $cpSection }}/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- end }}
-{{- range $name := $commonRest }}
-{{- $digest := index ($.images.common | default dict) $name }}
-{{- if $digest }}
-common/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- end }}
-{{- $kpNames := list (printf "kubeProxy%s" $k8s) "iptablesWrapperInit" "initContainer" }}
-{{- range $name := $kpNames }}
-{{- $digest := index ($.images.kubeProxy | default dict) $name }}
-{{- if $digest }}
-kubeProxy/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- end }}
-{{- $csiNames := list
-    (printf "csiExternalProvisioner%s" $k8s)
-    (printf "csiExternalAttacher%s" $k8s)
-    (printf "csiExternalResizer%s" $k8s)
-    (printf "csiExternalSnapshotter%s" $k8s)
-    (printf "csiLivenessprobe%s" $k8s)
-    (printf "csiNodeDriverRegistrar%s" $k8s) }}
-{{- range $name := $csiNames }}
-{{- $digest := index ($.images.common | default dict) $name }}
-{{- if $digest }}
-common/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- end }}
-{{- range $name := (list "checkKernelVersion" "cniMigrationInitChecker" "vxlanOffloadingFixer") }}
-{{- $digest := index ($.images.common | default dict) $name }}
-{{- if $digest }}
-common/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- end }}
-{{- range $name, $digest := (index $.images "chrony" | default dict) }}
-chrony/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- range $name, $digest := (index $.images "registryPackagesProxy" | default dict) }}
-registryPackagesProxy/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- range $name, $digest := (index $.images "monitoringKubernetes" | default dict) }}
-monitoringKubernetes/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-{{- range $name, $digest := (index $.images "kubeDns" | default dict) }}
-kubeDns/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
-{{- end }}
-PREFETCH_EOF
-
-list_count=$(grep -c . "$list_file" 2>/dev/null || echo 0)
-if [ "$list_count" -eq 0 ]; then
-  rm -f "$list_file"
-  bb-log-info "image prefetch: empty list; nothing to do"
-  return 0 2>/dev/null || exit 0
-fi
+systemctl reset-failed "$unit" >/dev/null 2>&1 || true
 
 # Materialize the prefetch driver as a standalone script so systemd-run only sees a
-# path. Passing the script inline via `bash -c "$VAR"` is unsafe: systemd's Exec=
-# syntax expands ${VAR} *itself* before bash runs (eating ${log_dir}, ${parallelism},
-# ${item#* } as bash parameter expansions etc.) and serializes newlines as literal
-# `\n` in the cmdline.
+# path. Passing it inline via `bash -c "$VAR"` is unsafe: systemd's Exec= syntax expands
+# ${VAR} itself before bash runs (eating ${log_dir}, ${item#* } as parameter expansions)
+# and serializes newlines as literal `\n`. The image list is embedded in the script as a
+# quoted heredoc — go-template still substitutes its actions while rendering this file.
+umask 077
 script_file="/run/ctr-prefetch.sh"
+{{- $k8s := .kubernetesVersion | toString | replace "." "" }}
+{{- $base := $.registry.imagesBase }}
+{{- $caCurrent := printf "clusterAutoscaler%s" $k8s }}
+{{- $cpmNames := list "etcd" (printf "controlPlaneManager%s" $k8s) (printf "kubeApiserver%s" $k8s) (printf "kubeControllerManager%s" $k8s) (printf "kubeScheduler%s" $k8s) }}
+{{- $commonRest := list "kubeRbacProxy" "iptablesWrapper" "init" "shellOperator" "distroless" }}
+{{- $kpNames := list (printf "kubeProxy%s" $k8s) "iptablesWrapperInit" "initContainer" }}
+{{- $commonNamed := list (printf "csiExternalProvisioner%s" $k8s) (printf "csiExternalAttacher%s" $k8s) (printf "csiExternalResizer%s" $k8s) (printf "csiExternalSnapshotter%s" $k8s) (printf "csiLivenessprobe%s" $k8s) (printf "csiNodeDriverRegistrar%s" $k8s) "checkKernelVersion" "cniMigrationInitChecker" "vxlanOffloadingFixer" }}
 cat > "$script_file" <<'EOSCRIPT'
 #!/bin/bash
 set -u
 
-# Deckhouse ships ctr/crictl/jq under /opt/deckhouse/bin, which is NOT on the default
-# PATH of a transient systemd unit. Without this, `command -v ctr` fails inside the
-# unit and the `until ctr version` loop spins until the deadline.
-export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-
-list_file="/run/ctr-prefetch.list"
 script_file="/run/ctr-prefetch.sh"
-hosts_dir="/etc/containerd/registry.d"
+results_file="/run/ctr-prefetch.results"
 log_dir="/var/log/d8/bashible"
 log_file="${log_dir}/ctr-prefetch.log"
 runtime_endpoint="unix:///run/containerd/containerd.sock"
 parallelism=4
 per_image_total_deadline=600
-ctr_ready_deadline=120
+cri_ready_deadline=120
+
+# Image list, one "<section>/<imageKey> <ref>" per line. The single-quoted heredoc
+# disables bash expansion; go-template substitutes its actions when rendering this file.
+images=$(cat <<'PREFETCH_EOF'
+{{- with .deckhouseImageRef }}
+deckhouse/controller {{ . }}
+{{- end }}
+{{- range $section := (list "deckhouse" "cniCilium") }}
+{{- range $name, $digest := (index $.images $section | default dict) }}
+{{ $section }}/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- with index ($.images.common | default dict) "coredns" }}
+common/coredns {{ $base }}@{{ . }}
+{{- end }}
+{{- range $name := $cpmNames }}
+{{- $digest := index ($.images.controlPlaneManager | default dict) $name }}
+{{- if $digest }}
+controlPlaneManager/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $name, $digest := (index $.images "nodeManager" | default dict) }}
+{{- if and (not (hasPrefix "nvidia" $name)) (ne $name "nodeFeatureDiscovery") (or (not (hasPrefix "clusterAutoscaler" $name)) (eq $name $caCurrent)) }}
+nodeManager/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- if .provider }}
+{{- $cpSection := printf "cloudProvider%s" (.provider | title) }}
+{{- range $name, $digest := (index $.images $cpSection | default dict) }}
+{{ $cpSection }}/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $name := $commonRest }}
+{{- $digest := index ($.images.common | default dict) $name }}
+{{- if $digest }}
+common/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $name := $kpNames }}
+{{- $digest := index ($.images.kubeProxy | default dict) $name }}
+{{- if $digest }}
+kubeProxy/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $name := $commonNamed }}
+{{- $digest := index ($.images.common | default dict) $name }}
+{{- if $digest }}
+common/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $section := (list "chrony" "registryPackagesProxy" "monitoringKubernetes" "kubeDns") }}
+{{- range $name, $digest := (index $.images $section | default dict) }}
+{{ $section }}/{{ $name }} {{ $base }}@{{ $digest }}
+{{- end }}
+{{- end }}
+PREFETCH_EOF
+)
 
 mkdir -p "$log_dir"
+: > "$results_file"
 
 ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
-# Single short append is atomic w.r.t. concurrent xargs workers (POSIX O_APPEND,
-# our lines are far below PIPE_BUF), so no flock is needed.
+# Single short append is atomic w.r.t. concurrent xargs workers (POSIX O_APPEND, our
+# lines are far below PIPE_BUF), so no flock is needed — same for $results_file below.
 log() { printf '%s\n' "$*" >> "$log_file"; echo "$*"; }
 
+total_count=$(printf '%s\n' "$images" | grep -c . || true)
+if [ "${total_count:-0}" -eq 0 ]; then
+  log "$(ts) image prefetch: empty list; nothing to do"
+  rm -f "$script_file" "$results_file"
+  exit 0
+fi
+
 session_start=$(date +%s.%N)
-total_count=$(grep -c . "$list_file" 2>/dev/null || echo 0)
 log "=== ctr-prefetch session started $(ts) ==="
 log "$(ts) START parallelism=${parallelism} count=${total_count}"
 
-deadline=$((SECONDS + ctr_ready_deadline))
-until ctr version >/dev/null 2>&1; do
+deadline=$((SECONDS + cri_ready_deadline))
+until crictl --runtime-endpoint="$runtime_endpoint" info >/dev/null 2>&1; do
   if [ $SECONDS -ge $deadline ]; then
-    log "$(ts) ABORT containerd not ready within ${ctr_ready_deadline}s"
+    log "$(ts) ABORT CRI not ready within ${cri_ready_deadline}s"
     exit 0
   fi
   sleep 1
 done
 
-# Returns image size in bytes via CRI; "-" on failure or jq/crictl absent.
+# Image size in bytes via a targeted CRI inspect; "-" on failure or jq absent.
 get_image_size() {
   local ref="$1"
-  if ! command -v crictl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
-    echo "-"; return 0
-  fi
-  crictl --runtime-endpoint="$runtime_endpoint" images -o json 2>/dev/null \
-    | jq -r --arg ref "$ref" '
-        (.images // [])[]
-        | select((.repoDigests // []) | index($ref))
-        | .size
-      ' 2>/dev/null \
-    | head -n1 \
+  command -v jq >/dev/null 2>&1 || { echo "-"; return 0; }
+  crictl --runtime-endpoint="$runtime_endpoint" inspecti -o json "$ref" 2>/dev/null \
+    | jq -r '.status.size // "-"' 2>/dev/null \
     | { read -r v || true; printf '%s\n' "${v:--}"; }
 }
 
@@ -260,16 +191,17 @@ pull_one() {
   local start_s=$SECONDS
   local delay=2
   while :; do
-    if ctr -n k8s.io images pull --hosts-dir "$hosts_dir" "$ref" >/dev/null 2>&1; then
-      ctr -n k8s.io images label "$ref" io.cri-containerd.pinned=pinned >/dev/null 2>&1 || true
+    if crictl --runtime-endpoint="$runtime_endpoint" pull "$ref" >/dev/null 2>&1; then
       dur=$(awk -v s="$start_ts" -v e="$(date +%s.%N)" 'BEGIN{printf "%.3f", e-s}')
       size_bytes=$(get_image_size "$ref")
       log "$(ts) OK    dur=${dur}s size=${size_bytes}B name=${name} ref=${ref}"
+      printf 'OK %s\n' "$size_bytes" >> "$results_file"
       return 0
     fi
     if [ $((SECONDS - start_s)) -ge $per_image_total_deadline ]; then
       dur=$(awk -v s="$start_ts" -v e="$(date +%s.%N)" 'BEGIN{printf "%.3f", e-s}')
       log "$(ts) FAIL  dur=${dur}s size=- name=${name} ref=${ref} reason=timeout"
+      printf 'FAIL 0\n' >> "$results_file"
       return 0
     fi
     sleep "$delay"
@@ -279,46 +211,37 @@ pull_one() {
   done
 }
 export -f ts log get_image_size pull_one
-export hosts_dir log_file runtime_endpoint per_image_total_deadline
+export log_file results_file runtime_endpoint per_image_total_deadline
 
-# Skip blank lines from xargs input (defensive against accidental empties).
-grep -v '^$' "$list_file" \
+printf '%s\n' "$images" | grep -v '^$' \
   | xargs -d '\n' -P "$parallelism" -I {} bash -c 'pull_one "$@"' _ {}
 
 elapsed=$(awk -v s="$session_start" -v e="$(date +%s.%N)" 'BEGIN{printf "%.3f", e-s}')
 
-# Count results only within the current session (log file accumulates across runs).
-session_start_lineno=$(grep -n '^=== ctr-prefetch session started' "$log_file" 2>/dev/null | tail -n1 | cut -d: -f1)
-: "${session_start_lineno:=1}"
-session_log=$(tail -n "+${session_start_lineno}" "$log_file" 2>/dev/null)
-
-ok_count=$(printf '%s\n' "$session_log" | grep -c '^[^ ]* OK ')
-fail_count=$(printf '%s\n' "$session_log" | grep -c '^[^ ]* FAIL ')
-total_bytes=$(printf '%s\n' "$session_log" | awk '
-  /^[^ ]* OK / {
-    for (i=1; i<=NF; i++) if ($i ~ /^size=[0-9]+B$/) {
-      gsub(/^size=|B$/, "", $i); sum += $i
-    }
-  }
-  END { printf "%.0f", sum+0 }')
+ok_count=$(grep -c '^OK ' "$results_file" 2>/dev/null || echo 0)
+fail_count=$(grep -c '^FAIL ' "$results_file" 2>/dev/null || echo 0)
+total_bytes=$(awk '$1=="OK" && $2 ~ /^[0-9]+$/ { s+=$2 } END { printf "%.0f", s+0 }' "$results_file")
 log "$(ts) DONE  elapsed=${elapsed}s ok=${ok_count} fail=${fail_count} bytes=${total_bytes}"
 
-rm -f "$list_file" "$script_file"
+rm -f "$script_file" "$results_file"
 EOSCRIPT
 chmod 700 "$script_file"
 
+# /opt/deckhouse/bin (crictl, jq) is NOT on a transient unit's default PATH, so declare
+# it at launch time instead of re-exporting inside the script.
 if ! systemd-run \
     --unit="$unit" \
     --description="Prefetch node images (parallel with bashible system prep)" \
+    --setenv=PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
     --collect \
     /bin/bash "$script_file" \
     >/dev/null 2>&1; then
   bb-log-warning "systemd-run failed to launch $unit"
-  rm -f "$list_file" "$script_file"
+  rm -f "$script_file"
   return 0 2>/dev/null || exit 0
 fi
 
-bb-log-info "$unit launched (${list_count} images, parallelism=4)"
-echo "[bashible-timing] step=035_prefetch_node_images.sh section=launched count=${list_count}"
+bb-log-info "$unit launched"
+echo "[bashible-timing] step=035_prefetch_node_images.sh section=launched"
 
 {{- end }}

--- a/candi/bashible/common-steps/all/035_prefetch_node_images.sh.tpl
+++ b/candi/bashible/common-steps/all/035_prefetch_node_images.sh.tpl
@@ -1,0 +1,324 @@
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Master-only background image prefetch.
+#
+# Fires a transient systemd unit `ctr-prefetch.service` right after containerd is
+# configured and restarted (030-033) and the local images are imported (034). The
+# unit pulls a curated set of images in parallel via `ctr pull` so that by the time
+# kubelet starts scheduling pods, the bulk of cold-start images is already in the
+# containerd content store.
+#
+# Image whitelist (order = start-priority; xargs -P workers pick lines top-to-bottom,
+# so earlier sections get scheduled first):
+#    0. deckhouse-controller (tag-based ref: `<imagesBase>:<tag>`). Injected by
+#       dhctl as `.deckhouseImageRef` and built from the same source the
+#       bootstrap Deployment uses for `params.Registry`
+#       (DeckhouseInstaller.GetInclusterImage(true)). Prefetching it here means
+#       kubelet's IfNotPresent pull of the bootstrap pod finds the ~200 MiB
+#       image already in containerd. Skipped when the ref is unavailable.
+#    1. deckhouse/*
+#    2. cniCilium/*
+#    3. common/coredns
+#    4. controlPlaneManager: etcd + kubeApiserver/kubeControllerManager/kubeScheduler/
+#                            controlPlaneManager for the current kubernetes version
+#    5. nodeManager/* (filtered: skip nvidia*, nodeFeatureDiscovery, non-current
+#                      clusterAutoscaler<N>)
+#    6. cloudProvider<Provider>/*
+#    7. common: kubeRbacProxy, iptablesWrapper, init, shellOperator, distroless
+#    8. kubeProxy: kubeProxy<N>, iptablesWrapperInit, initContainer
+#    9. common csi-sidecars for current k8s: csiExternalProvisioner<N>, csiExternalAttacher<N>,
+#       csiExternalResizer<N>, csiExternalSnapshotter<N>, csiLivenessprobe<N>,
+#       csiNodeDriverRegistrar<N>
+#   10. common misc: checkKernelVersion, cniMigrationInitChecker, vxlanOffloadingFixer
+#   11. chrony/*
+#   12. registryPackagesProxy/*
+#   13. monitoringKubernetes/*
+#   14. kubeDns/*
+#
+# Each line: "<section>/<imageKey> <ref>" — pull_one splits on the first space.
+#
+# This is fire-and-forget: failures never block bashible. If the unit dies, times out,
+# or some image cannot be pulled, kubelet will fetch it later as usual.
+
+{{- if and (eq .nodeGroup.name "master") (or (eq .cri "Containerd") (eq .cri "ContainerdV2")) }}
+
+if ! command -v systemd-run >/dev/null 2>&1 || ! command -v systemctl >/dev/null 2>&1; then
+  bb-log-warning "systemd-run/systemctl not available; skip image prefetch"
+  return 0 2>/dev/null || exit 0
+fi
+
+case "$(systemctl is-system-running 2>/dev/null || true)" in
+  running|degraded|starting|initializing|maintenance) ;;
+  *)
+    bb-log-warning "systemd not in usable state; skip image prefetch"
+    return 0 2>/dev/null || exit 0
+    ;;
+esac
+
+if ! command -v ctr >/dev/null 2>&1; then
+  bb-log-warning "ctr not available; skip image prefetch"
+  return 0 2>/dev/null || exit 0
+fi
+
+unit="ctr-prefetch.service"
+
+case "$(systemctl is-active $unit 2>/dev/null || true)" in
+  active|activating)
+    bb-log-info "$unit already running; nothing to do"
+    return 0 2>/dev/null || exit 0
+    ;;
+  failed)
+    systemctl reset-failed $unit >/dev/null 2>&1 || true
+    ;;
+  inactive|"")
+    systemctl stop $unit >/dev/null 2>&1 || true
+    systemctl reset-failed $unit >/dev/null 2>&1 || true
+    ;;
+esac
+
+# Render the prefetch list straight into a file via a quoted heredoc — no bash array
+# literal, no go-template trim acrobatics. The quoted EOF (single-quoted PREFETCH_EOF)
+# disables bash expansion; go-template still substitutes its actions as it produces
+# the file.
+list_file="/run/ctr-prefetch.list"
+umask 077
+{{- $k8s := .kubernetesVersion | toString | replace "." "" }}
+{{- $cpmNames := list "etcd"
+    (printf "controlPlaneManager%s" $k8s)
+    (printf "kubeApiserver%s" $k8s)
+    (printf "kubeControllerManager%s" $k8s)
+    (printf "kubeScheduler%s" $k8s) }}
+{{- $commonRest := list "kubeRbacProxy" "iptablesWrapper" "init" "shellOperator" "distroless" }}
+cat > "$list_file" <<'PREFETCH_EOF'
+{{- with .deckhouseImageRef }}
+deckhouse/controller {{ . }}
+{{- end }}
+{{- range $name, $digest := (index $.images "deckhouse" | default dict) }}
+deckhouse/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- range $name, $digest := (index $.images "cniCilium" | default dict) }}
+cniCilium/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- with index ($.images.common | default dict) "coredns" }}
+common/coredns {{ $.registry.imagesBase }}@{{ . }}
+{{- end }}
+{{- range $name := $cpmNames }}
+{{- $digest := index ($.images.controlPlaneManager | default dict) $name }}
+{{- if $digest }}
+controlPlaneManager/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- $caCurrent := printf "clusterAutoscaler%s" $k8s }}
+{{- range $name, $digest := (index $.images "nodeManager" | default dict) }}
+{{- if not (hasPrefix "nvidia" $name) }}
+{{- if ne $name "nodeFeatureDiscovery" }}
+{{- if or (not (hasPrefix "clusterAutoscaler" $name)) (eq $name $caCurrent) }}
+nodeManager/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .provider }}
+{{- $cpSection := printf "cloudProvider%s" (.provider | title) }}
+{{- range $name, $digest := (index $.images $cpSection | default dict) }}
+{{ $cpSection }}/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $name := $commonRest }}
+{{- $digest := index ($.images.common | default dict) $name }}
+{{- if $digest }}
+common/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- $kpNames := list (printf "kubeProxy%s" $k8s) "iptablesWrapperInit" "initContainer" }}
+{{- range $name := $kpNames }}
+{{- $digest := index ($.images.kubeProxy | default dict) $name }}
+{{- if $digest }}
+kubeProxy/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- $csiNames := list
+    (printf "csiExternalProvisioner%s" $k8s)
+    (printf "csiExternalAttacher%s" $k8s)
+    (printf "csiExternalResizer%s" $k8s)
+    (printf "csiExternalSnapshotter%s" $k8s)
+    (printf "csiLivenessprobe%s" $k8s)
+    (printf "csiNodeDriverRegistrar%s" $k8s) }}
+{{- range $name := $csiNames }}
+{{- $digest := index ($.images.common | default dict) $name }}
+{{- if $digest }}
+common/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $name := (list "checkKernelVersion" "cniMigrationInitChecker" "vxlanOffloadingFixer") }}
+{{- $digest := index ($.images.common | default dict) $name }}
+{{- if $digest }}
+common/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- end }}
+{{- range $name, $digest := (index $.images "chrony" | default dict) }}
+chrony/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- range $name, $digest := (index $.images "registryPackagesProxy" | default dict) }}
+registryPackagesProxy/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- range $name, $digest := (index $.images "monitoringKubernetes" | default dict) }}
+monitoringKubernetes/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+{{- range $name, $digest := (index $.images "kubeDns" | default dict) }}
+kubeDns/{{ $name }} {{ $.registry.imagesBase }}@{{ $digest }}
+{{- end }}
+PREFETCH_EOF
+
+list_count=$(grep -c . "$list_file" 2>/dev/null || echo 0)
+if [ "$list_count" -eq 0 ]; then
+  rm -f "$list_file"
+  bb-log-info "image prefetch: empty list; nothing to do"
+  return 0 2>/dev/null || exit 0
+fi
+
+# Materialize the prefetch driver as a standalone script so systemd-run only sees a
+# path. Passing the script inline via `bash -c "$VAR"` is unsafe: systemd's Exec=
+# syntax expands ${VAR} *itself* before bash runs (eating ${log_dir}, ${parallelism},
+# ${item#* } as bash parameter expansions etc.) and serializes newlines as literal
+# `\n` in the cmdline.
+script_file="/run/ctr-prefetch.sh"
+cat > "$script_file" <<'EOSCRIPT'
+#!/bin/bash
+set -u
+
+# Deckhouse ships ctr/crictl/jq under /opt/deckhouse/bin, which is NOT on the default
+# PATH of a transient systemd unit. Without this, `command -v ctr` fails inside the
+# unit and the `until ctr version` loop spins until the deadline.
+export PATH="/opt/deckhouse/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+list_file="/run/ctr-prefetch.list"
+script_file="/run/ctr-prefetch.sh"
+hosts_dir="/etc/containerd/registry.d"
+log_dir="/var/log/d8/bashible"
+log_file="${log_dir}/ctr-prefetch.log"
+runtime_endpoint="unix:///run/containerd/containerd.sock"
+parallelism=4
+per_image_total_deadline=600
+ctr_ready_deadline=120
+
+mkdir -p "$log_dir"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+# Single short append is atomic w.r.t. concurrent xargs workers (POSIX O_APPEND,
+# our lines are far below PIPE_BUF), so no flock is needed.
+log() { printf '%s\n' "$*" >> "$log_file"; echo "$*"; }
+
+session_start=$(date +%s.%N)
+total_count=$(grep -c . "$list_file" 2>/dev/null || echo 0)
+log "=== ctr-prefetch session started $(ts) ==="
+log "$(ts) START parallelism=${parallelism} count=${total_count}"
+
+deadline=$((SECONDS + ctr_ready_deadline))
+until ctr version >/dev/null 2>&1; do
+  if [ $SECONDS -ge $deadline ]; then
+    log "$(ts) ABORT containerd not ready within ${ctr_ready_deadline}s"
+    exit 0
+  fi
+  sleep 1
+done
+
+# Returns image size in bytes via CRI; "-" on failure or jq/crictl absent.
+get_image_size() {
+  local ref="$1"
+  if ! command -v crictl >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    echo "-"; return 0
+  fi
+  crictl --runtime-endpoint="$runtime_endpoint" images -o json 2>/dev/null \
+    | jq -r --arg ref "$ref" '
+        (.images // [])[]
+        | select((.repoDigests // []) | index($ref))
+        | .size
+      ' 2>/dev/null \
+    | head -n1 \
+    | { read -r v || true; printf '%s\n' "${v:--}"; }
+}
+
+pull_one() {
+  local item="$1"
+  local name="${item%% *}"
+  local ref="${item#* }"
+  local start_ts size_bytes dur
+  start_ts=$(date +%s.%N)
+  local start_s=$SECONDS
+  local delay=2
+  while :; do
+    if ctr -n k8s.io images pull --hosts-dir "$hosts_dir" "$ref" >/dev/null 2>&1; then
+      ctr -n k8s.io images label "$ref" io.cri-containerd.pinned=pinned >/dev/null 2>&1 || true
+      dur=$(awk -v s="$start_ts" -v e="$(date +%s.%N)" 'BEGIN{printf "%.3f", e-s}')
+      size_bytes=$(get_image_size "$ref")
+      log "$(ts) OK    dur=${dur}s size=${size_bytes}B name=${name} ref=${ref}"
+      return 0
+    fi
+    if [ $((SECONDS - start_s)) -ge $per_image_total_deadline ]; then
+      dur=$(awk -v s="$start_ts" -v e="$(date +%s.%N)" 'BEGIN{printf "%.3f", e-s}')
+      log "$(ts) FAIL  dur=${dur}s size=- name=${name} ref=${ref} reason=timeout"
+      return 0
+    fi
+    sleep "$delay"
+    if [ "$delay" -lt 30 ]; then
+      delay=$((delay * 2))
+    fi
+  done
+}
+export -f ts log get_image_size pull_one
+export hosts_dir log_file runtime_endpoint per_image_total_deadline
+
+# Skip blank lines from xargs input (defensive against accidental empties).
+grep -v '^$' "$list_file" \
+  | xargs -d '\n' -P "$parallelism" -I {} bash -c 'pull_one "$@"' _ {}
+
+elapsed=$(awk -v s="$session_start" -v e="$(date +%s.%N)" 'BEGIN{printf "%.3f", e-s}')
+
+# Count results only within the current session (log file accumulates across runs).
+session_start_lineno=$(grep -n '^=== ctr-prefetch session started' "$log_file" 2>/dev/null | tail -n1 | cut -d: -f1)
+: "${session_start_lineno:=1}"
+session_log=$(tail -n "+${session_start_lineno}" "$log_file" 2>/dev/null)
+
+ok_count=$(printf '%s\n' "$session_log" | grep -c '^[^ ]* OK ')
+fail_count=$(printf '%s\n' "$session_log" | grep -c '^[^ ]* FAIL ')
+total_bytes=$(printf '%s\n' "$session_log" | awk '
+  /^[^ ]* OK / {
+    for (i=1; i<=NF; i++) if ($i ~ /^size=[0-9]+B$/) {
+      gsub(/^size=|B$/, "", $i); sum += $i
+    }
+  }
+  END { printf "%.0f", sum+0 }')
+log "$(ts) DONE  elapsed=${elapsed}s ok=${ok_count} fail=${fail_count} bytes=${total_bytes}"
+
+rm -f "$list_file" "$script_file"
+EOSCRIPT
+chmod 700 "$script_file"
+
+if ! systemd-run \
+    --unit="$unit" \
+    --description="Prefetch node images (parallel with bashible system prep)" \
+    --collect \
+    /bin/bash "$script_file" \
+    >/dev/null 2>&1; then
+  bb-log-warning "systemd-run failed to launch $unit"
+  rm -f "$list_file" "$script_file"
+  return 0 2>/dev/null || exit 0
+fi
+
+bb-log-info "$unit launched (${list_count} images, parallelism=4)"
+echo "[bashible-timing] step=035_prefetch_node_images.sh section=launched count=${list_count}"
+
+{{- end }}

--- a/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
+++ b/candi/bashible/common-steps/all/062_install_kubelet_and_his_friends.sh.tpl
@@ -15,6 +15,12 @@
 {{- $kubernetesVersion := printf "%s%s" (.kubernetesVersion | toString) (index .k8s .kubernetesVersion "patch" | toString) | replace "." "" }}
 {{- $kubernetesCniVersion := "1.6.2" | replace "." "" }}
 
+# d8 is the largest registrypackage. Step 004 deliberately skips it; the 001 prefetch
+# keeps downloading it in parallel with the rest of bashible. Wait + install happen
+# here, right before the first `d8` invocation below.
+bb-rpp-wait-fetched "d8" "{{ .images.registrypackages.d8 }}" || true
+bb-package-install "d8:{{ .images.registrypackages.d8 }}"
+
 bb-event-on 'bb-package-installed' 'post-install-kubelet'
 
 post-install-kubelet() {

--- a/candi/bashible/common-steps/cluster-bootstrap/072_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/072_install_control_plane.sh.tpl
@@ -99,33 +99,71 @@ __sec wait_cp_trio
 
 node_name="$(bb-d8-node-name)"
 
+export BB_KUBE_AUTH_TYPE="super-admin-cert"
+export BB_KUBE_APISERVER_URL=""
+bb-curl-helper-extract-super-admin-certs
+
 # admin.conf authenticates as user "kubernetes-admin" in group
 # "kubeadm:cluster-admins" — but that group has NO permissions until the
-# kubeadm:cluster-admins ClusterRoleBinding (created below via super-admin.conf)
-# exists. If we used admin.conf for the Node-wait loop before creating the
-# binding, every `kubectl get node` would 403, and the loop would burn its full
-# 200s timeout instead of breaking on the first successful poll. Measured cost
-# of that bug: ~220s on every fresh bootstrap. So: bind first, then wait.
-#
-# Step is bashible-retried on failure, so every mutation must be idempotent —
-# the `get … || create` guard and `--overwrite` cover that.
-if ! kubectl --kubeconfig=/etc/kubernetes/super-admin.conf get clusterrolebinding kubeadm:cluster-admins >/dev/null 2>&1; then
-  kubectl --kubeconfig=/etc/kubernetes/super-admin.conf create clusterrolebinding kubeadm:cluster-admins --clusterrole=cluster-admin --group=kubeadm:cluster-admins
+# kubeadm:cluster-admins ClusterRoleBinding exists. If the Node-wait loop
+# below used admin.conf before creating the binding, every Node GET would
+# 403 and the loop would burn its full 200s timeout instead of breaking on
+# the first successful poll (~220s measured on every fresh bootstrap).
+# So: bind via super-admin certs first (they bypass RBAC), then wait.
+# Idempotent via get-or-create guard (step is bashible-retried on failure).
+if ! bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/kubeadm:cluster-admins" >/dev/null 2>&1; then
+  bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    --data @- <<'EOF'
+{
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "ClusterRoleBinding",
+  "metadata": { "name": "kubeadm:cluster-admins" },
+  "roleRef": {
+    "apiGroup": "rbac.authorization.k8s.io",
+    "kind": "ClusterRole",
+    "name": "cluster-admin"
+  },
+  "subjects": [
+    {
+      "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "Group",
+      "name": "kubeadm:cluster-admins"
+    }
+  ]
+}
+EOF
 fi
+
+export BB_KUBE_AUTH_TYPE="admin-cert"
+export BB_KUBE_APISERVER_URL=""
+bb-curl-helper-extract-admin-certs
 
 # kubelet registers the Node object slightly after the control-plane containers
 # report running, so the label/taint below can race ahead of it. Wait for the
 # Node to appear (≤200s) before touching it.
 for _ in $(seq 1 100); do
-  if kubectl --kubeconfig=/etc/kubernetes/admin.conf get node "$node_name" >/dev/null 2>&1; then
+  if bb-curl-kube "/api/v1/nodes/${node_name}" >/dev/null 2>&1; then
     break
   fi
   sleep 2
 done
 __sec wait_node_register
 
-kubectl --kubeconfig=/etc/kubernetes/admin.conf label node "$node_name" node-role.kubernetes.io/control-plane="" --overwrite
-kubectl --kubeconfig=/etc/kubernetes/admin.conf taint node "$node_name" node-role.kubernetes.io/control-plane:NoSchedule --overwrite
+node_taints_patch="$(
+  bb-curl-kube "/api/v1/nodes/${node_name}" | jq -c '
+    (.spec.taints // [])
+    | map(select(.key != "node-role.kubernetes.io/control-plane"))
+    + [{"key":"node-role.kubernetes.io/control-plane","effect":"NoSchedule"}]
+  '
+)"
+
+bb-curl-helper-patch-node-metadata "$node_name" "labels" "node-role.kubernetes.io/control-plane="
+bb-curl-kube "/api/v1/nodes/${node_name}" \
+  -X PATCH \
+  -H "Content-Type: application/strategic-merge-patch+json" \
+  --data "$(jq -nc --argjson taints "$node_taints_patch" '{"spec":{"taints":$taints}}')"
 __sec rbac_label_taint
 
 # CIS benchmark purposes
@@ -133,11 +171,6 @@ chmod 600 /etc/kubernetes/pki/*.{crt,key} /etc/kubernetes/pki/etcd/*.{crt,key}
 
 # Restrict permissions on admin kubeconfig files for security
 chmod 600 /etc/kubernetes/admin.conf /etc/kubernetes/super-admin.conf 2>/dev/null || true
-
-# Force admin-cert auth for operations requiring elevated privileges
-export BB_KUBE_AUTH_TYPE="admin-cert"
-export BB_KUBE_APISERVER_URL=""
-bb-curl-helper-extract-admin-certs
 
 # Upload pki for deckhouse
 declare -A pki_secret_files=(
@@ -205,21 +238,30 @@ if [ ! -f /root/.kube/config ]; then
   mkdir -p /root/.kube
   ln -s /etc/kubernetes/admin.conf /root/.kube/config
 fi
-
 # Allow kube-apiserver to proxy kubelet requests (kubectl logs/exec/port-forward) during bootstrap.
 # The same CRB is applied with heritage/module labels by module 040-control-plane-manager; nelm adopts it.
-kubectl --kubeconfig=/etc/kubernetes/super-admin.conf apply -f - <<EOF
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: d8:control-plane-manager:apiserver-kubelet-client
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:kubelet-api-admin
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: kube-apiserver-kubelet-client
+# Idempotent via get-or-create guard (step is bashible-retried on failure).
+if ! bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/d8:control-plane-manager:apiserver-kubelet-client" >/dev/null 2>&1; then
+  bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings" \
+    -X POST \
+    -H "Content-Type: application/json" \
+    --data @- <<'EOF'
+{
+  "apiVersion": "rbac.authorization.k8s.io/v1",
+  "kind": "ClusterRoleBinding",
+  "metadata": { "name": "d8:control-plane-manager:apiserver-kubelet-client" },
+  "roleRef": {
+    "apiGroup": "rbac.authorization.k8s.io",
+    "kind": "ClusterRole",
+    "name": "system:kubelet-api-admin"
+  },
+  "subjects": [
+    {
+      "apiGroup": "rbac.authorization.k8s.io",
+      "kind": "User",
+      "name": "kube-apiserver-kubelet-client"
+    }
+  ]
+}
 EOF
-
+fi

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -485,6 +485,10 @@ func (m *MetaConfig) ConfigForBashibleBundleTemplate(nodeIP string) (map[string]
 	}
 	configForBashibleBundleTemplate["registry"] = registryContext.ToMap()
 
+	if tag := m.deckhouseImageTag(); tag != "" && registryContext.ImagesBase != "" {
+		configForBashibleBundleTemplate["deckhouseImageRef"] = fmt.Sprintf("%s:%s", registryContext.ImagesBase, tag)
+	}
+
 	images := m.Images
 	configForBashibleBundleTemplate["images"] = images.ConvertToMap()
 	clusterMasterEndpoints := m.clusterMasterEndpointsBashibleContext()
@@ -760,6 +764,17 @@ func (m *MetaConfig) FindModuleConfig(module string) *ModuleConfig {
 	}
 
 	return nil
+}
+
+// deckhouseImageTag returns the deckhouse-controller image tag for the bashible
+// prefetch: semver from the installer's version file, falling back to DevBranch.
+func (m *MetaConfig) deckhouseImageTag() string {
+	if m.VersionFilePath != "" {
+		if tag, ok := ReadVersionTagFromInstallerContainer(m.VersionFilePath, m.DownloadRootDir); ok {
+			return tag
+		}
+	}
+	return m.DeckhouseConfig.DevBranch
 }
 
 func (m *MetaConfig) LoadInstallerVersion() error {

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -377,20 +377,24 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			Value: "3",
 		},
 		{
-			// The helm-chart deckhouse uses GOGC=50 for steady-state memory
-			// frugality. During the first converge — when the heap doubles
-			// while LoadModulesFromFS parses ~60 OpenAPI schemas and helm
-			// renders charts — aggressive GC wastes CPU on the critical path.
-			// 100 (the Go default) reduces GC frequency by ~50% and shortens
-			// the cold start measurably; helm later overrides this to 50 in
-			// the post-converge Deployment.
+			// GC trigger: a cycle runs once the heap grows GOGC% over the live set.
+			// The in-cluster deckhouse runs GOGC=50 (fires at +50%) for steady-state
+			// RSS frugality, and helm restores that on the post-converge Deployment.
+			// The first converge is allocation-heavy — LoadModulesFromFS parses ~60
+			// OpenAPI schemas, helm renders charts, hundreds of CRDs are applied — so
+			// 50 collects ~twice as often, and Go's concurrent GC steals CPU from the
+			// converge on a 2-vCPU master also running etcd/apiserver. 100 (the Go
+			// default) roughly halves those cycles; the extra heap is bounded by the
+			// GOMEMLIMIT backstop below.
 			Name:  "GOGC",
 			Value: "100",
 		},
 		{
-			// Soft memory ceiling that the Go runtime honors when triggering
-			// GC. Set just below the resource request above so the runtime
-			// starts shrinking before kubelet would even consider eviction.
+			// Soft heap ceiling — a backstop, not a speedup. With GOGC=100 the heap
+			// may grow to ~2x live size and this pod carries no memory limit, so an
+			// absolute cap keeps a pathological spike from eating the master VM's RAM
+			// (shared with etcd/apiserver/kubelet during bootstrap). It only engages
+			// near the limit; in the common case peak heap stays well below it.
 			Name:  "GOMEMLIMIT",
 			Value: "1400MiB",
 		},

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -201,6 +201,12 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			DNSPolicy:                    apiv1.DNSDefault,
 			ServiceAccountName:           "deckhouse",
 			AutomountServiceAccountToken: ptr.To(true),
+			// system-cluster-critical: protects the bootstrap pod from eviction
+			// under any node pressure while the cluster is being assembled, and
+			// gives it scheduling priority over everything else. The helm chart
+			// applies the same class, so when deckhouse later replaces this
+			// Deployment with its own, priority does not change.
+			PriorityClassName: "system-cluster-critical",
 			SecurityContext: &apiv1.PodSecurityContext{
 				RunAsUser:    ptr.To(int64(0)),
 				RunAsGroup:   ptr.To(int64(0)),
@@ -371,8 +377,52 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			Value: "3",
 		},
 		{
+			// The helm-chart deckhouse uses GOGC=50 for steady-state memory
+			// frugality. During the first converge — when the heap doubles
+			// while LoadModulesFromFS parses ~60 OpenAPI schemas and helm
+			// renders charts — aggressive GC wastes CPU on the critical path.
+			// 100 (the Go default) reduces GC frequency by ~50% and shortens
+			// the cold start measurably; helm later overrides this to 50 in
+			// the post-converge Deployment.
 			Name:  "GOGC",
+			Value: "100",
+		},
+		{
+			// Soft memory ceiling that the Go runtime honors when triggering
+			// GC. Set just below the resource request above so the runtime
+			// starts shrinking before kubelet would even consider eviction.
+			Name:  "GOMEMLIMIT",
+			Value: "1400MiB",
+		},
+		{
+			// Default client-go QPS/Burst is 5/10 and causes 5-second-class
+			// stalls on the first converge while deckhouse mass-applies CRDs
+			// (see "client-side throttling, not priority and fairness" in
+			// addon-operator logs). Bumping all three clients (main, object
+			// patcher, helm monitor) lets the bootstrap pod saturate kube-
+			// apiserver instead of itself.
+			Name:  "KUBE_CLIENT_QPS",
 			Value: "50",
+		},
+		{
+			Name:  "KUBE_CLIENT_BURST",
+			Value: "100",
+		},
+		{
+			Name:  "OBJECT_PATCHER_KUBE_CLIENT_QPS",
+			Value: "50",
+		},
+		{
+			Name:  "OBJECT_PATCHER_KUBE_CLIENT_BURST",
+			Value: "100",
+		},
+		{
+			Name:  "HELM_MONITOR_KUBE_CLIENT_QPS",
+			Value: "50",
+		},
+		{
+			Name:  "HELM_MONITOR_KUBE_CLIENT_BURST",
+			Value: "100",
 		},
 		{
 			Name:  "ADDON_OPERATOR_CONFIG_MAP",

--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -395,34 +395,34 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			Value: "1400MiB",
 		},
 		{
-			// Default client-go QPS/Burst is 5/10 and causes 5-second-class
-			// stalls on the first converge while deckhouse mass-applies CRDs
-			// (see "client-side throttling, not priority and fairness" in
-			// addon-operator logs). Bumping all three clients (main, object
-			// patcher, helm monitor) lets the bootstrap pod saturate kube-
-			// apiserver instead of itself.
+			// Disable client-side rate limiting during bootstrap. The bootstrap
+			// incarnation installs hundreds of CRDs + runs initial kube-binding
+			// Synchronization against a fresh, idle apiserver; the default client QPS
+			// (5/10) serialized that into tens of seconds (client-side throttling).
+			// QPS<0 makes client-go skip the rate limiter entirely (QPS=0 would fall
+			// back to the 5 default, not disable) and defer fairness to apiserver APF.
 			Name:  "KUBE_CLIENT_QPS",
-			Value: "50",
+			Value: "-1",
 		},
 		{
 			Name:  "KUBE_CLIENT_BURST",
-			Value: "100",
+			Value: "-1",
 		},
 		{
 			Name:  "OBJECT_PATCHER_KUBE_CLIENT_QPS",
-			Value: "50",
+			Value: "-1",
 		},
 		{
 			Name:  "OBJECT_PATCHER_KUBE_CLIENT_BURST",
-			Value: "100",
+			Value: "-1",
 		},
 		{
 			Name:  "HELM_MONITOR_KUBE_CLIENT_QPS",
-			Value: "50",
+			Value: "-1",
 		},
 		{
 			Name:  "HELM_MONITOR_KUBE_CLIENT_BURST",
-			Value: "100",
+			Value: "-1",
 		},
 		{
 			Name:  "ADDON_OPERATOR_CONFIG_MAP",

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -217,14 +217,21 @@ spec:
               value: "4223"
             - name: ADDON_OPERATOR_BATCHING_ENABLED
               value: "true"
+            # Disable client-side rate limiting; defer fairness to apiserver APF.
+            # QPS<0 makes client-go skip the limiter entirely (0 would fall back
+            # to the client-go default of 5, not disable).
             - name: OBJECT_PATCHER_KUBE_CLIENT_QPS
-              value: "30"
+              value: "-1"
             - name: OBJECT_PATCHER_KUBE_CLIENT_BURST
-              value: "60"
+              value: "-1"
             - name: KUBE_CLIENT_QPS
-              value: "20"
+              value: "-1"
             - name: KUBE_CLIENT_BURST
-              value: "40"
+              value: "-1"
+            - name: HELM_MONITOR_KUBE_CLIENT_QPS
+              value: "-1"
+            - name: HELM_MONITOR_KUBE_CLIENT_BURST
+              value: "-1"
             - name: GOGC
               value: "50"
             - name: ADDON_OPERATOR_PROMETHEUS_METRICS_PREFIX

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
@@ -109,6 +109,9 @@ func (c *Client) UpdateAuth(endpoints []string, token string) {
 	c.httpClient = newHTTPClient(c.cfg)
 }
 
+// installWorkerCount caps install parallelism at runtime.NumCPU because install
+// is CPU-bound: tar extraction + per-package install scripts (sometimes spawning
+// dpkg/rpm) compete for cores, not for the network.
 func installWorkerCount() int {
 	workers := runtime.NumCPU()
 	if workers < 1 {
@@ -118,13 +121,21 @@ func installWorkerCount() int {
 	return workers
 }
 
+// fetchWorkerCount sizes parallelism for network-bound downloads. Unlike
+// installWorkerCount it deliberately ignores NumCPU — fetching N small tarballs
+// over an HTTP connection (often via an ssh reverse-tunnel during bootstrap)
+// scales with link bandwidth, not with cores.
+func fetchWorkerCount() int {
+	return defaultFetchWorkers
+}
+
 func (c *Client) FetchAll(ctx context.Context, args []string) error {
 	refs, err := c.newPackageRefs(args)
 	if err != nil {
 		return err
 	}
 
-	return c.runAll(ctx, refs, c.fetchPackage)
+	return c.runAll(ctx, refs, fetchWorkerCount(), c.fetchPackage)
 }
 
 func (c *Client) InstallAll(ctx context.Context, args []string) error {
@@ -133,7 +144,7 @@ func (c *Client) InstallAll(ctx context.Context, args []string) error {
 		return err
 	}
 
-	return c.runAll(ctx, refs, c.installPackage)
+	return c.runAll(ctx, refs, installWorkerCount(), c.installPackage)
 }
 
 func (c *Client) InstallMissing(ctx context.Context, statuses []InstallStatus) error {
@@ -151,15 +162,15 @@ func (c *Client) InstallMissing(ctx context.Context, statuses []InstallStatus) e
 		}
 		missing = append(missing, ref)
 	}
-	return c.runAll(ctx, missing, c.installPackage)
+	return c.runAll(ctx, missing, installWorkerCount(), c.installPackage)
 }
 
-func (c *Client) runAll(ctx context.Context, refs []packageRef, action func(context.Context, packageRef) error) error {
+func (c *Client) runAll(ctx context.Context, refs []packageRef, maxWorkers int, action func(context.Context, packageRef) error) error {
 	if len(refs) == 0 {
 		return nil
 	}
 
-	workerCount := min(installWorkerCount(), len(refs))
+	workerCount := min(maxWorkers, len(refs))
 
 	if c.logger != nil {
 		c.logger.Printf("processing %d packages with %d workers", len(refs), workerCount)

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/constants.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/constants.go
@@ -25,7 +25,14 @@ const (
 	connectTimeout        = 10 * time.Second
 	responseHeaderTimeout = 60 * time.Second
 
-	defaultInstallWorkers  = 4
+	defaultInstallWorkers  = 8
+	// Fetch is network-bound (HTTP GET through ssh reverse-tunnel during
+	// bootstrap, or in-cluster registry-packages-proxy later) — runtime.NumCPU
+	// is the wrong cap for it. Master nodes typically have 2 vCPUs, which
+	// throttled bashible step 004 to ~14s on 11 small packages. 16 in-flight
+	// requests saturate the link without overwhelming the proxy.
+	defaultFetchWorkers = 16
+
 	packageInstallAttempts = 10
 
 	scriptExecTimeout     = 10 * time.Minute

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/constants.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/constants.go
@@ -25,7 +25,7 @@ const (
 	connectTimeout        = 10 * time.Second
 	responseHeaderTimeout = 60 * time.Second
 
-	defaultInstallWorkers  = 8
+	defaultInstallWorkers = 8
 	// Fetch is network-bound (HTTP GET through ssh reverse-tunnel during
 	// bootstrap, or in-cluster registry-packages-proxy later) — runtime.NumCPU
 	// is the wrong cap for it. Master nodes typically have 2 vCPUs, which


### PR DESCRIPTION
## Description

follow https://github.com/deckhouse/deckhouse/pull/19969 https://github.com/deckhouse/deckhouse/pull/20094 

- **bashible 035 (new)**: master-only background `ctr-prefetch.service`. Pulls a curated whitelist  of images via `ctr --hosts-dir /etc/containerd/registry.d` with `xargs -P 4` and per-image retry. Pinned with `io.cri-containerd.pinned=pinned`. Log at `/var/log/d8/bashible/ctr-prefetch.log`.
- **bashible 004/062**: `d8` install moved from 004 to 062 (first real use). The 001 background fetch keeps overlapping with steps 005–061.
- **bashible 003 disable unattended-upgrades**: replaced blocking `systemctl disable --now` + `bb-apt-remove` with `/etc/apt/apt.conf.d/20auto-upgrades` kill switch + `mask` + async `stop --no-block`. No-op on non-apt or non-systemd systems. Removes dpkg-lock stalls.
- **dhctl `MetaConfig`**: emits `deckhouseImageRef = <imagesBase>:<tag>` into the bashible context, same precedence as `DeckhouseInstaller.GetImageTag(true)`. Consumed by step 035.
- **dhctl bootstrap Deployment**: `resources.requests cpu: 1000m, memory: 1500Mi` (Burstable, no limits), `priorityClassName: system-cluster-critical`, `imagePullPolicy: IfNotPresent`, `GOGC=100`, `GOMEMLIMIT=1400MiB`, `KUBE_CLIENT_QPS/BURST=50/100` (incl. ObjectPatcher and HelmMonitor).

### Results on DKP-on-DVP (1-master)

| Phase | main | PR run 1 | PR run 2 | PR avg | Δ vs main |
|---|---:|---:|---:|---:|---:|
| dhctl init + ssh passphrase | 4 | 3 | 3 | 3 | -1 |
| Infrastructure (VM create) | 141 | 129 | 168 | 149 | +8 (DVP variance) |
| **bashible execution** | **154** | **50** | **46** | **48** | **-106 (-69%)** |
| **Create Manifests (MC retry)** | **19** | **7** | **7** | **7** | **-12 (-63%)** |
| **Waiting for Deckhouse Ready** | **288** | **238** | **236** | **237** | **-51 (-18%)** |
| Resources + NG + post-bootstrap | 210 | 210 | 140 | 175 | -35 |
| **TOTAL** | **822 (13m 42s)** | **643 (10m 43s)** | **606 (10m 06s)** | **624 (10m 24s)** | **-198 (-24%)** |


## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: fix
summary: "rpp-get: separate worker caps for fetch (16) and install (NumCPU)."
impact_level: low
---
section: candi
type: feature
summary: "Bashible: master-only step 035 pre-pulls a curated whitelist of node images via ctr so kubelet finds them already in the containerd store when pods schedule."
impact_level: low
---
section: candi
type: fix
summary: "Bashible: d8 install deferred from step 004 to 062 (first real use); no longer blocks the install batch."
impact_level: low
---
section: candi
type: fix
summary: "Bashible: disable unattended-upgrades via apt.conf kill switch + systemd mask + async stop instead of blocking disable --now / apt remove. Removes dpkg-lock stalls during bootstrap."
impact_level: low
---
section: dhctl
type: fix
summary: "Bashible context now carries deckhouseImageRef so the master image prefetch covers the bootstrap pod image."
impact_level: low
---
section: dhctl
type: fix
summary: "Bootstrap deckhouse Deployment: explicit Burstable resources, priorityClassName system-cluster-critical, IfNotPresent, GOGC=100, GOMEMLIMIT, KUBE_CLIENT_QPS/BURST=50/100."
impact_level: low
```
