### PR TITLE
[control-plane-manager] Add audit rule for pods/log resource requests

### DIFF
--- a/modules/040-control-plane-manager/hooks/audit_policy.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy.go
@@ -409,6 +409,23 @@ func appendBasicPolicyRules(policy *audit.Policy, extraData []ConfigMapInfo) {
 		}
 		policy.Rules = append(policy.Rules, rule)
 	}
+
+	// Capture kubectl get logs requests.
+	{
+		rule := audit.PolicyRule{
+			Level: audit.LevelRequest,
+			Resources: []audit.GroupResources{
+				{
+					Resources: []string{"pods/log"},
+				},
+			},
+			Verbs: []string{"get"},
+			OmitStages: []audit.Stage{
+				audit.StageRequestReceived,
+			},
+		}
+		policy.Rules = append(policy.Rules, rule)
+	}
 }
 
 func appendVirtualizationPolicyRules(policy *audit.Policy) {

--- a/modules/040-control-plane-manager/hooks/audit_policy_test.go
+++ b/modules/040-control-plane-manager/hooks/audit_policy_test.go
@@ -208,6 +208,31 @@ rules:
 					Expect(actualRule.Namespaces).To(Equal(expectedRule.Namespaces), "Namespaces in rule %d %+v should match expected rule %+v", i, actualRule, expectedRule)
 				}
 			}
+
+			hasKubectlLogsRule := false
+			for _, rule := range policy.Rules {
+				if rule.Level != audit.LevelRequest {
+					continue
+				}
+				if len(rule.Verbs) != 1 || rule.Verbs[0] != "get" {
+					continue
+				}
+				for _, resource := range rule.Resources {
+					for _, resourceName := range resource.Resources {
+						if resourceName == "pods/log" {
+							hasKubectlLogsRule = true
+							break
+						}
+					}
+					if hasKubectlLogsRule {
+						break
+					}
+				}
+				if hasKubectlLogsRule {
+					break
+				}
+			}
+			Expect(hasKubectlLogsRule).To(BeTrue(), "audit policy should contain request-level get rule for pods/log (kubectl get logs)")
 		})
 	})
 


### PR DESCRIPTION
## Description
Add an audit policy rule to capture kubectl get logs requests (pods/log) in control-plane-manager.

## Why do we need it, and what problem does it solve?

Previously, requests for pod logs were not explicitly captured by the basic audit policy.
This change ensures log access events are recorded, improving security/audit visibility and compliance coverage.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: control-plane-manager
type: fix
summary: Added an audit policy rule to log kubectl get logs requests (pods/log).
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
