### PR TITLE
[deckhouse] add VEX entries 

### DIFF
--- a/deckhouse-controller/known_vulnerabilities.vex
+++ b/deckhouse-controller/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-5a4509a04e8128126aee080324a6b663a7748bf44b58a9a4b9c74d4801844f53",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 18,
+  "version": 19,
   "statements": [
     {
       "vulnerability": {
@@ -330,8 +330,20 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Уязвимость CWE-79 (Cross-site Scripting) в Go stdlib v1.25.5 не эксплуатируема в бинарнике deckhouse-controller в составе образа deckhouse-oss: компонент не работает как веб-сервер, выводящий контент в браузер, XSS-уязвимости стандартной библиотеки не достигаются. Бамп Go toolchain будет выполнен в рамках планового апгрейда базовых образов.",
       "timestamp": "2026-06-01T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-6357"
+      },
+      "products": [
+        {"@id": "pkg:pypi/pip@25.3"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Функционал загрузки функциональности из недоверенных источников (CWE-829) pip версии 25.3 не используется в рамках текущих функциональных спецификаций и эксплуатационных процессов системы. Python-зависимости не обновляются, чтобы не нарушить совместимость с shell-operator; установка пакетов выполняется только из доверенных источников на этапе сборки образа.",
+      "timestamp": "2026-06-03T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-06-01T12:00:00Z"
+  "last_updated": "2026-06-03T12:00:00Z"
 }

--- a/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
+++ b/modules/800-deckhouse-tools/images/web/known_vulnerabilities.vex
@@ -2,7 +2,7 @@
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://openvex.dev/docs/public/vex-7c114e6cee1182ff2b165cba363ae5cfbf773e4da8518c90d80049d24c627e94",
   "author": "Deckhouse \u003ccontact@deckhouse.io\u003e",
-  "version": 17,
+  "version": 18,
   "statements": [
     {
       "vulnerability": {
@@ -475,8 +475,68 @@
       "justification": "vulnerable_code_not_in_execute_path",
       "impact_statement": "Зависимость github.com/Azure/go-ntlmssp является транзитивной, поступающей в d8 через цепочку deckhouse-cli (stronghold/vault command) → vault-plugin-secrets-openldap → go-ldap/ldap/v3. Уязвимость связана с panic при парсинге специально сформированных NTLM Type 2 challenge-сообщений от вредоносного NTLM-сервера. Функционал NTLM-аутентификации против произвольных LDAP-серверов в d8 не используется — LDAP-операции выполняются только в контексте управления Stronghold/Vault администратором кластера через d8 stronghold, где NTLM bind не применяется. Уязвимый исполняемый путь недостижим в рамках текущих функциональных спецификаций и эксплуатационных процессов системы.",
       "timestamp": "2026-05-15T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-45022"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость в github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации deckhouse-tools web источники репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности управлять входными данными в уязвимом исполняемом пути.",
+      "timestamp": "2026-06-03T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-41506"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-git/v5@v5.16.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость в github.com/go-git/go-git/v5 v5.16.2 проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации deckhouse-tools web источники репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности управлять входными данными в уязвимом исполняемом пути.",
+      "timestamp": "2026-06-03T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44973"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость в github.com/go-git/go-billy/v5 v5.6.2 (файловая абстракция для go-git) проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации deckhouse-tools web источники репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности управлять входными данными в уязвимом исполняемом пути.",
+      "timestamp": "2026-06-03T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-44740"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/go-git/go-billy/v5@v5.6.2"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary",
+      "impact_statement": "Уязвимость в github.com/go-git/go-billy/v5 v5.6.2 (файловая абстракция для go-git) проявляется при обработке данных Git-репозитория. В типовой модели эксплуатации deckhouse-tools web источники репозиториев определяются и контролируются администратором, что не предоставляет нарушителю возможности управлять входными данными в уязвимом исполняемом пути.",
+      "timestamp": "2026-06-03T12:00:00Z"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-pmwq-pjrm-6p5r"
+      },
+      "products": [
+        {"@id": "pkg:golang/github.com/in-toto/in-toto-golang@v0.9.0"}
+      ],
+      "status": "not_affected",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impact_statement": "Уязвимость в github.com/in-toto/in-toto-golang v0.9.0 связана с верификацией supply-chain attestations (in-toto layout/link metadata) в составе цепочки cosign/sigstore. В рамках deckhouse-tools web недоверенные in-toto-аттестации не верифицируются — соответствующий исполняемый путь не вызывается, что исключает возможность эксплуатации.",
+      "timestamp": "2026-06-03T12:00:00Z"
     }
   ],
   "timestamp": "2026-03-05T12:00:00Z",
-  "last_updated": "2026-05-15T12:00:00Z"
+  "last_updated": "2026-06-03T12:00:00Z"
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Add OpenVEX `not_affected` mitigations for 2026-06-03 findings on release-1.73 — same shared deps (d8 go-git/go-billy/in-toto, pip) surfacing in more images; VEX is per-image.

- **web** (v17→18): go-git CVE-2026-41506/-45022, go-billy CVE-2026-44740/-44973, in-toto GHSA-pmwq-pjrm-6p5r
- **deckhouse-controller** (v18→19): pip CVE-2026-6357

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Add VEX entries 1.73
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
