### PR TITLE
[deckhouse-controller] fix conditional dependency check

### DIFF
--- a/go_lib/dependency/extenders/moduledependency/moduledependency.go
+++ b/go_lib/dependency/extenders/moduledependency/moduledependency.go
@@ -17,7 +17,6 @@ limitations under the License.
 package moduledependency
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -363,65 +362,78 @@ func (e *Extender) CheckEnabling(moduleName string) error {
 	e.logger.Debug("check module enabling", slog.String("module", moduleName))
 	validateErr := &multierror.Error{ErrorFormat: errorFormatter}
 
-	req, found := e.modules[moduleName]
-	if !found {
-		e.logger.Warn("no module requirements found", slog.String("module", moduleName))
-		return nil
-	}
-
 	enabledModules := e.modulesStateHelper()
 
-	// check if the new requirements are satisfied
-	for _, parentModule := range req.matcher.GetConstraintsNames() {
-		parentVersion, err := e.modulesVersionHelper(parentModule)
-		if err != nil {
-			validateErr = multierror.Append(validateErr, fmt.Errorf("could not get the '%s' module version: %s", parentModule, err.Error()))
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-		}
-
-		// check if the parent module is disabled/absent
-		if parentVersion == "" || !slices.Contains(enabledModules, parentModule) {
-			// if parent req is optional and disabled just skip it
-			if _, ok := req.optional[parentModule]; ok {
-				e.logger.Debug("module`s requirement not met, but its optional",
-					slog.String("module", moduleName), slog.String("required", parentModule))
-				continue
+	// check if the new requirements are satisfied (only for modules that declare their own dependencies)
+	if req, found := e.modules[moduleName]; found {
+		for _, parentModule := range req.matcher.GetConstraintsNames() {
+			parentVersion, err := e.modulesVersionHelper(parentModule)
+			if err != nil {
+				validateErr = multierror.Append(validateErr, fmt.Errorf("could not get the '%s' module version: %s", parentModule, err.Error()))
+				if apierrors.IsNotFound(err) {
+					continue
+				}
 			}
 
-			validateErr = multierror.Append(validateErr, fmt.Errorf(`'%s' is not deployed`, parentModule))
-			continue
-		}
+			// check if the parent module is disabled/absent
+			if parentVersion == "" || !slices.Contains(enabledModules, parentModule) {
+				// if parent req is optional and disabled just skip it
+				if _, ok := req.optional[parentModule]; ok {
+					e.logger.Debug("module`s requirement not met, but its optional",
+						slog.String("module", moduleName), slog.String("required", parentModule))
+					continue
+				}
 
-		parsedParentVersion, err := parseParentVersion(parentVersion)
-		if err != nil {
-			validateErr = multierror.Append(validateErr, fmt.Errorf("dependency '%s' has unparsable version: %s", parentModule, parentVersion))
-			continue
-		}
+				validateErr = multierror.Append(validateErr, fmt.Errorf(`'%s' is not deployed`, parentModule))
+				continue
+			}
 
-		if err = req.matcher.ValidateModuleVersion(parentModule, parsedParentVersion); err != nil {
-			validateErr = multierror.Append(validateErr, fmt.Errorf("dependency '%s' not meet version constraint: %s", parentModule, err.Error()))
+			parsedParentVersion, err := parseParentVersion(parentVersion)
+			if err != nil {
+				validateErr = multierror.Append(validateErr, fmt.Errorf("dependency '%s' has unparsable version: %s", parentModule, parentVersion))
+				continue
+			}
+
+			if err = req.matcher.ValidateModuleVersion(parentModule, parsedParentVersion); err != nil {
+				validateErr = multierror.Append(validateErr, fmt.Errorf("dependency '%s' not meet version constraint: %s", parentModule, err.Error()))
+			}
 		}
+	} else {
+		e.logger.Warn("no module requirements found", slog.String("module", moduleName))
 	}
 
-	raw, err := e.modulesVersionHelper(moduleName)
-	if err != nil {
-		return errors.New("could not get current module version")
-	}
-
-	version, err := parseParentVersion(raw)
-	if err != nil {
-		return errors.New("could not parse current module version")
-	}
-
-	// check if the new module's version breaks current constraints
+	// check if enabling the module breaks constraints of already enabled dependent modules.
+	// this must run even if the module itself has no requirements, otherwise enabling a
+	// dependency with an incompatible version silently disables the dependent module.
+	var version *semver.Version
 	for dependent, r := range e.modules {
-		if slices.Contains(enabledModules, dependent) {
-			e.logger.Debug("check dependent", slog.String("module", moduleName), slog.String("dependent", dependent), slog.String("version", version.String()))
-			if err = r.matcher.ValidateModuleVersion(moduleName, version); err != nil {
-				validateErr = multierror.Append(validateErr, fmt.Errorf("module '%s' not meet requirement if module '%s' enabled: %s", dependent, moduleName, err.Error()))
+		if dependent == moduleName || r == nil || r.matcher == nil {
+			continue
+		}
+
+		// only dependents that actually constrain this module and are currently enabled matter
+		if !r.matcher.Has(moduleName) || !slices.Contains(enabledModules, dependent) {
+			continue
+		}
+
+		// lazily resolve the module version only when there is a dependent to validate against
+		if version == nil {
+			raw, err := e.modulesVersionHelper(moduleName)
+			if err != nil {
+				validateErr = multierror.Append(validateErr, fmt.Errorf("could not get the '%s' module version: %s", moduleName, err.Error()))
+				break
 			}
+
+			version, err = parseParentVersion(raw)
+			if err != nil {
+				validateErr = multierror.Append(validateErr, fmt.Errorf("could not parse the '%s' module version: %s", moduleName, err.Error()))
+				break
+			}
+		}
+
+		e.logger.Debug("check dependent", slog.String("module", moduleName), slog.String("dependent", dependent), slog.String("version", version.String()))
+		if err := r.matcher.ValidateModuleVersion(moduleName, version); err != nil {
+			validateErr = multierror.Append(validateErr, fmt.Errorf("module '%s' not meet requirement if module '%s' enabled: %s", dependent, moduleName, err.Error()))
 		}
 	}
 

--- a/go_lib/dependency/extenders/moduledependency/moduledependency_blackbox_test.go
+++ b/go_lib/dependency/extenders/moduledependency/moduledependency_blackbox_test.go
@@ -429,6 +429,98 @@ func TestFilter(t *testing.T) {
 	}
 }
 
+// TestCheckEnabling verifies that enabling a module is validated against constraints of
+// already enabled dependent modules, even when the enabled module declares no requirements
+// of its own (e.g. enabling 'sdn', which is an optional dependency of an enabled 'virtualization').
+func TestCheckEnabling(t *testing.T) {
+	tests := []struct {
+		name           string
+		moduleName     string
+		moduleVersion  string
+		dependents     map[string]map[string]string // dependent module -> its requirements
+		enabledModules []string
+		expectError    bool
+		errorContains  string
+	}{
+		{
+			name:           "module without requirements and no dependents can be enabled",
+			moduleName:     "standalone",
+			moduleVersion:  "1.0.0",
+			enabledModules: []string{},
+			expectError:    false,
+		},
+		{
+			name:          "enabling optional dependency with incompatible version is rejected",
+			moduleName:    "sdn",
+			moduleVersion: "0.6.2",
+			dependents: map[string]map[string]string{
+				"virtualization": {"sdn": ">=0.6.3 !optional"},
+			},
+			enabledModules: []string{"virtualization"},
+			expectError:    true,
+			errorContains:  "not meet requirement if module 'sdn' enabled",
+		},
+		{
+			name:          "enabling optional dependency with compatible version is allowed",
+			moduleName:    "sdn",
+			moduleVersion: "0.6.3",
+			dependents: map[string]map[string]string{
+				"virtualization": {"sdn": ">=0.6.3 !optional"},
+			},
+			enabledModules: []string{"virtualization"},
+			expectError:    false,
+		},
+		{
+			name:          "incompatible version is ignored when dependent module is disabled",
+			moduleName:    "sdn",
+			moduleVersion: "0.6.2",
+			dependents: map[string]map[string]string{
+				"virtualization": {"sdn": ">=0.6.3 !optional"},
+			},
+			enabledModules: []string{},
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extender := moduledependency.Instance()
+
+			versions := map[string]string{tt.moduleName: tt.moduleVersion}
+			extender.SetModulesVersionHelper(func(name string) (string, error) {
+				if v, ok := versions[name]; ok {
+					return v, nil
+				}
+				return "1.0.0", nil
+			})
+			extender.SetModulesStateHelper(func() []string { return tt.enabledModules })
+
+			// register dependents' constraints, then clean them up after the test
+			registered := make([]string, 0, len(tt.dependents))
+			for dependent, reqs := range tt.dependents {
+				require.NoError(t, extender.AddConstraint(dependent, reqs))
+				registered = append(registered, dependent)
+			}
+			extender.DeleteConstraint(tt.moduleName)
+			t.Cleanup(func() {
+				for _, dependent := range registered {
+					extender.DeleteConstraint(dependent)
+				}
+			})
+
+			err := extender.CheckEnabling(tt.moduleName)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestVersionHandlingWithPrereleaseAndMetadata tests the handling of prerelease and metadata in versions
 func TestVersionHandlingWithPrereleaseAndMetadata(t *testing.T) {
 	extender := moduledependency.Instance()


### PR DESCRIPTION
## Description

- Fixes the conditional (`!optional`) module dependency check so that enabling a module no longer disables an already running module that depends on it.
- Affects only the `ModuleDependency` extender (`CheckEnabling`) and its unit tests.

## Why do we need it, and what problem does it solve?

### **Problem:**

- A module can declare a conditional dependency on another module, e.g. `virtualization` → `sdn: ">= 0.6.2 !optional"`: it works without `sdn`, but if `sdn` is enabled it must satisfy the version constraint.
- When the dependent module was already running and a user enabled the dependency at an older, incompatible version, the running dependent module was **disabled and torn down** (its namespace and workloads removed) instead of the incompatible enable being rejected.
- Root cause: `CheckEnabling` (the ModuleConfig admission check) returned early for modules that declare no dependencies of their own (like `sdn`). Because of that, the reverse check "does enabling this module break an already enabled dependent?" never ran. The enable was allowed, and the runtime scheduler then disabled the dependent module.

### **Fix**

- `CheckEnabling` now always validates the module being enabled against the constraints of already enabled dependent modules, even when the module itself declares no dependencies.
- Result: enabling an incompatible dependency is **rejected by the admission webhook**, and the running dependent module stays up.

### **Impact**

- An already running module (and its workloads) is no longer unexpectedly disabled when an incompatible version of its optional dependency is enabled.

---

### Example

#### Before

<img width="3036" height="886" alt="2026-06-01 AT 17 58@2x" src="https://github.com/user-attachments/assets/030937c1-0fed-4f86-9e94-1cb60a977f97" />

#### After

<img width="3014" height="856" alt="2026-06-01 AT 18 02@2x" src="https://github.com/user-attachments/assets/153a3ef6-d432-4470-b130-57c14607b680" />



## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: A module that conditionally depends on another is no longer disabled when an incompatible version of that dependency is enabled; the enable is rejected instead.
```


<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
