### PR TITLE
[deckhouse] Fix applications charts rendering issue

### DIFF
--- a/deckhouse-controller/internal/registry/service.go
+++ b/deckhouse-controller/internal/registry/service.go
@@ -19,6 +19,7 @@ package registry
 import (
 	"archive/tar"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log/slog"
@@ -36,6 +37,7 @@ import (
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
 	"github.com/deckhouse/deckhouse/go_lib/dependency"
 	"github.com/deckhouse/deckhouse/go_lib/dependency/cr"
+	registryhelpers "github.com/deckhouse/deckhouse/go_lib/registry/helpers"
 	"github.com/deckhouse/deckhouse/pkg/log"
 )
 
@@ -321,10 +323,18 @@ func BuildRemote[T *v1alpha1.ModuleSource | *v1alpha1.PackageRepository](reg T) 
 			Scheme:       v.Spec.Registry.Scheme,
 		}
 	case *v1alpha1.PackageRepository:
+		dockerCFG := v.Spec.Registry.DockerCFG
+		// Application charts read .Application.Package.Registry.dockercfg to build imagePullSecrets;
+		// synthesize one from login/password so charts work regardless of which auth method the spec uses.
+		if dockerCFG == "" && v.Spec.Registry.Login != "" {
+			if raw, err := registryhelpers.DockerCfgFromCreds(v.Spec.Registry.Login, v.Spec.Registry.Password, v.Spec.Registry.Repo); err == nil {
+				dockerCFG = base64.StdEncoding.EncodeToString(raw)
+			}
+		}
 		return Remote{
 			Name:         v.Name,
 			Repository:   v.Spec.Registry.Repo,
-			DockerConfig: v.Spec.Registry.DockerCFG,
+			DockerConfig: dockerCFG,
 			Login:        v.Spec.Registry.Login,
 			Password:     v.Spec.Registry.Password,
 			CA:           v.Spec.Registry.CA,

--- a/deckhouse-controller/internal/registry/service_test.go
+++ b/deckhouse-controller/internal/registry/service_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+	registryhelpers "github.com/deckhouse/deckhouse/go_lib/registry/helpers"
+)
+
+const existingDockerCfg = "ZXhpc3Rpbmc=" // literally "existing" string
+
+func TestBuildRemote_PackageRepository_DockerCfgPreserved(t *testing.T) {
+	pr := &v1alpha1.PackageRepository{}
+	pr.Name = "test"
+	pr.Spec.Registry.Repo = "dev-registry.deckhouse.io/deckhouse/foxtrot/packages"
+	pr.Spec.Registry.DockerCFG = existingDockerCfg
+	pr.Spec.Registry.Login = "license-token"
+	pr.Spec.Registry.Password = "secret"
+
+	got := BuildRemote(pr)
+	// existing dockerCfg must not be overwritten
+	assert.Equal(t, got.DockerConfig, existingDockerCfg, "explicit dockerCfg must not be overwritten")
+	assert.Equal(t, got.Login, "license-token")
+	assert.Equal(t, got.Password, "secret")
+}
+
+func TestBuildRemote_PackageRepository_SynthesizeFromLoginPassword(t *testing.T) {
+	pr := &v1alpha1.PackageRepository{}
+	pr.Name = "test"
+	pr.Spec.Registry.Repo = "dev-registry.deckhouse.io/deckhouse/foxtrot/packages"
+	pr.Spec.Registry.Login = "license-token"
+	pr.Spec.Registry.Password = "secret"
+
+	got := BuildRemote(pr)
+	require.NotEmpty(t, got.DockerConfig, "synthesized dockerCfg must not be empty when login is set")
+
+	raw, err := base64.StdEncoding.DecodeString(got.DockerConfig)
+	require.NoError(t, err, "DockerConfig must be base64-encoded")
+
+	username, password, err := registryhelpers.CredsFromDockerCfg(raw, "dev-registry.deckhouse.io")
+	require.NoError(t, err)
+	assert.Equal(t, username, "license-token")
+	assert.Equal(t, password, "secret")
+}
+
+func TestBuildRemote_PackageRepository_NoCredentials(t *testing.T) {
+	pr := &v1alpha1.PackageRepository{}
+	pr.Name = "test"
+	pr.Spec.Registry.Repo = "dev-registry.deckhouse.io/deckhouse/foxtrot/packages"
+
+	got := BuildRemote(pr)
+	assert.Empty(t, got.DockerConfig, "no credentials → no synthesized dockerCfg")
+	assert.Empty(t, got.Login)
+	assert.Empty(t, got.Password)
+}
+
+func TestBuildRemote_ModuleSource_LoginPasswordNotApplicable(t *testing.T) {
+	ms := &v1alpha1.ModuleSource{}
+	ms.Name = "source"
+	ms.Spec.Registry.Repo = "dev-registry.deckhouse.io/deckhouse/modules"
+	ms.Spec.Registry.DockerCFG = existingDockerCfg
+
+	got := BuildRemote(ms)
+	assert.Equal(t, existingDockerCfg, got.DockerConfig)
+	assert.Empty(t, got.Login)
+	assert.Empty(t, got.Password)
+}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Fix Application install failure when `PackageRepository` uses `login/password` instead of `dockerCfg`.

**Before:**
- `PackageRepository` configured with only `login`+`password` (no `dockerCfg`) breaks `Application` install.
- Helm/nelm fails at server-side apply of the chart's `kubernetes.io/dockerconfigjson` Secret: `data[.dockerconfigjson]: Required value`, because `.Application.Package.Registry.dockercfg` resolves to an empty string.
- `Application.status.conditions` stays at `Installed=False`, `Reason=ManifestsApplyFailed`.

<img width="1398" height="584" alt="2026-05-28 AT 17 00@2x" src="https://github.com/user-attachments/assets/0a17403c-48ba-44b5-93de-1b272db5751f" />


**After:**
- `BuildRemote` derives `Remote.DockerConfig` from `login`/`password` (via `registryhelpers.DockerCfgFromCreds`) when the spec doesn't carry an explicit `dockerCfg`.
- The application chart receives a valid base64-encoded docker config JSON regardless of which auth field the user filled.
- `Application` installs cleanly with either auth method.
<img width="1294" height="458" alt="2026-05-28 AT 17 09@2x" src="https://github.com/user-attachments/assets/7d8c9f99-7c6d-41dc-a98f-d8df72bbd77c" />



## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

- Affects every user who configures a private registry with username/password
- `PackageRepository.spec.registry` advertises two equivalent ways to provide credentials: `dockerCfg` or `login`+`password`. Only the former actually worked end-to-end - the latter silently broke at chart render.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed an applications charts rendering issue.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
