### PR TITLE
[local-path-provisioner] Backport 1.76 admin-kubeconfig and user-authz cluster roles

### DIFF
--- a/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
+++ b/modules/031-local-path-provisioner/templates/rbac-for-us.yaml
@@ -65,3 +65,37 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Chart.Name }}
     namespace: d8-{{ .Chart.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - localpathprovisioners
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: d8:{{ .Chart.Name }}:admin-kubeconfig
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: kubeadm:cluster-admins

--- a/modules/031-local-path-provisioner/templates/user-authz-cluster-roles.yaml
+++ b/modules/031-local-path-provisioner/templates/user-authz-cluster-roles.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:{{ .Chart.Name }}:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - localpathprovisioners
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:{{ .Chart.Name }}:cluster-admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - localpathprovisioners
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update


### PR DESCRIPTION
## Description

Backport of #20245 to `release-1.76`.

Adds the standard Deckhouse kubeadm-admin / user-authz RBAC wiring for the cluster-scoped `LocalPathProvisioner` CRD:

- `modules/031-local-path-provisioner/templates/rbac-for-us.yaml` — new `d8:local-path-provisioner:admin-kubeconfig` `ClusterRole` granting full CRUD on `localpathprovisioners.deckhouse.io`, plus a `ClusterRoleBinding` to the `kubeadm:cluster-admins` group so the default kubeadm `admin.conf` (`kubernetes-admin`) can manage `LocalPathProvisioner` out of the box.
- `modules/031-local-path-provisioner/templates/user-authz-cluster-roles.yaml` — new `d8:user-authz:local-path-provisioner:user` (`access-level: User`, read) and `d8:user-authz:local-path-provisioner:cluster-admin` (`access-level: ClusterAdmin`, write) `ClusterRole`s for `localpathprovisioners`.

The template content is identical to the merged state of #20245.

### Note on user-authz docs

Unlike #20245 on `main`, this backport does not touch `modules/140-user-authz/docs/README{,_RU}.md`. The release-1.76 docs generator (`tools/helm_generate/.../authz-generate.go`) renders only the static `modules/140-user-authz/templates/cluster-roles.yaml` and does not aggregate per-module `user-authz-cluster-roles.yaml` roles into the docs (that per-module aggregation was added by a separate generator rewrite that landed on `main`, +801 diff lines, not present on release-1.76). `make generate` was run on this branch and produces no diff, so the committed docs stay consistent on release-1.76.

## Why do we need it, and what problem does it solve?

Reported by user:

```
root@sds-elastic-master-0:~# kubectl create -f localpathprovisioner.yaml
Error from server (Forbidden): error when creating "localpathprovisioner.yaml":
localpathprovisioners.deckhouse.io is forbidden: User "kubernetes-admin"
cannot create resource "localpathprovisioners" in API group "deckhouse.io"
at the cluster scope
```

The default kubeadm `admin.conf` identifies the user as `kubernetes-admin` in the `kubeadm:cluster-admins` group, which had no `ClusterRoleBinding` from the `local-path-provisioner` module. After this PR `kubectl create -f localpathprovisioner.yaml` works, and user-authz `User` / `ClusterAdmin` subjects can view / manage `LocalPathProvisioner` resources.

## Why do we need it in the patch release (if we do)?

Yes — fixes a usability blocker for the default kubeadm administrator on the 1.76 patch line.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: local-path-provisioner
type: fix
summary: Grant the default kubeadm `kubernetes-admin` user (`kubeadm:cluster-admins` group) and the user-authz `User` / `ClusterAdmin` access levels permissions on `LocalPathProvisioner` so that `kubectl create -f` on a `LocalPathProvisioner` no longer fails with "Forbidden".
impact_level: low
```