### PR TITLE
[terraform-manager][dhctl] Fix terraform-exporter and terraform-auto-converger pods CrashLoopBackoff

### DIFF
--- a/.werf/defines/candi.tmpl
+++ b/.werf/defines/candi.tmpl
@@ -14,6 +14,7 @@
   includePaths:
   - modules/*/openapi/config-values.yaml
   - global-hooks/openapi/config-values.yaml
+  - candi/terraform_versions.yml
   after: setup
 - image: version-map-artifact
   add: /version_map_{{ $context.Env }}.yml

--- a/dhctl/cmd/dhctl/commands/converge.go
+++ b/dhctl/cmd/dhctl/commands/converge.go
@@ -140,6 +140,14 @@ func DefineAutoConvergeCommand(cmd *kingpin.CmdClause, opts *options.Options) *k
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)
 
+		// in general path we check that /deckhouse/modules, /deckhouse/global-hooks,
+		// /deckhouse/candi/version_map.yml is present and if not download all deps from registry
+		// but in exporter and autoconverger we do not need it
+		// and we reset it here
+		// unfortianally global params parsed in place when we do no have command
+		// that user ran
+		opts.Global = opts.Global.RecheckNeedDownload(options.ConvergerPodsSpiCheckPaths...)
+
 		span := telemetry.SpanFromContext(ctx)
 		span.SetAttributes(opts.ToSpanAttributes()...)
 
@@ -202,6 +210,15 @@ func DefineConvergeMigrationCommand(cmd *kingpin.CmdClause, opts *options.Option
 		span.SetAttributes(opts.ToSpanAttributes()...)
 
 		logger := log.GetDefaultLogger()
+
+		// in general path we check that /deckhouse/modules, /deckhouse/global-hooks,
+		// /deckhouse/candi/version_map.yml is present and if not download all deps from registry
+		// but in exporter and autoconverger we do not need it
+		// and we reset it here
+		// unfortianally global params parsed in place when we do no have command
+		// that user ran
+		// converge migration also can run as sidecar of auto-converger pod
+		opts.Global = opts.Global.RecheckNeedDownload(options.ConvergerPodsSpiCheckPaths...)
 
 		loggerProvider := log.ExternalLoggerProvider(logger)
 		params := app.ProviderParams(&opts.Global, loggerProvider)

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -44,7 +44,7 @@ func DefineInfrastructureConvergeExporterCommand(cmd *kingpin.CmdClause, opts *o
 		ctx := kpcontext.ExtractContext(c)
 
 		// in general path we check that /deckhouse/modules, /deckhouse/global-hooks,
-		// /deckhouse/candi/version_map.yml is present and if not download all deps from registry 
+		// /deckhouse/candi/version_map.yml is present and if not download all deps from registry
 		// but in exporter and autoconverger we do not need it
 		// and we reset it here
 		// unfortianally global params parsed in place when we do no have command
@@ -80,11 +80,11 @@ func DefineInfrastructureConvergeExporterCommand(cmd *kingpin.CmdClause, opts *o
 		kubeCl := &client.KubernetesClient{KubeClient: kube}
 
 		exporter := operations.NewConvergeExporter(operations.ExporterParams{
-			Address:  opts.Converge.ListenAddress,
-			Path:     opts.Converge.MetricsPath,
-			Interval: opts.Converge.CheckInterval,
-			Logger:   logger,
-			KubeCl:   kubeCl,
+			Address:       opts.Converge.ListenAddress,
+			Path:          opts.Converge.MetricsPath,
+			Interval:      opts.Converge.CheckInterval,
+			Logger:        logger,
+			KubeCl:        kubeCl,
 			GlobalOptions: &opts.Global,
 		})
 

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -43,6 +43,14 @@ func DefineInfrastructureConvergeExporterCommand(cmd *kingpin.CmdClause, opts *o
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)
 
+		// in general path we check that /deckhouse/modules, /deckhouse/global-hooks,
+		// /deckhouse/candi/version_map.yml is present and if not download all deps from registry 
+		// but in exporter and autoconverger we do not need it
+		// and we reset it here
+		// unfortianally global params parsed in place when we do no have command
+		// that user ran
+		opts.Global = opts.Global.RecheckNeedDownload(options.ConvergerPodsSpiCheckPaths...)
+
 		logger := log.GetDefaultLogger()
 		params, err := app.DefaultProviderParams(&opts.Global)
 		if err != nil {
@@ -75,10 +83,9 @@ func DefineInfrastructureConvergeExporterCommand(cmd *kingpin.CmdClause, opts *o
 			Address:  opts.Converge.ListenAddress,
 			Path:     opts.Converge.MetricsPath,
 			Interval: opts.Converge.CheckInterval,
-			TmpDir:   opts.Global.TmpDir,
 			Logger:   logger,
-			IsDebug:  opts.Global.IsDebug,
 			KubeCl:   kubeCl,
+			GlobalOptions: &opts.Global,
 		})
 
 		exporter.Start(ctx)

--- a/dhctl/pkg/app/options/global.go
+++ b/dhctl/pkg/app/options/global.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	otattribute "go.opentelemetry.io/otel/attribute"
@@ -31,6 +32,12 @@ const (
 	DefaultVersionMap             = DefaultCandiDir + "/version_map.yml"
 	DefaultModulesDir             = DefaultDeckhouseDir + "/modules"
 )
+
+var ConvergerPodsSpiCheckPaths = []string{
+	DefaultModulesDir,
+	DefaultGlobalHooksModule,
+	DefaultVersionMap,
+}
 
 // GlobalOptions holds settings shared by every dhctl command.
 type GlobalOptions struct {
@@ -71,6 +78,21 @@ func (o GlobalOptions) ToSpanAttributes() []otattribute.KeyValue {
 		otattribute.String("global.downloadCacheDir", o.DownloadCacheDir),
 		otattribute.StringSlice("global.configPaths", o.ConfigPaths),
 	}
+}
+
+func (o GlobalOptions) RecheckNeedDownload(skip ...string) GlobalOptions {
+	if len(skip) == 0 || !o.NeedDownload || !CheckDirs(skip...) {
+		return o
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		root = "/"
+	}
+	cpy := o
+	cpy.NeedDownload = false
+	SetPaths(root, &cpy)
+	return cpy
 }
 
 // NewGlobalOptions returns GlobalOptions with defaults applied.
@@ -157,67 +179,70 @@ func readBuildFile(dst *string, filePath string) {
 	}
 }
 
-func CheckDirs() bool {
+func CheckDirs(skip ...string) bool {
 	// old global dirs to check
 	pwd, err := os.Getwd()
 	if err != nil {
 		return false
 	}
-	deckhouseDir := pwd + DefaultDeckhouseDir
-	candiDir := pwd + DefaultCandiDir
-	infrastructureVersions := pwd + DefaultInfrastructureVersions
-	globalHooksModule := pwd + DefaultGlobalHooksModule
-	versionMap := pwd + DefaultVersionMap
-	modulesDir := pwd + DefaultModulesDir
 
-	absDh, err := os.Stat("/deckhouse")
-	if err != nil {
-		return false
-	}
-	if !absDh.IsDir() {
-		return false
+	type pathToIsDir struct {
+		path  string
+		isDir bool
 	}
 
-	dh, err := os.Stat(deckhouseDir)
-	if err != nil {
-		return false
-	}
-	if !dh.IsDir() {
-		return false
-	}
-
-	candi, err := os.Stat(candiDir)
-	if err != nil {
-		return false
-	}
-	if !candi.IsDir() {
-		return false
-	}
-
-	_, err = os.Stat(infrastructureVersions)
-	if err != nil {
-		return false
-	}
-
-	globalHooks, err := os.Stat(globalHooksModule)
-	if err != nil {
-		return false
-	}
-	if !globalHooks.IsDir() {
-		return false
-	}
-
-	modules, err := os.Stat(modulesDir)
-	if err != nil {
-		return false
-	}
-	if !modules.IsDir() {
-		return false
+	// default path -> should dir
+	forCheckDefaults := []pathToIsDir{
+		{
+			path:  DefaultDeckhouseDir,
+			isDir: true,
+		},
+		{
+			path:  DefaultCandiDir,
+			isDir: true,
+		},
+		{
+			path:  DefaultInfrastructureVersions,
+			isDir: false,
+		},
+		{
+			path:  DefaultGlobalHooksModule,
+			isDir: true,
+		},
+		{
+			path:  DefaultVersionMap,
+			isDir: false,
+		},
+		{
+			path:  DefaultModulesDir,
+			isDir: true,
+		},
 	}
 
-	_, err = os.Stat(versionMap)
+	forCheck := make([]pathToIsDir, 0, len(forCheckDefaults))
 
-	return err == nil
+	for _, d := range forCheckDefaults {
+		if !slices.Contains(skip, d.path) {
+			withPwd := filepath.Join(pwd, d.path)
+			forCheck = append(forCheck, pathToIsDir{
+				path:  withPwd,
+				isDir: d.isDir,
+			})
+		}
+	}
+
+	for _, fd := range forCheck {
+		fileInfo, err := os.Stat(fd.path)
+		if err != nil {
+			return false
+		}
+
+		if fd.isDir && !fileInfo.IsDir() {
+			return false
+		}
+	}
+
+	return true
 }
 
 func SetPaths(root string, o *GlobalOptions) {
@@ -229,8 +254,8 @@ func SetPaths(root string, o *GlobalOptions) {
 	if err != nil {
 		dhctlPath = "/"
 	}
-	o.CandiDir = filepath.Join(root, "deckhouse", "candi")
 	o.DeckhouseDir = filepath.Join(root, "deckhouse")
+	o.CandiDir = filepath.Join(o.DeckhouseDir, "candi")
 	o.DhctlPath = dhctlPath
 	o.InfrastructureVersions = filepath.Join(o.CandiDir, "terraform_versions.yml")
 	o.GlobalHooksModule = filepath.Join(o.DeckhouseDir, "global-hooks")

--- a/dhctl/pkg/infrastructureprovider/cloud_provider.go
+++ b/dhctl/pkg/infrastructureprovider/cloud_provider.go
@@ -84,7 +84,7 @@ func CloudProviderGetter(params CloudProviderGetterParams) infrastructure.CloudP
 			}
 
 			additionalParams := params.getAdditionalParams()
-			diParams, err := params.gtFSDIParams()
+			diParams, err := params.getFSDIParams()
 			if err != nil {
 				return nil, err
 			}

--- a/dhctl/pkg/infrastructureprovider/provider_getter_params.go
+++ b/dhctl/pkg/infrastructureprovider/provider_getter_params.go
@@ -65,7 +65,7 @@ func (p *CloudProviderGetterParams) getProvidersCache() (CloudProvidersCache, er
 	return providersCache, nil
 }
 
-func (p *CloudProviderGetterParams) gtFSDIParams() (*fsprovider.DIParams, error) {
+func (p *CloudProviderGetterParams) getFSDIParams() (*fsprovider.DIParams, error) {
 	logger, err := p.getLogger()
 	if err != nil {
 		return nil, err

--- a/dhctl/pkg/operations/check/checker.go
+++ b/dhctl/pkg/operations/check/checker.go
@@ -225,7 +225,7 @@ func (c *Checker) checkConfiguration(ctx context.Context, kubeCl *client.Kuberne
 		return "", fmt.Errorf("Unable to get static/provider cluster config: %w", err)
 	}
 
-	inClusterMetaConfig, err := entity.GetMetaConfig(ctx, kubeCl, c.logger, nil)
+	inClusterMetaConfig, err := entity.GetMetaConfig(ctx, kubeCl, c.logger, &c.Options.Global)
 	if err != nil {
 		return "", fmt.Errorf("Unable to get in-cluster meta config: %w", err)
 	}

--- a/dhctl/pkg/operations/check/checker_test.go
+++ b/dhctl/pkg/operations/check/checker_test.go
@@ -595,6 +595,10 @@ func createTestCheckClusterConfig(t *testing.T, p testCheckClusterConfigParams) 
 	commanderUUID, err := uuid.NewUUID()
 	require.NoError(t, err, p.testName)
 
+	opts := options.New()
+	opts.Global.NeedDownload = false
+	options.SetPaths("/", &opts.Global)
+
 	return &testCheckClusterConfig{
 		testCheckClusterConfigBase: p.testCheckClusterConfigBase,
 		commanderMetaConfig:        commanderMetaConfig,
@@ -606,7 +610,7 @@ func createTestCheckClusterConfig(t *testing.T, p testCheckClusterConfigParams) 
 			CommanderMode: true,
 			IsDebug:       false,
 			CommanderUUID: commanderUUID,
-			Options: options.New(),
+			Options: opts,
 		}),
 	}
 }

--- a/dhctl/pkg/operations/check/checker_test.go
+++ b/dhctl/pkg/operations/check/checker_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/config"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/global"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
@@ -605,6 +606,7 @@ func createTestCheckClusterConfig(t *testing.T, p testCheckClusterConfigParams) 
 			CommanderMode: true,
 			IsDebug:       false,
 			CommanderUUID: commanderUUID,
+			Options: options.New(),
 		}),
 	}
 }

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -140,6 +140,7 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 			ChangeParams:           c.Params.ChangesSettings,
 			ProviderGetter:         c.Params.ProviderGetter,
 			Logger:                 c.Logger,
+			Opts:                   &c.Options.Global,
 		}, c.Params.CommanderModeParams)
 	} else {
 		convergeCtx = convergectx.NewContext(ctx, convergectx.Params{
@@ -149,6 +150,7 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 			ChangeParams:           c.Params.ChangesSettings,
 			ProviderGetter:         c.Params.ProviderGetter,
 			Logger:                 c.Logger,
+			Opts:                   &c.Options.Global,
 		})
 	}
 
@@ -440,6 +442,7 @@ func (c *Converger) AutoConverge(ctx context.Context, listenAddress string, chec
 		ChangeParams:           c.Params.ChangesSettings,
 		Logger:                 c.Logger,
 		ProviderGetter:         c.ProviderGetter,
+		Opts:                   &c.Options.Global,
 	})
 
 	metaConfig, err := convergeCtx.MetaConfig()

--- a/dhctl/pkg/operations/exporter.go
+++ b/dhctl/pkg/operations/exporter.go
@@ -99,10 +99,8 @@ type ExporterParams struct {
 	Address       string
 	Path          string
 	Interval      time.Duration
-	TmpDir        string
-	GlogalOptions *options.GlobalOptions
+	GlobalOptions *options.GlobalOptions
 	Logger        log.Logger
-	IsDebug       bool
 
 	// KubeCl is the in-cluster API client. The caller builds it via
 	// providerinitializer.GetProviders / kubeProvider.Client(ctx) just like
@@ -116,7 +114,9 @@ func NewConvergeExporter(params ExporterParams) *ConvergeExporter {
 		logger = log.GetDefaultLogger()
 	}
 
-	infraContext := infrastructure.NewContext(logger).WithDebug(params.IsDebug)
+	isDebug := params.GlobalOptions.IsDebug
+
+	infraContext := infrastructure.NewContext(logger).WithDebug(isDebug)
 	return &ConvergeExporter{
 		MetricsPath:           params.Path,
 		ListenAddress:         params.Address,
@@ -127,10 +127,10 @@ func NewConvergeExporter(params ExporterParams) *ConvergeExporter {
 		OneGaugeMetrics:       make(map[string]prometheus.Gauge),
 		GaugeMetrics:          make(map[string]*prometheus.GaugeVec),
 		CounterMetrics:        make(map[string]*prometheus.CounterVec),
-		tmpDir:                params.TmpDir,
-		globalOptions:         params.GlogalOptions,
+		tmpDir:                params.GlobalOptions.TmpDir,
+		globalOptions:         params.GlobalOptions,
 		logger:                logger,
-		isDebug:               params.IsDebug,
+		isDebug:               isDebug,
 	}
 }
 
@@ -277,7 +277,7 @@ func (c *ConvergeExporter) getStatistic(ctx context.Context, tmpCleaner cache.Tm
 		infrastructureprovider.MetaConfigPreparatorProvider(
 			infrastructureprovider.NewPreparatorProviderParams(c.logger),
 		),
-		nil,
+		c.globalOptions,
 	)
 	if err != nil {
 		log.ErrorLn(err)


### PR DESCRIPTION
## Description
Add candi/terraform_versions.yml file to common/candi image.
Forget in https://github.com/deckhouse/deckhouse/pull/18146/changes

Pass options.Global in places when dhctl operations needs and skipped after debug.
We were checked dirs and files which do not need for converge and terraform check.

Also skip check some dirs to prevents download deps from registry in exporter and auto-converger pods.

## Why do we need it, and what problem does it solve?
terraform exporter and auto-converger pods in CrashLoopBackoff. 
Skip downloading dhctl deps in exporter and auto-converger pods.

## Why do we need it in the patch release (if we do)?

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: terraform-manager
type: fix
summary: Add candi/terraform_versions.yml file to common/candi image.
impact_level: low
---
section: dhctl
type: fix
summary: Fix panics and prevent prevents download deps from registry in exporter and auto-converger pods.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
