### PR TITLE
[docs] Bump Hugo to v0.162.1

### DIFF
--- a/docs/site/backends/docs-builder/README.md
+++ b/docs/site/backends/docs-builder/README.md
@@ -174,7 +174,7 @@ When `--highAvailability` is enabled:
 ## Dependencies
 
 ### Core Dependencies
-- **Hugo:** v0.162.0 - Static site generator
+- **Hugo:** v0.162.1 - Static site generator
 - **Kubernetes Client:** v0.28.3 - K8s API integration
 - **Deckhouse Logger:** Custom structured logging
 - **Afero/Fsync:** File system operations

--- a/docs/site/backends/docs-builder/go.mod
+++ b/docs/site/backends/docs-builder/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bep/overlayfs v0.10.0
 	github.com/deckhouse/deckhouse/pkg/log v0.2.0
 	github.com/deckhouse/deckhouse/pkg/metrics-storage v0.3.0
-	github.com/gohugoio/hugo v0.162.0
+	github.com/gohugoio/hugo v0.162.1
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/fsync v0.10.1
@@ -34,7 +34,7 @@ require (
 	github.com/bep/goat v0.5.0 // indirect
 	github.com/bep/godartsass/v2 v2.5.0 // indirect
 	github.com/bep/golibsass v1.2.0 // indirect
-	github.com/bep/golocales v0.1.0 // indirect
+	github.com/bep/golocales v0.2.0 // indirect
 	github.com/bep/goportabletext v0.2.0 // indirect
 	github.com/bep/helpers v0.12.0 // indirect
 	github.com/bep/imagemeta v0.17.2 // indirect

--- a/docs/site/backends/docs-builder/go.sum
+++ b/docs/site/backends/docs-builder/go.sum
@@ -70,8 +70,8 @@ github.com/bep/godartsass/v2 v2.5.0 h1:tKRvwVdyjCIr48qgtLa4gHEdtRkPF8H1OeEhJAEv7
 github.com/bep/godartsass/v2 v2.5.0/go.mod h1:rjsi1YSXAl/UbsGL85RLDEjRKdIKUlMQHr6ChUNYOFU=
 github.com/bep/golibsass v1.2.0 h1:nyZUkKP/0psr8nT6GR2cnmt99xS93Ji82ZD9AgOK6VI=
 github.com/bep/golibsass v1.2.0/go.mod h1:DL87K8Un/+pWUS75ggYv41bliGiolxzDKWJAq3eJ1MA=
-github.com/bep/golocales v0.1.0 h1:rjWf1S4basIje+G+je5WMW8G+yzaoz4gEDFolrFVdvA=
-github.com/bep/golocales v0.1.0/go.mod h1:Hl78nje8mNL3LzLeJvYN9NsIZgyFJGrGfvgO9r1+mwE=
+github.com/bep/golocales v0.2.0 h1:4H1H5UPw3ainpj5zykeEfiMRQngyaIC/t+I4Dvn+fvE=
+github.com/bep/golocales v0.2.0/go.mod h1:Hl78nje8mNL3LzLeJvYN9NsIZgyFJGrGfvgO9r1+mwE=
 github.com/bep/goportabletext v0.2.0 h1:CZ9f8jADBWqHwBymQiJJPCTSV/tHSA+PYzlUf86Yze0=
 github.com/bep/goportabletext v0.2.0/go.mod h1:xDeA5+qcgKzJq6Q6XjAiBKtxLD3Yn7f6XP4joD3J3qU=
 github.com/bep/helpers v0.12.0 h1:tD6V2DQW0B+FUynF2etR/106S/TO9akm+vA/Hk24GxY=
@@ -175,8 +175,8 @@ github.com/gohugoio/hashstructure v0.6.0 h1:7wMB/2CfXoThFYhdWRGv3u3rUM761Cq29CxU
 github.com/gohugoio/hashstructure v0.6.0/go.mod h1:lapVLk9XidheHG1IQ4ZSbyYrXcaILU1ZEP/+vno5rBQ=
 github.com/gohugoio/httpcache v0.8.0 h1:hNdsmGSELztetYCsPVgjA960zSa4dfEqqF/SficorCU=
 github.com/gohugoio/httpcache v0.8.0/go.mod h1:fMlPrdY/vVJhAriLZnrF5QpN3BNAcoBClgAyQd+lGFI=
-github.com/gohugoio/hugo v0.162.0 h1:53tmaVTc6KTo41YRi7tOMcpHDkPqT3soxt+k6xyLs/o=
-github.com/gohugoio/hugo v0.162.0/go.mod h1:jQRZLi5aiQKwX1wYg1sgz374QGxuzMgJR8XssWySUhQ=
+github.com/gohugoio/hugo v0.162.1 h1:GjmVbhwMoh69+VN1hTXGFncDiDySwqGyr8yRYxnjT+8=
+github.com/gohugoio/hugo v0.162.1/go.mod h1:zdnn3irg2scM/ua3j96DmLNQu3X4BfOZrMX3Toz3La8=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.7.0 h1:I/n6v7VImJ3aISLnn73JAHXyjcQsMVvbguQPTk9Ehus=
 github.com/gohugoio/hugo-goldmark-extensions/extras v0.7.0/go.mod h1:9LJNfKWFmhEJ7HW0in5znezMwH+FYMBIhNZ3VWtRcRs=
 github.com/gohugoio/hugo-goldmark-extensions/passthrough v0.5.0 h1:p13Q0DBCrBRpJGtbtlgkYNCs4TnIlZJh8vHgnAiofrI=

--- a/tools/docs/external-module-docs.sh
+++ b/tools/docs/external-module-docs.sh
@@ -9,7 +9,7 @@ OUTPUT_DIR="${OUTPUT_DIR:-${TEMPLATE_DIR}/public}"
 MODULE_PATH="${MODULE_PATH:-}"
 CHANNEL="${CHANNEL:-alpha}"
 MODULE_VERSION="${MODULE_VERSION:-v0.1.0}"
-HUGO_IMAGE="${HUGO_IMAGE:-ghcr.io/gohugoio/hugo:v0.162.0}"
+HUGO_IMAGE="${HUGO_IMAGE:-ghcr.io/gohugoio/hugo:v0.162.1}"
 MODE="${MODE:-build}"
 POLL_INTERVAL="${POLL_INTERVAL:-700ms}"
 

--- a/tools/docs/run_external_modules.sh
+++ b/tools/docs/run_external_modules.sh
@@ -66,7 +66,7 @@ function prepare_channels() {
 }
 
 function run_hugo() {
-    docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src -w /src --entrypoint hugo ghcr.io/gohugoio/hugo:v0.162.0 server --disableFastRender --environment production
+    docker run --rm -p 1313:1313 -v $BUILDER_TEMPLATE_PATH:/src -w /src --entrypoint hugo ghcr.io/gohugoio/hugo:v0.162.1 server --disableFastRender --environment production
 }
 
 if [ "$1" = "clean" ]; then


### PR DESCRIPTION
## Description
- Upgrade the static site generator dependency from v0.162.0 to v0.162.1 across Go modules and container image references
- Update transitive locale handling dependency to align with the new upstream release requirements
- Synchronise version references in tooling scripts and documentation to maintain consistency

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Bump Hugo to v0.162.1
impact_level: low
```
