### PR TITLE
[user-authn] fix user-api (#20371)

### DIFF
--- a/modules/150-user-authn/images/user-api/src/cmd/main.go
+++ b/modules/150-user-authn/images/user-api/src/cmd/main.go
@@ -37,6 +37,7 @@ import (
 type Config struct {
 	ListenAddress string
 	DexURL        string
+	IssuerURL     string
 	TLSCertFile   string
 	TLSKeyFile    string
 }
@@ -54,7 +55,8 @@ func main() {
 	}
 
 	rootCmd.PersistentFlags().StringVar(&cfg.ListenAddress, "listen", ":8443", "Listen address and port")
-	rootCmd.PersistentFlags().StringVar(&cfg.DexURL, "dex-url", "https://dex.d8-user-authn.svc", "Dex OIDC issuer URL")
+	rootCmd.PersistentFlags().StringVar(&cfg.DexURL, "dex-url", "https://dex.d8-user-authn", "In-cluster Dex address for OIDC discovery (reachable in closed-loop clusters)")
+	rootCmd.PersistentFlags().StringVar(&cfg.IssuerURL, "issuer-url", "", "Public Dex issuer URL advertised in token claims (defaults to --dex-url if empty)")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSCertFile, "tls-cert-file", "", "TLS certificate file path")
 	rootCmd.PersistentFlags().StringVar(&cfg.TLSKeyFile, "tls-key-file", "", "TLS private key file path")
 
@@ -73,12 +75,13 @@ func run(cfg *Config) error {
 	slog.Info("Starting user-api service",
 		"listen", cfg.ListenAddress,
 		"dex_url", cfg.DexURL,
+		"issuer_url", cfg.IssuerURL,
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	oidcVerifier, err := auth.NewOIDCVerifier(ctx, cfg.DexURL)
+	oidcVerifier, err := auth.NewOIDCVerifier(ctx, cfg.DexURL, cfg.IssuerURL)
 	if err != nil {
 		return fmt.Errorf("failed to create OIDC verifier: %w", err)
 	}

--- a/modules/150-user-authn/images/user-api/src/go.mod
+++ b/modules/150-user-authn/images/user-api/src/go.mod
@@ -6,6 +6,7 @@ toolchain go1.25.7
 
 require (
 	github.com/coreos/go-oidc/v3 v3.17.0
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.49.0
@@ -20,7 +21,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/modules/150-user-authn/images/user-api/src/go.sum
+++ b/modules/150-user-authn/images/user-api/src/go.sum
@@ -14,8 +14,8 @@ github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=

--- a/modules/150-user-authn/images/user-api/src/pkg/api/handlers.go
+++ b/modules/150-user-authn/images/user-api/src/pkg/api/handlers.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -58,6 +57,14 @@ type ErrorResponse struct {
 }
 
 const maxRequestBodySize = 1 << 20 // 1 MB
+
+// localDexConnectorID is the connector ID Dex assigns to tokens issued by its
+// built-in local password database (enablePasswordDB: true). Self-service
+// password reset is only meaningful for those users; tokens minted by external
+// connectors (LDAP, OIDC, GitHub, ...) carry a different connector ID and a
+// federated user must never be able to reset a local user's password by
+// presenting a claim that merely matches a local username.
+const localDexConnectorID = "local"
 
 func NewHandler(verifier auth.Verifier, k8sClient k8s.Client, logger *slog.Logger) *Handler {
 	registry := prometheus.NewRegistry()
@@ -121,6 +128,17 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Authoritative origin check: only tokens from Dex's local password DB may
+	// reset a password. This prevents an external/federated user from taking
+	// over a local account by setting a claim that matches a local username.
+	if claims.ConnectorID != localDexConnectorID {
+		h.logger.Warn("Password reset attempted with non-local connector token",
+			"username", claims.Username, "connector_id", claims.ConnectorID, "remote_addr", r.RemoteAddr)
+		h.reqCounter.WithLabelValues("/api/v1/password/reset", "403").Inc()
+		h.writeError(w, http.StatusForbidden, "forbidden", "Password reset is only available for local users")
+		return
+	}
+
 	h.logger.Info("Password reset request", "username", claims.Username, "remote_addr", r.RemoteAddr)
 
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
@@ -169,13 +187,8 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 	operationName, err := h.k8sClient.CreatePasswordResetOperation(ctx, claims.Username, req.NewPasswordHash)
 	if err != nil {
 		h.logger.Error("Failed to create password reset operation", "error", err, "username", claims.Username)
-		if errors.Is(err, k8s.ErrOperationFailed) {
-			h.reqCounter.WithLabelValues("/api/v1/password/reset", "500").Inc()
-			h.writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create password reset operation")
-			return
-		}
 		h.reqCounter.WithLabelValues("/api/v1/password/reset", "500").Inc()
-		h.writeError(w, http.StatusInternalServerError, "internal_error", "Unexpected error")
+		h.writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create password reset operation")
 		return
 	}
 

--- a/modules/150-user-authn/images/user-api/src/pkg/api/handlers_test.go
+++ b/modules/150-user-authn/images/user-api/src/pkg/api/handlers_test.go
@@ -130,13 +130,28 @@ func TestHandler_ResetPassword(t *testing.T) {
 			authHeader: "Bearer validtoken",
 			body:       PasswordResetRequest{NewPasswordHash: validBcryptHash},
 			verifier: &mockVerifier{
-				claims: &auth.Claims{Username: "testuser", Email: "test@example.com"},
+				claims: &auth.Claims{Username: "testuser", Email: "test@example.com", ConnectorID: "local"},
 			},
 			k8sClient: &mockK8sClient{
 				isLocal:       true,
 				operationName: "self-password-reset-abc123",
 			},
 			wantStatus: http.StatusAccepted,
+		},
+		{
+			name:       "non-local connector token is forbidden",
+			authHeader: "Bearer validtoken",
+			body:       PasswordResetRequest{NewPasswordHash: validBcryptHash},
+			verifier: &mockVerifier{
+				// Federated user whose username collides with a local user must
+				// not be able to reset the local user's password.
+				claims: &auth.Claims{Username: "testuser", ConnectorID: "github"},
+			},
+			k8sClient: &mockK8sClient{
+				isLocal: true,
+			},
+			wantStatus:  http.StatusForbidden,
+			wantErrCode: "forbidden",
 		},
 		{
 			name:       "missing auth header",
@@ -161,7 +176,7 @@ func TestHandler_ResetPassword(t *testing.T) {
 			authHeader: "Bearer validtoken",
 			body:       PasswordResetRequest{NewPasswordHash: ""},
 			verifier: &mockVerifier{
-				claims: &auth.Claims{Username: "testuser"},
+				claims: &auth.Claims{Username: "testuser", ConnectorID: "local"},
 			},
 			k8sClient:   &mockK8sClient{},
 			wantStatus:  http.StatusBadRequest,
@@ -172,7 +187,7 @@ func TestHandler_ResetPassword(t *testing.T) {
 			authHeader: "Bearer validtoken",
 			body:       PasswordResetRequest{NewPasswordHash: "plaintext"},
 			verifier: &mockVerifier{
-				claims: &auth.Claims{Username: "testuser"},
+				claims: &auth.Claims{Username: "testuser", ConnectorID: "local"},
 			},
 			k8sClient:   &mockK8sClient{},
 			wantStatus:  http.StatusBadRequest,
@@ -183,7 +198,7 @@ func TestHandler_ResetPassword(t *testing.T) {
 			authHeader: "Bearer validtoken",
 			body:       PasswordResetRequest{NewPasswordHash: "$2y$10$invalidhash"},
 			verifier: &mockVerifier{
-				claims: &auth.Claims{Username: "testuser"},
+				claims: &auth.Claims{Username: "testuser", ConnectorID: "local"},
 			},
 			k8sClient:   &mockK8sClient{},
 			wantStatus:  http.StatusBadRequest,
@@ -194,7 +209,7 @@ func TestHandler_ResetPassword(t *testing.T) {
 			authHeader: "Bearer validtoken",
 			body:       PasswordResetRequest{NewPasswordHash: validBcryptHash},
 			verifier: &mockVerifier{
-				claims: &auth.Claims{Username: "externaluser"},
+				claims: &auth.Claims{Username: "externaluser", ConnectorID: "local"},
 			},
 			k8sClient: &mockK8sClient{
 				isLocal: false,
@@ -207,7 +222,7 @@ func TestHandler_ResetPassword(t *testing.T) {
 			authHeader: "Bearer validtoken",
 			body:       PasswordResetRequest{NewPasswordHash: validBcryptHash},
 			verifier: &mockVerifier{
-				claims: &auth.Claims{Username: "testuser"},
+				claims: &auth.Claims{Username: "testuser", ConnectorID: "local"},
 			},
 			k8sClient: &mockK8sClient{
 				isLocalErr: errors.New("k8s error"),
@@ -219,7 +234,7 @@ func TestHandler_ResetPassword(t *testing.T) {
 			authHeader: "Bearer validtoken",
 			body:       PasswordResetRequest{NewPasswordHash: validBcryptHash},
 			verifier: &mockVerifier{
-				claims: &auth.Claims{Username: "testuser"},
+				claims: &auth.Claims{Username: "testuser", ConnectorID: "local"},
 			},
 			k8sClient: &mockK8sClient{
 				isLocal:   true,

--- a/modules/150-user-authn/images/user-api/src/pkg/auth/oidc.go
+++ b/modules/150-user-authn/images/user-api/src/pkg/auth/oidc.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -40,6 +41,10 @@ type Claims struct {
 	Username string
 	Email    string
 	Groups   []string
+	// ConnectorID is the Dex connector that issued the token
+	// (federated_claims.connector_id). The built-in local password DB uses
+	// "local"; external providers use their own connector IDs.
+	ConnectorID string
 }
 
 type Verifier interface {
@@ -48,22 +53,19 @@ type Verifier interface {
 }
 
 type OIDCVerifier struct {
-	provider *oidc.Provider
 	verifier *oidc.IDTokenVerifier
 }
 
-func NewOIDCVerifier(ctx context.Context, issuerURL string) (*OIDCVerifier, error) {
-	// Skip TLS verification for Dex connection. This follows the same pattern
-	// as dex-authenticator (--ssl-insecure-skip-verify=true).
-	// The public Dex URL goes through Ingress with a certificate that may use
-	// different CAs depending on the HTTPS mode (CertManager, CustomCertificate, etc).
-	// Since this is internal cluster communication and the URL is resolved via DNS,
-	// skipping verification is acceptable and more robust than trying to handle
-	// all possible CA configurations.
+// NewOIDCVerifier creates a verifier for tokens issued by Dex.
+func NewOIDCVerifier(ctx context.Context, connectURL, issuerURL string) (*OIDCVerifier, error) {
+	// Skip TLS verification: this is in-cluster traffic to the Dex Service,
+	// same pattern as dex-authenticator (--ssl-insecure-skip-verify=true).
 	httpClient := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
+			// Never route in-cluster traffic through an egress proxy: a cluster-wide
+			// HTTP(S)_PROXY injected into pods can't reach cluster IPs.
+			Proxy: nil,
 			DialContext: (&net.Dialer{
 				Timeout:   30 * time.Second,
 				KeepAlive: 30 * time.Second,
@@ -77,23 +79,70 @@ func NewOIDCVerifier(ctx context.Context, issuerURL string) (*OIDCVerifier, erro
 	}
 
 	clientCtx := oidc.ClientContext(ctx, httpClient)
-	provider, err := oidc.NewProvider(clientCtx, issuerURL)
+
+	// Tokens carry the public issuer in "iss", so validation pins it. It must
+	// match Dex's configured issuer exactly, including the trailing slash.
+	expectedIssuer := issuerURL
+	if expectedIssuer == "" {
+		expectedIssuer = connectURL
+	}
+
+	// Discovery runs against the in-cluster connectURL; the discovery document
+	// advertises the public issuer, so allow the mismatch.
+	discoveryCtx := clientCtx
+	if expectedIssuer != connectURL {
+		discoveryCtx = oidc.InsecureIssuerURLContext(clientCtx, expectedIssuer)
+	}
+
+	provider, err := oidc.NewProvider(discoveryCtx, connectURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OIDC provider: %w", err)
 	}
 
-	// user-api validates tokens issued by Dex but doesn't have its own
-	// client_id registered in Dex. Tokens are issued to other clients
-	// (e.g., kubeconfig-generator, dex-authenticator) and we only need
-	// to verify the signature and extract user claims.
-	verifier := provider.Verifier(&oidc.Config{
+	// Fetch JWKS from the in-cluster host: the advertised jwks_uri points at the
+	// public URL, which is unreachable in closed-loop clusters.
+	keysURL, err := internalKeysURL(provider, connectURL)
+	if err != nil {
+		return nil, err
+	}
+	keySet := oidc.NewRemoteKeySet(clientCtx, keysURL)
+
+	// SkipClientIDCheck: user-api has no client_id of its own; tokens are issued
+	// to other clients and we only verify signature and extract claims.
+	verifier := oidc.NewVerifier(expectedIssuer, keySet, &oidc.Config{
 		SkipClientIDCheck: true,
 	})
 
 	return &OIDCVerifier{
-		provider: provider,
 		verifier: verifier,
 	}, nil
+}
+
+// internalKeysURL rewrites the advertised jwks_uri scheme/host to the in-cluster
+// connectURL (keeping its path), falling back to Dex's "/keys" path if absent.
+func internalKeysURL(provider *oidc.Provider, connectURL string) (string, error) {
+	conn, err := url.Parse(connectURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid connect URL %q: %w", connectURL, err)
+	}
+
+	fallback := strings.TrimSuffix(connectURL, "/") + "/keys"
+
+	var claims struct {
+		JWKSURL string `json:"jwks_uri"`
+	}
+	if err := provider.Claims(&claims); err != nil || claims.JWKSURL == "" {
+		return fallback, nil
+	}
+
+	jwks, err := url.Parse(claims.JWKSURL)
+	if err != nil {
+		return fallback, nil
+	}
+
+	jwks.Scheme = conn.Scheme
+	jwks.Host = conn.Host
+	return jwks.String(), nil
 }
 
 func (v *OIDCVerifier) ExtractToken(r *http.Request) (string, error) {
@@ -121,6 +170,9 @@ func (v *OIDCVerifier) Verify(ctx context.Context, token string) (*Claims, error
 		Email             string   `json:"email"`
 		Groups            []string `json:"groups"`
 		Name              string   `json:"name"`
+		FederatedClaims   struct {
+			ConnectorID string `json:"connector_id"`
+		} `json:"federated_claims"`
 	}
 
 	if err := idToken.Claims(&claims); err != nil {
@@ -142,8 +194,9 @@ func (v *OIDCVerifier) Verify(ctx context.Context, token string) (*Claims, error
 	}
 
 	return &Claims{
-		Username: username,
-		Email:    claims.Email,
-		Groups:   claims.Groups,
+		Username:    username,
+		Email:       claims.Email,
+		Groups:      claims.Groups,
+		ConnectorID: claims.FederatedClaims.ConnectorID,
 	}, nil
 }

--- a/modules/150-user-authn/images/user-api/src/pkg/auth/oidc_test.go
+++ b/modules/150-user-authn/images/user-api/src/pkg/auth/oidc_test.go
@@ -18,11 +18,18 @@ package auth
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 )
 
 type MockVerifier struct {
@@ -53,6 +60,98 @@ func extractBearerToken(r *http.Request) (string, error) {
 		return "", ErrInvalidAuthType
 	}
 	return parts[1], nil
+}
+
+// TestNewOIDCVerifier_RoutesDiscoveryAndJWKSInternally verifies the closed-loop
+// behaviour: discovery is fetched from the in-cluster connect URL, the public
+// issuer (which differs from the connect URL) is accepted for "iss" validation,
+// and JWKS keys are fetched from the connect host even though the discovery
+// document advertises an unreachable public jwks_uri.
+func TestNewOIDCVerifier_RoutesDiscoveryAndJWKSInternally(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	const keyID = "test-key"
+
+	// The public issuer host is deliberately unreachable: any attempt to fetch
+	// discovery or JWKS from it would fail, proving the code uses the connect host.
+	const publicIssuer = "https://dex.unreachable.invalid/"
+
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       priv.Public(),
+		KeyID:     keyID,
+		Algorithm: string(jose.RS256),
+		Use:       "sig",
+	}}}
+
+	var keysHits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 publicIssuer,
+			"authorization_endpoint": publicIssuer + "auth",
+			"token_endpoint":         publicIssuer + "token",
+			// Advertise the JWKS on the unreachable public host, as Dex does.
+			"jwks_uri": publicIssuer + "keys",
+		})
+	})
+	mux.HandleFunc("/keys", func(w http.ResponseWriter, _ *http.Request) {
+		keysHits++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	})
+
+	ts := httptest.NewTLSServer(mux)
+	defer ts.Close()
+
+	ctx := context.Background()
+	v, err := NewOIDCVerifier(ctx, ts.URL, publicIssuer)
+	if err != nil {
+		t.Fatalf("NewOIDCVerifier: %v", err)
+	}
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: jose.JSONWebKey{Key: priv, KeyID: keyID}},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+
+	now := time.Now()
+	token, err := jwt.Signed(signer).Claims(map[string]any{
+		"iss":                publicIssuer,
+		"aud":                "some-other-client",
+		"sub":                "CgR0ZXN0",
+		"iat":                now.Unix(),
+		"exp":                now.Add(time.Hour).Unix(),
+		"preferred_username": "alice",
+		"email":              "alice@example.com",
+		"groups":             []string{"admins"},
+		"federated_claims": map[string]any{
+			"connector_id": "local",
+			"user_id":      "alice",
+		},
+	}).Serialize()
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+
+	claims, err := v.Verify(ctx, token)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if claims.Username != "alice" {
+		t.Errorf("username = %q, want %q", claims.Username, "alice")
+	}
+	if claims.ConnectorID != "local" {
+		t.Errorf("connector ID = %q, want %q", claims.ConnectorID, "local")
+	}
+	if keysHits == 0 {
+		t.Error("JWKS was not fetched from the connect host; keys endpoint never hit")
+	}
 }
 
 func TestOIDCVerifier_ExtractToken(t *testing.T) {
@@ -116,4 +215,3 @@ func TestOIDCVerifier_ExtractToken(t *testing.T) {
 		})
 	}
 }
-

--- a/modules/150-user-authn/images/user-api/src/pkg/k8s/client_test.go
+++ b/modules/150-user-authn/images/user-api/src/pkg/k8s/client_test.go
@@ -18,6 +18,7 @@ package k8s
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"testing"
@@ -108,6 +109,29 @@ func TestPasswordCache(t *testing.T) {
 	}
 }
 
+func TestPasswordCache_StopIsIdempotent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	passwordGVR := schema.GroupVersionResource{
+		Group:    "dex.coreos.com",
+		Version:  "v1",
+		Resource: "passwords",
+	}
+	gvrToListKind := map[schema.GroupVersionResource]string{passwordGVR: "PasswordList"}
+	dynamicClient := fake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind)
+
+	cache := NewPasswordCache(dynamicClient, testLogger())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := cache.Start(ctx); err != nil {
+		t.Fatalf("Failed to start password cache: %v", err)
+	}
+
+	// Repeated Stop must not panic on closing an already-closed channel.
+	cache.Stop()
+	cache.Stop()
+}
+
 func TestK8sClient_CreatePasswordResetOperation(t *testing.T) {
 	scheme := runtime.NewScheme()
 
@@ -185,7 +209,7 @@ func TestK8sClient_IsLocalUser_CacheNotSynced(t *testing.T) {
 
 	// Don't start the cache, so it's not synced
 	_, err := client.IsLocalUser(context.Background(), "admin")
-	if err != ErrCacheNotSynced {
+	if !errors.Is(err, ErrCacheNotSynced) {
 		t.Errorf("IsLocalUser() error = %v, want %v", err, ErrCacheNotSynced)
 	}
 }

--- a/modules/150-user-authn/images/user-api/src/pkg/k8s/password_cache.go
+++ b/modules/150-user-authn/images/user-api/src/pkg/k8s/password_cache.go
@@ -44,6 +44,7 @@ type PasswordCache struct {
 	informer      cache.SharedIndexInformer
 	logger        *slog.Logger
 	stopCh        chan struct{}
+	stopOnce      sync.Once
 	synced        bool
 	dynamicClient dynamic.Interface
 }
@@ -73,11 +74,13 @@ func NewPasswordCache(dynamicClient dynamic.Interface, logger *slog.Logger) *Pas
 
 	pc.informer = informerFactory.ForResource(gvr).Informer()
 
-	_, _ = pc.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := pc.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    pc.onAdd,
 		UpdateFunc: pc.onUpdate,
 		DeleteFunc: pc.onDelete,
-	})
+	}); err != nil {
+		logger.Error("Failed to register password informer event handler", "error", err)
+	}
 
 	return pc
 }
@@ -90,6 +93,8 @@ func (pc *PasswordCache) Start(ctx context.Context) error {
 
 	pc.logger.Info("Waiting for password cache to sync")
 	if !cache.WaitForCacheSync(ctx.Done(), pc.informer.HasSynced) {
+		// Stop the informer goroutine started above so it doesn't leak.
+		pc.Stop()
 		return fmt.Errorf("failed to sync password cache")
 	}
 
@@ -101,9 +106,11 @@ func (pc *PasswordCache) Start(ctx context.Context) error {
 	return nil
 }
 
-// Stop stops the informer.
+// Stop stops the informer. It is safe to call multiple times.
 func (pc *PasswordCache) Stop() {
-	close(pc.stopCh)
+	pc.stopOnce.Do(func() {
+		close(pc.stopCh)
+	})
 }
 
 // IsLocalUser checks if the given username exists in the cache.

--- a/modules/150-user-authn/templates/user-api/deployment.yaml
+++ b/modules/150-user-authn/templates/user-api/deployment.yaml
@@ -90,7 +90,10 @@ spec:
         image: {{ include "helm_lib_module_image" (list . "userApi") }}
         args:
         - --listen=:8443
-        - --dex-url=https://{{ include "helm_lib_module_public_domain" (list . "dex") }}/
+        # In-cluster Dex Service for OIDC discovery (same address as dex-authenticator), so it works in closed-loop clusters.
+        - --dex-url=https://dex.d8-{{ .Chart.Name }}.svc
+        # Public issuer from token "iss" claims; used for validation, not connectivity.
+        - --issuer-url=https://{{ include "helm_lib_module_public_domain" (list . "dex") }}/
         - --tls-cert-file=/certs/tls.crt
         - --tls-key-file=/certs/tls.key
         ports:


### PR DESCRIPTION
## Description
Make `user-api` (self-service password reset) work in closed-loop/air-gapped clusters and harden token validation. OIDC discovery and JWKS are now fetched from the in-cluster Dex Service (no egress proxy), while the public issuer is still pinned for `iss` validation. Password reset is now restricted to tokens issued by Dex's local connector. No impact on critical cluster components.

## Why do we need it, and what problem does it solve?
In closed-loop clusters the public Dex Ingress URL is unreachable from inside the cluster, so `user-api` failed OIDC discovery/JWKS with `context deadline exceeded`. It also prevents a federated user whose claim matches a local username from resetting that local user's password.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authn
type: fix
summary: Fix user-api self-service password reset in closed-loop clusters and restrict it to local Dex users.
impact_level: low
```