### PR TITLE
[candi] Tune kubelet image pull serialization

### DIFF
--- a/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl
@@ -382,7 +382,7 @@ registryBurst: 20
 resolvConf: ${resolvConfPath}
 rotateCertificates: true
 runtimeRequestTimeout: 4m0s
-serializeImagePulls: true
+serializeImagePulls: false
 syncFrequency: 1m0s
 {{- if eq $resourceReservationMode "Auto" }}
 systemReserved:


### PR DESCRIPTION
## Description
This PR changes the generated kubelet configuration in `candi` to set `serializeImagePulls: false`.

The setting allows kubelet to pull images in parallel instead of serializing image pulls on a node. The change affects the kubelet config rendered by `candi/bashible/common-steps/all/064_configure_kubelet.sh.tpl` and is applied through the normal node reconfiguration flow, including the corresponding kubelet config update/restart behavior.

Manual benchmark results on a worker node (4/8Gi) with 10 test images and 5 runs per mode:

| Metric | `serializeImagePulls: true` | `serializeImagePulls: false` | Difference |
|---|---:|---:|---:|
| Average run duration | 65.8 s | 29.2 s | -36.6 s / -55.6% |
| Total image size per run | 1804.0 MiB | 1804.0 MiB | 0 |
| Average pull throughput | 27.55 MiB/s | 61.99 MiB/s | +125.0% |
| Average CPU | 22.94% | 33.32% | +10.38 pp |
| Average network RX | 86.66 Mb/s | 119.00 Mb/s | +37.3% |
| Average disk write | 40.06 MiB/s | 55.48 MiB/s | +38.5% |

The benchmark shows that disabling serialized image pulls reduces image pull time by about `2.25x` for the tested workload. The trade-off is a shorter but more intensive load profile on CPU, network RX, and disk writes.

## Why do we need it, and what problem does it solve?
Serial image pulls slow down pod startup when several images need to be pulled on the same node. Allowing kubelet to pull images in parallel reduces the time needed to prepare pods after scheduling, image cache cleanup, or node provisioning.

This is especially useful for nodes that start multiple workloads with uncached images: the benchmarked workload completed in `29.2 s` on average with `serializeImagePulls: false`, compared to `65.8 s` with the previous serialized behavior.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: chore
summary: Set kubelet `serializeImagePulls` to `false` to allow parallel image pulls on nodes.
impact: Kubelet configuration changes on nodes and is applied through the normal node reconfiguration flow.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:
gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):
node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
