### PR TITLE
Backport: [CI] add ingore alert CertmanagerCertificateChallengeStuck for e2e

### DIFF
--- a/testing/cloud_layouts/script-commander.sh
+++ b/testing/cloud_layouts/script-commander.sh
@@ -981,9 +981,12 @@ function wait_alerts_resolve() {
   "D8IstioPodsWithoutIstioSidecar" # Expected behaviour in clusters that start too quickly, and tests do start quickly
   "LoadAverageHigh" # Pointless, as test servers have minimal resources
   "SecurityEventsDetected" # This is normal for e2e tests
-  "D8NodeContainerdV2NotSupported" # This is normal for e2e tests for <1.36 clusters 
-  "D8NodeCgroupV2NotSupported" # This is normal for e2e tests for <1.36 clusters 
+  "D8NodeContainerdV2NotSupported" # This is normal for e2e tests for <1.36 clusters
+  "D8NodeCgroupV2NotSupported" # This is normal for e2e tests for <1.36 clusters
   "CertmanagerCertificateChallengePending" # This is normal for e2e tests
+  "D8ObsoletePublishAPIinUserAuthn" # Temporary while publish api is migrated between MCs
+  "D8SignatureErrorsDetected" # by default signatures not enabled for etcd keys
+  "CertmanagerCertificateChallengeStuck" # This is normal for e2e tests
   )
 
   # Alerts


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
add ingore alert CertmanagerCertificateChallengeStuck for e2e

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
for stable e2e tests

## Why do we need it in the patch release (if we do)?
Not related to release
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: add ingore alert CertmanagerCertificateChallengeStuck for e2e
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
