### PR TITLE
Build repro check fix

### DIFF
--- a/.github/ci_templates/build.yml
+++ b/.github/ci_templates/build.yml
@@ -60,6 +60,22 @@ steps:
   {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "webhook_url" "LOOP_SERVICE_NOTIFICATIONS" ) $secrets -}!}
   {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 2 }!}
   {!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 2 }!}
+  {!{- if coll.Has $ctx "printGitContext" }!}
+  - name: Print git context
+    run: |
+      # Diagnostic: which commit werf will actually build from.
+      # GITHUB_SHA is the workflow run's commit (immutable, runner-injected);
+      # git HEAD is what actions/checkout left in the work tree (may differ
+      # for runs that override `ref`, e.g. reproducibility-check.yml).
+      echo "==== git context ===="
+      echo "GITHUB_SHA env:        ${GITHUB_SHA}"
+      echo "GITHUB_REF env:        ${GITHUB_REF}"
+      echo "git HEAD (full):       $(git rev-parse HEAD)"
+      echo "git HEAD (short):      $(git rev-parse --short HEAD)"
+      git log -1 --pretty='format:  commit:  %H%n  author:  %an <%ae>%n  date:    %ad%n  subject: %s'
+      echo
+      echo "====================="
+  {!{- end }!}
   {!{- if or (eq $buildType "dev") (eq $buildType "main") (eq $buildType "pre-release") }!}
   {!{ tmpl.Exec "login_dev_registry_step" $ctx | strings.Indent 2 }!}
   {!{- end }!}

--- a/.github/scripts/python/reproducibility_check.py
+++ b/.github/scripts/python/reproducibility_check.py
@@ -55,6 +55,22 @@ def entry_lines(entry: dict) -> list:
 # a global meta-image, not a module (e.g. 'dev/install', 'base/vex').
 _NON_MODULE_PREFIXES = {"dev", "base"}
 
+# Images whose content is intentionally non-reproducible across runs and must
+# be skipped from the digest comparison:
+#
+# * release-channel-version / release-channel-version-prebuild
+#   .werf/werf-release-channel.yaml bakes the current Deckhouse version
+#   string, the per-tag CHANGELOG snippet, and the kubernetesVersions list
+#   into version.json/changelog.yaml. Even on the same commit these inputs
+#   can shift between runs (CHANGELOG additions on other branches, k8s
+#   version bumps), making the manifest digest unstable. The image is a
+#   pure metadata payload (no code), so it does not represent a build
+#   reproducibility risk and is excluded from the check.
+_IGNORED_IMAGES = {
+    "release-channel-version",
+    "release-channel-version-prebuild",
+}
+
 
 def split_module(image_name: str) -> tuple:
     """Return (module, image_subname) for table display.
@@ -81,8 +97,13 @@ def main(argv: list) -> int:
     baseline_images = load_report(baseline_path).get("Images") or {}
     rerun_images    = load_report(rerun_path).get("Images") or {}
 
+    all_names = sorted(set(baseline_images) | set(rerun_images))
+    ignored = sorted(n for n in all_names if n in _IGNORED_IMAGES)
+
     mismatched = []
-    for name in sorted(set(baseline_images) | set(rerun_images)):
+    for name in all_names:
+        if name in _IGNORED_IMAGES:
+            continue
         b_digest = baseline_images.get(name, {}).get("DockerImageDigest", "")
         r_digest = rerun_images.get(name, {}).get("DockerImageDigest", "")
         if b_digest != r_digest:
@@ -93,10 +114,13 @@ def main(argv: list) -> int:
     print(f"Baseline: {baseline_path}")
     print(f"Rerun:    {rerun_path}")
     print(f"Images in baseline: {len(baseline_images)}; in rerun: {len(rerun_images)}")
+    if ignored:
+        print(f"Ignored (non-reproducible by design): {', '.join(ignored)}")
     print()
 
+    compared = len(all_names) - len(ignored)
     if not mismatched:
-        print(f"OK: all {len(baseline_images)} image digests match. Build is reproducible.")
+        print(f"OK: all {compared} compared image digests match. Build is reproducible.")
         return 0
 
     print(f"Digest mismatch: {len(mismatched)} image(s) differ.")

--- a/.github/scripts/python/reproducibility_check.py
+++ b/.github/scripts/python/reproducibility_check.py
@@ -41,18 +41,32 @@ def detect_edition(report_path: Path) -> str:
     return parent or report_path.stem
 
 
-def load_digests(report_path: Path) -> dict:
+def load_report(report_path: Path) -> dict:
     with report_path.open(encoding="utf-8") as fh:
-        data = json.load(fh)
-    return {
-        name: info.get("DockerImageDigest", "")
-        for name, info in (data.get("Images") or {}).items()
-    }
+        return json.load(fh)
 
 
-def normalized_json(report_path: Path) -> list:
-    data = json.loads(report_path.read_text(encoding="utf-8"))
-    return json.dumps(data, sort_keys=True, indent=2).splitlines()
+def entry_lines(entry: dict) -> list:
+    return json.dumps(entry, sort_keys=True, indent=2).splitlines()
+
+
+# Deckhouse-specific: module images are rendered by .werf/defines/modules.tmpl as
+# "<ModuleName>/<ImageName>". Image names whose first segment is one of these is
+# a global meta-image, not a module (e.g. 'dev/install', 'base/vex').
+_NON_MODULE_PREFIXES = {"dev", "base"}
+
+
+def split_module(image_name: str) -> tuple:
+    """Return (module, image_subname) for table display.
+
+    Returns ('—', image_name) for global images that don't belong to a module.
+    """
+    if "/" not in image_name:
+        return "—", image_name
+    head, _, tail = image_name.partition("/")
+    if head in _NON_MODULE_PREFIXES:
+        return "—", image_name
+    return head, tail
 
 
 def main(argv: list) -> int:
@@ -64,48 +78,56 @@ def main(argv: list) -> int:
     rerun_path = Path(argv[2])
     edition = detect_edition(baseline_path)
 
-    baseline = load_digests(baseline_path)
-    rerun = load_digests(rerun_path)
+    baseline_images = load_report(baseline_path).get("Images") or {}
+    rerun_images    = load_report(rerun_path).get("Images") or {}
 
     mismatched = []
-    for image in sorted(set(baseline) | set(rerun)):
-        b = baseline.get(image, "")
-        r = rerun.get(image, "")
-        if b != r:
-            mismatched.append((image, b, r))
+    for name in sorted(set(baseline_images) | set(rerun_images)):
+        b_digest = baseline_images.get(name, {}).get("DockerImageDigest", "")
+        r_digest = rerun_images.get(name, {}).get("DockerImageDigest", "")
+        if b_digest != r_digest:
+            mismatched.append((name, b_digest, r_digest))
 
     print(f"# Build reproducibility check ({edition})")
     print()
     print(f"Baseline: {baseline_path}")
     print(f"Rerun:    {rerun_path}")
-    print(f"Images in baseline: {len(baseline)}; in rerun: {len(rerun)}")
+    print(f"Images in baseline: {len(baseline_images)}; in rerun: {len(rerun_images)}")
     print()
 
     if not mismatched:
-        print(f"OK: all {len(baseline)} image digests match. Build is reproducible.")
+        print(f"OK: all {len(baseline_images)} image digests match. Build is reproducible.")
         return 0
 
     print(f"Digest mismatch: {len(mismatched)} image(s) differ.")
     print()
-    print("| Image | Baseline digest | Rerun digest |")
-    print("|---|---|---|")
-    for image, baseline_digest, rerun_digest in mismatched:
-        print(f"| `{image}` | `{baseline_digest or '—'}` | `{rerun_digest or '—'}` |")
+    print("| Module | Image | Baseline digest | Rerun digest |")
+    print("|---|---|---|---|")
+    for name, b_digest, r_digest in mismatched:
+        module, image = split_module(name)
+        print(f"| `{module}` | `{image}` | `{b_digest or '—'}` | `{r_digest or '—'}` |")
     print()
 
-    print("## JSON diff")
+    print("## Per-image diff")
     print()
-    print("```diff")
-    diff = difflib.unified_diff(
-        normalized_json(baseline_path),
-        normalized_json(rerun_path),
-        fromfile=str(baseline_path),
-        tofile=str(rerun_path),
-        lineterm="",
-    )
-    for line in diff:
-        print(line)
-    print("```")
+    for name, _, _ in mismatched:
+        b_entry = baseline_images.get(name, {})
+        r_entry = rerun_images.get(name, {})
+        print(f"### `{name}`")
+        print()
+        print("```diff")
+        diff = difflib.unified_diff(
+            entry_lines(b_entry),
+            entry_lines(r_entry),
+            fromfile=f"baseline:Images.{name}",
+            tofile=f"rerun:Images.{name}",
+            lineterm="",
+        )
+        for line in diff:
+            print(line)
+        print("```")
+        print()
+
     return 1
 
 

--- a/.github/workflow_templates/reproducibility-check.yml
+++ b/.github/workflow_templates/reproducibility-check.yml
@@ -223,7 +223,7 @@ jobs:
     if: needs.resolve_target.outputs.baseline_workflow == 'main'
     env:
       WERF_ENV: "FE"
-{!{ tmpl.Exec "build_template" (slice (coll.Merge (coll.Dict "pullRequestRefField" "needs.resolve_target.outputs.sha") .) "main" "FE") | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" (slice (coll.Merge (coll.Dict "pullRequestRefField" "needs.resolve_target.outputs.sha" "printGitContext" true) .) "main" "FE") | strings.Indent 4 }!}
 
   build_fe_dev:
     name: Build FE (dev-style)
@@ -234,7 +234,7 @@ jobs:
     if: needs.resolve_target.outputs.baseline_workflow == 'dev'
     env:
       WERF_ENV: "FE"
-{!{ tmpl.Exec "build_template" (slice (coll.Merge (coll.Dict "pullRequestRefField" "needs.resolve_target.outputs.sha") .) "dev" "FE") | strings.Indent 4 }!}
+{!{ tmpl.Exec "build_template" (slice (coll.Merge (coll.Dict "pullRequestRefField" "needs.resolve_target.outputs.sha" "printGitContext" true) .) "dev" "FE") | strings.Indent 4 }!}
 
   compare_reports:
     name: Compare build reports

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -306,6 +306,20 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.resolve_target.outputs.sha }}
       # </template: checkout_full_step>
+      - name: Print git context
+        run: |
+          # Diagnostic: which commit werf will actually build from.
+          # GITHUB_SHA is the workflow run's commit (immutable, runner-injected);
+          # git HEAD is what actions/checkout left in the work tree (may differ
+          # for runs that override `ref`, e.g. reproducibility-check.yml).
+          echo "==== git context ===="
+          echo "GITHUB_SHA env:        ${GITHUB_SHA}"
+          echo "GITHUB_REF env:        ${GITHUB_REF}"
+          echo "git HEAD (full):       $(git rev-parse HEAD)"
+          echo "git HEAD (short):      $(git rev-parse --short HEAD)"
+          git log -1 --pretty='format:  commit:  %H%n  author:  %an <%ae>%n  date:    %ad%n  subject: %s'
+          echo
+          echo "====================="
 
       # <template: login_dev_registry_step>
       - name: Check dev registry credentials
@@ -608,6 +622,20 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.resolve_target.outputs.sha }}
       # </template: checkout_full_step>
+      - name: Print git context
+        run: |
+          # Diagnostic: which commit werf will actually build from.
+          # GITHUB_SHA is the workflow run's commit (immutable, runner-injected);
+          # git HEAD is what actions/checkout left in the work tree (may differ
+          # for runs that override `ref`, e.g. reproducibility-check.yml).
+          echo "==== git context ===="
+          echo "GITHUB_SHA env:        ${GITHUB_SHA}"
+          echo "GITHUB_REF env:        ${GITHUB_REF}"
+          echo "git HEAD (full):       $(git rev-parse HEAD)"
+          echo "git HEAD (short):      $(git rev-parse --short HEAD)"
+          git log -1 --pretty='format:  commit:  %H%n  author:  %an <%ae>%n  date:    %ad%n  subject: %s'
+          echo
+          echo "====================="
 
       # <template: login_dev_registry_step>
       - name: Check dev registry credentials


### PR DESCRIPTION
## Description
Build repro check minor fixes

## Why do we need it, and what problem does it solve?
 improvements

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Build repro check fix
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
