### PR TITLE
[deckhouse] add VEX entries 1.73

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 17,
+  "version": 18,
   "statements": [
     {
       "vulnerability": {
@@ -239,6 +239,7 @@
         "name": "CVE-2026-33997"
       },
       "products": [
+        {"@id": "pkg:golang/github.com/docker/docker@v28.3.3+incompatible"},
         {"@id": "pkg:golang/github.com/docker/docker@v28.5.2+incompatible"}
       ],
       "status": "not_affected",
@@ -269,8 +270,68 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Функционал обработки TAR/ZIP polyglot-архивов pip версии 25.3 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Python-зависимости не обновляются, чтобы не нарушить совместимость с shell-operator.",
       "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33809"
+      },
+      "products": [
+        {"@id": "pkg:golang/golang.org/x/image@v0.21.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-434 в golang.org/x/image v0.21.0 не эксплуатируема в образе deckhouse-oss: зависимость транзитивная и не входит в граф импорта бинарника deckhouse-controller (декодирование недоверенных изображений не выполняется), уязвимый путь не достигается в рамках исполнения компонента. Бамп зависимости будет выполнен в рамках планового апгрейда.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27142"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-79 (Cross-site Scripting) в Go stdlib v1.25.5 не эксплуатируема в бинарнике deckhouse-controller в составе образа deckhouse-oss: компонент не рендерит HTML и не отдаёт контент в браузер, XSS-пути стандартной библиотеки в рамках его исполнения не достигаются. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32282"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-59 (Improper Link Resolution Before File Access, symlink following) в Go stdlib v1.25.5 не эксплуатируема в бинарнике deckhouse-controller в составе образа deckhouse-oss: компонент не обрабатывает произвольные пути файловой системы от недоверенных пользователей. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32288"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.5 не эксплуатируема в бинарнике deckhouse-controller в составе образа deckhouse-oss: поверхность атаки ограничена, вектор подачи недоверенных данных в уязвимый путь отсутствует. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32289"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-79 (Cross-site Scripting) в Go stdlib v1.25.5 не эксплуатируема в бинарнике deckhouse-controller в составе образа deckhouse-oss: компонент не работает как веб-сервер, выводящий контент в браузер, XSS-уязвимости стандартной библиотеки не достигаются. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-04-22T12:00:00Z"
+  "last_updated": "2026-06-01T12:00:00Z"
 }

--- a/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
+++ b/modules/002-deckhouse/images/webhook-handler/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 15,
+  "version": 16,
   "statements": [
     {
       "vulnerability": {
@@ -119,8 +119,68 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Зависимость github.com/docker/docker версии v28.0.0 поступает через бинарь promtool, импортируемый из образа prometheus/prometheus (модуль 300-prometheus, Prometheus v2.55.1). Уязвимый функционал Docker Engine API не используется в рамках работы webhook-handler — promtool применяется только для валидации правил. Бамп требует обновления Prometheus в модуле 300-prometheus.",
       "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-27142"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-79 (Cross-site Scripting) в Go stdlib v1.25.5 не эксплуатируема в бинарниках label-converter и shell-operator в составе образа webhook-handler: компоненты не рендерят HTML и не отдают контент в браузер, XSS-пути стандартной библиотеки в рамках их исполнения не достигаются. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32282"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-59 (Improper Link Resolution Before File Access, symlink following) в Go stdlib v1.25.5 не эксплуатируема в бинарниках label-converter и shell-operator в составе образа webhook-handler: компоненты не обрабатывают произвольные пути файловой системы от недоверенных пользователей. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32288"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-770 (Allocation of Resources Without Limits) в Go stdlib v1.25.5 не эксплуатируема в бинарниках label-converter и shell-operator в составе образа webhook-handler: поверхность атаки ограничена, вектор подачи недоверенных данных в уязвимый путь отсутствует. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32289"
+      },
+      "products": [
+        {"@id": "pkg:golang/stdlib@v1.25.5"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CWE-79 (Cross-site Scripting) в Go stdlib v1.25.5 не эксплуатируема в бинарниках label-converter и shell-operator в составе образа webhook-handler: компоненты не работают как веб-сервер, выводящий контент в браузер, XSS-уязвимости стандартной библиотеки не достигаются. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
+      "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6357"
+      },
+      "products": [
+        {"@id": "pkg:pypi/pip@25.3"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Функционал загрузки функциональности из недоверенных источников (CWE-829) pip версии 25.3 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Установка пакетов выполняется только из доверенных источников на этапе сборки образа; версия Python не обновляется для сохранения совместимости с shell-operator.",
+      "timestamp": "2026-06-01T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-04T12:00:00Z",
-  "last_updated": "2026-04-22T12:00:00Z"
+  "last_updated": "2026-06-01T12:00:00Z"
 }

--- a/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
+++ b/modules/007-registrypackages/images/d8/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
   "author": "Deckhouse Deckhouse <contact@deckhouse.io>",
-  "version": 15,
+  "version": 16,
   "statements": [
     {
       "vulnerability": {
@@ -479,8 +479,80 @@
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
       "impact_statement": "Уязвимость в github.com/moby/spdystream v0.5.0 достигается исключительно через подкоманду d8 backup etcd, где spdystream приходит транзитивно из k8s.io/client-go/transport/spdy. Уязвимый код обрабатывает SPDY-фреймы от kube-apiserver, который в типовой модели эксплуатации является доверенным компонентом под управлением администратора кластера. Возможность подачи вредоносных SPDY-фреймов нарушителем исключена архитектурой взаимодействия d8 с Kubernetes API.",
       "timestamp": "2026-04-22T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32952"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/Azure/go-ntlmssp@v0.0.0-20221128193559-754e69321358"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Зависимость github.com/Azure/go-ntlmssp является транзитивной, поступающей в d8 через цепочку deckhouse-cli (stronghold/vault command) → vault-plugin-secrets-openldap → go-ldap/ldap/v3. Уязвимость связана с panic при парсинге специально сформированных NTLM Type 2 challenge-сообщений от вредоносного NTLM-сервера. Функционал NTLM-аутентификации против произвольных LDAP-серверов в d8 не используется — LDAP-операции выполняются только в контексте управления Stronghold/Vault администратором кластера через d8 stronghold, где NTLM bind не применяется. Уязвимый исполняемый путь недостижим в рамках текущих функциональных спецификаций и эксплуатационных процессов системы.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41506"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке данных Git-репозитория (pack/index). В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45022"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44740"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-billy/v5 v5.6.2 (файловая абстракция для go-git) проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44973"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/go-git/go-billy/v5 v5.6.2 (файловая абстракция для go-git) проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации источники Git-репозиториев определяются и контролируются администратором кластера, что не предоставляет нарушителю возможности подать вредоносные данные в уязвимый исполняемый путь.",
+      "timestamp": "2026-06-02T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-pmwq-pjrm-6p5r"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/in-toto/in-toto-golang@v0.9.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Эта неэксплуатируемая уязвимость относится к подкоманде d8 delivery-kit. Уязвимость в github.com/in-toto/in-toto-golang v0.9.0 связана с верификацией supply-chain attestations (in-toto layout/link metadata) в составе цепочки cosign/sigstore. d8 не верифицирует недоверенные in-toto-аттестации в рамках текущих сценариев эксплуатации — соответствующий исполняемый путь не вызывается, что исключает возможность эксплуатации.",
+      "timestamp": "2026-06-02T12:00:00Z"
     }
   ],
   "timestamp": "2025-10-09T14:21:14Z",
-  "last_updated": "2026-04-22T12:00:00Z"
+  "last_updated": "2026-06-02T12:00:00Z"
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Add OpenVEX `not_affected` mitigations for 2026-06 CVE findings on release-1.73. No bumps — fixes blocked by constraints (Python/helm/werf-chain not bumped, no fixed Go builder on 1.73), so unreachable paths are documented via VEX.

- **webhook-handler** (v15→16): stdlib CVE-2026-27142/-32282/-32288/-32289, pip CVE-2026-6357
- **deckhouse-controller** (v17→18): x/image CVE-2026-33809, stdlib CVE-2026-27142/-32282/-32288/-32289, docker CVE-2026-33997 (v28.3.3)
- **d8** (v15→16): go-ntlmssp CVE-2026-32952, go-git CVE-2026-41506/-45022, go-billy CVE-2026-44740/-44973, in-toto GHSA-pmwq-pjrm-6p5r

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Add VEX entries 1.73
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
