### PR TITLE
[docs] add rendering of application and package CRDs

### DIFF
--- a/docs/documentation/_tools/prepare_resources.sh
+++ b/docs/documentation/_tools/prepare_resources.sh
@@ -22,7 +22,7 @@ if [ -d /src/global ]; then
   cp -f /src/global/config-values.yaml _data/schemas/modules/global/
   echo -e "\ni18n:\n  ru:" >>_data/schemas/modules/global/config-values.yaml
   cat /src/global/doc-ru-config-values.yaml | sed 's/^/    /' >>_data/schemas/modules/global/config-values.yaml
-  for i in /src/global/crds/module* /src/global/crds/ssh_* /src/global/crds/deckhouse-release.yaml /src/global/crds/cni-migration.yaml /src/global/crds/cni-node-migration.yaml /src/global/cluster_configuration.yaml /src/global/init_configuration.yaml /src/global/static_cluster_configuration.yaml; do
+  for i in /src/global/crds/module* /src/global/crds/ssh_* /src/global/crds/application.yaml /src/global/crds/applicationpackage.yaml /src/global/crds/applicationpackageversion.yaml /src/global/crds/packagerepository.yaml /src/global/crds/packagerepositoryoperation.yaml /src/global/crds/deckhouse-release.yaml /src/global/crds/cni-migration.yaml /src/global/crds/cni-node-migration.yaml /src/global/cluster_configuration.yaml /src/global/init_configuration.yaml /src/global/static_cluster_configuration.yaml; do
     if [ -f "$i" ]; then
       cp -v $i /srv/jekyll-data/documentation/_data/schemas/crds/
       echo -e "\ni18n:\n  ru:" >>/srv/jekyll-data/documentation/_data/schemas/crds/$(echo $i | sed -E 's#/src/global(/crds)?/##' )

--- a/docs/documentation/pages/reference/api/CR.md
+++ b/docs/documentation/pages/reference/api/CR.md
@@ -8,6 +8,12 @@ permalink: en/reference/api/cr.html
 {{ site.data.schemas.crds.cni-migration | format_crd: "global" }}
 {{ site.data.schemas.crds.cni-node-migration | format_crd: "global" }}
 
+{{ site.data.schemas.crds.packagerepository | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackage | format_crd: "global" }}
+{{ site.data.schemas.crds.application | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackageversion | format_crd: "global" }}
+{{ site.data.schemas.crds.packagerepositoryoperation | format_crd: "global" }}
+
 {{ site.data.schemas.crds.deckhouse-release | format_crd: "global" }}
 
 {{ site.data.schemas.crds.init_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/reference/api/CR_RU.md
+++ b/docs/documentation/pages/reference/api/CR_RU.md
@@ -10,6 +10,12 @@ search: global custom resources, global configuration, global parameters, гло
 {{ site.data.schemas.crds.cni-migration | format_crd: "global" }}
 {{ site.data.schemas.crds.cni-node-migration | format_crd: "global" }}
 
+{{ site.data.schemas.crds.packagerepository | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackage | format_crd: "global" }}
+{{ site.data.schemas.crds.application | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackageversion | format_crd: "global" }}
+{{ site.data.schemas.crds.packagerepositoryoperation | format_crd: "global" }}
+
 {{ site.data.schemas.crds.deckhouse-release | format_crd: "global" }}
 
 {{ site.data.schemas.crds.init_configuration | format_cluster_configuration }}


### PR DESCRIPTION
## Description

This pull request updates the documentation to include several new global Custom Resource Definitions (CRDs) related to application packaging and repositories. The main changes ensure that these new CRDs are rendered in the reference documentation.

Added support for rendering of:
- application
- applicationpackage
- applicationpackageversion
- packagerepository
- packagerepositoryoperation

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Add rendering of application and package CRDs.
impact_level: low
```
