### PR TITLE
[control-plane] disable kube-api qps for kcm

### DIFF
--- a/candi/control-plane/kube-controller-manager.yaml.tpl
+++ b/candi/control-plane/kube-controller-manager.yaml.tpl
@@ -51,6 +51,7 @@ spec:
         - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
         - --controllers=*,bootstrapsigner,tokencleaner
         - --kubeconfig=/etc/kubernetes/controller-manager.conf
+        - --kube-api-qps=-1
         - --leader-elect=true
         - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
         - --root-ca-file=/etc/kubernetes/pki/ca.crt


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Set  `--kube-api-qps=-1` to the `kube-controller-manager` static pod manifest, which disables the client-side rate limit on requests from `kube-controller-manager` to `kube-apiserver`

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

`kube-controller-manager` uses a default QPS limit of 20 req/s when talking to `kube-apiserver`. On clusters with a large number of nodes or objects, this limit causes request queuing inside KCM, which slows down reconciliation loops (node lifecycle, garbage collection, endpoint updates, etc.) and can produce visible latency spikes or stalled controllers.

Setting `--kube-api-qps=-1` removes the artificial client-side cap, allowing KCM to issue requests at the rate the apiserver can actually serve. Excessive load is still regulated server-side through the `kube-apiserver` `FlowSchema` and Priority and Fairness (APF) subsystem, which provides fair queuing across all clients without relying on per-client static limits.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

Not necessarily

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Disabled the kube-api QPS rate limit for kube-controller-manager.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
