### PR TITLE
[admission-policy-engine] Harden constraint-exporter on API failures and ConfigMap conflicts

### DIFF
--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/exporter.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/exporter.go
@@ -17,13 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/klog/v2"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/flant/constraint_exporter/pkg/gatekeeper"
@@ -36,18 +36,19 @@ type Exporter struct {
 
 	kindTracker *kinds.KindTracker
 
-	metrics []prometheus.Metric
+	metricsMu sync.RWMutex
+	metrics   []prometheus.Metric
 }
 
 func NewExporter() *Exporter {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		klog.Fatalf("Create kubernetes config failed: %+v\n", err)
+		fatal("create kubernetes config failed", err)
 	}
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		klog.Fatalf("Create kubernetes client failed: %+v\n", err)
+		fatal("create kubernetes client failed", err)
 	}
 
 	return &Exporter{
@@ -89,7 +90,12 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		gatekeeper.Up, prometheus.GaugeValue, 1,
 	)
-	for _, m := range e.metrics {
+
+	e.metricsMu.RLock()
+	metrics := append(make([]prometheus.Metric, 0, len(e.metrics)), e.metrics...)
+	e.metricsMu.RUnlock()
+
+	for _, m := range metrics {
 		ch <- m
 	}
 }
@@ -99,38 +105,43 @@ func (e *Exporter) startScheduled(clientGVR controllerClient.Client, t time.Dura
 
 	for {
 		select {
-		case <-done:
+		case <-stopCh:
 			return
 		case <-ticker.C:
 			var (
-				constraints []gatekeeper.Constraint
-				mutations   []gatekeeper.Mutation
-				wg          sync.WaitGroup
+				constraints    []gatekeeper.Constraint
+				mutations      []gatekeeper.Mutation
+				constraintsErr error
+				mutationsErr   error
+				wg             sync.WaitGroup
 			)
 
 			wg.Add(1)
 			go func() {
-				var err error
-				constraints, err = e.fetchConstraints(clientGVR)
-				if err != nil {
-					klog.Warningf("Get constraints failed: %+v\n", err)
-				}
+				constraints, constraintsErr = e.fetchConstraints(clientGVR)
 				wg.Done()
 			}()
 
 			wg.Add(1)
 			go func() {
-				var err error
-				mutations, err = gatekeeper.GetMutations(clientGVR, e.client)
-				if err != nil {
-					klog.Warningf("Get mutations failed: %+v\n", err)
-				}
+				mutations, mutationsErr = gatekeeper.GetMutations(clientGVR, e.client)
 				wg.Done()
 			}()
 			wg.Wait()
 
+			if constraintsErr != nil || mutationsErr != nil {
+				if constraintsErr != nil {
+					slog.Warn("get constraints failed", "error", constraintsErr)
+				}
+				if mutationsErr != nil {
+					slog.Warn("get mutations failed", "error", mutationsErr)
+				}
+				slog.Warn("skip tracked objects update due to stale gatekeeper data")
+				continue
+			}
+
 			if e.kindTracker != nil {
-				go e.kindTracker.UpdateTrackedObjects(constraints, mutations)
+				e.kindTracker.UpdateTrackedObjects(constraints, mutations)
 			}
 		}
 	}
@@ -154,7 +165,9 @@ func (e *Exporter) fetchConstraints(clientGVR controllerClient.Client) ([]gateke
 	truncatedMetrics := gatekeeper.ExportViolationsTruncated(constraints)
 	allMetrics = append(allMetrics, truncatedMetrics...)
 
+	e.metricsMu.Lock()
 	e.metrics = allMetrics
+	e.metricsMu.Unlock()
 
 	return constraints, nil
 }

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/main.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -28,7 +29,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"k8s.io/klog/v2"
 )
 
 var (
@@ -52,34 +52,36 @@ func init() {
 
 var (
 	ticker *time.Ticker
-	done   = make(chan bool)
+	stopCh = make(chan struct{})
 )
 
 func main() {
 	flag.Parse()
 
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
 	ns := os.Getenv("POD_NAMESPACE")
 	if len(ns) == 0 {
-		klog.Fatal("Pod namespace is not set")
+		fatal("pod namespace is not set", nil)
 	}
 
 	exporter := NewExporter()
 	err := exporter.initKindTracker(ns, trackObjectsCMName)
 	if err != nil {
-		klog.Fatal(err)
+		fatal("init kind tracker failed", err)
 	}
 
 	clientGVR, err := exporter.createKubeClientGroupVersion()
 	if err != nil {
-		klog.Fatal(err)
+		fatal("create kube client failed", err)
 	}
 
 	go exporter.startScheduled(clientGVR, interval)
 	prometheus.Unregister(collectors.NewGoCollector())
 	prometheus.MustRegister(exporter)
 
-	done := make(chan os.Signal, 1)
-	signal.Notify(done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	mux := http.NewServeMux()
 	mux.Handle(metricsPath, promhttp.Handler())
@@ -91,13 +93,14 @@ func main() {
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			klog.Fatalf("listen: %s\n", err)
+			fatal("server start failed", err)
 		}
 	}()
-	klog.Info("Server Started")
+	slog.Info("server started", "listen_address", listenAddress, "metrics_path", metricsPath, "interval", interval.String())
 
-	<-done
-	klog.Info("Server Stopped")
+	<-signalCh
+	close(stopCh)
+	slog.Info("server stopping")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer func() {
@@ -106,6 +109,15 @@ func main() {
 	}()
 
 	if err := srv.Shutdown(ctx); err != nil {
-		klog.Fatalf("Server Shutdown Failed:%+v", err)
+		fatal("server shutdown failed", err)
 	}
+}
+
+func fatal(message string, err error) {
+	if err != nil {
+		slog.Error(message, "error", err)
+	} else {
+		slog.Error(message)
+	}
+	os.Exit(1)
 }

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/constraints.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/constraints.go
@@ -18,12 +18,12 @@ package gatekeeper
 
 import (
 	"context"
+	"log/slog"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -118,7 +118,7 @@ func GetConstraints(cClient controllerClient.Client, client *kubernetes.Clientse
 
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &constraint)
 				if err != nil {
-					klog.Error(err)
+					slog.Error("decode constraint failed", "kind", item.GetKind(), "name", item.GetName(), "error", err)
 					continue
 				}
 

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/mutations.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/gatekeeper/mutations.go
@@ -18,6 +18,7 @@ package gatekeeper
 
 import (
 	"context"
+	"log/slog"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -112,7 +112,7 @@ func getMutations(cClient listClient, discoveryClient discovery.DiscoveryInterfa
 				var mutation Mutation
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &mutation)
 				if err != nil {
-					klog.Error(err)
+					slog.Error("decode mutation failed", "kind", item.GetKind(), "name", item.GetName(), "error", err)
 					continue
 				}
 

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 
@@ -30,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
-	"k8s.io/klog/v2"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/yaml"
 
 	"github.com/flant/constraint_exporter/pkg/gatekeeper"
@@ -95,27 +96,7 @@ func (kt *KindTracker) UpdateTrackedObjects(constraints []gatekeeper.Constraint,
 		return
 	}
 
-	klog.Info("Checksums are not equal. Updating")
-
-	cm, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			err = kt.createCM()
-			if err != nil {
-				klog.Errorf("Create kinds cm failed: %s", err)
-				return
-			}
-		} else {
-			klog.Errorf("Get kinds cm failed: %s", err)
-			return
-		}
-	}
-	if len(cm.Annotations) == 0 {
-		cm.Annotations = make(map[string]string, 0)
-	}
-	if len(cm.Data) == 0 {
-		cm.Data = make(map[string]string)
-	}
+	slog.Info("checksums changed, updating tracked objects configmap")
 
 	constraintKinds := make([]gatekeeper.MatchKind, 0, len(deduplicatedConstraintKinds))
 	for _, k := range deduplicatedConstraintKinds {
@@ -127,21 +108,16 @@ func (kt *KindTracker) UpdateTrackedObjects(constraints []gatekeeper.Constraint,
 		mutationKinds = append(mutationKinds, m)
 	}
 
-	cm.Annotations[constraintChecksumAnnotation] = cchecksum
-	cm.Annotations[mutationChecksumAnnotation] = mchecksum
-
 	// convert kinds to the resources
 	resourceConstraintsData, resourceMutationsData, err := kt.convertKinds(constraintKinds, mutationKinds)
 	if err != nil {
-		klog.Errorf("Convert kinds to resources failed. Try later")
+		slog.Error("convert kinds to resources failed", "error", err)
 		return
 	}
-	cm.Data["validate-resources.yaml"] = string(resourceConstraintsData)
-	cm.Data["mutate-resources.yaml"] = string(resourceMutationsData)
 
-	_, err = kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Update(context.TODO(), cm, v1.UpdateOptions{})
+	err = kt.updateTrackedObjectsConfigMap(cchecksum, mchecksum, string(resourceConstraintsData), string(resourceMutationsData))
 	if err != nil {
-		klog.Errorf("Update tracked objects failed: %s", err)
+		slog.Error("update tracked objects failed", "error", err)
 		return
 	}
 
@@ -177,14 +153,19 @@ func (kt *KindTracker) FindInitialChecksum() error {
 	cm, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			klog.Info("Track objects configmap not found. Creating.")
+			slog.Info("track objects configmap not found, creating")
 			err = kt.createCM()
 			if err != nil {
 				return err
 			}
+			return nil
 		} else {
 			return err
 		}
+	}
+
+	if len(cm.Annotations) == 0 {
+		return nil
 	}
 
 	kt.latestConstraintsChecksum = cm.Annotations[constraintChecksumAnnotation]
@@ -213,6 +194,41 @@ func (kt *KindTracker) createCM() error {
 	_, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Create(context.TODO(), cm, v1.CreateOptions{})
 
 	return err
+}
+
+func (kt *KindTracker) updateTrackedObjectsConfigMap(constraintsChecksum, mutationsChecksum, validateData, mutateData string) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cm, err := kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+
+			if createErr := kt.createCM(); createErr != nil && !errors.IsAlreadyExists(createErr) {
+				return createErr
+			}
+
+			cm, err = kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Get(context.TODO(), kt.cmName, v1.GetOptions{})
+			if err != nil {
+				return err
+			}
+		}
+
+		if len(cm.Annotations) == 0 {
+			cm.Annotations = make(map[string]string)
+		}
+		if len(cm.Data) == 0 {
+			cm.Data = make(map[string]string)
+		}
+
+		cm.Annotations[constraintChecksumAnnotation] = constraintsChecksum
+		cm.Annotations[mutationChecksumAnnotation] = mutationsChecksum
+		cm.Data["validate-resources.yaml"] = validateData
+		cm.Data["mutate-resources.yaml"] = mutateData
+
+		_, err = kt.client.CoreV1().ConfigMaps(kt.cmNamespace).Update(context.TODO(), cm, v1.UpdateOptions{})
+		return err
+	})
 }
 
 type matchResource struct {
@@ -268,7 +284,13 @@ func (rm resourceMatcher) convertKindsToResource(kinds []gatekeeper.MatchKind) (
 						restMapping, err := rm.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 						if err != nil {
 							// skip outdated resources, like extensions/Ingress
-							klog.Warningf("Skip wildcard resource mapping. Group: %q, Kind: %q, Version: %q. Error: %q", gvk.Group, gvk.Kind, gvk.Version, err)
+							slog.Warn(
+								"skip wildcard resource mapping",
+								"group", gvk.Group,
+								"kind", gvk.Kind,
+								"version", gvk.Version,
+								"error", err,
+							)
 							continue
 						}
 
@@ -302,7 +324,7 @@ func (rm resourceMatcher) convertKindsToResource(kinds []gatekeeper.MatchKind) (
 					})
 					if err != nil {
 						// skip outdated resources, like extensions/Ingress
-						klog.Warningf("Skip resource mapping. Group: %q, Kind: %q. Error: %q", apiGroup, kind, err)
+						slog.Warn("skip resource mapping", "group", apiGroup, "kind", kind, "error", err)
 						continue
 					}
 

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds.go
@@ -43,7 +43,7 @@ const (
 )
 
 type KindTracker struct {
-	client      *kubernetes.Clientset
+	client      kubernetes.Interface
 	cmNamespace string
 	cmName      string
 
@@ -51,7 +51,7 @@ type KindTracker struct {
 	latestMutationsChecksum   string
 }
 
-func NewKindTracker(client *kubernetes.Clientset, cmNS, cmName string) *KindTracker {
+func NewKindTracker(client kubernetes.Interface, cmNS, cmName string) *KindTracker {
 	return &KindTracker{
 		client:      client,
 		cmNamespace: cmNS,

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds_test.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/stretchr/testify/require"
@@ -201,7 +202,7 @@ func TestResourceMapper(t *testing.T) {
 }
 
 func TestUpdateTrackedObjectsConfigMapRetryOnConflict(t *testing.T) {
-	client := fake.NewFakeCluster(fake.ClusterVersionV121).Kubernetes
+	client := k8sfake.NewSimpleClientset()
 
 	_, err := client.CoreV1().ConfigMaps("d8-admission-policy-engine").Create(context.Background(), &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -212,7 +213,7 @@ func TestUpdateTrackedObjectsConfigMapRetryOnConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	var updateAttempts int
-	client.Fake.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		updateAttempts++
 		if updateAttempts == 1 {
 			return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "configmaps"}, "constraint-exporter", assert.AnError)

--- a/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds_test.go
+++ b/modules/015-admission-policy-engine/images/constraint-exporter/src/pkg/kinds/kinds_test.go
@@ -17,9 +17,17 @@ limitations under the License.
 package kinds
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/flant/kube-client/fake"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/stretchr/testify/require"
 
@@ -190,4 +198,45 @@ func TestResourceMapper(t *testing.T) {
   - pods
 `, string(data))
 	})
+}
+
+func TestUpdateTrackedObjectsConfigMapRetryOnConflict(t *testing.T) {
+	client := fake.NewFakeCluster(fake.ClusterVersionV121).Kubernetes
+
+	_, err := client.CoreV1().ConfigMaps("d8-admission-policy-engine").Create(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "constraint-exporter",
+			Namespace: "d8-admission-policy-engine",
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	var updateAttempts int
+	client.Fake.PrependReactor("update", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateAttempts++
+		if updateAttempts == 1 {
+			return true, nil, apierrors.NewConflict(schema.GroupResource{Group: "", Resource: "configmaps"}, "constraint-exporter", assert.AnError)
+		}
+
+		obj := action.(k8stesting.UpdateAction).GetObject()
+		return false, obj, nil
+	})
+
+	kt := NewKindTracker(client, "d8-admission-policy-engine", "constraint-exporter")
+
+	err = kt.updateTrackedObjectsConfigMap("constraints", "mutations", "validate-data", "mutate-data")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, updateAttempts, 2)
+
+	require.Eventually(t, func() bool {
+		cm, getErr := client.CoreV1().ConfigMaps("d8-admission-policy-engine").Get(context.Background(), "constraint-exporter", metav1.GetOptions{})
+		if getErr != nil {
+			return false
+		}
+
+		return cm.Annotations[constraintChecksumAnnotation] == "constraints" &&
+			cm.Annotations[mutationChecksumAnnotation] == "mutations" &&
+			cm.Data["validate-resources.yaml"] == "validate-data" &&
+			cm.Data["mutate-resources.yaml"] == "mutate-data"
+	}, 5*time.Second, 50*time.Millisecond)
 }


### PR DESCRIPTION
## Description

Improves `admission-policy-engine` `constraint-exporter` reliability during Kubernetes API instability.

Changes include:
- switched exporter logs to structured format for easier debugging;
- added fail-safe behavior: skip tracked resources update when constraints/mutations cannot be fetched from API;
- added retry-on-conflict for tracked ConfigMap updates to handle concurrent writes safely.

No intentional restarts of critical control-plane components are introduced by this change.

## Why do we need it, and what problem does it solve?

During API degradation (`etcd` timeouts / connection errors), `constraint-exporter` could enter update flow with failed reads and also lose ConfigMap update races (`object has been modified`).

This PR hardens exporter behavior by:
- avoiding updates on failed/stale API reads;
- making ConfigMap updates conflict-resilient.

As a result, exporter keeps last-known-good tracked resources and behaves more predictably under API errors.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: admission-policy-engine
type: fix
summary: Improve constraint-exporter resilience under API failures and update conflicts.
impact_level: default