### PR TITLE
[control-plane] Add Kubernetes scheduler patch for graceful node shutdown

### DIFF
--- a/ee/modules/000-common/images/kubernetes/patches/1.32/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
+++ b/ee/modules/000-common/images/kubernetes/patches/1.32/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
@@ -26,11 +26,12 @@ diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go b/pkg/kubele
 index 989f0dc76e0..560a43d83a5 100644
 --- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
 +++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
-@@ -21,6 +21,7 @@ limitations under the License.
+@@ -21,7 +21,8 @@ limitations under the License.
  package nodeshutdown
  
  import (
 +	"context"
+ 	"errors"
  	"fmt"
  	"os"
  	"path/filepath"

--- a/ee/modules/000-common/images/kubernetes/patches/1.33/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
+++ b/ee/modules/000-common/images/kubernetes/patches/1.33/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
@@ -31,9 +31,9 @@ index 989f0dc76e0..560a43d83a5 100644
  
  import (
 +	"context"
+ 	"errors"
  	"fmt"
  	"os"
- 	"path/filepath"
 @@ -38,6 +39,7 @@ import (
  	"k8s.io/kubernetes/pkg/kubelet/metrics"
  	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown/systemd"

--- a/ee/modules/000-common/images/kubernetes/patches/1.34/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
+++ b/ee/modules/000-common/images/kubernetes/patches/1.34/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
@@ -26,11 +26,12 @@ diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go b/pkg/kubele
 index c998a2663d9..0d55f15dbeb 100644
 --- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
 +++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
-@@ -21,6 +21,7 @@ limitations under the License.
+@@ -21,7 +21,8 @@ limitations under the License.
  package nodeshutdown
  
  import (
 +	"context"
+ 	"errors"
  	"fmt"
  	"os"
  	"path/filepath"
@@ -120,10 +121,10 @@ index c998a2663d9..0d55f15dbeb 100644
  					m.recorder.Event(m.nodeRef, v1.EventTypeNormal, kubeletevents.NodeShutdown, "Shutdown manager detected shutdown cancellation")
  				}
  
--			    // Clean up memory manager state before shutdown
--			    if isShuttingDown {
--				    m.cleanupMemoryManagerState()
--			    }
+-				// Clean up memory manager state before shutdown
+-				if isShuttingDown {
+-					m.cleanupMemoryManagerState()
+-				}
 +				// Check if shutdown is postponed by the condition and prevent setting m.nodeShuttingDownNow=true to keep Ready status for the Node.
 +				if isShuttingDown {
 +					postponeStatus, err := m.conditionChecker.PostponeStatus()

--- a/ee/modules/000-common/images/kubernetes/patches/1.35/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
+++ b/ee/modules/000-common/images/kubernetes/patches/1.35/013-kubelet-graceful-shutdown-wait-for-external-inhibitors.patch
@@ -26,11 +26,12 @@ diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go b/pkg/kubele
 index 505b3a5c326..2c75ea64aee 100644
 --- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
 +++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
-@@ -21,6 +21,7 @@ limitations under the License.
+@@ -21,7 +21,8 @@ limitations under the License.
  package nodeshutdown
  
  import (
 +	"context"
+ 	"errors"
  	"fmt"
  	"os"
  	"path/filepath"

--- a/modules/000-common/images/kubernetes/patches/1.32/012-fix-scheduler-node-graceful-shutdown.patch
+++ b/modules/000-common/images/kubernetes/patches/1.32/012-fix-scheduler-node-graceful-shutdown.patch
@@ -1,0 +1,365 @@
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+index 989f0dc76e0..ab496787650 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+@@ -21,6 +21,7 @@ limitations under the License.
+ package nodeshutdown
+ 
+ import (
++	"errors"
+ 	"fmt"
+ 	"os"
+ 	"path/filepath"
+@@ -30,6 +31,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -290,7 +292,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+index a8aa021b2a5..bc7d029441a 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+@@ -30,6 +30,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -237,7 +238,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodestatus/setters_test.go b/pkg/kubelet/nodestatus/setters_test.go
+index 4fffe32e3c9..df3b3a39290 100644
+--- a/pkg/kubelet/nodestatus/setters_test.go
++++ b/pkg/kubelet/nodestatus/setters_test.go
+@@ -42,6 +42,7 @@ import (
+ 	fakecloud "k8s.io/cloud-provider/fake"
+ 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+ 	"k8s.io/component-base/version"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	"k8s.io/kubernetes/pkg/kubelet/cm"
+ 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+@@ -1667,8 +1668,8 @@ func TestReadyCondition(t *testing.T) {
+ 		{
+ 			desc:                      "new, not ready: shutdown active",
+ 			node:                      withCapacity.DeepCopy(),
+-			nodeShutdownManagerErrors: errors.New("node is shutting down"),
+-			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, "node is shutting down", now, now)},
++			nodeShutdownManagerErrors: errors.New(nodeutil.NodeShutdownMessage),
++			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, nodeutil.NodeShutdownMessage, now, now)},
+ 		},
+ 		{
+ 			desc:             "new, not ready: runtime and network errors",
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+index f807f95d5fa..5788dd80511 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+@@ -21,6 +21,7 @@ import (
+ 
+ 	v1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	v1helper "k8s.io/component-helpers/scheduling/corev1"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework"
+@@ -46,6 +47,8 @@ const (
+ 	ErrReasonUnknownCondition = "node(s) had unknown conditions"
+ 	// ErrReasonUnschedulable is used for NodeUnschedulable predicate error.
+ 	ErrReasonUnschedulable = "node(s) were unschedulable"
++	// ErrReasonNodeShutdown is used for shutting down Node predicate error.
++	ErrReasonNodeShutdown = "node(s) were shutting down"
+ )
+ 
+ // EventsToRegister returns the possible events that may make a Pod
+@@ -63,7 +66,7 @@ func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]framework.Cl
+ 
+ 	return []framework.ClusterEventWithHint{
+ 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeLabel event.
+-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
++		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeCondition}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+ 		// When the QueueingHint feature is enabled,
+ 		// the scheduling queue uses Pod/Update Queueing Hint
+ 		// to determine whether a Pod's update makes the Pod schedulable or not.
+@@ -112,9 +115,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
+ 
+ 	// We queue this Pod when -
+ 	// 1. the node is updated from unschedulable to schedulable.
+-	// 2. the node is added and is schedulable.
++	// 2. the node is updated from shutting down to not shutting down.
++	// 3. the node is added and is schedulable.
+ 	if (originalNode != nil && originalNode.Spec.Unschedulable && !modifiedNode.Spec.Unschedulable) ||
+-		(originalNode == nil && !modifiedNode.Spec.Unschedulable) {
++		(originalNode != nil && nodeutil.IsNodeInGracefulShutdown(originalNode) && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) ||
++		(originalNode == nil && !modifiedNode.Spec.Unschedulable && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) {
+ 		logger.V(5).Info("node was created or updated, pod may be schedulable now", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
+ 		return framework.Queue, nil
+ 	}
+@@ -131,6 +136,9 @@ func (pl *NodeUnschedulable) Name() string {
+ // Filter invoked at the filter extension point.
+ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+ 	node := nodeInfo.Node()
++	if nodeutil.IsNodeInGracefulShutdown(node) {
++		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeShutdown)
++	}
+ 
+ 	if !node.Spec.Unschedulable {
+ 		return nil
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+index ee4a6143b8c..d4e11159b06 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+@@ -21,6 +21,7 @@ import (
+ 	"testing"
+ 
+ 	v1 "k8s.io/api/core/v1"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+ 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+@@ -71,6 +72,23 @@ func TestNodeUnschedulable(t *testing.T) {
+ 				},
+ 			},
+ 		},
++		{
++			name:       "Does not schedule pod to shutting down node",
++			pod:        st.MakePod().Toleration(v1.TaintNodeNotReady).Obj(),
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, nodeutil.NodeShutdownMessage, "KubeletNotReady").Obj(),
++			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name:       "Does not schedule pod to node with shutdown reason",
++			pod:        &v1.Pod{},
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "", nodeutil.NodeShutdownMessage).Obj(),
++			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name: "Schedule pod to not ready node without shutdown signal",
++			pod:  &v1.Pod{},
++			node: st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "runtime error", "KubeletNotReady").Obj(),
++		},
+ 	}
+ 
+ 	for _, test := range testCases {
+@@ -125,6 +143,17 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: framework.QueueSkip,
+ 		},
++		{
++			name: "skip-queue-on-shutting-down-node-added",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: framework.QueueSkip,
++		},
+ 		{
+ 			name: "queue-on-schedulable-node-added",
+ 			pod:  &v1.Pod{},
+@@ -135,6 +164,40 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: framework.Queue,
+ 		},
++		{
++			name: "queue-on-shutdown-condition-cleared",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: framework.Queue,
++		},
++		{
++			name: "skip-queue-on-shutdown-condition-set",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			expectedHint: framework.QueueSkip,
++		},
+ 		{
+ 			name: "skip-unrelated-change-unschedulable-true",
+ 			pod:  &v1.Pod{},
+diff --git a/pkg/scheduler/scheduler_test.go b/pkg/scheduler/scheduler_test.go
+index 5806fd5e072..ae7ce39e89c 100644
+--- a/pkg/scheduler/scheduler_test.go
++++ b/pkg/scheduler/scheduler_test.go
+@@ -902,7 +902,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[framework.EventResource]framework.ActionType{
+ 				framework.Pod:                   framework.Add | framework.UpdatePodLabel | framework.UpdatePodScaleDown | framework.UpdatePodTolerations | framework.UpdatePodSchedulingGatesEliminated | framework.Delete,
+-				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
++				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.UpdateNodeCondition | framework.Delete,
+ 				framework.CSINode:               framework.All - framework.Delete,
+ 				framework.CSIDriver:             framework.Update,
+ 				framework.CSIStorageCapacity:    framework.All - framework.Delete,
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions.go b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+index 3ad4dda8911..0be0efe5a45 100644
+--- a/staging/src/k8s.io/component-helpers/node/util/conditions.go
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+@@ -19,6 +19,7 @@ package util
+ import (
+ 	"context"
+ 	"encoding/json"
++	"strings"
+ 	"time"
+ 
+ 	v1 "k8s.io/api/core/v1"
+@@ -27,6 +28,11 @@ import (
+ 	clientset "k8s.io/client-go/kubernetes"
+ )
+ 
++const (
++	// NodeShutdownMessage is used by kubelet when reporting that graceful node shutdown is active.
++	NodeShutdownMessage = "node is shutting down"
++)
++
+ // GetNodeCondition extracts the provided condition from the given status and returns that.
+ // Returns nil and -1 if the condition is not present, and the index of the located condition.
+ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType) (int, *v1.NodeCondition) {
+@@ -41,6 +47,18 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
+ 	return -1, nil
+ }
+ 
++// IsNodeInGracefulShutdown returns true when the NodeReady condition reports graceful node shutdown.
++func IsNodeInGracefulShutdown(node *v1.Node) bool {
++	if node == nil {
++		return false
++	}
++	_, condition := GetNodeCondition(&node.Status, v1.NodeReady)
++	if condition == nil || condition.Status != v1.ConditionFalse {
++		return false
++	}
++	return condition.Reason == NodeShutdownMessage || strings.Contains(condition.Message, NodeShutdownMessage)
++}
++
+ // SetNodeCondition updates specific node condition with patch operation.
+ func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.NodeCondition) error {
+ 	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions_test.go b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+new file mode 100644
+index 00000000000..086eec5d728
+--- /dev/null
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+@@ -0,0 +1,81 @@
++/*
++Copyright 2026 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package util
++
++import (
++	"testing"
++
++	v1 "k8s.io/api/core/v1"
++)
++
++func TestIsNodeInGracefulShutdown(t *testing.T) {
++	testCases := []struct {
++		name string
++		node *v1.Node
++		want bool
++	}{
++		{
++			name: "nil node",
++		},
++		{
++			name: "ready node",
++			node: nodeWithReadyCondition(v1.ConditionTrue, "KubeletReady", "kubelet is posting ready status"),
++		},
++		{
++			name: "not ready without shutdown signal",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "runtime error"),
++		},
++		{
++			name: "shutdown by message",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", NodeShutdownMessage),
++			want: true,
++		},
++		{
++			name: "shutdown by reason",
++			node: nodeWithReadyCondition(v1.ConditionFalse, NodeShutdownMessage, ""),
++			want: true,
++		},
++		{
++			name: "shutdown message with aggregated errors",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "[runtime error, "+NodeShutdownMessage+"]"),
++			want: true,
++		},
++	}
++
++	for _, tc := range testCases {
++		t.Run(tc.name, func(t *testing.T) {
++			if got := IsNodeInGracefulShutdown(tc.node); got != tc.want {
++				t.Fatalf("IsNodeInGracefulShutdown() = %v, want %v", got, tc.want)
++			}
++		})
++	}
++}
++
++func nodeWithReadyCondition(status v1.ConditionStatus, reason, message string) *v1.Node {
++	return &v1.Node{
++		Status: v1.NodeStatus{
++			Conditions: []v1.NodeCondition{
++				{
++					Type:    v1.NodeReady,
++					Status:  status,
++					Reason:  reason,
++					Message: message,
++				},
++			},
++		},
++	}
++}

--- a/modules/000-common/images/kubernetes/patches/1.33/012-fix-scheduler-node-graceful-shutdown.patch
+++ b/modules/000-common/images/kubernetes/patches/1.33/012-fix-scheduler-node-graceful-shutdown.patch
@@ -1,0 +1,398 @@
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+index 989f0dc76e0..ab496787650 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+@@ -21,6 +21,7 @@ limitations under the License.
+ package nodeshutdown
+ 
+ import (
++	"errors"
+ 	"fmt"
+ 	"os"
+ 	"path/filepath"
+@@ -30,6 +31,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -290,7 +292,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+index a8aa021b2a5..0af2e644909 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+@@ -21,6 +21,7 @@ limitations under the License.
+ package nodeshutdown
+ 
+ import (
++	"errors"
+ 	"fmt"
+ 	"path/filepath"
+ 	"strings"
+@@ -30,6 +31,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -237,7 +239,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodestatus/setters_test.go b/pkg/kubelet/nodestatus/setters_test.go
+index 53d22b1adfb..5ad71a56007 100644
+--- a/pkg/kubelet/nodestatus/setters_test.go
++++ b/pkg/kubelet/nodestatus/setters_test.go
+@@ -43,6 +43,7 @@ import (
+ 	"k8s.io/component-base/featuregate"
+ 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+ 	"k8s.io/component-base/version"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	"k8s.io/kubernetes/pkg/kubelet/cm"
+ 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+@@ -1709,8 +1710,8 @@ func TestReadyCondition(t *testing.T) {
+ 		{
+ 			desc:                      "new, not ready: shutdown active",
+ 			node:                      withCapacity.DeepCopy(),
+-			nodeShutdownManagerErrors: errors.New("node is shutting down"),
+-			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, "node is shutting down", now, now)},
++			nodeShutdownManagerErrors: errors.New(nodeutil.NodeShutdownMessage),
++			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, nodeutil.NodeShutdownMessage, now, now)},
+ 		},
+ 		{
+ 			desc:             "new, not ready: runtime and network errors",
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+index 50a4264aa1a..4177edc9dbc 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+@@ -21,6 +21,7 @@ import (
+ 
+ 	v1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	v1helper "k8s.io/component-helpers/scheduling/corev1"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework"
+@@ -46,6 +47,8 @@ const (
+ 	ErrReasonUnknownCondition = "node(s) had unknown conditions"
+ 	// ErrReasonUnschedulable is used for NodeUnschedulable predicate error.
+ 	ErrReasonUnschedulable = "node(s) were unschedulable"
++	// ErrReasonNodeShutdown is used for shutting down Node predicate error.
++	ErrReasonNodeShutdown = "node(s) were shutting down"
+ )
+ 
+ // EventsToRegister returns the possible events that may make a Pod
+@@ -57,13 +60,13 @@ func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]framework.Cl
+ 			// Ideally, it's supposed to register only Add | UpdateNodeTaint because UpdateNodeLabel will never change the result from this plugin.
+ 			// But, we may miss Node/Add event due to preCheck, and we decided to register UpdateNodeTaint | UpdateNodeLabel for all plugins registering Node/Add.
+ 			// See: https://github.com/kubernetes/kubernetes/issues/109437
+-			{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeLabel}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
++			{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeLabel | framework.UpdateNodeCondition}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+ 		}, nil
+ 	}
+ 
+ 	return []framework.ClusterEventWithHint{
+ 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeLabel event.
+-		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
++		{Event: framework.ClusterEvent{Resource: framework.Node, ActionType: framework.Add | framework.UpdateNodeTaint | framework.UpdateNodeCondition}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+ 		// When the QueueingHint feature is enabled,
+ 		// the scheduling queue uses Pod/Update Queueing Hint
+ 		// to determine whether a Pod's update makes the Pod schedulable or not.
+@@ -112,9 +115,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
+ 
+ 	// We queue this Pod when -
+ 	// 1. the node is updated from unschedulable to schedulable.
+-	// 2. the node is added and is schedulable.
++	// 2. the node is updated from shutting down to not shutting down.
++	// 3. the node is added and is schedulable.
+ 	if (originalNode != nil && originalNode.Spec.Unschedulable && !modifiedNode.Spec.Unschedulable) ||
+-		(originalNode == nil && !modifiedNode.Spec.Unschedulable) {
++		(originalNode != nil && nodeutil.IsNodeInGracefulShutdown(originalNode) && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) ||
++		(originalNode == nil && !modifiedNode.Spec.Unschedulable && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) {
+ 		logger.V(5).Info("node was created or updated, pod may be schedulable now", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
+ 		return framework.Queue, nil
+ 	}
+@@ -131,6 +136,9 @@ func (pl *NodeUnschedulable) Name() string {
+ // Filter invoked at the filter extension point.
+ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
+ 	node := nodeInfo.Node()
++	if nodeutil.IsNodeInGracefulShutdown(node) {
++		return framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeShutdown)
++	}
+ 
+ 	if !node.Spec.Unschedulable {
+ 		return nil
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+index 0ded5785a3d..54867b88990 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+@@ -22,6 +22,7 @@ import (
+ 	"github.com/google/go-cmp/cmp"
+ 
+ 	v1 "k8s.io/api/core/v1"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+ 	st "k8s.io/kubernetes/pkg/scheduler/testing"
+@@ -72,6 +73,23 @@ func TestNodeUnschedulable(t *testing.T) {
+ 				},
+ 			},
+ 		},
++		{
++			name:       "Does not schedule pod to shutting down node",
++			pod:        st.MakePod().Toleration(v1.TaintNodeNotReady).Obj(),
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, nodeutil.NodeShutdownMessage, "KubeletNotReady").Obj(),
++			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name:       "Does not schedule pod to node with shutdown reason",
++			pod:        &v1.Pod{},
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "", nodeutil.NodeShutdownMessage).Obj(),
++			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name: "Schedule pod to not ready node without shutdown signal",
++			pod:  &v1.Pod{},
++			node: st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "runtime error", "KubeletNotReady").Obj(),
++		},
+ 	}
+ 
+ 	for _, test := range testCases {
+@@ -126,6 +144,17 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: framework.QueueSkip,
+ 		},
++		{
++			name: "skip-queue-on-shutting-down-node-added",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: framework.QueueSkip,
++		},
+ 		{
+ 			name: "queue-on-schedulable-node-added",
+ 			pod:  &v1.Pod{},
+@@ -136,6 +165,40 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: framework.Queue,
+ 		},
++		{
++			name: "queue-on-shutdown-condition-cleared",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: framework.Queue,
++		},
++		{
++			name: "skip-queue-on-shutdown-condition-set",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			expectedHint: framework.QueueSkip,
++		},
+ 		{
+ 			name: "skip-unrelated-change-unschedulable-true",
+ 			pod:  &v1.Pod{},
+diff --git a/pkg/scheduler/scheduler_test.go b/pkg/scheduler/scheduler_test.go
+index a9dd787e7df..61b99070eb7 100644
+--- a/pkg/scheduler/scheduler_test.go
++++ b/pkg/scheduler/scheduler_test.go
+@@ -875,7 +875,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[framework.EventResource]framework.ActionType{
+ 				framework.Pod:                   framework.Add | framework.UpdatePodLabel | framework.Delete,
+-				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
++				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.UpdateNodeCondition | framework.Delete,
+ 				framework.CSINode:               framework.All - framework.Delete,
+ 				framework.CSIDriver:             framework.Update,
+ 				framework.CSIStorageCapacity:    framework.All - framework.Delete,
+@@ -890,7 +890,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[framework.EventResource]framework.ActionType{
+ 				framework.Pod:                   framework.Add | framework.UpdatePodLabel | framework.UpdatePodScaleDown | framework.Delete,
+-				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
++				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.UpdateNodeCondition | framework.Delete,
+ 				framework.CSINode:               framework.All - framework.Delete,
+ 				framework.CSIDriver:             framework.Update,
+ 				framework.CSIStorageCapacity:    framework.All - framework.Delete,
+@@ -906,7 +906,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[framework.EventResource]framework.ActionType{
+ 				framework.Pod:                   framework.Add | framework.UpdatePodLabel | framework.UpdatePodScaleDown | framework.UpdatePodToleration | framework.UpdatePodSchedulingGatesEliminated | framework.Delete,
+-				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.Delete,
++				framework.Node:                  framework.Add | framework.UpdateNodeAllocatable | framework.UpdateNodeLabel | framework.UpdateNodeTaint | framework.UpdateNodeCondition | framework.Delete,
+ 				framework.CSINode:               framework.All - framework.Delete,
+ 				framework.CSIDriver:             framework.Update,
+ 				framework.CSIStorageCapacity:    framework.All - framework.Delete,
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions.go b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+index 3ad4dda8911..0be0efe5a45 100644
+--- a/staging/src/k8s.io/component-helpers/node/util/conditions.go
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+@@ -19,6 +19,7 @@ package util
+ import (
+ 	"context"
+ 	"encoding/json"
++	"strings"
+ 	"time"
+ 
+ 	v1 "k8s.io/api/core/v1"
+@@ -27,6 +28,11 @@ import (
+ 	clientset "k8s.io/client-go/kubernetes"
+ )
+ 
++const (
++	// NodeShutdownMessage is used by kubelet when reporting that graceful node shutdown is active.
++	NodeShutdownMessage = "node is shutting down"
++)
++
+ // GetNodeCondition extracts the provided condition from the given status and returns that.
+ // Returns nil and -1 if the condition is not present, and the index of the located condition.
+ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType) (int, *v1.NodeCondition) {
+@@ -41,6 +47,18 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
+ 	return -1, nil
+ }
+ 
++// IsNodeInGracefulShutdown returns true when the NodeReady condition reports graceful node shutdown.
++func IsNodeInGracefulShutdown(node *v1.Node) bool {
++	if node == nil {
++		return false
++	}
++	_, condition := GetNodeCondition(&node.Status, v1.NodeReady)
++	if condition == nil || condition.Status != v1.ConditionFalse {
++		return false
++	}
++	return condition.Reason == NodeShutdownMessage || strings.Contains(condition.Message, NodeShutdownMessage)
++}
++
+ // SetNodeCondition updates specific node condition with patch operation.
+ func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.NodeCondition) error {
+ 	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions_test.go b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+new file mode 100644
+index 00000000000..086eec5d728
+--- /dev/null
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+@@ -0,0 +1,81 @@
++/*
++Copyright 2026 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package util
++
++import (
++	"testing"
++
++	v1 "k8s.io/api/core/v1"
++)
++
++func TestIsNodeInGracefulShutdown(t *testing.T) {
++	testCases := []struct {
++		name string
++		node *v1.Node
++		want bool
++	}{
++		{
++			name: "nil node",
++		},
++		{
++			name: "ready node",
++			node: nodeWithReadyCondition(v1.ConditionTrue, "KubeletReady", "kubelet is posting ready status"),
++		},
++		{
++			name: "not ready without shutdown signal",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "runtime error"),
++		},
++		{
++			name: "shutdown by message",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", NodeShutdownMessage),
++			want: true,
++		},
++		{
++			name: "shutdown by reason",
++			node: nodeWithReadyCondition(v1.ConditionFalse, NodeShutdownMessage, ""),
++			want: true,
++		},
++		{
++			name: "shutdown message with aggregated errors",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "[runtime error, "+NodeShutdownMessage+"]"),
++			want: true,
++		},
++	}
++
++	for _, tc := range testCases {
++		t.Run(tc.name, func(t *testing.T) {
++			if got := IsNodeInGracefulShutdown(tc.node); got != tc.want {
++				t.Fatalf("IsNodeInGracefulShutdown() = %v, want %v", got, tc.want)
++			}
++		})
++	}
++}
++
++func nodeWithReadyCondition(status v1.ConditionStatus, reason, message string) *v1.Node {
++	return &v1.Node{
++		Status: v1.NodeStatus{
++			Conditions: []v1.NodeCondition{
++				{
++					Type:    v1.NodeReady,
++					Status:  status,
++					Reason:  reason,
++					Message: message,
++				},
++			},
++		},
++	}
++}

--- a/modules/000-common/images/kubernetes/patches/1.33/012-fix-scheduler-node-graceful-shutdown.patch
+++ b/modules/000-common/images/kubernetes/patches/1.33/012-fix-scheduler-node-graceful-shutdown.patch
@@ -28,18 +28,10 @@ index 989f0dc76e0..ab496787650 100644
  	return nil
  }
 diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
-index a8aa021b2a5..0af2e644909 100644
+index a8aa021b2a5..bc7d029441a 100644
 --- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
 +++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
-@@ -21,6 +21,7 @@ limitations under the License.
- package nodeshutdown
- 
- import (
-+	"errors"
- 	"fmt"
- 	"path/filepath"
- 	"strings"
-@@ -30,6 +31,7 @@ import (
+@@ -30,6 +30,7 @@ import (
  	v1 "k8s.io/api/core/v1"
  	utilfeature "k8s.io/apiserver/pkg/util/feature"
  	"k8s.io/client-go/tools/record"
@@ -47,7 +39,7 @@ index a8aa021b2a5..0af2e644909 100644
  	"k8s.io/klog/v2"
  	"k8s.io/kubernetes/pkg/features"
  	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
-@@ -237,7 +239,7 @@ func (m *managerImpl) ShutdownStatus() error {
+@@ -237,7 +238,7 @@ func (m *managerImpl) ShutdownStatus() error {
  	defer m.nodeShuttingDownMutex.Unlock()
  
  	if m.nodeShuttingDownNow {

--- a/modules/000-common/images/kubernetes/patches/1.34/012-fix-scheduler-node-graceful-shutdown.patch
+++ b/modules/000-common/images/kubernetes/patches/1.34/012-fix-scheduler-node-graceful-shutdown.patch
@@ -1,0 +1,397 @@
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+index e9adac6ca57..ebeee5c42b3 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+@@ -21,6 +21,7 @@ limitations under the License.
+ package nodeshutdown
+ 
+ import (
++	"errors"
+ 	"fmt"
+ 	"os"
+ 	"path/filepath"
+@@ -30,6 +31,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -246,10 +248,10 @@ func (m *managerImpl) start() (chan struct{}, error) {
+ 					m.recorder.Event(m.nodeRef, v1.EventTypeNormal, kubeletevents.NodeShutdown, "Shutdown manager detected shutdown cancellation")
+ 				}
+ 
+-			    // Clean up memory manager state before shutdown
+-			    if isShuttingDown {
+-				    m.cleanupMemoryManagerState()
+-			    }
++				// Clean up memory manager state before shutdown
++				if isShuttingDown {
++					m.cleanupMemoryManagerState()
++				}
+ 
+ 				m.nodeShuttingDownMutex.Lock()
+ 				m.nodeShuttingDownNow = isShuttingDown
+@@ -287,7 +289,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+index 4c129d499dd..0c32481ee67 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+@@ -21,6 +21,7 @@ limitations under the License.
+ package nodeshutdown
+ 
+ import (
++	"errors"
+ 	"fmt"
+ 	"path/filepath"
+ 	"strings"
+@@ -30,6 +31,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -233,7 +235,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodestatus/setters_test.go b/pkg/kubelet/nodestatus/setters_test.go
+index 6e5971ed9af..341bdf109a1 100644
+--- a/pkg/kubelet/nodestatus/setters_test.go
++++ b/pkg/kubelet/nodestatus/setters_test.go
+@@ -41,6 +41,7 @@ import (
+ 	"k8s.io/component-base/featuregate"
+ 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+ 	"k8s.io/component-base/version"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	"k8s.io/kubernetes/pkg/kubelet/cm"
+ 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+@@ -1247,8 +1248,8 @@ func TestReadyCondition(t *testing.T) {
+ 		{
+ 			desc:                      "new, not ready: shutdown active",
+ 			node:                      withCapacity.DeepCopy(),
+-			nodeShutdownManagerErrors: errors.New("node is shutting down"),
+-			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, "node is shutting down", now, now)},
++			nodeShutdownManagerErrors: errors.New(nodeutil.NodeShutdownMessage),
++			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, nodeutil.NodeShutdownMessage, now, now)},
+ 		},
+ 		{
+ 			desc:             "new, not ready: runtime and network errors",
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+index f5f328cfe46..53b3833f47f 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+@@ -21,6 +21,7 @@ import (
+ 
+ 	v1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	v1helper "k8s.io/component-helpers/scheduling/corev1"
+ 	"k8s.io/klog/v2"
+ 	fwk "k8s.io/kube-scheduler/framework"
+@@ -47,6 +48,8 @@ const (
+ 	ErrReasonUnknownCondition = "node(s) had unknown conditions"
+ 	// ErrReasonUnschedulable is used for NodeUnschedulable predicate error.
+ 	ErrReasonUnschedulable = "node(s) were unschedulable"
++	// ErrReasonNodeShutdown is used for shutting down Node predicate error.
++	ErrReasonNodeShutdown = "node(s) were shutting down"
+ )
+ 
+ // EventsToRegister returns the possible events that may make a Pod
+@@ -64,7 +67,7 @@ func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]fwk.ClusterE
+ 
+ 	return []fwk.ClusterEventWithHint{
+ 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeLabel event.
+-		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
++		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+ 		// When the QueueingHint feature is enabled,
+ 		// the scheduling queue uses Pod/Update Queueing Hint
+ 		// to determine whether a Pod's update makes the Pod schedulable or not.
+@@ -113,9 +116,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
+ 
+ 	// We queue this Pod when -
+ 	// 1. the node is updated from unschedulable to schedulable.
+-	// 2. the node is added and is schedulable.
++	// 2. the node is updated from shutting down to not shutting down.
++	// 3. the node is added and is schedulable.
+ 	if (originalNode != nil && originalNode.Spec.Unschedulable && !modifiedNode.Spec.Unschedulable) ||
+-		(originalNode == nil && !modifiedNode.Spec.Unschedulable) {
++		(originalNode != nil && nodeutil.IsNodeInGracefulShutdown(originalNode) && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) ||
++		(originalNode == nil && !modifiedNode.Spec.Unschedulable && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) {
+ 		logger.V(5).Info("node was created or updated, pod may be schedulable now", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
+ 		return fwk.Queue, nil
+ 	}
+@@ -132,6 +137,9 @@ func (pl *NodeUnschedulable) Name() string {
+ // Filter invoked at the filter extension point.
+ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+ 	node := nodeInfo.Node()
++	if nodeutil.IsNodeInGracefulShutdown(node) {
++		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown)
++	}
+ 
+ 	if !node.Spec.Unschedulable {
+ 		return nil
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+index 03b9222b3e1..51bbcf13217 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+@@ -22,6 +22,7 @@ import (
+ 	"github.com/google/go-cmp/cmp"
+ 
+ 	v1 "k8s.io/api/core/v1"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	fwk "k8s.io/kube-scheduler/framework"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+@@ -73,6 +74,23 @@ func TestNodeUnschedulable(t *testing.T) {
+ 				},
+ 			},
+ 		},
++		{
++			name:       "Does not schedule pod to shutting down node",
++			pod:        st.MakePod().Toleration(v1.TaintNodeNotReady).Obj(),
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, nodeutil.NodeShutdownMessage, "KubeletNotReady").Obj(),
++			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name:       "Does not schedule pod to node with shutdown reason",
++			pod:        &v1.Pod{},
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "", nodeutil.NodeShutdownMessage).Obj(),
++			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name: "Schedule pod to not ready node without shutdown signal",
++			pod:  &v1.Pod{},
++			node: st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "runtime error", "KubeletNotReady").Obj(),
++		},
+ 	}
+ 
+ 	for _, test := range testCases {
+@@ -127,6 +145,17 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: fwk.QueueSkip,
+ 		},
++		{
++			name: "skip-queue-on-shutting-down-node-added",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: fwk.QueueSkip,
++		},
+ 		{
+ 			name: "queue-on-schedulable-node-added",
+ 			pod:  &v1.Pod{},
+@@ -137,6 +166,40 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: fwk.Queue,
+ 		},
++		{
++			name: "queue-on-shutdown-condition-cleared",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: fwk.Queue,
++		},
++		{
++			name: "skip-queue-on-shutdown-condition-set",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			expectedHint: fwk.QueueSkip,
++		},
+ 		{
+ 			name: "skip-unrelated-change-unschedulable-true",
+ 			pod:  &v1.Pod{},
+diff --git a/pkg/scheduler/scheduler_test.go b/pkg/scheduler/scheduler_test.go
+index 27c6524c03e..0e7258a7802 100644
+--- a/pkg/scheduler/scheduler_test.go
++++ b/pkg/scheduler/scheduler_test.go
+@@ -950,7 +950,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[fwk.EventResource]fwk.ActionType{
+ 				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
++				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete,
+ 				fwk.CSINode:               fwk.All - fwk.Delete,
+ 				fwk.CSIDriver:             fwk.Update,
+ 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+@@ -986,7 +986,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[fwk.EventResource]fwk.ActionType{
+ 				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
++				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete,
+ 				fwk.CSINode:               fwk.All - fwk.Delete,
+ 				fwk.CSIDriver:             fwk.Update,
+ 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions.go b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+index 3ad4dda8911..0be0efe5a45 100644
+--- a/staging/src/k8s.io/component-helpers/node/util/conditions.go
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+@@ -19,6 +19,7 @@ package util
+ import (
+ 	"context"
+ 	"encoding/json"
++	"strings"
+ 	"time"
+ 
+ 	v1 "k8s.io/api/core/v1"
+@@ -27,6 +28,11 @@ import (
+ 	clientset "k8s.io/client-go/kubernetes"
+ )
+ 
++const (
++	// NodeShutdownMessage is used by kubelet when reporting that graceful node shutdown is active.
++	NodeShutdownMessage = "node is shutting down"
++)
++
+ // GetNodeCondition extracts the provided condition from the given status and returns that.
+ // Returns nil and -1 if the condition is not present, and the index of the located condition.
+ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType) (int, *v1.NodeCondition) {
+@@ -41,6 +47,18 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
+ 	return -1, nil
+ }
+ 
++// IsNodeInGracefulShutdown returns true when the NodeReady condition reports graceful node shutdown.
++func IsNodeInGracefulShutdown(node *v1.Node) bool {
++	if node == nil {
++		return false
++	}
++	_, condition := GetNodeCondition(&node.Status, v1.NodeReady)
++	if condition == nil || condition.Status != v1.ConditionFalse {
++		return false
++	}
++	return condition.Reason == NodeShutdownMessage || strings.Contains(condition.Message, NodeShutdownMessage)
++}
++
+ // SetNodeCondition updates specific node condition with patch operation.
+ func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.NodeCondition) error {
+ 	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions_test.go b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+new file mode 100644
+index 00000000000..086eec5d728
+--- /dev/null
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+@@ -0,0 +1,81 @@
++/*
++Copyright 2026 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package util
++
++import (
++	"testing"
++
++	v1 "k8s.io/api/core/v1"
++)
++
++func TestIsNodeInGracefulShutdown(t *testing.T) {
++	testCases := []struct {
++		name string
++		node *v1.Node
++		want bool
++	}{
++		{
++			name: "nil node",
++		},
++		{
++			name: "ready node",
++			node: nodeWithReadyCondition(v1.ConditionTrue, "KubeletReady", "kubelet is posting ready status"),
++		},
++		{
++			name: "not ready without shutdown signal",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "runtime error"),
++		},
++		{
++			name: "shutdown by message",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", NodeShutdownMessage),
++			want: true,
++		},
++		{
++			name: "shutdown by reason",
++			node: nodeWithReadyCondition(v1.ConditionFalse, NodeShutdownMessage, ""),
++			want: true,
++		},
++		{
++			name: "shutdown message with aggregated errors",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "[runtime error, "+NodeShutdownMessage+"]"),
++			want: true,
++		},
++	}
++
++	for _, tc := range testCases {
++		t.Run(tc.name, func(t *testing.T) {
++			if got := IsNodeInGracefulShutdown(tc.node); got != tc.want {
++				t.Fatalf("IsNodeInGracefulShutdown() = %v, want %v", got, tc.want)
++			}
++		})
++	}
++}
++
++func nodeWithReadyCondition(status v1.ConditionStatus, reason, message string) *v1.Node {
++	return &v1.Node{
++		Status: v1.NodeStatus{
++			Conditions: []v1.NodeCondition{
++				{
++					Type:    v1.NodeReady,
++					Status:  status,
++					Reason:  reason,
++					Message: message,
++				},
++			},
++		},
++	}
++}

--- a/modules/000-common/images/kubernetes/patches/1.35/012-fix-scheduler-node-graceful-shutdown.patch
+++ b/modules/000-common/images/kubernetes/patches/1.35/012-fix-scheduler-node-graceful-shutdown.patch
@@ -1,0 +1,400 @@
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+index 505b3a5c326..ca420e58033 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_linux.go
+@@ -21,6 +21,7 @@ limitations under the License.
+ package nodeshutdown
+ 
+ import (
++	"errors"
+ 	"fmt"
+ 	"os"
+ 	"path/filepath"
+@@ -31,6 +32,7 @@ import (
+ 	"k8s.io/apimachinery/pkg/util/wait"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -311,7 +313,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+index 4c129d499dd..0c32481ee67 100644
+--- a/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
++++ b/pkg/kubelet/nodeshutdown/nodeshutdown_manager_windows.go
+@@ -21,6 +21,7 @@ limitations under the License.
+ package nodeshutdown
+ 
+ import (
++	"errors"
+ 	"fmt"
+ 	"path/filepath"
+ 	"strings"
+@@ -30,6 +31,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+ 	"k8s.io/client-go/tools/record"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/klog/v2"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	kubeletevents "k8s.io/kubernetes/pkg/kubelet/events"
+@@ -233,7 +235,7 @@ func (m *managerImpl) ShutdownStatus() error {
+ 	defer m.nodeShuttingDownMutex.Unlock()
+ 
+ 	if m.nodeShuttingDownNow {
+-		return fmt.Errorf("node is shutting down")
++		return errors.New(nodeutil.NodeShutdownMessage)
+ 	}
+ 	return nil
+ }
+diff --git a/pkg/kubelet/nodestatus/setters_test.go b/pkg/kubelet/nodestatus/setters_test.go
+index c7f441a9dc3..b8d5f711fd8 100644
+--- a/pkg/kubelet/nodestatus/setters_test.go
++++ b/pkg/kubelet/nodestatus/setters_test.go
+@@ -41,6 +41,7 @@ import (
+ 	"k8s.io/component-base/featuregate"
+ 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+ 	"k8s.io/component-base/version"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	"k8s.io/kubernetes/pkg/features"
+ 	"k8s.io/kubernetes/pkg/kubelet/cm"
+ 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+@@ -1248,8 +1249,8 @@ func TestReadyCondition(t *testing.T) {
+ 		{
+ 			desc:                      "new, not ready: shutdown active",
+ 			node:                      withCapacity.DeepCopy(),
+-			nodeShutdownManagerErrors: errors.New("node is shutting down"),
+-			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, "node is shutting down", now, now)},
++			nodeShutdownManagerErrors: errors.New(nodeutil.NodeShutdownMessage),
++			expectConditions:          []v1.NodeCondition{*makeReadyCondition(false, nodeutil.NodeShutdownMessage, now, now)},
+ 		},
+ 		{
+ 			desc:             "new, not ready: runtime and network errors",
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+index 345cc73aff1..ae45db02e8f 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+@@ -22,6 +22,7 @@ import (
+ 	v1 "k8s.io/api/core/v1"
+ 	"k8s.io/apimachinery/pkg/runtime"
+ 	utilfeature "k8s.io/apiserver/pkg/util/feature"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	v1helper "k8s.io/component-helpers/scheduling/corev1"
+ 	"k8s.io/klog/v2"
+ 	fwk "k8s.io/kube-scheduler/framework"
+@@ -49,6 +50,8 @@ const (
+ 	ErrReasonUnknownCondition = "node(s) had unknown conditions"
+ 	// ErrReasonUnschedulable is used for NodeUnschedulable predicate error.
+ 	ErrReasonUnschedulable = "node(s) were unschedulable"
++	// ErrReasonNodeShutdown is used for shutting down Node predicate error.
++	ErrReasonNodeShutdown = "node(s) were shutting down"
+ )
+ 
+ // EventsToRegister returns the possible events that may make a Pod
+@@ -66,7 +69,7 @@ func (pl *NodeUnschedulable) EventsToRegister(_ context.Context) ([]fwk.ClusterE
+ 
+ 	return []fwk.ClusterEventWithHint{
+ 		// When QueueingHint is enabled, we don't use preCheck and we don't need to register UpdateNodeLabel event.
+-		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
++		{Event: fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition}, QueueingHintFn: pl.isSchedulableAfterNodeChange},
+ 		// When the QueueingHint feature is enabled,
+ 		// the scheduling queue uses Pod/Update Queueing Hint
+ 		// to determine whether a Pod's update makes the Pod schedulable or not.
+@@ -115,9 +118,11 @@ func (pl *NodeUnschedulable) isSchedulableAfterNodeChange(logger klog.Logger, po
+ 
+ 	// We queue this Pod when -
+ 	// 1. the node is updated from unschedulable to schedulable.
+-	// 2. the node is added and is schedulable.
++	// 2. the node is updated from shutting down to not shutting down.
++	// 3. the node is added and is schedulable.
+ 	if (originalNode != nil && originalNode.Spec.Unschedulable && !modifiedNode.Spec.Unschedulable) ||
+-		(originalNode == nil && !modifiedNode.Spec.Unschedulable) {
++		(originalNode != nil && nodeutil.IsNodeInGracefulShutdown(originalNode) && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) ||
++		(originalNode == nil && !modifiedNode.Spec.Unschedulable && !nodeutil.IsNodeInGracefulShutdown(modifiedNode)) {
+ 		logger.V(5).Info("node was created or updated, pod may be schedulable now", "pod", klog.KObj(pod), "node", klog.KObj(modifiedNode))
+ 		return fwk.Queue, nil
+ 	}
+@@ -141,6 +146,9 @@ func (pl *NodeUnschedulable) SignPod(ctx context.Context, pod *v1.Pod) ([]fwk.Si
+ // Filter invoked at the filter extension point.
+ func (pl *NodeUnschedulable) Filter(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+ 	node := nodeInfo.Node()
++	if nodeutil.IsNodeInGracefulShutdown(node) {
++		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown)
++	}
+ 
+ 	if !node.Spec.Unschedulable {
+ 		return nil
+diff --git a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+index 4b39623fe9d..1cec0c6b529 100644
+--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
++++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable_test.go
+@@ -22,6 +22,7 @@ import (
+ 	"github.com/google/go-cmp/cmp"
+ 
+ 	v1 "k8s.io/api/core/v1"
++	nodeutil "k8s.io/component-helpers/node/util"
+ 	fwk "k8s.io/kube-scheduler/framework"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework"
+ 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+@@ -73,6 +74,23 @@ func TestNodeUnschedulable(t *testing.T) {
+ 				},
+ 			},
+ 		},
++		{
++			name:       "Does not schedule pod to shutting down node",
++			pod:        st.MakePod().Toleration(v1.TaintNodeNotReady).Obj(),
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, nodeutil.NodeShutdownMessage, "KubeletNotReady").Obj(),
++			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name:       "Does not schedule pod to node with shutdown reason",
++			pod:        &v1.Pod{},
++			node:       st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "", nodeutil.NodeShutdownMessage).Obj(),
++			wantStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, ErrReasonNodeShutdown),
++		},
++		{
++			name: "Schedule pod to not ready node without shutdown signal",
++			pod:  &v1.Pod{},
++			node: st.MakeNode().Name("node").Condition(v1.NodeReady, v1.ConditionFalse, "runtime error", "KubeletNotReady").Obj(),
++		},
+ 	}
+ 
+ 	for _, test := range testCases {
+@@ -127,6 +145,17 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: fwk.QueueSkip,
+ 		},
++		{
++			name: "skip-queue-on-shutting-down-node-added",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: fwk.QueueSkip,
++		},
+ 		{
+ 			name: "queue-on-schedulable-node-added",
+ 			pod:  &v1.Pod{},
+@@ -137,6 +166,40 @@ func TestIsSchedulableAfterNodeChange(t *testing.T) {
+ 			},
+ 			expectedHint: fwk.Queue,
+ 		},
++		{
++			name: "queue-on-shutdown-condition-cleared",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			expectedHint: fwk.Queue,
++		},
++		{
++			name: "skip-queue-on-shutdown-condition-set",
++			pod:  &v1.Pod{},
++			newObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionFalse,
++				nodeutil.NodeShutdownMessage,
++				"KubeletNotReady",
++			).Obj(),
++			oldObj: st.MakeNode().Name("node").Condition(
++				v1.NodeReady,
++				v1.ConditionTrue,
++				"kubelet is posting ready status",
++				"KubeletReady",
++			).Obj(),
++			expectedHint: fwk.QueueSkip,
++		},
+ 		{
+ 			name: "skip-unrelated-change-unschedulable-true",
+ 			pod:  &v1.Pod{},
+diff --git a/pkg/scheduler/scheduler_test.go b/pkg/scheduler/scheduler_test.go
+index 519c6fc71a2..9cb892e5be6 100644
+--- a/pkg/scheduler/scheduler_test.go
++++ b/pkg/scheduler/scheduler_test.go
+@@ -983,7 +983,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[fwk.EventResource]fwk.ActionType{
+ 				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
++				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete,
+ 				fwk.CSINode:               fwk.All - fwk.Delete,
+ 				fwk.CSIDriver:             fwk.Update,
+ 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+@@ -1019,7 +1019,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: defaults.PluginsV1.MultiPoint.Enabled},
+ 			want: map[fwk.EventResource]fwk.ActionType{
+ 				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
++				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete,
+ 				fwk.CSINode:               fwk.All - fwk.Delete,
+ 				fwk.CSIDriver:             fwk.Update,
+ 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+@@ -1041,7 +1041,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 				// NodeDeclaredFeatures adds fwk.Update
+ 				fwk.Pod: fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete | fwk.Update,
+ 				// NodeDeclaredFeatures adds fwk.UpdateNodeDeclaredFeature
+-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete | fwk.UpdateNodeDeclaredFeature,
++				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete | fwk.UpdateNodeDeclaredFeature,
+ 				fwk.CSINode:               fwk.All - fwk.Delete,
+ 				fwk.CSIDriver:             fwk.Update,
+ 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+@@ -1063,7 +1063,7 @@ func Test_UnionedGVKs(t *testing.T) {
+ 			plugins: schedulerapi.PluginSet{Enabled: append(defaults.PluginsV1.MultiPoint.Enabled, schedulerapi.Plugin{Name: names.GangScheduling})},
+ 			want: map[fwk.EventResource]fwk.ActionType{
+ 				fwk.Pod:                   fwk.Add | fwk.UpdatePodLabel | fwk.UpdatePodScaleDown | fwk.UpdatePodGeneratedResourceClaim | fwk.UpdatePodToleration | fwk.UpdatePodSchedulingGatesEliminated | fwk.Delete,
+-				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.Delete,
++				fwk.Node:                  fwk.Add | fwk.UpdateNodeAllocatable | fwk.UpdateNodeLabel | fwk.UpdateNodeTaint | fwk.UpdateNodeCondition | fwk.Delete,
+ 				fwk.CSINode:               fwk.All - fwk.Delete,
+ 				fwk.CSIDriver:             fwk.Update,
+ 				fwk.CSIStorageCapacity:    fwk.All - fwk.Delete,
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions.go b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+index 3ad4dda8911..0be0efe5a45 100644
+--- a/staging/src/k8s.io/component-helpers/node/util/conditions.go
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions.go
+@@ -19,6 +19,7 @@ package util
+ import (
+ 	"context"
+ 	"encoding/json"
++	"strings"
+ 	"time"
+ 
+ 	v1 "k8s.io/api/core/v1"
+@@ -27,6 +28,11 @@ import (
+ 	clientset "k8s.io/client-go/kubernetes"
+ )
+ 
++const (
++	// NodeShutdownMessage is used by kubelet when reporting that graceful node shutdown is active.
++	NodeShutdownMessage = "node is shutting down"
++)
++
+ // GetNodeCondition extracts the provided condition from the given status and returns that.
+ // Returns nil and -1 if the condition is not present, and the index of the located condition.
+ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType) (int, *v1.NodeCondition) {
+@@ -41,6 +47,18 @@ func GetNodeCondition(status *v1.NodeStatus, conditionType v1.NodeConditionType)
+ 	return -1, nil
+ }
+ 
++// IsNodeInGracefulShutdown returns true when the NodeReady condition reports graceful node shutdown.
++func IsNodeInGracefulShutdown(node *v1.Node) bool {
++	if node == nil {
++		return false
++	}
++	_, condition := GetNodeCondition(&node.Status, v1.NodeReady)
++	if condition == nil || condition.Status != v1.ConditionFalse {
++		return false
++	}
++	return condition.Reason == NodeShutdownMessage || strings.Contains(condition.Message, NodeShutdownMessage)
++}
++
+ // SetNodeCondition updates specific node condition with patch operation.
+ func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.NodeCondition) error {
+ 	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+diff --git a/staging/src/k8s.io/component-helpers/node/util/conditions_test.go b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+new file mode 100644
+index 00000000000..086eec5d728
+--- /dev/null
++++ b/staging/src/k8s.io/component-helpers/node/util/conditions_test.go
+@@ -0,0 +1,81 @@
++/*
++Copyright 2026 The Kubernetes Authors.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++    http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License.
++*/
++
++package util
++
++import (
++	"testing"
++
++	v1 "k8s.io/api/core/v1"
++)
++
++func TestIsNodeInGracefulShutdown(t *testing.T) {
++	testCases := []struct {
++		name string
++		node *v1.Node
++		want bool
++	}{
++		{
++			name: "nil node",
++		},
++		{
++			name: "ready node",
++			node: nodeWithReadyCondition(v1.ConditionTrue, "KubeletReady", "kubelet is posting ready status"),
++		},
++		{
++			name: "not ready without shutdown signal",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "runtime error"),
++		},
++		{
++			name: "shutdown by message",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", NodeShutdownMessage),
++			want: true,
++		},
++		{
++			name: "shutdown by reason",
++			node: nodeWithReadyCondition(v1.ConditionFalse, NodeShutdownMessage, ""),
++			want: true,
++		},
++		{
++			name: "shutdown message with aggregated errors",
++			node: nodeWithReadyCondition(v1.ConditionFalse, "KubeletNotReady", "[runtime error, "+NodeShutdownMessage+"]"),
++			want: true,
++		},
++	}
++
++	for _, tc := range testCases {
++		t.Run(tc.name, func(t *testing.T) {
++			if got := IsNodeInGracefulShutdown(tc.node); got != tc.want {
++				t.Fatalf("IsNodeInGracefulShutdown() = %v, want %v", got, tc.want)
++			}
++		})
++	}
++}
++
++func nodeWithReadyCondition(status v1.ConditionStatus, reason, message string) *v1.Node {
++	return &v1.Node{
++		Status: v1.NodeStatus{
++			Conditions: []v1.NodeCondition{
++				{
++					Type:    v1.NodeReady,
++					Status:  status,
++					Reason:  reason,
++					Message: message,
++				},
++			},
++		},
++	}
++}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added Kubernetes patch files for versions `1.32`, `1.33`, `1.34`, and `1.35` based on upstream Kubernetes PR [kubernetes/kubernetes#139249](https://github.com/kubernetes/kubernetes/pull/139249).

The patch makes graceful node shutdown visible to `kube-scheduler`: nodes whose `NodeReady` condition reports `node is shutting down` are rejected by the `NodeUnschedulable` filter even if a `Pod` tolerates the `node.kubernetes.io/not-ready` taint. The existing EE kubelet graceful shutdown patch files were renamed from `007` to `013` so the new scheduler patch is applied earlier in the Kubernetes patch sequence.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
During graceful node shutdown, `kubelet` marks the node as not ready and later rejects newly assigned pods locally, but `kube-scheduler` could still bind pods that tolerate `node.kubernetes.io/not-ready` to the shutting down node.

This could leave pods assigned to a node that is already waiting for reboot and later make them visible in `Unknown` status after the node comes back. With this patch, such pods are scheduled to healthy nodes instead.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: feature
summary: Added a Kubernetes scheduler patch that prevents scheduling pods onto nodes during graceful shutdown.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
