### PR TITLE
[Node-controller] add metrics and monitoring for node-controller internals

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2661,7 +2661,7 @@ alerts:
         Check node-controller logs:
 
         ```bash
-        kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+        kubectl -n d8-cloud-instance-manager logs deploy/node-controller --all-pods=true
         ```
       summary: |
         Node-controller reconcile errors are high for {{ $labels.controller }}.
@@ -2680,7 +2680,7 @@ alerts:
         To inspect node-controller logs:
 
         ```bash
-        kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+        kubectl -n d8-cloud-instance-manager logs deploy/node-controller --all-pods=true
         ```
       summary: |
         Node-controller reconcile p99 is high for {{ $labels.controller }}.
@@ -2699,7 +2699,7 @@ alerts:
         To inspect node-controller logs:
 
         ```bash
-        kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+        kubectl -n d8-cloud-instance-manager logs deploy/node-controller --all-pods=true
         ```
       summary: |
         Node-controller workqueue {{ $labels.name }} has a high backlog.

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2650,6 +2650,45 @@ alerts:
         Node {{ $labels.node }} is using deprecated containerd v1 – migration to v2 required.
       severity: "8"
       markupFormat: markdown
+    - name: D8NodeControllerReconcileErrorsHigh
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
+      moduleUrl: 040-node-manager
+      module: node-manager
+      edition: ce
+      description: |
+        Controller `{{ $labels.controller }}` has a reconcile error rate above 0.1 errors per second for more than 10 minutes.
+
+        Check node-controller logs and recent NodeGroup or Node changes.
+      summary: |
+        Node-controller reconcile errors are high for {{ $labels.controller }}.
+      severity: "8"
+      markupFormat: markdown
+    - name: D8NodeControllerReconcileP99High
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
+      moduleUrl: 040-node-manager
+      module: node-manager
+      edition: ce
+      description: |
+        The p99 reconcile duration for controller `{{ $labels.controller }}` has been above 5 seconds for more than 10 minutes.
+
+        This may indicate slow reconciliation, Kubernetes API latency, or degraded controller performance.
+      summary: |
+        Node-controller reconcile p99 is high for {{ $labels.controller }}.
+      severity: "8"
+      markupFormat: markdown
+    - name: D8NodeControllerWorkqueueDepthHigh
+      sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
+      moduleUrl: 040-node-manager
+      module: node-manager
+      edition: ce
+      description: |
+        The node-controller workqueue `{{ $labels.name }}` has more than 50 queued objects for more than 15 minutes.
+
+        This may indicate that the controller cannot process reconciliation events fast enough.
+      summary: |
+        Node-controller workqueue {{ $labels.name }} has a high backlog.
+      severity: "8"
+      markupFormat: markdown
     - name: D8NodeGroupIsNotUpdating
       sourceFile: modules/040-node-manager/monitoring/prometheus-rules/node-update.yaml
       moduleUrl: 040-node-manager

--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -2658,7 +2658,11 @@ alerts:
       description: |
         Controller `{{ $labels.controller }}` has a reconcile error rate above 0.1 errors per second for more than 10 minutes.
 
-        Check node-controller logs and recent NodeGroup or Node changes.
+        Check node-controller logs:
+
+        ```bash
+        kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+        ```
       summary: |
         Node-controller reconcile errors are high for {{ $labels.controller }}.
       severity: "8"
@@ -2672,6 +2676,12 @@ alerts:
         The p99 reconcile duration for controller `{{ $labels.controller }}` has been above 5 seconds for more than 10 minutes.
 
         This may indicate slow reconciliation, Kubernetes API latency, or degraded controller performance.
+
+        To inspect node-controller logs:
+
+        ```bash
+        kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+        ```
       summary: |
         Node-controller reconcile p99 is high for {{ $labels.controller }}.
       severity: "8"
@@ -2685,6 +2695,12 @@ alerts:
         The node-controller workqueue `{{ $labels.name }}` has more than 50 queued objects for more than 15 minutes.
 
         This may indicate that the controller cannot process reconciliation events fast enough.
+
+        To inspect node-controller logs:
+
+        ```bash
+        kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+        ```
       summary: |
         Node-controller workqueue {{ $labels.name }} has a high backlog.
       severity: "8"

--- a/ee/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
+++ b/ee/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
@@ -1,0 +1,1552 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 40,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of requests sent by node-controller to the Kubernetes API server per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(\nrate(\nrest_client_requests_total{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}[5m]\n))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rest_client_requests_total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Current Go heap memory usage",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(\ngo_memstats_heap_alloc_bytes{\nnamespace=\"d8-cloud-instance-manager\",\npod=~\"node-controller.*\"\n}\n)/1024/1024",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Go_memstats_heap_alloc_bytes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of reconcile loops executed per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile per second",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of objects waiting in the workqueue",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 9,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue depth",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Duration of the slowest reconcile loops",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile duration p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Total number of objects in the informer cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "objects"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 15,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of objects in Go heap",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 18,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_memstats_heap_objects{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Go_memstats_heap_objects",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of goroutines",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_goroutines{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Num_of_goroutines",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Actual process memory usage in RAM",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 6
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(process_resident_memory_bytes{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"}) / 1024 / 1024",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Process_resident_memory_bytes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of reconcile errors",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Errors count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of controller-runtime client Get/List operations",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation) (\n  rate(node_controller_client_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node_controller_client_requests_total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Cache size by object type",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "objects"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (kind, api_group)(\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{api_group}}/{{kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cache size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Duration of kube-apiserver requests to the node-controller webhook",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le) (\n    rate(rest_client_request_duration_seconds_bucket{\n      job=\"kube-apiserver\",\n      host=\"node-controller-webhook.d8-cloud-instance-manager.svc:443\"\n    }[5m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node controller webhook request duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "GC pause duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Go_gc_duration_seconds p75",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Controllers with the longest reconcile duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (controller, le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile duration p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Controllers with the highest error rate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Controllers with the highest reconcile rate",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Workqueues with accumulated backlog",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": ""
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue depth",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "$ds_prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Node controller metrics",
+  "uid": "dfnfm56h7k7wgf",
+  "version": 18,
+  "weekStart": ""
+}

--- a/ee/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
+++ b/ee/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
@@ -18,15 +18,28 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 40,
+  "id": 45,
   "links": [],
   "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Short stats",
+      "type": "row"
+    },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Number of requests sent by node-controller to the Kubernetes API server per second",
+      "description": "Number of reconcile errors",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -41,12 +54,16 @@
                 "value": null
               },
               {
+                "color": "#EAB839",
+                "value": 0.01
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 0.1
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -54,9 +71,9 @@
         "h": 6,
         "w": 3,
         "x": 0,
-        "y": 0
+        "y": 1
       },
-      "id": 16,
+      "id": 10,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -81,14 +98,297 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(\nrate(\nrest_client_requests_total{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}[5m]\n))",
+          "expr": "sum (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Rest_client_requests_total",
+      "title": "Reconcile Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of objects waiting in the workqueue",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Depth",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Duration of the slowest reconcile loops",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Duration p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Total number of objects in the informer cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "objects"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Informer Cache Objects",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of goroutines",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_goroutines{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
       "type": "stat"
     },
     {
@@ -122,9 +422,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 3,
-        "x": 3,
-        "y": 0
+        "w": 4,
+        "x": 15,
+        "y": 1
       },
       "id": 11,
       "options": {
@@ -163,287 +463,7 @@
           "useBackend": false
         }
       ],
-      "title": "Go_memstats_heap_alloc_bytes",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of reconcile loops executed per second",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 6,
-        "y": 0
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Reconcile per second",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of objects waiting in the workqueue",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 9,
-        "y": 0
-      },
-      "id": 9,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Workqueue depth",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Duration of the slowest reconcile loops",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 12,
-        "y": 0
-      },
-      "id": 7,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.99,\n  sum by (le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Reconcile duration p99",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Total number of objects in the informer cache",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "objects"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 15,
-        "y": 0
-      },
-      "id": 8,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Cache size",
+      "title": "Go Heap Allocated Memory",
       "type": "stat"
     },
     {
@@ -464,10 +484,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -477,8 +493,8 @@
       "gridPos": {
         "h": 6,
         "w": 3,
-        "x": 18,
-        "y": 0
+        "x": 19,
+        "y": 1
       },
       "id": 12,
       "options": {
@@ -512,224 +528,27 @@
           "refId": "A"
         }
       ],
-      "title": "Go_memstats_heap_objects",
+      "title": "Go Heap Objects",
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of goroutines",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
+      "collapsed": false,
       "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 21,
-        "y": 0
-      },
-      "id": 13,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(go_goroutines{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Num_of_goroutines",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Actual process memory usage in RAM",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "mbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
-      "id": 14,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(process_resident_memory_bytes{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"}) / 1024 / 1024",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Process_resident_memory_bytes",
-      "type": "stat"
+      "id": 25,
+      "panels": [],
+      "title": "Resources usage",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Number of reconcile errors",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 3,
-        "y": 6
-      },
-      "id": 10,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Errors count",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of controller-runtime client Get/List operations",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -739,11 +558,11 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "cores",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 30,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -751,60 +570,93 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
             }
           },
+          "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 12
+        "y": 8
       },
-      "id": 18,
+      "id": 23,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "10.4.19",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "datasource": {
@@ -812,14 +664,21 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (operation) (\n  rate(node_controller_client_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
+          "expr": "sum by(pod) (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (rate(container_cpu_usage_seconds_total{node=~\".*\", container!=\"POD\", pod=~\".*\", namespace=\"d8-cloud-instance-manager\"}[$__rate_interval]))\n)",
+          "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
-      "title": "Node_controller_client_requests_total",
+      "title": "Usage by pod",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {}
+        }
+      ],
       "type": "timeseries"
     },
     {
@@ -827,7 +686,7 @@
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Cache size by object type",
+      "description": "The Working set bytes metric is the actual memory used by the container, as it includes active file memory. When its value approaches the limit, the container can be killed by the OOMKiller. This value can be higher than the sum RSS and Cache since not all active file memory is Cache.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -841,7 +700,250 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Working set bytes without kmem"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(0, 0, 0)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Kmem"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(255, 0, 0)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "normal"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_rss{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "RSS",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_cache{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Cache",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_swap{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Swap",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_working_set_bytes:without_kmem{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Working set bytes without kmem",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory:kmem{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Kmem",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Usage by state",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Reconcile stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of webhook requests processed per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -850,9 +952,6 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -875,32 +974,26 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "objects"
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 9,
+        "w": 12,
         "x": 0,
-        "y": 20
+        "y": 18
       },
-      "id": 1,
+      "id": 28,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
-            "max",
-            "mean"
+            "lastNotNull"
           ],
-          "displayMode": "list",
+          "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
@@ -909,7 +1002,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.19",
       "targets": [
         {
           "datasource": {
@@ -917,112 +1009,15 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (kind, api_group)(\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "{{api_group}}/{{kind}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Cache size",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Duration of kube-apiserver requests to the node-controller webhook",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 27
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.95,\n  sum by (le) (\n    rate(rest_client_request_duration_seconds_bucket{\n      job=\"kube-apiserver\",\n      host=\"node-controller-webhook.d8-cloud-instance-manager.svc:443\"\n    }[5m])\n  )\n)",
+          "expr": "sum by (webhook)(\nrate(\ncontroller_runtime_webhook_latency_seconds_count{\nnamespace=\"d8-cloud-instance-manager\",\npod=~\"node-controller.*\"\n}[$__rate_interval]\n))",
           "instant": false,
-          "legendFormat": "__auto",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Node controller webhook request duration p95",
+      "title": "Webhook Request Rate",
       "type": "timeseries"
     },
     {
@@ -1030,7 +1025,7 @@
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "GC pause duration",
+      "description": "Number of Reconcile requests processed per second",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1043,8 +1038,8 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1059,10 +1054,10 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -1075,29 +1070,27 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "ms"
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 18
       },
-      "id": 15,
+      "id": 5,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
@@ -1112,14 +1105,15 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)",
+          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
           "instant": false,
-          "legendFormat": "__auto",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Go_gc_duration_seconds p75",
+      "title": "Reconcile Request Rate",
       "type": "timeseries"
     },
     {
@@ -1172,10 +1166,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -1184,10 +1174,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 27
       },
       "id": 2,
       "options": {
@@ -1219,7 +1209,98 @@
           "refId": "A"
         }
       ],
-      "title": "Reconcile duration p99",
+      "title": "Reconcile Duration p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller)(\ncontroller_runtime_active_workers{\njob=\"node-controller\"\n}\n)",
+          "instant": false,
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
       "type": "timeseries"
     },
     {
@@ -1272,10 +1353,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -1283,10 +1360,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 35
+        "x": 0,
+        "y": 36
       },
       "id": 3,
       "options": {
@@ -1315,7 +1392,7 @@
           "refId": "A"
         }
       ],
-      "title": "Reconcile errors",
+      "title": "Reconcile Error Rate ",
       "type": "timeseries"
     },
     {
@@ -1323,7 +1400,7 @@
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Controllers with the highest reconcile rate",
+      "description": "Number of controller-runtime client Get/List operations",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1336,8 +1413,114 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 100,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation) (\n  rate(node_controller_client_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Client Request Rate by Operation",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 29,
+      "panels": [],
+      "title": "Cache and queue depth",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1375,21 +1558,22 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 9,
+        "w": 24,
         "x": 0,
-        "y": 43
+        "y": 46
       },
-      "id": 5,
+      "id": 30,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -1406,16 +1590,20 @@
             "type": "prometheus",
             "uid": "$ds_prometheus"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "exemplar": false,
+          "expr": "sum by(api_group, kind) (node_controller_cache_objects)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": false,
-          "interval": "1m",
-          "legendFormat": "{{controller}}",
+          "legendFormat": "{{api_group}}/{{kind}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "Reconcile total",
+      "title": "Cache by objects",
       "type": "timeseries"
     },
     {
@@ -1480,9 +1668,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 43
+        "w": 24,
+        "x": 0,
+        "y": 55
       },
       "id": 4,
       "options": {
@@ -1511,10 +1699,138 @@
           "refId": "A"
         }
       ],
-      "title": "Workqueue depth",
+      "title": "Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "GC pause duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC Pause Duration p75",
       "type": "timeseries"
     }
   ],
+  "refresh": "",
   "schemaVersion": 39,
   "tags": [],
   "templating": {
@@ -1522,8 +1838,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "$ds_prometheus"
+          "text": "main",
+          "value": "P0D6E4079E36703EB"
         },
         "hide": 0,
         "includeAll": false,
@@ -1532,6 +1848,7 @@
         "name": "ds_prometheus",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1540,13 +1857,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Node controller metrics",
-  "uid": "dfnfm56h7k7wgf",
-  "version": 18,
+  "title": "Node controller",
+  "uid": "dfnfm56h7k7wg1f",
+  "version": 1,
   "weekStart": ""
 }

--- a/ee/modules/040-node-manager/templates/monitoring.yaml
+++ b/ee/modules/040-node-manager/templates/monitoring.yaml
@@ -23,6 +23,8 @@
 
 {{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager" $prometheusRules) }}
 
+{{- include "helm_lib_single_dashboard" (list . "node-controller" "Kubernetes Cluster" (.Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json")) }}
+
 {{- if not (.Values.global.enabledModules | has "gpu") }}
 {{- if include "nvidia_gpu_enabled" . }}
   {{- include "helm_lib_grafana_dashboard_definitions" . }}

--- a/ee/modules/040-node-manager/templates/monitoring.yaml
+++ b/ee/modules/040-node-manager/templates/monitoring.yaml
@@ -7,6 +7,7 @@
   "monitoring/prometheus-rules/node-unmanaged.tpl"
   "monitoring/prometheus-rules/node-update.yaml"
   "monitoring/prometheus-rules/standby-deployment-unavailable.yaml"
+  "monitoring/prometheus-rules/node-controller.yaml"
 }}
 
 {{- if include "cluster_autoscaler_enabled" . }}

--- a/ee/modules/040-node-manager/templates/monitoring.yaml
+++ b/ee/modules/040-node-manager/templates/monitoring.yaml
@@ -24,11 +24,6 @@
 
 {{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager" $prometheusRules) }}
 
-{{- include "helm_lib_single_dashboard" (list . "node-controller" "Kubernetes Cluster" (.Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json")) }}
+{{- include "helm_lib_grafana_dashboard_definitions" . }}
 
-{{- if not (.Values.global.enabledModules | has "gpu") }}
-{{- if include "nvidia_gpu_enabled" . }}
-  {{- include "helm_lib_grafana_dashboard_definitions" . }}
-{{- end }}
 
-{{- end }}

--- a/modules/040-node-manager/images/node-controller/src/cmd/main.go
+++ b/modules/040-node-manager/images/node-controller/src/cmd/main.go
@@ -117,7 +117,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = mgr.Add(cachemetrics.NewCollector(mgr.GetClient())); err != nil {
+	instrumentedClient := &cachemetrics.InstrumentedClient{
+		Client: mgr.GetClient(),
+	}
+
+	if err = mgr.Add(cachemetrics.NewCollector(instrumentedClient)); err != nil {
 		setupLog.Error(err, "unable to add cache metrics collector")
 		os.Exit(1)
 	}
@@ -135,7 +139,7 @@ func main() {
 	}
 	setupLog.V(1).Info("max-concurrent-reconciles parsed", "default", defaultMaxConcurrent, "perController", perControllerMaxConcurrent)
 
-	if err = register.SetupAll(mgr, disabledControllers, defaultMaxConcurrent, perControllerMaxConcurrent); err != nil {
+	if err = register.SetupAll(mgr, instrumentedClient, disabledControllers, defaultMaxConcurrent, perControllerMaxConcurrent); err != nil {
 		setupLog.Error(err, "unable to setup controllers")
 		os.Exit(1)
 	}

--- a/modules/040-node-manager/images/node-controller/src/cmd/main.go
+++ b/modules/040-node-manager/images/node-controller/src/cmd/main.go
@@ -42,6 +42,7 @@ import (
 	deckhousev1alpha2 "github.com/deckhouse/node-controller/api/deckhouse.io/v1alpha2"
 	mcmv1alpha1 "github.com/deckhouse/node-controller/api/machine.sapcloud.io/v1alpha1"
 	"github.com/deckhouse/node-controller/internal/common"
+	cachemetrics "github.com/deckhouse/node-controller/internal/metrics/cache"
 	"github.com/deckhouse/node-controller/internal/register"
 	_ "github.com/deckhouse/node-controller/internal/register/controllers"
 	"github.com/deckhouse/node-controller/internal/webhook"
@@ -113,6 +114,11 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err = mgr.Add(cachemetrics.NewCollector(mgr.GetClient())); err != nil {
+		setupLog.Error(err, "unable to add cache metrics collector")
 		os.Exit(1)
 	}
 

--- a/modules/040-node-manager/images/node-controller/src/go.mod
+++ b/modules/040-node-manager/images/node-controller/src/go.mod
@@ -3,7 +3,7 @@ module github.com/deckhouse/node-controller
 go 1.24.2
 
 require (
-	github.com/deckhouse/deckhouse v1.74.8
+    github.com/deckhouse/deckhouse v1.74.8
 	github.com/deckhouse/deckhouse/go_lib/dependency/k8s/drain v0.0.0-00010101000000-000000000000
 	github.com/go-logr/logr v1.4.3
 	github.com/prometheus/client_golang v1.22.0

--- a/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/collector.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/collector.go
@@ -20,31 +20,17 @@ import (
 	"context"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	capiv1beta2 "github.com/deckhouse/node-controller/api/cluster.x-k8s.io/v1beta2"
 	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
 	deckhousev1alpha2 "github.com/deckhouse/node-controller/api/deckhouse.io/v1alpha2"
 	mcmv1alpha1 "github.com/deckhouse/node-controller/api/machine.sapcloud.io/v1alpha1"
 )
-
-var cacheObjectsGauge = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Name: "node_controller_cache_objects",
-		Help: "Number of objects currently stored in informer cache",
-	},
-	[]string{"kind", "api_group"},
-)
-
-func init() {
-	ctrlmetrics.Registry.MustRegister(cacheObjectsGauge)
-}
 
 type Collector struct {
 	client client.Client

--- a/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/collector.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/collector.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	capiv1beta2 "github.com/deckhouse/node-controller/api/cluster.x-k8s.io/v1beta2"
+	deckhousev1 "github.com/deckhouse/node-controller/api/deckhouse.io/v1"
+	deckhousev1alpha2 "github.com/deckhouse/node-controller/api/deckhouse.io/v1alpha2"
+	mcmv1alpha1 "github.com/deckhouse/node-controller/api/machine.sapcloud.io/v1alpha1"
+)
+
+var cacheObjectsGauge = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "node_controller_cache_objects",
+		Help: "Number of objects currently stored in informer cache",
+	},
+	[]string{"kind", "api_group"},
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(cacheObjectsGauge)
+}
+
+type Collector struct {
+	client client.Client
+}
+
+func NewCollector(c client.Client) *Collector {
+	return &Collector{
+		client: c,
+	}
+}
+
+func (c *Collector) Start(ctx context.Context) error {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		c.collect(ctx)
+
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-ticker.C:
+		}
+	}
+}
+
+func (c *Collector) collect(ctx context.Context) {
+	_ = c.collectTyped(ctx, "Node", "", &corev1.NodeList{})
+
+	_ = c.collectTyped(ctx, "Secret", "", &corev1.SecretList{})
+
+	_ = c.collectTyped(ctx, "NodeGroup", "deckhouse.io", &deckhousev1.NodeGroupList{})
+
+	_ = c.collectTyped(ctx, "Machine", "machine.sapcloud.io", &mcmv1alpha1.MachineList{})
+
+	_ = c.collectTyped(ctx, "Machine", "cluster.x-k8s.io", &capiv1beta2.MachineList{})
+
+	_ = c.collectTyped(ctx, "Instance", "deckhouse.io", &deckhousev1alpha2.InstanceList{})
+
+	_ = c.collectUnstructured(
+		ctx,
+		"MachineDeployment",
+		"machine.sapcloud.io",
+		schema.GroupVersionKind{
+			Group:   "machine.sapcloud.io",
+			Version: "v1alpha1",
+			Kind:    "MachineDeploymentList",
+		},
+	)
+
+	_ = c.collectUnstructured(
+		ctx,
+		"MachineDeployment",
+		"cluster.x-k8s.io",
+		schema.GroupVersionKind{
+			Group:   "cluster.x-k8s.io",
+			Version: "v1beta2",
+			Kind:    "MachineDeploymentList",
+		},
+	)
+}
+
+func (c *Collector) collectTyped(
+	ctx context.Context,
+	kind string,
+	apiGroup string,
+	list client.ObjectList,
+) error {
+	if err := c.client.List(ctx, list); err != nil {
+		return err
+	}
+
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return err
+	}
+
+	cacheObjectsGauge.WithLabelValues(kind, apiGroup).Set(float64(len(items)))
+	return nil
+}
+
+func (c *Collector) collectUnstructured(
+	ctx context.Context,
+	kind string,
+	apiGroup string,
+	gvk schema.GroupVersionKind,
+) error {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(gvk)
+
+	if err := c.client.List(ctx, list); err != nil {
+		return err
+	}
+
+	cacheObjectsGauge.WithLabelValues(
+		kind,
+		apiGroup,
+	).Set(float64(len(list.Items)))
+
+	return nil
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/instrumented_client.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/instrumented_client.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type InstrumentedClient struct {
+	client.Client
+}
+
+func (c *InstrumentedClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	cacheRequestsTotal.WithLabelValues("get").Inc()
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *InstrumentedClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	cacheRequestsTotal.WithLabelValues("list").Inc()
+	return c.Client.List(ctx, list, opts...)
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/metrics.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/metrics.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	cacheObjectsGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "node_controller_cache_objects",
+			Help: "Number of objects currently stored in informer cache",
+		},
+		[]string{"kind", "api_group"},
+	)
+
+	cacheRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_controller_cache_requests_total",
+			Help: "Number of cache requests",
+		},
+		[]string{"operation"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		cacheObjectsGauge,
+		cacheRequestsTotal,
+	)
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/metrics.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/metrics/cache/metrics.go
@@ -32,8 +32,8 @@ var (
 
 	cacheRequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "node_controller_cache_requests_total",
-			Help: "Number of cache requests",
+			Name: "node_controller_client_requests_total",
+			Help: "Total number of controller-runtime client Get/List requests",
 		},
 		[]string{"operation"},
 	)

--- a/modules/040-node-manager/images/node-controller/src/internal/metrics/monitoring/grafana-dashboards/node-controller.json
+++ b/modules/040-node-manager/images/node-controller/src/internal/metrics/monitoring/grafana-dashboards/node-controller.json
@@ -1,0 +1,1437 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 40,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 0
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(\nrate(\nrest_client_requests_total{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}[5m]\n))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "rest_client_requests_total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "code",
+          "expr": "go_memstats_heap_alloc_bytes{\n\npod=~\"node-controller.*\"\n\n} /1024/1024",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "go_memstats_heap_alloc_bytes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 6,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "reconcile per second",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 9,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "workqueue depth",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "reconcile duration p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "objects"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 15,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum (\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "cache size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 18,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_memstats_heap_objects{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "go_memstats_heap_objects",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_goroutines{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Num_of_goroutines",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "mbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 6
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum(process_resident_memory_bytes{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"}) / 1024 / 1024",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "process_resident_memory_bytes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "erros coint",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "objects"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (kind, api_group)(\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{api_group}}/{{kind}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "cache size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 19
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le) (\n    rate(rest_client_request_duration_seconds_bucket{\n      job=\"kube-apiserver\",\n      host=\"node-controller-webhook.d8-cloud-instance-manager.svc:443\"\n    }[5m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "rest_client_request_duration_seconds_bucket",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "go_gc_duration_seconds p75",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (controller, le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile duration p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "instant": false,
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": ""
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (name) (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue depth",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "$ds_prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "ds_prometheus",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Node controller metrics",
+  "uid": "dfnfm56h7k7wgf",
+  "version": 12,
+  "weekStart": ""
+}

--- a/modules/040-node-manager/images/node-controller/src/internal/register/register.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/register/register.go
@@ -36,7 +36,7 @@ func RegisterController(name string, obj client.Object, r Reconciler) {
 	entries = append(entries, entry{name: name, obj: obj, reconciler: r})
 }
 
-func SetupAll(mgr ctrl.Manager, disabledControllers string, defaultMaxConcurrent int, perControllerMaxConcurrent map[string]int) error {
+func SetupAll(mgr ctrl.Manager, c client.Client, disabledControllers string, defaultMaxConcurrent int, perControllerMaxConcurrent map[string]int) error {
 	setupLog := ctrl.Log.WithName("setup")
 
 	disabled := make(map[string]bool)
@@ -70,7 +70,7 @@ func SetupAll(mgr ctrl.Manager, disabledControllers string, defaultMaxConcurrent
 			maxConcurrent = v
 		}
 
-		if err := setupController(mgr, e.name, e.obj, e.reconciler, maxConcurrent); err != nil {
+		if err := setupController(mgr, c, e.name, e.obj, e.reconciler, maxConcurrent); err != nil {
 			return fmt.Errorf("setting up controller %s: %w", e.name, err)
 		}
 		setupLog.Info("controller enabled", "controller", e.name, "maxConcurrentReconciles", maxConcurrent)

--- a/modules/040-node-manager/images/node-controller/src/internal/register/setup.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/register/setup.go
@@ -24,13 +24,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
-func setupController(mgr ctrl.Manager, name string, obj client.Object, r Reconciler, maxConcurrentReconciles int) error {
+func setupController(mgr ctrl.Manager, c client.Client, name string, obj client.Object, r Reconciler, maxConcurrentReconciles int) error {
 	if maxConcurrentReconciles < 1 {
 		maxConcurrentReconciles = 1
 	}
 
 	if v, ok := r.(NeedsClient); ok {
-		v.InjectClient(mgr.GetClient())
+		v.InjectClient(c)
 	}
 	if v, ok := r.(NeedsRecorder); ok {
 		v.InjectRecorder(mgr.GetEventRecorderFor(name))

--- a/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
+++ b/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
@@ -26,6 +26,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Сколько запросов node-controller отправляет в Kubernetes API server в секунду",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -87,7 +88,7 @@
           "refId": "A"
         }
       ],
-      "title": "rest_client_requests_total",
+      "title": "Rest_client_requests_total",
       "type": "stat"
     },
     {
@@ -95,6 +96,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Сколько памяти сейчас занято Go heap",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -150,17 +152,18 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "go_memstats_heap_alloc_bytes{\n\npod=~\"node-controller.*\"\n\n} /1024/1024",
+          "exemplar": false,
+          "expr": "sum(\ngo_memstats_heap_alloc_bytes{\nnamespace=\"d8-cloud-instance-manager\",\npod=~\"node-controller.*\"\n}\n)/1024/1024",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
-          "instant": false,
+          "instant": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
           "refId": "A",
           "useBackend": false
         }
       ],
-      "title": "go_memstats_heap_alloc_bytes",
+      "title": "Go_memstats_heap_alloc_bytes",
       "type": "stat"
     },
     {
@@ -168,6 +171,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Сколько reconcile-циклов выполняется в секунду",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -229,7 +233,7 @@
           "refId": "A"
         }
       ],
-      "title": "reconcile per second",
+      "title": "Reconcile per second",
       "type": "stat"
     },
     {
@@ -237,6 +241,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Сколько объектов ждёт обработки в очереди",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -298,7 +303,7 @@
           "refId": "A"
         }
       ],
-      "title": "workqueue depth",
+      "title": "Workqueue depth",
       "type": "stat"
     },
     {
@@ -306,6 +311,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Насколько долго выполняются самые медленные reconcile",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -367,7 +373,7 @@
           "refId": "A"
         }
       ],
-      "title": "reconcile duration p99",
+      "title": "Reconcile duration p99",
       "type": "stat"
     },
     {
@@ -375,6 +381,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Сколько объектов всего лежит в informer cache",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -436,7 +443,7 @@
           "refId": "A"
         }
       ],
-      "title": "cache size",
+      "title": "Cache size",
       "type": "stat"
     },
     {
@@ -444,6 +451,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Количество объектов в Go heap",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -504,7 +512,7 @@
           "refId": "A"
         }
       ],
-      "title": "go_memstats_heap_objects",
+      "title": "Go_memstats_heap_objects",
       "type": "stat"
     },
     {
@@ -512,6 +520,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Количество goroutine",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -580,7 +589,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "",
+      "description": "Реальная память процесса в RAM",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -642,7 +651,7 @@
           "refId": "A"
         }
       ],
-      "title": "process_resident_memory_bytes",
+      "title": "Process_resident_memory_bytes",
       "type": "stat"
     },
     {
@@ -650,6 +659,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Количество ошибок reconcile",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -711,7 +721,7 @@
           "refId": "A"
         }
       ],
-      "title": "erros coint",
+      "title": "Erros count",
       "type": "stat"
     },
     {
@@ -719,6 +729,105 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Сколько раз код controller-а обращается к cache через Get/List",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation) (\n  rate(node_controller_cache_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Node_controller_client_requests_total",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "description": "Размер cache по типам объектов",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -781,7 +890,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 20
       },
       "id": 1,
       "options": {
@@ -816,7 +925,7 @@
           "refId": "A"
         }
       ],
-      "title": "cache size",
+      "title": "Сache size",
       "type": "timeseries"
     },
     {
@@ -824,6 +933,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Длительность запросов kube-apiserver к webhook node-controller",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -883,7 +993,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 27
       },
       "id": 17,
       "options": {
@@ -912,7 +1022,7 @@
           "refId": "A"
         }
       ],
-      "title": "rest_client_request_duration_seconds_bucket",
+      "title": "Node controller webhook request duration p95",
       "type": "timeseries"
     },
     {
@@ -920,6 +1030,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Длительность GC-пауз",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -979,7 +1090,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 27
       },
       "id": 15,
       "options": {
@@ -1008,7 +1119,7 @@
           "refId": "A"
         }
       ],
-      "title": "go_gc_duration_seconds p75",
+      "title": "Go_gc_duration_seconds p75",
       "type": "timeseries"
     },
     {
@@ -1016,6 +1127,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Какие контроллеры выполняются дольше всего",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1075,7 +1187,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 35
       },
       "id": 2,
       "options": {
@@ -1115,6 +1227,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "У каких контроллеров чаще ошибки",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1173,7 +1286,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 35
       },
       "id": 3,
       "options": {
@@ -1210,6 +1323,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "Какие контроллеры чаще всего запускаются",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1269,7 +1383,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 43
       },
       "id": 5,
       "options": {
@@ -1309,6 +1423,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
+      "description": "У каких очередей накапливается backlog",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1367,7 +1482,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 43
       },
       "id": 4,
       "options": {
@@ -1432,6 +1547,6 @@
   "timezone": "browser",
   "title": "Node controller metrics",
   "uid": "dfnfm56h7k7wgf",
-  "version": 12,
+  "version": 18,
   "weekStart": ""
 }

--- a/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
+++ b/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
@@ -26,7 +26,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Сколько запросов node-controller отправляет в Kubernetes API server в секунду",
+      "description": "Number of requests sent by node-controller to the Kubernetes API server per second",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -96,7 +96,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Сколько памяти сейчас занято Go heap",
+      "description": "Current Go heap memory usage",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -171,7 +171,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Сколько reconcile-циклов выполняется в секунду",
+      "description": "Number of reconcile loops executed per second",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -241,7 +241,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Сколько объектов ждёт обработки в очереди",
+      "description": "Number of objects waiting in the workqueue",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -311,7 +311,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Насколько долго выполняются самые медленные reconcile",
+      "description": "Duration of the slowest reconcile loops",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -381,7 +381,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Сколько объектов всего лежит в informer cache",
+      "description": "Total number of objects in the informer cache",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -451,7 +451,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Количество объектов в Go heap",
+      "description": "Number of objects in Go heap",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -520,7 +520,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Количество goroutine",
+      "description": "Number of goroutines",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -589,7 +589,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Реальная память процесса в RAM",
+      "description": "Actual process memory usage in RAM",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -659,7 +659,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Количество ошибок reconcile",
+      "description": "Number of reconcile errors",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -729,7 +729,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Сколько раз код controller-а обращается к cache через Get/List",
+      "description": "Number of controller-runtime client Get/List operations",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -827,7 +827,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Размер cache по типам объектов",
+      "description": "Cache size by object type",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -933,7 +933,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Длительность запросов kube-apiserver к webhook node-controller",
+      "description": "Duration of kube-apiserver requests to the node-controller webhook",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1030,7 +1030,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Длительность GC-пауз",
+      "description": "GC pause duration",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1127,7 +1127,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Какие контроллеры выполняются дольше всего",
+      "description": "Controllers with the longest reconcile duration",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1227,7 +1227,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "У каких контроллеров чаще ошибки",
+      "description": "Controllers with the highest error rate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1323,7 +1323,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "Какие контроллеры чаще всего запускаются",
+      "description": "Controllers with the highest reconcile rate",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1423,7 +1423,7 @@
         "type": "prometheus",
         "uid": "${ds_prometheus}"
       },
-      "description": "У каких очередей накапливается backlog",
+      "description": "Workqueues with accumulated backlog",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
+++ b/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
@@ -18,15 +18,28 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 40,
+  "id": 45,
   "links": [],
   "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 26,
+      "panels": [],
+      "title": "Short stats",
+      "type": "row"
+    },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Number of requests sent by node-controller to the Kubernetes API server per second",
+      "description": "Number of reconcile errors",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -41,12 +54,16 @@
                 "value": null
               },
               {
+                "color": "#EAB839",
+                "value": 0.01
+              },
+              {
                 "color": "red",
-                "value": 80
+                "value": 0.1
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -54,9 +71,9 @@
         "h": 6,
         "w": 3,
         "x": 0,
-        "y": 0
+        "y": 1
       },
-      "id": 16,
+      "id": 10,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
@@ -81,14 +98,297 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(\nrate(\nrest_client_requests_total{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}[5m]\n))",
+          "expr": "sum (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Rest_client_requests_total",
+      "title": "Reconcile Error Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of objects waiting in the workqueue",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Workqueue Depth",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Duration of the slowest reconcile loops",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reconcile Duration p99",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Total number of objects in the informer cache",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "objects"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Informer Cache Objects",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of goroutines",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(go_goroutines{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Goroutines",
       "type": "stat"
     },
     {
@@ -122,9 +422,9 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 3,
-        "x": 3,
-        "y": 0
+        "w": 4,
+        "x": 15,
+        "y": 1
       },
       "id": 11,
       "options": {
@@ -163,287 +463,7 @@
           "useBackend": false
         }
       ],
-      "title": "Go_memstats_heap_alloc_bytes",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of reconcile loops executed per second",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 6,
-        "y": 0
-      },
-      "id": 6,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Reconcile per second",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of objects waiting in the workqueue",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 9,
-        "y": 0
-      },
-      "id": 9,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Workqueue depth",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Duration of the slowest reconcile loops",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 12,
-        "y": 0
-      },
-      "id": 7,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.99,\n  sum by (le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Reconcile duration p99",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Total number of objects in the informer cache",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "objects"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 15,
-        "y": 0
-      },
-      "id": 8,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Cache size",
+      "title": "Go Heap Allocated Memory",
       "type": "stat"
     },
     {
@@ -464,10 +484,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -477,8 +493,8 @@
       "gridPos": {
         "h": 6,
         "w": 3,
-        "x": 18,
-        "y": 0
+        "x": 19,
+        "y": 1
       },
       "id": 12,
       "options": {
@@ -512,224 +528,27 @@
           "refId": "A"
         }
       ],
-      "title": "Go_memstats_heap_objects",
+      "title": "Go Heap Objects",
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of goroutines",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
+      "collapsed": false,
       "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 21,
-        "y": 0
-      },
-      "id": 13,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(go_goroutines{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Num_of_goroutines",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Actual process memory usage in RAM",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "mbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
-      "id": 14,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(process_resident_memory_bytes{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"}) / 1024 / 1024",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Process_resident_memory_bytes",
-      "type": "stat"
+      "id": 25,
+      "panels": [],
+      "title": "Resources usage",
+      "type": "row"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Number of reconcile errors",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 3,
-        "x": 3,
-        "y": 6
-      },
-      "id": 10,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "10.4.19",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Errors count",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Number of controller-runtime client Get/List operations",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -739,11 +558,11 @@
             "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
-            "axisLabel": "",
+            "axisLabel": "cores",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 30,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -751,60 +570,93 @@
               "viz": false
             },
             "insertNulls": false,
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
               "type": "linear"
             },
-            "showPoints": "auto",
+            "showPoints": "never",
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
             }
           },
+          "links": [],
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total"
+            },
+            "properties": [
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 0
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 12
+        "y": 8
       },
-      "id": 18,
+      "id": 23,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
         },
         "tooltip": {
-          "mode": "single",
-          "sort": "none"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
-      "pluginVersion": "10.4.19",
+      "pluginVersion": "8.5.13",
       "targets": [
         {
           "datasource": {
@@ -812,14 +664,21 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (operation) (\n  rate(node_controller_client_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
+          "expr": "sum by(pod) (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (rate(container_cpu_usage_seconds_total{node=~\".*\", container!=\"POD\", pod=~\".*\", namespace=\"d8-cloud-instance-manager\"}[$__rate_interval]))\n)",
+          "format": "time_series",
           "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
+          "intervalFactor": 1,
+          "legendFormat": "{{ pod }}",
           "refId": "A"
         }
       ],
-      "title": "Node_controller_client_requests_total",
+      "title": "Usage by pod",
+      "transformations": [
+        {
+          "id": "calculateField",
+          "options": {}
+        }
+      ],
       "type": "timeseries"
     },
     {
@@ -827,7 +686,7 @@
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Cache size by object type",
+      "description": "The Working set bytes metric is the actual memory used by the container, as it includes active file memory. When its value approaches the limit, the container can be killed by the OOMKiller. This value can be higher than the sum RSS and Cache since not all active file memory is Cache.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -841,7 +700,250 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Working set bytes without kmem"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(0, 0, 0)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "none"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Kmem"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgb(255, 0, 0)",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              },
+              {
+                "id": "custom.stacking",
+                "value": {
+                  "group": false,
+                  "mode": "normal"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "8.5.13",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_rss{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "RSS",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_cache{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Cache",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_swap{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Swap",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory_working_set_bytes:without_kmem{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Working set bytes without kmem",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (\n  max(kube_controller_pod{node=~\".*\", namespace=\"d8-cloud-instance-manager\", controller=\"deploy/node-controller\", pod=~\".*\"}) by(pod)\n  * on (pod)\n  sum by (pod) (avg_over_time(container_memory:kmem{node=~\".*\", namespace=\"d8-cloud-instance-manager\", pod=~\".*\", container!=\"POD\"}[$__rate_interval]))\n)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "Kmem",
+          "range": true,
+          "refId": "E"
+        }
+      ],
+      "title": "Usage by state",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Reconcile stats",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "Number of webhook requests processed per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -850,9 +952,6 @@
             },
             "insertNulls": false,
             "lineInterpolation": "linear",
-            "lineStyle": {
-              "fill": "solid"
-            },
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -875,32 +974,26 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "objects"
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 9,
+        "w": 12,
         "x": 0,
-        "y": 20
+        "y": 18
       },
-      "id": 1,
+      "id": 28,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull",
-            "max",
-            "mean"
+            "lastNotNull"
           ],
-          "displayMode": "list",
+          "displayMode": "table",
           "placement": "right",
           "showLegend": true
         },
@@ -909,7 +1002,6 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "10.4.19",
       "targets": [
         {
           "datasource": {
@@ -917,112 +1009,15 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (kind, api_group)(\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "{{api_group}}/{{kind}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Cache size",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$ds_prometheus"
-      },
-      "description": "Duration of kube-apiserver requests to the node-controller webhook",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "ms"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 27
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$ds_prometheus"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(\n  0.95,\n  sum by (le) (\n    rate(rest_client_request_duration_seconds_bucket{\n      job=\"kube-apiserver\",\n      host=\"node-controller-webhook.d8-cloud-instance-manager.svc:443\"\n    }[5m])\n  )\n)",
+          "expr": "sum by (webhook)(\nrate(\ncontroller_runtime_webhook_latency_seconds_count{\nnamespace=\"d8-cloud-instance-manager\",\npod=~\"node-controller.*\"\n}[$__rate_interval]\n))",
           "instant": false,
-          "legendFormat": "__auto",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Node controller webhook request duration p95",
+      "title": "Webhook Request Rate",
       "type": "timeseries"
     },
     {
@@ -1030,7 +1025,7 @@
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "GC pause duration",
+      "description": "Number of Reconcile requests processed per second",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1043,8 +1038,8 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 100,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1059,10 +1054,10 @@
               "type": "linear"
             },
             "showPoints": "auto",
-            "spanNulls": false,
+            "spanNulls": true,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -1075,29 +1070,27 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
-          "unit": "ms"
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 18
       },
-      "id": 15,
+      "id": 5,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
@@ -1112,14 +1105,15 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)",
+          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
           "instant": false,
-          "legendFormat": "__auto",
+          "interval": "1m",
+          "legendFormat": "{{controller}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Go_gc_duration_seconds p75",
+      "title": "Reconcile Request Rate",
       "type": "timeseries"
     },
     {
@@ -1172,10 +1166,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           },
@@ -1184,10 +1174,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 27
       },
       "id": 2,
       "options": {
@@ -1219,7 +1209,98 @@
           "refId": "A"
         }
       ],
-      "title": "Reconcile duration p99",
+      "title": "Reconcile Duration p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 21,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by(controller)(\ncontroller_runtime_active_workers{\njob=\"node-controller\"\n}\n)",
+          "instant": false,
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
       "type": "timeseries"
     },
     {
@@ -1272,10 +1353,6 @@
               {
                 "color": "green",
                 "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
               }
             ]
           }
@@ -1283,10 +1360,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 35
+        "x": 0,
+        "y": 36
       },
       "id": 3,
       "options": {
@@ -1315,7 +1392,7 @@
           "refId": "A"
         }
       ],
-      "title": "Reconcile errors",
+      "title": "Reconcile Error Rate ",
       "type": "timeseries"
     },
     {
@@ -1323,7 +1400,7 @@
         "type": "prometheus",
         "uid": "$ds_prometheus"
       },
-      "description": "Controllers with the highest reconcile rate",
+      "description": "Number of controller-runtime client Get/List operations",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1336,8 +1413,114 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
-            "drawStyle": "bars",
-            "fillOpacity": 100,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation) (\n  rate(node_controller_client_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Client Request Rate by Operation",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "id": 29,
+      "panels": [],
+      "title": "Cache and queue depth",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -1375,21 +1558,22 @@
               }
             ]
           },
-          "unit": "reqps"
+          "unit": "short"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 9,
+        "w": 24,
         "x": 0,
-        "y": 43
+        "y": 46
       },
-      "id": 5,
+      "id": 30,
       "options": {
         "legend": {
           "calcs": [
-            "lastNotNull"
+            "lastNotNull",
+            "max"
           ],
           "displayMode": "table",
           "placement": "right",
@@ -1406,16 +1590,20 @@
             "type": "prometheus",
             "uid": "$ds_prometheus"
           },
+          "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
+          "exemplar": false,
+          "expr": "sum by(api_group, kind) (node_controller_cache_objects)",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
           "instant": false,
-          "interval": "1m",
-          "legendFormat": "{{controller}}",
+          "legendFormat": "{{api_group}}/{{kind}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "useBackend": false
         }
       ],
-      "title": "Reconcile total",
+      "title": "Cache by objects",
       "type": "timeseries"
     },
     {
@@ -1480,9 +1668,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 43
+        "w": 24,
+        "x": 0,
+        "y": 55
       },
       "id": 4,
       "options": {
@@ -1511,10 +1699,138 @@
           "refId": "A"
         }
       ],
-      "title": "Workqueue depth",
+      "title": "Workqueue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$ds_prometheus"
+      },
+      "description": "GC pause duration",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$ds_prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC Pause Duration p75",
       "type": "timeseries"
     }
   ],
+  "refresh": "",
   "schemaVersion": 39,
   "tags": [],
   "templating": {
@@ -1522,8 +1838,8 @@
       {
         "current": {
           "selected": false,
-          "text": "Prometheus",
-          "value": "$ds_prometheus"
+          "text": "main",
+          "value": "P0D6E4079E36703EB"
         },
         "hide": 0,
         "includeAll": false,
@@ -1532,6 +1848,7 @@
         "name": "ds_prometheus",
         "options": [],
         "query": "prometheus",
+        "queryValue": "",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1540,13 +1857,13 @@
     ]
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Node controller metrics",
-  "uid": "dfnfm56h7k7wgf",
-  "version": 18,
+  "title": "Node controller",
+  "uid": "dfnfm56h7k7wg1f",
+  "version": 1,
   "weekStart": ""
 }

--- a/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
+++ b/modules/040-node-manager/monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json
@@ -24,7 +24,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Number of requests sent by node-controller to the Kubernetes API server per second",
       "fieldConfig": {
@@ -78,7 +78,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum(\nrate(\nrest_client_requests_total{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}[5m]\n))",
@@ -94,7 +94,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Current Go heap memory usage",
       "fieldConfig": {
@@ -148,7 +148,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -169,7 +169,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Number of reconcile loops executed per second",
       "fieldConfig": {
@@ -223,7 +223,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
@@ -239,7 +239,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Number of objects waiting in the workqueue",
       "fieldConfig": {
@@ -293,7 +293,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",
@@ -309,7 +309,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Duration of the slowest reconcile loops",
       "fieldConfig": {
@@ -363,7 +363,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(\n  0.99,\n  sum by (le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
@@ -379,7 +379,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Total number of objects in the informer cache",
       "fieldConfig": {
@@ -433,7 +433,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum (\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
@@ -449,7 +449,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Number of objects in Go heap",
       "fieldConfig": {
@@ -502,7 +502,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum(go_memstats_heap_objects{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
@@ -518,7 +518,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Number of goroutines",
       "fieldConfig": {
@@ -571,7 +571,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum(go_goroutines{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"})",
@@ -587,7 +587,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Actual process memory usage in RAM",
       "fieldConfig": {
@@ -641,7 +641,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum(process_resident_memory_bytes{namespace=\"d8-cloud-instance-manager\", pod=~\"node-controller.*\"}) / 1024 / 1024",
@@ -657,7 +657,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Number of reconcile errors",
       "fieldConfig": {
@@ -711,7 +711,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
@@ -721,13 +721,13 @@
           "refId": "A"
         }
       ],
-      "title": "Erros count",
+      "title": "Errors count",
       "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Number of controller-runtime client Get/List operations",
       "fieldConfig": {
@@ -809,10 +809,10 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (operation) (\n  rate(node_controller_cache_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
+          "expr": "sum by (operation) (\n  rate(node_controller_client_requests_total{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\"\n  }[$__rate_interval])\n)",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -825,7 +825,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Cache size by object type",
       "fieldConfig": {
@@ -914,7 +914,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum by (kind, api_group)(\nnode_controller_cache_objects{\nnamespace=\"d8-cloud-instance-manager\",\njob=\"node-controller\"\n}\n)",
@@ -925,13 +925,13 @@
           "refId": "A"
         }
       ],
-      "title": "Сache size",
+      "title": "Cache size",
       "type": "timeseries"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Duration of kube-apiserver requests to the node-controller webhook",
       "fieldConfig": {
@@ -1012,7 +1012,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(\n  0.95,\n  sum by (le) (\n    rate(rest_client_request_duration_seconds_bucket{\n      job=\"kube-apiserver\",\n      host=\"node-controller-webhook.d8-cloud-instance-manager.svc:443\"\n    }[5m])\n  )\n)",
@@ -1028,7 +1028,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "GC pause duration",
       "fieldConfig": {
@@ -1109,7 +1109,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "max(\n  go_gc_duration_seconds{\n    namespace=\"d8-cloud-instance-manager\",\n    pod=~\"node-controller.*\",\n    quantile=\"0.75\"\n  }\n)",
@@ -1125,7 +1125,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Controllers with the longest reconcile duration",
       "fieldConfig": {
@@ -1209,7 +1209,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "histogram_quantile(\n  0.99,\n  sum by (controller, le) (\n    rate(controller_runtime_reconcile_time_seconds_bucket{\n      namespace=\"d8-cloud-instance-manager\",\n      job=\"node-controller\"\n    }[1m])\n  )\n)",
@@ -1225,7 +1225,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Controllers with the highest error rate",
       "fieldConfig": {
@@ -1305,7 +1305,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_errors_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
@@ -1321,7 +1321,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Controllers with the highest reconcile rate",
       "fieldConfig": {
@@ -1404,7 +1404,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum by (controller) (\n  rate(controller_runtime_reconcile_total{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }[1m])\n)",
@@ -1421,7 +1421,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${ds_prometheus}"
+        "uid": "$ds_prometheus"
       },
       "description": "Workqueues with accumulated backlog",
       "fieldConfig": {
@@ -1501,7 +1501,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${ds_prometheus}"
+            "uid": "$ds_prometheus"
           },
           "editorMode": "code",
           "expr": "sum by (name) (\n  workqueue_depth{\n    namespace=\"d8-cloud-instance-manager\",\n    job=\"node-controller\"\n  }\n)",

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
@@ -24,7 +24,7 @@
           To inspect node-controller logs:
 
           ```bash
-          kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+          kubectl -n d8-cloud-instance-manager logs deploy/node-controller --all-pods=true
           ```
 
     - alert: D8NodeControllerReconcileP99High
@@ -54,7 +54,7 @@
           To inspect node-controller logs:
 
           ```bash
-          kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+          kubectl -n d8-cloud-instance-manager logs deploy/node-controller --all-pods=true
           ```
 
     - alert: D8NodeControllerReconcileErrorsHigh
@@ -79,5 +79,5 @@
           Check node-controller logs:
 
           ```bash
-          kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+          kubectl -n d8-cloud-instance-manager logs deploy/node-controller --all-pods=true
           ```

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
@@ -21,6 +21,12 @@
 
           This may indicate that the controller cannot process reconciliation events fast enough.
 
+          To inspect node-controller logs:
+
+          ```bash
+          kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+          ```
+
     - alert: D8NodeControllerReconcileP99High
       expr: |
         histogram_quantile(
@@ -45,6 +51,12 @@
 
           This may indicate slow reconciliation, Kubernetes API latency, or degraded controller performance.
 
+          To inspect node-controller logs:
+
+          ```bash
+          kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+          ```
+
     - alert: D8NodeControllerReconcileErrorsHigh
       expr: |
         sum by (controller) (
@@ -64,4 +76,8 @@
         description: |
           Controller `{{ $labels.controller }}` has a reconcile error rate above 0.1 errors per second for more than 10 minutes.
 
-          Check node-controller logs and recent NodeGroup or Node changes.
+          Check node-controller logs:
+
+          ```bash
+          kubectl -n d8-cloud-instance-manager logs deploy/node-controller
+          ```

--- a/modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
+++ b/modules/040-node-manager/monitoring/prometheus-rules/node-controller.yaml
@@ -1,0 +1,67 @@
+- name: d8.node-controller
+  rules:
+    - alert: D8NodeControllerWorkqueueDepthHigh
+      expr: |
+        max by (name) (
+          workqueue_depth{
+            namespace="d8-cloud-instance-manager",
+            job="node-controller"
+          }
+        ) > 50
+      for: 15m
+      labels:
+        tier: cluster
+        severity_level: "8"
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        summary: Node-controller workqueue {{ $labels.name }} has a high backlog.
+        description: |
+          The node-controller workqueue `{{ $labels.name }}` has more than 50 queued objects for more than 15 minutes.
+
+          This may indicate that the controller cannot process reconciliation events fast enough.
+
+    - alert: D8NodeControllerReconcileP99High
+      expr: |
+        histogram_quantile(
+          0.99,
+          sum by (controller, le) (
+            rate(controller_runtime_reconcile_time_seconds_bucket{
+              namespace="d8-cloud-instance-manager",
+              job="node-controller"
+            }[5m])
+          )
+        ) > 5
+      for: 10m
+      labels:
+        tier: cluster
+        severity_level: "8"
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        summary: Node-controller reconcile p99 is high for {{ $labels.controller }}.
+        description: |
+          The p99 reconcile duration for controller `{{ $labels.controller }}` has been above 5 seconds for more than 10 minutes.
+
+          This may indicate slow reconciliation, Kubernetes API latency, or degraded controller performance.
+
+    - alert: D8NodeControllerReconcileErrorsHigh
+      expr: |
+        sum by (controller) (
+          rate(controller_runtime_reconcile_errors_total{
+            namespace="d8-cloud-instance-manager",
+            job="node-controller"
+          }[5m])
+        ) > 0.1
+      for: 10m
+      labels:
+        tier: cluster
+        severity_level: "8"
+      annotations:
+        plk_markup_format: markdown
+        plk_protocol_version: "1"
+        summary: Node-controller reconcile errors are high for {{ $labels.controller }}.
+        description: |
+          Controller `{{ $labels.controller }}` has a reconcile error rate above 0.1 errors per second for more than 10 minutes.
+
+          Check node-controller logs and recent NodeGroup or Node changes.

--- a/modules/040-node-manager/templates/monitoring.yaml
+++ b/modules/040-node-manager/templates/monitoring.yaml
@@ -24,10 +24,4 @@
 
 {{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager" $prometheusRules) }}
 
-{{- include "helm_lib_single_dashboard" (list . "node-controller" "Kubernetes Cluster" (.Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json")) }}
-
-{{- if not (.Values.global.enabledModules | has "gpu") }}
-  {{- if include "nvidia_gpu_enabled" . }}
-    {{- include "helm_lib_grafana_dashboard_definitions" . }}
-  {{- end }}
-{{- end }}
+{{ include "helm_lib_grafana_dashboard_definitions" . }}

--- a/modules/040-node-manager/templates/monitoring.yaml
+++ b/modules/040-node-manager/templates/monitoring.yaml
@@ -7,6 +7,7 @@
   "monitoring/prometheus-rules/node-unmanaged.tpl"
   "monitoring/prometheus-rules/node-update.yaml"
   "monitoring/prometheus-rules/standby-deployment-unavailable.yaml"
+  "monitoring/prometheus-rules/node-controller.yaml"
 }}
 
 {{- if include "cluster_autoscaler_enabled" . }}

--- a/modules/040-node-manager/templates/monitoring.yaml
+++ b/modules/040-node-manager/templates/monitoring.yaml
@@ -22,3 +22,11 @@
 {{- end }}
 
 {{- include "helm_lib_prometheus_rules" (list . "d8-cloud-instance-manager" $prometheusRules) }}
+
+{{- include "helm_lib_single_dashboard" (list . "node-controller" "Kubernetes Cluster" (.Files.Get "monitoring/grafana-dashboards/kubernetes-cluster/node-controller.json")) }}
+
+{{- if not (.Values.global.enabledModules | has "gpu") }}
+  {{- if include "nvidia_gpu_enabled" . }}
+    {{- include "helm_lib_grafana_dashboard_definitions" . }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

Adds internal metrics for node-controller observability.

The implementation introduces background collectors registered in controller-runtime manager which periodically collect information about shared informer cache contents and controller-runtime client read operations, exporting them through Prometheus metrics.

Added metrics provide visibility into cache object distribution, controller read behavior, and help analyze node-controller internal activity.

No critical cluster components are affected. No controller restart behavior or reconciliation logic was changed.

## Why do we need it, and what problem does it solve?

Currently node-controller relies heavily on shared informer cache and controller-runtime client operations, but there is limited visibility into internal cache state and object access patterns.

This change introduces metrics allowing operators and developers to:

* monitor cache growth over time;
* understand cache memory pressure sources;
* observe object distribution inside shared cache;
* analyze controller-runtime client read patterns;
* debug cache-related and performance-related issues.

The feature improves observability of node-controller internals and simplifies debugging and performance analysis.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: feature
summary: Add internal metrics for node-controller observability
impact_level: low