### PR TITLE
[istio] Vex mitigation implementation for pilot-v1x21

### DIFF
--- a/modules/110-istio/images/pilot-v1x21x6/werf.inc.yaml
+++ b/modules/110-istio/images/pilot-v1x21x6/werf.inc.yaml
@@ -58,3 +58,5 @@ shell:
   - strip /src/istio/out/pilot-discovery
   - chmod 0700 /src/istio/out/pilot-discovery
   - chown 1337:1337 /src/istio/out/pilot-discovery
+---
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName)) }}

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -361,6 +361,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"operatorV1x25x2":            "imageHash-istio-operatorV1x25x2",
 		"pilotV1x19x7":               "imageHash-istio-pilotV1x19x7",
 		"pilotV1x21x6":               "imageHash-istio-pilotV1x21x6",
+		"pilotV1x21x6VexArtifact":    "imageHash-istio-pilotV1x21x6VexArtifact",
 		"pilotV1x25x2":               "imageHash-istio-pilotV1x25x2",
 		"proxyv2V1x19x7":             "imageHash-istio-proxyv2V1x19x7",
 		"proxyv2V1x21x6":             "imageHash-istio-proxyv2V1x21x6",


### PR DESCRIPTION
## Description
The vex configuration was not applied to the pilot-v1x21 image because there was no necessary import.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: fix
summary: Vex mitigation implementation for pilot-v1x21
impact_level: low
```
