### PR TITLE
[cni-cilium] Migrate to Golang GOST

### DIFF
--- a/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/base-cilium-dev/werf.inc.yaml
@@ -24,7 +24,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/golang-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 ---
 image: {{ .ModuleName }}/base-cilium-dev

--- a/modules/021-cni-cilium/images/bin-cni-plugins/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-cni-plugins/werf.inc.yaml
@@ -27,7 +27,7 @@ shell:
   - rm -rf /src/plugins/.git
 ---
 image: {{ .ModuleName }}/cni-plugins-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
@@ -41,8 +41,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache bash git binutils tar
+  - pm install bash git binutils tar
   install:
   - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY)
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0

--- a/modules/021-cni-cilium/images/bin-gops/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/bin-gops/werf.inc.yaml
@@ -16,7 +16,7 @@ shell:
   - cd /src/gops
 ---
 image: {{ .ModuleName }}/gops-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
@@ -30,8 +30,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache bash git binutils
+  - pm install bash git binutils
   install:
   - export GO_VERSION=${GOLANG_VERSION} GOPROXY=$(cat /run/secrets/GOPROXY)
   - export GOOS=linux GOARCH=amd64 CGO_ENABLED=0

--- a/modules/021-cni-cilium/images/check-wg-kernel-compat/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/check-wg-kernel-compat/werf.inc.yaml
@@ -13,7 +13,7 @@ shell:
   - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact

--- a/modules/021-cni-cilium/images/operator/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/operator/werf.inc.yaml
@@ -3,7 +3,7 @@
 # #####################################################################
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/bin-cilium-src-artifact
@@ -17,8 +17,7 @@ secrets:
   value: {{ .GOPROXY }}
 shell:
   beforeInstall:
-  {{- include "alpine packages proxy" . | nindent 2 }}
-  - apk add --no-cache make git bash
+  - pm install make git bash
   install:
   - export GO_VERSION=${GOLANG_VERSION}
   - export GOPROXY=$(cat /run/secrets/GOPROXY)

--- a/modules/021-cni-cilium/images/safe-agent-updater/werf.inc.yaml
+++ b/modules/021-cni-cilium/images/safe-agent-updater/werf.inc.yaml
@@ -14,7 +14,7 @@ shell:
   - cd /src
 ---
 image: {{ .ModuleName }}/{{ .ImageName }}-build-artifact
-from: {{ index $.Images ( eq $.SVACE_ENABLED "false" | ternary "builder/golang-alpine" "builder/golang-alpine-svace" ) }}
+from: {{ index $.Images "builder/golang" }}
 final: false
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact


### PR DESCRIPTION
## Description
Switch build stages from builder/golang-alpine to unified builder/golang in 021-cnu-cilium images

## Why do we need it, and what problem does it solve?
New builder/golang image from container-factory with GOST patches and enabled Green Tea GC

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-cilium
type: chore
summary: swap to unified Golang GOST builder
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
