### PR TITLE
[istio] Exclude v1.27 from CSE build

### DIFF
--- a/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/cni-v1x27x9/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -94,3 +95,4 @@ shell:
         done
       done
     done
+{{- end }}

--- a/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/common-v1x27x9/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $kialiVersion := printf "v%s" (include "get_oss_version_by_id" (list "kiali-for-istio-1-27" $ )) }}
@@ -34,3 +35,4 @@ shell:
   # kiali
   - cd /src/kiali/
   - git apply --verbose /patches/001-kiali-gomod_gosum.patch
+{{- end }}

--- a/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/kiali-v1x27x9/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -47,3 +48,4 @@ shell:
   - go build -o /src/kiali/out/kiali /src/kiali/
   - strip /src/kiali/out/kiali
   - chmod 0755 /src/kiali/out/kiali
+{{- end }}

--- a/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x27x9/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -51,3 +52,4 @@ shell:
   - strip /src/istio/out/pilot-discovery
   - chmod 0700 /src/istio/out/pilot-discovery
   - chown 1337:1337 /src/istio/out/pilot-discovery
+{{- end }}

--- a/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/proxyv2-v1x27x9/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- if ne $.Env "CSE" }}
 ---
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 {{- $istioImageVersion := (printf "v%s" (replace "." "x" $istioVersion)) }} {{- /* 1.27.9 -> v1x27x9 */}}
@@ -289,3 +290,4 @@ shell:
   - git clone --depth 1 --branch {{ $istioVersion }} $(cat /run/secrets/SOURCE_REPO)/istio/proxy.git /src/proxy
   - cd /src/proxy/
 ---
+{{- end }}

--- a/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
+++ b/modules/110-istio/images/ztunnel-v1x27x9/werf.inc.yaml
@@ -1,3 +1,4 @@
+{{- if ne $.Env "CSE" }}
 {{- $istioVersion := include "get_oss_version_by_id" (list "istio-1-27" $ ) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
@@ -82,3 +83,4 @@ git:
   tag: {{ $istioVersion }}
   to: /src/ztunnel
 ---
+{{- end }}


### PR DESCRIPTION
## Description
Images of v1.27 wraped in condition not to build in CSE env.

## Why do we need it, and what problem does it solve?
This fixes CSE build because of llvm-17 in 1.27. 

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: fix
summary: Excluded Istio v1.27 images from the CSE build.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
