### PR TITLE
[deckhouse] forbid manual ApplicationPackage changes

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/register.go
@@ -69,6 +69,7 @@ func RegisterAdmissionHandlers(
 	reg.RegisterHandler("/validate/v1/deckhouse-registry-secret", withInvalidReason(RegistrySecretHandler()))
 	reg.RegisterHandler("/validate/v1alpha1/module-configs", withInvalidReason(moduleConfigValidationHandler(cli, storage, metricStorage, mm, validator, settings, exts)))
 	reg.RegisterHandler("/validate/v1alpha1/modules", withInvalidReason(moduleValidationHandler()))
+	reg.RegisterHandler("/validate/v1alpha1/application-packages", withInvalidReason(applicationPackageValidationHandler()))
 	reg.RegisterHandler("/validate/v1/configuration-secret", withInvalidReason(clusterConfigurationHandler(mm, cli, schemaStore)))
 	reg.RegisterHandler("/validate/v1/provider-configuration-secret", withInvalidReason(providerConfigurationHandler(schemaStore)))
 	reg.RegisterHandler("/validate/v1/static-configuration-secret", withInvalidReason(staticConfigurationHandler(schemaStore)))

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_package.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_package.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Flant JSC
+Copyright 2026 Flant JSC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_package.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_application_package.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"net/http"
+
+	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
+	"github.com/slok/kubewebhook/v2/pkg/model"
+	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
+)
+
+func applicationPackageValidationHandler() http.Handler {
+	vf := kwhvalidating.ValidatorFunc(func(_ context.Context, review *model.AdmissionReview, _ metav1.Object) (*kwhvalidating.ValidatorResult, error) {
+		// system:serviceaccount:kube-system:generic-garbage-collector is allowed because
+		// ApplicationPackage has an owner reference on PackageRepository, so cascade
+		// deletion must pass admission.
+		if review.UserInfo.Username != "system:serviceaccount:d8-system:deckhouse" &&
+			review.UserInfo.Username != "system:serviceaccount:kube-system:generic-garbage-collector" {
+			return rejectResult("manual ApplicationPackage change is forbidden")
+		}
+
+		return allowResult(nil)
+	})
+
+	wh, _ := kwhvalidating.NewWebhook(kwhvalidating.WebhookConfig{
+		ID:        "application-package-operations",
+		Validator: vf,
+		Logger:    nil,
+		Obj:       &v1alpha1.ApplicationPackage{},
+	})
+
+	return kwhhttp.MustHandlerFor(kwhhttp.HandlerConfig{Webhook: wh, Logger: nil})
+}

--- a/modules/002-deckhouse/templates/admission/validation.yaml
+++ b/modules/002-deckhouse/templates/admission/validation.yaml
@@ -62,6 +62,31 @@ webhooks:
         namespace: d8-system
         port: 4223
         path: /validate/v1alpha1/modules
+  - name: application-packages.deckhouse-webhook.deckhouse.io
+    rules:
+      - apiGroups:
+          - "deckhouse.io"
+        apiVersions:
+          - "v1alpha1"
+        resources:
+          - "applicationpackages"
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        scope: Cluster
+    admissionReviewVersions:
+      - v1
+    matchPolicy: Equivalent
+    failurePolicy: Ignore
+    sideEffects: None
+    clientConfig:
+      caBundle: {{ .Values.deckhouse.internal.admissionWebhookCert.ca | b64enc }}
+      service:
+        name: deckhouse
+        namespace: d8-system
+        port: 4223
+        path: /validate/v1alpha1/application-packages
   - name: module-configs.deckhouse-webhook.deckhouse.io
     rules:
       - apiGroups:


### PR DESCRIPTION
## Description

Adds a validating admission webhook that rejects manual `create` / `update` / `delete` on `ApplicationPackage` (`deckhouse.io/v1alpha1`). Allowed callers: the deckhouse controller SA and the kube garbage collector SA (the latter is needed for cascade deletion via the owner reference on `PackageRepository`). Mirrors the existing protection of `Module` / `ModuleConfig`. No critical components are restarted.

## Why do we need it, and what problem does it solve?

`ApplicationPackage` is a system-owned aggregator over `ApplicationPackageVersion`; the controller creates and reconciles it, and it is already labeled `heritage: deckhouse`. Manual changes desync the packages subsystem (broken `.status.UsedBy`, dangling `Application` references, stuck reconciliation). The webhook enforces read-only access that has always been there by design.


### Testing

Verified on a dev cluster after deploying the branch. All three checks pass.

**1. Webhook is registered in `ValidatingWebhookConfiguration`**

```console
$ k get validatingwebhookconfiguration deckhouse-webhook -o yaml | grep application-packages
      path: /validate/v1alpha1/application-packages
  name: application-packages.deckhouse-webhook.deckhouse.io
```

**2. Manual `create` is rejected**

```console
$ echo 'apiVersion: deckhouse.io/v1alpha1
kind: ApplicationPackage
metadata: {name: ap-test}' | k apply -f -
The request is invalid: error when creating "STDIN": admission webhook "application-packages.deckhouse-webhook.deckhouse.io" denied the request: manual ApplicationPackage change is forbidden
```

**3. Manual `delete` of an existing `ApplicationPackage` is rejected**

```console
$ k delete applicationpackage $(k get applicationpackage -o jsonpath='{.items[0].metadata.name}')
The request is invalid: admission webhook "application-packages.deckhouse-webhook.deckhouse.io" denied the request: manual ApplicationPackage change is forbidden
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature 
summary: Forbid manual ApplicationPackage changes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
