### PR TITLE
[cni-simple-bridge] Fix ip rules for 2 NICs systems

### DIFF
--- a/modules/035-cni-simple-bridge/images/simple-bridge/src/rootfs/bin/simple-bridge
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/src/rootfs/bin/simple-bridge
@@ -11,7 +11,7 @@ function ensure_pod_network_route() {
   fi
 }
 
-function patch_netplan() {
+function add_iprule() {
   local pod_cidr=$1
 
   if ! ip rule show | grep -q "10000:.*to $pod_cidr"; then
@@ -95,9 +95,8 @@ while true; do
   ]
 }
 END
-    if command -v netplan >/dev/null 2>&1 && [ $(find /sys/class/net/ -type l ! -lname '*/devices/virtual/*' | wc -l) -ge 2 ]; then
-      echo "patching netplan"
-      patch_netplan "$podcidr"
+    if [ $(find /sys/class/net/ -type l ! -lname '*/devices/virtual/*' | wc -l) -ge 2 ]; then
+      add_iprule "$podcidr"
     fi
 
     if [ "$ROUTE_POD_NETWORK_TO_GW" == "true" ]; then

--- a/modules/035-cni-simple-bridge/images/simple-bridge/src/rootfs/bin/simple-bridge
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/src/rootfs/bin/simple-bridge
@@ -11,6 +11,14 @@ function ensure_pod_network_route() {
   fi
 }
 
+function patch_netplan() {
+  local pod_cidr=$1
+
+  if ! ip rule show | grep -q "10000:.*to $pod_cidr"; then
+    ip rule add to "$pod_cidr" table 254 priority 10000
+  fi
+}
+
 while true; do
   node_object="$(curl --max-time 5 -s -S -f --resolve "kubernetes.default:443:$KUBERNETES_SERVICE_HOST" -s "https://kubernetes.default/api/v1/nodes/$NODE_NAME" --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)")"
 
@@ -87,6 +95,10 @@ while true; do
   ]
 }
 END
+    if command -v netplan >/dev/null 2>&1 && [ $(find /sys/class/net/ -type l ! -lname '*/devices/virtual/*' | wc -l) -ge 2 ]; then
+      echo "patching netplan"
+      patch_netplan "$podcidr"
+    fi
 
     if [ "$ROUTE_POD_NETWORK_TO_GW" == "true" ]; then
       SECONDS=0
@@ -95,12 +107,12 @@ END
         ensure_pod_network_route "$POD_SUBNET" "$gw"
         sleep 30
 
-        if (( SECONDS >= 3600 )); then
+        if (( SECONDS >= 60 )); then
           break
         fi
       done
     else
-      sleep 3600
+      sleep 60
     fi
   else
     echo "Waiting for .spec.podCIDR to be assigned to $NODE_NAME"

--- a/modules/035-cni-simple-bridge/images/simple-bridge/src/rootfs/bin/simple-bridge
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/src/rootfs/bin/simple-bridge
@@ -1,4 +1,17 @@
 #!/bin/bash -e
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 function sigterm() {
   exit $?

--- a/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
+++ b/modules/035-cni-simple-bridge/images/simple-bridge/werf.inc.yaml
@@ -31,7 +31,7 @@ imageSpec:
   config:
     entrypoint: ["/sbin/iptables-wrapper"]
 ---
-{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /bin/bash /bin/grep /usr/sbin/ip /usr/sbin/bridge" }}
+{{ $simpleBridgeBinaries := "/bin/awk /bin/cat /bin/rm /bin/echo /usr/bin/tee /bin/sleep /bin/hostname /bin/bash /bin/grep /usr/sbin/ip /usr/sbin/bridge /bin/find /bin/wc" }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-binaries-artifact
 final: false

--- a/modules/035-cni-simple-bridge/templates/daemonset.yaml
+++ b/modules/035-cni-simple-bridge/templates/daemonset.yaml
@@ -111,10 +111,6 @@ spec:
           mountPath: /run
         - name: cni
           mountPath: /etc/cni/net.d
-        - name: etc-netplan
-          mountPath: /etc/netplan
-        - name: netplan
-          mountPath: /usr/local/bin/netplan
         - name: tmp
           mountPath: /tmp
         - mountPath: /sbin
@@ -148,12 +144,6 @@ spec:
         emptyDir:
           medium: Memory
           sizeLimit: 4Mi
-      - name: etc-netplan
-        hostPath:
-          path: /etc/netplan
-      - name: netplan
-        hostPath:
-          path: /sbin/netplan
       - name: net
         hostPath:
           path: /sys/class/net

--- a/modules/035-cni-simple-bridge/templates/daemonset.yaml
+++ b/modules/035-cni-simple-bridge/templates/daemonset.yaml
@@ -111,10 +111,17 @@ spec:
           mountPath: /run
         - name: cni
           mountPath: /etc/cni/net.d
+        - name: etc-netplan
+          mountPath: /etc/netplan
+        - name: netplan
+          mountPath: /usr/local/bin/netplan
         - name: tmp
           mountPath: /tmp
         - mountPath: /sbin
           name: sbin
+          readOnly: true
+        - mountPath: /sys/class/net
+          name: net
           readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
@@ -141,3 +148,12 @@ spec:
         emptyDir:
           medium: Memory
           sizeLimit: 4Mi
+      - name: etc-netplan
+        hostPath:
+          path: /etc/netplan
+      - name: netplan
+        hostPath:
+          path: /sbin/netplan
+      - name: net
+        hostPath:
+          path: /sys/class/net


### PR DESCRIPTION
## Description

Fix for ip rules, what idempotently checks configuration and patches it once a minute

## Why do we need it, and what problem does it solve?

For Ubuntu 24.04 with 2 NIC in YC/AWS, if route to podCIDR network doesn't exists, packets from pod on host network is routed to default route and will never be received by pod in podCIDR

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cni-simple-bridge
type: fix
summary: Fix simple bridge script to add ip rule for two NICs nodes.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
