### PR TITLE
[node-manager] Fix calculate NodeGroup status

### DIFF
--- a/modules/040-node-manager/hooks/internal/conditions/calculate.go
+++ b/modules/040-node-manager/hooks/internal/conditions/calculate.go
@@ -200,7 +200,7 @@ func CalculateNodeGroupConditions(
 		curTime, _ = time.Parse(time.RFC3339, timeStr)
 	}
 
-	staicDesired := ng.Desired
+	staticDesired := ng.Desired
 
 	for _, node := range nodes {
 		if !node.Unschedulable {
@@ -216,7 +216,7 @@ func CalculateNodeGroupConditions(
 			if node.UnderCAPS {
 				continue
 			}
-			staicDesired++
+			staticDesired++
 		}
 
 		if node.Updating {
@@ -235,7 +235,7 @@ func CalculateNodeGroupConditions(
 	isReady := readySchedulableNodes >= minPerAllZone
 	if ng.Type == ngv1.NodeTypeStatic {
 		if ng.Desired > 0 {
-			isReady = readySchedulableNodes == int(staicDesired)
+			isReady = readySchedulableNodes == int(staticDesired)
 		} else {
 			isReady = readySchedulableNodes == len(nodes)
 		}

--- a/modules/040-node-manager/hooks/internal/conditions/calculate.go
+++ b/modules/040-node-manager/hooks/internal/conditions/calculate.go
@@ -48,6 +48,7 @@ type Node struct {
 	Updating                  bool
 	CreationTimestamp         time.Time
 	WaitingDisruptiveApproval bool
+	UnderCAPS                 bool
 }
 
 func NodeToConditionsNode(node *corev1.Node) *Node {
@@ -88,6 +89,8 @@ func NodeToConditionsNode(node *corev1.Node) *Node {
 	}
 
 	res.Unschedulable = node.Spec.Unschedulable
+
+	_, res.UnderCAPS = node.Annotations["cluster.x-k8s.io/owner-kind"]
 
 	return res
 }
@@ -197,6 +200,8 @@ func CalculateNodeGroupConditions(
 		curTime, _ = time.Parse(time.RFC3339, timeStr)
 	}
 
+	staicDesired := ng.Desired
+
 	for _, node := range nodes {
 		if !node.Unschedulable {
 			schedulableNodes++
@@ -205,6 +210,13 @@ func CalculateNodeGroupConditions(
 			if node.Ready || inGracePeriod {
 				readySchedulableNodes++
 			}
+		}
+
+		if ng.Type == ngv1.NodeTypeStatic {
+			if node.UnderCAPS {
+				continue
+			}
+			staicDesired++
 		}
 
 		if node.Updating {
@@ -223,7 +235,7 @@ func CalculateNodeGroupConditions(
 	isReady := readySchedulableNodes >= minPerAllZone
 	if ng.Type == ngv1.NodeTypeStatic {
 		if ng.Desired > 0 {
-			isReady = readySchedulableNodes == int(ng.Desired)
+			isReady = readySchedulableNodes == int(staicDesired)
 		} else {
 			isReady = readySchedulableNodes == len(nodes)
 		}


### PR DESCRIPTION
## Description

Fix static NodeGroup readiness calculation 

## Why do we need it, and what problem does it solve?

Now readiness of NodeGroup calculates wrong, if static NodeGroup has not only CAPS, but static nodes

## Why do we need it in the patch release (if we do)?

Affected 1.75, not affected main

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Fix static NodeGroup readiness calculation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
