### PR TITLE
[node-manager] capi webhook cert fix

### DIFF
--- a/go_lib/hooks/tls_certificate/internal_tls.go
+++ b/go_lib/hooks/tls_certificate/internal_tls.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	"github.com/flant/addon-operator/sdk"
 	"github.com/flant/shell-operator/pkg/kube_events_manager/types"
@@ -43,6 +44,10 @@ const (
 	// certificate encryption algorithm
 	keyAlgorithm = "ecdsa"
 	keySize      = 256
+
+	// caOrganization is placed in the CA Subject (O=) in StrictTLS mode so the
+	// CA Subject differs from the CN-only leaf Subject.
+	caOrganization = "Deckhouse"
 
 	SnapshotKey = "secret"
 )
@@ -82,6 +87,16 @@ type GenSelfSignedTLSHookConf struct {
 	// often it is module name
 	CN string
 
+	// StrictTLS opts the hook into issuing certificates accepted by strict
+	// external validators. When enabled:
+	//   - the CA Subject is made distinct from the leaf: CN="<CN>-ca" plus
+	//     O=Deckhouse, OU=<module>, so the leaf is not seen as depth-0 self-signed;
+	//   - the leaf gets a real "server auth" EKU by default (instead of the bogus
+	//     "requestheader-client" that yields an empty ExtendedKeyUsage);
+	//   - legacy certificates violating these rules are re-issued.
+	// Default (false) fully preserves the previous behavior.
+	StrictTLS bool
+
 	// Namespace - namespace for TLS secret
 	Namespace string
 	// TLSSecretName - TLS secret name
@@ -116,6 +131,15 @@ type GenSelfSignedTLSHookConf struct {
 
 func (gss GenSelfSignedTLSHookConf) path() string {
 	return strings.TrimSuffix(gss.FullValuesPathPrefix, ".")
+}
+
+// caOU derives the CA Organizational Unit for StrictTLS mode from Namespace
+// (stripping the "d8-" prefix), falling back to CN.
+func (gss GenSelfSignedTLSHookConf) caOU() string {
+	if trimmed := strings.TrimPrefix(gss.Namespace, "d8-"); trimmed != "" && trimmed != gss.Namespace {
+		return trimmed
+	}
+	return gss.CN
 }
 
 type certValues struct {
@@ -189,6 +213,13 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 			"key encipherment",
 			"requestheader-client",
 		}
+		if conf.StrictTLS {
+			usages = []string{
+				"signing",
+				"key encipherment",
+				"server auth",
+			}
+		}
 	} else {
 		for _, v := range conf.Usages {
 			usages = append(usages, string(v))
@@ -207,6 +238,11 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 		var err error
 
 		cn, sans := conf.CN, conf.SANs(ctx, input)
+		caCN, caOU := cn, ""
+		if conf.StrictTLS {
+			caCN = cn + "-ca"
+			caOU = conf.caOU()
+		}
 
 		certs, err := sdkobjectpatch.UnmarshalToStruct[certificate.Certificate](input.Snapshots, SnapshotKey)
 		if err != nil {
@@ -216,7 +252,7 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 		if len(certs) == 0 {
 			// No certificate in snapshot => generate a new one.
 			// Secret will be updated by Helm.
-			cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
+			cert, err = generateNewSelfSignedTLS(input, caCN, caOU, cn, sans, usages)
 			if err != nil {
 				return err
 			}
@@ -235,10 +271,20 @@ func genSelfSignedTLS(conf GenSelfSignedTLSHookConf) func(ctx context.Context, i
 				input.Logger.Error(err.Error())
 			}
 
-			// In case of errors, both these flags are false to avoid regeneration loop for the
+			// Strict-validation re-issue is opt-in via StrictTLS, so other modules
+			// keep their current certificates untouched.
+			certInvalid := false
+			if conf.StrictTLS {
+				certInvalid, err = isLegacyInvalidCert(cert.Cert)
+				if err != nil {
+					input.Logger.Error(err.Error())
+				}
+			}
+
+			// In case of errors, these flags are false to avoid regeneration loop for the
 			// certificate.
-			if caOutdated || certOutdated {
-				cert, err = generateNewSelfSignedTLS(input, cn, sans, usages)
+			if caOutdated || certOutdated || certInvalid {
+				cert, err = generateNewSelfSignedTLS(input, caCN, caOU, cn, sans, usages)
 				if err != nil {
 					return err
 				}
@@ -286,6 +332,26 @@ func isIrrelevantCert(certData string, desiredSANSs []string) (bool, error) {
 	return false, nil
 }
 
+// isLegacyInvalidCert reports whether a leaf certificate lacks the properties
+// required by strict TLS validators: a Subject distinct from the Issuer
+// (otherwise it looks depth-0 self-signed) and a non-empty ExtendedKeyUsage.
+func isLegacyInvalidCert(certData string) (bool, error) {
+	cert, err := certificate.ParseCertificate(certData)
+	if err != nil {
+		return false, fmt.Errorf("parse certificate: %w", err)
+	}
+
+	if cert.Subject.String() == cert.Issuer.String() {
+		return true, nil
+	}
+
+	if len(cert.ExtKeyUsage) == 0 && len(cert.UnknownExtKeyUsage) == 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func isOutdatedCA(ca string) (bool, error) {
 	// Issue a new certificate if there is no CA in the secret.
 	// Without CA it is not possible to validate the certificate.
@@ -305,12 +371,17 @@ func isOutdatedCA(ca string) (bool, error) {
 	return false, nil
 }
 
-func generateNewSelfSignedTLS(input *go_hook.HookInput, cn string, sans, usages []string) (certificate.Certificate, error) {
-	ca, err := certificate.GenerateCA(input.Logger,
-		cn,
+func generateNewSelfSignedTLS(input *go_hook.HookInput, caCN, caOU, cn string, sans, usages []string) (certificate.Certificate, error) {
+	caOptions := []certificate.Option{
 		certificate.WithKeyAlgo(keyAlgorithm),
 		certificate.WithKeySize(keySize),
-		certificate.WithCAExpiry(caExpiryDurationStr))
+		certificate.WithCAExpiry(caExpiryDurationStr),
+	}
+	if caOU != "" {
+		caOptions = append(caOptions, certificate.WithNames(csr.Name{O: caOrganization, OU: caOU}))
+	}
+
+	ca, err := certificate.GenerateCA(input.Logger, caCN, caOptions...)
 	if err != nil {
 		return certificate.Certificate{}, err
 	}

--- a/modules/040-node-manager/hooks/generate_capi_webhook_certs.go
+++ b/modules/040-node-manager/hooks/generate_capi_webhook_certs.go
@@ -33,6 +33,9 @@ var _ = tls_certificate.RegisterInternalTLSHook(tls_certificate.GenSelfSignedTLS
 	}),
 
 	CN: cn,
+	// Issue a certificate accepted by strict validators: distinct CA Subject and a
+	// real "server auth" EKU. Legacy certificates are re-issued automatically.
+	StrictTLS: true,
 
 	Namespace:            "d8-cloud-instance-manager",
 	TLSSecretName:        "capi-webhook-tls",

--- a/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
+++ b/modules/040-node-manager/hooks/generate_capi_webhook_certs_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cloudflare/cfssl/csr"
 	"github.com/flant/addon-operator/pkg/module_manager/go_hook"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -53,18 +54,22 @@ var _ = Describe("Node Manager hooks :: generate_webhook_certs ::", func() {
 			certCA, err := x509.ParseCertificate(blockCA.Bytes)
 			Expect(err).To(BeNil())
 			Expect(certCA.IsCA).To(BeTrue())
-			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
+			Expect(certCA.Subject.CommonName).To(Equal("capi-controller-manager-webhook-ca"))
+			Expect(certCA.Subject.Organization).To(ContainElement("Deckhouse"))
 
 			block, _ := pem.Decode([]byte(f.ValuesGet("nodeManager.internal.capiControllerManagerWebhookCert.crt").String()))
 			cert, err := x509.ParseCertificate(block.Bytes)
 			Expect(err).To(BeNil())
 			Expect(cert.IsCA).To(BeFalse())
 			Expect(cert.Subject.CommonName).To(Equal("capi-controller-manager-webhook"))
+
+			Expect(cert.Subject.String()).NotTo(Equal(cert.Issuer.String()))
+			Expect(cert.ExtKeyUsage).To(ContainElement(x509.ExtKeyUsageServerAuth))
 		})
 	})
 	Context("With secrets", func() {
 		caAuthority, _ := genWebhookCa(nil)
-		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, "capi-manager-webhook", "capi-webhook-service")
+		tlsAuthority, _ := genWebhookTLS(&go_hook.HookInput{Logger: log.NewNop()}, caAuthority, cn, "capi-webhook-service")
 
 		BeforeEach(func() {
 			f.BindingContexts.Set(f.KubeStateSet(fmt.Sprintf(`
@@ -97,9 +102,10 @@ data:
 })
 
 func genWebhookCa(logEntry *log.Logger) (*certificate.Authority, error) {
-	ca, err := certificate.GenerateCA(logEntry, cn, certificate.WithKeyAlgo("ecdsa"),
+	ca, err := certificate.GenerateCA(logEntry, cn+"-ca", certificate.WithKeyAlgo("ecdsa"),
 		certificate.WithKeySize(256),
-		certificate.WithCAExpiry("87600h"))
+		certificate.WithCAExpiry("87600h"),
+		certificate.WithNames(csr.Name{O: "Deckhouse", OU: "cloud-instance-manager"}))
 	if err != nil {
 		return nil, fmt.Errorf("cannot generate CA: %v", err)
 	}
@@ -116,7 +122,7 @@ func genWebhookTLS(input *go_hook.HookInput, ca *certificate.Authority, cn strin
 		certificate.WithSigningDefaultExpiry((24*time.Hour)*365*10),
 		certificate.WithSigningDefaultUsage([]string{"signing",
 			"key encipherment",
-			"requestheader-client",
+			"server auth",
 		}),
 		certificate.WithSANs(
 			sanPrefix+".d8-cloud-instance-manager",

--- a/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
+++ b/modules/040-node-manager/templates/capi-controller-manager/deployment.yaml
@@ -59,7 +59,7 @@ spec:
   template:
     metadata:
       annotations:
-        node-manager.deckhouse.io/force-rollout-v1-72-5: ""
+        node-manager.deckhouse.io/force-rollout-v1-73-x: ""
       labels:
         app: capi-controller-manager
         cluster.x-k8s.io/provider: cluster-api


### PR DESCRIPTION
## Description

Add an opt-in `StrictTLS` flag to the internal TLS hook (`go_lib/hooks/tls_certificate`) and enable it for the CAPI webhook certificate (`capi-webhook-tls`). Default behavior of `RegisterInternalTLSHook` is unchanged; all other consumers are unaffected.
When `StrictTLS` is set, the hook:
- issues the CA with a Subject distinct from the leaf (`CN=<CN>-ca`, `O=Deckhouse`, `OU=<module>`), so the leaf is no longer a depth-0 self-signed certificate;
- sets a real `server auth` ExtendedKeyUsage on the leaf instead of the bogus `requestheader-client` default;
- re-issues existing certificates that violate these rules (Subject == Issuer or empty EKU).
The `capi-controller-manager` deployment is rolled out via the rollout annotation so the pod picks up the re-issued certificate.

## Why do we need it, and what problem does it solve?

The CAPI webhook certificate was issued with CA and leaf sharing the same Subject and with an empty ExtendedKeyUsage. Go/kube-apiserver accept such certificates, so the webhook kept working, but strict validators (`openssl verify`, Trivy, MaxPatrol) reject them (`X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT`, missing EKU). Strict mode produces a certificate accepted by these validators.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary:  Issue the CAPI webhook certificate so strict TLS validators accept it (distinct CA Subject, `server auth` EKU); legacy certificates are re-issued, restarting `capi-controller-manager`
impact: The `capi-controller-manager` pod will be restarted to pick up the re-issued webhook certificate
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
