### PR TITLE
[node-manager] self-heal Instance.spec.nodeRef from machine

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/internal/controller/instance/controller.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/instance/controller.go
@@ -96,6 +96,7 @@ func (r *InstanceController) Reconcile(ctx context.Context, req ctrl.Request) (c
 		r.reconcileDeletion,
 		nonTerminalStep(r.instanceSvc.EnsureInstanceFinalizer),
 		nonTerminalStep(r.reconcileMachineRef),
+		nonTerminalStep(r.reconcileNodeRef),
 		r.reconcileSourceExistence,
 		nonTerminalStep(r.instanceSvc.ReconcileBashibleHeartbeat),
 		nonTerminalStep(r.instanceSvc.ReconcileBashibleStatus),
@@ -218,6 +219,37 @@ func (r *InstanceController) reconcileMachineRef(ctx context.Context, instance *
 	return nil
 }
 
+func (r *InstanceController) reconcileNodeRef(ctx context.Context, instance *deckhousev1alpha2.Instance) error {
+	if instance.Spec.NodeRef.Name != "" {
+		return nil
+	}
+
+	ref := instance.Spec.MachineRef
+	if ref == nil || ref.Name == "" {
+		return nil
+	}
+
+	machineObj, err := r.machineFactory.NewMachineFromRef(ctx, r.Client, ref)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	nodeName := machineObj.GetNodeName()
+	if nodeName == "" {
+		return nil
+	}
+
+	if err := r.patchInstanceNodeRef(ctx, instance, nodeName); err != nil {
+		return err
+	}
+
+	log.FromContext(ctx).Info("instance node ref self-healed", "instance", instance.Name, "node", nodeName)
+	return nil
+}
+
 func (r *InstanceController) reconcileMachineStatus(ctx context.Context, instance *deckhousev1alpha2.Instance) error {
 	ref := instance.Spec.MachineRef
 	if ref == nil || ref.Name == "" {
@@ -286,6 +318,17 @@ func (r *InstanceController) createInstanceFromMachine(ctx context.Context, m ma
 
 	if err := instancecommon.EnsureInstanceExists(ctx, r.Client, m.GetName(), spec); err != nil {
 		return fmt.Errorf("ensure instance for machine %q: %w", m.GetName(), err)
+	}
+
+	return nil
+}
+
+func (r *InstanceController) patchInstanceNodeRef(ctx context.Context, instance *deckhousev1alpha2.Instance, nodeName string) error {
+	patch := client.MergeFrom(instance.DeepCopy())
+	instance.Spec.NodeRef = deckhousev1alpha2.NodeRef{Name: nodeName}
+
+	if err := r.Client.Patch(ctx, instance, patch); err != nil {
+		return fmt.Errorf("patch instance %q node ref: %w", instance.Name, err)
 	}
 
 	return nil

--- a/modules/040-node-manager/images/node-controller/src/internal/controller/instance/controller_test.go
+++ b/modules/040-node-manager/images/node-controller/src/internal/controller/instance/controller_test.go
@@ -742,6 +742,65 @@ func TestReconcileExistingInstanceBindsMachineSource(t *testing.T) {
 	}, persisted.Spec.MachineRef)
 }
 
+func TestReconcileExistingInstanceBindsNodeRefFromMachine(t *testing.T) {
+	t.Parallel()
+
+	capiRef := &deckhousev1alpha2.MachineRef{
+		Kind:       "Machine",
+		APIVersion: capiv1beta2.GroupVersion.String(),
+		Name:       "worker-capi",
+		Namespace:  machine.MachineNamespace,
+	}
+	mcmRef := &deckhousev1alpha2.MachineRef{
+		Kind:       "Machine",
+		APIVersion: mcmv1alpha1.SchemeGroupVersion.String(),
+		Name:       "worker-mcm",
+		Namespace:  machine.MachineNamespace,
+	}
+
+	tests := []struct {
+		name        string
+		instance    *deckhousev1alpha2.Instance
+		machine     client.Object
+		wantNodeRef deckhousev1alpha2.NodeRef
+	}{
+		{
+			name: "capi machine reports node ref after instance creation",
+			instance: existingInstanceWithFinalizer("worker-capi", deckhousev1alpha2.InstanceSpec{
+				MachineRef: capiRef,
+			}, deckhousev1alpha2.InstancePhaseRunning),
+			machine:     capiMachine("worker-capi", "worker-capi-node"),
+			wantNodeRef: deckhousev1alpha2.NodeRef{Name: "worker-capi-node"},
+		},
+		{
+			name: "mcm machine reports node ref after instance creation",
+			instance: existingInstanceWithFinalizer("worker-mcm", deckhousev1alpha2.InstanceSpec{
+				MachineRef: mcmRef,
+			}, deckhousev1alpha2.InstancePhaseRunning),
+			machine:     mcmMachine("worker-mcm", "worker-mcm-node"),
+			wantNodeRef: deckhousev1alpha2.NodeRef{Name: "worker-mcm-node"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := ctrl.LoggerInto(context.Background(), ctrl.Log.WithName("test"))
+			controller, k8sClient := newTestInstanceController(t, nil, tt.instance, tt.machine)
+
+			result, err := controller.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: tt.instance.Name}})
+			require.NoError(t, err)
+			require.Equal(t, ctrl.Result{RequeueAfter: instanceRequeueInterval}, result)
+
+			persisted := &deckhousev1alpha2.Instance{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: tt.instance.Name}, persisted)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantNodeRef, persisted.Spec.NodeRef)
+		})
+	}
+}
+
 func TestReconcileSourceExistence(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Description

 Add `reconcileNodeRef` step to Instance reconcile pipeline. The step patches `spec.nodeRef` of an Instance when it is empty and the linked Machine already reports a node name in its status.

## Why do we need it, and what problem does it solve?

 If a Machine is created before its underlying node joins the cluster, `createInstanceFromMachine` persists the Instance with empty `spec.nodeRef`. After that, the pipeline never updates this field: only `MachineRef` is self-healed, and `reconcileMachineStatus` writes only `status`. As a result Instances created from Machine source
  stay with `nodeRef: {}` forever, even though the node is `Ready`.

  The new step is symmetric to `reconcileMachineRef` and fixes the field on the next reconcile triggered by Machine watcher

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix 
summary: Filled empty Instance.spec.nodeRef when the linked Machine reports a node name.
impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
