### PR TITLE
[deckhouse] persist default scanInterval on PackageRepository when unset

### DIFF
--- a/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/controller.go
@@ -142,10 +142,17 @@ func (r *reconciler) handleCreateOrUpdate(ctx context.Context, repo *v1alpha1.Pa
 		}
 	}
 
-	scanInterval := defaultScanInterval
-	if interval := repo.Spec.ScanInterval; interval != nil {
-		scanInterval = max(interval.Duration, minScanInterval)
+	// Persist the default scan interval into the spec when it was not set at creation,
+	// so the effective interval is always visible on the resource.
+	if repo.Spec.ScanInterval == nil {
+		original := repo.DeepCopy()
+		repo.Spec.ScanInterval = &metav1.Duration{Duration: defaultScanInterval}
+		if err := r.client.Patch(ctx, repo, client.MergeFrom(original)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("set default scan interval: %w", err)
+		}
 	}
+
+	scanInterval := max(repo.Spec.ScanInterval.Duration, minScanInterval)
 
 	// Check if there are any existing PackageRepositoryOperations for this repository
 	operations := new(v1alpha1.PackageRepositoryOperationList)

--- a/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/active-operation.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/active-operation.yaml
@@ -8,13 +8,14 @@ metadata:
   finalizers:
   - packages.deckhouse.io/package-version-exists
   name: deckhouse
-  resourceVersion: "3"
+  resourceVersion: "4"
 spec:
   registry:
     ca: test-ca
     dockerCfg: test-docker-cfg
     repo: registry.example.com/test
     scheme: https
+  scanInterval: 6h0m0s
 status:
   lastNewVersions: 0
   partialScanAvailable: false

--- a/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/successful-reconcile.yaml
+++ b/deckhouse-controller/pkg/controller/packages/package-repository/testdata/golden/successful-reconcile.yaml
@@ -8,13 +8,14 @@ metadata:
   finalizers:
   - packages.deckhouse.io/package-version-exists
   name: deckhouse
-  resourceVersion: "3"
+  resourceVersion: "4"
 spec:
   registry:
     ca: test-ca
     dockerCfg: test-docker-cfg
     repo: registry.example.com/test
     scheme: https
+  scanInterval: 6h0m0s
 status:
   lastNewVersions: 0
   partialScanAvailable: false


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
The PackageRepository controller writes the default scanInterval (6h) into spec.scanInterval on first reconcile when it was not set at creation. No effect on critical cluster components.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Previously spec.scanInterval stayed empty when omitted, so the effective interval was not visible on the resource. Now the default is always persisted.
```
spec:
  scanInterval: 6h0m0s
```
## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: feature
summary: Persist default scanInterval on PackageRepository.
impact_level: low
```