### PR TITLE
[node-manager]: collect and expose Deckhouse release info on nodes

### DIFF
--- a/candi/bashible/common-steps/all/096_update_deckhouse_release_info.sh.tpl
+++ b/candi/bashible/common-steps/all/096_update_deckhouse_release_info.sh.tpl
@@ -25,7 +25,12 @@ deckhouse_version="$(
 
 modules="$(
   bb-curl-kube "/apis/deckhouse.io/v1alpha1/modulereleases" |
-  jq '[.items[] | select(.status.phase=="Deployed") | .metadata.name]'
+  jq '
+    .items
+    | map(select(.status.phase=="Deployed"))
+    | map({key: .spec.moduleName, value: ("v" + .spec.version)})
+    | from_entries
+  '
 )"
 
 if [[ -z "$deckhouse_version" || -z "$modules" ]]; then

--- a/candi/bashible/common-steps/all/096_update_deckhouse_release_info.sh.tpl
+++ b/candi/bashible/common-steps/all/096_update_deckhouse_release_info.sh.tpl
@@ -16,9 +16,7 @@
 set -euo pipefail
 
 tmp_file="$(mktemp)"
-target_file="/var/lib/bashible/deckhouse-release-info.json"
-
-echo "$(date): updating Deckhouse release info"
+target_file="/var/lib/bashible/d8.version"
 
 deckhouse_version="$(
   bb-curl-kube "/apis/deckhouse.io/v1alpha1/deckhousereleases" |
@@ -43,6 +41,4 @@ jq -n \
 
 mv "$tmp_file" "$target_file"
 
-echo "$(date): release info updated successfully"
-
-) >> /var/log/deckhouse-release-info.log 2>&1 || true
+) || true

--- a/candi/bashible/common-steps/all/096_update_deckhouse_release_info.sh.tpl
+++ b/candi/bashible/common-steps/all/096_update_deckhouse_release_info.sh.tpl
@@ -1,0 +1,48 @@
+# Copyright 2021 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+(
+set -euo pipefail
+
+tmp_file="$(mktemp)"
+target_file="/var/lib/bashible/deckhouse-release-info.json"
+
+echo "$(date): updating Deckhouse release info"
+
+deckhouse_version="$(
+  bb-curl-kube "/apis/deckhouse.io/v1alpha1/deckhousereleases" |
+  jq -r '.items[] | select(.status.phase=="Deployed") | .metadata.name'
+)"
+
+modules="$(
+  bb-curl-kube "/apis/deckhouse.io/v1alpha1/modulereleases" |
+  jq '[.items[] | select(.status.phase=="Deployed") | .metadata.name]'
+)"
+
+if [[ -z "$deckhouse_version" || -z "$modules" ]]; then
+  bb-log-error "Failed to get Deckhouse release info"
+  exit 0
+fi
+
+jq -n \
+  --arg deckhouse "$deckhouse_version" \
+  --argjson modules "$modules" \
+  '{deckhouse: $deckhouse, modules: $modules}' \
+  > "$tmp_file"
+
+mv "$tmp_file" "$target_file"
+
+echo "$(date): release info updated successfully"
+
+) >> /var/log/deckhouse-release-info.log 2>&1 || true

--- a/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/bashible/rbac-for-us.yaml
@@ -289,6 +289,14 @@ rules:
       - bootstrap
     verbs:
       - get
+  - apiGroups:
+      - deckhouse.io
+    resources:
+      - modulereleases
+      - deckhousereleases
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description

Adds collection and persistence of Deckhouse release information on nodes.

The change introduces a bashible script which periodically retrieves deployed Deckhouse release information from Kubernetes API and stores it locally on nodes in JSON format.

Additionally, the d8:node-manager:bashible:bashible-apiserver ClusterRole receives read-only permissions for:
	•	modulereleases.deckhouse.io
	•	deckhousereleases.deckhouse.io

The implementation does not modify reconciliation logic and does not restart critical cluster components.

## Why do we need it, and what problem does it solve?

Some node-level bashible logic requires access to information about the currently deployed Deckhouse version and deployed module versions.

Bashible runs on nodes and uses `bb-curl-kube` to access the Kubernetes API using the node kubeconfig. Previously, the permissions available to node identities were not enough to read `ModuleRelease` and `DeckhouseRelease` resources.

This change allows bashible to retrieve release information from the Kubernetes API and persist it locally on the node in `/var/lib/bashible/deckhouse-release-info.json`.

The collection step is non-blocking: failures while retrieving release information are logged and do not interrupt the bashible converge cycle.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: feature
summary: Add local collection of Deckhouse release information on nodes
impact_level: low