### PR TITLE
[cni-flannel, network-policy-engine] Revert deprecation status to General Availability

### DIFF
--- a/modules/035-cni-flannel/module.yaml
+++ b/modules/035-cni-flannel/module.yaml
@@ -1,5 +1,5 @@
 name: cni-flannel
-stage: Deprecated
+stage: General Availability
 critical: true
 weight: 35
 subsystems:

--- a/modules/050-network-policy-engine/module.yaml
+++ b/modules/050-network-policy-engine/module.yaml
@@ -1,5 +1,5 @@
 name: network-policy-engine
-stage: Deprecated
+stage: General Availability
 subsystems:
   - networking
 namespace: d8-system


### PR DESCRIPTION
## Description

Revert the `stage` field from `Deprecated` to `General Availability` for `cni-flannel` and `network-policy-engine` modules. This reverts changes introduced in PR #19666.

## Why do we need it, and what problem does it solve?

Setting the `Deprecated` stage for `cni-flannel` and `network-policy-engine` modules caused deprecation alerts to fire in clusters. This alarmed users who rely on these modules in production. Reverting the stage back to `General Availability` removes the alerts and restores normal operation.

Reverts #19666.

## Why do we need it in the patch release (if we do)?

Deprecation alerts are actively firing in user clusters right now, causing confusion and unnecessary concern. The fix needs to be delivered as soon as possible to stop the alerts.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-flannel
type: fix
summary: Reverted module stage from Deprecated back to General Availability to stop false deprecation alerts.
impact_level: default
---
section: network-policy-engine
type: fix
summary: Reverted module stage from Deprecated back to General Availability to stop false deprecation alerts.
impact_level: default
```