### PR TITLE
[deckhouse] fix application update summary reporting Ready while manifests still applying

### DIFF
--- a/deckhouse-controller/pkg/controller/packages/application/status/summary.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary.go
@@ -207,6 +207,17 @@ var summarySuspended = advice{
 // there is no message or tip.
 var summaryReady = advice{state: stateReady}
 
+// summaryUpdating is the fixed Summary for an update that is mid-flight with no
+// failing gate: the new version's manifests are still being applied
+// (ManifestsApplied=False/ApplyingManifests), so the previous version is the
+// one serving. It is the positive-progress counterpart to summaryReady — see
+// the update branch of summarize for why "no blocker" alone cannot mean Ready.
+var summaryUpdating = advice{
+	state:   stateUpdating,
+	message: "Update in progress: the new version is being applied; the previous version is still serving",
+	tip:     "The previous version continues to serve while the new version is applied. No action is required unless this state persists.",
+}
+
 // summarize computes the user-facing Summary (state, message, tip) from the
 // same condmap.State the mappers consume. It is a pure function — no I/O.
 //
@@ -238,7 +249,19 @@ func summarize(state condmap.State) (string, string, string) {
 	case phaseUpdate:
 		blocker, ok := pipelineBlocker(state, updatePipeline)
 		if !ok {
-			return summaryReady.state, summaryReady.message, summaryReady.tip // update done
+			// "No blocker" is not the same as "update finished". firstFalse skips a
+			// transient ManifestsApplied=False/ApplyingManifests exactly as the
+			// mapper does, so the update pipeline reads clear during every re-apply
+			// window. But mapUpdateInstalled only flips UpdateInstalled (and mapReady
+			// only flips Ready) to True once ManifestsApplied is actually True; until
+			// then it returns empty and leaves the previous — possibly failed —
+			// conditions sticky. Mirror that success gate here, otherwise a mid-apply
+			// retry over a failed update would report Ready while the conditions a
+			// client also reads still say ManifestsApplyFailed.
+			if state.IntEqual(intManifestsApplied, metav1.ConditionTrue) {
+				return summaryReady.state, summaryReady.message, summaryReady.tip // update done
+			}
+			return summaryUpdating.state, summaryUpdating.message, summaryUpdating.tip
 		}
 		return adviseFor(phaseUpdate, reasonOf(state, blocker))
 

--- a/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
+++ b/deckhouse-controller/pkg/controller/packages/application/status/summary_test.go
@@ -443,6 +443,26 @@ func TestSummarize_EdgeCases(t *testing.T) {
 		assert.Empty(t, tip)
 	})
 
+	t.Run("update mid-apply is updating, not ready, even over a sticky failure", func(t *testing.T) {
+		// Regression: a working version is installed, then switched to a broken
+		// one. The new version's manifests fail, so the mapper records
+		// UpdateInstalled/Ready=False/ManifestsApplyFailed (sticky). On the next
+		// reconcile attempt nelm re-enters the apply window and emits
+		// ManifestsApplied=False/ApplyingManifests, which firstFalse skips as
+		// transient progress — so the update pipeline reads clear and the mapper
+		// leaves the sticky failure untouched (Scaled=False keeps mapReady from
+		// re-asserting True). summarize sees the same state and must NOT jump to
+		// Ready: an update with manifests not yet applied is still updating, never
+		// ready. Before the fix this returned stateReady, contradicting the
+		// conditions a client also reads.
+		opts := updatingApp(
+			intCond(intManifestsApplied, metav1.ConditionFalse, string(intstatus.ConditionReasonApplyingManifests)),
+			intCond(intScaled, metav1.ConditionFalse, "Reconciling"),
+		)
+		state, _, _ := summaryFor(opts...)
+		assert.Equal(t, stateUpdating, state)
+	})
+
 	t.Run("unknown reconcile reason falls back to generic phrasing", func(t *testing.T) {
 		// The health monitor is the only writer that can produce an arbitrary
 		// reason (it passes through), so it exercises the defensive fallback.


### PR DESCRIPTION
## Description

In the update phase `summarize` returned `Ready` whenever the update pipeline had no
failing gate. But "no blocker" ≠ "update finished": `firstFalse` skips a transient
`ManifestsApplied=False/ApplyingManifests`, so the pipeline reads clear during every
re-apply window while the previous — possibly failed — conditions stay sticky.

Now `summarize` returns `Ready` only when `ManifestsApplied=True`, and otherwise
reports a new `Updating` summary (the new version is still being applied; the
previous version keeps serving).

## Why do we need it, and what problem does it solve?

Without the gate, a mid-apply retry over a failed update reported `Ready` while the
conditions a client also reads still said `ManifestsApplyFailed` — a self-contradicting
status. An update whose manifests are not yet applied is now reported as `Updating`,
never `Ready`.


## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse-controller
type: fix
summary: Application update summary no longer reports Ready while the new version's manifests are still being applied.
impact_level: low
```
