### PR TITLE
[ci] fix kube-state-metrics stageDependencies for patches (backport #20011)

### DIFF
--- a/modules/340-monitoring-kubernetes/images/kube-state-metrics/werf.inc.yaml
+++ b/modules/340-monitoring-kubernetes/images/kube-state-metrics/werf.inc.yaml
@@ -26,7 +26,7 @@ git:
   - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/patches
     to: /patches
     stageDependencies:
-      setup:
+      install:
         - "**/*"
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact


### PR DESCRIPTION
## Description
Backport of #20011 (commit `3c86c284c2`) to `release-1.73`.
Changes `stageDependencies.setup` to `stageDependencies.install` for the `/patches` mount in [modules/340-monitoring-kubernetes/images/kube-state-metrics/werf.inc.yaml](https://github.com/deckhouse/deckhouse/blob/release-1.73/modules/340-monitoring-kubernetes/images/kube-state-metrics/werf.inc.yaml).

## Why do we need it, and what problem does it solve?
The `kube-state-metrics-src-artifact` image uses only the `install` stage (clone + `git apply /patches/*.patch`); there is no `setup` stage. With `stageDependencies.setup`, edits to files under `images/kube-state-metrics/patches/` did not invalidate the `install` stage, so the image was not rebuilt and patch changes silently had no effect. Binding patches to `install` restores correct rebuild behavior.

## Why do we need it in the patch release (if we do)?
Without this fix any patch update for `kube-state-metrics` in `release-1.73` is effectively a no-op, which blocks future CVE/bug fixes that rely on the patches mechanism.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: monitoring-kubernetes
type: fix
summary: Rebuild `kube-state-metrics` image when its patches change (correct `stageDependencies` from `setup` to `install`).
impact_level: low
```