### PR TITLE
[operator-prometheus] add op_ functions support

### DIFF
--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/005-op-functions.patch
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/005-op-functions.patch
@@ -1,0 +1,82 @@
+diff --git a/promql/parser/lex.go b/promql/parser/lex.go
+--- a/promql/parser/lex.go
++++ b/promql/parser/lex.go
+@@ -66,6 +66,13 @@ func (i ItemType) IsAggregatorWithParam() bool {
+ 	return i == TOPK || i == BOTTOMK || i == COUNT_VALUES || i == QUANTILE
+ }
+ 
++// OP_FUNCTIONS
++
++// IsOPTop is an ad-hoc checker function for OP_TOP aggregate operator.
++func (i ItemType) IsOPTop() bool {
++	return i == OP_TOP
++}
++
+ // IsKeyword returns true if the Item corresponds to a keyword.
+ // Returns false otherwise.
+ func (i ItemType) IsKeyword() bool { return i > keywordsStart && i < keywordsEnd }
+@@ -115,6 +122,7 @@ var key = map[string]ItemType{
+ 	"stdvar":       STDVAR,
+ 	"topk":         TOPK,
+ 	"bottomk":      BOTTOMK,
++	"op_top":       OP_TOP, // OP_FUNCTIONS
+ 	"count_values": COUNT_VALUES,
+ 	"quantile":     QUANTILE,
+ 
+diff --git a/promql/parser/generated_parser.y b/promql/parser/generated_parser.y
+--- a/promql/parser/generated_parser.y
++++ b/promql/parser/generated_parser.y
+@@ -124,6 +124,7 @@ STDDEV
+ STDVAR
+ SUM
+ TOPK
++OP_TOP
+ %token	aggregatorsEnd
+ 
+ // Keywords.
+@@ -598,7 +599,7 @@ metric          : metric_identifier label_set
+                 ;
+ 
+ 
+-metric_identifier: AVG | BOTTOMK | BY | COUNT | COUNT_VALUES | GROUP | IDENTIFIER |  LAND | LOR | LUNLESS | MAX | METRIC_IDENTIFIER | MIN | OFFSET | QUANTILE | STDDEV | STDVAR | SUM | TOPK | WITHOUT | START | END;
++metric_identifier: AVG | BOTTOMK | BY | COUNT | COUNT_VALUES | GROUP | IDENTIFIER |  LAND | LOR | LUNLESS | MAX | METRIC_IDENTIFIER | MIN | OFFSET | QUANTILE | STDDEV | STDVAR | SUM | TOPK | OP_TOP | WITHOUT | START | END;
+ 
+ label_set       : LEFT_BRACE label_set_list RIGHT_BRACE
+                         { $$ = labels.New($2...) }
+@@ -835,10 +836,10 @@ series_value    : IDENTIFIER
+  * Keyword lists.
+  */
+ 
+-aggregate_op    : AVG | BOTTOMK | COUNT | COUNT_VALUES | GROUP | MAX | MIN | QUANTILE | STDDEV | STDVAR | SUM | TOPK ;
++aggregate_op    : AVG | BOTTOMK | COUNT | COUNT_VALUES | GROUP | MAX | MIN | QUANTILE | STDDEV | STDVAR | SUM | TOPK | OP_TOP ;
+ 
+ // Inside of grouping options label names can be recognized as keywords by the lexer. This is a list of keywords that could also be a label name.
+-maybe_label     : AVG | BOOL | BOTTOMK | BY | COUNT | COUNT_VALUES | GROUP | GROUP_LEFT | GROUP_RIGHT | IDENTIFIER | IGNORING | LAND | LOR | LUNLESS | MAX | METRIC_IDENTIFIER | MIN | OFFSET | ON | QUANTILE | STDDEV | STDVAR | SUM | TOPK | START | END | ATAN2;
++maybe_label     : AVG | BOOL | BOTTOMK | BY | COUNT | COUNT_VALUES | GROUP | GROUP_LEFT | GROUP_RIGHT | IDENTIFIER | IGNORING | LAND | LOR | LUNLESS | MAX | METRIC_IDENTIFIER | MIN | OFFSET | ON | QUANTILE | STDDEV | STDVAR | SUM | TOPK | OP_TOP | START | END | ATAN2;
+ 
+ unary_op        : ADD | SUB;
+ 
+diff --git a/promql/parser/parse.go b/promql/parser/parse.go
+--- a/promql/parser/parse.go
++++ b/promql/parser/parse.go
+@@ -448,6 +448,20 @@ func (p *parser) newAggregateExpr(op Item, modifier, args Node) (ret *AggregateE
+ 		return
+ 	}
+ 
++	// OP_FUNCTIONS
++	if ret.Op.IsOPTop() {
++		ret.Expr = arguments[len(arguments)-1]
++		ret.Param = &NumberLiteral{Val: 0}
++		if len(arguments) > 1 {
++			ret.Param = arguments[0]
++			ret.Grouping = make([]string, len(arguments)-2)
++			for i, argument := range arguments[1 : len(arguments)-1] {
++				ret.Grouping[i] = argument.String()
++			}
++		}
++		return ret
++	}
++
+ 	desiredArgs := 1
+ 	if ret.Op.IsAggregatorWithParam() {
+ 		desiredArgs = 2

--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/006-printer-op-top-aggregate-string.patch
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/006-printer-op-top-aggregate-string.patch
@@ -1,0 +1,44 @@
+diff --git a/promql/parser/printer.go b/promql/parser/printer.go
+--- a/promql/parser/printer.go
++++ b/promql/parser/printer.go
+@@ -62,14 +62,35 @@ func (es Expressions) String() (s string) {
+ }
+ 
+ func (node *AggregateExpr) String() string {
+-	aggrString := node.getAggOpStr()
+-	aggrString += "("
++	var aggrString strings.Builder
++	if node.Op.IsOPTop() {
++		_, _ = aggrString.WriteString(node.Op.String())
++		_, _ = aggrString.WriteString("(")
++
++		// op_top(limit, arg1, ..., expr) — Param is the limit, Grouping holds middle args
++		_, _ = aggrString.WriteString(node.Param.String())
++		for _, g := range node.Grouping {
++			_, _ = aggrString.WriteString(", ")
++			_, _ = aggrString.WriteString(g)
++		}
++
++		_, _ = aggrString.WriteString(", ")
++		_, _ = aggrString.WriteString(node.Expr.String())
++		_, _ = aggrString.WriteString(")")
++
++		return aggrString.String()
++	}
++
++	_, _ = aggrString.WriteString(node.getAggOpStr())
++	_, _ = aggrString.WriteString("(")
+ 	if node.Op.IsAggregatorWithParam() {
+-		aggrString += fmt.Sprintf("%s, ", node.Param)
++		_, _ = aggrString.WriteString(node.Param.String())
++		_, _ = aggrString.WriteString(", ")
+ 	}
+-	aggrString += fmt.Sprintf("%s)", node.Expr)
++	_, _ = aggrString.WriteString(node.Expr.String())
++	_, _ = aggrString.WriteString(")")
+ 
+-	return aggrString
++	return aggrString.String()
+ }
+ 
+ func (node *AggregateExpr) getAggOpStr() string {

--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/README.md
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/README.md
@@ -47,4 +47,40 @@ go mod tidy
 git diff
 ```
 
-`
+## 005-op-functions.patch
+
+Applied to vendored `github.com/prometheus/prometheus` after `go mod vendor`.
+
+Patches existing vendored Prometheus parser files to:
+- Register `OP_TOP` as a keyword and aggregate operator in the parser lexer and grammar
+- Handle `op_top` argument parsing in `newAggregateExpr`
+
+No engine changes are needed: prometheus-operator only parses PromQL to validate
+PrometheusRule CRs (via `rulefmt.Parse` in admission/`ValidateRule`/`po-lint` and
+`parser.ParseExpr` in `namespacelabeler`) — it never evaluates queries.
+
+The parser is regenerated from the `.y` grammar using `goyacc` during the build.
+
+## 006-printer-op-top-aggregate-string.patch
+
+Applied to vendored `github.com/prometheus/prometheus` after `go mod vendor`.
+
+Patches existing vendored Prometheus files to:
+- Add to the `String` method of the `AggregateExpr` struct to print the expression with the `op_top` function
+
+Required for `namespacelabeler`: after injecting the namespace matcher into the AST
+it serialises the expression back via `parsedExpr.String()` and writes the result
+into `Rule.Expr`. Without this patch an `op_top(...)` expression would be rewritten
+as plain `topk(...)` (or otherwise broken) when an enforced namespace label is set.
+
+## op_funcs_init.go.tpl
+
+Copied into vendored `github.com/prometheus/prometheus/promql/parser/` after `go mod vendor`.
+
+Registers custom PromQL op-functions (`op_defined`, `op_replace_nan`, `op_smoothie`,
+`op_zero_if_none`) in `parser.Functions` so `parser.ParseExpr` accepts them. The file
+is placed directly in the `parser` package,
+because prometheus-operator only imports `promql/parser` and never links the
+`promql` package, so registering via the `promql.FunctionCalls` map would have no
+effect. No stub `FunctionCalls` entries are added — the engine is never executed
+inside the operator.

--- a/modules/200-operator-prometheus/images/prometheus-operator/patches/op_funcs_init.go.tpl
+++ b/modules/200-operator-prometheus/images/prometheus-operator/patches/op_funcs_init.go.tpl
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser
+
+func init() {
+	registerOPFunctions()
+}
+
+func registerOPFunctions() {
+	Functions["op_defined"] = &Function{
+		Name:       "op_defined",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	}
+	Functions["op_replace_nan"] = &Function{
+		Name:       "op_replace_nan",
+		ArgTypes:   []ValueType{ValueTypeMatrix, ValueTypeScalar, ValueTypeScalar},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+	}
+	Functions["op_smoothie"] = &Function{
+		Name:       "op_smoothie",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+	}
+	Functions["op_zero_if_none"] = &Function{
+		Name:       "op_zero_if_none",
+		ArgTypes:   []ValueType{ValueTypeMatrix, ValueTypeScalar},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+	}
+}

--- a/modules/200-operator-prometheus/images/prometheus-operator/werf.inc.yaml
+++ b/modules/200-operator-prometheus/images/prometheus-operator/werf.inc.yaml
@@ -16,7 +16,10 @@ shell:
   install:
     - git clone --depth 1 --branch "v{{ $version }}" $(cat /run/secrets/SOURCE_REPO)/prometheus-operator/prometheus-operator.git /src
     - cd /src
-    - git apply /patches/*.patch --verbose
+    - git apply /patches/001-endpointslices.patch --verbose
+    - git apply /patches/002-endpointslices_fallback.patch --verbose
+    - git apply /patches/003-alertmanager_tls_assets.patch --verbose
+    - git apply /patches/004-fix_cve.patch --verbose
     - rm -r .git
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $version | replace "." "-" }}
@@ -25,6 +28,10 @@ final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
     add: /src
+    before: install
+  - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
+    add: /patches
+    to: /patches
     before: install
 mount:
 {{ include "mount points for golang builds" . }}
@@ -37,6 +44,12 @@ shell:
     - export CGO_ENABLED=0 GOOS=linux GOARCH=amd64
     - GOPROXY=$(cat /run/secrets/GOPROXY) go mod download
     - go mod vendor
+    - GOPROXY=$(cat /run/secrets/GOPROXY) go install golang.org/x/tools/cmd/goyacc@latest
+    - cp /patches/op_funcs_init.go.tpl /src/vendor/github.com/prometheus/prometheus/promql/parser/op_funcs_init.go
+    - patch -d /src/vendor/github.com/prometheus/prometheus -p1 < /patches/005-op-functions.patch
+    - patch -d /src/vendor/github.com/prometheus/prometheus -p1 < /patches/006-printer-op-top-aggregate-string.patch
+    - cd /src/vendor/github.com/prometheus/prometheus/promql/parser && goyacc -l -o generated_parser.y.go generated_parser.y
+    - cd /src
     - export VERSION=$(cat VERSION | tr -d " \t\n\r")
     - export GO_BUILD_LDFLAGS="-X github.com/prometheus/common/version.Version=${VERSION} -X github.com/prometheus/common/version.BuildUser=deckhouse"
     - go build -ldflags="-s -w ${GO_BUILD_LDFLAGS}" -o /operator cmd/operator/main.go


### PR DESCRIPTION
## Description

Adds patches to the `prometheus-operator` image so its vendored Prometheus parser recognises `op_*` PromQL functions (`op_top`, `op_defined`, `op_replace_nan`, `op_smoothie`, `op_zero_if_none`).

Three new artefacts under `modules/200-operator-prometheus/images/prometheus-operator/patches/`:
- `005-op-functions.patch` — registers `OP_TOP` aggregate operator in lexer, grammar and `newAggregateExpr` (`promql/parser/{lex,generated_parser.y,parse}.go`).
- `006-printer-op-top-aggregate-string.patch` — teaches `AggregateExpr.String()` to print `op_top(limit, [labels...], expr)` correctly so `namespacelabeler` does not lose the limit on AST round-trip.
- `op_funcs_init.go.tpl` — registers the non-aggregate `op_*` functions in `parser.Functions` (placed directly in the `parser` package because the operator does not link the `promql` engine).

`werf.inc.yaml` is updated to apply these to the vendored `github.com/prometheus/prometheus` after `go mod vendor` and to regenerate the parser via `goyacc` before `go build`.

## Why do we need it, and what problem does it solve?

The operator's vendored Prometheus parser does not know about `op_top`/`op_defined`/`op_replace_nan`/`op_smoothie`/`op_zero_if_none` and rejects every `PrometheusRule` containing them.

The printer patch additionally prevents a silent miscompilation of `op_top(N, …)` rules whenever `enforcedNamespaceLabel` is set on a CR: without it the round-trip through `namespacelabeler` drops the limit `N` and turns the alert into `op_top(0, …)` with no parser error.

## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: common
type: fix
summary: Added support for `op_*` PromQL functions to the `operator-prometheus` parser.
impact_level: default
```