### PR TITLE
[local-path-provisioner][common] Fix CVE-2026-44543 in local-path-provisioner and mitigate CVE-2026-29181 in CSI sidecars

### DIFF
--- a/modules/000-common/images/csi-external-attacher/known_vulnerabilities.vex
+++ b/modules/000-common/images/csi-external-attacher/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1d0384d5d5694a2c596111d21b5a01b23ad9cb77ac560ea7750c727dfdb0be46",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-29181"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "Уязвимость CVE-2026-29181 связана с обработкой входящих HTTP baggage-заголовков пакетом OpenTelemetry. Образ csi-external-attacher работает как gRPC-клиент к CSI-драйверу по Unix-сокету и как watcher Kubernetes API server; входящих HTTP-запросов от внешних источников он не принимает, otelhttp/otelgrpc baggage propagation в штатной конфигурации не активируется. Следовательно, уязвимый код разбора baggage-заголовков не достигается и эксплуатация уязвимости в данном контексте невозможна.",
+      "timestamp": "2026-05-28T08:00:00Z"
+    }
+  ],
+  "timestamp": "2026-05-28T08:00:00Z"
+}

--- a/modules/000-common/images/csi-external-attacher/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-attacher/werf.inc.yaml
@@ -69,5 +69,7 @@ shell:
   - cp bin/csi-attacher /csi-attacher
   - chown 64535:64535 /csi-attacher
   - chmod 0755 /csi-attacher
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName ($version | replace "." "-"))) }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-provisioner/known_vulnerabilities.vex
+++ b/modules/000-common/images/csi-external-provisioner/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-056b3a8ff9da447e8209b7544ac6e7cb53de91062266249de064f9582c768025",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-29181"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "Уязвимость CVE-2026-29181 связана с обработкой входящих HTTP baggage-заголовков пакетом OpenTelemetry. Образ csi-external-provisioner работает как gRPC-клиент к CSI-драйверу по Unix-сокету и как watcher Kubernetes API server; входящих HTTP-запросов от внешних источников он не принимает, otelhttp/otelgrpc baggage propagation в штатной конфигурации не активируется. Следовательно, уязвимый код разбора baggage-заголовков не достигается и эксплуатация уязвимости в данном контексте невозможна.",
+      "timestamp": "2026-05-28T08:00:00Z"
+    }
+  ],
+  "timestamp": "2026-05-28T08:00:00Z"
+}

--- a/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-provisioner/werf.inc.yaml
@@ -71,5 +71,7 @@ shell:
   - cp bin/csi-provisioner /csi-provisioner
   - chown 64535:64535 /csi-provisioner
   - chmod 0755 /csi-provisioner
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName ($version | replace "." "-"))) }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-resizer/known_vulnerabilities.vex
+++ b/modules/000-common/images/csi-external-resizer/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-383c59e1e8e174c5ac09edcd448bf4bd6b835799c2bec62853b1cc2e209958fa",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-29181"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "Уязвимость CVE-2026-29181 связана с обработкой входящих HTTP baggage-заголовков пакетом OpenTelemetry. Образ csi-external-resizer работает как gRPC-клиент к CSI-драйверу по Unix-сокету и как watcher Kubernetes API server; входящих HTTP-запросов от внешних источников он не принимает, otelhttp/otelgrpc baggage propagation в штатной конфигурации не активируется. Следовательно, уязвимый код разбора baggage-заголовков не достигается и эксплуатация уязвимости в данном контексте невозможна.",
+      "timestamp": "2026-05-28T08:00:00Z"
+    }
+  ],
+  "timestamp": "2026-05-28T08:00:00Z"
+}

--- a/modules/000-common/images/csi-external-resizer/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-resizer/werf.inc.yaml
@@ -69,5 +69,7 @@ shell:
   - cp bin/csi-resizer /csi-resizer
   - chown 64535:64535 /csi-resizer
   - chmod 0755 /csi-resizer
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName ($version | replace "." "-"))) }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-external-snapshotter/known_vulnerabilities.vex
+++ b/modules/000-common/images/csi-external-snapshotter/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-9751ce60ed810045aeead27f79210851fa6af9928f2ec460ba8f2327ad95f117",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-29181"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "Уязвимость CVE-2026-29181 связана с обработкой входящих HTTP baggage-заголовков пакетом OpenTelemetry. Образ csi-external-snapshotter работает как gRPC-клиент к CSI-драйверу по Unix-сокету и как watcher Kubernetes API server; входящих HTTP-запросов от внешних источников он не принимает, otelhttp/otelgrpc baggage propagation в штатной конфигурации не активируется. Следовательно, уязвимый код разбора baggage-заголовков не достигается и эксплуатация уязвимости в данном контексте невозможна.",
+      "timestamp": "2026-05-28T08:00:00Z"
+    }
+  ],
+  "timestamp": "2026-05-28T08:00:00Z"
+}

--- a/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
+++ b/modules/000-common/images/csi-external-snapshotter/werf.inc.yaml
@@ -71,5 +71,7 @@ shell:
   - cp bin/snapshot-controller bin/csi-snapshotter bin/snapshot-validation-webhook /
   - chown 64535:64535 /snapshot-controller /csi-snapshotter /snapshot-validation-webhook
   - chmod 0755 /snapshot-controller /csi-snapshotter /snapshot-validation-webhook
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName ($version | replace "." "-"))) }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-livenessprobe/known_vulnerabilities.vex
+++ b/modules/000-common/images/csi-livenessprobe/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-367613a38d2822c0c8c76f27845a4ccbaa2f0c7c8bac4394ca2b9243ce3b3756",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-29181"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "Уязвимость CVE-2026-29181 связана с обработкой входящих HTTP baggage-заголовков пакетом OpenTelemetry. Образ csi-livenessprobe запускает минимальный HTTP-сервер только для health-проверки CSI-драйвера, обращающейся по localhost от kubelet, и не подключает otelhttp-инструментирование к этому handler-у, поэтому baggage-заголовки запросов не извлекаются. Функциональность OpenTelemetry в штатной конфигурации не активируется. Следовательно, уязвимый код разбора baggage-заголовков не достигается и эксплуатация уязвимости в данном контексте невозможна.",
+      "timestamp": "2026-05-28T08:00:00Z"
+    }
+  ],
+  "timestamp": "2026-05-28T08:00:00Z"
+}

--- a/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
+++ b/modules/000-common/images/csi-livenessprobe/werf.inc.yaml
@@ -71,5 +71,7 @@ shell:
   - cp bin/livenessprobe /livenessprobe
   - chown 64535:64535 /livenessprobe
   - chmod 0755 /livenessprobe
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName ($version | replace "." "-"))) }}
   {{- end }}
 {{- end }}

--- a/modules/000-common/images/csi-node-driver-registrar/known_vulnerabilities.vex
+++ b/modules/000-common/images/csi-node-driver-registrar/known_vulnerabilities.vex
@@ -1,0 +1,23 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-d8ad700216d779d30ca63d9c127075c785f5b257fc078e9e589d4e3d13a79cf4",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-29181"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "inline_mitigations_already_exist",
+      "impact_statement": "Уязвимость CVE-2026-29181 связана с обработкой входящих HTTP baggage-заголовков пакетом OpenTelemetry. Образ csi-node-driver-registrar взаимодействует только локально по Unix-сокету: регистрирует CSI-плагин в kubelet и проксирует gRPC-вызовы к драйверу. HTTP-сервер не запускается, otelhttp/otelgrpc baggage propagation в штатной конфигурации не активируется. Следовательно, уязвимый код разбора baggage-заголовков не достигается и эксплуатация уязвимости в данном контексте невозможна.",
+      "timestamp": "2026-05-28T08:00:00Z"
+    }
+  ],
+  "timestamp": "2026-05-28T08:00:00Z"
+}

--- a/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
+++ b/modules/000-common/images/csi-node-driver-registrar/werf.inc.yaml
@@ -69,5 +69,7 @@ shell:
   - cp bin/csi-node-driver-registrar /csi-node-driver-registrar
   - chown 64535:64535 /csi-node-driver-registrar
   - chmod 0755 /csi-node-driver-registrar
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName ($version | replace "." "-"))) }}
   {{- end }}
 {{- end }}

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/003-cve-2026-44543-helperpod-validation.patch
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/003-cve-2026-44543-helperpod-validation.patch
@@ -1,0 +1,85 @@
+diff --git a/util.go b/util.go
+index c323d21..69f9b32 100644
+--- a/util.go
++++ b/util.go
+@@ -38,5 +38,80 @@ func loadHelperPodFile(helperPodYaml string) (*v1.Pod, error) {
+ 	if len(p.Spec.Containers) == 0 {
+ 		return nil, fmt.Errorf("helper pod template does not specify any container")
+ 	}
++	if err := validateHelperPodTemplate(&p); err != nil {
++		return nil, err
++	}
+ 	return &p, nil
+ }
++
++// validateHelperPodTemplate backports the HelperPod template validation from
++// upstream v0.0.36 (CVE-2026-44543, GHSA-7fxv-8wr2-mfc4) to v0.0.34 to reject
++// unsafe security-sensitive fields that could be injected via edits to the
++// local-path-config ConfigMap.
++//
++// Deckhouse-specific deviation from upstream: runAsUser=0/runAsGroup=0 are
++// permitted because the helper container must manage host-path directories
++// with arbitrary permissions, which requires root inside the pod. All other
++// dangerous fields (privileged, capabilities, host namespaces, custom
++// volumes/initContainers/probes, etc.) remain forbidden.
++func validateHelperPodTemplate(p *v1.Pod) error {
++	forbid := func(cond bool, field string) error {
++		if !cond {
++			return nil
++		}
++		return fmt.Errorf("helper pod template must not %s", field)
++	}
++
++	if len(p.Spec.Containers) != 1 {
++		return fmt.Errorf("helper pod template must specify exactly one container")
++	}
++
++	container := p.Spec.Containers[0]
++	checks := []struct {
++		invalid bool
++		field   string
++	}{
++		{len(p.Spec.InitContainers) > 0, "define initContainers"},
++		{len(p.Spec.EphemeralContainers) > 0, "define ephemeralContainers"},
++		{len(p.Spec.Volumes) > 0, "define custom volumes"},
++		{p.Spec.HostNetwork || p.Spec.HostPID || p.Spec.HostIPC, "enable host namespaces"},
++		{p.Spec.NodeName != "", "set spec.nodeName"},
++		{p.Spec.ServiceAccountName != "", "set spec.serviceAccountName"},
++		{len(container.VolumeMounts) > 0, "define custom volumeMounts"},
++		{len(container.EnvFrom) > 0, "define envFrom"},
++		{container.Lifecycle != nil, "define container lifecycle hooks"},
++		{container.LivenessProbe != nil, "define container livenessProbe"},
++		{container.ReadinessProbe != nil, "define container readinessProbe"},
++		{container.StartupProbe != nil, "define container startupProbe"},
++	}
++	for _, check := range checks {
++		if err := forbid(check.invalid, check.field); err != nil {
++			return err
++		}
++	}
++	for _, env := range container.Env {
++		if err := forbid(env.ValueFrom != nil, fmt.Sprintf("define env.valueFrom (env %q)", env.Name)); err != nil {
++			return err
++		}
++	}
++
++	if psc := p.Spec.SecurityContext; psc != nil {
++		if err := forbid(len(psc.Sysctls) > 0, "define sysctls"); err != nil {
++			return err
++		}
++	}
++
++	if sc := container.SecurityContext; sc != nil {
++		if err := forbid(sc.Privileged != nil && *sc.Privileged, "set privileged: true"); err != nil {
++			return err
++		}
++		if err := forbid(sc.Capabilities != nil && len(sc.Capabilities.Add) > 0, "add capabilities"); err != nil {
++			return err
++		}
++		if err := forbid(sc.AllowPrivilegeEscalation != nil && *sc.AllowPrivilegeEscalation, "set allowPrivilegeEscalation: true"); err != nil {
++			return err
++		}
++	}
++
++	return nil
++}

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
@@ -15,3 +15,31 @@ Adds support for clusters where containerd forces `readOnlyRootFilesystem` for e
 * therefore the helper-pod can still create or remove directories even though the container root filesystem is read-only.
 
 The patch touches `provisioner.go`.
+
+### 003-cve-2026-44543-helperpod-validation.patch
+
+Backports the HelperPod template validation introduced in upstream `v0.0.36`
+(CVE-2026-44543, [GHSA-7fxv-8wr2-mfc4](https://github.com/rancher/local-path-provisioner/security/advisories/GHSA-7fxv-8wr2-mfc4),
+CVSS 8.7 High) to `v0.0.34`. The provisioner now rejects unsafe security-sensitive
+fields in `helperPod.yaml` loaded from the `local-path-config` ConfigMap, so an
+attacker with edit permission on that ConfigMap cannot inject a privileged
+HelperPod with the host root filesystem mounted.
+
+The following fields are forbidden:
+
+* `initContainers` / `ephemeralContainers`;
+* extra containers (only one container is allowed);
+* custom `volumes` / `volumeMounts` (the provisioner injects the host-path volume itself);
+* `hostNetwork` / `hostPID` / `hostIPC`;
+* `spec.nodeName` / `spec.serviceAccountName`;
+* `envFrom`, `env.valueFrom`;
+* `lifecycle`, `livenessProbe`, `readinessProbe`, `startupProbe`;
+* `spec.securityContext.sysctls`;
+* `securityContext.privileged: true`, `capabilities.add`, `allowPrivilegeEscalation: true`.
+
+Deckhouse-specific deviation from upstream: `runAsUser=0` / `runAsGroup=0` are
+intentionally still allowed, because the helper container manages directories on
+the host-path volume that were originally created by root and therefore must run
+as root itself.
+
+The patch touches `util.go`.


### PR DESCRIPTION
## Description

Two-step fix for image vulnerabilities reported by trivy in `local-path-provisioner` and `csi-*` images, **without** touching upstream CSI sidecar versions or pulling fresh dependency trees through go.mod patches.

### 1. `local-path-provisioner` — backport HelperPod template validation (CVE-2026-44543)

Backports the HelperPod template validation introduced in upstream [`v0.0.36`](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.36) to `v0.0.34` as a new patch, **without** bumping the upstream version (avoids the `go 1.26.x` toolchain requirement that `v0.0.35`/`v0.0.36` introduce and the regression that would happen if we used `--allow-unsafe-helper-pod-template` to keep our root helper).

- `modules/031-local-path-provisioner/images/local-path-provisioner/patches/003-cve-2026-44543-helperpod-validation.patch` — new patch on `util.go`. Adds `validateHelperPodTemplate` called from `loadHelperPodFile`. Rejects extra/init/ephemeral containers, custom `volumes` / `volumeMounts`, `hostNetwork` / `hostPID` / `hostIPC`, `spec.nodeName` / `spec.serviceAccountName`, `envFrom`, `env.valueFrom`, `lifecycle`, `livenessProbe`, `readinessProbe`, `startupProbe`, `spec.securityContext.sysctls`, `securityContext.privileged: true`, `capabilities.add`, `allowPrivilegeEscalation: true`.
- `modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md` — documents the new patch and the Deckhouse-specific deviation.

Deckhouse-specific deviation from upstream: `runAsUser=0` / `runAsGroup=0` are intentionally still allowed, because the helper container in `templates/configmap.yaml` runs as root to manage host-path directories created by root. Without this exception the helper pod would be rejected and PV provisioning/teardown would fail.

### 2. CSI sidecars — mark CVE-2026-29181 as `not_affected` via OpenVEX

Trivy flags [CVE-2026-29181](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-mh2q-q3fh-2475) (OpenTelemetry-Go multi-value `baggage:` header DoS amplification, fixed upstream in `otel v1.41.0`) on `go.opentelemetry.io/otel v1.39.0` in all 6 CSI sidecars (attacher / provisioner / resizer / snapshotter / livenessprobe / node-driver-registrar) for every k8s version in `version_map.yml` (1.31 → 1.35).

The vulnerable code path is the HTTP `baggage:` header extractor in `go.opentelemetry.io/otel/baggage` and `go.opentelemetry.io/otel/propagation`. CSI sidecars do **not** accept inbound HTTP requests carrying `baggage:` headers:

- `csi-external-{attacher,provisioner,resizer,snapshotter}`: gRPC clients to the CSI driver (Unix socket) plus K8s API watchers. No HTTP server.
- `csi-node-driver-registrar`: local-only Unix-socket gRPC for kubelet plugin registration. No HTTP server.
- `csi-livenessprobe`: runs a minimal HTTP `/healthz` handler that does not wire `otelhttp`, so the baggage extractor is never invoked.

In all six sidecars OpenTelemetry tracing is not activated in the default Deckhouse configuration. The fix therefore mirrors the **existing Deckhouse precedent** for the same CVE in `kubectl` / `kubelet` / `crictl` (see `modules/007-registrypackages/images/{kubectl,kubelet,crictl}/known_vulnerabilities.vex`), which already mark CVE-2026-29181 `not_affected` with the same `inline_mitigations_already_exist` justification.

Changes:

- `modules/000-common/images/csi-{external-attacher,external-provisioner,external-resizer,external-snapshotter,livenessprobe,node-driver-registrar}/known_vulnerabilities.vex` — six new OpenVEX 0.2 attestation files, one per image, each with a single `not_affected` statement for `CVE-2026-29181` against `pkg:golang/go.opentelemetry.io/otel`. Wording slightly tailored per sidecar (gRPC-only vs. healthz HTTP).
- `modules/000-common/images/csi-{...}/werf.inc.yaml` — wire `{{- include "vex mitigation" ... }}` into each werf template so cosign attaches the VEX attestation to every per-k8s-version image variant (e.g. `common/csi-external-attacher-1-31` … `-1-35`). Same pattern that `csi-vsphere-syncer/werf.inc.yaml` already uses.

`csi-vsphere-syncer` skipped per request (image is being deprecated).

## Why do we need it, and what problem does it solve?

- **CVE-2026-44543 / [GHSA-7fxv-8wr2-mfc4](https://github.com/rancher/local-path-provisioner/security/advisories/GHSA-7fxv-8wr2-mfc4)** — *HelperPod Template Injection*, CVSS 8.7 **High** (`CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:N`). A user with edit permission on the `local-path-config` ConfigMap could replace `helperPod.yaml` with a template injecting a `privileged: true` container, `hostPath: /` volume, extra capabilities, host namespaces, etc., and the next PVC provisioning/cleanup would mount the host root filesystem and grant node-level compromise (host file r/w, ServiceAccount token theft from co-located pods, access to other tenants' local-path volumes).
- **CVE-2026-29181 / [GHSA-mh2q-q3fh-2475](https://github.com/open-telemetry/opentelemetry-go/security/advisories/GHSA-mh2q-q3fh-2475)** — *Multi-value baggage header DoS amplification* in OpenTelemetry-Go `v1.36.0 ≤ v ≤ v1.40.0`, fixed in `v1.41.0`. Trivy raises it as **High** on all CSI sidecar images, but the vulnerable code is unreachable in our sidecars, so we suppress the false-positive with a signed VEX attestation rather than churn the `go.mod` patch set (which would also force `go 1.25.0` for otel `v1.42.0+`).

## Why do we need it in the patch release (if we do)?

Yes — CVE-2026-44543 is CVSS 8.7 High in a default-enabled component (`local-path-provisioner`) with no in-cluster mitigation other than restricting ConfigMap write access. CVE-2026-29181 has no exploitation path in CSI sidecars but generates non-zero trivy reports for every supported branch. Both should be backported to every currently supported patch release.

## Verification

### Patch (`local-path-provisioner`)

Fresh `git clone --depth 1 --branch v0.0.34 https://github.com/rancher/local-path-provisioner.git`:

```
=== 001-fix-directory-or-create.patch ===
Applied patch provisioner.go cleanly.
=== 002-workspace-emptydir.patch ===
Applied patch provisioner.go cleanly.
=== 003-cve-2026-44543-helperpod-validation.patch ===
Applied patch util.go cleanly.

go build .              # exit 0
go test -run TestValidateHelperPodTemplate -v .
--- PASS: TestValidateHelperPodTemplate_DeckhouseConfigAccepted    (0.00s)
--- PASS: TestValidateHelperPodTemplate_RejectsPrivileged          (0.00s)
--- PASS: TestValidateHelperPodTemplate_RejectsHostPathInjection   (0.00s)
--- PASS: TestValidateHelperPodTemplate_RejectsHostNetwork         (0.00s)
--- PASS: TestValidateHelperPodTemplate_RejectsAddedCapabilities   (0.00s)
PASS
```

The "deckhouse-config-accepted" case feeds the exact template rendered by `modules/031-local-path-provisioner/templates/configmap.yaml` (`runAsUser: 0`, `runAsGroup: 0`, `readOnlyRootFilesystem: true`, no custom volumes/mounts).

### VEX (CSI sidecars)

All 6 files are valid OpenVEX 0.2 JSON with the required schema fields (`@context`, `@id`, `author`, `version`, `statements`, `timestamp`; per-statement `vulnerability`, `products`, `status`, `justification`, `impact_statement`, `timestamp`). The `werf.inc.yaml` for each sidecar gets the `vex mitigation` include in the same place where `csi-vsphere-syncer/werf.inc.yaml` already uses it.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: local-path-provisioner
type: fix
summary: Backport HelperPod template validation to `local-path-provisioner` v0.0.34 to fix CVE-2026-44543 (HelperPod Template Injection, GHSA-7fxv-8wr2-mfc4, CVSS 8.7 High).
impact: The `local-path-provisioner` Pod is restarted during the update. PV provisioning and teardown briefly pauses while the new Pod becomes `Ready`; existing volumes are not affected. If you use a custom `helperPod.yaml` template in the `local-path-config` ConfigMap, remove any unsupported security-sensitive settings before upgrading. Otherwise, the `local-path-provisioner` will reject the template after the update.
impact_level: high
```

```changes
section: common
type: fix
summary: Mark CVE-2026-29181 (OpenTelemetry-Go baggage DoS) as `not_affected` for all CSI sidecar images via signed OpenVEX attestation; the vulnerable HTTP `baggage:` header parser is unreachable in the Unix-socket gRPC code path the sidecars use.
impact_level: low
```
