### PR TITLE
[container-base] New target to update alt_base_images.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,6 +439,36 @@ update-base-images-versions:
 	cd candi && curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml
 	$(MAKE) render-workflow
 
+BASE_LIMIT_KEYS := REGISTRY_PATH \
+                builder/distroless \
+                builder/golang-1.25 \
+                builder/golang-1.26 \
+                builder/golang \
+                minget-0.1 \
+                minget
+
+.PHONY: update-container-factory
+update-container-factory: ## Download container-factory digests and update candi/alt_base_images.yml
+	@set -e; \
+	test -n "$(version)" || (echo 'Err: version is required. Example: make update-container-factory version=v1.0.37' >&2; exit 1); \
+	ver="$(version)"; \
+	case "$$ver" in \
+	  v[0-9]*.[0-9]*.[0-9]*) ;; \
+	  [0-9]*.[0-9]*.[0-9]*) ver="v$$ver" ;; \
+	esac; \
+	cd candi; \
+	URL="https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$$ver/base_images.yml"; \
+	curl --fail -sSL "$$URL" -o .alt_base_images.full.yml; \
+	{ \
+	  echo "# version=$$ver"; \
+	  for key in $(BASE_LIMIT_KEYS); do \
+	    line=$$(grep -F "$${key}:" .alt_base_images.full.yml | head -n1); \
+	    echo "$$line"; \
+	  done; \
+	} > alt_base_images.yml; \
+	rm -f .alt_base_images.full.yml; \
+	echo "Updated candi/alt_base_images.yml to version $$ver"
+
 ##@ Build
 .PHONY: build
 set-build-envs:


### PR DESCRIPTION
## Description
Adds a Makefile target to download and regenerate `candi/alt_base_images.yml`

## Why do we need it, and what problem does it solve?
Removes the need to update images for every container-base release.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
Added `update-container-factory` Makefile target to automate regeneration of `candi/alt_base_images.yml` for a specified container-base release.

```changes
section: candi
type: chore
summary: removes the need to manually update alt_base_images.yml for every container-base release.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
