### PR TITLE
[cni-cilium] Fixed CVE-2026-41520 for cilium-bugtool util (#20067)

### DIFF
--- a/modules/021-cni-cilium/images/agent/known_vulnerabilities.vex
+++ b/modules/021-cni-cilium/images/agent/known_vulnerabilities.vex
@@ -1,8 +1,8 @@
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
-  "@id": "https://openvex.dev/docs/public/vex-46521c2aa62c064cd1a854f470eef8288baab5bb530a3fcdce78453624e88f57",
-  "author": "Deckhouse \u003ccontact @deckhouse.io\u003e",
-  "version": 2,
+  "@id": "https://openvex.dev/docs/public/vex-7bb761a58a11caa496221e01e7c02e2c7b45e3ba1a30404eb9d12aac0440c6eb",
+  "author": "Deckhouse <contact@deckhouse.io>",
+  "version": 3,
   "statements": [
     {
       "vulnerability": {
@@ -31,8 +31,21 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33726 не эксплуатируема в Deckhouse, поскольку функция Per-Endpoint Routing не используется и не может быть включена пользователем самостоятельно, а именно её активация является обязательным условием для реализации данной уязвимости.",
       "timestamp": "2026-04-02T14:53:20.279471Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41520"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/cilium/cilium@v1.17.4"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Устранено downstream-патчем modules/021-cni-cilium/images/bin-cilium/patches/014-bugtool-remove-sensitive-files.patch (verbatim cherry-pick cilium/cilium@3e26bef96e1ec6ea1b5034fee3f0bc6ddfabcae6, вошёл в релиз v1.17.15). Применяется ко всем бинарям cilium-стека в сборке Deckhouse.",
+      "timestamp": "2026-05-22T14:18:47.138556373Z"
     }
   ],
   "timestamp": "2025-10-14T07:34:04Z",
-  "last_updated": "2026-04-02T14:53:20Z"
+  "last_updated": "2026-05-22T14:20:09Z"
 }

--- a/modules/021-cni-cilium/images/bin-cilium/patches/014-bugtool-remove-sensitive-files.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/014-bugtool-remove-sensitive-files.patch
@@ -1,0 +1,30 @@
+diff --git a/bugtool/cmd/root.go b/bugtool/cmd/root.go
+--- a/bugtool/cmd/root.go
++++ b/bugtool/cmd/root.go
+@@ -287,6 +287,8 @@ func runTool() {
+ 		defer printDisclaimer()
+ 		runAll(commands, cmdDir, k8sPods)
+ 
++		removeSensitiveFiles(cmdDir)
++
+ 		if excludeObjectFiles {
+ 			removeObjectFiles(cmdDir, k8sPods)
+ 		}
+@@ -437,6 +439,17 @@ func removeObjectFiles(cmdDir string, k8sPods []string) {
+ 	}
+ }
+ 
++// removeSensitiveFiles removes sensitive files (e.g. WireGuard private key files) from
++// the copied state directory.
++func removeSensitiveFiles(cmdDir string) {
++	matches, _ := filepath.Glob(filepath.Join(cmdDir, defaults.StateDir, "*.key"))
++	for _, m := range matches {
++		if err := os.Remove(m); err != nil {
++			fmt.Fprintf(os.Stderr, "Failed to remove sensitive file: %s\n", err)
++		}
++	}
++}
++
+ func execCommand(prompt string) ([]byte, error) {
+ 	ctx, cancel := context.WithTimeout(context.Background(), execTimeout)
+ 	defer cancel()

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -68,3 +68,15 @@ Added an implementation of the Least Connections load balancing algorithm.
 ## 013-ignore-egress-gateway-inactual-warning.patch
 
 Ignore error when using IPv4 address for egress gateway other than assigned
+
+## 014-bugtool-remove-sensitive-files.patch
+
+Verbatim cherry-pick of the upstream fix for **CVE-2026-41520** (GHSA-gj49-89wh-h4gj): `cilium-bugtool` was archiving the entire state directory, which on nodes with WireGuard Transparent Encryption enabled included `cilium_wg0.key` — leaking the node's WireGuard private key in any bugtool / `cilium sysdump` archive.
+
+The patch removes `*.key` files from the state directory copy before archiving.
+
+- Advisory: <https://github.com/cilium/cilium/security/advisories/GHSA-gj49-89wh-h4gj>
+- Upstream backport into release-1.17 branch: <https://github.com/cilium/cilium/commit/3e26bef96e1ec6ea1b5034fee3f0bc6ddfabcae6>
+- Released in cilium v1.17.15 / v1.18.9 / v1.19.3.
+
+**Remove this patch when the base cilium version in `modules/021-cni-cilium/oss.yaml` is bumped to v1.17.15 or newer** — the fix is then already in the upstream sources and this patch will fail to apply.


### PR DESCRIPTION
(cherry picked from commit c7d5ad372af3d23f6ee5ca1d6746423c0418e901)

## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Backport upstream fix for https://github.com/advisories/GHSA-gj49-89wh-h4gj into Cilium v1.17.4 without bumping the base version.

cilium-bugtool (and archives produced via cilium sysdump) copied the full Cilium state directory, including *.key files. On nodes with WireGuard transparent encryption this leaked the node's WireGuard private key (cilium_wg0.key) into support bundles.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Closes [CVE-2026-41520](https://nvd.nist.gov/vuln/detail/CVE-2026-41520) — [GHSA-gj49-89wh-h4gj](https://github.com/cilium/cilium/security/advisories/GHSA-gj49-89wh-h4gj): sensitive information disclosure via cilium-bugtool / sysdump when WireGuard encryption is enabled.

Trivy reports the issue on cni-cilium/agent (binary usr/bin/hubble / cilium toolchain built from the same bin-cilium sources). A full bump to Cilium v1.17.15+ would also fix it, but is a larger change; the upstream backport patch is sufficient.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

The vulnerability is present in all supported releases up to 1.73.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: fix
summary: Fixed CVE-2026-41520 for cilium-bugtool util
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
