### PR TITLE
[ci] Switch to ubuntu-slim runners

### DIFF
--- a/.github/ci_templates/antivirus_tests.yml
+++ b/.github/ci_templates/antivirus_tests.yml
@@ -132,7 +132,7 @@ kaspersky-scan:
 # <template: set_security_antivirus_requirement_status>
 set_security_antivirus_requirement_status:
   name: Set commit status after antivirus scan run
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   needs: [drweb-scan, kaspersky-scan]
   if: ${{ always() }}
   permissions:

--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -2,7 +2,7 @@
 # <template: check_changelog_template>
 check_changelog:
   name: Check changelog
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   steps:
   {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
     - name: Check for tag

--- a/.github/ci_templates/cve_tests.yaml
+++ b/.github/ci_templates/cve_tests.yaml
@@ -3,7 +3,7 @@
 # <template: set_security_scan_requirement_status>
 set_security_scan_requirement_status:
   name: Set commit status after security scan run
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   needs: test_cve_report_main
   if: ${{ always() }}
   permissions:

--- a/.github/ci_templates/e2e_tests.yml
+++ b/.github/ci_templates/e2e_tests.yml
@@ -411,7 +411,7 @@ It sets run_{CRI}_{VERSION} outputs to use as conditionals for later jobs.
 # <template: check_e2e_labels_job>
 check_e2e_labels:
   name: Check e2e labels
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   permissions:
     contents: read
     issues: write

--- a/.github/ci_templates/helper_jobs.yml
+++ b/.github/ci_templates/helper_jobs.yml
@@ -15,7 +15,7 @@ See:
 {!{- $ctx := . }!}
 git_info:
   name: Get git info
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
 {!{- if coll.Has $ctx "dependJobs" -}!}
 {!{- if gt (len $ctx.dependJobs) 0 }!}
   needs:
@@ -103,7 +103,7 @@ git_info:
 {!{- $ctx := . }!}
 block-until-image-is-not-ready:
   name: Block until the docker image is not ready
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   permissions:
     contents: read
     actions: read
@@ -177,7 +177,7 @@ block-until-image-is-not-ready:
 # <template: pull_request_info>
 pull_request_info:
   name: Get pull request reference
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   outputs:
     ref: ${{ steps.pr_props.outputs.ref }}
     ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
@@ -402,7 +402,7 @@ pull_request_info:
 # <template: skip_tests_repos>
 skip_tests_repos:
   name: Skip tests repos
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
   steps:
   - name: Do nothing

--- a/.github/ci_templates/rootless_scan.yml
+++ b/.github/ci_templates/rootless_scan.yml
@@ -53,7 +53,7 @@ steps:
 # <template: set_security_rootless_requirement_status>
 set_security_rootless_requirement_status:
   name: Set commit status after security rootless scan run
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   needs:
     - pull_request_info
     - security_scan_images

--- a/.github/ci_templates/scripts.yml
+++ b/.github/ci_templates/scripts.yml
@@ -72,7 +72,7 @@ Use statusConfig to set status source and render options.
 # <template: check_label_job>
 check_label:
   name: Check label
-  runs-on: "ubuntu-latest"
+  runs-on: "ubuntu-slim"
   outputs:
     should_run: ${{ steps.check_label.outputs.should_run }}
     labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflow_templates/autolabel.yml
+++ b/.github/workflow_templates/autolabel.yml
@@ -14,16 +14,16 @@
 
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   triage:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
-    - uses: actions/labeler@v4
-      with:
-        sync-labels: true
-        dot: true
+      - uses: actions/labeler@v4
+        with:
+          sync-labels: true
+          dot: true

--- a/.github/workflow_templates/build-and-test_dev.yml
+++ b/.github/workflow_templates/build-and-test_dev.yml
@@ -200,7 +200,7 @@ jobs:
       - go_generate
       - dhctl_tests
       - tests
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
       - name: Set commit status after e2e run

--- a/.github/workflow_templates/build-and-test_release.yml
+++ b/.github/workflow_templates/build-and-test_release.yml
@@ -56,7 +56,7 @@ jobs:
 {!{ tmpl.Exec "git_info_job" $ctx | strings.Indent 2 }!}
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       BUILD_CE: ${{steps.detect_editions.outputs.BUILD_CE}}
       BUILD_EE: ${{steps.detect_editions.outputs.BUILD_EE}}
@@ -87,7 +87,7 @@ jobs:
 
   check_branch_name:
     name: Check branch name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
       with:

--- a/.github/workflow_templates/check-pr-milestone.yml
+++ b/.github/workflow_templates/check-pr-milestone.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   check-pr-milestone:
     name: Check milestone
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
     - name: Check milestone
       uses: {!{ index (ds "actions") "actions/github-script" }!}

--- a/.github/workflow_templates/create_release.yml
+++ b/.github/workflow_templates/create_release.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   create-release:
     permissions: write-all
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
 
     steps:
       {!{- $secrets := slice -}!}

--- a/.github/workflow_templates/deploy-channel.multi.yml
+++ b/.github/workflow_templates/deploy-channel.multi.yml
@@ -79,7 +79,7 @@ permissions:
 jobs:
 {!{ tmpl.Exec "git_info_job" . | strings.Indent 2 }!}
   check_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - name: Check if triggered by a tag
         run: |
@@ -90,7 +90,7 @@ jobs:
           fi
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
@@ -133,7 +133,7 @@ Jobs for visual control allowed editions when approving deploy to environments.
     name: Enable {!{$werfEnv}!}
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable {!{$werfEnv}!}"
 {!{ end }!}

--- a/.github/workflow_templates/dispatch-slash-command.yml
+++ b/.github/workflow_templates/dispatch-slash-command.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   conditions:
     name: Check conditions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       trigger_for_release_issue: ${{steps.check.outputs.trigger_for_release_issue}}
       trigger_for_changelog: ${{steps.check.outputs.trigger_for_changelog}}
@@ -78,7 +78,7 @@ jobs:
 
   trigger_for_release_issue:
     name: Trigger workflow by comment
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - conditions
     if: ${{needs.conditions.outputs.trigger_for_release_issue == 'true'}}
@@ -94,7 +94,7 @@ jobs:
 
   trigger_for_pull_request:
     name: Trigger workflow by comment from pull-request
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
     - conditions
     if: ${{needs.conditions.outputs.trigger_for_pull_request == 'true'}}
@@ -110,7 +110,7 @@ jobs:
 
   trigger_for_changelog:
     name: Dispatch Changelog Event
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - conditions
     if: ${{needs.conditions.outputs.trigger_for_changelog == 'true'}}

--- a/.github/workflow_templates/e2e-autoclean.yml
+++ b/.github/workflow_templates/e2e-autoclean.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ {!{ $enableWorkflowOnTestRepos }!} || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflow_templates/e2e-daily.yml
+++ b/.github/workflow_templates/e2e-daily.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ {!{ $enableWorkflowOnTestRepos }!} || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflow_templates/gitleaks.yml
+++ b/.github/workflow_templates/gitleaks.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   gitleaks_full_scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       id-token: write

--- a/.github/workflow_templates/k8s-autoupdate.yml
+++ b/.github/workflow_templates/k8s-autoupdate.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ {!{ $enableWorkflowOnTestRepos }!} || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflow_templates/on-milestone-created.yml
+++ b/.github/workflow_templates/on-milestone-created.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   create_release_issue_for_milestone:
     name: Create issue for milestone
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
 {!{ tmpl.Exec "checkout_step" . | strings.Indent 6 }!}
       - name: Create issue

--- a/.github/workflow_templates/on-pull-request-backport.yml
+++ b/.github/workflow_templates/on-pull-request-backport.yml
@@ -34,7 +34,7 @@ jobs:
   detect_pr_by_label:
     concurrency: source_pr
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.milestone != null && contains(github.event.pull_request.labels.*.name, 'status/backport') }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       release_branch: ${{ steps.from_milestone.outputs.release_branch }}
       commit: ${{ steps.from_milestone.outputs.commit }}
@@ -54,7 +54,7 @@ jobs:
   detect_pr_by_comment:
     concurrency: source_pr
     if: ${{ github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.state == 'closed' && github.event.pull_request.user.login != 'deckhouse-BOaTswain' && !contains(github.event.issue.labels.*.name, 'issue/release') }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       release_branch: ${{ steps.comment_info.outputs.branch }}
       commit: ${{ steps.pr_info.outputs.commit }}
@@ -87,7 +87,7 @@ jobs:
             core.setOutput('commit', response.data.merge_commit_sha)
 
   backport_to_release_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: [detect_pr_by_label, detect_pr_by_comment]
     if: always() && (needs.detect_pr_by_label.outputs.release_branch || needs.detect_pr_by_comment.outputs.release_branch)
     steps:

--- a/.github/workflow_templates/on-pull-request-labeled.yml
+++ b/.github/workflow_templates/on-pull-request-labeled.yml
@@ -24,7 +24,7 @@ jobs:
 {!{ tmpl.Exec "pull_request_info_job" . | strings.Indent 2 }!}
   rerun_workflow_for_pull_request:
     name: Rerun workflow for pull request
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - pull_request_info
     steps:

--- a/.github/workflow_templates/on-push-release-tag.yml
+++ b/.github/workflow_templates/on-push-release-tag.yml
@@ -38,7 +38,7 @@ on:
 jobs:
   start_release_build_workflow:
     name: Start build for release
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       id-token: write

--- a/.github/workflow_templates/pr-auto-asigner.yml
+++ b/.github/workflow_templates/pr-auto-asigner.yml
@@ -15,7 +15,7 @@
 name: "Pull Request Auto Assigner"
 on:
   pull_request_target:
-     types:
+    types:
       - opened
       - reopened
 
@@ -24,6 +24,6 @@ permissions:
 
 jobs:
   assign-author:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0

--- a/.github/workflow_templates/run-ci-tests-on-changes.yml
+++ b/.github/workflow_templates/run-ci-tests-on-changes.yml
@@ -16,24 +16,24 @@ name: Run Ci Tests On Changes
 on:
   push:
     paths:
-      - '.github/scripts/js/**'
+      - ".github/scripts/js/**"
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16'
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
 
-    - name: Install dependencies
-      run: npm ci
-      working-directory: .github/scripts/js
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .github/scripts/js
 
-    - name: Run Jest tests
-      run: npm test
-      working-directory: .github/scripts/js
+      - name: Run Jest tests
+        run: npm test
+        working-directory: .github/scripts/js

--- a/.github/workflow_templates/security-scans.yml
+++ b/.github/workflow_templates/security-scans.yml
@@ -45,7 +45,7 @@ jobs:
   # ============================================================================
   gitleaks_scan:
     name: Gitleaks scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: pull_request_info
     permissions:
       contents: read
@@ -65,7 +65,7 @@ jobs:
 
   set_security_gitleaks_requirement_status:
     name: Set commit status after gitleaks scan run
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: gitleaks_scan
     if: ${{ always() }}
     permissions:
@@ -171,7 +171,7 @@ jobs:
   # ============================================================================
   security_scans_required:
     name: Security scans required
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ always() && needs.pull_request_info.result == 'success' }}
     needs:
       - pull_request_info

--- a/.github/workflow_templates/stage_registry_clean.yml
+++ b/.github/workflow_templates/stage_registry_clean.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ {!{ $enableWorkflowOnTestRepos }!} || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflow_templates/stale.yml
+++ b/.github/workflow_templates/stale.yml
@@ -20,7 +20,7 @@ on:
 jobs:
 {!{ tmpl.Exec "skip_tests_repos" . | strings.Indent 2 }!}
   stale:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - skip_tests_repos
     permissions:

--- a/.github/workflow_templates/suspend-channel.multi.yml
+++ b/.github/workflow_templates/suspend-channel.multi.yml
@@ -80,7 +80,7 @@ jobs:
 
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflow_templates/update-dependabot-pr.yml
+++ b/.github/workflow_templates/update-dependabot-pr.yml
@@ -30,19 +30,19 @@ jobs:
         github.actor == 'dependabot-preview[bot]' ||
         github.actor == 'dependabot-preview'
       )
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       pull-requests: write
       contents: read
     steps:
-    - uses: devindford/Append_PR_Comment@v1.1.3
-      with:
-        repo-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        body-update-action: 'suffix'
-        body-template: |
-          ---
-          ```changes
-          section: dependabot
-          type: chore
-          summary: ${{ github.event.pull_request.title }}
-          ```
+      - uses: devindford/Append_PR_Comment@v1.1.3
+        with:
+          repo-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          body-update-action: "suffix"
+          body-template: |
+            ---
+            ```changes
+            section: dependabot
+            type: chore
+            summary: ${{ github.event.pull_request.title }}
+            ```

--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -162,7 +162,7 @@ jobs:
 
   pull_request_changes_validation:
     name: Pull Request Changes validation
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - discover
       - pull_request_info

--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -18,16 +18,16 @@
 
 name: "Pull Request Labeler"
 on:
-- pull_request_target
+  - pull_request_target
 
 jobs:
   triage:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
-    - uses: actions/labeler@v4
-      with:
-        sync-labels: true
-        dot: true
+      - uses: actions/labeler@v4
+        with:
+          sync-labels: true
+          dot: true

--- a/.github/workflows/build-and-test_dev.yml
+++ b/.github/workflows/build-and-test_dev.yml
@@ -60,7 +60,7 @@ jobs:
   # <template: pull_request_info>
   pull_request_info:
     name: Get pull request reference
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ref: ${{ steps.pr_props.outputs.ref }}
       ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
@@ -289,7 +289,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -3612,7 +3612,7 @@ jobs:
       - go_generate
       - dhctl_tests
       - tests
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/build-and-test_main.yml
+++ b/.github/workflows/build-and-test_main.yml
@@ -61,7 +61,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}

--- a/.github/workflows/build-and-test_pre-release.yml
+++ b/.github/workflows/build-and-test_pre-release.yml
@@ -61,7 +61,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}

--- a/.github/workflows/build-and-test_release.yml
+++ b/.github/workflows/build-and-test_release.yml
@@ -78,7 +78,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -153,7 +153,7 @@ jobs:
   # </template: git_info_job>
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       BUILD_CE: ${{steps.detect_editions.outputs.BUILD_CE}}
       BUILD_EE: ${{steps.detect_editions.outputs.BUILD_EE}}
@@ -184,7 +184,7 @@ jobs:
 
   check_branch_name:
     name: Check branch name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
 
     # <template: checkout_step>
@@ -218,7 +218,7 @@ jobs:
   # <template: check_changelog_template>
   check_changelog:
     name: Check changelog
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/changelog-by-milestone.yml
+++ b/.github/workflows/changelog-by-milestone.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   condition_check:
     name: Check conditions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Check PR
         id: pr
@@ -88,7 +88,7 @@ jobs:
     needs: condition_check
     if: needs.condition_check.outputs.ok == 'ok'
     name: Open Milestones
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Find Open Milestones
         id: milestones
@@ -110,7 +110,7 @@ jobs:
   changelogs:
     if: needs.milestones.outputs.count > 0
     name: Changelog ${{ matrix.milestone.title }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: milestones
     strategy:
       max-parallel: 1

--- a/.github/workflows/check-pr-milestone.yml
+++ b/.github/workflows/check-pr-milestone.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   check-pr-milestone:
     name: Check milestone
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
     - name: Check milestone
       uses: actions/github-script@v6.4.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-slim' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       # required for all workflows

--- a/.github/workflows/conformance-pr-on-label.yml
+++ b/.github/workflows/conformance-pr-on-label.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   conformance-on-label:
     name: Check sonobuoy junit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ startsWith(github.event.label.name, 'tests/conformance/') }}
     steps:
       - name: Checkout PR head

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   create-release:
     permissions: write-all
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
 
     steps:
       # <template: import_secrets>

--- a/.github/workflows/cve-weekly.yml
+++ b/.github/workflows/cve-weekly.yml
@@ -42,7 +42,7 @@ jobs:
   # <template: skip_tests_repos>
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -70,7 +70,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -144,7 +144,7 @@ jobs:
 
   # </template: git_info_job>
   check_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - name: Check if triggered by a tag
         run: |
@@ -155,7 +155,7 @@ jobs:
           fi
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
@@ -196,7 +196,7 @@ jobs:
     name: Enable CE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable CE"
 
@@ -205,7 +205,7 @@ jobs:
     name: Enable EE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable EE"
 
@@ -214,7 +214,7 @@ jobs:
     name: Enable FE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable FE"
 
@@ -223,7 +223,7 @@ jobs:
     name: Enable BE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable BE"
 
@@ -232,7 +232,7 @@ jobs:
     name: Enable SE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE"
 
@@ -241,7 +241,7 @@ jobs:
     name: Enable SE-plus
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE-plus"
 

--- a/.github/workflows/deploy-beta.yml
+++ b/.github/workflows/deploy-beta.yml
@@ -70,7 +70,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -144,7 +144,7 @@ jobs:
 
   # </template: git_info_job>
   check_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - name: Check if triggered by a tag
         run: |
@@ -155,7 +155,7 @@ jobs:
           fi
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
@@ -196,7 +196,7 @@ jobs:
     name: Enable CE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable CE"
 
@@ -205,7 +205,7 @@ jobs:
     name: Enable EE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable EE"
 
@@ -214,7 +214,7 @@ jobs:
     name: Enable FE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable FE"
 
@@ -223,7 +223,7 @@ jobs:
     name: Enable BE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable BE"
 
@@ -232,7 +232,7 @@ jobs:
     name: Enable SE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE"
 
@@ -241,7 +241,7 @@ jobs:
     name: Enable SE-plus
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE-plus"
 

--- a/.github/workflows/deploy-early-access.yml
+++ b/.github/workflows/deploy-early-access.yml
@@ -70,7 +70,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -144,7 +144,7 @@ jobs:
 
   # </template: git_info_job>
   check_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - name: Check if triggered by a tag
         run: |
@@ -155,7 +155,7 @@ jobs:
           fi
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
@@ -196,7 +196,7 @@ jobs:
     name: Enable CE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable CE"
 
@@ -205,7 +205,7 @@ jobs:
     name: Enable EE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable EE"
 
@@ -214,7 +214,7 @@ jobs:
     name: Enable FE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable FE"
 
@@ -223,7 +223,7 @@ jobs:
     name: Enable BE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable BE"
 
@@ -232,7 +232,7 @@ jobs:
     name: Enable SE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE"
 
@@ -241,7 +241,7 @@ jobs:
     name: Enable SE-plus
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE-plus"
 

--- a/.github/workflows/deploy-rock-solid.yml
+++ b/.github/workflows/deploy-rock-solid.yml
@@ -70,7 +70,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -144,7 +144,7 @@ jobs:
 
   # </template: git_info_job>
   check_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - name: Check if triggered by a tag
         run: |
@@ -155,7 +155,7 @@ jobs:
           fi
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
@@ -196,7 +196,7 @@ jobs:
     name: Enable CE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable CE"
 
@@ -205,7 +205,7 @@ jobs:
     name: Enable EE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable EE"
 
@@ -214,7 +214,7 @@ jobs:
     name: Enable FE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable FE"
 
@@ -223,7 +223,7 @@ jobs:
     name: Enable BE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable BE"
 
@@ -232,7 +232,7 @@ jobs:
     name: Enable SE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE"
 
@@ -241,7 +241,7 @@ jobs:
     name: Enable SE-plus
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE-plus"
 

--- a/.github/workflows/deploy-stable.yml
+++ b/.github/workflows/deploy-stable.yml
@@ -70,7 +70,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -144,7 +144,7 @@ jobs:
 
   # </template: git_info_job>
   check_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - name: Check if triggered by a tag
         run: |
@@ -155,7 +155,7 @@ jobs:
           fi
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: check_branch
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
@@ -196,7 +196,7 @@ jobs:
     name: Enable CE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable CE"
 
@@ -205,7 +205,7 @@ jobs:
     name: Enable EE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable EE"
 
@@ -214,7 +214,7 @@ jobs:
     name: Enable FE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable FE"
 
@@ -223,7 +223,7 @@ jobs:
     name: Enable BE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable BE"
 
@@ -232,7 +232,7 @@ jobs:
     name: Enable SE
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE"
 
@@ -241,7 +241,7 @@ jobs:
     name: Enable SE-plus
     needs:
       - detect_editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - run: ": Enable SE-plus"
 

--- a/.github/workflows/deploy-web-stage.yml
+++ b/.github/workflows/deploy-web-stage.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test.yml
+++ b/.github/workflows/deploy-web-test.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test10.yml
+++ b/.github/workflows/deploy-web-test10.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test2.yml
+++ b/.github/workflows/deploy-web-test2.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test3.yml
+++ b/.github/workflows/deploy-web-test3.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test4.yml
+++ b/.github/workflows/deploy-web-test4.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test5.yml
+++ b/.github/workflows/deploy-web-test5.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test6.yml
+++ b/.github/workflows/deploy-web-test6.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test7.yml
+++ b/.github/workflows/deploy-web-test7.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test8.yml
+++ b/.github/workflows/deploy-web-test8.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/deploy-web-test9.yml
+++ b/.github/workflows/deploy-web-test9.yml
@@ -79,7 +79,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -156,7 +156,7 @@ jobs:
   # <template: check_label_job>
   check_label:
     name: Check label
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       should_run: ${{ steps.check_label.outputs.should_run }}
       labels: ${{ steps.check_label.outputs.labels }}

--- a/.github/workflows/dispatch-slash-command.yml
+++ b/.github/workflows/dispatch-slash-command.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   conditions:
     name: Check conditions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       trigger_for_release_issue: ${{steps.check.outputs.trigger_for_release_issue}}
       trigger_for_changelog: ${{steps.check.outputs.trigger_for_changelog}}
@@ -82,7 +82,7 @@ jobs:
 
   trigger_for_release_issue:
     name: Trigger workflow by comment
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - conditions
     if: ${{needs.conditions.outputs.trigger_for_release_issue == 'true'}}
@@ -103,7 +103,7 @@ jobs:
 
   trigger_for_pull_request:
     name: Trigger workflow by comment from pull-request
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
     - conditions
     if: ${{needs.conditions.outputs.trigger_for_pull_request == 'true'}}
@@ -124,7 +124,7 @@ jobs:
 
   trigger_for_changelog:
     name: Dispatch Changelog Event
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - conditions
     if: ${{needs.conditions.outputs.trigger_for_changelog == 'true'}}

--- a/.github/workflows/e2e-abort-aws.yml
+++ b/.github/workflows/e2e-abort-aws.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-azure.yml
+++ b/.github/workflows/e2e-abort-azure.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-dvp.yml
+++ b/.github/workflows/e2e-abort-dvp.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-eks.yml
+++ b/.github/workflows/e2e-abort-eks.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-gcp.yml
+++ b/.github/workflows/e2e-abort-gcp.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-openstack.yml
+++ b/.github/workflows/e2e-abort-openstack.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-static.yml
+++ b/.github/workflows/e2e-abort-static.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-vcd.yml
+++ b/.github/workflows/e2e-abort-vcd.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-vsphere.yml
+++ b/.github/workflows/e2e-abort-vsphere.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-yandex-cloud.yml
+++ b/.github/workflows/e2e-abort-yandex-cloud.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-abort-zvirt.yml
+++ b/.github/workflows/e2e-abort-zvirt.yml
@@ -84,7 +84,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-autoclean.yml
+++ b/.github/workflows/e2e-autoclean.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflows/e2e-aws.yml
+++ b/.github/workflows/e2e-aws.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-daily.yml
+++ b/.github/workflows/e2e-daily.yml
@@ -56,7 +56,7 @@ permissions:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing
@@ -68,7 +68,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
     - skip_tests_repos
     outputs:

--- a/.github/workflows/e2e-dvp.yml
+++ b/.github/workflows/e2e-dvp.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-eks.yml
+++ b/.github/workflows/e2e-eks.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-gcp.yml
+++ b/.github/workflows/e2e-gcp.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-openstack.yml
+++ b/.github/workflows/e2e-openstack.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-static.yml
+++ b/.github/workflows/e2e-static.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-vcd.yml
+++ b/.github/workflows/e2e-vcd.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-vsphere.yml
+++ b/.github/workflows/e2e-vsphere.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-yandex-cloud.yml
+++ b/.github/workflows/e2e-yandex-cloud.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/e2e-zvirt.yml
+++ b/.github/workflows/e2e-zvirt.yml
@@ -104,7 +104,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -182,7 +182,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -249,7 +249,7 @@ jobs:
   # <template: check_e2e_labels_job>
   check_e2e_labels:
     name: Check e2e labels
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   gitleaks_full_scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/k8s-autoupdate.yml
+++ b/.github/workflows/k8s-autoupdate.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflows/on-milestone-created.yml
+++ b/.github/workflows/on-milestone-created.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   create_release_issue_for_milestone:
     name: Create issue for milestone
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
 
       # <template: checkout_step>

--- a/.github/workflows/on-pull-request-backport.yml
+++ b/.github/workflows/on-pull-request-backport.yml
@@ -38,7 +38,7 @@ jobs:
   detect_pr_by_label:
     concurrency: source_pr
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.milestone != null && contains(github.event.pull_request.labels.*.name, 'status/backport') }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       release_branch: ${{ steps.from_milestone.outputs.release_branch }}
       commit: ${{ steps.from_milestone.outputs.commit }}
@@ -58,7 +58,7 @@ jobs:
   detect_pr_by_comment:
     concurrency: source_pr
     if: ${{ github.event_name == 'issue_comment' && github.event.action == 'created' && github.event.issue.state == 'closed' && github.event.pull_request.user.login != 'deckhouse-BOaTswain' && !contains(github.event.issue.labels.*.name, 'issue/release') }}
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       release_branch: ${{ steps.comment_info.outputs.branch }}
       commit: ${{ steps.pr_info.outputs.commit }}
@@ -91,7 +91,7 @@ jobs:
             core.setOutput('commit', response.data.merge_commit_sha)
 
   backport_to_release_branch:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: [detect_pr_by_label, detect_pr_by_comment]
     if: always() && (needs.detect_pr_by_label.outputs.release_branch || needs.detect_pr_by_comment.outputs.release_branch)
     steps:

--- a/.github/workflows/on-pull-request-labeled.yml
+++ b/.github/workflows/on-pull-request-labeled.yml
@@ -29,7 +29,7 @@ jobs:
   # <template: pull_request_info>
   pull_request_info:
     name: Get pull request reference
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ref: ${{ steps.pr_props.outputs.ref }}
       ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
@@ -255,7 +255,7 @@ jobs:
   # </template: pull_request_info>
   rerun_workflow_for_pull_request:
     name: Rerun workflow for pull request
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - pull_request_info
     steps:

--- a/.github/workflows/on-push-release-tag.yml
+++ b/.github/workflows/on-push-release-tag.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   start_release_build_workflow:
     name: Start build for release
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pr-auto-asigner.yml
+++ b/.github/workflows/pr-auto-asigner.yml
@@ -19,7 +19,7 @@
 name: "Pull Request Auto Assigner"
 on:
   pull_request_target:
-     types:
+    types:
       - opened
       - reopened
 
@@ -28,6 +28,6 @@ permissions:
 
 jobs:
   assign-author:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.0

--- a/.github/workflows/run-ci-tests-on-changes.yml
+++ b/.github/workflows/run-ci-tests-on-changes.yml
@@ -20,24 +20,24 @@ name: Run Ci Tests On Changes
 on:
   push:
     paths:
-      - '.github/scripts/js/**'
+      - ".github/scripts/js/**"
 
 jobs:
   test:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16'
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
 
-    - name: Install dependencies
-      run: npm ci
-      working-directory: .github/scripts/js
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .github/scripts/js
 
-    - name: Run Jest tests
-      run: npm test
-      working-directory: .github/scripts/js
+      - name: Run Jest tests
+        run: npm test
+        working-directory: .github/scripts/js

--- a/.github/workflows/security-scans.yml
+++ b/.github/workflows/security-scans.yml
@@ -40,7 +40,7 @@ jobs:
   # <template: pull_request_info>
   pull_request_info:
     name: Get pull request reference
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ref: ${{ steps.pr_props.outputs.ref }}
       ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
@@ -269,7 +269,7 @@ jobs:
   # </template: block-until-image-is-not-ready>
   block-until-image-is-not-ready:
     name: Block until the docker image is not ready
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       contents: read
       actions: read
@@ -339,7 +339,7 @@ jobs:
   # ============================================================================
   gitleaks_scan:
     name: Gitleaks scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: pull_request_info
     permissions:
       contents: read
@@ -391,7 +391,7 @@ jobs:
 
   set_security_gitleaks_requirement_status:
     name: Set commit status after gitleaks scan run
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: gitleaks_scan
     if: ${{ always() }}
     permissions:
@@ -572,7 +572,7 @@ jobs:
   # <template: set_security_scan_requirement_status>
   set_security_scan_requirement_status:
     name: Set commit status after security scan run
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: test_cve_report_main
     if: ${{ always() }}
     permissions:
@@ -719,7 +719,7 @@ jobs:
   # <template: set_security_rootless_requirement_status>
   set_security_rootless_requirement_status:
     name: Set commit status after security rootless scan run
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - pull_request_info
       - security_scan_images
@@ -1014,7 +1014,7 @@ jobs:
   # <template: set_security_antivirus_requirement_status>
   set_security_antivirus_requirement_status:
     name: Set commit status after antivirus scan run
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs: [drweb-scan, kaspersky-scan]
     if: ${{ always() }}
     permissions:
@@ -1118,7 +1118,7 @@ jobs:
   # ============================================================================
   security_scans_required:
     name: Security scans required
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: ${{ always() && needs.pull_request_info.result == 'success' }}
     needs:
       - pull_request_info

--- a/.github/workflows/stage_registry_clean.yml
+++ b/.github/workflows/stage_registry_clean.yml
@@ -46,7 +46,7 @@ env:
 jobs:
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,14 +26,14 @@ jobs:
   # <template: skip_tests_repos>
   skip_tests_repos:
     name: Skip tests repos
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     if: ${{ false || github.repository == 'deckhouse/deckhouse' }}
     steps:
     - name: Do nothing
       run: echo "Empty action to fulfil Github requirements."
   # </template: skip_tests_repos>
   stale:
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - skip_tests_repos
     permissions:

--- a/.github/workflows/suspend-alpha.yml
+++ b/.github/workflows/suspend-alpha.yml
@@ -69,7 +69,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -145,7 +145,7 @@ jobs:
 
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/suspend-beta.yml
+++ b/.github/workflows/suspend-beta.yml
@@ -69,7 +69,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -145,7 +145,7 @@ jobs:
 
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/suspend-early-access.yml
+++ b/.github/workflows/suspend-early-access.yml
@@ -69,7 +69,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -145,7 +145,7 @@ jobs:
 
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/suspend-rock-solid.yml
+++ b/.github/workflows/suspend-rock-solid.yml
@@ -69,7 +69,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -145,7 +145,7 @@ jobs:
 
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/suspend-stable.yml
+++ b/.github/workflows/suspend-stable.yml
@@ -69,7 +69,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}
@@ -145,7 +145,7 @@ jobs:
 
   detect_editions:
     name: Detect editions
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       DEPLOY_CE: ${{steps.detect_editions.outputs.DEPLOY_CE}}
       DEPLOY_EE: ${{steps.detect_editions.outputs.DEPLOY_EE}}

--- a/.github/workflows/svace.yml
+++ b/.github/workflows/svace.yml
@@ -58,7 +58,7 @@ jobs:
 
   git_info:
     name: Get git info
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ci_commit_tag: ${{ steps.git_info.outputs.ci_commit_tag }}
       ci_commit_branch: ${{ steps.git_info.outputs.ci_commit_branch }}

--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -34,19 +34,19 @@ jobs:
         github.actor == 'dependabot-preview[bot]' ||
         github.actor == 'dependabot-preview'
       )
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     permissions:
       pull-requests: write
       contents: read
     steps:
-    - uses: devindford/Append_PR_Comment@v1.1.3
-      with:
-        repo-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
-        body-update-action: 'suffix'
-        body-template: |
-          ---
-          ```changes
-          section: dependabot
-          type: chore
-          summary: ${{ github.event.pull_request.title }}
-          ```
+      - uses: devindford/Append_PR_Comment@v1.1.3
+        with:
+          repo-token: ${{secrets.BOATSWAIN_GITHUB_TOKEN}}
+          body-update-action: "suffix"
+          body-template: |
+            ---
+            ```changes
+            section: dependabot
+            type: chore
+            summary: ${{ github.event.pull_request.title }}
+            ```

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -71,7 +71,7 @@ jobs:
   # <template: pull_request_info>
   pull_request_info:
     name: Get pull request reference
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     outputs:
       ref: ${{ steps.pr_props.outputs.ref }}
       ref_slug: ${{ steps.pr_props.outputs.ref_slug }}
@@ -693,7 +693,7 @@ jobs:
 
   pull_request_changes_validation:
     name: Pull Request Changes validation
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-slim"
     needs:
       - discover
       - pull_request_info


### PR DESCRIPTION
## Description
Switch to ubuntu-slim runners.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Switch to ubuntu-slim runners.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
