### PR TITLE
[istio] Fix werf new git wave

### DIFF
--- a/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
@@ -35,7 +35,6 @@ import:
   add: /iptables-wrapper
   to: /sbin/iptables-wrapper
   before: setup
-git:
 {{- include "image mount points" . }}
 imageSpec:
   config:

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -13,7 +13,6 @@ import:
   owner: 64535
   group: 64535
   before: install
-git:
 {{- include "image mount points" . }}
 imageSpec:
   config:

--- a/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
@@ -18,7 +18,6 @@ import:
   owner: 1337
   group: 1337
   after: setup
-git:
 {{- include "image mount points" . }}
 imageSpec:
   config:

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -63,7 +63,6 @@ import:
   add: /d8-curl
   to: /usr/bin/curl
   before: setup
-git:
 {{- include "image mount points" . }}
 imageSpec:
   config:


### PR DESCRIPTION
## Description
Removed useless `git:` before `{{- include "image mount points" . }}`.

## Why do we need it, and what problem does it solve?
This fixes build for 1.27 images.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Fixed werf files for Istio v1.27.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
