### PR TITLE
[cni-cilium] added patch for enabling snat logic for remote node

### DIFF
--- a/modules/021-cni-cilium/images/bin-cilium/patches/019-bpf-masquerade-remote-node.patch
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/019-bpf-masquerade-remote-node.patch
@@ -1,0 +1,30 @@
+diff --git a/bpf/lib/nat.h b/bpf/lib/nat.h
+index 4124bcf6..e21e21e6 100644
+--- a/bpf/lib/nat.h
++++ b/bpf/lib/nat.h
+@@ -688,8 +688,10 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
+ 		 */
+ 
+ 		if (!is_defined(TUNNEL_MODE) || remote_ep->flag_skip_tunnel) {
+-			if (identity_is_remote_node(remote_ep->sec_identity))
+-				return NAT_PUNT_TO_STACK;
++			if (identity_is_remote_node(remote_ep->sec_identity)) {
++				target->addr = IPV4_MASQUERADE;
++				return NAT_NEEDED;
++			}
+ 		}
+ 
+ 		if (local_ep) {
+@@ -1520,8 +1522,10 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
+ 	remote_ep = lookup_ip6_remote_endpoint(&tuple->daddr, 0);
+ 	if (remote_ep) {
+ 		if (!is_defined(TUNNEL_MODE) || remote_ep->flag_skip_tunnel) {
+-			if (identity_is_remote_node(remote_ep->sec_identity))
+-				return NAT_PUNT_TO_STACK;
++			if (identity_is_remote_node(remote_ep->sec_identity)) {
++				ipv6_addr_copy(&target->addr, &masq_addr);
++				return NAT_NEEDED;
++			}
+ 		}
+ 
+ 		if (local_ep) {

--- a/modules/021-cni-cilium/images/bin-cilium/patches/README.md
+++ b/modules/021-cni-cilium/images/bin-cilium/patches/README.md
@@ -96,3 +96,19 @@ The patch removes `*.key` files from the state directory copy before archiving.
 - Released in cilium v1.17.15 / v1.18.9 / v1.19.3.
 
 **Remove this patch when the base cilium version in `modules/021-cni-cilium/oss.yaml` is bumped to v1.17.15 or newer** — the fix is then already in the upstream sources and this patch will fail to apply.
+
+## 019-bpf-masquerade-remote-node.patch
+
+Backport the BPF masquerading behavior for traffic from endpoints to remote node
+addresses. In Cilium 1.17 such traffic is punted to the stack without SNAT in
+native routing mode or when the ipcache entry has `skiptunnel`, which breaks
+connectivity when pod CIDRs are not routable from the target node address.
+
+This mirrors the `enable-remote-node-masquerade` behavior introduced upstream in
+Cilium 1.19, but applies it unconditionally for Deckhouse BPF masquerading.
+
+Upstream PR <https://github.com/cilium/cilium/pull/37568>.
+
+**Remove this patch when the base Cilium version is bumped to 1.19 or newer**,
+and explicitly enable the upstream option in the `cilium-config` ConfigMap:
+`enable-remote-node-masquerade: "true"`.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

This PR adds a Deckhouse patch for Cilium 1.17 that enables BPF SNAT for traffic from pods to remote node addresses. The change backports the relevant datapath behavior from upstream Cilium PR [cilium/cilium#37568](https://github.com/cilium/cilium/pull/37568), where this behavior was introduced for Cilium 1.19 via enable-remote-node-masquerade.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

In Cilium 1.17 with BPF masquerading, traffic from a pod to an IP classified as remote-node can be passed to the stack without SNAT. As a result, packets leave the source node with the pod IP as the source address, which may break connectivity when the destination network cannot route pod CIDRs back. This patch makes such traffic masquerade to the node IP, restoring the expected behavior while Deckhouse still uses Cilium 1.17.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: feature
summary: Added patch for enabling snat logic for remote node
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
