### PR TITLE
[docs] Update code ownership assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,7 +103,7 @@
 600-namespace-configurator/                                      @nabokihms @AlwxSin
 610-service-with-healthchecks                                    @AndreyPavlovFlant @apolovov
 800-deckhouse-tools/                                             @RomanenkoDenys @borg-z @090809
-810-documentation/                                               @z9r5
+810-documentation/                                               @zhbert
 
 /candi/                                  @borg-z @090809
 /candi/control-plane/                    @sprait
@@ -116,11 +116,11 @@ cloud-controller-manager/                @aleksey-su @pabateman
 csi/                                     @AleksZimin @duckhawk @szhem
 deckhouse-controller/                    @ldmonster
 dhctl/                                   @borg-z @090809
-docs/                                    @z9r5
+docs/                                    @zhbert
 docs/documentation/pages/architecture/   @voitenkov
 helm_lib/                                @ldmonster
-crds/                                    @z9r5
-openapi/                                 @z9r5
+crds/                                    @zhbert
+openapi/                                 @zhbert
 /pkg/                                    @ldmonster
 testing/cloud_layouts/                   @Nikolay1224 @KraMorK @Taior @himax1991
 /monitoring/prometheus-rules/            @sudoroot-null


### PR DESCRIPTION
## Description

Reassign documentation-related ownership across multiple path entries to reflect current team responsibility.  Replace prior reviewer with new assignee for docs, CRDs, OpenAPI specs, and documentation module paths

## Why do we need it, and what problem does it solve?

z9r5 is going to chilling on vacation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Update code ownership assignments.
impact_level: low
```
