### PR TITLE
[dhctl] chore(dhctl-for-commander): fix failed task progress

### DIFF
--- a/dhctl/pkg/operations/check/checker.go
+++ b/dhctl/pkg/operations/check/checker.go
@@ -212,7 +212,7 @@ func (c *Checker) checkConfiguration(ctx context.Context, kubeCl *client.Kuberne
 		inClusterSource = "in-cluster"
 	)
 
-	defer c.switchPhase(ctx, phases.CheckConfiguration)()
+	c.beginPhase(ctx, phases.CheckConfiguration)
 
 	clusterConfig, err := getClusterConfig(metaConfig, commanderSource)
 	if err != nil {
@@ -256,6 +256,8 @@ func (c *Checker) checkConfiguration(ctx context.Context, kubeCl *client.Kuberne
 		}
 	}
 
+	c.completePhase(ctx, phases.CheckConfiguration)
+
 	return syncStatus, nil
 }
 
@@ -267,7 +269,7 @@ type InfraResult struct {
 }
 
 func (c *Checker) checkInfra(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, infrastructureContext *infrastructure.Context) (*InfraResult, error) {
-	defer c.switchPhase(ctx, phases.CheckInfra)()
+	c.beginPhase(ctx, phases.CheckInfra)
 
 	stat, hasTerraformState, err := CheckState(
 		ctx, kubeCl, metaConfig, infrastructureContext,
@@ -310,6 +312,8 @@ func (c *Checker) checkInfra(ctx context.Context, kubeCl *client.KubernetesClien
 		migrateToTofuStatus = CheckStatusOutOfSync
 	}
 
+	c.completePhase(ctx, phases.CheckInfra)
+
 	return &InfraResult{
 		Status:                  checkStatus,
 		Statistics:              stat,
@@ -349,17 +353,24 @@ func (c *Checker) GetKubeClient(ctx context.Context) (*client.KubernetesClient, 
 	return &client.KubernetesClient{KubeClient: kubeCl}, nil
 }
 
-func (c *Checker) switchPhase(ctx context.Context, s phases.OperationPhase) func() {
-	if !c.Embedded {
-		_, _ = c.PhasedExecutionContext.SwitchPhase(ctx, s, false, c.StateCache, nil)
-		return func() {}
+func (c *Checker) beginPhase(ctx context.Context, phase phases.OperationPhase) {
+	if c.Embedded {
+		return
 	}
 
-	return func() {
+	_, _ = c.PhasedExecutionContext.SwitchPhase(ctx, phase, false, c.StateCache, nil)
+}
+
+func (c *Checker) completePhase(ctx context.Context, phase phases.OperationPhase) {
+	if c.Embedded {
 		if c.ExternalPhasedContext != nil {
-			c.ExternalPhasedContext.CompleteSubPhase(phases.OperationSubPhase(s))
+			c.ExternalPhasedContext.CompleteSubPhase(phases.OperationSubPhase(phase))
 		}
+
+		return
 	}
+
+	_ = c.PhasedExecutionContext.CompletePhase(ctx, c.StateCache, nil)
 }
 
 type configTypeForCompare map[string]any

--- a/dhctl/pkg/operations/check/checker_test.go
+++ b/dhctl/pkg/operations/check/checker_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
@@ -31,8 +32,10 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/state/cache"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/tests"
+	utilcache "github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 
 func TestCheckClusterConfig(t *testing.T) {
@@ -696,4 +699,125 @@ func (f *testCheckSpecificClusterFiller) Static(_ context.Context, metaConfig *c
 
 func (f *testCheckSpecificClusterFiller) Incorrect(_ context.Context, metaConfig *config.MetaConfig) (nilType, error) {
 	return nil, config.UnsupportedClusterTypeErr(metaConfig)
+}
+
+func TestChecker_progress(t *testing.T) {
+	t.Parallel()
+	require.Len(t, phases.CheckPhases(), 2)
+
+	for _, tc := range []struct {
+		name     string
+		embedded bool
+		exec     []phases.OperationPhase
+		wantSubs []phases.OperationSubPhase
+	}{
+		{
+			name: "standalone/cloud",
+			exec: []phases.OperationPhase{phases.CheckInfra, phases.CheckConfiguration},
+		},
+		{
+			name: "standalone/static",
+			exec: []phases.OperationPhase{phases.CheckConfiguration},
+		},
+		{
+			name:     "embedded/cloud",
+			embedded: true,
+			exec:     []phases.OperationPhase{phases.CheckInfra, phases.CheckConfiguration},
+			wantSubs: []phases.OperationSubPhase{
+				phases.OperationSubPhase(phases.CheckInfra),
+				phases.OperationSubPhase(phases.CheckConfiguration),
+			},
+		},
+		{
+			name:     "embedded/static",
+			embedded: true,
+			exec:     []phases.OperationPhase{phases.CheckConfiguration},
+			wantSubs: []phases.OperationSubPhase{phases.OperationSubPhase(phases.CheckConfiguration)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			progress, subs := runCheckerProgress(t, tc.embedded, tc.exec...)
+
+			if tc.embedded {
+				require.Equal(t, tc.wantSubs, subs)
+				require.Equal(t, phases.ConvergeCheckPhase, progress.CurrentPhase)
+				require.Equal(t, phases.OperationSubPhase(phases.CheckConfiguration), progress.CompletedSubPhase)
+				return
+			}
+
+			require.Equal(t, phases.OperationCheck, progress.Operation)
+			require.Equal(t, 1.0, progress.Progress)
+			require.Equal(t, phases.CheckConfiguration, progress.CompletedPhase)
+
+			for _, phase := range tc.exec {
+				i := slices.IndexFunc(progress.Phases, func(p phases.PhaseWithSubPhases) bool { return p.Phase == phase })
+				require.NotEqual(t, -1, i)
+				require.NotNil(t, progress.Phases[i].Action)
+				require.NotEqual(t, phases.ProgressActionSkip, *progress.Phases[i].Action)
+			}
+		})
+	}
+}
+
+func runCheckerProgress(
+	t *testing.T, embedded bool, exec ...phases.OperationPhase,
+) (phases.Progress, []phases.OperationSubPhase) {
+	t.Helper()
+
+	var progress phases.Progress
+	var subs []phases.OperationSubPhase
+
+	ctx := t.Context()
+	state := utilcache.NewTestCache()
+
+	var checker *Checker
+	if embedded {
+		checker = NewChecker(&Params{CommanderMode: true, StateCache: state, Embedded: true})
+		parent := phases.NewDefaultPhasedExecutionContext(
+			phases.OperationConverge, nil,
+			func(p phases.Progress) error {
+				progress = p
+				return nil
+			},
+		)
+
+		checker.SetExternalPhasedContext(extCtx{parent: parent, subs: &subs})
+		require.NoError(t, parent.InitPipeline(ctx, state))
+
+		_, err := parent.StartPhase(ctx, phases.ConvergeCheckPhase, false, state)
+		require.NoError(t, err)
+	} else {
+		checker = NewChecker(&Params{
+			CommanderMode: true,
+			StateCache:    state,
+			OnProgressFunc: func(p phases.Progress) error {
+				progress = p
+				return nil
+			},
+		})
+		require.NoError(t, checker.PhasedExecutionContext.InitPipeline(ctx, state))
+	}
+
+	for _, phase := range exec {
+		checker.beginPhase(ctx, phase)
+		checker.completePhase(ctx, phase)
+	}
+
+	if !embedded {
+		require.NoError(t, checker.PhasedExecutionContext.Finalize(ctx, state))
+	}
+
+	return progress, subs
+}
+
+type extCtx struct {
+	parent phases.DefaultPhasedExecutionContext
+	subs   *[]phases.OperationSubPhase
+}
+
+func (e extCtx) CompleteSubPhase(subPhase phases.OperationSubPhase) {
+	*e.subs = append(*e.subs, subPhase)
+	e.parent.CompleteSubPhase(subPhase)
 }

--- a/dhctl/pkg/operations/commander/detach/detacher.go
+++ b/dhctl/pkg/operations/commander/detach/detacher.go
@@ -171,5 +171,10 @@ func (op *Detacher) Detach(ctx context.Context) (err error) {
 		return err
 	}
 
+	err = op.PhasedExecutionContext.CompletePhaseAndPipeline(ctx, stateCache, nil)
+	if err != nil {
+		return fmt.Errorf("unable to complete phase: %w", err)
+	}
+
 	return nil
 }

--- a/dhctl/pkg/operations/phases/phased_execution_context.go
+++ b/dhctl/pkg/operations/phases/phased_execution_context.go
@@ -155,6 +155,11 @@ func (pec *phasedExecutionContext[OperationPhaseDataT]) Finalize(ctx context.Con
 		return nil
 	}
 
+	// Keep the last reported progress when the operation failed mid-phase.
+	if pec.currentPhase != "" && pec.currentPhase != pec.completedPhase {
+		return pec.setLastState(ctx, stateCache)
+	}
+
 	err := pec.progressTracker.Complete(pec.completedPhase)
 	if err != nil {
 		log.ErrorF("Failed to complete progress: %v", err)

--- a/dhctl/pkg/operations/phases/progress_test.go
+++ b/dhctl/pkg/operations/phases/progress_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/operations/phases"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/cache"
 )
 
 var (
@@ -438,6 +439,42 @@ func TestProgressTracker_Progress_CurrentPhase(t *testing.T) {
 	require.NotNil(t, installAdditionalPhase)
 	assert.NotNil(t, installAdditionalPhase.Action)
 	assert.Equal(t, phases.ProgressActionSkip, *installAdditionalPhase.Action)
+}
+
+func TestPhasedExecutionContext_Finalize_DoesNotCompleteOnMidPhaseFailure(t *testing.T) {
+	t.Parallel()
+
+	var lastProgress phases.Progress
+
+	pec := phases.NewDefaultPhasedExecutionContext(
+		phases.OperationBootstrap,
+		func(data phases.OnPhaseFuncData[phases.DefaultContextType]) error { return nil },
+		func(progress phases.Progress) error {
+			lastProgress = progress
+			return nil
+		},
+	)
+
+	state := cache.NewTestCache()
+	ctx := t.Context()
+
+	require.NoError(t, pec.InitPipeline(ctx, state))
+
+	_, err := pec.StartPhase(ctx, phases.ExecuteBashibleBundlePhase, false, state)
+	require.NoError(t, err)
+	require.NoError(t, pec.CompletePhase(ctx, state, nil))
+
+	_, err = pec.SwitchPhase(ctx, phases.CreateResourcesPhase, false, state, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, phases.CreateResourcesPhase, lastProgress.CurrentPhase)
+	require.NotEqual(t, 1.0, lastProgress.Progress)
+
+	require.NoError(t, pec.Finalize(ctx, state))
+
+	require.Equal(t, phases.CreateResourcesPhase, lastProgress.CurrentPhase)
+	require.NotEqual(t, 1.0, lastProgress.Progress)
+	require.NotEqual(t, phases.FinalizationPhase, lastProgress.CompletedPhase)
 }
 
 func readJSONLinesFromFile(t *testing.T, filename string) []phases.Progress {


### PR DESCRIPTION
## Description

Fix incorrect dhctl progress reporting that caused Commander to show 100% progress or mark the wrong phase as failed/completed. `Finalize()` no longer calls `Complete()` when the operation failed mid-phase, so progress stays partial and points to the actual failing step. 

Standalone check now explicitly completes each phase on success, fixing the last phase being reported as skip. Successful Commander detach now calls CompletePhaseAndPipeline so progress reaches 100% on success.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
