### PR TITLE
Migrate to Golang GOST

### DIFF
--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
 # version=v1.0.35
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:c17d7784bd24d43686a8026cc3a375114275619a0cbae752f5c96b2a58993e6e" # from: builder/scratch
-builder/golang-1.25: "sha256:d48d6f95ea18ef5cad5c8dab985a675525c5e2f16387365f319ceed6534556f7" # from: builder/distroless
-builder/golang-1.26: "sha256:b2ca3683572bfe5c365d40bbd5df89fbfe659649e80db61931962a5899fa7cdc" # from: builder/distroless
-builder/golang: "sha256:3c008bec0613d756717cd81722adc20c43181a998bc72e32cc2c24819be0e9d0" # from: builder/distroless
+builder/distroless: "sha256:fda12da28afcf9d311a9f350d3d99bba0a9097adc06b5abe04716ec39ad8b936" # from: builder/scratch
+builder/golang-1.25: "sha256:a7091549578f4a187ec03419b798174ef4e7dc21f69033218f62974d99328372" # from: builder/distroless
+builder/golang-1.26: "sha256:2d004bf90cf8ebb10d1177d051552e199e14b80d3ded66649c7ce5cea139711a" # from: builder/distroless
+builder/golang: "sha256:da900c4a319a37675a90b8a1bcc9a5abcc580f26f63b120e50b00cd525cd14b7" # from: builder/distroless
 minget-0.1: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch
 minget: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v1.0.32
+# version=v1.0.34
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:eb86b7c429cde7a3d7349098ba56fa167c6f14fe54924d18c099655cd02d19e8" # from: builder/scratch
-builder/golang-1.25: "sha256:ea80dd12a9ecbdf1e7cccdc9dc575d893e37c02fb123e084f6d64d07ebb4376b" # from: builder/distroless
-builder/golang-1.26: "sha256:207baa1f0642b56f5b98bdca553d152b3922d1794110ca5b2f7ce9b9bed5d05e" # from: builder/distroless
-builder/golang: "sha256:6570c11bd3d41c1ac60da51d56c4fff35026ca325337d83ad38452441d1e7427" # from: builder/distroless
+builder/distroless: "sha256:27eded316cf3165eb6f54a6b1f43b464f53c5adbfa0e7d08e1e2c0778dbaf706" # from: builder/scratch
+builder/golang-1.25: "sha256:3cf85dfcb170f6bb4ce40dcfdfa76b01a3b9adf94cdacdc4fdea5048d38262b6" # from: builder/distroless
+builder/golang-1.26: "sha256:a76eafaea8d005915442fa71750d8bc94735273b9faeef5eb3b1e0769a8ae705" # from: builder/distroless
+builder/golang: "sha256:29ff6892f23d6debdafb21e574d7ec893ed79eee766e62d083f00de7553c1c2c" # from: builder/distroless
 minget-0.1: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch
 minget: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,8 +1,8 @@
-# version=v1.0.34
+# version=v1.0.35
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/distroless: "sha256:27eded316cf3165eb6f54a6b1f43b464f53c5adbfa0e7d08e1e2c0778dbaf706" # from: builder/scratch
-builder/golang-1.25: "sha256:3cf85dfcb170f6bb4ce40dcfdfa76b01a3b9adf94cdacdc4fdea5048d38262b6" # from: builder/distroless
-builder/golang-1.26: "sha256:a76eafaea8d005915442fa71750d8bc94735273b9faeef5eb3b1e0769a8ae705" # from: builder/distroless
-builder/golang: "sha256:29ff6892f23d6debdafb21e574d7ec893ed79eee766e62d083f00de7553c1c2c" # from: builder/distroless
+builder/distroless: "sha256:c17d7784bd24d43686a8026cc3a375114275619a0cbae752f5c96b2a58993e6e" # from: builder/scratch
+builder/golang-1.25: "sha256:d48d6f95ea18ef5cad5c8dab985a675525c5e2f16387365f319ceed6534556f7" # from: builder/distroless
+builder/golang-1.26: "sha256:b2ca3683572bfe5c365d40bbd5df89fbfe659649e80db61931962a5899fa7cdc" # from: builder/distroless
+builder/golang: "sha256:3c008bec0613d756717cd81722adc20c43181a998bc72e32cc2c24819be0e9d0" # from: builder/distroless
 minget-0.1: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch
 minget: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch

--- a/modules/007-registrypackages/images/cfssl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/cfssl/werf.inc.yaml
@@ -22,7 +22,7 @@ shell:
     - rm -rf /src/cfssl/.git
 ---
 image: "{{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}"
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
   - image: "{{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}"
@@ -34,9 +34,6 @@ secrets:
   - id: GOPROXY
     value: "{{ $.GOPROXY }}"
 shell:
-  beforeInstall:
-    {{- include "alpine packages proxy" . | nindent 4 }}
-    - apk add --no-cache make
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - export GOOS=linux

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -74,7 +74,7 @@ secrets:
   value: {{ $.GOPROXY }}
 shell:
   beforeInstall:
-  - pm install libseccomp-devel
+  - pm install libseccomp-devel git
   - mkdir -p /out
   install:
   - cd /src
@@ -183,7 +183,7 @@ secrets:
   value: {{ $.GOPROXY }}
 shell:
   beforeInstall:
-  - pm install libseccomp-devel
+  - pm install libseccomp-devel git
   - mkdir -p /out
   install:
   - cd /src/containerd

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -74,7 +74,7 @@ secrets:
   value: {{ $.GOPROXY }}
 shell:
   beforeInstall:
-  - pm install libseccomp-devel git
+  - pm install libseccomp-devel git pkgconf
   - mkdir -p /out
   install:
   - cd /src
@@ -183,7 +183,7 @@ secrets:
   value: {{ $.GOPROXY }}
 shell:
   beforeInstall:
-  - pm install libseccomp-devel git
+  - pm install libseccomp-devel git pkgconf
   - mkdir -p /out
   install:
   - cd /src/containerd

--- a/modules/007-registrypackages/images/containerd/werf.inc.yaml
+++ b/modules/007-registrypackages/images/containerd/werf.inc.yaml
@@ -60,7 +60,7 @@ shell:
   - rm -rf /src/.git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-runc-artifact-{{ $runc_version }}
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm" "builder/golang-bookworm-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-runc-src-artifact-{{ $runc_version }}
@@ -74,8 +74,7 @@ secrets:
   value: {{ $.GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "debian packages proxy" $ | nindent 2 }}
-  - apt-get update && apt-get install libseccomp-dev -y
+  - pm install libseccomp-devel
   - mkdir -p /out
   install:
   - cd /src
@@ -170,7 +169,7 @@ shell:
   - rm -rf install_v1 install_v2
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-bookworm" "builder/golang-bookworm-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
@@ -184,8 +183,7 @@ secrets:
   value: {{ $.GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "debian packages proxy" $ | nindent 2 }}
-  - apt-get update && apt-get install libseccomp-dev -y
+  - pm install libseccomp-devel
   - mkdir -p /out
   install:
   - cd /src/containerd
@@ -224,7 +222,7 @@ secrets:
   value: {{ $.SOURCE_REPO }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-pidumount-src-artifact
@@ -234,9 +232,6 @@ secrets:
 - id: GOPROXY
   value: {{ $.GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" $ | nindent 2 }}
-  - apk add --no-cache gcc musl-dev
   install:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=1

--- a/modules/007-registrypackages/images/crictl/werf.inc.yaml
+++ b/modules/007-registrypackages/images/crictl/werf.inc.yaml
@@ -61,7 +61,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
@@ -75,9 +75,6 @@ secrets:
 - id: GOPROXY
   value: {{ $.GOPROXY }}
 shell:
-  beforeInstall:
-  {{- include "alpine packages proxy" $ | nindent 2 }}
-  - apk add --no-cache make
   setup:
   - export GOPROXY=$(cat /run/secrets/GOPROXY)
   - cd /src/cri-tools

--- a/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
@@ -39,7 +39,7 @@ git:
     - '**/*'
 shell:
   beforeInstall:
-  - pm install python@3.12 gnu-glibc perl python-wheel coreutils
+  - pm install python@3.12 gnu-glibc gnu-gcc-lib gnu-glibc-locale perl python-wheel coreutils curl
   - pip3 install -f file:///wheels --no-index cryptography==44.0.1
   install:
   - mv /mk-ca-bundle.pl /ca-certificates/mozilla

--- a/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
@@ -39,7 +39,7 @@ git:
     - '**/*'
 shell:
   beforeInstall:
-  - pm install python@3.12 python-wheel coreutils
+  - pm install python@3.12 gnu-glibc perl python-wheel coreutils
   - pip3 install -f file:///wheels --no-index cryptography==44.0.1
   install:
   - mv /mk-ca-bundle.pl /ca-certificates/mozilla

--- a/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
+++ b/modules/007-registrypackages/images/d8-ca-updater/werf.inc.yaml
@@ -25,7 +25,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-bookworm" }}
+from: {{ index $.Images "builder/distroless" }}
 git:
 - add: /{{ $.ModulePath }}modules/{{ $.ModulePriority }}-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
   to: /
@@ -39,8 +39,8 @@ git:
     - '**/*'
 shell:
   beforeInstall:
-  {{- include "debian packages proxy" . | nindent 2 }}
-  - apt-get install -y python3-cryptography
+  - pm install python@3.12 python-wheel coreutils
+  - pip3 install -f file:///wheels --no-index cryptography==44.0.1
   install:
   - mv /mk-ca-bundle.pl /ca-certificates/mozilla
   - cd /ca-certificates/mozilla

--- a/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
+++ b/modules/007-registrypackages/images/docker-registry/werf.inc.yaml
@@ -52,7 +52,7 @@ imageSpec:
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src
@@ -65,8 +65,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make git
+  - pm install make git
   setup:
   - export GOPROXY=$(cat /run/secrets/GOPROXY) CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=auto
   - cd /src/docker_auth/auth_server

--- a/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
+++ b/modules/007-registrypackages/images/ec2-describe-tags/werf.inc.yaml
@@ -41,7 +41,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact-{{ $image_version }}
   add: /src

--- a/modules/007-registrypackages/images/ecr-credential-provider/werf.inc.yaml
+++ b/modules/007-registrypackages/images/ecr-credential-provider/werf.inc.yaml
@@ -62,7 +62,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
   add: /src
@@ -75,8 +75,7 @@ secrets:
   value: {{ $.GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" $ | nindent 2 }}
-  - apk add --no-cache make bash
+  - pm install make bash
   install:
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - export CGO_ENABLED=0

--- a/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
+++ b/modules/007-registrypackages/images/kubernetes-cni/werf.inc.yaml
@@ -73,7 +73,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:
@@ -86,8 +86,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make bash
+  - pm install make bash
   setup:
     - export GOPROXY=$(cat /run/secrets/GOPROXY)
     - cd /src/plugins

--- a/modules/007-registrypackages/images/rpp-get/werf.inc.yaml
+++ b/modules/007-registrypackages/images/rpp-get/werf.inc.yaml
@@ -38,7 +38,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/modules/007-registrypackages/images/systemctl-power-commands-wrapper/werf.inc.yaml
+++ b/modules/007-registrypackages/images/systemctl-power-commands-wrapper/werf.inc.yaml
@@ -29,7 +29,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/modules/007-registrypackages/images/tail-log/werf.inc.yaml
+++ b/modules/007-registrypackages/images/tail-log/werf.inc.yaml
@@ -38,7 +38,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
+++ b/modules/007-registrypackages/images/toml-merge/werf.inc.yaml
@@ -41,7 +41,7 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/modules/007-registrypackages/images/xfsprogs/werf.inc.yaml
+++ b/modules/007-registrypackages/images/xfsprogs/werf.inc.yaml
@@ -1,34 +1,12 @@
 {{- $version := include "get_oss_version_by_id" (list "xfsprogs" $ )  -}}
 {{- $image_version := $version | replace "." "-" }}
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
-final: false
-fromImage: common/src-artifact
-git:
-- add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
-  to: /src/scripts
-  stageDependencies:
-    install:
-    - '**/*'
-secrets:
-- id: SOURCE_REPO
-  value: {{ .SOURCE_REPO }}
-shell:
-  install:
-  - git clone --depth 1 --branch v{{ $version }} $(cat /run/secrets/SOURCE_REPO)/xfs/xfsprogs-dev.git /src/xfsprogs-dev
-  - rm -rf /src/xfsprogs-dev/.git
----
 image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $image_version }}
 from: {{ index $.Images "builder/scratch" }}
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
-  add: /
+  add: /out
   to: /
-  includePaths:
-  - mkfs.xfs
-  - xfs_*
-  - install
-  - uninstall
   before: setup
 imageSpec:
   config:
@@ -41,35 +19,15 @@ imageSpec:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-{{ $image_version }}
 final: false
-from: {{ index $.Images "builder/golang-bookworm" }}
-import:
-- image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact-{{ $image_version }}
-  add: /src
-  to: /src
-  before: install
+from: {{ index $.Images "builder/distroless" }}
+git:
+- add: /{{ $.ModulePath }}/modules/007-{{ $.ModuleName }}/images/{{ $.ImageName }}/scripts
+  to: /scripts
+  stageDependencies:
+    install:
+    - '**/*'
 shell:
-  beforeInstall:
-  {{- include "debian packages proxy" . | nindent 2 }}
-  - apt-get update && apt-get install -y make libinih-dev libblkid-dev gettext liburcu-dev libtool libicu-dev pkg-config
-  setup:
-  - cd /src/xfsprogs-dev
-  - libtoolize -c -i -f
-  - cp -f include/install-sh .
-  - aclocal -I m4 &&	autoconf
-  - LDFLAGS="-static" ./configure --enable-shared=no  --disable-scrub
-  - make LLDFLAGS=-all-static
-  - strip mkfs/mkfs.xfs &&
-    strip repair/xfs_repair &&
-    strip quota/xfs_quota &&
-    strip growfs/xfs_growfs &&
-    strip mdrestore/xfs_mdrestore &&
-    strip spaceman/xfs_spaceman
-  - mv mkfs/mkfs.xfs /mkfs.xfs &&
-    mv repair/xfs_repair /xfs_repair &&
-    mv quota/xfs_quota /xfs_quota &&
-    mv growfs/xfs_growfs /xfs_growfs &&
-    mv mdrestore/xfs_mdrestore /xfs_mdrestore &&
-    mv spaceman/xfs_spaceman /xfs_spaceman &&
-    mv spaceman/xfs_info.sh /xfs_info &&
-    mv /src/scripts/* /
-  - chmod +x /mkfs.xfs /xfs_repair /xfs_quota /xfs_growfs /xfs_mdrestore /xfs_spaceman /xfs_info /install /uninstall
+  install:
+  - pm install coreutils xfsprogs
+  - for script in /scripts/*; do install -D -m 0755 $script /out/$(basename "$script"); done
+  - cp /usr/sbin/{mkfs.xfs,xfs_growfs,xfs_info,xfs_mdrestore,xfs_quota,xfs_repair,xfs_spaceman} /out

--- a/modules/007-registrypackages/oss.yaml
+++ b/modules/007-registrypackages/oss.yaml
@@ -155,7 +155,7 @@
   logo: /images/logos/linux.svg
   license: GPL-2.0 license
   id: xfsprogs
-  version: "6.7.0"
+  version: "6.16.0"
 - name: jq
   link: https://github.com/jqlang/jq
   description: Lightweight and flexible command-line JSON processor.

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -475,7 +475,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"tomlMerge01":                     "imageHash-registrypackages-tomlMerge01",
 		"virtWhat125":                     "imageHash-registrypackages-virtWhat125",
 		"which223":                        "imageHash-registrypackages-which223",
-		"xfsprogs670":                     "imageHash-registrypackages-xfsprogs670",
+		"xfsprogs6160":                    "imageHash-registrypackages-xfsprogs6160",
 		"yq4471":                          "imageHash-registrypackages-yq4471",
 	},
 	"serviceWithHealthchecks": map[string]interface{}{


### PR DESCRIPTION
## Description
- new builder/golang and builder/distroless digests in candi/alt_base_images.yml
- switch build stages from builder/golang-alpine(-bookworm) to unified builder/golang in 007-registrypackages images
- containerd - align with builder/golang, add `pm install` build deps 
- xfsprogs - replace source compile with ready-to-use base image

## Why do we need it, and what problem does it solve?
New builder/golang image from container-factory with enabled Green Tea GC (GOEXPERIMENT=greenteagc), which improves Go compile performance and memory behavior compared to the default GC.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: chore
summary: Use unified golang builder and pm-based tooling for 007-registrypackages image builds
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
