### PR TITLE
[local-path-provisioner] Add admin-kubeconfig and user-authz cluster roles

### DIFF
--- a/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
+++ b/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
@@ -85,20 +85,6 @@ rules:
   - deletecollection
   - patch
   - update
-- apiGroups:
-  - deckhouse.io
-  resourceNames:
-  - local-path-provisioner
-  resources:
-  - moduleconfigs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
-  - patch
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
+++ b/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
@@ -65,3 +65,51 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Chart.Name }}
     namespace: d8-{{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - localpathprovisioners
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+- apiGroups:
+  - deckhouse.io
+  resourceNames:
+  - local-path-provisioner
+  resources:
+  - moduleconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: kubeadm:cluster-admins

--- a/modules/031-local-path-provisioner/templates/user-authz-cluster-roles.yaml
+++ b/modules/031-local-path-provisioner/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:{{ .Chart.Name }}:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - localpathprovisioners
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:{{ .Chart.Name }}:cluster-admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - localpathprovisioners
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -189,6 +189,7 @@ read:
     - deckhouse.io/ingressmetrics
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
+    - deckhouse.io/localpathprovisioners
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases
@@ -576,6 +577,7 @@ write:
     - deckhouse.io/ingressistiocontrollers
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
+    - deckhouse.io/localpathprovisioners
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
     - deckhouse.io/projects

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -198,6 +198,7 @@ read:
     - deckhouse.io/ingressmetrics
     - deckhouse.io/instances
     - deckhouse.io/keepalivedinstances
+    - deckhouse.io/localpathprovisioners
     - deckhouse.io/moduledocumentations
     - deckhouse.io/modulepulloverrides
     - deckhouse.io/modulereleases
@@ -585,6 +586,7 @@ write:
     - deckhouse.io/ingressistiocontrollers
     - deckhouse.io/istiofederations
     - deckhouse.io/istiomulticlusters
+    - deckhouse.io/localpathprovisioners
     - deckhouse.io/openstackinstanceclasses
     - deckhouse.io/operationpolicies
     - deckhouse.io/projects


### PR DESCRIPTION
## Description

Adds the standard Deckhouse user-authz / kubeadm-admin RBAC wiring for the cluster-scoped `LocalPathProvisioner` CRD, matching the pattern already used in `admission-policy-engine`, `loki` and `sds-local-volume` ([deckhouse/sds-local-volume#205](https://github.com/deckhouse/sds-local-volume/pull/205/files)).

Two changes:

- `templates/rbac-for-us.yaml` — new `d8:local-path-provisioner:admin-kubeconfig` `ClusterRole` granting full CRUD on `localpathprovisioners.deckhouse.io` and on `moduleconfigs.deckhouse.io` named `local-path-provisioner`, plus a `ClusterRoleBinding` to the `kubeadm:cluster-admins` group. This is what makes the default `kubernetes-admin` kubeconfig from kubeadm capable of creating `LocalPathProvisioner` resources out of the box.
- `templates/user-authz-cluster-roles.yaml` — new `d8:user-authz:local-path-provisioner:user` (read) and `d8:user-authz:local-path-provisioner:cluster-editor` (write) `ClusterRole`s, annotated with `user-authz.deckhouse.io/access-level: User` / `ClusterEditor`, so user-authz subjects pick them up automatically for the same `localpathprovisioners` and `moduleconfigs/local-path-provisioner` objects.

`templates/rbacv2/manage/{edit,view}.yaml` already exists in this module and is left untouched — it aggregates into `rbac.deckhouse.io/aggregate-to-infrastructure-as: manager / viewer`, which is the same shape as `462-loki` uses and is orthogonal to the kubeadm-admin and user-authz flows above.

## Why do we need it, and what problem does it solve?

Reported by user:

```
root@sds-elastic-master-0:~# kubectl create -f localpathprovisioner.yaml
Error from server (Forbidden): error when creating "localpathprovisioner.yaml":
localpathprovisioners.deckhouse.io is forbidden: User "kubernetes-admin"
cannot create resource "localpathprovisioners" in API group "deckhouse.io"
at the cluster scope
```

The default kubeadm `admin.conf` kubeconfig identifies the user as `kubernetes-admin` in the `kubeadm:cluster-admins` group. Until this PR no `ClusterRoleBinding` referenced that group from the `local-path-provisioner` module, so the cluster admin literally could not create a `LocalPathProvisioner` without first hand-crafting a kubeconfig with elevated permissions. After this PR `kubectl create -f localpathprovisioner.yaml` (the example from the user) just works, and downstream users that are mapped to user-authz `User` / `ClusterEditor` roles also see / can manage `LocalPathProvisioner` resources.

## Why do we need it in the patch release (if we do)?

Yes — fixes a usability blocker for the default kubeadm administrator on every supported branch.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: local-path-provisioner
type: fix
summary: Grant the default kubeadm `kubernetes-admin` user (`kubeadm:cluster-admins` group) and the user-authz `User` / `ClusterEditor` access levels permissions on `LocalPathProvisioner` and the module's `ModuleConfig` so that `kubectl create -f` on a `LocalPathProvisioner` no longer fails with "Forbidden".
impact_level: low
```