### PR TITLE
[cni-cilium] Change cilium-agent healthcheck port to 9879

### DIFF
--- a/modules/021-cni-cilium/templates/_agent-daemonset.tpl
+++ b/modules/021-cni-cilium/templates/_agent-daemonset.tpl
@@ -49,7 +49,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -62,7 +62,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"
@@ -77,7 +77,7 @@ spec:
           httpGet:
             host: "127.0.0.1"
             path: /healthz
-            port: 9876
+            port: 9879
             scheme: HTTP
             httpHeaders:
             - name: "brief"

--- a/modules/021-cni-cilium/templates/configmap.yaml
+++ b/modules/021-cni-cilium/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
 
   metrics: "+cilium_bpf_map_pressure"
 
-  agent-health-port: "9876"
+  agent-health-port: "9879"
   prometheus-serve-addr: "127.0.0.1:9092"
   operator-prometheus-serve-addr: "127.0.0.1:9094"
   operator-api-serve-addr: "127.0.0.1:9234"


### PR DESCRIPTION
## Description

Change the default cilium-agent health check port from 9876 to 9879 to avoid conflicts with Istio's ControlZ port.

The upstream Cilium project already changed the binary default to 9879 in [cilium/cilium#19830](https://github.com/cilium/cilium/pull/19830) (landed in v1.12+). Since Deckhouse ships Cilium v1.17.4 which already defaults to 9879 at the binary level, only the hardcoded references in the Helm templates need updating.

### Changes

- **`templates/configmap.yaml`** - `agent-health-port` value changed from `"9876"` to `"9879"`.
- **`templates/_agent-daemonset.tpl`** - All three Kubernetes probes (startup, liveness, readiness) now target port `9879` instead of `9876`.

## Why do we need it, and what problem does it solve?

The default cilium-agent health check port 9876 conflicts with Istio's ControlZ port (also 9876). If Istio install-cni daemon starts before Cilium agent on a node, Cilium agent will fail to bind port 9876 and crash, entering a crashloop with no automatic recovery. Since the health check API is only exposed on 127.0.0.1 for liveness/readiness probes, changing the default is safe and resolves the crashloop scenario cleanly.

## Why do we need it in the patch release (if we do)?

Yes. The race condition between Istio CNI and Cilium on port 9876 causes an unrecoverable cilium-agent crashloop on affected nodes. Users cannot reliably work around this - the port overlap is in the default configuration, and the crash happens before Cilium can process any `CiliumNodeConfig` overrides.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: cni-cilium
type: fix
summary: Changed default cilium-agent health check port from 9876 to 9879 to avoid conflict with Istio's ControlZ port.
impact_level: default
```