### PR TITLE
[cilium-hubble] fix cve-2026-41520

### DIFF
--- a/modules/500-cilium-hubble/images/ui/known_vulnerabilities.vex
+++ b/modules/500-cilium-hubble/images/ui/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-c98e1c56ffe0fe4145a5cd040f16f368f68a1952ec43fed27c57faa9ddb6d2a0",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 1,
+  "version": 2,
   "statements": [
     {
       "vulnerability": {
@@ -17,7 +17,22 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CVE-2026-33726 не эксплуатируема в Deckhouse, поскольку функция Per-Endpoint Routing не используется и не может быть включена пользователем самостоятельно, а именно её активация является обязательным условием для реализации данной уязвимости.",
       "timestamp": "2026-04-02T11:59:01.94567Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41520"
+      },
+      "products": [
+        {
+          "@id": "pkg:golang/github.com/cilium/cilium@v1.17.3"
+        }
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость CVE-2026-41520 относится к утилите cilium-bugtool, которая собирает диагностический архив Cilium; в текущей ветке этот код исправлен downstream-патчем modules/021-cni-cilium/images/bin-cilium/patches/014-bugtool-remove-sensitive-files.patch. Бинарь hubble-ui-backend не содержит и не запускает cilium-bugtool, не создаёт bugtool/sysdump-архивы и не читает локальный state directory Cilium с WireGuard private key файлами.",
+      "timestamp": "2026-06-02T07:44:00Z"
     }
   ],
-  "timestamp": "2026-04-02T11:59:01Z"
+  "timestamp": "2026-04-02T11:59:01Z",
+  "last_updated": "2026-06-02T07:44:00Z"
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add a VEX statement for cilium-hubble/ui-backend to mark https://github.com/advisories/GHSA-gj49-89wh-h4gj as not_affected.

The real fix for this CVE is delivered in a separate cni-cilium backport PR: it applies the upstream Cilium fix to cilium-bugtool, removing *.key files from the collected Cilium state directory before the debug archive is created.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Trivy reports https://github.com/advisories/GHSA-gj49-89wh-h4gj for cilium-hubble/ui-backend because the binary includes the github.com/cilium/cilium Go module.

However, https://github.com/advisories/GHSA-gj49-89wh-h4gj is specific to cilium-bugtool / cilium sysdump archive generation. hubble-ui-backend does not contain or execute cilium-bugtool, does not create bugtool/sysdump archives, and does not read the local Cilium state directory with WireGuard private key files.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

The vulnerability is present in all supported releases up to 1.73.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cilium-hubble
type: fix
summary: Fixed CVE-2026-41520 in hubble-ui-backend
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
