### PR TITLE
Disable client-side kube-client rate limiting during bootstrap

### DIFF
--- a/dhctl/pkg/kubernetes/actions/manifests/manifests.go
+++ b/dhctl/pkg/kubernetes/actions/manifests/manifests.go
@@ -426,6 +426,36 @@ func DeckhouseDeployment(params DeckhouseDeploymentParams) *appsv1.Deployment {
 			Name:  "MODULES_DIR",
 			Value: strings.Join(modulesDirs, pathSeparator),
 		},
+		// Disable client-side rate limiting during bootstrap. The bootstrap
+		// incarnation installs hundreds of CRDs + runs initial kube-binding
+		// Synchronization against a fresh, idle apiserver; the default client QPS
+		// (5/10) serialized that into tens of seconds (client-side throttling).
+		// QPS<0 makes client-go skip the rate limiter entirely (QPS=0 would fall
+		// back to the 5 default, not disable) and defer fairness to apiserver APF.
+		{
+			Name:  "KUBE_CLIENT_QPS",
+			Value: "-1",
+		},
+		{
+			Name:  "KUBE_CLIENT_BURST",
+			Value: "-1",
+		},
+		{
+			Name:  "OBJECT_PATCHER_KUBE_CLIENT_QPS",
+			Value: "-1",
+		},
+		{
+			Name:  "OBJECT_PATCHER_KUBE_CLIENT_BURST",
+			Value: "-1",
+		},
+		{
+			Name:  "HELM_MONITOR_KUBE_CLIENT_QPS",
+			Value: "-1",
+		},
+		{
+			Name:  "HELM_MONITOR_KUBE_CLIENT_BURST",
+			Value: "-1",
+		},
 	}
 
 	// Deployment composition

--- a/modules/002-deckhouse/templates/deployment.yaml
+++ b/modules/002-deckhouse/templates/deployment.yaml
@@ -217,14 +217,21 @@ spec:
               value: "4223"
             - name: ADDON_OPERATOR_BATCHING_ENABLED
               value: "true"
+            # Disable client-side rate limiting; defer fairness to apiserver APF.
+            # QPS<0 makes client-go skip the limiter entirely (0 would fall back
+            # to the client-go default of 5, not disable).
             - name: OBJECT_PATCHER_KUBE_CLIENT_QPS
-              value: "30"
+              value: "-1"
             - name: OBJECT_PATCHER_KUBE_CLIENT_BURST
-              value: "60"
+              value: "-1"
             - name: KUBE_CLIENT_QPS
-              value: "20"
+              value: "-1"
             - name: KUBE_CLIENT_BURST
-              value: "40"
+              value: "-1"
+            - name: HELM_MONITOR_KUBE_CLIENT_QPS
+              value: "-1"
+            - name: HELM_MONITOR_KUBE_CLIENT_BURST
+              value: "-1"
             - name: GOGC
               value: "50"
             - name: ADDON_OPERATOR_PROMETHEUS_METRICS_PREFIX


### PR DESCRIPTION
## What

Set the deckhouse-controller kube-client QPS/Burst to `-1` (disable client-side rate limiting, defer fairness to apiserver API Priority & Fairness) in both:
- the dhctl bootstrap Deployment (`dhctl/pkg/kubernetes/actions/manifests/manifests.go`) — the first deckhouse incarnation previously ran at the client-go default QPS=5/Burst=10 because no QPS env was set there;
- the `002-deckhouse` module Deployment template.

Covers all three effective client families read by deckhouse-controller: `KUBE_CLIENT_*`, `OBJECT_PATCHER_KUBE_CLIENT_*`, `HELM_MONITOR_KUBE_CLIENT_*`.

## Why

During bootstrap deckhouse installs hundreds of CRDs and runs initial kube-binding Synchronization against a fresh, idle apiserver. Client-side throttling serialized this (observed a 6.6s POST-CRD wait and a ~1/s cadence on EnableKubernetesBindings), inflating "Waiting for Deckhouse to become Ready". `QPS=-1` disables the client limiter (note: `0` would fall back to the client-go default of 5, not disable); apiserver APF handles fairness.