### PR TITLE
Fixed ssh cleanup in dhctl (release-1.76)

### DIFF
--- a/dhctl/pkg/system/node/gossh/client.go
+++ b/dhctl/pkg/system/node/gossh/client.go
@@ -575,4 +575,12 @@ func (s *Client) stopKubeproxy() {
 	cmd := NewSSHCommand(s, "killall kubectl")
 	cmd.Sudo(context.Background())
 	_ = cmd.Run(context.Background())
+
+	// SIGKILL is used because d8 did not exit
+	// after a single SIGINT/SIGTERM — it required two signals due to
+	// incorrect signal handling.
+	// Fixed in https://github.com/deckhouse/deckhouse-cli/releases/tag/v0.30.8
+	cmd = NewSSHCommand(s, "pkill -9 -f 'd8 k proxy'")
+	cmd.Sudo(context.Background())
+	_ = cmd.Run(context.Background())
 }


### PR DESCRIPTION
## Description

This PR fixes the `killall kubectl` command for the `d8 k` alias in `dhctl`.

## Why do we need it, and what problem does it solve?

This PR fixes the `killall kubectl` command for the `d8 k` alias in `dhctl`.

## Why do we need it in the patch release (if we do)?

This PR fixes the `killall kubectl` command for the `d8 k` alias in `dhctl`.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: fixed the `killall kubectl` command for the `d8 k` alias
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
