### PR TITLE
[istio] Refactor hooks to prepare for 1.27

### DIFF
--- a/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
+++ b/modules/110-istio/hooks/discovery_operator_versions_to_install_test.go
@@ -291,4 +291,56 @@ spec:
 			Expect(exists).To(BeFalse())
 		})
 	})
+
+	Context("Unknown versions in versionsToInstall are skipped", func() {
+		BeforeEach(func() {
+			values := `
+internal:
+  versionMap:
+    "1.25":
+        revision: "v1x25"
+        supportsOperator: true
+  versionsToInstall: ["1.25", "1.30"]
+`
+			f.ValuesSetFromYaml("istio", []byte(values))
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should keep only known operator-supported versions", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(Equal([]string{"1.25"}))
+
+			value, exists := requirements.GetValue(minVersionValuesKey)
+			Expect(exists).To(BeTrue())
+			Expect(value).To(BeEquivalentTo("1.25"))
+		})
+	})
+
+	Context("All operator-free versions clear minimal version", func() {
+		BeforeEach(func() {
+			values := `
+internal:
+  versionMap:
+    "1.27":
+        revision: "v1x27"
+        supportsOperator: false
+    "1.28":
+        revision: "v1x28"
+        supportsOperator: false
+  versionsToInstall: ["1.27", "1.28"]
+`
+			f.ValuesSetFromYaml("istio", []byte(values))
+			f.BindingContexts.Set(f.KubeStateSet(``))
+			f.RunHook()
+		})
+
+		It("Should keep operatorVersionsToInstall empty and remove requirement", func() {
+			Expect(f).To(ExecuteSuccessfully())
+			Expect(f.ValuesGet("istio.internal.operatorVersionsToInstall").AsStringSlice()).To(BeEmpty())
+
+			_, exists := requirements.GetValue(minVersionValuesKey)
+			Expect(exists).To(BeFalse())
+		})
+	})
 })

--- a/modules/110-istio/hooks/ensure_crds_istio.go
+++ b/modules/110-istio/hooks/ensure_crds_istio.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
@@ -29,6 +30,7 @@ import (
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/hooks/ensure_crds"
 	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib"
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/istio_versions"
 )
 
 var _ = sdk.RegisterFunc(&go_hook.HookConfig{
@@ -74,6 +76,16 @@ func ensureCRDs(ctx context.Context, input *go_hook.HookInput, dc dependency.Con
 	}
 	if len(crds) == 0 {
 		return fmt.Errorf("no CRD files found matching pattern: %s", crdsGlob)
+	}
+
+	versionMap := istio_versions.VersionMapJSONToVersionMap(input.Values.Get("istio.internal.versionMap").String())
+	if !versionMap.DoesVersionSupportOperator(CRDversionToInstall) {
+		for _, crdFile := range crds {
+			fileName := filepath.Base(crdFile)
+			if fileName == "crd-operator.yaml" || strings.HasPrefix(fileName, "sailoperator.io_") {
+				return fmt.Errorf("unsupported CRD file for operator-free version %s: %s", CRDversionToInstall, fileName)
+			}
+		}
 	}
 
 	return ensure_crds.EnsureCRDsHandler(crdsGlob)(ctx, input, dc)

--- a/modules/110-istio/hooks/purge_orphan_resources.go
+++ b/modules/110-istio/hooks/purge_orphan_resources.go
@@ -20,15 +20,18 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"regexp"
 
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
+	"github.com/deckhouse/deckhouse/modules/110-istio/hooks/lib/istio_versions"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -70,6 +73,22 @@ var _ = sdk.RegisterFunc(&go_hook.HookConfig{
 	OnAfterDeleteHelm: &go_hook.OrderedConfig{Order: 10},
 }, dependency.WithExternalDependencies(purgeOrphanResources))
 
+func isOperatorSupportedRevision(versionMap istio_versions.IstioVersionsMap, revision string) bool {
+	if revision == "" {
+		return true
+	}
+	version := versionMap.GetVersionByRevision(revision)
+	if version == "" {
+		return true
+	}
+	return versionMap.DoesVersionSupportOperator(version)
+}
+
+func isOperatorResourceByName(versionMap istio_versions.IstioVersionsMap, name string) bool {
+	revision := regexp.MustCompile(`v\d+x\d+`).FindString(name)
+	return isOperatorSupportedRevision(versionMap, revision)
+}
+
 func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc dependency.Container) error {
 	patch, err := json.Marshal(deleteFinalizersPatch)
 	if err != nil {
@@ -79,6 +98,7 @@ func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc depend
 	if err != nil {
 		return err
 	}
+	versionMap := istio_versions.VersionMapJSONToVersionMap(input.Values.Get("istio.internal.versionMap").String())
 
 	// Clean up cluster-wide IstioFederation resources
 	federations, err := k8sClient.Dynamic().Resource(istioFederationGVR).List(context.TODO(), metav1.ListOptions{})
@@ -138,6 +158,10 @@ func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc depend
 			input.Logger.Warn("Failed to list IstioOperator resources", log.Err(err))
 		} else {
 			for _, iop := range iops.Items {
+				revision, _, _ := unstructured.NestedString(iop.Object, "spec", "revision")
+				if !isOperatorSupportedRevision(versionMap, revision) {
+					continue
+				}
 				_, err = k8sClient.Dynamic().Resource(iopGVR).Namespace(istioSystemNs).Patch(context.TODO(), iop.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
 				if err != nil {
 					input.Logger.Warn("Failed to remove finalizers from IstioOperator",
@@ -173,6 +197,10 @@ func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc depend
 			input.Logger.Warn("Failed to list Istio resources", log.Err(err))
 		} else {
 			for _, istio := range istios.Items {
+				revision, _, _ := unstructured.NestedString(istio.Object, "spec", "revision")
+				if !isOperatorSupportedRevision(versionMap, revision) {
+					continue
+				}
 				_, err = k8sClient.Dynamic().Resource(istioGVR).Namespace(istioSystemNs).Patch(context.TODO(), istio.GetName(), types.MergePatchType, patch, metav1.PatchOptions{})
 				if err != nil {
 					input.Logger.Warn("Failed to remove finalizers from Istio",
@@ -246,6 +274,9 @@ func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc depend
 		input.Logger.Warn("Failed to list ClusterRoles", log.Err(err))
 	} else {
 		for _, icr := range icrs.Items {
+			if !isOperatorResourceByName(versionMap, icr.GetName()) {
+				continue
+			}
 			err := k8sClient.RbacV1().ClusterRoles().Delete(context.TODO(), icr.GetName(), metav1.DeleteOptions{})
 			if err != nil {
 				input.Logger.Warn("Failed to delete ClusterRole",
@@ -263,6 +294,9 @@ func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc depend
 		input.Logger.Warn("Failed to list ClusterRoleBindings", log.Err(err))
 	} else {
 		for _, icrb := range icrbs.Items {
+			if !isOperatorResourceByName(versionMap, icrb.GetName()) {
+				continue
+			}
 			err := k8sClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), icrb.GetName(), metav1.DeleteOptions{})
 			if err != nil {
 				input.Logger.Warn("Failed to delete ClusterRoleBinding",
@@ -280,6 +314,9 @@ func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc depend
 		input.Logger.Warn("Failed to list MutatingWebhookConfigurations", log.Err(err))
 	} else {
 		for _, imwc := range imwcs.Items {
+			if !isOperatorResourceByName(versionMap, imwc.GetName()) {
+				continue
+			}
 			err := k8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), imwc.GetName(), metav1.DeleteOptions{})
 			if err != nil {
 				input.Logger.Warn("Failed to delete MutatingWebhookConfiguration",
@@ -297,6 +334,9 @@ func purgeOrphanResources(_ context.Context, input *go_hook.HookInput, dc depend
 		input.Logger.Warn("Failed to list ValidatingWebhookConfigurations", log.Err(err))
 	} else {
 		for _, ivwc := range ivwcs.Items {
+			if !isOperatorResourceByName(versionMap, ivwc.GetName()) {
+				continue
+			}
 			err := k8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), ivwc.GetName(), metav1.DeleteOptions{})
 			if err != nil {
 				input.Logger.Warn("Failed to delete ValidatingWebhookConfiguration",

--- a/modules/110-istio/hooks/purge_orphan_resources_test.go
+++ b/modules/110-istio/hooks/purge_orphan_resources_test.go
@@ -325,4 +325,77 @@ metadata:
 			Expect(string(f.LoggerOutput.Contents())).To(ContainSubstring("\"msg\":\"Istio deleted\",\"name\":\"v1x16\""))
 		})
 	})
+
+	Context("Cluster with operator-free 1.27 resources", func() {
+		BeforeEach(func() {
+			f.BindingContexts.Set(f.GenerateAfterDeleteHelmContext())
+			f.ValuesSetFromYaml("istio", []byte(`
+internal:
+  versionMap:
+    "1.21":
+      revision: "v1x21"
+      supportsOperator: true
+    "1.25":
+      revision: "v1x25"
+      supportsOperator: true
+    "1.27":
+      revision: "v1x27"
+      supportsOperator: false
+`))
+			f.KubeStateSet(`
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: d8-istio
+  annotations:
+    deletionTimestamp: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ns1
+---
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  name: v1x21
+  namespace: d8-istio
+spec:
+  revision: v1x21
+---
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: v1x25
+  namespace: d8-istio
+spec:
+  revision: v1x25
+---
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: v1x27
+  namespace: d8-istio
+spec:
+  revision: v1x27
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-ca-root-cert
+  namespace: ns1
+`)
+			f.RunHook()
+		})
+
+		It("Should keep operator-free resources and clean operator-supported ones", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			Expect(f.KubernetesResource("IstioOperator", "d8-istio", "v1x21").Exists()).To(BeFalse())
+			Expect(f.KubernetesResource("Istio", "d8-istio", "v1x25").Exists()).To(BeFalse())
+
+			Expect(f.KubernetesResource("Istio", "d8-istio", "v1x27").Exists()).To(BeTrue())
+		})
+	})
 })


### PR DESCRIPTION
## Description
Refactor hooks for non-operator logic.
Now istio has _config-driven_ operator discovery, safe CRDs for non-operator Istio, and scoped purge so operator cleanup does not touch 1.27+.

**discovery_operator_versions_to_install.go** 

- Removed watch over `istiooperators` and fetch for `istios` to find out which `operatorVersionToInstall` have to be filled up. 
- Fiilling up `operatorVersionToInstall` logic replaced with iterating over `versionToInstall` with `supportOperator` condition.

Tests were adjusted to new logic.

**ensure_crds_istio.go**

- Added validation over files in directory of "non-operator" versions to have no "operator-like" files in it.

**purge_orphan_resources.go**

- Added two helpers `isOperatorSupportedRevision()` and `isOperatorResourceByName()` to be used as condition for "operator" and "non-operator" versions resources to be cleaned up.

Module uninstall still cleans the old operator stack, without tearing down a future native 1.27 control plane by mistake.

Tests were adjusted to new logic.

## Why do we need it, and what problem does it solve?

Istio 1.27+ no longer uses the operator, IOP, or Sail. Hooks must follow what we configure to install, not leftover CRs in the cluster.

Now operator discovery is config-only; CRD install is guarded for operator-free versions; module-uninstall cleanup  touches only those resources that are used by the revision.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Refactored Istio hooks to prepare for v1.27.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
