### PR TITLE
[ingress-nginx] Fix  HPA CPU metric calculation.

### DIFF
--- a/modules/402-ingress-nginx/docs/FAQ.md
+++ b/modules/402-ingress-nginx/docs/FAQ.md
@@ -227,6 +227,12 @@ HPA is set with attributes `minReplicas` and `maxReplicas` in a [IngressNginxCon
 
 The IngressNginxController is deployed using DaemonSet. DaemonSet does not provide horizontal scaling capabilities, so `hpa-scaler` Deployment will be created with the HPA resource, which is observing custom metric `prometheus-metrics-adapter-d8-ingress-nginx-cpu-utilization-for-hpa`. If CPU utilization exceeds 50%, the HPA-controller scales `hpa-scaler` Deployment with a new replica (with respect to `minReplicas` and `maxReplicas`).
 
+{% alert level="warning" %}
+HPA for `IngressNginxController` scales based on the actual CPU usage of the controller Pods, not on CPU pressure on the node itself.
+
+If CPU resources on frontend nodes are already heavily utilized by other workloads and the controller Pods cannot consistently consume CPU above the scaling threshold, HPA may not trigger a scale-up even under high request load.
+{% endalert %}
+
 `hpa-scaler` Deployment has HardPodAntiAffinity, and it will order a new Node (inside its NodeGroup), where one more ingress-controller will be set.
 
 Notes:

--- a/modules/402-ingress-nginx/docs/FAQ.md
+++ b/modules/402-ingress-nginx/docs/FAQ.md
@@ -228,7 +228,7 @@ HPA is set with attributes `minReplicas` and `maxReplicas` in a [IngressNginxCon
 The IngressNginxController is deployed using DaemonSet. DaemonSet does not provide horizontal scaling capabilities, so `hpa-scaler` Deployment will be created with the HPA resource, which is observing custom metric `prometheus-metrics-adapter-d8-ingress-nginx-cpu-utilization-for-hpa`. If CPU utilization exceeds 50%, the HPA-controller scales `hpa-scaler` Deployment with a new replica (with respect to `minReplicas` and `maxReplicas`).
 
 {% alert level="warning" %}
-HPA for `IngressNginxController` scales based on the actual CPU usage of the controller Pods, not on CPU pressure on the node itself.
+HPA for IngressNginxController scales based on the actual CPU usage of the controller Pods, not on CPU pressure on the node itself.
 
 If CPU resources on frontend nodes are already heavily utilized by other workloads and the controller Pods cannot consistently consume CPU above the scaling threshold, HPA may not trigger a scale-up even under high request load.
 {% endalert %}

--- a/modules/402-ingress-nginx/docs/FAQ_RU.md
+++ b/modules/402-ingress-nginx/docs/FAQ_RU.md
@@ -228,6 +228,12 @@ spec:
 
 IngressNginxController разворачивается с помощью DaemonSet. DaemonSet не предоставляет возможности горизонтального масштабирования, поэтому создается дополнительный deployment `hpa-scaler` и HPA resource, который следит за предварительно созданной метрикой `prometheus-metrics-adapter-d8-ingress-nginx-cpu-utilization-for-hpa`. Если CPU utilization превысит 50%, HPA закажет новую реплику для `hpa-scaler` (с учетом minReplicas и maxReplicas).
 
+{% alert level="warning" %}
+HPA для `IngressNginxController` масштабирует контроллер по фактическому потреблению CPU Pod'ами контроллера, а не по самому факту CPU pressure на узле.
+
+Если CPU на frontend-узлах уже занят другой нагрузкой и Pod'ы контроллера не могут стабильно потреблять CPU выше порога масштабирования, HPA может не запустить scale-up даже при высокой входящей нагрузке.
+{% endalert %}
+
 Deployment `hpa-scaler` обладает HardPodAntiAffinity (запрет на размещение подов с одинаковыми лейблами на одном узле), поэтому он попытается выделить для себя новый узел (если это возможно
 в рамках своей группы узлов), куда автоматически будет размещен еще один instance Ingress-контроллера.
 

--- a/modules/402-ingress-nginx/docs/FAQ_RU.md
+++ b/modules/402-ingress-nginx/docs/FAQ_RU.md
@@ -229,9 +229,9 @@ spec:
 IngressNginxController разворачивается с помощью DaemonSet. DaemonSet не предоставляет возможности горизонтального масштабирования, поэтому создается дополнительный deployment `hpa-scaler` и HPA resource, который следит за предварительно созданной метрикой `prometheus-metrics-adapter-d8-ingress-nginx-cpu-utilization-for-hpa`. Если CPU utilization превысит 50%, HPA закажет новую реплику для `hpa-scaler` (с учетом minReplicas и maxReplicas).
 
 {% alert level="warning" %}
-HPA для `IngressNginxController` масштабирует контроллер по фактическому потреблению CPU Pod'ами контроллера, а не по самому факту CPU pressure на узле.
+HPA для IngressNginxController масштабирует контроллер по фактическому потреблению CPU подами контроллера, а не по самому факту CPU pressure на узле.
 
-Если CPU на frontend-узлах уже занят другой нагрузкой и Pod'ы контроллера не могут стабильно потреблять CPU выше порога масштабирования, HPA может не запустить scale-up даже при высокой входящей нагрузке.
+Если CPU на frontend-узлах уже занят другой нагрузкой и поды контроллера не могут стабильно потреблять CPU выше порога масштабирования, HPA может не запустить scale-up даже при высокой входящей нагрузке.
 {% endalert %}
 
 Deployment `hpa-scaler` обладает HardPodAntiAffinity (запрет на размещение подов с одинаковыми лейблами на одном узле), поэтому он попытается выделить для себя новый узел (если это возможно

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/hpa.yaml
@@ -15,5 +15,5 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-port-with-pp/controller/hpa.yaml
@@ -13,7 +13,7 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/hpa.yaml
@@ -15,5 +15,5 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/host-with-failover/controller/hpa.yaml
@@ -13,7 +13,7 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v110/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v110/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v110/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v110/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v112/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v112/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v112/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-annotation-validation-v112/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added-and-with-istio/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-envoy-header-added/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers-and-with-istio/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-hide-headers/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-istio/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-pp/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/hpa.yaml
@@ -15,5 +15,5 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-with-terminating/controller/hpa.yaml
@@ -13,7 +13,7 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/hpa.yaml
@@ -15,5 +15,5 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb-without-hpa/controller/hpa.yaml
@@ -13,7 +13,7 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/hpa.yaml
@@ -15,7 +15,7 @@ spec:
     rules:
     - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
         namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
-        container!="POD"}[1m]) * 100)))
+        container!="POD"}[3m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/template_tests/testdata/golden/lb/controller/hpa.yaml
@@ -13,9 +13,9 @@ spec:
   groups:
   - name: prometheus-metrics-adapter.d8-ingress-nginx
     rules:
-    - expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet",
-        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m])
-        * 100))
+    - expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet",
+        namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx",
+        container!="POD"}[1m]) * 100)))
       record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
 ---
 apiVersion: autoscaling/v2

--- a/modules/402-ingress-nginx/templates/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/templates/controller/hpa.yaml
@@ -11,7 +11,7 @@ spec:
     - name: prometheus-metrics-adapter.d8-ingress-nginx
       rules:
         - record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
-          expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet", namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx", container!="POD"}[1m]) * 100)))
+          expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet", namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx", container!="POD"}[3m]) * 100)))
 {{- end }}
 
 {{- define "ingress-controller-lb-hpa" }}

--- a/modules/402-ingress-nginx/templates/controller/hpa.yaml
+++ b/modules/402-ingress-nginx/templates/controller/hpa.yaml
@@ -11,7 +11,7 @@ spec:
     - name: prometheus-metrics-adapter.d8-ingress-nginx
       rules:
         - record: kube_adapter_metric_d8_ingress_nginx_ds_cpu_utilization
-          expr: avg by (controller_name) (kube_controller_pod{controller_type="DaemonSet", namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) round(rate(container_cpu_usage_seconds_total{container!="POD"}[1m]) * 100))
+          expr: avg by (controller_name) (sum by (pod, controller_name) (kube_controller_pod{controller_type="DaemonSet", namespace="d8-ingress-nginx"} * on (pod) group_right(controller_name) (rate(container_cpu_usage_seconds_total{namespace="d8-ingress-nginx", container!="POD"}[1m]) * 100)))
 {{- end }}
 
 {{- define "ingress-controller-lb-hpa" }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The metric used by HPA now sums CPU usage across containers within each controller pod and then averages across pods. The smoothing window was also increased from `1m` to `3m` to reduce noise.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

The previous metric averaged container-level CPU series after joining them with `controller_name`. For ingress controller pods with multiple containers, this diluted the actual pod CPU usage and caused HPA to see values significantly lower than the real load.

As a result:
- HPA could stay near or below threshold even when ingress controller pods were already consuming much more CPU.
- Autoscaling decisions were noisy because the metric was calculated over a `1m` window.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Test

<details>

<summary>HPA TEST</summary>

Before change:
 
the HPA metric was significantly lower than actual pod CPU usage because container CPU was averaged incorrectly.

<img width="1195" height="753" alt="image" src="https://github.com/user-attachments/assets/94ef54f9-f9ca-4e63-a3c3-7d62f5f9af41" />

After change:

<img width="1336" height="695" alt="image" src="https://github.com/user-attachments/assets/4fa370b7-20ab-42f2-a25e-78ed3c67a525" />


Metric graph

<img width="1886" height="807" alt="image" src="https://github.com/user-attachments/assets/ae2fce55-67c3-4640-9578-a8c8fdacfdb5" />

With Istio sidecar

<img width="1152" height="671" alt="image" src="https://github.com/user-attachments/assets/f1780552-a360-44c6-ba20-5d38f5046566" />

<img width="1041" height="797" alt="image" src="https://github.com/user-attachments/assets/eca17f14-76f3-4c93-9bb0-e149a1c9b4f2" />

Scale-up and post-scale load redistribution

<img width="1898" height="797" alt="image" src="https://github.com/user-attachments/assets/9f6aaf79-2484-4597-ab5f-830bee32817a" />


</details>

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [x] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed IngressNginxController HPA CPU metric calculation to use per-pod CPU and smoother averaging in `ingress-nginx`.
impact: HPA for LoadBalancer-based IngressNginxController may scale more accurately under real load and react less noisily due to the metric window change from 1m to 3m.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
