### PR TITLE
[dhctl] Add logs output to interactive mode

### DIFF
--- a/dhctl/cmd/dhctl/action.go
+++ b/dhctl/cmd/dhctl/action.go
@@ -415,9 +415,18 @@ func (i *actionIniter) cleanupProgressbar() onShutdownFunc {
 			if err != nil {
 				log.WarnF("failed to stop progress bar printer: %v", err)
 			}
+
+			if err := pb.LogBox.Stop(); err != nil {
+				log.WarnF("failed to stop logbox: %v", err)
+			}
+
 			_, err = pb.MultiPrinter.Stop()
 			if err != nil {
 				log.WarnF("failed to stop multi printer: %v", err)
+			}
+
+			if pb.WriterFabric != nil {
+				pb.WriterFabric.Cleanup()
 			}
 		}
 	}

--- a/dhctl/pkg/log/interactive.go
+++ b/dhctl/pkg/log/interactive.go
@@ -17,6 +17,7 @@ package log
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/deckhouse/deckhouse/pkg/log"
 	external "github.com/deckhouse/lib-dhctl/pkg/log"
@@ -80,6 +81,7 @@ type InteractiveLogger struct {
 
 	// channels for updating labels
 	phaseChan chan string
+	logChan   chan string
 
 	pbStarted bool
 }
@@ -87,10 +89,13 @@ type InteractiveLogger struct {
 func newInteractiveLogger(logger external.Logger, interactive bool) *InteractiveLogger {
 	// buffered chan to make sure we won't get stucked
 	phaseChan := make(chan string, 5)
+	// logs can appears really often, so wee need larger buffer
+	logChan := make(chan string, 100)
 	return &InteractiveLogger{
 		logger:      logger,
 		interactive: interactive,
 		phaseChan:   phaseChan,
+		logChan:     logChan,
 	}
 }
 
@@ -144,10 +149,16 @@ func (i *InteractiveLogger) LogProcess(p, t string, run func() error) error {
 
 	if i.pbStarted {
 		i.phaseChan <- t
+		i.logChan <- fmt.Sprintf("process started: %s", t)
 	}
 
 	if err := run(); err != nil {
 		return err
+	}
+
+	if i.pbStarted {
+		i.phaseChan <- t
+		i.logChan <- fmt.Sprintf("process finished: %s", t)
 	}
 
 	return nil
@@ -156,6 +167,9 @@ func (i *InteractiveLogger) LogProcess(p, t string, run func() error) error {
 func (i *InteractiveLogger) LogInfoF(format string, a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
+		if i.pbStarted {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
 	} else {
 		i.logger.InfoFWithoutLn(format, a...)
 	}
@@ -164,17 +178,34 @@ func (i *InteractiveLogger) LogInfoF(format string, a ...interface{}) {
 func (i *InteractiveLogger) LogInfoLn(a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
+		if i.pbStarted {
+			i.logChan <- fmt.Sprintf("%s", a...)
+		}
 	} else {
 		i.logger.InfoLn(a...)
 	}
 }
 
 func (i *InteractiveLogger) LogErrorF(format string, a ...interface{}) {
-	i.logger.ErrorF(format, a...)
+	if i.interactive {
+		i.logger.DebugF(format, a...)
+		if i.pbStarted {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
+	} else {
+		i.logger.ErrorF(format, a...)
+	}
 }
 
 func (i *InteractiveLogger) LogErrorLn(a ...interface{}) {
-	i.logger.ErrorF("%v", a...)
+	if i.interactive {
+		i.logger.DebugLn(a...)
+		if i.pbStarted {
+			i.logChan <- fmt.Sprintf("%s", a...)
+		}
+	} else {
+		i.logger.ErrorF("%v", a...)
+	}
 }
 
 func (i *InteractiveLogger) LogDebugF(format string, a ...interface{}) {
@@ -204,18 +235,24 @@ func (i *InteractiveLogger) LogFailRetry(l string) {
 }
 
 func (i *InteractiveLogger) LogWarnLn(a ...interface{}) {
-	if !i.interactive {
-		i.logger.WarnF("%s", a...)
-	} else {
+	if i.interactive {
 		i.logger.DebugF("%v", a...)
+		if i.pbStarted {
+			i.logChan <- fmt.Sprintf("%s", a...)
+		}
+	} else {
+		i.logger.WarnF("%s", a...)
 	}
 }
 
 func (i *InteractiveLogger) LogWarnF(format string, a ...interface{}) {
-	if !i.interactive {
-		i.logger.WarnFWithoutLn(format, a...)
-	} else {
+	if i.interactive {
 		i.logger.DebugF(format, a...)
+		if i.pbStarted {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
+	} else {
+		i.logger.WarnFWithoutLn(format, a...)
 	}
 }
 
@@ -231,6 +268,10 @@ func (i *InteractiveLogger) GetPhaseChan() chan string {
 	return i.phaseChan
 }
 
+func (i *InteractiveLogger) GetLogChan() chan string {
+	return i.logChan
+}
+
 func getInteractiveLoggerWrapper(loggerType string, opts LoggerOptions, interactive bool) (*InteractiveLogger, error) {
 	extOpts := external.LoggerOptions{
 		OutStream:   opts.OutStream,
@@ -243,6 +284,10 @@ func getInteractiveLoggerWrapper(loggerType string, opts LoggerOptions, interact
 				OptionsSetter: CommonOptions,
 			},
 		},
+	}
+
+	if loggerType == "pretty" {
+		loggerType = "simple"
 	}
 
 	extLogger, err := external.NewLoggerWithOptions(external.Type(loggerType), extOpts)
@@ -332,6 +377,7 @@ type InteractiveLoggerWrapper struct {
 	interactive bool
 
 	phaseChan chan string
+	logChan   chan string
 }
 
 func (i *InteractiveLoggerWrapper) Process(p external.Process, t string, run func() error) error {
@@ -341,10 +387,15 @@ func (i *InteractiveLoggerWrapper) Process(p external.Process, t string, run fun
 
 	if isPbStarted() {
 		i.phaseChan <- t
+		i.logChan <- fmt.Sprintf("process started: %s", t)
 	}
 
 	if err := run(); err != nil {
 		return err
+	}
+
+	if isPbStarted() {
+		i.logChan <- fmt.Sprintf("process finished: %s", t)
 	}
 
 	return nil
@@ -353,6 +404,9 @@ func (i *InteractiveLoggerWrapper) Process(p external.Process, t string, run fun
 func (i *InteractiveLoggerWrapper) InfoFWithoutLn(format string, a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugFWithoutLn(format, a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
 	} else {
 		i.logger.InfoFWithoutLn(format, a...)
 	}
@@ -361,6 +415,9 @@ func (i *InteractiveLoggerWrapper) InfoFWithoutLn(format string, a ...interface{
 func (i *InteractiveLoggerWrapper) InfoLn(a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf("%s", a...)
+		}
 	} else {
 		i.logger.InfoLn(a...)
 	}
@@ -369,6 +426,9 @@ func (i *InteractiveLoggerWrapper) InfoLn(a ...interface{}) {
 func (i *InteractiveLoggerWrapper) InfoF(format string, a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
 	} else {
 		i.logger.InfoF(format, a...)
 	}
@@ -377,6 +437,9 @@ func (i *InteractiveLoggerWrapper) InfoF(format string, a ...interface{}) {
 func (i *InteractiveLoggerWrapper) ErrorFWithoutLn(format string, a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugFWithoutLn(format, a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
 	} else {
 		i.logger.ErrorFWithoutLn(format, a...)
 	}
@@ -385,6 +448,9 @@ func (i *InteractiveLoggerWrapper) ErrorFWithoutLn(format string, a ...interface
 func (i *InteractiveLoggerWrapper) ErrorLn(a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugLn(a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf("%s", a...)
+		}
 	} else {
 		i.logger.ErrorLn(a...)
 	}
@@ -393,6 +459,9 @@ func (i *InteractiveLoggerWrapper) ErrorLn(a ...interface{}) {
 func (i *InteractiveLoggerWrapper) ErrorF(format string, a ...interface{}) {
 	if i.interactive {
 		i.logger.DebugF(format, a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
 	} else {
 		i.logger.ErrorF(format, a...)
 	}
@@ -411,26 +480,35 @@ func (i *InteractiveLoggerWrapper) DebugF(format string, a ...interface{}) {
 }
 
 func (i *InteractiveLoggerWrapper) WarnFWithoutLn(format string, a ...interface{}) {
-	if !i.interactive {
-		i.logger.WarnFWithoutLn(format, a...)
-	} else {
+	if i.interactive {
 		i.logger.DebugFWithoutLn(format, a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
+	} else {
+		i.logger.WarnFWithoutLn(format, a...)
 	}
 }
 
 func (i *InteractiveLoggerWrapper) WarnLn(a ...interface{}) {
-	if !i.interactive {
-		i.logger.WarnLn(a...)
-	} else {
+	if i.interactive {
 		i.logger.DebugLn(a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf("%s", a...)
+		}
+	} else {
+		i.logger.WarnLn(a...)
 	}
 }
 
 func (i *InteractiveLoggerWrapper) WarnF(format string, a ...interface{}) {
-	if !i.interactive {
-		i.logger.WarnF(format, a...)
-	} else {
+	if i.interactive {
 		i.logger.DebugF(format, a...)
+		if isPbStarted() {
+			i.logChan <- fmt.Sprintf(format, a...)
+		}
+	} else {
+		i.logger.WarnF(format, a...)
 	}
 }
 
@@ -497,10 +575,10 @@ func isPbStarted() bool {
 	return started
 }
 
-func WithProgressBar() {
+func WithProgressBar(b bool) {
 	logger := GetDefaultLogger()
 	l, ok := logger.(*InteractiveLogger)
 	if ok {
-		l.pbStarted = true
+		l.pbStarted = b
 	}
 }

--- a/dhctl/pkg/log/logger.go
+++ b/dhctl/pkg/log/logger.go
@@ -416,7 +416,7 @@ func ExternalLoggerProvider(logger Logger) external.LoggerProvider {
 		l = ext.logger
 	} else {
 		i := logger.(*InteractiveLogger)
-		wrapper := &InteractiveLoggerWrapper{logger: i.logger, interactive: i.interactive, phaseChan: i.phaseChan}
+		wrapper := &InteractiveLoggerWrapper{logger: i.logger, interactive: i.interactive, phaseChan: i.phaseChan, logChan: i.logChan}
 		return external.SimpleLoggerProvider(wrapper)
 	}
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-base-infra.go
@@ -106,7 +106,7 @@ func (b *ClusterBootstrapper) BaseInfrastructure(ctx context.Context) error {
 		}
 		labelChan := intLogger.GetPhaseChan()
 		phasesChan := make(chan phases.Progress, 5)
-		pbParam := progressbar.NewPbParams(100, "Base infrastructure", labelChan, phasesChan)
+		pbParam := progressbar.NewPbParams(100, "Base infrastructure", labelChan, phasesChan, intLogger.GetLogChan())
 
 		if err := progressbar.InitProgressBar(pbParam); err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-bashible.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-bashible.go
@@ -61,7 +61,7 @@ func (b *ClusterBootstrapper) ExecuteBashible(ctx context.Context) error {
 		}
 		labelChan := intLogger.GetPhaseChan()
 		phasesChan := make(chan phases.Progress, 5)
-		pbParam := progressbar.NewPbParams(100, "Bashible bundle", labelChan, phasesChan)
+		pbParam := progressbar.NewPbParams(100, "Bashible bundle", labelChan, phasesChan, intLogger.GetLogChan())
 
 		if err := progressbar.InitProgressBar(pbParam); err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-deckhouse.go
@@ -62,7 +62,7 @@ func (b *ClusterBootstrapper) InstallDeckhouse(ctx context.Context) error {
 		}
 		labelChan := intLogger.GetPhaseChan()
 		phasesChan := make(chan phases.Progress, 5)
-		pbParam := progressbar.NewPbParams(100, "Install Deckhouse", labelChan, phasesChan)
+		pbParam := progressbar.NewPbParams(100, "Install Deckhouse", labelChan, phasesChan, intLogger.GetLogChan())
 
 		if err := progressbar.InitProgressBar(pbParam); err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-post-bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-post-bootstrap.go
@@ -57,7 +57,7 @@ func (b *ClusterBootstrapper) ExecPostBootstrap(ctx context.Context) error {
 		}
 		labelChan := intLogger.GetPhaseChan()
 		phasesChan := make(chan phases.Progress, 5)
-		pbParam := progressbar.NewPbParams(100, "Executing post-bootstrap script", labelChan, phasesChan)
+		pbParam := progressbar.NewPbParams(100, "Executing post-bootstrap script", labelChan, phasesChan, intLogger.GetLogChan())
 
 		if err := progressbar.InitProgressBar(pbParam); err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
@@ -65,7 +65,7 @@ func (b *ClusterBootstrapper) CreateResources(ctx context.Context) error {
 		}
 		labelChan := intLogger.GetPhaseChan()
 		phasesChan := make(chan phases.Progress, 5)
-		pbParam := progressbar.NewPbParams(100, "Create resources", labelChan, phasesChan)
+		pbParam := progressbar.NewPbParams(100, "Create resources", labelChan, phasesChan, intLogger.GetLogChan())
 
 		if err := progressbar.InitProgressBar(pbParam); err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/name212/govalue"
+	"github.com/pterm/pterm"
 	otattribute "go.opentelemetry.io/otel/attribute"
 
 	libcon "github.com/deckhouse/lib-connection/pkg"
@@ -348,9 +349,9 @@ func (b *ClusterBootstrapper) bootstrapLoadConfig(ctx context.Context, bctx *boo
 	// TODO(dhctl-for-commander): pass stateCache externally using params as in Destroyer, this variable will be unneeded then
 	b.lastState = nil
 
-	printBanner()
-
 	interactive := input.IsTerminal() && !b.Options.Global.ShowProgress
+	printBanner(interactive)
+
 	if interactive {
 		_, phasesChan, err := progressbar.InitProgressBarWithDeferredFunc("Bootstrap cluster", b.logger)
 		if err != nil {
@@ -557,6 +558,20 @@ func (b *ClusterBootstrapper) bootstrapBaseInfra(ctx context.Context, bctx *boot
 
 			bctx.masterAddressesForSSH[masterNodeName] = masterOutputs.MasterIPForSSH
 			state.SaveMasterHostsToCache(ctx, bctx.stateCache, bctx.masterAddressesForSSH)
+
+			interactive := input.IsTerminal() && !b.Options.Global.ShowProgress
+			if interactive {
+				sshProvider, err := b.SSHProviderInitializer.GetSSHProvider(ctx)
+				if err != nil {
+					return err
+				}
+				sshClient, err := sshProvider.Client(ctx)
+				if err != nil {
+					return err
+				}
+				sshString := sshClient.Session().String()
+				progressbar.GetDefaultPb().LogBox.WithStatusString(fmt.Sprintf("First master connection string: %s", sshString))
+			}
 			return nil
 		})
 		if err != nil {
@@ -634,6 +649,7 @@ func (b *ClusterBootstrapper) bootstrapPostInfraPreflights(ctx context.Context, 
 
 	return nil
 }
+
 func (b *ClusterBootstrapper) bootstrapKubernetes(ctx context.Context, bctx *bootstrapContext) error {
 	if shouldStop, err := b.PhasedExecutionContext.SwitchPhase(ctx, phases.InstallKubernetesPhase, false, bctx.stateCache, nil); err != nil {
 		return err
@@ -864,7 +880,7 @@ func (b *ClusterBootstrapper) bootstrapFinalize(ctx context.Context, bctx *boots
 
 	interactive := input.IsTerminal() && !b.Options.Global.ShowProgress
 	if interactive {
-		progressbar.InfoF("%s\n", "Deckhouse cluster was created successfully! Kubernetes Master Node addresses for SSH:")
+		progressbar.InfoF("%s", "Deckhouse cluster was created successfully! Kubernetes Master Node addresses for SSH:")
 	}
 
 	if bctx.metaConfig.ClusterType == config.CloudClusterType {
@@ -914,9 +930,12 @@ func (b *ClusterBootstrapper) GetLastState() phases.DhctlState {
 	return b.PhasedExecutionContext.GetLastState()
 }
 
-func printBanner() {
-	log.InteractiveInfoLn(banner)
-	log.InteractiveInfoLn("")
+func printBanner(iteractive bool) {
+	if iteractive {
+		pterm.Println(banner)
+	} else {
+		log.InfoLn(banner)
+	}
 }
 
 func generateClusterUUID(ctx context.Context, stateCache state.Cache) (string, error) {

--- a/dhctl/pkg/util/input/confirmation.go
+++ b/dhctl/pkg/util/input/confirmation.go
@@ -52,11 +52,13 @@ func (c *Confirmation) Ask() bool {
 
 	pb := progressbar.GetDefaultPb()
 	if pb != nil {
-		confirmWriter := pb.MultiPrinter.NewWriter()
+		confirmWriter := pb.LogBox.ShiftDown()
+
 		oldWriter := pb.MultiPrinter.Writer
 		pterm.SetDefaultOutput(confirmWriter)
 		result, _ := pterm.DefaultInteractiveConfirm.Show(c.message)
 		pterm.SetDefaultOutput(oldWriter)
+		pb.LogBox.ShiftUp(confirmWriter)
 
 		return result
 	} else {

--- a/dhctl/pkg/util/progressbar/logbox.go
+++ b/dhctl/pkg/util/progressbar/logbox.go
@@ -1,0 +1,234 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package progressbar
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pterm/pterm"
+)
+
+// Implementation of rolling logs from log.Info*
+// To keep them from being removed from screen during pb/spinners refresh, it will be just a 10 spinners
+
+type LogBox struct {
+	writerFabric        *WriterFabric
+	SpinnerPrinterArray [11]*pterm.SpinnerPrinter
+	writerArray         [11]io.Writer
+	logChan             chan string
+	stopChan            chan struct{}
+	mu                  sync.Mutex
+	lastFilledString    int
+	started             bool
+	status              string
+}
+
+func newLogBox(writerFabric *WriterFabric, logChan chan string) *LogBox {
+	spinnerArray := [11]*pterm.SpinnerPrinter{}
+	writerArray := [11]io.Writer{}
+	spinnerStyle := pterm.NewStyle(pterm.FgDarkGray)
+	for i := range 11 {
+		style := spinnerStyle
+		if i == 0 {
+			style = pterm.NewStyle(pterm.FgLightYellow)
+		}
+		writer := writerFabric.GetWriter()
+		staticSpinner := pterm.DefaultSpinner.
+			WithSequence(" ").
+			WithDelay(time.Hour).
+			WithWriter(writer).
+			WithMessageStyle(style).
+			WithRemoveWhenDone(true).
+			WithShowTimer(false)
+		spinnerArray[i] = staticSpinner
+		writerArray[i] = writer
+	}
+
+	stopCh := make(chan struct{})
+
+	return &LogBox{
+		writerFabric:        writerFabric,
+		SpinnerPrinterArray: spinnerArray,
+		logChan:             logChan,
+		stopChan:            stopCh,
+		writerArray:         writerArray,
+		lastFilledString:    0,
+	}
+}
+
+func (b *LogBox) Start() error {
+	for i := range 11 {
+		msg := ""
+		if i == 0 {
+			msg = b.status
+		}
+		_, err := b.SpinnerPrinterArray[i].Start(msg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (b *LogBox) Stop() error {
+	if b.started {
+		b.stopChan <- struct{}{}
+		for i := range 11 {
+			err := b.SpinnerPrinterArray[i].Stop()
+			if err != nil {
+				return err
+			}
+			b.writerFabric.PutWriter(b.writerArray[i])
+		}
+	}
+
+	return nil
+}
+
+func (b *LogBox) putMsg(msg string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.lastFilledString != 10 {
+		b.SpinnerPrinterArray[b.lastFilledString+1].UpdateText(msg)
+		b.lastFilledString++
+	} else {
+		for i := range 9 {
+			b.SpinnerPrinterArray[i+1].UpdateText(b.SpinnerPrinterArray[i+2].Text)
+		}
+		b.SpinnerPrinterArray[10].UpdateText(msg)
+	}
+}
+
+func (b *LogBox) Update() {
+	b.started = true
+	for {
+		select {
+		case <-b.stopChan:
+			b.started = false
+			return
+		case msg, ok := <-b.logChan:
+			if !ok {
+				continue
+			}
+
+			new := strings.TrimSuffix(msg, "\n")
+			splitted := strings.Split(new, "\n")
+			for _, s := range splitted {
+				s = "    " + s
+				b.putMsg(s)
+			}
+		}
+	}
+}
+
+// set the text of first string to given one
+func (b *LogBox) WithStatusString(s string) *LogBox {
+	if b == nil {
+		return nil
+	}
+
+	b.status = s
+
+	if len(b.SpinnerPrinterArray) == 0 {
+		return b
+	}
+
+	b.SpinnerPrinterArray[0].UpdateText(s)
+
+	return b
+}
+
+func (b *LogBox) getStatusString() string {
+	if b == nil {
+		return ""
+	}
+
+	return b.status
+}
+
+func (b *LogBox) ShiftDown() io.Writer {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	wr := b.writerArray[0]
+	wrArr := append(b.writerArray[1:], b.writerFabric.GetWriter())
+
+	for i := range 11 {
+		b.SpinnerPrinterArray[i].SetWriter(wrArr[i])
+		b.writerArray[i] = wrArr[i]
+	}
+
+	return wr
+}
+
+func (b *LogBox) ShiftUp(w io.Writer) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	wr := b.writerArray[0]
+	copy(b.writerArray[1:], b.writerArray[0:10])
+	b.writerArray[0] = w
+
+	for i := range 11 {
+		b.SpinnerPrinterArray[i].SetWriter(b.writerArray[i])
+	}
+
+	b.writerFabric.PutWriter(wr)
+}
+
+type WriterFabric struct {
+	mp     *pterm.MultiPrinter
+	witers []io.Writer
+}
+
+func newWriterFabric(mp *pterm.MultiPrinter) WriterFabric {
+	return WriterFabric{
+		mp:     mp,
+		witers: make([]io.Writer, 0),
+	}
+}
+
+func (w *WriterFabric) GetWriter() io.Writer {
+	if len(w.witers) != 0 {
+		writer := w.witers[0]
+		w.witers = w.witers[1:]
+
+		return writer
+	}
+
+	return w.mp.NewWriter()
+}
+
+func (w *WriterFabric) PutWriter(writer io.Writer) {
+	w.witers = append(w.witers, writer)
+}
+
+func (w *WriterFabric) Cleanup() {
+	if w == nil {
+		return
+	}
+
+	if len(w.witers) > 0 {
+		for range w.witers {
+			fmt.Print("\033[1F\033[2K")
+		}
+	}
+}

--- a/dhctl/pkg/util/progressbar/logbox.go
+++ b/dhctl/pkg/util/progressbar/logbox.go
@@ -126,7 +126,8 @@ func (b *LogBox) Update() {
 			return
 		case msg, ok := <-b.logChan:
 			if !ok {
-				continue
+				b.started = false
+				return
 			}
 
 			new := strings.TrimSuffix(msg, "\n")
@@ -195,21 +196,21 @@ func (b *LogBox) ShiftUp(w io.Writer) {
 }
 
 type WriterFabric struct {
-	mp     *pterm.MultiPrinter
-	witers []io.Writer
+	mp      *pterm.MultiPrinter
+	writers []io.Writer
 }
 
 func newWriterFabric(mp *pterm.MultiPrinter) WriterFabric {
 	return WriterFabric{
-		mp:     mp,
-		witers: make([]io.Writer, 0),
+		mp:      mp,
+		writers: make([]io.Writer, 0),
 	}
 }
 
 func (w *WriterFabric) GetWriter() io.Writer {
-	if len(w.witers) != 0 {
-		writer := w.witers[0]
-		w.witers = w.witers[1:]
+	if len(w.writers) != 0 {
+		writer := w.writers[0]
+		w.writers = w.writers[1:]
 
 		return writer
 	}
@@ -218,7 +219,7 @@ func (w *WriterFabric) GetWriter() io.Writer {
 }
 
 func (w *WriterFabric) PutWriter(writer io.Writer) {
-	w.witers = append(w.witers, writer)
+	w.writers = append(w.writers, writer)
 }
 
 func (w *WriterFabric) Cleanup() {
@@ -226,8 +227,8 @@ func (w *WriterFabric) Cleanup() {
 		return
 	}
 
-	if len(w.witers) > 0 {
-		for range w.witers {
+	if len(w.writers) > 0 {
+		for range w.writers {
 			fmt.Print("\033[1F\033[2K")
 		}
 	}

--- a/dhctl/pkg/util/progressbar/progressbar.go
+++ b/dhctl/pkg/util/progressbar/progressbar.go
@@ -36,14 +36,16 @@ type PbParam struct {
 	size       int
 	labelChan  chan string
 	phasesChan chan phases.Progress
+	logChan    chan string
 }
 
-func NewPbParams(size int, startMsg string, labelChan chan string, phasesChan chan phases.Progress) *PbParam {
+func NewPbParams(size int, startMsg string, labelChan chan string, phasesChan chan phases.Progress, logChan chan string) *PbParam {
 	return &PbParam{
 		size:       size,
 		startMsg:   startMsg,
 		labelChan:  labelChan,
 		phasesChan: phasesChan,
+		logChan:    logChan,
 	}
 }
 
@@ -52,6 +54,8 @@ type Pb struct {
 	MultiPrinter       *pterm.MultiPrinter
 	SpinnerPrinter     *pterm.SpinnerPrinter
 	StopCh             chan struct{}
+	LogBox             *LogBox
+	WriterFabric       *WriterFabric
 }
 
 func InitProgressBarWithDeferredFunc(name string, logger log.Logger) (func(), chan phases.Progress, error) {
@@ -61,8 +65,9 @@ func InitProgressBarWithDeferredFunc(name string, logger log.Logger) (func(), ch
 	}
 	labelChan := intLogger.GetPhaseChan()
 	phasesChan := make(chan phases.Progress, 5)
+	logChan := intLogger.GetLogChan()
 
-	pbParam := NewPbParams(100, name, labelChan, phasesChan)
+	pbParam := NewPbParams(100, name, labelChan, phasesChan, logChan)
 
 	if err := InitProgressBar(pbParam); err != nil {
 		return nil, phasesChan, err
@@ -77,19 +82,28 @@ func InitProgressBarWithDeferredFunc(name string, logger log.Logger) (func(), ch
 
 func InitProgressBar(param *PbParam) error {
 	multi := pterm.DefaultMultiPrinter
+	writerFabric := newWriterFabric(&multi)
 	if param.size == 0 {
 		param.size = 100
 	}
+
+	width := pterm.GetTerminalWidth()
+	effectiveWidth := width - 10
+	if width < 160 {
+		effectiveWidth = 120
+	}
 	p := pterm.DefaultProgressbar.
 		WithTotal(param.size).
-		WithMaxWidth(120).
-		WithWriter(multi.NewWriter()).
+		WithMaxWidth(effectiveWidth).
+		WithWriter(writerFabric.GetWriter()).
 		WithTitle(param.startMsg)
 
 	staticSpinner := pterm.DefaultSpinner.
 		WithSequence(" ").
 		WithDelay(time.Hour).
-		WithWriter(multi.NewWriter())
+		WithWriter(writerFabric.GetWriter())
+
+	logBox := newLogBox(&writerFabric, param.logChan)
 
 	_, startErr := multi.Start()
 	if startErr != nil {
@@ -106,6 +120,11 @@ func InitProgressBar(param *PbParam) error {
 		return err
 	}
 
+	err = logBox.Start()
+	if err != nil {
+		return err
+	}
+
 	stopChan := make(chan struct{}, 2)
 
 	defaultpb = &Pb{
@@ -113,11 +132,14 @@ func InitProgressBar(param *PbParam) error {
 		MultiPrinter:       &multi,
 		SpinnerPrinter:     staticSpinner,
 		StopCh:             stopChan,
+		LogBox:             logBox,
+		WriterFabric:       &writerFabric,
 	}
 
-	log.WithProgressBar()
+	log.WithProgressBar(true)
 
-	go updateProgress(p, param.labelChan, param.phasesChan, stopChan, staticSpinner, &multi)
+	go updateProgress(p, param.labelChan, param.phasesChan, stopChan, staticSpinner, &writerFabric)
+	go logBox.Update()
 
 	return nil
 }
@@ -128,7 +150,7 @@ func updateProgress(
 	successChan chan phases.Progress,
 	stopChan chan struct{},
 	spinner *pterm.SpinnerPrinter,
-	mp *pterm.MultiPrinter,
+	writerFabric *WriterFabric,
 ) {
 	if p == nil {
 		return
@@ -176,7 +198,12 @@ func updateProgress(
 					continue
 				}
 
-				pterm.Success.WithWriter(mp.NewWriter()).Println(completed)
+				status := defaultpb.LogBox.getStatusString()
+				if err := defaultpb.LogBox.Stop(); err != nil {
+					return
+				}
+
+				pterm.Success.WithWriter(writerFabric.GetWriter()).Println(completed)
 				increment := int(math.Round(msg.Progress*100) - float64(p.Current))
 
 				if increment == 0 {
@@ -190,6 +217,13 @@ func updateProgress(
 				p.Add(increment)
 				lastCompleted = completed
 				p.UpdateTitle(phaseToString(msg, false))
+
+				logBox := newLogBox(writerFabric, defaultpb.LogBox.logChan).WithStatusString(status)
+				if err := logBox.Start(); err != nil {
+					return
+				}
+				defaultpb.LogBox = logBox
+				go logBox.Update()
 			}
 		}
 	}
@@ -197,18 +231,18 @@ func updateProgress(
 
 // if Progressbar used, this func allows to print to new MultiPrinter Writer
 func InfoF(format string, a ...any) {
-	writer := defaultpb.MultiPrinter.NewWriter()
+	writer := defaultpb.LogBox.ShiftDown()
 	pterm.Info.WithWriter(writer).Printf(format, a...)
 }
 
 func WarnF(format string, a ...any) {
-	writer := defaultpb.MultiPrinter.NewWriter()
+	writer := defaultpb.LogBox.ShiftDown()
 	pterm.Warning.WithWriter(writer).Printf(format, a...)
 }
 
 func ErrorF(format string, a ...any) {
 	if defaultpb != nil {
-		writer := defaultpb.MultiPrinter.NewWriter()
+		writer := defaultpb.WriterFabric.GetWriter()
 		pterm.Error.WithWriter(writer).Printf(format, a...)
 	} else {
 		pterm.Error.Printf(format, a...)
@@ -333,6 +367,10 @@ func FinishDefaultProgressBar() {
 	// stopping the updateProgress goroutine
 	pb.StopCh <- struct{}{}
 	time.Sleep(50 * time.Millisecond)
+
+	if err := pb.LogBox.Stop(); err != nil {
+		log.WarnF("failed to stop log box: %s\n", err.Error())
+	}
 
 	pb.ProgressBarPrinter.Add(100 - pb.ProgressBarPrinter.Current)
 	if _, err := pb.MultiPrinter.Stop(); err != nil {


### PR DESCRIPTION
## Description

Add the area in interactive mode, which shows the logs of ongoing processes

## Why do we need it, and what problem does it solve?

Some processes are taking too long, e.g. `terraform apply` sometimes takes like 10m, and we should keep end user informed, what it's not just a lag, and process keep doing it's work.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: Added a log area to the interactive mode of dhctl.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
