### PR TITLE
[deckhouse-controller] k8s version validation fix

### DIFF
--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration.go
@@ -324,16 +324,6 @@ func validateKubernetesVersionDowngrade(oldVersion, newVersion string, secret *v
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse old version: %w", err)
 		}
-
-		if maxUsedVersionSemver != nil {
-			// extra validation: if the cluster was on a higher version already,
-			// we cannot downgrade more, than 1 minor from a higher version,
-			// so set oldVersion to maxUsedVersion
-			if maxUsedVersionSemver.GreaterThan(oldVersionSemver) {
-				nameForOldVersion = "maxUsedControlPlaneKubernetesVersion"
-				oldVersionSemver = maxUsedVersionSemver
-			}
-		}
 	}
 
 	// Resolve newVersion: if it's "Automatic", get actual version from secret
@@ -363,6 +353,16 @@ func validateKubernetesVersionDowngrade(oldVersion, newVersion string, secret *v
 		newVersionSemver, err = parseVersion(newVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse new version: %w", err)
+		}
+
+		// Switching to an explicit version: guard against downgrading more than
+		// 1 minor below the highest version the cluster ever ran. This baseline only
+		// makes sense for an explicit target — a switch to "Automatic" is compared
+		// against the actual current version, so a no-op like "1.33" -> Automatic(=1.33)
+		// stays allowed.
+		if maxUsedVersionSemver != nil && maxUsedVersionSemver.GreaterThan(oldVersionSemver) {
+			nameForOldVersion = "maxUsedControlPlaneKubernetesVersion"
+			oldVersionSemver = maxUsedVersionSemver
 		}
 	}
 

--- a/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration_test.go
+++ b/deckhouse-controller/pkg/apis/deckhouse.io/validation/validate_cluster_configuration_test.go
@@ -292,6 +292,30 @@ func TestValidateKubernetesVersionDowngrade(t *testing.T) {
 			},
 			expectValid: false,
 		},
+		{
+			name: "new version Automatic resolves to current version, " +
+				"maxUsedControlPlaneKubernetesVersion is greater than current version",
+			oldVersion: "1.33.0",
+			newVersion: "Automatic",
+			secretData: map[string][]byte{
+				"deckhouseDefaultKubernetesVersion":    []byte("1.33.0"),
+				"maxUsedControlPlaneKubernetesVersion": []byte("1.34.0"),
+			},
+			expectValid: true, // Automatic equals current version, not a downgrade despite higher maxUsed
+			expectError: false,
+		},
+		{
+			name: "new version Automatic is real downgrade, " +
+				"maxUsedControlPlaneKubernetesVersion is greater than current version",
+			oldVersion: "1.34.0",
+			newVersion: "Automatic",
+			secretData: map[string][]byte{
+				"deckhouseDefaultKubernetesVersion":    []byte("1.33.0"),
+				"maxUsedControlPlaneKubernetesVersion": []byte("1.34.0"),
+			},
+			expectValid: false, // Automatic below current version is still rejected
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Fixed `ClusterConfiguration` validation for switching `kubernetesVersion` from an explicit version to `Automatic`.
Now `maxUsedControlPlaneKubernetesVersion` is used only for downgrades to an explicit version and is not used for `... -> Automatic` validation.

## Why do we need it, and what problem does it solve?

Before this change, the webhook could reject a valid change like `1.33 -> Automatic` if `maxUsedControlPlaneKubernetesVersion` was higher than the current configured version.
This caused a false "will downgrade kubernetes version" validation error.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: Fixed validation for switching ClusterConfiguration kubernetesVersion from an explicit version to Automatic.
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
