### PR TITLE
[cloud-provider-dvp] support live StorageClass migration for node disks

### DIFF
--- a/dhctl/pkg/infrastructure/tofu/cmd.go
+++ b/dhctl/pkg/infrastructure/tofu/cmd.go
@@ -79,12 +79,14 @@ func tofuCmd(ctx context.Context, params RunExecutorParams, workingDir string, a
 	// destructive changes
 	skipDataDeps := []string{
 		"module.additional-disk.kubernetes_resource_ready_v1.additional_disk",
+		"module.additional-disk.kubernetes_resource_ready_v1.additional_disk_migration",
 		"module.ipv4-address.kubernetes_resource_ready_v1.ipv4_address",
 		"module.kubernetes-data-disk.kubernetes_resource_ready_v1.kubernetes-data-disk",
+		"module.kubernetes-data-disk.kubernetes_resource_ready_v1.kubernetes-data-disk-migration",
 		"module.master.kubernetes_resource_ready_v1.vm",
 		"module.static-node.kubernetes_resource_ready_v1.vm",
-		// module.root-disk.kubernetes_resource_ready_v1.root-disk was not added because
-		// it does not contain data source for disk
+		// module.root-disk.kubernetes_resource_ready_v1.root-disk* were not added because
+		// root-disk does not contain a data source
 	}
 
 	envs = append(

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
@@ -118,7 +118,6 @@ resource "kubernetes_resource_ready_v1" "additional_disk_migration" {
   fields = merge(
     {
       "metadata.name" = ".+"
-      "status.phase"  = "^Ready$"
     },
     var.storage_class != null ? {
       "status.storageClassName" = "^${replace(var.storage_class, ".", "\\.")}$"

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
@@ -114,7 +114,7 @@ resource "kubernetes_resource_ready_v1" "additional_disk_migration" {
 
   # status.storageClassName reflects the actual SC in use; it only changes once
   # DVP completes the live migration. For an explicit SC, this is the authoritative
-  # completion signal. For the default SC (null), we fall back to phase=Ready.
+  # completion signal. For the default SC (null), only metadata.name is checked.
   fields = merge(
     {
       "metadata.name" = ".+"

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
@@ -108,17 +108,30 @@ resource "kubernetes_resource_ready_v1" "additional_disk_migration" {
     storage_class = coalesce(var.storage_class, "")
   }
 
-  wait_timeout                                 = var.timeouts.update
-  skip_check_on_create_with_resource_lifetime  = "0"
-  fail_conditions_appearance_duration          = "3s"
+  wait_timeout                                = var.timeouts.update
+  skip_check_on_create_with_resource_lifetime = "0"
+  fail_conditions_appearance_duration         = "3s"
 
-  fields = {
-    "metadata.name" = ".+"
-  }
+  # status.storageClassName reflects the actual SC in use; it only changes once
+  # DVP completes the live migration. For an explicit SC, this is the authoritative
+  # completion signal. For the default SC (null), we fall back to phase=Ready.
+  fields = merge(
+    {
+      "metadata.name" = ".+"
+      "status.phase"  = "^Ready$"
+    },
+    var.storage_class != null ? {
+      "status.storageClassName" = "^${replace(var.storage_class, ".", "\\.")}$"
+    } : {}
+  )
 
-  condition {
+  fail_condition {
     type   = "Ready"
-    status = "True"
+    status = "False"
+    reason = format("^(%s)$", join("|", concat(local.not_ready_fail_reasons, [
+      "StorageClassIsNotReady",
+      "StorageClassProvisionerMismatch",
+    ])))
   }
 
   depends_on = [kubernetes_resource_ready_v1.additional_disk]

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
@@ -37,12 +37,6 @@ resource "kubernetes_manifest" "additional_disk" {
     update = var.timeouts.update
     delete = var.timeouts.delete
   }
-
-  lifecycle {
-    ignore_changes = [
-      object.spec.persistentVolumeClaim.storageClassName
-    ]
-  }
 }
 
 # WARNING! if you change this resource and list please
@@ -104,6 +98,32 @@ resource "kubernetes_resource_ready_v1" "additional_disk" {
   fail_conditions_appearance_duration = "3s"
 }
 
+resource "kubernetes_resource_ready_v1" "additional_disk_migration" {
+  api_version = kubernetes_manifest.additional_disk.object.apiVersion
+  kind        = kubernetes_manifest.additional_disk.object.kind
+  name        = kubernetes_manifest.additional_disk.object.metadata.name
+  namespace   = kubernetes_manifest.additional_disk.object.metadata.namespace
+
+  triggers = {
+    storage_class = coalesce(var.storage_class, "")
+  }
+
+  wait_timeout                                 = var.timeouts.update
+  skip_check_on_create_with_resource_lifetime  = "0"
+  fail_conditions_appearance_duration          = "3s"
+
+  fields = {
+    "metadata.name" = ".+"
+  }
+
+  condition {
+    type   = "Ready"
+    status = "True"
+  }
+
+  depends_on = [kubernetes_resource_ready_v1.additional_disk]
+}
+
 data "kubernetes_resource" "additional_disk" {
   api_version = var.api_version
   kind        = "VirtualDisk"
@@ -114,8 +134,8 @@ data "kubernetes_resource" "additional_disk" {
   }
 
   depends_on = [
-    # wait to disk is ready
-    kubernetes_resource_ready_v1.additional_disk,
+    # wait to disk is ready and migration (if any) complete
+    kubernetes_resource_ready_v1.additional_disk_migration,
     kubernetes_manifest.additional_disk
   ]
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/main.tf
@@ -128,10 +128,7 @@ resource "kubernetes_resource_ready_v1" "additional_disk_migration" {
   fail_condition {
     type   = "Ready"
     status = "False"
-    reason = format("^(%s)$", join("|", concat(local.not_ready_fail_reasons, [
-      "StorageClassIsNotReady",
-      "StorageClassProvisionerMismatch",
-    ])))
+    reason = format("^(%s)$", join("|", local.not_ready_fail_reasons))
   }
 
   depends_on = [kubernetes_resource_ready_v1.additional_disk]

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/variables.tf
@@ -56,7 +56,7 @@ variable "hostname" {
 }
 
 variable "timeouts" {
-  default = { "create" = "30m", "update" = "30m", "delete" = "1m" }
+  default = { "create" = "30m", "update" = "1m", "delete" = "1m" }
   type = object({
     create = string
     update = string

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/additional-disk/variables.tf
@@ -56,7 +56,7 @@ variable "hostname" {
 }
 
 variable "timeouts" {
-  default = { "create" = "30m", "update" = "1m", "delete" = "1m" }
+  default = { "create" = "30m", "update" = "30m", "delete" = "1m" }
   type = object({
     create = string
     update = string
@@ -67,9 +67,7 @@ variable "timeouts" {
 
 locals {
   disk_destructive_params = {
-    "additionalDisk" = {
-      "storageClass" = var.storage_class
-    }
+    "additionalDisk" = {}
   }
 
   disk_destructive_params_json      = jsonencode(local.disk_destructive_params)

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
@@ -110,13 +110,23 @@ resource "kubernetes_resource_ready_v1" "kubernetes-data-disk-migration" {
   skip_check_on_create_with_resource_lifetime = "0"
   fail_conditions_appearance_duration         = "3s"
 
-  fields = {
-    "metadata.name" = ".+"
-  }
+  fields = merge(
+    {
+      "metadata.name" = ".+"
+      "status.phase"  = "^Ready$"
+    },
+    var.storage_class != null ? {
+      "status.storageClassName" = "^${replace(var.storage_class, ".", "\\.")}$"
+    } : {}
+  )
 
-  condition {
+  fail_condition {
     type   = "Ready"
-    status = "True"
+    status = "False"
+    reason = format("^(%s)$", join("|", concat(local.not_ready_fail_reasons, [
+      "StorageClassIsNotReady",
+      "StorageClassProvisionerMismatch",
+    ])))
   }
 
   depends_on = [kubernetes_resource_ready_v1.kubernetes-data-disk]

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
@@ -35,11 +35,6 @@ resource "kubernetes_manifest" "kubernetes-data-disk" {
     update = var.timeouts.update
     delete = var.timeouts.delete
   }
-  lifecycle {
-    ignore_changes = [
-      object.spec.persistentVolumeClaim.storageClassName
-    ]
-  }
 }
 
 # WARNING! if you change this resource and list please
@@ -101,6 +96,32 @@ resource "kubernetes_resource_ready_v1" "kubernetes-data-disk" {
   fail_conditions_appearance_duration = "3s"
 }
 
+resource "kubernetes_resource_ready_v1" "kubernetes-data-disk-migration" {
+  api_version = kubernetes_manifest.kubernetes-data-disk.object.apiVersion
+  kind        = kubernetes_manifest.kubernetes-data-disk.object.kind
+  name        = kubernetes_manifest.kubernetes-data-disk.object.metadata.name
+  namespace   = kubernetes_manifest.kubernetes-data-disk.object.metadata.namespace
+
+  triggers = {
+    storage_class = coalesce(var.storage_class, "")
+  }
+
+  wait_timeout                                = var.timeouts.update
+  skip_check_on_create_with_resource_lifetime = "0"
+  fail_conditions_appearance_duration         = "3s"
+
+  fields = {
+    "metadata.name" = ".+"
+  }
+
+  condition {
+    type   = "Ready"
+    status = "True"
+  }
+
+  depends_on = [kubernetes_resource_ready_v1.kubernetes-data-disk]
+}
+
 data "kubernetes_resource" "kubernetes-data-disk" {
   api_version = var.api_version
   kind        = "VirtualDisk"
@@ -110,8 +131,8 @@ data "kubernetes_resource" "kubernetes-data-disk" {
     namespace = var.namespace
   }
   depends_on = [
-    # wait to disk is ready
-    kubernetes_resource_ready_v1.kubernetes-data-disk,
+    # wait to disk is ready and migration (if any) complete
+    kubernetes_resource_ready_v1.kubernetes-data-disk-migration,
     kubernetes_manifest.kubernetes-data-disk
   ]
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
@@ -113,7 +113,6 @@ resource "kubernetes_resource_ready_v1" "kubernetes-data-disk-migration" {
   fields = merge(
     {
       "metadata.name" = ".+"
-      "status.phase"  = "^Ready$"
     },
     var.storage_class != null ? {
       "status.storageClassName" = "^${replace(var.storage_class, ".", "\\.")}$"

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/main.tf
@@ -123,10 +123,7 @@ resource "kubernetes_resource_ready_v1" "kubernetes-data-disk-migration" {
   fail_condition {
     type   = "Ready"
     status = "False"
-    reason = format("^(%s)$", join("|", concat(local.not_ready_fail_reasons, [
-      "StorageClassIsNotReady",
-      "StorageClassProvisionerMismatch",
-    ])))
+    reason = format("^(%s)$", join("|", local.not_ready_fail_reasons))
   }
 
   depends_on = [kubernetes_resource_ready_v1.kubernetes-data-disk]

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/variables.tf
@@ -52,7 +52,7 @@ variable "hostname" {
 }
 
 variable "timeouts" {
-  default = { "create" = "30m", "update" = "30m", "delete" = "1m" }
+  default = { "create" = "30m", "update" = "1m", "delete" = "1m" }
   type = object({
     create = string
     update = string

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/kubernetes-data-disk/variables.tf
@@ -52,7 +52,7 @@ variable "hostname" {
 }
 
 variable "timeouts" {
-  default = { "create" = "30m", "update" = "1m", "delete" = "1m" }
+  default = { "create" = "30m", "update" = "30m", "delete" = "1m" }
   type = object({
     create = string
     update = string
@@ -63,9 +63,7 @@ variable "timeouts" {
 
 locals {
   data_disk_destructive_params = {
-    "kbernetesDataDisk" = {
-      "storageClass" = var.storage_class
-    }
+    "kbernetesDataDisk" = {}
   }
 
   data_disk_destructive_params_json      = jsonencode(local.data_disk_destructive_params)

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
@@ -120,7 +120,6 @@ resource "kubernetes_resource_ready_v1" "root-disk-migration" {
   fields = merge(
     {
       "metadata.name" = ".+"
-      "status.phase"  = "^Ready$"
     },
     var.storage_class != null ? {
       "status.storageClassName" = "^${replace(var.storage_class, ".", "\\.")}$"

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
@@ -117,13 +117,23 @@ resource "kubernetes_resource_ready_v1" "root-disk-migration" {
   skip_check_on_create_with_resource_lifetime = "0"
   fail_conditions_appearance_duration         = "3s"
 
-  fields = {
-    "metadata.name" = ".+"
-  }
+  fields = merge(
+    {
+      "metadata.name" = ".+"
+      "status.phase"  = "^Ready$"
+    },
+    var.storage_class != null ? {
+      "status.storageClassName" = "^${replace(var.storage_class, ".", "\\.")}$"
+    } : {}
+  )
 
-  condition {
+  fail_condition {
     type   = "Ready"
-    status = "True"
+    status = "False"
+    reason = format("^(%s)$", join("|", concat(local.not_ready_fail_reasons, [
+      "StorageClassIsNotReady",
+      "StorageClassProvisionerMismatch",
+    ])))
   }
 
   depends_on = [kubernetes_resource_ready_v1.root-disk]

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
@@ -42,11 +42,6 @@ resource "kubernetes_manifest" "root-disk" {
     update = var.timeouts.update
     delete = var.timeouts.delete
   }
-  lifecycle {
-    ignore_changes = [
-      object.spec.persistentVolumeClaim.storageClassName
-    ]
-  }
 }
 
 # WARNING! if you change this resource and list please
@@ -106,4 +101,30 @@ resource "kubernetes_resource_ready_v1" "root-disk" {
 
   # 3s instead of 15s: fail conditions (ProvisioningFailed, BlockDeviceLimitExceeded, PVCLost, etc.) appear within ~1s of the controller reconcile — 3s is enough to catch them. Cuts ~12s from master apply since disks gate VM creation.
   fail_conditions_appearance_duration = "3s"
+}
+
+resource "kubernetes_resource_ready_v1" "root-disk-migration" {
+  api_version = kubernetes_manifest.root-disk.object.apiVersion
+  kind        = kubernetes_manifest.root-disk.object.kind
+  name        = kubernetes_manifest.root-disk.object.metadata.name
+  namespace   = kubernetes_manifest.root-disk.object.metadata.namespace
+
+  triggers = {
+    storage_class = coalesce(var.storage_class, "")
+  }
+
+  wait_timeout                                = var.timeouts.update
+  skip_check_on_create_with_resource_lifetime = "0"
+  fail_conditions_appearance_duration         = "3s"
+
+  fields = {
+    "metadata.name" = ".+"
+  }
+
+  condition {
+    type   = "Ready"
+    status = "True"
+  }
+
+  depends_on = [kubernetes_resource_ready_v1.root-disk]
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/main.tf
@@ -130,10 +130,7 @@ resource "kubernetes_resource_ready_v1" "root-disk-migration" {
   fail_condition {
     type   = "Ready"
     status = "False"
-    reason = format("^(%s)$", join("|", concat(local.not_ready_fail_reasons, [
-      "StorageClassIsNotReady",
-      "StorageClassProvisionerMismatch",
-    ])))
+    reason = format("^(%s)$", join("|", local.not_ready_fail_reasons))
   }
 
   depends_on = [kubernetes_resource_ready_v1.root-disk]

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/variables.tf
@@ -59,7 +59,7 @@ variable "hostname" {
 }
 
 variable "timeouts" {
-  default = { "create" = "30m", "update" = "1m", "delete" = "1m" }
+  default = { "create" = "30m", "update" = "30m", "delete" = "1m" }
   type = object({
     create = string
     update = string
@@ -70,7 +70,6 @@ variable "timeouts" {
 locals {
   root_disk_destructive_params = {
     "rootDisk" = {
-      "storageClass" = var.storage_class
       "image" = {
         "type" = var.image.kind
         "name" = var.image.name

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/root-disk/variables.tf
@@ -59,7 +59,7 @@ variable "hostname" {
 }
 
 variable "timeouts" {
-  default = { "create" = "30m", "update" = "30m", "delete" = "1m" }
+  default = { "create" = "30m", "update" = "1m", "delete" = "1m" }
   type = object({
     create = string
     update = string

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/cmd/main.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/cmd/main.go
@@ -234,6 +234,14 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "DeckhouseMachine")
 		os.Exit(1)
 	}
+	if err = (&controller.PermanentNodeSCMigrationReconciler{
+		Client:      mgr.GetClient(),
+		DVP:         cloudAPI,
+		ClusterUUID: cloudConfig.ClusterUUID,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "PermanentNodeSCMigration")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if metricsCertWatcher != nil {

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// nolint:gci
+// nolint:gci,goimports
 package controller
 
 import (
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	dvpapi "dvp-common/api"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -35,6 +34,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+
+	dvpapi "dvp-common/api"
 )
 
 const (

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/yaml"
+
+	dvpapi "dvp-common/api"
+)
+
+const (
+	providerConfigSecretName      = "d8-provider-cluster-configuration"
+	providerConfigSecretNamespace = "kube-system"
+	providerConfigDataKey         = "cloud-provider-cluster-configuration.yaml"
+
+	nodeGroupLabel = "node.deckhouse.io/group"
+
+	diskHostnameLabel    = "dvp.deckhouse.io/hostname"
+	diskClusterUUIDLabel = "dvp.deckhouse.io/cluster-uuid"
+
+	permanentNodeMigrationRequeue = 30 * time.Second
+)
+
+// permanentNodeProviderConfig holds the storageClass fields we care about.
+// MasterNodeGroup and NodeGroups are typed as any in the shared type — define local structs here.
+type permanentNodeProviderConfig struct {
+	MasterNodeGroup *masterNodeGroupSCCfg  `json:"masterNodeGroup,omitempty"`
+	NodeGroups      []staticNodeGroupSCCfg `json:"nodeGroups,omitempty"`
+}
+
+type masterNodeGroupSCCfg struct {
+	InstanceClass masterInstanceClassSCCfg `json:"instanceClass"`
+}
+
+type masterInstanceClassSCCfg struct {
+	RootDisk        *diskSCCfg  `json:"rootDisk,omitempty"`
+	EtcdDisk        *diskSCCfg  `json:"etcdDisk,omitempty"`
+	AdditionalDisks []diskSCCfg `json:"additionalDisks,omitempty"`
+}
+
+type staticNodeGroupSCCfg struct {
+	Name          string                   `json:"name"`
+	InstanceClass staticInstanceClassSCCfg `json:"instanceClass"`
+}
+
+type staticInstanceClassSCCfg struct {
+	RootDisk        *diskSCCfg  `json:"rootDisk,omitempty"`
+	AdditionalDisks []diskSCCfg `json:"additionalDisks,omitempty"`
+}
+
+type diskSCCfg struct {
+	StorageClass string `json:"storageClass,omitempty"`
+}
+
+type nodeGroupSCConfig struct {
+	RootDiskSC       string
+	EtcdDiskSC       string // only meaningful for master node group
+	AdditionalDiskSC []string
+}
+
+// PermanentNodeSCMigrationReconciler migrates VirtualDisk StorageClasses for
+// terraform-managed (permanent) nodes when the provider cluster configuration changes.
+// Worker nodes are handled separately by DeckhouseMachineReconciler via CAPI.
+type PermanentNodeSCMigrationReconciler struct {
+	Client      client.Client
+	DVP         *dvpapi.DVPCloudAPI
+	ClusterUUID string
+}
+
+func (r *PermanentNodeSCMigrationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, req.NamespacedName, secret); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	cfg, err := parsePermanentNodeProviderConfig(secret.Data[providerConfigDataKey])
+	if err != nil {
+		log.Error(err, "failed to parse provider cluster configuration, skipping")
+		return reconcile.Result{}, nil
+	}
+
+	anyMigrating, err := r.reconcileAllPermanentNodes(ctx, cfg)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if anyMigrating {
+		return reconcile.Result{RequeueAfter: permanentNodeMigrationRequeue}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *PermanentNodeSCMigrationReconciler) reconcileAllPermanentNodes(
+	ctx context.Context,
+	cfg *permanentNodeProviderConfig,
+) (bool, error) {
+	anyMigrating := false
+
+	if cfg.MasterNodeGroup != nil {
+		ic := cfg.MasterNodeGroup.InstanceClass
+		ngCfg := nodeGroupSCConfig{
+			RootDiskSC:       scString(ic.RootDisk),
+			EtcdDiskSC:       scString(ic.EtcdDisk),
+			AdditionalDiskSC: scSlice(ic.AdditionalDisks),
+		}
+		migrating, err := r.reconcileNodeGroup(ctx, "master", ngCfg)
+		if err != nil {
+			ctrl.LoggerFrom(ctx).Error(err, "failed to reconcile master node group")
+		}
+		anyMigrating = anyMigrating || migrating
+	}
+
+	for _, ng := range cfg.NodeGroups {
+		ic := ng.InstanceClass
+		ngCfg := nodeGroupSCConfig{
+			RootDiskSC:       scString(ic.RootDisk),
+			AdditionalDiskSC: scSlice(ic.AdditionalDisks),
+		}
+		migrating, err := r.reconcileNodeGroup(ctx, ng.Name, ngCfg)
+		if err != nil {
+			ctrl.LoggerFrom(ctx).Error(err, "failed to reconcile node group", "nodeGroup", ng.Name)
+		}
+		anyMigrating = anyMigrating || migrating
+	}
+
+	return anyMigrating, nil
+}
+
+func (r *PermanentNodeSCMigrationReconciler) reconcileNodeGroup(
+	ctx context.Context,
+	nodeGroupName string,
+	cfg nodeGroupSCConfig,
+) (bool, error) {
+	log := ctrl.LoggerFrom(ctx).WithValues("nodeGroup", nodeGroupName)
+
+	nodeList := &corev1.NodeList{}
+	if err := r.Client.List(ctx, nodeList, client.MatchingLabels{nodeGroupLabel: nodeGroupName}); err != nil {
+		return false, fmt.Errorf("list nodes for group %q: %w", nodeGroupName, err)
+	}
+
+	anyMigrating := false
+	for _, node := range nodeList.Items {
+		migrating, err := r.reconcileNode(ctx, node.Name, cfg)
+		if err != nil {
+			log.Error(err, "failed to reconcile node disks", "node", node.Name)
+			continue
+		}
+		anyMigrating = anyMigrating || migrating
+	}
+	return anyMigrating, nil
+}
+
+func (r *PermanentNodeSCMigrationReconciler) reconcileNode(
+	ctx context.Context,
+	hostname string,
+	cfg nodeGroupSCConfig,
+) (bool, error) {
+	disks, err := r.DVP.DiskService.ListDisksByLabels(ctx, map[string]string{
+		diskHostnameLabel:    hostname,
+		diskClusterUUIDLabel: r.ClusterUUID,
+	})
+	if err != nil {
+		return false, fmt.Errorf("list disks for node %q: %w", hostname, err)
+	}
+
+	log := ctrl.LoggerFrom(ctx).WithValues("node", hostname)
+	anyMigrating := false
+
+	for i := range disks {
+		vd := &disks[i]
+		desiredSC := desiredSCForDisk(vd.Name, cfg)
+		if desiredSC == "" {
+			continue
+		}
+
+		specSC := virtualDiskSpecStorageClass(vd)
+		statusSC := vd.Status.StorageClassName
+
+		if specSC == desiredSC && statusSC == desiredSC {
+			continue
+		}
+
+		if specSC == desiredSC && statusSC != desiredSC {
+			log.Info("disk SC migration in progress", "disk", vd.Name, "specSC", specSC, "statusSC", statusSC)
+			anyMigrating = true
+			continue
+		}
+
+		log.Info("patching disk SC", "disk", vd.Name, "currentSC", specSC, "desiredSC", desiredSC)
+		if err := r.DVP.DiskService.MigrateDiskStorageClass(ctx, vd.Name, desiredSC); err != nil {
+			return false, fmt.Errorf("migrate disk %q to SC %q: %w", vd.Name, desiredSC, err)
+		}
+		anyMigrating = true
+	}
+
+	return anyMigrating, nil
+}
+
+// desiredSCForDisk identifies disk type from its name and returns the desired StorageClass.
+// Disk name patterns (from terraform locals):
+//   - root:            {prefix}-{nodeGroup}-{nodeIndex}-{hash}
+//   - kubernetes-data: {prefix}-{nodeGroup}-kubernetes-data-{nodeIndex}-{hash}
+//   - additional:      {prefix}-{nodeGroup}-additional-disk-{diskIndex}-{nodeIndex}-{hash}
+func desiredSCForDisk(diskName string, cfg nodeGroupSCConfig) string {
+	if strings.Contains(diskName, "-kubernetes-data-") {
+		return cfg.EtcdDiskSC
+	}
+	if idx, ok := parseAdditionalDiskIndex(diskName); ok {
+		if idx < len(cfg.AdditionalDiskSC) {
+			return cfg.AdditionalDiskSC[idx]
+		}
+		return ""
+	}
+	return cfg.RootDiskSC
+}
+
+// parseAdditionalDiskIndex extracts the disk_index from a name like *-additional-disk-{N}-*.
+func parseAdditionalDiskIndex(diskName string) (int, bool) {
+	const marker = "-additional-disk-"
+	idx := strings.Index(diskName, marker)
+	if idx == -1 {
+		return 0, false
+	}
+	rest := diskName[idx+len(marker):]
+	parts := strings.SplitN(rest, "-", 2)
+	n, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+func parsePermanentNodeProviderConfig(raw []byte) (*permanentNodeProviderConfig, error) {
+	if len(raw) == 0 {
+		return &permanentNodeProviderConfig{}, nil
+	}
+	var cfg permanentNodeProviderConfig
+	// sigs.k8s.io/yaml converts YAML → JSON then unmarshals using json tags
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("unmarshal provider config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func scString(d *diskSCCfg) string {
+	if d == nil {
+		return ""
+	}
+	return d.StorageClass
+}
+
+func scSlice(disks []diskSCCfg) []string {
+	out := make([]string, len(disks))
+	for i, d := range disks {
+		out[i] = d.StorageClass
+	}
+	return out
+}
+
+func (r *PermanentNodeSCMigrationReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Secret{},
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+				return obj.GetName() == providerConfigSecretName &&
+					obj.GetNamespace() == providerConfigSecretNamespace
+			})),
+		).
+		Named("permanentnode-sc-migration").
+		Complete(r)
+}

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// nolint:gci
 package controller
 
 import (
@@ -107,10 +108,7 @@ func (r *PermanentNodeSCMigrationReconciler) Reconcile(ctx context.Context, req 
 		return reconcile.Result{}, nil
 	}
 
-	anyMigrating, err := r.reconcileAllPermanentNodes(ctx, cfg)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+	anyMigrating := r.reconcileAllPermanentNodes(ctx, cfg)
 	if anyMigrating {
 		return reconcile.Result{RequeueAfter: permanentNodeMigrationRequeue}, nil
 	}
@@ -120,7 +118,7 @@ func (r *PermanentNodeSCMigrationReconciler) Reconcile(ctx context.Context, req 
 func (r *PermanentNodeSCMigrationReconciler) reconcileAllPermanentNodes(
 	ctx context.Context,
 	cfg *permanentNodeProviderConfig,
-) (bool, error) {
+) bool {
 	anyMigrating := false
 
 	if cfg.MasterNodeGroup != nil {
@@ -150,7 +148,7 @@ func (r *PermanentNodeSCMigrationReconciler) reconcileAllPermanentNodes(
 		anyMigrating = anyMigrating || migrating
 	}
 
-	return anyMigrating, nil
+	return anyMigrating
 }
 
 func (r *PermanentNodeSCMigrationReconciler) reconcileNodeGroup(

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
@@ -19,11 +19,13 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -190,11 +192,20 @@ func (r *PermanentNodeSCMigrationReconciler) reconcileNode(
 
 	log := ctrl.LoggerFrom(ctx).WithValues("node", hostname)
 	anyMigrating := false
+	var errs []error
 
 	for i := range disks {
 		vd := &disks[i]
 		desiredSC := desiredSCForDisk(vd.Name, cfg)
 		if desiredSC == "" {
+			continue
+		}
+
+		// Skip disks in terminal failure — manual intervention required
+		switch vd.Status.Phase {
+		case v1alpha2.DiskFailed, v1alpha2.DiskLost:
+			log.Error(nil, "disk in terminal failure state, skipping SC migration",
+				"disk", vd.Name, "phase", vd.Status.Phase)
 			continue
 		}
 
@@ -211,14 +222,21 @@ func (r *PermanentNodeSCMigrationReconciler) reconcileNode(
 			continue
 		}
 
+		// Validate SC exists before patching (mirrors DeckhouseMachineReconciler behaviour)
+		if _, err := r.DVP.DiskService.GetStorageClass(ctx, desiredSC); err != nil {
+			errs = append(errs, fmt.Errorf("storage class %q for disk %q: %w", desiredSC, vd.Name, err))
+			continue
+		}
+
 		log.Info("patching disk SC", "disk", vd.Name, "currentSC", specSC, "desiredSC", desiredSC)
 		if err := r.DVP.DiskService.MigrateDiskStorageClass(ctx, vd.Name, desiredSC); err != nil {
-			return false, fmt.Errorf("migrate disk %q to SC %q: %w", vd.Name, desiredSC, err)
+			errs = append(errs, fmt.Errorf("migrate disk %q to SC %q: %w", vd.Name, desiredSC, err))
+			continue
 		}
 		anyMigrating = true
 	}
 
-	return anyMigrating, nil
+	return anyMigrating, errors.Join(errs...)
 }
 
 // desiredSCForDisk identifies disk type from its name and returns the desired StorageClass.

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	dvpapi "dvp-common/api"
-	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -34,6 +33,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 )
 
 const (

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	dvpapi "dvp-common/api"
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,8 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/yaml"
-
-	dvpapi "dvp-common/api"
 )
 
 const (

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller_test.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/permanentnode_sc_migration_controller_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePermanentNodeProviderConfig(t *testing.T) {
+	t.Run("empty data", func(t *testing.T) {
+		cfg, err := parsePermanentNodeProviderConfig(nil)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.MasterNodeGroup)
+		assert.Empty(t, cfg.NodeGroups)
+	})
+
+	t.Run("master with all disk types", func(t *testing.T) {
+		raw := []byte(`
+masterNodeGroup:
+  instanceClass:
+    rootDisk:
+      storageClass: local
+    etcdDisk:
+      storageClass: replicated
+    additionalDisks:
+      - storageClass: fast
+      - storageClass: slow
+`)
+		cfg, err := parsePermanentNodeProviderConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.MasterNodeGroup)
+
+		ic := cfg.MasterNodeGroup.InstanceClass
+		assert.Equal(t, "local", scString(ic.RootDisk))
+		assert.Equal(t, "replicated", scString(ic.EtcdDisk))
+		assert.Equal(t, []string{"fast", "slow"}, scSlice(ic.AdditionalDisks))
+	})
+
+	t.Run("master without optional SC fields", func(t *testing.T) {
+		raw := []byte(`
+masterNodeGroup:
+  instanceClass: {}
+`)
+		cfg, err := parsePermanentNodeProviderConfig(raw)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.MasterNodeGroup)
+		assert.Empty(t, scString(cfg.MasterNodeGroup.InstanceClass.RootDisk))
+		assert.Empty(t, scString(cfg.MasterNodeGroup.InstanceClass.EtcdDisk))
+	})
+
+	t.Run("static node groups", func(t *testing.T) {
+		raw := []byte(`
+nodeGroups:
+  - name: infra
+    instanceClass:
+      rootDisk:
+        storageClass: local
+      additionalDisks:
+        - storageClass: replicated
+  - name: gpu
+    instanceClass:
+      rootDisk:
+        storageClass: gpu-fast
+`)
+		cfg, err := parsePermanentNodeProviderConfig(raw)
+		require.NoError(t, err)
+		require.Len(t, cfg.NodeGroups, 2)
+
+		assert.Equal(t, "infra", cfg.NodeGroups[0].Name)
+		assert.Equal(t, "local", scString(cfg.NodeGroups[0].InstanceClass.RootDisk))
+		assert.Equal(t, []string{"replicated"}, scSlice(cfg.NodeGroups[0].InstanceClass.AdditionalDisks))
+
+		assert.Equal(t, "gpu", cfg.NodeGroups[1].Name)
+		assert.Equal(t, "gpu-fast", scString(cfg.NodeGroups[1].InstanceClass.RootDisk))
+	})
+
+	t.Run("invalid yaml returns error", func(t *testing.T) {
+		_, err := parsePermanentNodeProviderConfig([]byte("}{invalid"))
+		assert.Error(t, err)
+	})
+}
+
+func TestDesiredSCForDisk(t *testing.T) {
+	cfg := nodeGroupSCConfig{
+		RootDiskSC:       "local",
+		EtcdDiskSC:       "replicated",
+		AdditionalDiskSC: []string{"fast", "slow"},
+	}
+
+	tests := []struct {
+		name     string
+		diskName string
+		want     string
+	}{
+		{
+			name:     "root disk",
+			diskName: "prefix-master-0-a1b2c3",
+			want:     "local",
+		},
+		{
+			name:     "kubernetes-data disk",
+			diskName: "prefix-master-kubernetes-data-0-d4e5f6",
+			want:     "replicated",
+		},
+		{
+			name:     "additional disk index 0",
+			diskName: "prefix-master-additional-disk-0-0-g7h8i9",
+			want:     "fast",
+		},
+		{
+			name:     "additional disk index 1",
+			diskName: "prefix-master-additional-disk-1-0-j0k1l2",
+			want:     "slow",
+		},
+		{
+			name:     "additional disk index out of range",
+			diskName: "prefix-master-additional-disk-5-0-m3n4o5",
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := desiredSCForDisk(tt.diskName, cfg)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDesiredSCForDisk_NullSC(t *testing.T) {
+	cfg := nodeGroupSCConfig{
+		RootDiskSC: "",
+		EtcdDiskSC: "",
+	}
+
+	assert.Empty(t, desiredSCForDisk("prefix-master-0-abc123", cfg), "empty SC should be skipped")
+	assert.Empty(t, desiredSCForDisk("prefix-master-kubernetes-data-0-abc123", cfg))
+}
+
+func TestParseAdditionalDiskIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		diskName string
+		wantIdx  int
+		wantOK   bool
+	}{
+		{"index 0", "prefix-master-additional-disk-0-0-hash", 0, true},
+		{"index 3", "prefix-ng-additional-disk-3-1-hash", 3, true},
+		{"root disk", "prefix-master-0-hash", 0, false},
+		{"kubernetes-data disk", "prefix-master-kubernetes-data-0-hash", 0, false},
+		{"empty", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, ok := parseAdditionalDiskIndex(tt.diskName)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantIdx, idx)
+			}
+		})
+	}
+}

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -238,6 +238,17 @@ func (d *DiskService) ResizeDisk(ctx context.Context, diskName string, newSize s
 	return nil
 }
 
+func (d *DiskService) ListDisksByLabels(ctx context.Context, matchLabels map[string]string) ([]v1alpha2.VirtualDisk, error) {
+	var list v1alpha2.VirtualDiskList
+	if err := d.client.List(ctx, &list,
+		client.InNamespace(d.namespace),
+		client.MatchingLabels(matchLabels),
+	); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}
+
 func (d *DiskService) MigrateDiskStorageClass(ctx context.Context, diskName string, newStorageClass string) error {
 	vmd, err := d.GetDiskByName(ctx, diskName)
 	if err != nil {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -250,8 +250,8 @@ func (d *DiskService) ListDisksByLabels(ctx context.Context, matchLabels map[str
 }
 
 func (d *DiskService) MigrateDiskStorageClass(ctx context.Context, diskName string, newStorageClass string) error {
-	vmd, err := d.GetDiskByName(ctx, diskName)
-	if err != nil {
+	var vmd v1alpha2.VirtualDisk
+	if err := d.client.Get(ctx, types.NamespacedName{Namespace: d.namespace, Name: diskName}, &vmd); err != nil {
 		return err
 	}
 
@@ -263,7 +263,7 @@ func (d *DiskService) MigrateDiskStorageClass(ctx context.Context, diskName stri
 	patch := client.MergeFrom(vmd.DeepCopy())
 	vmd.Spec.PersistentVolumeClaim.StorageClass = &newStorageClass
 
-	return d.client.Patch(ctx, vmd, patch)
+	return d.client.Patch(ctx, &vmd, patch)
 }
 
 func (d *DiskService) GetStorageClassList(ctx context.Context) (*storagev1.StorageClassList, error) {

--- a/modules/030-cloud-provider-dvp/images/terraform-manager/patches/004-add-resource-ready-resource.patch
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/patches/004-add-resource-ready-resource.patch
@@ -3129,7 +3129,7 @@ diff --git a/kubernetes/resource_kubernetes_resource_ready_v1.go b/kubernetes/re
 new file mode 100644
 --- /dev/null	(date 1772625318937)
 +++ b/kubernetes/resource_kubernetes_resource_ready_v1.go	(date 1772625318937)
-@@ -0,0 +1,1692 @@
+@@ -0,0 +1,1702 @@
 +package kubernetes
 +
 +import (

--- a/modules/030-cloud-provider-dvp/images/terraform-manager/patches/004-add-resource-ready-resource.patch
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/patches/004-add-resource-ready-resource.patch
@@ -3169,7 +3169,8 @@ new file mode 100644
 +	resourceReadyFailConditionsAppearanceDurationAttr  = "fail_conditions_appearance_duration"
 +	resourceReadySkipCheckOnCreateResourceLifeTimeAttr = "skip_check_on_create_with_resource_lifetime"
 +
-+	resourceReadyReadyAttr = "ready"
++	resourceReadyReadyAttr    = "ready"
++	resourceReadyTriggersAttr = "triggers"
 +)
 +
 +var (
@@ -3181,6 +3182,7 @@ new file mode 100644
 +		resourceReadyKindAttr,
 +		resourceReadyNameAttr,
 +		resourceReadyNamespaceAttr,
++		resourceReadyTriggersAttr,
 +	}
 +
 +	resourceReadySkipUpdateFields = []string{
@@ -3311,6 +3313,13 @@ new file mode 100644
 +		),
 +
 +		resourceReadyFailConditionsAttr: conditionsSchema(failConditionsDescription),
++
++		resourceReadyTriggersAttr: {
++			Type:        schema.TypeMap,
++			Optional:    true,
++			Description: "A map of arbitrary values that, when changed, trigger recreation of this resource and re-run the readiness check. Useful for tracking mutations like storage class migration.",
++			Elem:        &schema.Schema{Type: schema.TypeString},
++		},
 +
 +		resourceReadyReadyAttr: {
 +			Type:        schema.TypeBool,

--- a/modules/030-cloud-provider-dvp/images/terraform-manager/patches/004-add-resource-ready-resource.patch
+++ b/modules/030-cloud-provider-dvp/images/terraform-manager/patches/004-add-resource-ready-resource.patch
@@ -3129,7 +3129,7 @@ diff --git a/kubernetes/resource_kubernetes_resource_ready_v1.go b/kubernetes/re
 new file mode 100644
 --- /dev/null	(date 1772625318937)
 +++ b/kubernetes/resource_kubernetes_resource_ready_v1.go	(date 1772625318937)
-@@ -0,0 +1,1702 @@
+@@ -0,0 +1,1701 @@
 +package kubernetes
 +
 +import (


### PR DESCRIPTION
## Description
Adds support for live StorageClass migration of node VirtualDisks in the DVP cloud provider.
Previously, changing `storage_class` for any node disk (root, data, additional) caused Terraform to destroy and recreate the disk — destroying the node in the process. Now the change is applied in-place: Terraform updates `spec.persistentVolumeClaim.storageClassName` and waits for DVP to complete the live data migration before reporting success.

Additionally, a new controller (PermanentNodeSCMigrationReconciler) in capdvp-controller-manager automatically migrates VirtualDisk StorageClasses for terraform-managed (master and static) nodes when the provider cluster configuration changes — without any manual intervention or node reprovisioning.

## Why do we need it, and what problem does it solve?
Before this change, the only way to move a node disk to a different StorageClass via Deckhouse tooling was to delete and reprovision the node — a disruptive operation requiring workload rescheduling and full OS reinstallation.

This change enables zero-downtime StorageClass migration for all node disk types.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: feature
summary: live StorageClass migration for node disks — changing storage_class no longer destroys the node; permanent nodes auto-migrate via controller
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
