### PR TITLE
[istio] Refactor helpers

### DIFF
--- a/modules/110-istio/docs/EXAMPLES.md
+++ b/modules/110-istio/docs/EXAMPLES.md
@@ -652,7 +652,7 @@ The module can run in two modes, controlled by [`telemetryAPI.enabled`](configur
 | Mode | Behaviour |
 |------|-----------|
 | **`false` (default)** | Classic path: full `telemetry.v2` in the Istio Operator / `Istio` resource (including Sail’s `telemetry.v2.prometheus`). The module **always** deploys **`Telemetry`** `main-access-log-format` in `d8-istio` for stdout access logs only; there is no `spec.metrics` / `spec.tracing` on that object and no `defaultProviders.metrics`. |
-| **`true`** | Telemetry API path: `meshConfig.defaultProviders.metrics` selects the built-in Prometheus provider; `telemetry.v2` integrations are toggled off; the same **`Telemetry`** `main-access-log-format` gains `spec.metrics` (and optional `spec.tracing` via **`deckhouse-tracing-otlp`** or **`deckhouse-tracing`** when [`tracing.collector`](configuration.html#parameters-tracing-collector) is configured). Access log format comes from [`dataPlane.accessLog`](configuration.html#parameters-dataplane-accesslog). |
+| **`true`** | Telemetry API path: `meshConfig.defaultProviders.metrics` selects the built-in Prometheus provider; `telemetry.v2` integrations are toggled off; the same **`Telemetry`** `main-access-log-format` gains `spec.metrics` (and optional `spec.tracing` via **`deckhouse-tracing`** when [`tracing.collector`](configuration.html#parameters-tracing-collector) is configured). Access log format comes from [`dataPlane.accessLog`](configuration.html#parameters-dataplane-accesslog). |
 
 ### Enabling Telemetry API mode
 
@@ -722,7 +722,7 @@ For tag removal, disabling specific metrics or modes, follow [Customizing Istio 
 [`tracing.collector`](configuration.html#parameters-tracing-collector) is the single ModuleConfig entry for mesh-wide trace export (Zipkin or OpenTelemetry).
 
 - **`telemetryAPI.enabled: false`** plus [`tracing.enabled`](configuration.html#parameters-tracing-enabled) `true` — **legacy only**: `meshConfig.defaultConfig.tracing.zipkin` from [`tracing.collector.zipkin.address`](configuration.html#parameters-tracing-collector) (`host:port`, Jaeger Zipkin port `9411`). OpenTelemetry needs Telemetry API mode.
-- **`telemetryAPI.enabled: true`** plus **`tracing.enabled: true`** — the module registers **`deckhouse-tracing-otlp`** when [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry) has `service` and `port`, otherwise **`deckhouse-tracing`** when [`tracing.collector.zipkin.address`](configuration.html#parameters-tracing-collector) is set (OpenTelemetry wins if both are configured). Legacy `defaultConfig.tracing` is omitted; mesh-wide **`Telemetry`** `main-access-log-format` gets `spec.tracing` ([`tracing.sampling`](configuration.html#parameters-tracing-sampling) → `randomSamplingPercentage`, default `1.0`).
+- **`telemetryAPI.enabled: true`** plus **`tracing.enabled: true`** — the module registers **`deckhouse-tracing`** when [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry) has `service` and `port`, or when [`tracing.collector.zipkin.address`](configuration.html#parameters-tracing-collector) is set (OpenTelemetry wins if both are configured). Legacy `defaultConfig.tracing` is omitted; mesh-wide **`Telemetry`** `main-access-log-format` gets `spec.tracing` ([`tracing.sampling`](configuration.html#parameters-tracing-sampling) → `randomSamplingPercentage`, default `1.0`).
 
 Exporters the module does not model (SkyWalking, custom TLS stacks, extra provider names) still need **namespace-scoped** `Telemetry` with **`selector`**—not a second selector-less CR in **`d8-istio`** ([IST0160](https://istio.io/latest/docs/reference/config/analysis/ist0160/)). See [Distributed tracing with Telemetry API](https://istio.io/latest/docs/tasks/observability/distributed-tracing/telemetry-api/).
 
@@ -757,7 +757,7 @@ To see traces inside Kiali UI, configure [`tracing.kiali`](configuration.html#pa
 
 {% alert level="info" %}OpenTelemetry export in the chart follows [Distributed tracing with OpenTelemetry](https://istio.io/v1.25/docs/tasks/observability/distributed-tracing/opentelemetry/) on **Istio 1.25+**. On **Istio 1.21** use Zipkin/Jaeger via [`tracing.collector.zipkin`](configuration.html#parameters-tracing-collector) or upgrade the control-plane revision.{% endalert %}
 
-Deploy a Collector reachable from the mesh, then enable Telemetry API mode and point [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry) at it. The module adds extension provider **`deckhouse-tracing-otlp`** and `spec.tracing` on **`main-access-log-format`**—do not patch the generated `Istio` / `IstioOperator` `meshConfig` for mesh-wide OTLP.
+Deploy a Collector reachable from the mesh, then enable Telemetry API mode and point [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry) at it. The module adds extension provider **`deckhouse-tracing`** and `spec.tracing` on **`main-access-log-format`**—do not patch the generated `Istio` / `IstioOperator` `meshConfig` for mesh-wide OTLP.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -781,7 +781,7 @@ spec:
 
 For HTTP OTLP, add `collector.opentelemetry.http.path` (and optional `timeout`) per [`tracing.collector.opentelemetry.http`](configuration.html#parameters-tracing-collector-opentelemetry).
 
-Per-workload overrides still use **namespaced** `Telemetry` with **`selector`** referencing **`deckhouse-tracing-otlp`** (or another provider you define yourself outside `d8-istio`). Do not add a second selector-less `Telemetry` in **`d8-istio`** ([IST0160](https://istio.io/latest/docs/reference/config/analysis/ist0160/)).
+Per-workload overrides still use **namespaced** `Telemetry` with **`selector`** referencing **`deckhouse-tracing`** (or another provider you define yourself outside `d8-istio`). Do not add a second selector-less `Telemetry` in **`d8-istio`** ([IST0160](https://istio.io/latest/docs/reference/config/analysis/ist0160/)).
 
 #### Example — tracing only for selected workloads
 

--- a/modules/110-istio/docs/EXAMPLES_RU.md
+++ b/modules/110-istio/docs/EXAMPLES_RU.md
@@ -656,7 +656,7 @@ annotations:
 | Режим | Поведение |
 |-------|-----------|
 | **`false` (по умолчанию)** | Legacy: полностью включён `telemetry.v2` в ресурсе Istio Operator / `Istio` (в т.ч. `telemetry.v2.prometheus` для Sail). Модуль **всегда** создаёт **`Telemetry`** `main-access-log-format` в `d8-istio` только для access log; без `spec.metrics` / `spec.tracing` и без `defaultProviders.metrics`. |
-| **`true`** | Режим Telemetry API: в `meshConfig` выставлен `defaultProviders.metrics: [prometheus]`, фильтры `telemetry.v2` выключены; тот же **`Telemetry`** `main-access-log-format` дополняется `spec.metrics` (и при настроенной трассировке — `spec.tracing` через **`deckhouse-tracing-otlp`** или **`deckhouse-tracing`** из [`tracing.collector`](configuration.html#parameters-tracing-collector)). Формат журнала — в [`dataPlane.accessLog`](configuration.html#parameters-dataplane-accesslog). |
+| **`true`** | Режим Telemetry API: в `meshConfig` выставлен `defaultProviders.metrics: [prometheus]`, фильтры `telemetry.v2` выключены; тот же **`Telemetry`** `main-access-log-format` дополняется `spec.metrics` (и при настроенной трассировке — `spec.tracing` через **`deckhouse-tracing`** из [`tracing.collector`](configuration.html#parameters-tracing-collector)). Формат журнала — в [`dataPlane.accessLog`](configuration.html#parameters-dataplane-accesslog). |
 
 ### Как включить режим Telemetry API
 
@@ -726,7 +726,7 @@ spec:
 [`tracing.collector`](configuration.html#parameters-tracing-collector) — единая точка настройки mesh-wide экспорта (Zipkin или OpenTelemetry).
 
 - При **`telemetryAPI.enabled: false`** и [`tracing.enabled`](configuration.html#parameters-tracing-enabled) `true` — **только legacy**: `meshConfig.defaultConfig.tracing.zipkin` из [`tracing.collector.zipkin.address`](configuration.html#parameters-tracing-collector). OTLP требует режима Telemetry API.
-- При **`telemetryAPI.enabled: true`** и **`tracing.enabled: true`** модуль создаёт **`deckhouse-tracing-otlp`**, если заданы [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry) `service` и `port`, иначе **`deckhouse-tracing`** при [`tracing.collector.zipkin.address`](configuration.html#parameters-tracing-collector) (при одновременной настройке приоритет у OpenTelemetry). `defaultConfig.tracing` не заполняется; в **`Telemetry`** `main-access-log-format` добавляется `spec.tracing` ([`tracing.sampling`](configuration.html#parameters-tracing-sampling) → `randomSamplingPercentage`, по умолчанию `1.0`).
+- При **`telemetryAPI.enabled: true`** и **`tracing.enabled: true`** модуль создаёт **`deckhouse-tracing`**, если заданы [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry) `service` и `port`, или при [`tracing.collector.zipkin.address`](configuration.html#parameters-tracing-collector) (при одновременной настройке приоритет у OpenTelemetry). `defaultConfig.tracing` не заполняется; в **`Telemetry`** `main-access-log-format` добавляется `spec.tracing` ([`tracing.sampling`](configuration.html#parameters-tracing-sampling) → `randomSamplingPercentage`, по умолчанию `1.0`).
 
 Нестандартные провайдеры — через **`Telemetry` с `selector`** в неймспейсе приложения, не второй бесселекторный CR в **`d8-istio`** ([IST0160](https://istio.io/latest/docs/reference/config/analysis/ist0160/)). См. [tracing telemetry API](https://istio.io/latest/docs/tasks/observability/distributed-tracing/telemetry-api/).
 
@@ -761,7 +761,7 @@ spec:
 
 {% alert level="info" %}Экспорт OpenTelemetry в модуле соответствует [распределённой трассировке с OpenTelemetry](https://istio.io/v1.25/docs/tasks/observability/distributed-tracing/opentelemetry/) на **Istio 1.25+**. На **Istio 1.21** используйте Zipkin/Jaeger через [`tracing.collector.zipkin`](configuration.html#parameters-tracing-collector) или обновите ревизию control plane.{% endalert %}
 
-Разверните Collector, доступный из mesh, включите Telemetry API и укажите [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry). Модуль добавит провайдер **`deckhouse-tracing-otlp`** и `spec.tracing` в **`main-access-log-format`** — **не** дописывайте OTLP вручную в `meshConfig` CR `Istio` / `IstioOperator`.
+Разверните Collector, доступный из mesh, включите Telemetry API и укажите [`tracing.collector.opentelemetry`](configuration.html#parameters-tracing-collector-opentelemetry). Модуль добавит провайдер **`deckhouse-tracing`** и `spec.tracing` в **`main-access-log-format`** — **не** дописывайте OTLP вручную в `meshConfig` CR `Istio` / `IstioOperator`.
 
 ```yaml
 apiVersion: deckhouse.io/v1alpha1
@@ -785,7 +785,7 @@ spec:
 
 Для HTTP OTLP задайте `collector.opentelemetry.http.path` (и при необходимости `timeout`) — см. [`tracing.collector.opentelemetry.http`](configuration.html#parameters-tracing-collector-opentelemetry).
 
-Точечные настройки по workload — **`Telemetry` с `selector`** в неймспейсе приложения, ссылаясь на **`deckhouse-tracing-otlp`**. В **`d8-istio`** не создавайте второй бесселекторный `Telemetry` ([IST0160](https://istio.io/latest/docs/reference/config/analysis/ist0160/)).
+Точечные настройки по workload — **`Telemetry` с `selector`** в неймспейсе приложения, ссылаясь на **`deckhouse-tracing`**. В **`d8-istio`** не создавайте второй бесселекторный `Telemetry` ([IST0160](https://istio.io/latest/docs/reference/config/analysis/ist0160/)).
 
 #### Пример — трассировка только для части приложений
 

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -210,7 +210,7 @@ properties:
           Tracing collection settings (single source for both legacy control-plane tracing and the Telemetry API path).
 
           - If [`telemetryAPI.enabled`](#parameters-telemetryapi-enabled) is `false` and [`tracing.enabled`](#parameters-tracing-enabled) is `true`, the module fills `meshConfig.defaultConfig.tracing.zipkin` from `collector.zipkin.address` (with [`tracing.sampling`](#parameters-tracing-sampling)). OpenTelemetry export requires the Telemetry API path.
-          - If `telemetryAPI.enabled` is `true` and tracing is enabled, configure **either** [`collector.opentelemetry`](#parameters-tracing-collector-opentelemetry) **or** [`collector.zipkin`](#parameters-tracing-collector-zipkin). When both are set, OpenTelemetry wins: extension provider **`deckhouse-tracing-otlp`** and `spec.tracing` on **`Telemetry`** `main-access-log-format`. Otherwise Zipkin uses **`deckhouse-tracing`** the same way.
+          - If `telemetryAPI.enabled` is `true` and tracing is enabled, configure **either** [`collector.opentelemetry`](#parameters-tracing-collector-opentelemetry) **or** [`collector.zipkin`](#parameters-tracing-collector-zipkin). When both are set, OpenTelemetry wins. In either case the extension provider is named **`deckhouse-tracing`** with `spec.tracing` on **`Telemetry`** `main-access-log-format`.
         default: {}
         properties:
           opentelemetry:
@@ -284,7 +284,7 @@ properties:
     description: |
       [Telemetry API](https://istio.io/latest/docs/tasks/observability/telemetry/) (`telemetry.istio.io`) integration.
 
-      When `enabled` is `true`, the module drives mesh metrics via the Telemetry API and `meshConfig.defaultProviders.metrics: [prometheus]`, keeps `values.telemetry.enabled` but disables the legacy `telemetry.v2` filters, and extends the always-present **`Telemetry`** `main-access-log-format` in `d8-istio` with `spec.metrics` (and—when [`tracing.enabled`](#parameters-tracing-enabled) is `true` with a configured [`tracing.collector`](#parameters-tracing-collector)—`spec.tracing` via **`deckhouse-tracing-otlp`** or **`deckhouse-tracing`**) so Grafana/Kiali keep seeing `istio_*` series from sidecars.
+      When `enabled` is `true`, the module drives mesh metrics via the Telemetry API and `meshConfig.defaultProviders.metrics: [prometheus]`, keeps `values.telemetry.enabled` but disables the legacy `telemetry.v2` filters, and extends the always-present **`Telemetry`** `main-access-log-format` in `d8-istio` with `spec.metrics` (and—when [`tracing.enabled`](#parameters-tracing-enabled) is `true` with a configured [`tracing.collector`](#parameters-tracing-collector)—`spec.tracing` via **`deckhouse-tracing`**) so Grafana/Kiali keep seeing `istio_*` series from sidecars.
 
       When `false` (default), the full legacy `telemetry.v2` stack stays on (including Sail’s `telemetry.v2.prometheus`), without `defaultProviders.metrics`, while **`Telemetry`** `main-access-log-format` still enables access logs (backwards compatible with releases since the access-log Telemetry was introduced).
 

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -81,7 +81,7 @@ properties:
           ```
       collector:
         description: |
-          Единая конфигурация коллектора трассов для **legacy** (`meshConfig.defaultConfig.tracing`) и для **Telemetry API** (провайдер в `extensionProviders` и `spec.tracing` в CR **`Telemetry`** `main-access-log-format` при [`telemetryAPI.enabled`](#parameters-telemetryapi-enabled): **`deckhouse-tracing-otlp`** для OpenTelemetry или **`deckhouse-tracing`** для Zipkin).
+          Единая конфигурация коллектора трассов для **legacy** (`meshConfig.defaultConfig.tracing`) и для **Telemetry API** (провайдер в `extensionProviders` и `spec.tracing` в CR **`Telemetry`** `main-access-log-format` при [`telemetryAPI.enabled`](#parameters-telemetryapi-enabled): **`deckhouse-tracing`**).
 
           В legacy-режиме используется только Zipkin. Если заданы и OpenTelemetry, и Zipkin при включённом Telemetry API, приоритет у OpenTelemetry.
         properties:
@@ -130,7 +130,7 @@ properties:
     description: |
       Интеграция с [Telemetry API](https://istio.io/latest/docs/tasks/observability/telemetry/) Istio (ресурсы `telemetry.istio.io`).
 
-      Если `enabled` — `true`, метрики mesh идут через Telemetry API: в `meshConfig` выставляется `defaultProviders.metrics: [prometheus]`, `telemetry.enabled` остаётся `true`, а `telemetry.v2` выключается; к уже существующему **`Telemetry`** `main-access-log-format` добавляются `spec.metrics` (и при [`tracing.enabled`](#parameters-tracing-enabled) с настроенным [`tracing.collector`](#parameters-tracing-collector) — `spec.tracing` через **`deckhouse-tracing-otlp`** или **`deckhouse-tracing`**), чтобы серии `istio_*` снова были видны в Grafana/Kiali.
+      Если `enabled` — `true`, метрики mesh идут через Telemetry API: в `meshConfig` выставляется `defaultProviders.metrics: [prometheus]`, `telemetry.enabled` остаётся `true`, а `telemetry.v2` выключается; к уже существующему **`Telemetry`** `main-access-log-format` добавляются `spec.metrics` (и при [`tracing.enabled`](#parameters-tracing-enabled) с настроенным [`tracing.collector`](#parameters-tracing-collector) — `spec.tracing` через **`deckhouse-tracing`**), чтобы серии `istio_*` снова были видны в Grafana/Kiali.
 
       Если `false` (по умолчанию), остаётся полный legacy-путь `telemetry.v2` (в т.ч. `prometheus` в Sail), без `defaultProviders.metrics`, а **`Telemetry`** `main-access-log-format` по-прежнему включает access log (совместимость с релизами, где этот CR уже был).
 

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -114,7 +114,10 @@ const istioValues = `
       ingressGateway:
         inlet: LoadBalancer
         nodePort: {}
-    tracing: {}
+    tracing:
+      collector:
+        opentelemetry: {}
+        zipkin: {}
     controlPlane:
       replicasManagement:
         mode: Standard
@@ -308,7 +311,7 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(foundZipkinIOP).To(BeTrue())
 		})
 
-		It("adds OpenTelemetry tracing to main-access-log-format and deckhouse-tracing-otlp extension provider when collector.opentelemetry is set", func() {
+		It("adds OpenTelemetry tracing to main-access-log-format and deckhouse-tracing extension provider when collector.opentelemetry is set", func() {
 			f.ValuesSet("istio.telemetryAPI.enabled", true)
 			f.ValuesSet("istio.tracing.enabled", true)
 			f.ValuesSet("istio.tracing.collector.opentelemetry.service", "opentelemetry-collector.observability.svc.cluster.local")
@@ -319,17 +322,16 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(f.RenderError).ShouldNot(HaveOccurred())
 
 			mesh := f.KubernetesResource("Telemetry", "d8-istio", "main-access-log-format")
-			Expect(mesh.Field("spec.tracing.0.providers.0.name").String()).To(Equal("deckhouse-tracing-otlp"))
+			Expect(mesh.Field("spec.tracing.0.providers.0.name").String()).To(Equal("deckhouse-tracing"))
 
 			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
 			foundOtelEP := false
 			for _, ep := range istioV25.Field("spec.values.meshConfig.extensionProviders").Array() {
-				if ep.Get("name").String() == "deckhouse-tracing-otlp" {
+				if ep.Get("name").String() == "deckhouse-tracing" {
 					Expect(ep.Get("opentelemetry.service").String()).To(Equal("opentelemetry-collector.observability.svc.cluster.local"))
 					Expect(ep.Get("opentelemetry.port").Int()).To(Equal(int64(4317)))
 					foundOtelEP = true
 				}
-				Expect(ep.Get("name").String()).NotTo(Equal("deckhouse-tracing"))
 			}
 			Expect(foundOtelEP).To(BeTrue())
 		})

--- a/modules/110-istio/templates/_helpers.tpl
+++ b/modules/110-istio/templates/_helpers.tpl
@@ -40,26 +40,11 @@
   {{- end -}}
 {{- end -}}
 
-{{- define "istio.tracing.telemetryAPIProviderName" -}}
-  {{- if .Values.istio.tracing.enabled -}}
-    {{- $otel := .Values.istio.tracing.collector.opentelemetry | default dict -}}
-    {{- if and $otel.service $otel.port -}}
-deckhouse-tracing-otlp
-    {{- else -}}
-      {{- with .Values.istio.tracing.collector.zipkin -}}
-        {{- with .address -}}
-deckhouse-tracing
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-
-{{- define "istio.tracing.telemetryAPIExtensionProvider.body" -}}
-  {{- $root := . -}}
-  {{- $otel := $root.Values.istio.tracing.collector.opentelemetry | default dict -}}
+{{- define "istioTracingProvider" -}}
+  {{- $otel := $.Values.istio.tracing.collector.opentelemetry | default dict -}}
+  {{- $zipkin := $.Values.istio.tracing.collector.zipkin | default dict -}}
   {{- if and $otel.service $otel.port -}}
-- name: deckhouse-tracing-otlp
+- name: deckhouse-tracing
   opentelemetry:
     service: {{ $otel.service | quote }}
     port: {{ $otel.port }}
@@ -70,21 +55,9 @@ deckhouse-tracing
       timeout: {{ $otel.http.timeout | quote }}
       {{- end }}
     {{- end }}
-  {{- else -}}
-    {{- with $root.Values.istio.tracing.collector.zipkin -}}
-      {{- with .address -}}
+  {{- else if $zipkin.address }}
 - name: deckhouse-tracing
   zipkin:
-    address: {{ . | quote }}
-      {{- end -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-
-{{- define "istio.tracing.telemetryAPIExtensionProvider" -}}
-  {{- $root := .root -}}
-  {{- $indent := .indent | int -}}
-  {{- if and $root.Values.istio.tracing.enabled ($root.Values.istio.telemetryAPI | default dict).enabled -}}
-{{ include "istio.tracing.telemetryAPIExtensionProvider.body" $root | nindent $indent }}
-  {{- end -}}
+    address: {{ $zipkin.address | quote }}
+  {{- end }}
 {{- end -}}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -95,9 +95,9 @@ spec:
           {{- end }}
         {{- end }}
       name: main-access-log-format
-      {{- if and $.Values.istio.tracing.enabled $telemetryAPI.enabled }}
-{{- include "istio.tracing.telemetryAPIExtensionProvider" (dict "root" $ "indent" 4) }}
-      {{- end }}
+    {{- if and $.Values.istio.tracing.enabled $telemetryAPI.enabled }}
+    {{- include "istioTracingProvider" $ | nindent 4 }}
+    {{- end }}
 
     # The rules below exclude upmeter-related namespaces from istiod's point of view.
     # So, upmeter's events used to affect the traffic between control-plane and data-plane will be reduced.

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -130,7 +130,7 @@ spec:
           {{- end }}
         name: main-access-log-format
       {{- if and $.Values.istio.tracing.enabled $telemetryAPI.enabled }}
-{{- include "istio.tracing.telemetryAPIExtensionProvider" (dict "root" $ "indent" 6) }}
+      {{- include "istioTracingProvider" $ | nindent 6 }}
       {{- end }}
 
       # The rules below exclude upmeter-related namespaces from istiod's point of view.

--- a/modules/110-istio/templates/control-plane/telemetry-main-access-log-format.yaml
+++ b/modules/110-istio/templates/control-plane/telemetry-main-access-log-format.yaml
@@ -15,10 +15,10 @@ spec:
   metrics:
   - providers:
     - name: prometheus
-{{- with include "istio.tracing.telemetryAPIProviderName" . }}
+{{- if (include "istioTracingProvider" .) }}
   tracing:
   - providers:
-    - name: {{ . }}
-    randomSamplingPercentage: {{ $.Values.istio.tracing.sampling | default 1.0 }}
+    - name: deckhouse-tracing
+    randomSamplingPercentage: {{ .Values.istio.tracing.sampling | default 1.0 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

This commit refactors the tracing extension provider helpers in the `istio` module to use a single unified provider name (`deckhouse-tracing`) for both OpenTelemetry and Zipkin tracing backends.

Previously, the module registered two separate extension providers depending on the configured tracing collector:
- **`deckhouse-tracing-otlp`** — when `collector.opentelemetry.service` and `port` were set.
- **`deckhouse-tracing`** — when `collector.zipkin.address` was set.

This introduced unnecessary complexity in the Helm helpers and required users to know which provider name to reference in per-workload `Telemetry` resources. Now both backends produce the same provider name `deckhouse-tracing`, simplifying the API surface and documentation.

### What changed

- **`templates/_helpers.tpl`** — Removed the `istio.tracing.telemetryAPIProviderName` and `istio.tracing.telemetryAPIExtensionProvider` helpers. Replaced them with a single `istioTracingProvider` helper that outputs a `deckhouse-tracing` extension provider for either OpenTelemetry or Zipkin based on which collector configuration is present.

- **`templates/control-plane/iop.yaml`** and **`istios.yaml`** — Updated to call `istioTracingProvider` with `nindent` instead of the old `istio.tracing.telemetryAPIExtensionProvider`.

- **`templates/control-plane/telemetry-main-access-log-format.yaml`** — Simplified the tracing block to use `include "istioTracingProvider" .` as a simple presence check, hardcoding `deckhouse-tracing` in the provider list.

- **Documentation** (`EXAMPLES.md`, `EXAMPLES_RU.md`, `openapi/config-values.yaml`, `openapi/doc-ru-config-values.yaml`) — All references to `deckhouse-tracing-otlp` have been replaced with `deckhouse-tracing`.

- **Tests** (`template_tests/module_test.go`) — Updated test values to properly nest `opentelemetry` and `zipkin` under `tracing.collector` (preventing nil-pointer issues), changed the test expectation from `deckhouse-tracing-otlp` to `deckhouse-tracing`, and removed the assertion that `deckhouse-tracing` should not appear (it now always appears).