### PR TITLE
[registry-package-proxy] fix rpp to fetch icon from release image

### DIFF
--- a/go_lib/registry-packages-proxy/proxy/packages_handler_test.go
+++ b/go_lib/registry-packages-proxy/proxy/packages_handler_test.go
@@ -39,10 +39,12 @@ const (
 	testPackageRepositoryName = "packages-repo"
 	testPackageName           = "my-package"
 	// testImagePath mirrors what handleGetIcon passes to the registry client:
-	// the package name verbatim (no synthetic "packages/" prefix is added).
-	// The PackageRepository CR's spec.registry.repo is what carries any
-	// "packages/" sub-path in real clusters.
-	testImagePath   = "my-package"
+	// the package name followed by the "/version" segment, since version
+	// images (which carry docs/icon.svg) live at <package>/version:<tag>.
+	// No synthetic "packages/" prefix is added; the PackageRepository CR's
+	// spec.registry.repo is what carries any "packages/" sub-path in real
+	// clusters.
+	testImagePath   = testPackageName + "/version"
 	testIconPath    = "docs/icon.svg"
 	testIconContent = "<svg>icon</svg>"
 )

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -869,8 +869,8 @@ func (p *Proxy) handleGetIcon(w http.ResponseWriter, r *http.Request, cfg *regis
 		return
 	}
 
-	imagePath := packageName
-	p.logger.Debugf("handleGetIcon for %q/%q/version:%q", cfg.Repository, imagePath, version)
+	imagePath := packageName + "/version"
+	p.logger.Debugf("handleGetIcon for %q/%q:%q", cfg.Repository, imagePath, version)
 
 	if version == "" {
 		resolved, ok := p.resolveLatestVersion(w, r, cfg, imagePath)

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -869,8 +869,8 @@ func (p *Proxy) handleGetIcon(w http.ResponseWriter, r *http.Request, cfg *regis
 		return
 	}
 
-	imagePath := packageName + "/version"
-	p.logger.Debugf("handleGetIcon for %q/%q:%q", cfg.Repository, imagePath, version)
+	imagePath := packageName
+	p.logger.Debugf("handleGetIcon for %q/%q/version:%q", cfg.Repository, imagePath, version)
 
 	if version == "" {
 		resolved, ok := p.resolveLatestVersion(w, r, cfg, imagePath)

--- a/go_lib/registry-packages-proxy/proxy/proxy.go
+++ b/go_lib/registry-packages-proxy/proxy/proxy.go
@@ -869,7 +869,7 @@ func (p *Proxy) handleGetIcon(w http.ResponseWriter, r *http.Request, cfg *regis
 		return
 	}
 
-	imagePath := packageName
+	imagePath := packageName + "/version"
 	p.logger.Debugf("handleGetIcon for %q/%q:%q", cfg.Repository, imagePath, version)
 
 	if version == "" {


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: registrypackages
type: fix
summary: Fixed `registry-package-proxy` to fetch icon from the release image.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
