### PR TITLE
[deckhouse] fixed src-artifact in webhook-operator

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -45,32 +45,14 @@ git:
 # - 'ee/fe/modules/*/webhooks/'
   excludePaths:
     - '**/*_test.py'
-  stageDependencies:
-    install:
-      - '**/*'
 - add: /{{ .ModulePath }}modules/002-deckhouse/images/webhook-handler/src/entrypoint.sh
   to: /entrypoint.sh
-  stageDependencies:
-    install:
-      - '**/*'
 - add: /{{ .ModulePath }}shell_lib/semver.sh
   to: /{{ .ModulePath }}frameworks/shell/semver.sh
-  stageDependencies:
-    install:
-      - '**/*'
 - add: /{{ .ModulePath }}python_lib
   to: /frameworks/python
-  stageDependencies:
-    install:
-      - '**/*'
 - add: /{{ .ModulePath }}modules/002-deckhouse/images/webhook-handler/operator/internal/controller/templates
   to: /internal/controller/templates
-  stageDependencies:
-    install:
-      - '**/*'
-shell:
-  install:
-  - set -e
 imageSpec:
   config:
     env: {"PYTHONPATH": "/frameworks/python"}
@@ -162,9 +144,6 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}-webhook-operator-src-artifact
 fromImage: common/src-artifact
 final: false
-shell:
-  install:
-  - cd /operator
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/operator
   to: /src
@@ -172,6 +151,3 @@ git:
   - '**/*.go'
   - '**/*.mod'
   - '**/*.sum'
-  stageDependencies:
-    install:
-    - '**/*'

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -45,14 +45,32 @@ git:
 # - 'ee/fe/modules/*/webhooks/'
   excludePaths:
     - '**/*_test.py'
+  stageDependencies:
+    install:
+      - '**/*'
 - add: /{{ .ModulePath }}modules/002-deckhouse/images/webhook-handler/src/entrypoint.sh
   to: /entrypoint.sh
+  stageDependencies:
+    install:
+      - '**/*'
 - add: /{{ .ModulePath }}shell_lib/semver.sh
   to: /{{ .ModulePath }}frameworks/shell/semver.sh
+  stageDependencies:
+    install:
+      - '**/*'
 - add: /{{ .ModulePath }}python_lib
   to: /frameworks/python
+  stageDependencies:
+    install:
+      - '**/*'
 - add: /{{ .ModulePath }}modules/002-deckhouse/images/webhook-handler/operator/internal/controller/templates
   to: /internal/controller/templates
+  stageDependencies:
+    install:
+      - '**/*'
+shell:
+  install:
+  - set -e
 imageSpec:
   config:
     env: {"PYTHONPATH": "/frameworks/python"}
@@ -144,6 +162,9 @@ shell:
 image: {{ .ModuleName }}/{{ .ImageName }}-webhook-operator-src-artifact
 fromImage: common/src-artifact
 final: false
+shell:
+  install:
+  - set -e
 git:
 - add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/operator
   to: /src
@@ -151,3 +172,6 @@ git:
   - '**/*.go'
   - '**/*.mod'
   - '**/*.sum'
+  stageDependencies:
+    install:
+      - '**/*'

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -142,7 +142,8 @@ from: {{ index $.Images "builder/golang-alpine" }}
 final: false
 import:
   - image: {{ $.ModuleName }}/{{ $.ImageName }}-webhook-operator-src-artifact
-    add: /operator
+    add: /src
+    to: /operator
     before: install
 mount:
 {{ include "mount points for golang builds" . }}
@@ -165,8 +166,8 @@ shell:
   install:
   - cd /operator
 git:
-- add: /{{ .ModulePath }}modules/002-deckhouse/images/webhook-handler/operator
-  to: /operator
+- add: /{{ .ModulePath }}modules/{{ .ModulePriority }}-{{ .ModuleName }}/images/{{ .ImageName }}/operator
+  to: /src
   includePaths:
   - '**/*.go'
   - '**/*.mod'

--- a/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
+++ b/modules/002-deckhouse/images/webhook-handler/werf.inc.yaml
@@ -174,4 +174,4 @@ git:
   - '**/*.sum'
   stageDependencies:
     install:
-      - '**/*'
+    - '**/*'


### PR DESCRIPTION
## Description
move to /src
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
src-artifact don't find /src
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix
summary: fixed src-artifact in webhook-operator
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
