### PR TITLE
[deckhouse-controller] delete module documentation when module is disabled

### DIFF
--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -319,6 +319,12 @@ func (r *reconciler) processModule(ctx context.Context, moduleConfig *v1alpha1.M
 			r.logger.Error("failed to enable the module", slog.String("module", module.Name), log.Err(err))
 			return ctrl.Result{}, err
 		}
+
+		// restore documentation for the re-enabled module from its deployed release
+		if err := r.ensureModuleDocumentation(ctx, module); err != nil {
+			r.logger.Error("failed to ensure module documentation", slog.String("module", module.Name), log.Err(err))
+			return ctrl.Result{}, err
+		}
 	}
 
 	if module.IsExperimental() {
@@ -566,4 +572,22 @@ func (r *reconciler) enableModule(ctx context.Context, module *v1alpha1.Module) 
 
 		return true
 	})
+}
+
+func (r *reconciler) ensureModuleDocumentation(ctx context.Context, module *v1alpha1.Module) error {
+	releases := new(v1alpha1.ModuleReleaseList)
+	if err := r.client.List(ctx, releases, client.MatchingLabels{
+		v1alpha1.ModuleReleaseLabelModule: module.Name,
+		v1alpha1.ModuleReleaseLabelStatus: v1alpha1.ModuleReleaseLabelDeployed,
+	}); err != nil {
+		return fmt.Errorf("list module releases: %w", err)
+	}
+
+	for i := range releases.Items {
+		if err := utils.EnsureModuleDocumentationForRelease(ctx, r.client, &releases.Items[i]); err != nil {
+			return fmt.Errorf("ensure module documentation: %w", err)
+		}
+	}
+
+	return nil
 }

--- a/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/config/controller.go
@@ -523,6 +523,12 @@ func (r *reconciler) removeFinalizer(ctx context.Context, config *v1alpha1.Modul
 
 func (r *reconciler) disableModule(ctx context.Context, module *v1alpha1.Module) error {
 	r.logger.Debug("disable the module", slog.String("module", module.Name))
+
+	// remove module documentation immediately on disable so docs-builder drops it
+	if err := utils.DeleteModuleDocumentation(ctx, r.client, module.Name); err != nil {
+		return fmt.Errorf("delete module documentation: %w", err)
+	}
+
 	return utils.UpdateStatus[*v1alpha1.Module](ctx, r.client, module, func(module *v1alpha1.Module) bool {
 		if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionFalse) {
 			return false

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -36,6 +36,7 @@ import (
 	addonutils "github.com/flant/addon-operator/pkg/utils"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -639,11 +640,23 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		Controller: ptr.To(true),
 	}
 
-	// mpo not found - update the docs from the module release version
-	if err = utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
-		r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
+	// do not (re)create documentation for a module disabled by config
+	module := new(v1alpha1.Module)
+	if err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, module); err != nil {
+		if !apierrors.IsNotFound(err) {
+			r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
 
-		return res, fmt.Errorf("ensure module documentation: %w", err)
+			return res, fmt.Errorf("get module: %w", err)
+		}
+	}
+
+	// mpo not found - update the docs from the module release version
+	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) {
+		if err = utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
+			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
+
+			return res, fmt.Errorf("ensure module documentation: %w", err)
+		}
 	}
 
 	r.log.Debug("delete outdated releases for module", slog.String("module", release.GetModuleName()))

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -633,14 +633,12 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 	// do not (re)create documentation for a module disabled by config
 	module := new(v1alpha1.Module)
 	if err = r.client.Get(ctx, client.ObjectKey{Name: release.GetModuleName()}, module); err != nil {
-		if !apierrors.IsNotFound(err) {
-			r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
+		r.log.Error("failed to get module", slog.String("module", release.GetModuleName()), log.Err(err))
 
-			return res, fmt.Errorf("get module: %w", err)
-		}
+		return res, fmt.Errorf("get module: %w", err)
 	}
 
-	// mpo not found - update the docs from the module release version
+	// ensure documentation only for a module enabled by config
 	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) {
 		if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))

--- a/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/release/controller.go
@@ -16,7 +16,6 @@ package release
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -623,15 +622,6 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 		return res, nil
 	}
 
-	// Use mount point path: /modules/<module> (modules are mounted at /deckhouse/downloaded/modules/<module>)
-	modulePath := fmt.Sprintf("/modules/%s", release.GetModuleName())
-	moduleVersion := "v" + release.GetVersion().String()
-
-	moduleChecksum := release.Labels[v1alpha1.ModuleReleaseLabelReleaseChecksum]
-	if moduleChecksum == "" {
-		moduleChecksum = fmt.Sprintf("%x", md5.Sum([]byte(moduleVersion)))
-	}
-
 	ownerRef := metav1.OwnerReference{
 		APIVersion: v1alpha1.ModuleReleaseGVK.GroupVersion().String(),
 		Kind:       v1alpha1.ModuleReleaseGVK.Kind,
@@ -652,7 +642,7 @@ func (r *reconciler) handleDeployedRelease(ctx context.Context, release *v1alpha
 
 	// mpo not found - update the docs from the module release version
 	if module.IsCondition(v1alpha1.ModuleConditionEnabledByModuleConfig, corev1.ConditionTrue) {
-		if err = utils.EnsureModuleDocumentation(ctx, r.client, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef); err != nil {
+		if err = utils.EnsureModuleDocumentationForRelease(ctx, r.client, release); err != nil {
 			r.log.Error("failed to ensure module documentation", slog.String("module", release.GetModuleName()), log.Err(err))
 
 			return res, fmt.Errorf("ensure module documentation: %w", err)

--- a/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
@@ -318,6 +318,21 @@ func EnsureModuleDocumentation(
 	return nil
 }
 
+// DeleteModuleDocumentation deletes module documentation, ignoring NotFound
+func DeleteModuleDocumentation(ctx context.Context, cli client.Client, moduleName string) error {
+	md := &v1alpha1.ModuleDocumentation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: moduleName,
+		},
+	}
+
+	if err := cli.Delete(ctx, md); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete the '%s' module documentation: %w", moduleName, err)
+	}
+
+	return nil
+}
+
 // GetNotificationConfig gets config from discovery secret
 func GetNotificationConfig(ctx context.Context, cli client.Client) (releaseUpdater.NotificationConfig, error) {
 	secret := new(corev1.Secret)

--- a/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
+++ b/deckhouse-controller/pkg/controller/module-controllers/utils/utils.go
@@ -16,6 +16,7 @@ package utils //nolint:revive
 
 import (
 	"context"
+	"crypto/md5"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/deckhouse/deckhouse-controller/pkg/apis/deckhouse.io/v1alpha1"
@@ -331,6 +333,28 @@ func DeleteModuleDocumentation(ctx context.Context, cli client.Client, moduleNam
 	}
 
 	return nil
+}
+
+// EnsureModuleDocumentationForRelease ensures module documentation from a deployed release
+func EnsureModuleDocumentationForRelease(ctx context.Context, cli client.Client, release *v1alpha1.ModuleRelease) error {
+	// mount point path: /modules/<module>
+	modulePath := fmt.Sprintf("/modules/%s", release.GetModuleName())
+	moduleVersion := "v" + release.GetVersion().String()
+
+	moduleChecksum := release.Labels[v1alpha1.ModuleReleaseLabelReleaseChecksum]
+	if moduleChecksum == "" {
+		moduleChecksum = fmt.Sprintf("%x", md5.Sum([]byte(moduleVersion)))
+	}
+
+	ownerRef := metav1.OwnerReference{
+		APIVersion: v1alpha1.ModuleReleaseGVK.GroupVersion().String(),
+		Kind:       v1alpha1.ModuleReleaseGVK.Kind,
+		Name:       release.GetName(),
+		UID:        release.GetUID(),
+		Controller: ptr.To(true),
+	}
+
+	return EnsureModuleDocumentation(ctx, cli, release.GetModuleName(), release.GetModuleSource(), moduleChecksum, moduleVersion, modulePath, ownerRef)
 }
 
 // GetNotificationConfig gets config from discovery secret


### PR DESCRIPTION
## Description

Fixes a bug where a module's documentation was **not removed when the module was disabled**: the `ModuleDocumentation` resource (and the docs served by docs-builder, visible in the web UI) stayed in the cluster and even survived controller restarts, although the module was off.

Root cause: nothing deleted the documentation on disable, and the release controller actively brought it back — it `Owns` `ModuleDocumentation`, so removing the resource instantly triggered an owner reconcile that recreated it. The "check" that should have prevented this was missing.

Fix, all in `deckhouse-controller`:
- **config controller** — deletes the module's `ModuleDocumentation` on disable (docs-builder then drops the rendered docs via its finalizer);
- **release controller** — no longer recreates `ModuleDocumentation` for a module disabled by config (the missing check: ensure docs only for an enabled module);
- **config controller** — restores `ModuleDocumentation` on re-enable, so disable/enable round-trips correctly.


## Why do we need it, and what problem does it solve?

A disabled module kept its documentation published in the cluster (web UI) and it persisted across controller restarts — misleading, since a disabled module shouldn't keep serving docs. The fix makes documentation follow the module's enabled state: removed on disable, back on enable.


### Manual test (cluster) — `console` module

```console
# disable → documentation deleted
$ dcmd console
Module console disabled
$ k get moduledocumentation console
Error from server (NotFound): moduledocumentations.deckhouse.io "console" not found

# restart while disabled → still gone
$ restartdc && k -n d8-system rollout status deployment deckhouse
deployment "deckhouse" successfully rolled out
$ k get moduledocumentation console
Error from server (NotFound): moduledocumentations.deckhouse.io "console" not found

# re-enable → restored (already back before the module finishes installing)
$ dcme console
Module console enabled
$ k get module console
NAME      STAGE                  SOURCE      PHASE        ENABLED   READY
console   General Availability   deckhouse   Downloaded   False     False
$ k get moduledocumentation console
NAME      RESULT
console   Rendered
```

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Deleted module documentation when a module is disabled.
impact_level: default
```

