### PR TITLE
[dhctl] fix(dhctl-for-commander): fix executor goroutine leak

### DIFF
--- a/dhctl/pkg/kubernetes/client/client.go
+++ b/dhctl/pkg/kubernetes/client/client.go
@@ -167,7 +167,7 @@ func (k *KubernetesClient) startRemoteKubeProxy(ctx context.Context, sshCl node.
 			log.InfoF("Using host %s\n", sshCl.Session().Host())
 
 			k.KubeProxy = sshCl.KubeProxy()
-			port, err = k.KubeProxy.Start(-1)
+			port, err = k.KubeProxy.Start(ctx, -1)
 
 			if err != nil {
 				sshCl.Session().ChoiceNewHost()

--- a/dhctl/pkg/system/node/clissh/cmd/ssh-agent.go
+++ b/dhctl/pkg/system/node/clissh/cmd/ssh-agent.go
@@ -31,6 +31,8 @@ import (
 
 const SSHAgentPath = "ssh-agent"
 
+var RegisterCleanupOnShutdown = true
+
 type SSHAgent struct {
 	*process.Executor
 
@@ -105,9 +107,11 @@ func (a *SSHAgent) Start() error {
 
 	// save auth sock in session to access it from other cmds and frontends
 	a.AgentSettings.AuthSock = a.AuthSock
-	tomb.RegisterOnShutdown("Delete SSH agent temporary directory", func() {
-		_ = os.RemoveAll(filepath.Dir(a.AuthSock))
-	})
+	if RegisterCleanupOnShutdown {
+		tomb.RegisterOnShutdown("Delete SSH agent temporary directory", func() {
+			_ = os.RemoveAll(filepath.Dir(a.AuthSock))
+		})
+	}
 	return nil
 }
 

--- a/dhctl/pkg/system/node/clissh/frontend/kube-proxy.go
+++ b/dhctl/pkg/system/node/clissh/frontend/kube-proxy.go
@@ -29,6 +29,8 @@ import (
 
 const DefaultLocalAPIPort = 22322
 
+var kubeProxyPortReadyTimeout = 20 * time.Second
+
 type KubeProxy struct {
 	Session *session.Session
 
@@ -54,7 +56,7 @@ func NewKubeProxy(sess *session.Session) *KubeProxy {
 	}
 }
 
-func (k *KubeProxy) Start(useLocalPort int) (string, error) {
+func (k *KubeProxy) Start(ctx context.Context, useLocalPort int) (string, error) {
 	startID := rand.Int()
 
 	log.DebugF("Kube-proxy start id=[%d]; port:%d\n", startID, useLocalPort)
@@ -70,7 +72,7 @@ func (k *KubeProxy) Start(useLocalPort int) (string, error) {
 	}()
 
 	proxyCommandErrorCh := make(chan error, 1)
-	proxy, port, err := k.runKubeProxy(proxyCommandErrorCh, startID)
+	proxy, port, err := k.runKubeProxy(ctx, proxyCommandErrorCh, startID)
 	if err != nil {
 		log.DebugF("[%d] Got error from runKubeProxy func: %v\n", startID, err)
 		return "", err
@@ -82,7 +84,7 @@ func (k *KubeProxy) Start(useLocalPort int) (string, error) {
 	k.port = port
 
 	tunnelErrorCh := make(chan error)
-	tun, localPort, lastError := k.upTunnel(port, useLocalPort, tunnelErrorCh, startID)
+	tun, localPort, lastError := k.upTunnel(ctx, port, useLocalPort, tunnelErrorCh, startID)
 	if lastError != nil {
 		log.DebugF("[%d] Got error from upTunnel func: %v\n", startID, err)
 		return "", fmt.Errorf("tunnel up error: max retries reached, last error: %w", lastError)
@@ -93,6 +95,7 @@ func (k *KubeProxy) Start(useLocalPort int) (string, error) {
 
 	k.healthMonitorsByStartID[startID] = make(chan struct{}, 1)
 	go k.healthMonitor(
+		ctx,
 		proxyCommandErrorCh,
 		tunnelErrorCh,
 		k.healthMonitorsByStartID[startID],
@@ -141,12 +144,17 @@ func (k *KubeProxy) Stop(startID int) {
 	k.stop = true
 }
 
-func (k *KubeProxy) tryToRestartFully(startID int) {
+func (k *KubeProxy) tryToRestartFully(ctx context.Context, startID int) {
 	log.DebugF("[%d] Try restart kubeproxy fully\n", startID)
 	for {
+		if err := ctx.Err(); err != nil {
+			log.DebugF("[%d] Stop kubeproxy restart: %v\n", startID, err)
+			return
+		}
+
 		k.Stop(startID)
 
-		_, err := k.Start(k.localPort)
+		_, err := k.Start(ctx, k.localPort)
 
 		if err == nil {
 			k.stop = false
@@ -162,14 +170,19 @@ func (k *KubeProxy) tryToRestartFully(startID int) {
 			err,
 			sleepTimeout,
 		)
-		time.Sleep(sleepTimeout * time.Second)
+		select {
+		case <-time.After(sleepTimeout * time.Second):
+		case <-ctx.Done():
+			log.DebugF("[%d] Stop kubeproxy restart sleep: %v\n", startID, ctx.Err())
+			return
+		}
 
 		k.Session.ChoiceNewHost()
 		log.DebugF("[%d] New host selected %v\n", startID, k.Session.Host())
 	}
 }
 
-func (k *KubeProxy) proxyCMD(startID int) *Command {
+func (k *KubeProxy) proxyCMD(ctx context.Context, startID int) *Command {
 	kubectlProxy := fmt.Sprintf(
 		// --disable-filter is needed to exec into etcd pods
 		"kubectl proxy --as=dhctl --as-group=system:masters --port=%s --kubeconfig /etc/kubernetes/admin.conf --disable-filter",
@@ -183,12 +196,13 @@ func (k *KubeProxy) proxyCMD(startID int) *Command {
 	log.DebugF("[%d] Proxy command for start: %s\n", startID, command)
 
 	cmd := NewCommand(k.Session, command)
-	cmd.Sudo(context.Background())
+	cmd.Sudo(ctx)
 	cmd.Executor = cmd.Executor.CaptureStderr(nil).CaptureStdout(nil)
 	return cmd
 }
 
 func (k *KubeProxy) healthMonitor(
+	ctx context.Context,
 	proxyErrorCh, tunnelErrorCh chan error,
 	stopCh chan struct{},
 	startID int,
@@ -203,7 +217,7 @@ func (k *KubeProxy) healthMonitor(
 			log.DebugF("[%d] Proxy failed with error %v\n", startID, err)
 			// if proxy crushed, we need to restart kube-proxy fully
 			// with proxy and tunnel (tunnel depends on proxy)
-			k.tryToRestartFully(startID)
+			k.tryToRestartFully(ctx, startID)
 			// if we restart proxy fully
 			// this monitor must be finished because new monitor was started
 			return
@@ -215,15 +229,19 @@ func (k *KubeProxy) healthMonitor(
 
 			log.DebugF("[%d] Tunnel stopped before restart. Starting new tunnel...\n", startID)
 
-			k.tunnel, _, err = k.upTunnel(k.port, k.localPort, tunnelErrorCh, startID)
+			k.tunnel, _, err = k.upTunnel(ctx, k.port, k.localPort, tunnelErrorCh, startID)
 			if err != nil {
 				log.DebugF("[%d] Tunnel was not up: %v. Try to restart fully\n", startID, err)
-				k.tryToRestartFully(startID)
+				k.tryToRestartFully(ctx, startID)
 				return
 			}
 
 			log.DebugF("[%d] Tunnel re up successfully\n")
 
+		case <-ctx.Done():
+			log.DebugF("[%d] Kubeproxy monitor stopped by context: %v", startID, ctx.Err())
+			k.Stop(startID)
+			return
 		case <-stopCh:
 			log.DebugF("[%d] Kubeproxy monitor stopped")
 			return
@@ -232,6 +250,7 @@ func (k *KubeProxy) healthMonitor(
 }
 
 func (k *KubeProxy) upTunnel(
+	ctx context.Context,
 	kubeProxyPort string,
 	useLocalPort int,
 	tunnelErrorCh chan error,
@@ -263,6 +282,11 @@ func (k *KubeProxy) upTunnel(
 	var lastError error
 	var tun *Tunnel
 	for {
+		if err := ctx.Err(); err != nil {
+			lastError = err
+			break
+		}
+
 		log.DebugF("[%d] Start %d iteration for up tunnel\n", startID, retries)
 
 		if k.proxy.WaitError() != nil {
@@ -280,7 +304,8 @@ func (k *KubeProxy) upTunnel(
 
 		log.DebugF("[%d] Try up tunnel on %v\n", startID, tunnelAddress)
 		tun = NewTunnel(k.Session, "L", tunnelAddress)
-		err := tun.Up()
+		err := tun.UpContext(ctx)
+
 		if err != nil {
 			log.DebugF("[%d] Start tunnel was failed. Cleaning...\n", startID)
 			tun.Stop()
@@ -316,11 +341,16 @@ func (k *KubeProxy) upTunnel(
 }
 
 func (k *KubeProxy) runKubeProxy(
+	ctx context.Context,
 	waitCh chan error,
 	startID int,
 ) (*Command, string, error) {
 	log.DebugF("[%d] Begin starting proxy\n", startID)
-	proxy := k.proxyCMD(startID)
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+
+	proxy := k.proxyCMD(ctx, startID)
 
 	port := ""
 	portReady := make(chan struct{}, 1)
@@ -369,24 +399,48 @@ Status: %w`
 	case <-onStart:
 	case err := <-waitCh:
 		return nil, "", returnWaitErr(err)
+	case <-ctx.Done():
+		proxy.Stop()
+		return nil, "", ctx.Err()
 	}
 
-	// Wait for proxy startup
-	t := time.NewTicker(20 * time.Second)
-	defer t.Stop()
-	select {
-	case e := <-waitCh:
-		return nil, "", returnWaitErr(e)
-	case <-t.C:
-		log.DebugF("[%d] Starting proxy command timeout\n", startID)
-		return nil, "", fmt.Errorf("timeout waiting for api proxy port")
-	case <-portReady:
-		if port == "" {
-			log.DebugF("[%d] Starting proxy command: empty port\n", startID)
-			return nil, "", fmt.Errorf("got empty port from kubectl proxy")
-		}
+	if err := waitForKubeProxyPort(ctx, waitCh, portReady, func() string { return port }, proxy.Stop, returnWaitErr, startID); err != nil {
+		return nil, "", err
 	}
 
 	log.DebugF("[%d] Proxy process started with port: %s\n", startID, port)
 	return proxy, port, nil
+}
+
+func waitForKubeProxyPort(
+	ctx context.Context,
+	waitCh chan error,
+	portReady chan struct{},
+	port func() string,
+	stopProxy func(),
+	returnWaitErr func(error) error,
+	startID int,
+) error {
+	t := time.NewTimer(kubeProxyPortReadyTimeout)
+	defer t.Stop()
+
+	select {
+	case e := <-waitCh:
+		return returnWaitErr(e)
+	case <-t.C:
+		log.DebugF("[%d] Starting proxy command timeout\n", startID)
+		stopProxy()
+		return fmt.Errorf("timeout waiting for api proxy port")
+	case <-portReady:
+		if port() == "" {
+			log.DebugF("[%d] Starting proxy command: empty port\n", startID)
+			stopProxy()
+			return fmt.Errorf("got empty port from kubectl proxy")
+		}
+	case <-ctx.Done():
+		stopProxy()
+		return ctx.Err()
+	}
+
+	return nil
 }

--- a/dhctl/pkg/system/node/clissh/frontend/kube_proxy_test.go
+++ b/dhctl/pkg/system/node/clissh/frontend/kube_proxy_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+)
+
+const kubeProxyTestTimeout = 5 * time.Second
+
+func TestKubeProxyRunKubeProxyReturnsCanceledContextBeforeCommandStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	kubeProxy := NewKubeProxy(&session.Session{})
+
+	proxy, port, err := kubeProxy.runKubeProxy(ctx, make(chan error, 1), 1)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, proxy)
+	require.Empty(t, port)
+}
+
+func TestWaitForKubeProxyPortStopsProxyOnTimeout(t *testing.T) {
+	oldTimeout := kubeProxyPortReadyTimeout
+	kubeProxyPortReadyTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		kubeProxyPortReadyTimeout = oldTimeout
+	})
+
+	stopped := false
+	err := waitForKubeProxyPort(
+		context.Background(),
+		make(chan error, 1),
+		make(chan struct{}, 1),
+		func() string { return "" },
+		func() { stopped = true },
+		func(err error) error { return fmt.Errorf("wait error: %w", err) },
+		1,
+	)
+
+	require.ErrorContains(t, err, "timeout waiting for api proxy port")
+	require.True(t, stopped)
+}
+
+func TestKubeProxyHealthMonitorStopsTunnelOnContextCancel(t *testing.T) {
+	tunnelCmd := exec.Command("sleep", "60")
+	require.NoError(t, tunnelCmd.Start())
+	t.Cleanup(func() {
+		if tunnelCmd.ProcessState == nil {
+			_ = tunnelCmd.Process.Kill()
+			_ = tunnelCmd.Wait()
+		}
+	})
+
+	tunnelWaitCh := make(chan error, 1)
+	go func() {
+		tunnelWaitCh <- tunnelCmd.Wait()
+	}()
+
+	startID := 42
+	stopCh := make(chan struct{}, 1)
+	kubeProxy := NewKubeProxy(&session.Session{})
+	kubeProxy.tunnel = NewTunnel(&session.Session{}, "L", "127.0.0.1:2222:127.0.0.1:22")
+	kubeProxy.tunnel.sshCmd = tunnelCmd
+	kubeProxy.port = "12345"
+	kubeProxy.healthMonitorsByStartID[startID] = stopCh
+
+	ctx, cancel := context.WithCancel(context.Background())
+	monitorDone := make(chan struct{})
+	go func() {
+		kubeProxy.healthMonitor(ctx, make(chan error, 1), make(chan error, 1), stopCh, startID)
+		close(monitorDone)
+	}()
+
+	cancel()
+
+	select {
+	case <-monitorDone:
+	case <-time.After(kubeProxyTestTimeout):
+		require.FailNow(t, "health monitor must stop on context cancellation")
+	}
+
+	select {
+	case <-tunnelWaitCh:
+	case <-time.After(kubeProxyTestTimeout):
+		require.FailNow(t, "context cancellation must stop tunnel process")
+	}
+
+	require.True(t, kubeProxy.stop)
+	require.Nil(t, kubeProxy.tunnel)
+	require.Equal(t, "12345", kubeProxy.port)
+	require.NotContains(t, kubeProxy.healthMonitorsByStartID, startID)
+}

--- a/dhctl/pkg/system/node/clissh/frontend/tunnel.go
+++ b/dhctl/pkg/system/node/clissh/frontend/tunnel.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
+	"sync/atomic"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/clissh/cmd"
@@ -33,8 +35,23 @@ type Tunnel struct {
 	Address string
 	sshCmd  *exec.Cmd
 
-	stopCh  chan struct{}
-	errorCh chan error
+	pipesMutex      sync.Mutex
+	stdoutReadPipe  *os.File
+	stdoutWritePipe *os.File
+	stdinReadPipe   *os.File
+	stdinWritePipe  *os.File
+
+	stopOnce sync.Once
+	stopped  atomic.Bool
+	stopCh   chan struct{}
+	errorCh  chan error
+}
+
+type tunnelPipes struct {
+	stdoutReadPipe  *os.File
+	stdoutWritePipe *os.File
+	stdinReadPipe   *os.File
+	stdinWritePipe  *os.File
 }
 
 func NewTunnel(sess *session.Session, ttype, address string) *Tunnel {
@@ -42,6 +59,7 @@ func NewTunnel(sess *session.Session, ttype, address string) *Tunnel {
 		Session: sess,
 		Type:    ttype,
 		Address: address,
+		stopCh:  make(chan struct{}, 1),
 		errorCh: make(chan error, 1),
 	}
 }
@@ -50,6 +68,10 @@ func (t *Tunnel) Up() error {
 	if t.Session == nil {
 		return fmt.Errorf("up tunnel '%s': SSH client is undefined", t.String())
 	}
+	t.stopOnce = sync.Once{}
+	t.stopped.Store(false)
+	t.stopCh = make(chan struct{}, 1)
+	t.errorCh = make(chan error, 1)
 
 	t.sshCmd = cmd.NewSSH(t.Session).
 		WithArgs(
@@ -67,16 +89,26 @@ func (t *Tunnel) Up() error {
 		return fmt.Errorf("unable to create os pipe for stdout: %w", err)
 	}
 	t.sshCmd.Stdout = stdoutWritePipe
+	t.pipesMutex.Lock()
+	t.stdoutReadPipe = stdoutReadPipe
+	t.stdoutWritePipe = stdoutWritePipe
+	t.pipesMutex.Unlock()
 
 	// Create separate stdin pipe to prevent reading from main process Stdin
-	stdinReadPipe, _, err := os.Pipe()
+	stdinReadPipe, stdinWritePipe, err := os.Pipe()
 	if err != nil {
+		t.closePipes()
 		return fmt.Errorf("unable to create os pipe for stdin: %w", err)
 	}
 	t.sshCmd.Stdin = stdinReadPipe
+	t.pipesMutex.Lock()
+	t.stdinReadPipe = stdinReadPipe
+	t.stdinWritePipe = stdinWritePipe
+	t.pipesMutex.Unlock()
 
 	err = t.sshCmd.Start()
 	if err != nil {
+		t.closePipes()
 		return fmt.Errorf("tunnel up: %w", err)
 	}
 
@@ -91,12 +123,19 @@ func (t *Tunnel) Up() error {
 		log.DebugF("stop line consumer for '%s'", t.String())
 	}()
 
-	go func() {
-		t.errorCh <- t.sshCmd.Wait()
-	}()
+	sshCmd := t.sshCmd
+	errorCh := t.errorCh
+	pipes := tunnelPipes{
+		stdoutReadPipe:  stdoutReadPipe,
+		stdoutWritePipe: stdoutWritePipe,
+		stdinReadPipe:   stdinReadPipe,
+		stdinWritePipe:  stdinWritePipe,
+	}
+	t.waitForSSH(sshCmd, errorCh, pipes)
 
 	select {
-	case err = <-t.errorCh:
+	case err = <-errorCh:
+		t.closePipes()
 		return fmt.Errorf("cannot open tunnel '%s': %w", t.String(), err)
 	case <-tunnelReadyCh:
 	}
@@ -104,18 +143,30 @@ func (t *Tunnel) Up() error {
 	return nil
 }
 
+func (t *Tunnel) waitForSSH(sshCmd *exec.Cmd, errorCh chan<- error, pipes tunnelPipes) {
+	go func() {
+		err := sshCmd.Wait()
+		t.closePipeSet(pipes)
+		errorCh <- err
+	}()
+}
+
 func (t *Tunnel) HealthMonitor(errorOutCh chan<- error) {
 	defer log.DebugF("Tunnel health monitor stopped\n")
 	log.DebugF("Tunnel health monitor started\n")
 
-	t.stopCh = make(chan struct{}, 1)
-
 	for {
 		select {
 		case err := <-t.errorCh:
-			errorOutCh <- err
+			if t.stopped.Load() {
+				return
+			}
+			select {
+			case errorOutCh <- err:
+			case <-t.stopCh:
+				return
+			}
 		case <-t.stopCh:
-			_ = t.sshCmd.Process.Kill()
 			return
 		}
 	}
@@ -125,13 +176,72 @@ func (t *Tunnel) Stop() {
 	if t == nil {
 		return
 	}
-	if t.Session == nil {
-		log.ErrorF("bug: down tunnel '%s': no session", t.String())
+	t.stopOnce.Do(func() {
+		t.stopped.Store(true)
+		t.closePipes()
+		t.killProcess()
+		t.signalStop()
+
+		if t.Session == nil {
+			log.ErrorF("bug: down tunnel '%s': no session", t.String())
+			return
+		}
+	})
+}
+
+func (t *Tunnel) signalStop() {
+	if t.stopCh == nil {
 		return
 	}
 
-	if t.sshCmd != nil && t.stopCh != nil {
-		t.stopCh <- struct{}{}
+	select {
+	case t.stopCh <- struct{}{}:
+	default:
+	}
+}
+
+func (t *Tunnel) killProcess() {
+	if t.sshCmd == nil || t.sshCmd.Process == nil {
+		return
+	}
+
+	err := t.sshCmd.Process.Kill()
+	if err != nil {
+		log.DebugF("Cannot kill tunnel process %d: %v\n", t.sshCmd.Process.Pid, err)
+	}
+}
+
+func (t *Tunnel) closePipes() {
+	t.pipesMutex.Lock()
+	defer t.pipesMutex.Unlock()
+
+	t.closePipeSet(tunnelPipes{
+		stdoutReadPipe:  t.stdoutReadPipe,
+		stdoutWritePipe: t.stdoutWritePipe,
+		stdinReadPipe:   t.stdinReadPipe,
+		stdinWritePipe:  t.stdinWritePipe,
+	})
+	t.stdoutReadPipe = nil
+	t.stdoutWritePipe = nil
+	t.stdinReadPipe = nil
+	t.stdinWritePipe = nil
+}
+
+func (t *Tunnel) closePipeSet(pipes tunnelPipes) {
+	t.closePipeFile(pipes.stdoutReadPipe, "stdout read pipe")
+	t.closePipeFile(pipes.stdoutWritePipe, "stdout write pipe")
+	t.closePipeFile(pipes.stdinReadPipe, "stdin read pipe")
+	t.closePipeFile(pipes.stdinWritePipe, "stdin write pipe")
+}
+
+func (t *Tunnel) closePipeFile(pipe *os.File, name string) {
+	if pipe == nil {
+		return
+	}
+
+	err := pipe.Close()
+	if err != nil {
+		log.DebugF("Cannot close tunnel %s: %v\n", name, err)
 	}
 }
 

--- a/dhctl/pkg/system/node/clissh/frontend/tunnel.go
+++ b/dhctl/pkg/system/node/clissh/frontend/tunnel.go
@@ -65,9 +65,17 @@ func NewTunnel(sess *session.Session, ttype, address string) *Tunnel {
 }
 
 func (t *Tunnel) Up() error {
+	return t.UpContext(context.Background())
+}
+
+func (t *Tunnel) UpContext(ctx context.Context) error {
 	if t.Session == nil {
 		return fmt.Errorf("up tunnel '%s': SSH client is undefined", t.String())
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	t.stopOnce = sync.Once{}
 	t.stopped.Store(false)
 	t.stopCh = make(chan struct{}, 1)
@@ -82,7 +90,7 @@ func (t *Tunnel) Up() error {
 			fmt.Sprintf("-%s", t.Type), t.Address,
 		).
 		WithCommand("echo", "SUCCESS", "&&", "cat").
-		Cmd(context.Background())
+		Cmd(ctx)
 
 	stdoutReadPipe, stdoutWritePipe, err := os.Pipe()
 	if err != nil {
@@ -105,6 +113,11 @@ func (t *Tunnel) Up() error {
 	t.stdinReadPipe = stdinReadPipe
 	t.stdinWritePipe = stdinWritePipe
 	t.pipesMutex.Unlock()
+
+	if err = ctx.Err(); err != nil {
+		t.closePipes()
+		return err
+	}
 
 	err = t.sshCmd.Start()
 	if err != nil {
@@ -138,6 +151,9 @@ func (t *Tunnel) Up() error {
 		t.closePipes()
 		return fmt.Errorf("cannot open tunnel '%s': %w", t.String(), err)
 	case <-tunnelReadyCh:
+	case <-ctx.Done():
+		t.Stop()
+		return ctx.Err()
 	}
 
 	return nil

--- a/dhctl/pkg/system/node/clissh/frontend/tunnel_test.go
+++ b/dhctl/pkg/system/node/clissh/frontend/tunnel_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+)
+
+func TestTunnelStopClosesPipesAndUnblocksLineConsumer(t *testing.T) {
+	stdoutReadPipe, stdoutWritePipe, err := os.Pipe()
+	require.NoError(t, err)
+	stdinReadPipe, stdinWritePipe, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = stdoutReadPipe.Close()
+		_ = stdoutWritePipe.Close()
+		_ = stdinReadPipe.Close()
+		_ = stdinWritePipe.Close()
+	})
+
+	tun := NewTunnel(&session.Session{}, "L", "127.0.0.1:2222:127.0.0.1:22")
+	tun.stdoutReadPipe = stdoutReadPipe
+	tun.stdoutWritePipe = stdoutWritePipe
+	tun.stdinReadPipe = stdinReadPipe
+	tun.stdinWritePipe = stdinWritePipe
+
+	consumerDone := make(chan struct{})
+	go func() {
+		tun.consumeLines(stdoutReadPipe, nil)
+		close(consumerDone)
+	}()
+
+	tun.Stop()
+	tun.Stop()
+
+	select {
+	case <-consumerDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "Stop must close stdout read pipe and unblock consumeLines")
+	}
+
+	_, err = stdoutWritePipe.Write([]byte("line\n"))
+	require.Error(t, err, "Stop must close stdout write pipe")
+
+	_, err = stdinWritePipe.Write([]byte("line\n"))
+	require.Error(t, err, "Stop must close stdin write pipe")
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, readErr := stdinReadPipe.Read(make([]byte, 1))
+		errCh <- readErr
+	}()
+
+	select {
+	case err = <-errCh:
+		errIs := errors.Is(err, os.ErrClosed) || errors.Is(err, io.ErrClosedPipe)
+		require.True(t, errIs, "Stop must close stdin read pipe, got %v", err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "Stop must close stdin read pipe")
+	}
+}
+
+func TestTunnelStopKillsProcessWithoutHealthMonitor(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	tun := NewTunnel(&session.Session{}, "L", "127.0.0.1:2222:127.0.0.1:22")
+	tun.sshCmd = cmd
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	tun.Stop()
+
+	select {
+	case <-waitCh:
+	case <-time.After(time.Second):
+		require.FailNow(t, "Stop must kill ssh process without HealthMonitor")
+	}
+}
+
+func TestTunnelStopBeforeHealthMonitorStartsKillsProcessAndStopsMonitor(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		if cmd.ProcessState == nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	tun := NewTunnel(&session.Session{}, "L", "127.0.0.1:2222:127.0.0.1:22")
+	tun.sshCmd = cmd
+
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	tun.Stop()
+
+	select {
+	case err := <-waitCh:
+		tun.errorCh <- err
+	case <-time.After(time.Second):
+		require.FailNow(t, "Stop must kill ssh process before HealthMonitor starts")
+	}
+
+	monitorDone := make(chan struct{})
+	go func() {
+		tun.HealthMonitor(make(chan error))
+		close(monitorDone)
+	}()
+
+	select {
+	case <-monitorDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "HealthMonitor must observe earlier Stop and exit")
+	}
+}
+
+func TestTunnelStopWithoutSessionStopsHealthMonitor(t *testing.T) {
+	tun := NewTunnel(nil, "L", "127.0.0.1:2222:127.0.0.1:22")
+
+	monitorDone := make(chan struct{})
+	go func() {
+		tun.HealthMonitor(make(chan error))
+		close(monitorDone)
+	}()
+
+	tun.Stop()
+
+	select {
+	case <-monitorDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "Stop must stop HealthMonitor even when session is missing")
+	}
+}
+
+func TestTunnelUpResetsErrorChannelBeforeReuse(t *testing.T) {
+	sess := session.NewSession(session.Input{
+		AvailableHosts: []session.Host{{Host: "127.0.0.1", Name: "localhost"}},
+		User:           "nobody",
+		Port:           "1",
+		ExtraArgs:      "-o ConnectTimeout=1",
+	})
+	sess.AgentSettings = &session.AgentSettings{}
+	tun := NewTunnel(sess, "L", "127.0.0.1:2222:127.0.0.1:22")
+	t.Cleanup(tun.Stop)
+
+	oldErrorCh := tun.errorCh
+	staleErr := errors.New("stale wait error")
+	oldErrorCh <- staleErr
+
+	err := tun.Up()
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), staleErr.Error())
+	require.NotEqual(t, oldErrorCh, tun.errorCh)
+}
+
+func TestTunnelWaitForSSHUsesProvidedCommandAndErrorChannel(t *testing.T) {
+	waitCmd := exec.Command("sh", "-c", "exit 7")
+	require.NoError(t, waitCmd.Start())
+
+	tunnelCmd := exec.Command("sleep", "60")
+	require.NoError(t, tunnelCmd.Start())
+	t.Cleanup(func() {
+		if tunnelCmd.ProcessState == nil {
+			_ = tunnelCmd.Process.Kill()
+			_ = tunnelCmd.Wait()
+		}
+	})
+
+	tun := NewTunnel(&session.Session{}, "L", "127.0.0.1:2222:127.0.0.1:22")
+	tun.sshCmd = tunnelCmd
+	tun.errorCh = make(chan error, 1)
+	waitErrorCh := make(chan error, 1)
+
+	tun.waitForSSH(waitCmd, waitErrorCh, tunnelPipes{})
+
+	select {
+	case err := <-waitErrorCh:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "waitForSSH must send wait result to the provided error channel")
+	}
+
+	select {
+	case err := <-tun.errorCh:
+		require.FailNow(t, "waitForSSH must not send to Tunnel.errorCh", "got %v", err)
+	default:
+	}
+
+	require.NoError(t, syscall.Kill(tunnelCmd.Process.Pid, 0))
+}
+
+func TestTunnelWaitForSSHClosesPipesAndUnblocksLineConsumer(t *testing.T) {
+	stdoutReadPipe, stdoutWritePipe, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = stdoutReadPipe.Close()
+		_ = stdoutWritePipe.Close()
+	})
+
+	waitCmd := exec.Command("sh", "-c", "exit 0")
+	require.NoError(t, waitCmd.Start())
+
+	tun := NewTunnel(&session.Session{}, "L", "127.0.0.1:2222:127.0.0.1:22")
+	tun.stdoutReadPipe = stdoutReadPipe
+	tun.stdoutWritePipe = stdoutWritePipe
+
+	consumerDone := make(chan struct{})
+	go func() {
+		tun.consumeLines(stdoutReadPipe, nil)
+		close(consumerDone)
+	}()
+
+	waitErrorCh := make(chan error, 1)
+	tun.waitForSSH(waitCmd, waitErrorCh, tunnelPipes{
+		stdoutReadPipe:  stdoutReadPipe,
+		stdoutWritePipe: stdoutWritePipe,
+	})
+
+	select {
+	case err = <-waitErrorCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "waitForSSH must send wait result")
+	}
+
+	select {
+	case <-consumerDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "waitForSSH must close stdout pipes and unblock consumeLines")
+	}
+}
+
+func TestTunnelWaitForSSHDoesNotClosePipesFromNextRun(t *testing.T) {
+	oldReadPipe, oldWritePipe, err := os.Pipe()
+	require.NoError(t, err)
+	newReadPipe, newWritePipe, err := os.Pipe()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = oldReadPipe.Close()
+		_ = oldWritePipe.Close()
+		_ = newReadPipe.Close()
+		_ = newWritePipe.Close()
+	})
+
+	waitCmd := exec.Command("sh", "-c", "sleep 0.1")
+	require.NoError(t, waitCmd.Start())
+
+	tun := NewTunnel(&session.Session{}, "L", "127.0.0.1:2222:127.0.0.1:22")
+	tun.stdoutReadPipe = oldReadPipe
+	tun.stdoutWritePipe = oldWritePipe
+
+	waitErrorCh := make(chan error, 1)
+	tun.waitForSSH(waitCmd, waitErrorCh, tunnelPipes{
+		stdoutReadPipe:  oldReadPipe,
+		stdoutWritePipe: oldWritePipe,
+	})
+
+	tun.pipesMutex.Lock()
+	tun.stdoutReadPipe = newReadPipe
+	tun.stdoutWritePipe = newWritePipe
+	tun.pipesMutex.Unlock()
+
+	select {
+	case err = <-waitErrorCh:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		require.FailNow(t, "waitForSSH must send wait result")
+	}
+
+	_, err = newWritePipe.Write([]byte("line\n"))
+	require.NoError(t, err, "old waitForSSH must not close pipes from the next run")
+}

--- a/dhctl/pkg/system/node/gossh/client.go
+++ b/dhctl/pkg/system/node/gossh/client.go
@@ -16,6 +16,7 @@ package gossh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -34,6 +35,11 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
 	genssh "github.com/deckhouse/deckhouse/dhctl/pkg/system/node/ssh"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
+)
+
+var (
+	errSSHClientNeverStarted = errors.New("ssh client has not been started")
+	errSSHClientStopped      = errors.New("ssh client has been stopped")
 )
 
 func NewClient(ctx context.Context, session *session.Session, privKeys []session.AgentPrivateKey) *Client {
@@ -60,6 +66,9 @@ type Client struct {
 
 	stopChan chan struct{}
 	live     bool
+	stopGen  uint64
+	started  bool
+	stopped  bool
 
 	kubeProxies []*KubeProxy
 	sessionList []*ssh.Session
@@ -68,6 +77,7 @@ type Client struct {
 
 	ctx          context.Context
 	sessionMutex sync.Mutex
+	clientMutex  sync.RWMutex
 
 	silent bool
 }
@@ -100,6 +110,15 @@ func (s *Client) OnlyPreparePrivateKeys() error {
 }
 
 func (s *Client) Start() error {
+	return s.start(false, 0)
+}
+
+func (s *Client) start(automatic bool, expectedStopGen uint64) error {
+	stopGen, err := s.prepareStart(automatic, expectedStopGen)
+	if err != nil {
+		return err
+	}
+
 	if s.ctx != nil {
 		select {
 		case <-s.ctx.Done():
@@ -111,6 +130,10 @@ func (s *Client) Start() error {
 		return fmt.Errorf("possible bug in ssh client: session should be created before start")
 	}
 
+	if !automatic {
+		s.resetForStart()
+	}
+
 	log.DebugLn("Starting go ssh client....")
 
 	if err := s.initSigners(); err != nil {
@@ -119,16 +142,20 @@ func (s *Client) Start() error {
 
 	var agentClient agent.ExtendedAgent
 	socket := os.Getenv("SSH_AUTH_SOCK")
+	var socketConn net.Conn
 	if socket != "" {
 		log.DebugLn("Dialing SSH agent unix socket...")
-		socketConn, err := net.Dial("unix", socket)
+		var err error
+		socketConn, err = net.Dial("unix", socket)
 		if err != nil {
 			return fmt.Errorf("Failed to open SSH_AUTH_SOCK: %v", err)
 		}
+		defer socketConn.Close()
 		agentClient = agent.NewClient(socketConn)
 	}
 
 	var bastionClient *ssh.Client
+	bastionClientOwned := false
 	var client *ssh.Client
 	if s.Settings.BastionHost != "" {
 		bastionConfig := &ssh.ClientConfig{}
@@ -180,6 +207,12 @@ func (s *Client) Start() error {
 		if err != nil {
 			return fmt.Errorf("Could not connect to %s", fullHost)
 		}
+		bastionClientOwned = true
+		defer func() {
+			if bastionClientOwned && bastionClient != nil {
+				_ = bastionClient.Close()
+			}
+		}()
 		log.DebugF("Connected successfully to bastion host %s\n", bastionAddr)
 	}
 
@@ -226,7 +259,6 @@ func (s *Client) Start() error {
 	if bastionClient == nil {
 		log.DebugLn("Try to direct connect host master host")
 
-		var err error
 		connectToHost := func() error {
 			if len(s.kubeProxies) == 0 {
 				s.Settings.ChoiceNewHost()
@@ -248,13 +280,8 @@ func (s *Client) Start() error {
 			return fmt.Errorf("Failed to connect to master host (last %s): %w", lastHost, err)
 		}
 
-		s.sshClient = client
-		s.live = true
-
-		if s.stopChan == nil {
-			stopCh := make(chan struct{})
-			s.stopChan = stopCh
-			go s.keepAlive()
+		if err = s.setConnectionState(stopGen, client, nil, nil, nil, true); err != nil {
+			return err
 		}
 
 		return nil
@@ -264,7 +291,6 @@ func (s *Client) Start() error {
 
 	var (
 		addr             string
-		err              error
 		targetClientConn ssh.Conn
 		targetNewChan    <-chan ssh.NewChannel
 		targetReqChan    <-chan *ssh.Request
@@ -284,6 +310,9 @@ func (s *Client) Start() error {
 		} else {
 			targetClientConn, targetNewChan, targetReqChan, err = ssh.NewClientConn(targetConn, addr, config)
 		}
+		if err != nil {
+			_ = targetConn.Close()
+		}
 
 		return err
 	}
@@ -301,37 +330,33 @@ func (s *Client) Start() error {
 	clientConn = targetClientConn
 	client = ssh.NewClient(targetClientConn, targetNewChan, targetReqChan)
 
-	s.sshClient = client
-	s.BastionClient = bastionClient
-	s.NetConn = &targetConn
-	s.SSHConn = &clientConn
-	s.live = true
-
-	if s.stopChan == nil {
-		stopCh := make(chan struct{})
-		s.stopChan = stopCh
-		go s.keepAlive()
+	if err = s.setConnectionState(stopGen, client, &clientConn, &targetConn, bastionClient, true); err != nil {
+		return err
 	}
+	bastionClientOwned = false
 
 	return nil
 }
 
-func (s *Client) keepAlive() {
+func (s *Client) keepAlive(stopCh chan struct{}, stopGen uint64) {
 	defer log.DebugLn("keep-alive goroutine stopped")
 	errorsCount := 0
 	for {
 		select {
-		case <-s.stopChan:
+		case <-stopCh:
 			log.DebugLn("Stopping keep-alive goroutine.")
-			close(s.stopChan)
-			s.stopChan = nil
+			s.clientMutex.Lock()
+			if s.stopChan == stopCh {
+				s.stopChan = nil
+			}
+			s.clientMutex.Unlock()
 			return
 		default:
-			session, err := s.sshClient.NewSession()
+			session, err := s.NewSession()
 			if err != nil {
 				log.DebugF("Keep-alive to %s failed: %v\n", s.Settings.Host(), err)
 				if errorsCount > 3 {
-					s.restart()
+					s.restart(stopCh, stopGen)
 					return
 				}
 				errorsCount++
@@ -341,13 +366,14 @@ func (s *Client) keepAlive() {
 			if _, err := session.SendRequest("keepalive@openssh.com", false, nil); err != nil {
 				log.DebugF("Keep-alive failed: %v\n", err)
 				if errorsCount > 3 {
-					s.restart()
+					_ = session.Close()
+					s.restart(stopCh, stopGen)
 					return
 				}
 				errorsCount++
 			}
 			session.Close()
-			for _, sess := range s.sessionList {
+			for _, sess := range s.sessionsSnapshot() {
 				if sess != nil {
 					if _, err := sess.SendRequest("keepalive@openssh.com", false, nil); err != nil {
 						log.DebugF("Keep-alive for session failed: %v\n", err)
@@ -361,12 +387,216 @@ func (s *Client) keepAlive() {
 	}
 }
 
-func (s *Client) restart() {
-	s.live = false
-	s.stopChan = nil
+func (s *Client) restart(stopCh chan struct{}, expectedStopGen uint64) {
+	stopGen, ok := s.claimAutoRestart(stopCh, expectedStopGen)
+	if !ok {
+		return
+	}
+
+	s.setLive(false)
+	s.closeSessions()
+	s.closeConnections()
 	s.silent = true
-	_ = s.Start()
+	if err := s.start(true, stopGen); err != nil {
+		log.DebugF("SSH client restart failed: %v\n", err)
+	}
+}
+
+func (s *Client) closeSessions() {
+	log.DebugLn("closing sessions")
+	s.sessionMutex.Lock()
+	defer s.sessionMutex.Unlock()
+
+	for _, sess := range s.sessionList {
+		if sess != nil {
+			_ = sess.Signal(ssh.SIGKILL)
+			_ = sess.Close()
+		}
+	}
 	s.sessionList = nil
+}
+
+func (s *Client) closeConnections() {
+	s.clientMutex.Lock()
+	defer s.clientMutex.Unlock()
+
+	if s.sshClient != nil {
+		s.sshClient.Close()
+		s.sshClient = nil
+	}
+	if s.SSHConn != nil {
+		sshconn := *s.SSHConn
+		sshconn.Close()
+		s.SSHConn = nil
+	}
+	if s.NetConn != nil {
+		netconn := *s.NetConn
+		netconn.Close()
+		s.NetConn = nil
+	}
+	if s.BastionClient != nil {
+		s.BastionClient.Close()
+		s.BastionClient = nil
+	}
+	s.live = false
+}
+
+func (s *Client) resetForStart() {
+	if !s.hasPublishedConnection() {
+		return
+	}
+
+	log.DebugLn("closing existing SSH client before start")
+	s.stopKeepAlive()
+	s.closeSessions()
+	s.closeConnections()
+}
+
+func (s *Client) hasPublishedConnection() bool {
+	s.clientMutex.RLock()
+	defer s.clientMutex.RUnlock()
+
+	return s.live ||
+		s.stopChan != nil ||
+		s.sshClient != nil ||
+		s.SSHConn != nil ||
+		s.NetConn != nil ||
+		s.BastionClient != nil
+}
+
+func (s *Client) setConnectionState(
+	stopGen uint64,
+	client *ssh.Client,
+	sshConn *ssh.Conn,
+	netConn *net.Conn,
+	bastionClient *ssh.Client,
+	live bool,
+) error {
+	s.clientMutex.Lock()
+	defer s.clientMutex.Unlock()
+
+	if stopGen != s.stopGen {
+		if client != nil {
+			client.Close()
+		}
+		if sshConn != nil {
+			(*sshConn).Close()
+		}
+		if netConn != nil {
+			(*netConn).Close()
+		}
+		if bastionClient != nil {
+			bastionClient.Close()
+		}
+		return fmt.Errorf("ssh client start interrupted by stop")
+	}
+
+	s.sshClient = client
+	s.SSHConn = sshConn
+	s.NetConn = netConn
+	s.BastionClient = bastionClient
+	s.live = live
+	s.started = true
+
+	if live && s.stopChan == nil {
+		stopCh := make(chan struct{})
+		s.stopChan = stopCh
+		go s.keepAlive(stopCh, stopGen)
+	}
+
+	return nil
+}
+
+func (s *Client) prepareStart(automatic bool, expectedStopGen uint64) (uint64, error) {
+	s.clientMutex.Lock()
+	defer s.clientMutex.Unlock()
+
+	if automatic {
+		if s.stopped || s.stopGen != expectedStopGen {
+			return 0, fmt.Errorf("ssh client automatic restart was stopped")
+		}
+	} else {
+		s.stopped = false
+		s.stopGen++
+	}
+
+	return s.stopGen, nil
+}
+
+func (s *Client) claimAutoRestart(stopCh chan struct{}, expectedStopGen uint64) (uint64, bool) {
+	s.clientMutex.Lock()
+	defer s.clientMutex.Unlock()
+
+	if s.stopped || s.stopChan != stopCh || s.stopGen != expectedStopGen {
+		return 0, false
+	}
+
+	s.stopChan = nil
+	return expectedStopGen, true
+}
+
+func (s *Client) setLive(live bool) {
+	s.clientMutex.Lock()
+	defer s.clientMutex.Unlock()
+	s.live = live
+}
+
+func (s *Client) getSSHClient() (*ssh.Client, bool) {
+	s.clientMutex.RLock()
+	defer s.clientMutex.RUnlock()
+
+	if s.sshClient == nil || !s.live {
+		return nil, false
+	}
+
+	return s.sshClient, true
+}
+
+func (s *Client) snapshotSSHClient() (*ssh.Client, error) {
+	return s.snapshotSSHClientWithOptions(false)
+}
+
+func (s *Client) snapshotSSHClientWithOptions(allowStopped bool) (*ssh.Client, error) {
+	s.clientMutex.RLock()
+	defer s.clientMutex.RUnlock()
+
+	if s.stopped && !allowStopped {
+		return nil, errSSHClientStopped
+	}
+
+	if s.sshClient == nil || !s.live {
+		if !s.started {
+			return nil, errSSHClientNeverStarted
+		}
+		if s.stopped {
+			return nil, errSSHClientStopped
+		}
+		return nil, fmt.Errorf("ssh client is not connected")
+	}
+
+	return s.sshClient, nil
+}
+
+func (s *Client) NewSession() (*ssh.Session, error) {
+	return s.newSession(false)
+}
+
+func (s *Client) newSession(allowStopped bool) (*ssh.Session, error) {
+	sshClient, err := s.snapshotSSHClientWithOptions(allowStopped)
+	if err != nil {
+		return nil, err
+	}
+
+	return sshClient.NewSession()
+}
+
+func (s *Client) withSSHClient(fn func(*ssh.Client) error) error {
+	sshClient, err := s.snapshotSSHClient()
+	if err != nil {
+		return err
+	}
+
+	return fn(sshClient)
 }
 
 func DialTimeout(ctx context.Context, network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
@@ -406,6 +636,7 @@ func DialTimeout(ctx context.Context, network, addr string, config *ssh.ClientCo
 		c, chans, reqs, err = ssh.NewClientConn(tcpConn, addr, config)
 	}
 	if err != nil {
+		tcpConn.Close()
 		return nil, err
 	}
 
@@ -442,7 +673,7 @@ func (s *Client) KubeProxy() node.KubeProxy {
 
 // File is used to upload and download files and directories
 func (s *Client) File() node.File {
-	return NewSSHFile(s.sshClient)
+	return NewSSHFile(s)
 }
 
 // UploadScript is used to upload script and execute it on remote server
@@ -459,51 +690,35 @@ func (s *Client) Check() node.Check {
 
 // Stop the client
 func (s *Client) Stop() {
-	if s.sshClient == nil {
-		log.DebugLn("no SSH client found to stop. Exiting...")
-		return
-	}
 	log.DebugLn("SSH Client is stopping now")
+	s.clientMutex.Lock()
+	s.stopGen++
+	s.stopped = true
+	s.clientMutex.Unlock()
+
 	log.DebugLn("stopping kube proxies")
 	for _, p := range s.kubeProxies {
 		p.StopAll()
 	}
 	s.kubeProxies = nil
 
-	log.DebugLn("closing sessions")
-	for _, sess := range s.sessionList {
-		if sess != nil {
-			_ = sess.Signal(ssh.SIGKILL)
-			_ = sess.Close()
-		}
-	}
-	s.sessionList = nil
+	s.closeSessions()
 
 	// by starting kubeproxy on remote, there is one more process starts
 	// it cannot be killed by sending any signal to his parrent process
 	// so we need to use killall command to kill all this processes
-	log.DebugLn("stopping kube proxies on remote")
-	s.stopKubeproxy()
-	log.DebugLn("kube proxies on remote were stopped")
+	if _, ok := s.getSSHClient(); ok {
+		log.DebugLn("stopping kube proxies on remote")
+		s.stopKubeproxy()
+		log.DebugLn("kube proxies on remote were stopped")
+	} else {
+		log.DebugLn("no SSH client found to stop remote kube proxies. Skip.")
+	}
 
 	log.DebugLn("stopping keep-alive goroutine")
-	if s.stopChan != nil {
-		log.DebugLn("sendind message to stop keep-alive")
-		s.stopChan <- struct{}{}
-	}
+	s.stopKeepAlive()
 
-	s.sshClient.Close()
-	if s.SSHConn != nil {
-		sshconn := *s.SSHConn
-		sshconn.Close()
-	}
-	if s.NetConn != nil {
-		netconn := *s.NetConn
-		netconn.Close()
-	}
-	if s.BastionClient != nil {
-		s.BastionClient.Close()
-	}
+	s.closeConnections()
 	log.DebugLn("SSH Client is stopped")
 }
 
@@ -543,17 +758,49 @@ func (s *Client) Loop(fn node.SSHLoopHandler) error {
 }
 
 func (s *Client) GetClient() *ssh.Client {
+	s.clientMutex.RLock()
+	defer s.clientMutex.RUnlock()
+	if !s.live {
+		return nil
+	}
 	return s.sshClient
 }
 
+func (s *Client) stopKeepAlive() {
+	s.clientMutex.Lock()
+	defer s.clientMutex.Unlock()
+
+	if s.stopChan == nil {
+		return
+	}
+
+	log.DebugLn("sendind message to stop keep-alive")
+	close(s.stopChan)
+	s.stopChan = nil
+}
+
 func (s *Client) Live() bool {
+	s.clientMutex.RLock()
+	defer s.clientMutex.RUnlock()
 	return s.live
 }
 
 func (s *Client) RegisterSession(sess *ssh.Session) {
+	if sess == nil {
+		return
+	}
 	s.sessionMutex.Lock()
 	defer s.sessionMutex.Unlock()
 	s.sessionList = append(s.sessionList, sess)
+}
+
+func (s *Client) sessionsSnapshot() []*ssh.Session {
+	s.sessionMutex.Lock()
+	defer s.sessionMutex.Unlock()
+
+	sessions := make([]*ssh.Session, len(s.sessionList))
+	copy(sessions, s.sessionList)
+	return sessions
 }
 
 func (s *Client) UnregisterSession(sess *ssh.Session) {
@@ -572,7 +819,7 @@ func (s *Client) UnregisterSession(sess *ssh.Session) {
 }
 
 func (s *Client) stopKubeproxy() {
-	cmd := NewSSHCommand(s, "killall kubectl")
+	cmd := newSSHCommand(s, "killall kubectl", true)
 	cmd.Sudo(context.Background())
 	_ = cmd.Run(context.Background())
 }

--- a/dhctl/pkg/system/node/gossh/client_test.go
+++ b/dhctl/pkg/system/node/gossh/client_test.go
@@ -17,11 +17,14 @@ package gossh
 import (
 	"context"
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"os/exec"
 	"testing"
 	"time"
 
+	ssh "github.com/deckhouse/lib-gossh"
 	"github.com/stretchr/testify/require"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
@@ -402,6 +405,11 @@ func TestClientStart(t *testing.T) {
 					require.Error(t, err)
 					require.Contains(t, err.Error(), c.err)
 				}
+				if c.title == "With bastion, key auth, wrong target host" {
+					require.False(t, sshClient.Live())
+					require.Nil(t, sshClient.BastionClient)
+					require.Nil(t, sshClient.stopChan)
+				}
 				sshClient.Stop()
 			})
 		}
@@ -543,6 +551,47 @@ func TestClientWithDebug(t *testing.T) {
 }
 
 func TestDialContext(t *testing.T) {
+	t.Run("closes tcp connection on ssh handshake error", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		defer listener.Close()
+
+		accepted := make(chan net.Conn, 1)
+		serverDone := make(chan error, 1)
+		go func() {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				serverDone <- acceptErr
+				return
+			}
+			accepted <- conn
+			_, copyErr := io.Copy(io.Discard, conn)
+			_ = conn.Close()
+			serverDone <- copyErr
+		}()
+
+		_, err = DialTimeout(context.Background(), "tcp", listener.Addr().String(), &ssh.ClientConfig{
+			User:            "user",
+			Auth:            []ssh.AuthMethod{ssh.Password("password")},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+			Timeout:         50 * time.Millisecond,
+		})
+		require.Error(t, err)
+
+		select {
+		case <-accepted:
+		case <-time.After(time.Second):
+			t.Fatal("server did not accept TCP connection")
+		}
+
+		select {
+		case err = <-serverDone:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("server connection was not closed after handshake error")
+		}
+	})
+
 	t.Run("client start with small context test", func(t *testing.T) {
 		settings := session.NewSession(session.Input{
 			AvailableHosts: []session.Host{{Host: "1.2.3.4", Name: "1.2.3.4"}},
@@ -563,6 +612,131 @@ func TestDialContext(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "deadline exceeded")
 	})
+}
+
+func TestClientCloseConnections(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	netConn := net.Conn(clientConn)
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+	sshClient.NetConn = &netConn
+
+	sshClient.closeConnections()
+
+	require.Nil(t, sshClient.NetConn)
+
+	_, err := serverConn.Write([]byte("test"))
+	require.Error(t, err)
+}
+
+func TestNewSSHCommandWithoutConnectedClient(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+
+	var cmd *SSHCommand
+	require.NotPanics(t, func() {
+		cmd = NewSSHCommand(sshClient, "echo", "test")
+	})
+	require.ErrorContains(t, cmd.Run(context.Background()), "ssh session not started")
+}
+
+func TestNewSSHCommandWithStoppedClient(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+	sshClient.started = true
+	sshClient.stopped = true
+
+	var cmd *SSHCommand
+	require.NotPanics(t, func() {
+		cmd = NewSSHCommand(sshClient, "echo", "test")
+	})
+	require.ErrorContains(t, cmd.Run(context.Background()), "ssh session not started")
+}
+
+func TestNewSSHCommandWithStoppingLiveClient(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+	sshClient.started = true
+	sshClient.live = true
+	sshClient.stopped = true
+
+	var cmd *SSHCommand
+	require.NotPanics(t, func() {
+		cmd = NewSSHCommand(sshClient, "echo", "test")
+	})
+	require.ErrorContains(t, cmd.Run(context.Background()), "ssh session not started")
+}
+
+func TestClientStopDuringStartPreventsPublishingConnection(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+
+	stopGen, err := sshClient.prepareStart(false, 0)
+	require.NoError(t, err)
+
+	sshClient.Stop()
+
+	err = sshClient.setConnectionState(stopGen, nil, nil, nil, nil, true)
+	require.ErrorContains(t, err, "ssh client start interrupted by stop")
+	require.False(t, sshClient.Live())
+	require.Nil(t, sshClient.stopChan)
+}
+
+func TestClientStopDuringAutoRestartPreventsReconnect(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+	stopCh := make(chan struct{})
+	sshClient.started = true
+	sshClient.stopChan = stopCh
+
+	stopGen := sshClient.stopGen
+	_, ok := sshClient.claimAutoRestart(stopCh, stopGen)
+	require.True(t, ok)
+
+	sshClient.Stop()
+
+	err := sshClient.start(true, stopGen)
+	require.ErrorContains(t, err, "ssh client automatic restart was stopped")
+	require.False(t, sshClient.Live())
+	require.Nil(t, sshClient.stopChan)
+}
+
+func TestClientManualStartInvalidatesPreviousStart(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+
+	firstStopGen, err := sshClient.prepareStart(false, 0)
+	require.NoError(t, err)
+
+	secondStopGen, err := sshClient.prepareStart(false, 0)
+	require.NoError(t, err)
+	require.NotEqual(t, firstStopGen, secondStopGen)
+
+	err = sshClient.setConnectionState(firstStopGen, nil, nil, nil, nil, true)
+	require.ErrorContains(t, err, "ssh client start interrupted by stop")
+	require.False(t, sshClient.Live())
+	require.Nil(t, sshClient.stopChan)
+}
+
+func TestClientManualStartInvalidatesAutoRestart(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+	stopCh := make(chan struct{})
+	sshClient.started = true
+	sshClient.stopChan = stopCh
+	oldStopGen := sshClient.stopGen
+
+	_, err := sshClient.prepareStart(false, 0)
+	require.NoError(t, err)
+
+	_, ok := sshClient.claimAutoRestart(stopCh, oldStopGen)
+	require.False(t, ok)
+}
+
+func TestClientResetForStartClosesPublishedConnection(t *testing.T) {
+	sshClient := NewClient(context.Background(), session.NewSession(session.Input{}), nil)
+	sshClient.live = true
+	sshClient.started = true
+	sshClient.stopChan = make(chan struct{})
+
+	sshClient.resetForStart()
+
+	require.False(t, sshClient.Live())
+	require.Nil(t, sshClient.stopChan)
 }
 
 func TestClientLoop(t *testing.T) {

--- a/dhctl/pkg/system/node/gossh/command.go
+++ b/dhctl/pkg/system/node/gossh/command.go
@@ -88,6 +88,10 @@ type SSHCommand struct {
 }
 
 func NewSSHCommand(client *Client, name string, arg ...string) *SSHCommand {
+	return newSSHCommand(client, name, false, arg...)
+}
+
+func newSSHCommand(client *Client, name string, allowStopped bool, arg ...string) *SSHCommand {
 	args := make([]string, len(arg))
 	copy(args, arg)
 	cmd := name + " "
@@ -102,10 +106,15 @@ func NewSSHCommand(client *Client, name string, arg ...string) *SSHCommand {
 	var session *ssh.Session
 	var err error
 
-	err = retry.NewSilentLoop("Establish new session", 10, 5*time.Second).Run(func() error {
-		session, err = client.sshClient.NewSession()
+	err = retry.NewSilentLoop("Establish new session", 10, 5*time.Second).BreakIf(func(err error) bool {
+		return errors.Is(err, errSSHClientNeverStarted) || errors.Is(err, errSSHClientStopped)
+	}).Run(func() error {
+		session, err = client.newSession(allowStopped)
 		return err
 	})
+	if err != nil {
+		log.DebugF("Cannot establish ssh session: %v\n", err)
+	}
 	client.RegisterSession(session)
 
 	return &SSHCommand{

--- a/dhctl/pkg/system/node/gossh/file.go
+++ b/dhctl/pkg/system/node/gossh/file.go
@@ -36,20 +36,29 @@ import (
 )
 
 type SSHFile struct {
-	sshClient *ssh.Client
+	client *Client
 }
 
-func NewSSHFile(client *ssh.Client) *SSHFile {
-	return &SSHFile{sshClient: client}
+func NewSSHFile(client *Client) *SSHFile {
+	return &SSHFile{client: client}
 }
 
 func (f *SSHFile) Upload(ctx context.Context, srcPath, remotePath string) error {
+	sshClient, err := f.client.snapshotSSHClient()
+	if err != nil {
+		return err
+	}
+
+	return f.upload(ctx, sshClient, srcPath, remotePath)
+}
+
+func (f *SSHFile) upload(ctx context.Context, sshClient *ssh.Client, srcPath, remotePath string) error {
 	fType, err := CheckLocalPath(srcPath)
 	if err != nil {
 		return fmt.Errorf("failed to open local file: %w", err)
 	}
 
-	session, err := f.sshClient.NewSession()
+	session, err := sshClient.NewSession()
 	if err != nil {
 		return err
 	}
@@ -62,7 +71,7 @@ func (f *SSHFile) Upload(ctx context.Context, srcPath, remotePath string) error 
 		}
 		defer localFile.Close()
 
-		rType, err := getRemoteFileStat(f.sshClient, remotePath)
+		rType, err := getRemoteFileStat(sshClient, remotePath)
 		if err != nil {
 			if !strings.ContainsAny(err.Error(), "No such file or directory") {
 				return err
@@ -86,7 +95,7 @@ func (f *SSHFile) Upload(ctx context.Context, srcPath, remotePath string) error 
 			return fmt.Errorf("could not read directory: %w", err)
 		}
 		for _, file := range files {
-			err = f.Upload(ctx, srcPath+"/"+file.Name(), remotePath+"/"+file.Name())
+			err = f.upload(ctx, sshClient, srcPath+"/"+file.Name(), remotePath+"/"+file.Name())
 			if err != nil {
 				return err
 			}
@@ -119,7 +128,16 @@ func (f *SSHFile) UploadBytes(ctx context.Context, data []byte, remotePath strin
 }
 
 func (f *SSHFile) Download(ctx context.Context, remotePath, dstPath string) error {
-	fType, err := getRemoteFileStat(f.sshClient, remotePath)
+	sshClient, err := f.client.snapshotSSHClient()
+	if err != nil {
+		return err
+	}
+
+	return f.download(ctx, sshClient, remotePath, dstPath)
+}
+
+func (f *SSHFile) download(ctx context.Context, sshClient *ssh.Client, remotePath, dstPath string) error {
+	fType, err := getRemoteFileStat(sshClient, remotePath)
 	if err != nil {
 		return err
 	}
@@ -140,12 +158,12 @@ func (f *SSHFile) Download(ctx context.Context, remotePath, dstPath string) erro
 			return fmt.Errorf("failed to open local file: %w", err)
 		}
 		defer localFile.Close()
-		if err := CopyFromRemote(ctx, localFile, remotePath, f.sshClient); err != nil {
+		if err := CopyFromRemote(ctx, localFile, remotePath, sshClient); err != nil {
 			return fmt.Errorf("failed to copy file from remote host: %w", err)
 		}
 	} else {
 		// recursive copy logic
-		filesString, err := getRemoteFilesList(f.sshClient, remotePath)
+		filesString, err := getRemoteFilesList(sshClient, remotePath)
 		if err != nil {
 			return err
 		}
@@ -162,7 +180,7 @@ func (f *SSHFile) Download(ctx context.Context, remotePath, dstPath string) erro
 		re := regexp.MustCompile(`\s+`)
 		files := re.Split(filesString, -1)
 		for _, file := range files {
-			err = f.Download(ctx, filepath.Join(remotePath, file), filepath.Join(dstPath, file))
+			err = f.download(ctx, sshClient, filepath.Join(remotePath, file), filepath.Join(dstPath, file))
 			if err != nil {
 				return err
 			}

--- a/dhctl/pkg/system/node/gossh/kube-proxy.go
+++ b/dhctl/pkg/system/node/gossh/kube-proxy.go
@@ -30,6 +30,8 @@ import (
 
 const DefaultLocalAPIPort = 22322
 
+var kubeProxyPortReadyTimeout = 20 * time.Second
+
 type KubeProxy struct {
 	Session   *session.Session
 	sshClient *Client
@@ -57,7 +59,7 @@ func NewKubeProxy(client *Client, sess *session.Session) *KubeProxy {
 	}
 }
 
-func (k *KubeProxy) Start(useLocalPort int) (string, error) {
+func (k *KubeProxy) Start(ctx context.Context, useLocalPort int) (string, error) {
 	startID := rand.Int()
 
 	log.DebugF("Kube-proxy start id=[%d]; port:%d\n", startID, useLocalPort)
@@ -77,7 +79,7 @@ func (k *KubeProxy) Start(useLocalPort int) (string, error) {
 	var port string
 	var err error
 	for {
-		proxy, port, err = k.runKubeProxy(proxyCommandErrorCh, startID)
+		proxy, port, err = k.runKubeProxy(ctx, proxyCommandErrorCh, startID)
 		if err != nil {
 			log.DebugF("[%d] Got error from runKubeProxy func: %v\n", startID, err)
 			return "", err
@@ -101,7 +103,7 @@ func (k *KubeProxy) Start(useLocalPort int) (string, error) {
 	k.port = port
 
 	tunnelErrorCh := make(chan error)
-	tun, localPort, lastError := k.upTunnel(port, useLocalPort, tunnelErrorCh, startID)
+	tun, localPort, lastError := k.upTunnel(ctx, port, useLocalPort, tunnelErrorCh, startID)
 	if lastError != nil {
 		log.DebugF("[%d] Got error from upTunnel func: %v\n", startID, err)
 		return "", fmt.Errorf("tunnel up error: max retries reached, last error: %w", lastError)
@@ -112,6 +114,7 @@ func (k *KubeProxy) Start(useLocalPort int) (string, error) {
 
 	k.healthMonitorsByStartID[startID] = make(chan struct{}, 1)
 	go k.healthMonitor(
+		ctx,
 		proxyCommandErrorCh,
 		tunnelErrorCh,
 		k.healthMonitorsByStartID[startID],
@@ -161,12 +164,17 @@ func (k *KubeProxy) Stop(startID int) {
 	k.stop = true
 }
 
-func (k *KubeProxy) tryToRestartFully(startID int) {
+func (k *KubeProxy) tryToRestartFully(ctx context.Context, startID int) {
 	log.DebugF("[%d] Try restart kubeproxy fully\n", startID)
 	for {
+		if err := ctx.Err(); err != nil {
+			log.DebugF("[%d] Stop kubeproxy restart: %v\n", startID, err)
+			return
+		}
+
 		k.Stop(startID)
 
-		_, err := k.Start(k.localPort)
+		_, err := k.Start(ctx, k.localPort)
 
 		if err == nil {
 			k.stop = false
@@ -182,14 +190,19 @@ func (k *KubeProxy) tryToRestartFully(startID int) {
 			err,
 			sleepTimeout,
 		)
-		time.Sleep(sleepTimeout * time.Second)
+		select {
+		case <-time.After(sleepTimeout * time.Second):
+		case <-ctx.Done():
+			log.DebugF("[%d] Stop kubeproxy restart sleep: %v\n", startID, ctx.Err())
+			return
+		}
 
 		k.Session.ChoiceNewHost()
 		log.DebugF("[%d] New host selected %v\n", startID, k.Session.Host())
 	}
 }
 
-func (k *KubeProxy) proxyCMD(startID int) *SSHCommand {
+func (k *KubeProxy) proxyCMD(ctx context.Context, startID int) *SSHCommand {
 	kubectlProxy := fmt.Sprintf(
 		// --disable-filter is needed to exec into etcd pods
 		"kubectl proxy --as=dhctl --as-group=system:masters --port=%s --kubeconfig /etc/kubernetes/admin.conf --disable-filter",
@@ -203,11 +216,12 @@ func (k *KubeProxy) proxyCMD(startID int) *SSHCommand {
 	log.DebugF("[%d] Proxy command for start: %s\n", startID, command)
 
 	cmd := NewSSHCommand(k.sshClient, command)
-	cmd.Sudo(context.Background())
+	cmd.Sudo(ctx)
 	return cmd
 }
 
 func (k *KubeProxy) healthMonitor(
+	ctx context.Context,
 	proxyErrorCh, tunnelErrorCh chan error,
 	stopCh chan struct{},
 	startID int,
@@ -223,7 +237,7 @@ func (k *KubeProxy) healthMonitor(
 			log.DebugF("[%d] Proxy failed with error %v\n", startID, err)
 			// if proxy crushed, we need to restart kube-proxy fully
 			// with proxy and tunnel (tunnel depends on proxy)
-			k.tryToRestartFully(startID)
+			k.tryToRestartFully(ctx, startID)
 			// if we restart proxy fully
 			// this monitor must be finished because new monitor was started
 			return
@@ -236,20 +250,24 @@ func (k *KubeProxy) healthMonitor(
 			log.DebugF("[%d] Tunnel stopped before restart. Starting new tunnel...\n", startID)
 
 			if proxyErrorCount < 3 {
-				k.tunnel, _, err = k.upTunnel(k.port, k.localPort, tunnelErrorCh, startID)
+				k.tunnel, _, err = k.upTunnel(ctx, k.port, k.localPort, tunnelErrorCh, startID)
 				if err != nil {
 					log.DebugF("[%d] Tunnel was not up: %v. Try to restart fully\n", startID, err)
-					k.tryToRestartFully(startID)
+					k.tryToRestartFully(ctx, startID)
 					return
 				}
 				proxyErrorCount++
 			} else {
-				k.tryToRestartFully(startID)
+				k.tryToRestartFully(ctx, startID)
 				return
 			}
 
 			log.DebugF("[%d] Tunnel re up successfully\n")
 
+		case <-ctx.Done():
+			log.DebugF("[%d] Kubeproxy monitor stopped by context: %v", startID, ctx.Err())
+			k.Stop(startID)
+			return
 		case <-stopCh:
 			log.DebugF("[%d] Kubeproxy monitor stopped")
 			return
@@ -258,6 +276,7 @@ func (k *KubeProxy) healthMonitor(
 }
 
 func (k *KubeProxy) upTunnel(
+	ctx context.Context,
 	kubeProxyPort string,
 	useLocalPort int,
 	tunnelErrorCh chan error,
@@ -289,6 +308,11 @@ func (k *KubeProxy) upTunnel(
 	var lastError error
 	var tun *Tunnel
 	for {
+		if err := ctx.Err(); err != nil {
+			lastError = err
+			break
+		}
+
 		log.DebugF("[%d] Start %d iteration for up tunnel\n", startID, retries)
 
 		if k.proxy.WaitError() != nil {
@@ -342,11 +366,16 @@ func (k *KubeProxy) upTunnel(
 }
 
 func (k *KubeProxy) runKubeProxy(
+	ctx context.Context,
 	waitCh chan error,
 	startID int,
 ) (*SSHCommand, string, error) {
 	log.DebugF("[%d] Begin starting proxy\n", startID)
-	proxy := k.proxyCMD(startID)
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
+	}
+
+	proxy := k.proxyCMD(ctx, startID)
 
 	port := ""
 	portReady := make(chan struct{}, 1)
@@ -395,24 +424,49 @@ Status: %w`
 	case <-onStart:
 	case err := <-waitCh:
 		return nil, "", returnWaitErr(err)
+	case <-ctx.Done():
+		proxy.Stop()
+		return nil, "", ctx.Err()
 	}
 
-	// Wait for proxy startup
-	t := time.NewTicker(20 * time.Second)
-	defer t.Stop()
-	select {
-	case e := <-waitCh:
-		return nil, "", returnWaitErr(e)
-	case <-t.C:
-		log.DebugF("[%d] Starting proxy command timeout\n", startID)
-		return nil, "", fmt.Errorf("timeout waiting for api proxy port")
-	case <-portReady:
-		if port == "" {
-			log.DebugF("[%d] Starting proxy command: empty port\n", startID)
-			return nil, "", fmt.Errorf("got empty port from kubectl proxy")
-		}
+	err = waitForKubeProxyPort(ctx, waitCh, portReady, func() string { return port }, proxy.Stop, returnWaitErr, startID)
+	if err != nil {
+		return nil, "", err
 	}
 
 	log.DebugF("[%d] Proxy process started with port: %s\n", startID, port)
 	return proxy, port, nil
+}
+
+func waitForKubeProxyPort(
+	ctx context.Context,
+	waitCh chan error,
+	portReady chan struct{},
+	port func() string,
+	stopProxy func(),
+	returnWaitErr func(error) error,
+	startID int,
+) error {
+	t := time.NewTimer(kubeProxyPortReadyTimeout)
+	defer t.Stop()
+
+	select {
+	case e := <-waitCh:
+		return returnWaitErr(e)
+	case <-t.C:
+		log.DebugF("[%d] Starting proxy command timeout\n", startID)
+		stopProxy()
+		return fmt.Errorf("timeout waiting for api proxy port")
+	case <-portReady:
+		if port() == "" {
+			log.DebugF("[%d] Starting proxy command: empty port\n", startID)
+			stopProxy()
+			return fmt.Errorf("got empty port from kubectl proxy")
+		}
+	case <-ctx.Done():
+		stopProxy()
+		return ctx.Err()
+	}
+
+	return nil
 }

--- a/dhctl/pkg/system/node/gossh/kube_proxy_test.go
+++ b/dhctl/pkg/system/node/gossh/kube_proxy_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gossh
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
+)
+
+const kubeProxyTestTimeout = 5 * time.Second
+
+func TestKubeProxyRunKubeProxyReturnsCanceledContextBeforeCommandStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	kubeProxy := NewKubeProxy(nil, &session.Session{})
+
+	proxy, port, err := kubeProxy.runKubeProxy(ctx, make(chan error, 1), 1)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, proxy)
+	require.Empty(t, port)
+}
+
+func TestWaitForKubeProxyPortStopsProxyOnTimeout(t *testing.T) {
+	oldTimeout := kubeProxyPortReadyTimeout
+	kubeProxyPortReadyTimeout = 10 * time.Millisecond
+	t.Cleanup(func() {
+		kubeProxyPortReadyTimeout = oldTimeout
+	})
+
+	stopped := false
+	err := waitForKubeProxyPort(
+		context.Background(),
+		make(chan error, 1),
+		make(chan struct{}, 1),
+		func() string { return "" },
+		func() { stopped = true },
+		func(err error) error { return fmt.Errorf("wait error: %w", err) },
+		1,
+	)
+
+	require.ErrorContains(t, err, "timeout waiting for api proxy port")
+	require.True(t, stopped)
+}
+
+func TestKubeProxyHealthMonitorStopsTunnelOnContextCancel(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+	acceptErrCh := make(chan error, 1)
+	go func() {
+		_, err := listener.Accept()
+		acceptErrCh <- err
+	}()
+
+	startID := 42
+	stopCh := make(chan struct{}, 1)
+	kubeProxy := NewKubeProxy(nil, &session.Session{})
+	kubeProxy.tunnel = NewTunnel(nil, "")
+	kubeProxy.tunnel.remoteListener = listener
+	kubeProxy.tunnel.started = true
+	kubeProxy.port = "12345"
+	kubeProxy.healthMonitorsByStartID[startID] = stopCh
+
+	ctx, cancel := context.WithCancel(context.Background())
+	monitorDone := make(chan struct{})
+	go func() {
+		kubeProxy.healthMonitor(ctx, make(chan error, 1), make(chan error, 1), stopCh, startID)
+		close(monitorDone)
+	}()
+
+	cancel()
+
+	select {
+	case <-monitorDone:
+	case <-time.After(kubeProxyTestTimeout):
+		require.FailNow(t, "health monitor must stop on context cancellation")
+	}
+
+	select {
+	case err = <-acceptErrCh:
+		require.Error(t, err, "context cancellation must close tunnel listener")
+	case <-time.After(kubeProxyTestTimeout):
+		require.FailNow(t, "context cancellation must unblock tunnel listener")
+	}
+
+	require.True(t, kubeProxy.stop)
+	require.Nil(t, kubeProxy.tunnel)
+	require.Equal(t, "12345", kubeProxy.port)
+	require.NotContains(t, kubeProxy.healthMonitorsByStartID, startID)
+}

--- a/dhctl/pkg/system/node/gossh/reverse-tunnel.go
+++ b/dhctl/pkg/system/node/gossh/reverse-tunnel.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 	"time"
 
+	ssh "github.com/deckhouse/lib-gossh"
 	"github.com/pkg/errors"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -89,7 +90,12 @@ func (t *ReverseTunnel) upNewTunnel(oldId int) (int, error) {
 	localAddress := net.JoinHostPort(localBind, localPort)
 
 	// reverse listen on remote server port
-	listener, err := t.sshClient.GetClient().Listen("tcp", remoteAddress)
+	var listener net.Listener
+	err := t.sshClient.withSSHClient(func(sshClient *ssh.Client) error {
+		var listenErr error
+		listener, listenErr = sshClient.Listen("tcp", remoteAddress)
+		return listenErr
+	})
 	if err != nil {
 		return -1, errors.Wrap(err, fmt.Sprintf("failed to listen remote on %s", remoteAddress))
 	}

--- a/dhctl/pkg/system/node/gossh/tunnel.go
+++ b/dhctl/pkg/system/node/gossh/tunnel.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	ssh "github.com/deckhouse/lib-gossh"
 	pkgerrors "github.com/pkg/errors"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
@@ -106,7 +107,12 @@ func (t *Tunnel) acceptTunnelConnection(id int, remoteAddress string, listener n
 			return
 		}
 
-		remoteConn, err := t.sshClient.GetClient().Dial("tcp", remoteAddress)
+		var remoteConn net.Conn
+		err = t.sshClient.withSSHClient(func(sshClient *ssh.Client) error {
+			var dialErr error
+			remoteConn, dialErr = sshClient.Dial("tcp", remoteAddress)
+			return dialErr
+		})
 		if err != nil {
 			e := fmt.Errorf("[%d] Cannot dial to %s: %s", id, remoteAddress, err.Error())
 			t.errorCh <- e

--- a/dhctl/pkg/system/node/gossh/tunnel.go
+++ b/dhctl/pkg/system/node/gossh/tunnel.go
@@ -15,6 +15,7 @@
 package gossh
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -22,7 +23,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 
 	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
 )
@@ -80,7 +81,7 @@ func (t *Tunnel) upNewTunnel(oldId int) (int, error) {
 
 	listener, err := net.Listen("tcp", localAddress)
 	if err != nil {
-		return -1, errors.Wrap(err, fmt.Sprintf("failed to listen local on %s", localAddress))
+		return -1, pkgerrors.Wrap(err, fmt.Sprintf("failed to listen local on %s", localAddress))
 	}
 
 	log.DebugF("[%d] Listen remote %s successful\n", id, localAddress)
@@ -97,9 +98,12 @@ func (t *Tunnel) acceptTunnelConnection(id int, remoteAddress string, listener n
 	for {
 		localConn, err := listener.Accept()
 		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return
+			}
 			e := fmt.Errorf("[%d] Accept(): %s", id, err.Error())
 			t.errorCh <- e
-			continue
+			return
 		}
 
 		remoteConn, err := t.sshClient.GetClient().Dial("tcp", remoteAddress)

--- a/dhctl/pkg/system/node/gossh/tunnel_test.go
+++ b/dhctl/pkg/system/node/gossh/tunnel_test.go
@@ -16,6 +16,7 @@ package gossh
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"os"
 	"testing"
@@ -26,6 +27,32 @@ import (
 	ssh_testing "github.com/deckhouse/deckhouse/dhctl/pkg/system/node/gossh/testing"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/system/node/session"
 )
+
+func TestTunnelAcceptTunnelConnectionStopsSilentlyAfterListenerClose(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	tun := NewTunnel(nil, "")
+	done := make(chan struct{})
+	go func() {
+		tun.acceptTunnelConnection(1, "127.0.0.1:1", listener)
+		close(done)
+	}()
+
+	require.NoError(t, listener.Close())
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "acceptTunnelConnection must stop after listener close")
+	}
+
+	select {
+	case err = <-tun.errorCh:
+		require.FailNow(t, "listener close must not be reported as tunnel error", "got %v", err)
+	default:
+	}
+}
 
 func TestTunnel(t *testing.T) {
 	testName := "TestTunnel"

--- a/dhctl/pkg/system/node/gossh/upload-script.go
+++ b/dhctl/pkg/system/node/gossh/upload-script.go
@@ -109,7 +109,7 @@ func (u *SSHUploadScript) Execute(ctx context.Context) ([]byte, error) {
 
 	remotePath := genssh.ExecuteRemoteScriptPath(u, scriptName, false)
 	log.DebugF("Uploading script %s to %s\n", u.ScriptPath, remotePath)
-	err := NewSSHFile(u.sshClient.sshClient).Upload(ctx, u.ScriptPath, remotePath)
+	err := u.sshClient.File().Upload(ctx, u.ScriptPath, remotePath)
 	if err != nil {
 		return nil, fmt.Errorf("upload: %v", err)
 	}
@@ -193,7 +193,7 @@ func (u *SSHUploadScript) ExecuteBundle(ctx context.Context, parentDir, bundleDi
 	)
 
 	// upload to node's deckhouse tmp directory
-	err = NewSSHFile(u.sshClient.sshClient).Upload(ctx, bundleLocalFilepath, app.DeckhouseNodeTmpPath)
+	err = u.sshClient.File().Upload(ctx, bundleLocalFilepath, app.DeckhouseNodeTmpPath)
 	if err != nil {
 		return nil, fmt.Errorf("upload: %v", err)
 	}

--- a/dhctl/pkg/system/node/interface.go
+++ b/dhctl/pkg/system/node/interface.go
@@ -95,7 +95,7 @@ type ReverseTunnel interface {
 }
 
 type KubeProxy interface {
-	Start(useLocalPort int) (port string, err error)
+	Start(ctx context.Context, useLocalPort int) (port string, err error)
 
 	StopAll()
 

--- a/dhctl/pkg/system/node/testssh/client.go
+++ b/dhctl/pkg/system/node/testssh/client.go
@@ -447,7 +447,7 @@ func (c *Client) isStopped() bool {
 
 type kubeProxy struct{}
 
-func (k *kubeProxy) Start(useLocalPort int) (string, error) {
+func (k *kubeProxy) Start(_ context.Context, useLocalPort int) (string, error) {
 	i := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 	return fmt.Sprintf("%d", i), nil
 }

--- a/dhctl/pkg/system/process/executor.go
+++ b/dhctl/pkg/system/process/executor.go
@@ -496,6 +496,7 @@ func (e *Executor) Start() error {
 
 	err = e.cmd.Start()
 	if err != nil {
+		e.forceClosePipes()
 		return err
 	}
 

--- a/dhctl/pkg/system/process/executor.go
+++ b/dhctl/pkg/system/process/executor.go
@@ -18,12 +18,14 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"reflect"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -115,6 +117,11 @@ type Executor struct {
 	pipesMutex     sync.Mutex
 	stdoutPipeFile *os.File
 	stderrPipeFile *os.File
+	// Read ends of pipes - need to be closed to unblock goroutines stuck in Read()
+	stdoutReadPipe        *os.File
+	stderrReadPipe        *os.File
+	stdoutHandlerReadPipe *os.File
+	stderrHandlerReadPipe *os.File
 
 	StderrBuffer   *bytes.Buffer
 	StderrSplitter bufio.SplitFunc
@@ -122,10 +129,12 @@ type Executor struct {
 
 	WaitHandler func(err error)
 
-	started bool
-	stop    bool
-	waitCh  chan struct{}
-	stopCh  chan struct{}
+	started  atomic.Bool
+	stop     atomic.Bool
+	waitCh   chan struct{}
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	stopOnce sync.Once
 
 	lockWaitError sync.RWMutex
 	waitError     error
@@ -255,6 +264,7 @@ func (e *Executor) SetupStreamHandlers() error {
 
 		e.pipesMutex.Lock()
 		e.stdoutPipeFile = stdoutWritePipe
+		e.stdoutReadPipe = stdoutReadPipe
 		e.pipesMutex.Unlock()
 
 		// create pipe for StdoutHandler
@@ -263,6 +273,9 @@ func (e *Executor) SetupStreamHandlers() error {
 			if err != nil {
 				return fmt.Errorf("unable to create os pipe for stdoutHandler: %s", err)
 			}
+			e.pipesMutex.Lock()
+			e.stdoutHandlerReadPipe = stdoutHandlerReadPipe
+			e.pipesMutex.Unlock()
 		}
 	}
 
@@ -280,6 +293,7 @@ func (e *Executor) SetupStreamHandlers() error {
 
 		e.pipesMutex.Lock()
 		e.stderrPipeFile = stderrWritePipe
+		e.stderrReadPipe = stderrReadPipe
 		e.pipesMutex.Unlock()
 
 		// create pipe for StderrHandler
@@ -288,6 +302,9 @@ func (e *Executor) SetupStreamHandlers() error {
 			if err != nil {
 				return fmt.Errorf("unable to create os pipe for stderrHandler: %s", err)
 			}
+			e.pipesMutex.Lock()
+			e.stderrHandlerReadPipe = stderrHandlerReadPipe
+			e.pipesMutex.Unlock()
 		}
 	}
 
@@ -304,6 +321,12 @@ func (e *Executor) SetupStreamHandlers() error {
 	// - Copy to buffer if capture is enabled
 	// - Copy to pipe if StdoutHandler is set
 	go func() {
+		defer func() {
+			if stdoutHandlerWritePipe != nil {
+				_ = stdoutHandlerWritePipe.Close()
+			}
+			e.closeStdoutReadPipe()
+		}()
 		e.readFromStreams(stdoutReadPipe, stdoutHandlerWritePipe)
 	}()
 
@@ -311,6 +334,7 @@ func (e *Executor) SetupStreamHandlers() error {
 		if e.StdoutHandler == nil {
 			return
 		}
+		defer e.closeStdoutHandlerReadPipe()
 		e.ConsumeLines(stdoutHandlerReadPipe, e.StdoutHandler)
 		log.DebugF("stop line consumer for '%s'\n", e.cmd.Args[0])
 	}()
@@ -326,6 +350,12 @@ func (e *Executor) SetupStreamHandlers() error {
 
 		log.DebugLn("Start reading from stderr pipe")
 		defer log.DebugLn("Stop reading from stderr pipe")
+		defer func() {
+			if stderrHandlerWritePipe != nil {
+				_ = stderrHandlerWritePipe.Close()
+			}
+			e.closeStderrReadPipe()
+		}()
 
 		buf := make([]byte, 16)
 		for {
@@ -342,7 +372,11 @@ func (e *Executor) SetupStreamHandlers() error {
 				_, _ = stderrHandlerWritePipe.Write(buf[:n])
 			}
 
-			if err == io.EOF {
+			if err != nil {
+				if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+					break
+				}
+				log.DebugF("Error reading from stderr: %s\n", err)
 				break
 			}
 		}
@@ -352,6 +386,7 @@ func (e *Executor) SetupStreamHandlers() error {
 		if e.StderrHandler == nil {
 			return
 		}
+		defer e.closeStderrHandlerReadPipe()
 		e.ConsumeLines(stderrHandlerReadPipe, e.StderrHandler)
 		log.DebugF("stop sdterr line consumer for '%s'\n", e.cmd.Args[0])
 	}()
@@ -377,14 +412,6 @@ func (e *Executor) readFromStreams(stdoutReadPipe io.Reader, stdoutHandlerWriteP
 	errorsCount := 0
 	for {
 		n, err := stdoutReadPipe.Read(buf)
-		if err != nil && err != io.EOF {
-			log.DebugF("Error reading from stdout: %s\n", err)
-			errorsCount++
-			if errorsCount > 1000 {
-				panic(fmt.Errorf("readFromStreams: too many errors, last error %v", err))
-			}
-			continue
-		}
 
 		m := 0
 		if !matchersDone {
@@ -426,9 +453,17 @@ func (e *Executor) readFromStreams(stdoutReadPipe io.Reader, stdoutHandlerWriteP
 			_, _ = stdoutHandlerWritePipe.Write(buf[m:n])
 		}
 
-		if err == io.EOF {
-			log.DebugLn("readFromStreams: EOF")
-			break
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+				break
+			}
+
+			log.DebugF("Error reading from stdout: %s\n", err)
+			errorsCount++
+			if errorsCount > 1000 {
+				panic(fmt.Errorf("readFromStreams: too many errors, last error %v", err))
+			}
+			continue
 		}
 	}
 }
@@ -463,9 +498,9 @@ func (e *Executor) Start() error {
 	if err != nil {
 		return err
 	}
-	e.started = true
 
 	e.ProcessWait()
+	e.started.Store(true)
 
 	log.DebugF("Register stoppable: '%s'\n", e.cmd.String())
 	e.Session.RegisterStoppable(e)
@@ -477,24 +512,20 @@ func (e *Executor) ProcessWait() {
 	waitErrCh := make(chan error, 1)
 	e.waitCh = make(chan struct{}, 1)
 	e.stopCh = make(chan struct{}, 1)
+	e.doneCh = make(chan struct{})
 
 	// wait for process in go routine
 	go func() {
 		waitErrCh <- e.cmd.Wait()
 	}()
 
-	go func() {
-		if e.timeout > 0 {
-			time.Sleep(e.timeout)
-			if e.stopCh != nil {
-				e.stopCh <- struct{}{}
-			}
-		}
-	}()
+	go e.waitForTimeout()
 
 	// watch for wait or stop
 	go func() {
 		defer func() {
+			e.closeWritePipes()
+			close(e.doneCh)
 			close(e.waitCh)
 			close(waitErrCh)
 		}()
@@ -502,9 +533,10 @@ func (e *Executor) ProcessWait() {
 		for {
 			select {
 			case err := <-waitErrCh:
-				if e.stop {
+				if e.stop.Load() {
 					// Ignore error if Stop() was called.
 					// close(e.waitCh)
+					e.killProcessGroup()
 					return
 				}
 				e.setWaitError(err)
@@ -514,28 +546,48 @@ func (e *Executor) ProcessWait() {
 				// close(e.waitCh)
 				return
 			case <-e.stopCh:
-				e.stop = true
-				// Prevent next readings from the closed channel.
-				e.stopCh = nil
+				e.stop.Store(true)
 				// The usual e.cmd.Process.Kill() is not working for the process
 				// started with the new process group (Setpgid: true).
 				// Negative pid number is used to send a signal to all processes in the group.
-				err := syscall.Kill(-e.cmd.Process.Pid, syscall.SIGKILL)
-				if err != nil {
-					e.killError = err
-				}
+				e.killProcessGroup()
+				e.forceClosePipes()
 			}
 		}
 	}()
 }
 
-func (e *Executor) closePipes() {
-	log.DebugLn("Starting close piped")
-	defer log.DebugLn("Stop close piped")
+func (e *Executor) waitForTimeout() {
+	if e.timeout <= 0 {
+		return
+	}
+
+	timer := time.NewTimer(e.timeout)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		e.signalStop()
+	case <-e.doneCh:
+		return
+	}
+}
+
+func (e *Executor) killProcessGroup() {
+	err := syscall.Kill(-e.cmd.Process.Pid, syscall.SIGKILL)
+	if err != nil {
+		e.killError = err
+	}
+}
+
+func (e *Executor) closeWritePipes() {
+	log.DebugLn("Starting close write pipes")
+	defer log.DebugLn("Stop close write pipes")
 
 	e.pipesMutex.Lock()
 	defer e.pipesMutex.Unlock()
 
+	// Close write ends first
 	if e.stdoutPipeFile != nil {
 		err := e.stdoutPipeFile.Close()
 		if err != nil {
@@ -553,28 +605,78 @@ func (e *Executor) closePipes() {
 	}
 }
 
+func (e *Executor) forceClosePipes() {
+	e.closeWritePipes()
+
+	log.DebugLn("Starting force close pipes")
+	defer log.DebugLn("Stop force close pipes")
+
+	e.closeStdoutReadPipe()
+	e.closeStderrReadPipe()
+	e.closeStdoutHandlerReadPipe()
+	e.closeStderrHandlerReadPipe()
+}
+
+func (e *Executor) closeStdoutReadPipe() {
+	e.closePipeFile(&e.stdoutReadPipe, "stdout read pipe")
+}
+
+func (e *Executor) closeStderrReadPipe() {
+	e.closePipeFile(&e.stderrReadPipe, "stderr read pipe")
+}
+
+func (e *Executor) closeStdoutHandlerReadPipe() {
+	e.closePipeFile(&e.stdoutHandlerReadPipe, "stdout handler read pipe")
+}
+
+func (e *Executor) closeStderrHandlerReadPipe() {
+	e.closePipeFile(&e.stderrHandlerReadPipe, "stderr handler read pipe")
+}
+
+func (e *Executor) closePipeFile(pipe **os.File, name string) {
+	e.pipesMutex.Lock()
+	defer e.pipesMutex.Unlock()
+
+	if *pipe != nil {
+		err := (*pipe).Close()
+		if err != nil {
+			log.DebugF("Cannot close %s: %v\n", name, err)
+		}
+		*pipe = nil
+	}
+}
+
 func (e *Executor) Stop() {
-	if e.stop {
-		log.DebugF("Stop '%s': already stopped\n", e.cmd.String())
-		return
-	}
-	if !e.started {
-		log.DebugF("Stop '%s': not started yet\n", e.cmd.String())
-		return
-	}
 	if e.cmd == nil {
 		log.DebugF("Possible BUG: Call Executor.Stop with Cmd==nil\n")
 		return
 	}
-
-	e.stop = true
-	log.DebugF("Stop '%s'\n", e.cmd.String())
-	if e.stopCh != nil {
-		close(e.stopCh)
+	if !e.started.Load() {
+		log.DebugF("Stop '%s': not started yet\n", e.cmd.String())
+		return
 	}
+
+	if e.stop.CompareAndSwap(false, true) {
+		log.DebugF("Stop '%s'\n", e.cmd.String())
+		e.signalStop()
+	} else {
+		log.DebugF("Stop '%s': already stopping\n", e.cmd.String())
+	}
+
+	// Close pipes immediately to unblock goroutines stuck in Read()
+	// This must happen before waiting for waitCh
+	e.forceClosePipes()
 	<-e.waitCh
 	log.DebugF("Stopped '%s': %d\n", e.cmd.String(), e.cmd.ProcessState.ExitCode())
-	e.closePipes()
+}
+
+func (e *Executor) signalStop() {
+	e.stopOnce.Do(func() {
+		select {
+		case e.stopCh <- struct{}{}:
+		default:
+		}
+	})
 }
 
 // Run executes a command and blocks until it is finished or stopped.
@@ -588,7 +690,7 @@ func (e *Executor) Run(_ context.Context) error {
 
 	<-e.waitCh
 
-	e.closePipes()
+	e.closeWritePipes()
 
 	return e.WaitError()
 }

--- a/dhctl/pkg/system/process/executor.go
+++ b/dhctl/pkg/system/process/executor.go
@@ -144,6 +144,8 @@ type Executor struct {
 	timeout time.Duration
 }
 
+var RegisterStoppables = true
+
 func NewDefaultExecutor(cmd *exec.Cmd) *Executor {
 	return NewExecutor(DefaultSession, cmd)
 }
@@ -503,8 +505,10 @@ func (e *Executor) Start() error {
 	e.ProcessWait()
 	e.started.Store(true)
 
-	log.DebugF("Register stoppable: '%s'\n", e.cmd.String())
-	e.Session.RegisterStoppable(e)
+	if RegisterStoppables {
+		log.DebugF("Register stoppable: '%s'\n", e.cmd.String())
+		e.Session.RegisterStoppable(e)
+	}
 
 	return nil
 }

--- a/dhctl/pkg/system/process/executor_test.go
+++ b/dhctl/pkg/system/process/executor_test.go
@@ -187,6 +187,29 @@ func TestExecutor_Run_CleansUpReadPipesOnNormalExit(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond, "executor must clean up read-side pipes after normal exit")
 }
 
+func TestExecutor_Start_CleansUpPipesWhenCommandStartFails(t *testing.T) {
+	e := NewDefaultExecutor(exec.Command("missing-binary-for-executor-test"))
+	e.CaptureStdout(nil)
+	e.CaptureStderr(nil)
+	e.WithStdoutHandler(func(_ string) {})
+	e.WithStderrHandler(func(_ string) {})
+
+	err := e.Start()
+	require.Error(t, err)
+
+	require.Eventually(t, func() bool {
+		e.pipesMutex.Lock()
+		defer e.pipesMutex.Unlock()
+
+		return e.stdoutPipeFile == nil &&
+			e.stderrPipeFile == nil &&
+			e.stdoutReadPipe == nil &&
+			e.stderrReadPipe == nil &&
+			e.stdoutHandlerReadPipe == nil &&
+			e.stderrHandlerReadPipe == nil
+	}, 5*time.Second, 10*time.Millisecond, "executor must clean up pipes when command start fails")
+}
+
 func waitForReady(t *testing.T, ready <-chan struct{}, timeoutMessage string) {
 	t.Helper()
 	waitForSignal(t, ready, 5*time.Second, timeoutMessage, nil)

--- a/dhctl/pkg/system/process/executor_test.go
+++ b/dhctl/pkg/system/process/executor_test.go
@@ -1,0 +1,251 @@
+// Copyright 2021 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package process
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecutor_Stop_WithStdoutPipeClose(t *testing.T) {
+	cmd := exec.Command("yes", "out")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	ready := make(chan struct{})
+	var once sync.Once
+
+	e := NewDefaultExecutor(cmd)
+	e.WithStdoutHandler(func(_ string) {
+		once.Do(func() { close(ready) })
+	})
+
+	require.NoError(t, e.Start(), "start executor")
+
+	waitForReady(t, ready, "stdout handler did not receive output")
+	stopWithTimeout(t, e, cmd)
+}
+
+func TestExecutor_Stop_WithStderrPipeClose(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "yes err 1>&2")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	ready := make(chan struct{})
+	var once sync.Once
+
+	e := NewDefaultExecutor(cmd)
+	e.WithStderrHandler(func(_ string) {
+		once.Do(func() { close(ready) })
+	})
+
+	require.NoError(t, e.Start(), "start executor")
+
+	waitForReady(t, ready, "stderr handler did not receive output")
+	stopWithTimeout(t, e, cmd)
+}
+
+func TestExecutor_ReadFromStreams_StopsOnClosedReader(t *testing.T) {
+	e := NewDefaultExecutor(exec.Command("echo", "test"))
+
+	done := make(chan struct{})
+	go func() {
+		e.readFromStreams(&errReader{err: os.ErrClosed}, io.Discard)
+		close(done)
+	}()
+
+	waitForReady(t, done, "readFromStreams must stop on closed reader")
+}
+
+func TestExecutor_ReadFromStreams_HandlesLastChunkOnEOF(t *testing.T) {
+	e := NewDefaultExecutor(exec.Command("echo", "test"))
+	e.CaptureStdout(nil)
+
+	e.readFromStreams(&eofChunkReader{chunk: []byte("tail")}, io.Discard)
+
+	assert.Equal(t, "tail", string(e.StdoutBytes()))
+}
+
+func TestExecutor_Stop_WithTimeoutRace_DoesNotPanic(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		cmd := exec.Command("sleep", "1")
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+		e := NewDefaultExecutor(cmd)
+		e.WithTimeout(time.Millisecond)
+
+		require.NoError(t, e.Start(), "start executor")
+		time.Sleep(time.Millisecond)
+
+		done := make(chan struct{})
+		go func() {
+			e.Stop()
+			close(done)
+		}()
+
+		waitForSignal(t, done, 5*time.Second, "executor stop timed out in timeout race", func() {
+			if cmd.Process != nil {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+		})
+	}
+}
+
+func TestExecutor_Timeout_CleansUpStreamGoroutines(t *testing.T) {
+	cmd := exec.Command("yes", "out")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	ready := make(chan struct{})
+	var once sync.Once
+
+	e := NewDefaultExecutor(cmd)
+	e.WithTimeout(10 * time.Millisecond)
+	e.WithStdoutHandler(func(_ string) {
+		once.Do(func() { close(ready) })
+	})
+	t.Cleanup(e.forceClosePipes)
+
+	require.NoError(t, e.Start(), "start executor")
+	waitForReady(t, ready, "stdout handler did not receive output")
+	waitForReady(t, e.waitCh, "executor did not stop on timeout")
+
+	require.Eventually(t, func() bool {
+		return countGoroutinesWithStack("process.(*Executor).readFromStreams") == 0 &&
+			countGoroutinesWithStack("process.(*Executor).ConsumeLines") == 0
+	}, 5*time.Second, 10*time.Millisecond, "executor timeout must clean up stream goroutines")
+}
+
+func TestExecutor_TimeoutGoroutine_StopsAfterProcessExit(t *testing.T) {
+	e := NewDefaultExecutor(exec.Command("true"))
+	e.WithTimeout(time.Hour)
+
+	require.NoError(t, e.Start(), "start executor")
+	waitForReady(t, e.waitCh, "executor did not finish")
+
+	require.Eventually(t, func() bool {
+		return countGoroutinesWithStack("process.(*Executor).waitForTimeout") == 0
+	}, 5*time.Second, 10*time.Millisecond, "executor timeout goroutine must stop after process exit")
+}
+
+func TestExecutor_Stop_KillsProcessGroupChildren(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 60 & wait")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	e := NewDefaultExecutor(cmd)
+	require.NoError(t, e.Start(), "start executor")
+
+	pid := cmd.Process.Pid
+	t.Cleanup(func() {
+		_ = syscall.Kill(-pid, syscall.SIGKILL)
+	})
+
+	stopWithTimeout(t, e, cmd)
+
+	require.Eventually(t, func() bool {
+		return syscall.Kill(-pid, 0) != nil
+	}, 5*time.Second, 10*time.Millisecond, "executor stop must kill process group children")
+}
+
+func TestExecutor_Run_CleansUpReadPipesOnNormalExit(t *testing.T) {
+	e := NewDefaultExecutor(exec.Command("sh", "-c", "printf out; printf err >&2"))
+	e.CaptureStdout(nil)
+	e.CaptureStderr(nil)
+	e.WithStdoutHandler(func(_ string) {})
+	e.WithStderrHandler(func(_ string) {})
+	t.Cleanup(e.forceClosePipes)
+
+	require.NoError(t, e.Run(nil), "run executor")
+
+	require.Eventually(t, func() bool {
+		e.pipesMutex.Lock()
+		defer e.pipesMutex.Unlock()
+
+		return e.stdoutReadPipe == nil &&
+			e.stderrReadPipe == nil &&
+			e.stdoutHandlerReadPipe == nil &&
+			e.stderrHandlerReadPipe == nil
+	}, 5*time.Second, 10*time.Millisecond, "executor must clean up read-side pipes after normal exit")
+}
+
+func waitForReady(t *testing.T, ready <-chan struct{}, timeoutMessage string) {
+	t.Helper()
+	waitForSignal(t, ready, 5*time.Second, timeoutMessage, nil)
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}, timeout time.Duration, timeoutMessage string, onTimeout func()) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		if onTimeout != nil {
+			onTimeout()
+		}
+		require.FailNow(t, timeoutMessage)
+	}
+}
+
+func countGoroutinesWithStack(needle string) int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+
+	return strings.Count(string(buf[:n]), needle)
+}
+
+func stopWithTimeout(t *testing.T, e *Executor, cmd *exec.Cmd) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		e.Stop()
+		close(done)
+	}()
+
+	waitForSignal(t, done, 5*time.Second, "executor stop timed out", func() {
+		if cmd.Process != nil {
+			_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		}
+	})
+}
+
+type errReader struct {
+	err error
+}
+
+func (r *errReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
+type eofChunkReader struct {
+	chunk []byte
+	sent  bool
+}
+
+func (r *eofChunkReader) Read(p []byte) (int, error) {
+	if r.sent {
+		return 0, io.EOF
+	}
+	r.sent = true
+	n := copy(p, r.chunk)
+	return n, io.EOF
+}


### PR DESCRIPTION
## Description

process/executor.go:

- Fixed goroutine leaks caused by stream readers getting stuck on pipe reads during Stop() and timeout-driven termination.
- Fixed a send on closed channel panic in the race between timeout handling and explicit Stop().
- Fixed data races on executor lifecycle flags (started / stop) by switching them to atomic state.

clissh/frontend/tunnel.go:

Implemented a safer frontend.Tunnel shutdown lifecycle in dhctl:

- Stop() now closes pipe ends directly to unblock consumeLines.
- Stop() is idempotent and kills the SSH process without depending on HealthMonitor.

kube proxy:

- Support context.Context in KubeProxy.Start

Commander cluster-manager integration:

Added two dhctl process-wide switches used by Cluster Manager to disable global shutdown cleanup registration. This prevents accumulation of stale session stoppables and cleanup closures across repeated dhctl client runs, while keeping cleanup owned by the per-task Cluster Manager lifecycle.

UPD 24.06.2026

- Reworked the Go SSH client lifecycle to make Start(), Stop(), and keep-alive restart safer under partial starts, repeated starts, and concurrent stops.
- Added explicit cleanup for SSH sessions, direct SSH connections, bastion clients, and tunneled net connections during stop/restart.
- Prevented stale keep-alive auto-restarts from publishing a new SSH client after manual stop or restart.
- Replaced direct raw SSH client access in commands, file transfers, and tunnels with guarded client snapshots.
- Made SSH commands return a controlled “session not started” error instead of panicking when the client is not connected or already stopped.
- Fixed connection leaks on failed SSH handshakes and failed bastion target connection attempts.
- Added tests for stopped/unstarted client handling, interrupted starts, auto-restart invalidation, repeated starts, and connection cleanup.

<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: <kebab-case of a module name> | <1st level dir in the repo>
type: fix | feature | chore
summary: <ONE-LINE of what effectively changes for a user>
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default | high | low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
