### PR TITLE
[operator-trivy] Bump trivy patchset commit for in-toto fix test

### DIFF
--- a/ee/modules/500-operator-trivy/images/operator/patches/017-fix-cve5.patch
+++ b/ee/modules/500-operator-trivy/images/operator/patches/017-fix-cve5.patch
@@ -1,0 +1,51 @@
+diff --git a/go.mod b/go.mod
+index 9af98bc..503964a 100644
+--- a/go.mod
++++ b/go.mod
+@@ -201,7 +201,8 @@ require (
+ 	github.com/hashicorp/go-version v1.8.0 // indirect
+ 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+ 	github.com/huandu/xstrings v1.5.0 // indirect
+-	github.com/in-toto/in-toto-golang v0.9.0 // indirect
++	github.com/in-toto/attestation v1.1.2 // indirect
++	github.com/in-toto/in-toto-golang v0.11.0 // indirect
+ 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+ 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 // indirect
+ 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+@@ -269,7 +270,7 @@ require (
+ 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
+ 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+ 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
+-	github.com/secure-systems-lab/go-securesystemslib v0.8.0 // indirect
++	github.com/secure-systems-lab/go-securesystemslib v0.10.0 // indirect
+ 	github.com/shibumi/go-pathspec v1.3.0 // indirect
+ 	github.com/shopspring/decimal v1.4.0 // indirect
+ 	github.com/sigstore/cosign/v2 v2.2.4 // indirect
+diff --git a/go.sum b/go.sum
+index ae88d26..7471f34 100644
+--- a/go.sum
++++ b/go.sum
+@@ -662,8 +662,10 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
+ github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
+ github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+-github.com/in-toto/in-toto-golang v0.9.0 h1:tHny7ac4KgtsfrG6ybU8gVOZux2H8jN05AXJ9EBM1XU=
+-github.com/in-toto/in-toto-golang v0.9.0/go.mod h1:xsBVrVsHNsB61++S6Dy2vWosKhuA3lUTQd+eF9HdeMo=
++github.com/in-toto/attestation v1.1.2 h1:MBFn6lsMq6dptQZJBhalXTcWMb/aJy3V+GX3VYj/V1E=
++github.com/in-toto/attestation v1.1.2/go.mod h1:gYFddHMZj3DiQ0b62ltNi1Vj5rC879bTmBbrv9CRHpM=
++github.com/in-toto/in-toto-golang v0.11.0 h1:nfidMYBFx+E0lnmX5KUnN2Pdm8zdNKal1ayjJuzzRoA=
++github.com/in-toto/in-toto-golang v0.11.0/go.mod h1:u3PjTnwFKjp5a1YCcw8SJg0G+tMeKfVoWsWeFMDCMtw=
+ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
+@@ -939,8 +941,8 @@ github.com/sassoftware/relic v7.2.1+incompatible h1:Pwyh1F3I0r4clFJXkSI8bOyJINGq
+ github.com/sassoftware/relic v7.2.1+incompatible/go.mod h1:CWfAxv73/iLZ17rbyhIEq3K9hs5w6FpNMdUT//qR+zk=
+ github.com/sassoftware/relic/v7 v7.6.2 h1:rS44Lbv9G9eXsukknS4mSjIAuuX+lMq/FnStgmZlUv4=
+ github.com/sassoftware/relic/v7 v7.6.2/go.mod h1:kjmP0IBVkJZ6gXeAu35/KCEfca//+PKM6vTAsyDPY+k=
+-github.com/secure-systems-lab/go-securesystemslib v0.8.0 h1:mr5An6X45Kb2nddcFlbmfHkLguCE9laoZCUzEEpIZXA=
+-github.com/secure-systems-lab/go-securesystemslib v0.8.0/go.mod h1:UH2VZVuJfCYR8WgMlCU1uFsOUU+KeyrTWcSS73NBOzU=
++github.com/secure-systems-lab/go-securesystemslib v0.10.0 h1:l+H5ErcW0PAehBNrBxoGv1jjNpGYdZ9RcheFkB2WI14=
++github.com/secure-systems-lab/go-securesystemslib v0.10.0/go.mod h1:MRKONWmRoFzPNQ9USRF9i1mc7MvAVvF1LlW8X5VWDvk=
+ github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+ github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
+ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/ee/modules/500-operator-trivy/images/operator/patches/README.md
+++ b/ee/modules/500-operator-trivy/images/operator/patches/README.md
@@ -82,3 +82,9 @@ Fixec CVEs:
 - CVE-2026-35206
 - GHSA-xmrv-pmrh-hhx2
 - GHSA-3xc5-wrhm-f963
+
+# 017-fix-cve5.patch
+
+Fixes CVE:
+
+- GHSA-pmwq-pjrm-6p5r

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -1,7 +1,7 @@
 # Trivy version
 {{- $trivyVersion := "v0.55.2" }}
-{{- $trivyDbForkCommit := "11b0c9f9e5e4785e0a51948b33f33edf62fa0d29" }}
-{{- $trivyDbPatchCommit := "bf69cbe30e41c19e4c69b050a29a025f886ac2fd" }}
+{{- $trivyDbForkCommit := "df65ebde46f4ab443fb6f4702b05b8fe6332c356" }}
+{{- $trivyDbPatchCommit := "bbed03c788ca3a04a5b93e2c7a2f2213659ed9ec" }}
 
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -29,7 +29,7 @@ shell:
   - git clone --depth 1 --branch {{ $trivyVersion }} git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy-db.git /src/trivy-db-patch
   - git clone --depth 1 --branch {{ $trivyVersion }} $(cat /run/secrets/SOURCE_REPO)/aquasecurity/trivy.git /src/trivy
   - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy.git /src/trivy-patch
-  - cd /src/trivy-patch && git checkout b77a0bc31a1ef76f510e630fc7e4363dede45170 # last commit from branch main. Werf trigger for rebuild
+  - cd /src/trivy-patch && git checkout 7f9ae5c0561de84b903a326b0927df2d376903fe # last commit from branch main. Werf trigger for rebuild
   - cd /src/trivy-db && git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/{{ $trivyVersion }}/*.patch
   - cd /src/trivy && git apply --verbose --whitespace=fix /src/trivy-patch/patches/{{ $trivyVersion }}/*.patch
   - rm -rf /src/trivy/docs /src/trivy/integration

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -1,5 +1,6 @@
 # Trivy version
 {{- $trivyVersion := "v0.55.2" }}
+{{- $trivyCommitSHA := "928c7c0f1a5c9432a2ba2daa5268dae53dc8eb7b" }}
 {{- $trivyDbForkCommit := "167ba4f2faebe8b7c6daac6b8c86c415c9acc023" }}
 {{- $trivyDbPatchCommit := "bbed03c788ca3a04a5b93e2c7a2f2213659ed9ec" }}
 
@@ -31,7 +32,8 @@ shell:
   - cd /src/trivy-db && git checkout {{ $trivyDbForkCommit }}
   - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy-db.git /src/trivy-db-patch
   - cd /src/trivy-db-patch && git checkout {{ $trivyDbPatchCommit }}
-  - git clone --depth 1 --branch {{ $trivyVersion }} $(cat /run/secrets/SOURCE_REPO)/aquasecurity/trivy.git /src/trivy
+  - git clone $(cat /run/secrets/SOURCE_REPO)/aquasecurity/trivy.git /src/trivy
+  - cd /src/trivy && git checkout {{ $trivyCommitSHA }}
   - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy.git /src/trivy-patch
   - cd /src/trivy-patch && git checkout b7e5795dfd1ad07be2f3553b9ae292c2e263414d # last commit from branch main. Werf trigger for rebuild
   - cd /src/trivy-db && git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/{{ $trivyVersion }}/*.patch

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -1,6 +1,6 @@
 # Trivy version
 {{- $trivyVersion := "v0.55.2" }}
-{{- $trivyDbForkCommit := "df65ebde46f4ab443fb6f4702b05b8fe6332c356" }}
+{{- $trivyDbForkCommit := "167ba4f2faebe8b7c6daac6b8c86c415c9acc023" }}
 {{- $trivyDbPatchCommit := "bbed03c788ca3a04a5b93e2c7a2f2213659ed9ec" }}
 
 ---

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -1,5 +1,7 @@
 # Trivy version
 {{- $trivyVersion := "v0.55.2" }}
+{{- $trivyDbForkCommit := "11b0c9f9e5e4785e0a51948b33f33edf62fa0d29" }}
+{{- $trivyDbPatchCommit := "bf69cbe30e41c19e4c69b050a29a025f886ac2fd" }}
 
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}
@@ -25,8 +27,10 @@ secrets:
   value: {{ .DECKHOUSE_PRIVATE_REPO }}
 shell:
   install:
-  - git clone --depth 1 --branch {{ $trivyVersion }} git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/3p/aquasecurity/trivy-db.git /src/trivy-db # Not original trivy-db repo anymore
-  - git clone --depth 1 --branch {{ $trivyVersion }} git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy-db.git /src/trivy-db-patch
+  - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/3p/aquasecurity/trivy-db.git /src/trivy-db # Not original trivy-db repo anymore
+  - cd /src/trivy-db && git checkout {{ $trivyDbForkCommit }}
+  - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy-db.git /src/trivy-db-patch
+  - cd /src/trivy-db-patch && git checkout {{ $trivyDbPatchCommit }}
   - git clone --depth 1 --branch {{ $trivyVersion }} $(cat /run/secrets/SOURCE_REPO)/aquasecurity/trivy.git /src/trivy
   - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy.git /src/trivy-patch
   - cd /src/trivy-patch && git checkout 7f9ae5c0561de84b903a326b0927df2d376903fe # last commit from branch main. Werf trigger for rebuild

--- a/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
+++ b/ee/modules/500-operator-trivy/images/trivy/werf.inc.yaml
@@ -33,7 +33,7 @@ shell:
   - cd /src/trivy-db-patch && git checkout {{ $trivyDbPatchCommit }}
   - git clone --depth 1 --branch {{ $trivyVersion }} $(cat /run/secrets/SOURCE_REPO)/aquasecurity/trivy.git /src/trivy
   - git clone git@$(cat /run/secrets/DECKHOUSE_PRIVATE_REPO):deckhouse/trivy.git /src/trivy-patch
-  - cd /src/trivy-patch && git checkout 7f9ae5c0561de84b903a326b0927df2d376903fe # last commit from branch main. Werf trigger for rebuild
+  - cd /src/trivy-patch && git checkout b7e5795dfd1ad07be2f3553b9ae292c2e263414d # last commit from branch main. Werf trigger for rebuild
   - cd /src/trivy-db && git apply --verbose --whitespace=fix /src/trivy-db-patch/patches/{{ $trivyVersion }}/*.patch
   - cd /src/trivy && git apply --verbose --whitespace=fix /src/trivy-patch/patches/{{ $trivyVersion }}/*.patch
   - rm -rf /src/trivy/docs /src/trivy/integration


### PR DESCRIPTION
## Description
Pin `operator-trivy` image build to a fixed `deckhouse/trivy` commit with `in-toto-golang` security fix (`GHSA-pmwq-pjrm-6p5r`).

## Why do we need it, and what problem does it solve?
Ensures deterministic builds and guarantees the security fix is always included.

## Why do we need it in the patch release (if we do)?
Required for `release-1.73` to reliably deliver the security fix.

## Checklist
- [ ] The code is covered by unit tests. *(Not applicable)*
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: operator-trivy
type: fix
summary: Pin trivy image build to a fixed deckhouse/trivy commit with in-toto-golang security fix.
impact_level: low
impact: default