### PR TITLE
[cloud-provider-dvp] add labels to cloudinit secrets

### DIFF
--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/master/main.tf
@@ -16,6 +16,7 @@ resource "kubernetes_secret" "cloudinit-secret" {
   metadata {
     name      = local.cloudinit_secret_name
     namespace = var.namespace
+    labels = local.cloudinit_secret_labels
   }
   data = {
     userData = templatefile("${path.module}/templates/cloudinit.tftpl", {

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/master/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/master/variables.tf
@@ -227,4 +227,10 @@ locals {
     },
     var.additional_annotations
   )
+
+  cloudinit_secret_labels = {
+    "deckhouse.io/managed-by"       = "deckhouse"
+    "dvp.deckhouse.io/cluster-uuid" = var.cluster_uuid
+    "dvp.deckhouse.io/hostname"     = var.hostname
+  }
 }

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/main.tf
@@ -16,6 +16,7 @@ resource "kubernetes_secret" "cloudinit-secret" {
   metadata {
     name      = local.cloudinit_secret_name
     namespace = var.namespace
+    labels = local.cloudinit_secret_labels
   }
   data = {
     userData = templatefile("${path.module}/templates/cloudinit.tftpl", {

--- a/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/variables.tf
+++ b/modules/030-cloud-provider-dvp/candi/terraform-modules/static-node/variables.tf
@@ -222,4 +222,10 @@ locals {
     },
     var.additional_annotations
   )
+
+  cloudinit_secret_labels = {
+    "deckhouse.io/managed-by"       = "deckhouse"
+    "dvp.deckhouse.io/cluster-uuid" = var.cluster_uuid
+    "dvp.deckhouse.io/hostname"     = var.hostname
+  }
 }


### PR DESCRIPTION
## Description
Add `deckhouse.io/managed-by`, `dvp.deckhouse.io/cluster-uuid`, `dvp.deckhouse.io/hostname` labels to cloudinit secrets

## Why do we need it, and what problem does it solve?
Other DVP VM resources already have them. 

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: add labels to cloudinit secrets in the terraform
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
