### PR TITLE
[candi] bashible logs cleanup

### DIFF
--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -191,7 +191,6 @@ bb-indent-text() {
 }
 
 function annotate_node() {
-  echo "Annotating node $(bb-d8-node-name) with ${@}"
   attempt=0
   until error=$(bb-curl-helper-patch-node-metadata "$(bb-d8-node-name)" "annotations" "${@}" 2>&1); do
     attempt=$(( attempt + 1 ))
@@ -524,9 +523,7 @@ function main() {
     # parsed by dhctl-side measurement tooling to map where bashible time goes.
     local start_ts
     start_ts=$(date +%s.%N)
-    echo ===
-    echo === Step: $step
-    echo ===
+    echo "=== Step ${step_base} ==="
 
     span_ctx=$(bb-telemetry-start-span "$step_base" "${BB_TELEMETRY_PARENT_SPAN_ID:-}")
 
@@ -539,17 +536,15 @@ function main() {
         bb-event-error-create "$step"
         {{- end }}
         bb-bashible-ready-steps-failed "$step_base"
-        >&2 echo "ERROR: Failed to execute step $step, retry limit reached"
+        >&2 echo "ERROR: Failed to execute step ${step_base}, retry limit reached"
 
         bb-telemetry-end-span "$span_ctx" "$step_base"
 
         return 1
       fi
-      >&2 echo "Failed to execute step $step, retrying in 2 seconds"
+      >&2 echo "Failed to execute step ${step_base}, retrying in 2 seconds"
       sleep 2
-      echo ===
-      echo === Step: $step
-      echo ===
+      echo "=== Step ${step_base} retry ${attempt} ==="
       if [ "$attempt" -gt 2 ]; then
         sx=x
       fi
@@ -592,7 +587,7 @@ function main() {
         bb-run-step "$s" || exit 1
       done
     else
-      echo "=== bashible parallel-group '$group_name' start (${#steps[@]} steps) ==="
+      echo "=== Group ${group_name} start (${#steps[@]} steps) ==="
       local -a pids=()
       local s
       for s in "${steps[@]}"; do
@@ -607,10 +602,10 @@ function main() {
         fi
       done
       if [ "$failed" -gt 0 ]; then
-        >&2 echo "ERROR: parallel-group '$group_name': $failed of ${#steps[@]} steps failed"
+        >&2 echo "ERROR: Group ${group_name}: ${failed} of ${#steps[@]} steps failed"
         exit 1
       fi
-      echo "=== bashible parallel-group '$group_name' done ==="
+      echo "=== Group ${group_name} done ==="
     fi
   }
 

--- a/candi/bashible/bashible.sh.tpl
+++ b/candi/bashible/bashible.sh.tpl
@@ -78,7 +78,7 @@ bb-curl-kube() {
       if [[ -n "${kube_server:-}" ]]; then
         export BB_KUBE_APISERVER_URL="$kube_server"
       else
-        >&2 echo "bb-curl-kube: cannot resolve API server endpoint"
+        >&2 echo "bb-curl-kube: cannot resolve Kubernetes API server endpoint"
         return 1
       fi
     fi
@@ -131,7 +131,7 @@ bb-curl-helper-patch-node-metadata() {
   bb-curl-kube "/api/v1/nodes/${node_name}" \
     -X PATCH \
     -H "Content-Type: application/strategic-merge-patch+json" \
-    --data "$patch"
+    --data "$patch" >/dev/null
 }
 
 bb-label-node-bashible-first-run-finished() {
@@ -140,16 +140,16 @@ bb-label-node-bashible-first-run-finished() {
 
   while [ $attempt -le $max_attempts ]; do
     if bb-curl-helper-patch-node-metadata "$(bb-d8-node-name)" "labels" "node.deckhouse.io/bashible-first-run-finished=true"; then
-      echo "Successfully set label node.deckhouse.io/bashible-first-run-finished on node $(bb-d8-node-name)"
+      echo "Set label node.deckhouse.io/bashible-first-run-finished on node $(bb-d8-node-name)"
       return 0
     fi
 
-    echo "[$attempt/$max_attempts] Failed to set label on node $(bb-d8-node-name), retrying in 5 seconds..."
+    echo "Attempt $attempt of $max_attempts to set first-run-finished label on node $(bb-d8-node-name) failed, retrying in 5 seconds"
     attempt=$((attempt + 1))
     sleep 5
   done
 
-  echo "ERROR: Timed out after $max_attempts attempts. Could not set label node.deckhouse.io/bashible-first-run-finished on node $(bb-d8-node-name)." >&2
+  echo "ERROR: Could not set node.deckhouse.io/bashible-first-run-finished label on node $(bb-d8-node-name) after $max_attempts attempts" >&2
   bb-bashible-ready-error "Failed to set node.deckhouse.io/bashible-first-run-finished label"
   exit 1
 }
@@ -166,12 +166,12 @@ bb-node-has-bashible-uninitialized-taint() {
         return 1
       fi
     fi
-    echo "[$attempt/$max_attempts] Failed to get node $(bb-d8-node-name), retrying in 5 seconds..."
+    echo "Attempt $attempt of $max_attempts to read node $(bb-d8-node-name) failed, retrying in 5 seconds"
     attempt=$((attempt + 1))
     sleep 5
   done
 
-  echo "ERROR: Timed out after $max_attempts attempts. Could not check taint node.deckhouse.io/bashible-uninitialized on node $(bb-d8-node-name)." >&2
+  echo "ERROR: Could not check the node.deckhouse.io/bashible-uninitialized taint on node $(bb-d8-node-name) after $max_attempts attempts" >&2
   return 1
 }
 
@@ -191,23 +191,22 @@ bb-indent-text() {
 }
 
 function annotate_node() {
-  echo "Annotate node $(bb-d8-node-name) with annotation ${@}"
+  echo "Annotating node $(bb-d8-node-name) with ${@}"
   attempt=0
   until error=$(bb-curl-helper-patch-node-metadata "$(bb-d8-node-name)" "annotations" "${@}" 2>&1); do
     attempt=$(( attempt + 1 ))
     if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
-      >&2 echo "ERROR: Failed to annotate node $(bb-d8-node-name) with annotation ${@} after ${MAX_RETRIES} retries. Last error: ${error}"
+      >&2 echo "ERROR: Failed to annotate node $(bb-d8-node-name) with ${@} after ${MAX_RETRIES} retries. Last error: ${error}"
       bb-bashible-ready-error "Failed to annotate node after retry limit"
       exit 1
     fi
     if [ "$attempt" -gt "2" ]; then
-      >&2 echo "Failed to annotate node $(bb-d8-node-name) with annotation ${@} after 3 tries. Last message: ${error}"
-      >&2 echo "Retrying..."
+      >&2 echo "Failed to annotate node $(bb-d8-node-name) with ${@} after 3 tries, will keep retrying. Last error: ${error}"
       attempt=0
     fi
     sleep 10
   done
-  echo "Successful annotate node $(bb-d8-node-name) with annotation ${@}"
+  echo "Annotated node $(bb-d8-node-name) with ${@}"
 }
 
 function get_secret() {
@@ -218,11 +217,11 @@ function get_secret() {
     until bb-curl-kube "/api/v1/namespaces/d8-cloud-instance-manager/secrets/$secret"; do
       attempt=$(( attempt + 1 ))
       if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
-        >&2 echo "ERROR: Failed to get secret $secret"
+        >&2 echo "ERROR: Failed to get secret $secret after ${MAX_RETRIES} retries"
         bb-bashible-ready-error "Failed to get secret ${secret} after retry limit"
         exit 1
       fi
-      >&2 echo "failed to get secret $secret"
+      >&2 echo "Failed to get secret $secret, retrying in 2 seconds"
       sleep 2
     done
 {{ if eq .runType "Normal" }}
@@ -235,14 +234,14 @@ function get_secret() {
         then
           return 0
         else
-          >&2 echo "failed to get secret $secret with curl https://$server..."
+          >&2 echo "Failed to get secret $secret from $server"
         fi
       done
       sleep 2
     done
 {{ end }}
   else
-    >&2 echo "failed to get secret $secret: can't find kubelet.conf or bootstrap-token"
+    >&2 echo "Failed to get secret $secret: neither kubelet.conf nor bootstrap-token is available"
     bb-bashible-ready-error "Failed to get secret ${secret}: kubelet.conf and bootstrap-token are unavailable"
     exit 1
   fi
@@ -257,11 +256,11 @@ function get_bundle() {
     until bb-curl-kube "/apis/bashible.deckhouse.io/v1alpha1/${resource}s/${name}"; do
       attempt=$(( attempt + 1 ))
       if [ -n "${MAX_RETRIES-}" ] && [ "$attempt" -gt "${MAX_RETRIES}" ]; then
-        >&2 echo "ERROR: Failed to get $resource $name"
+        >&2 echo "ERROR: Failed to get $resource $name after ${MAX_RETRIES} retries"
         bb-bashible-ready-error "Failed to get ${resource} ${name} after retry limit"
         exit 1
       fi
-      >&2 echo "failed to get $resource $name"
+      >&2 echo "Failed to get $resource $name, retrying in 2 seconds"
       sleep 2
     done
 {{ if eq .runType "Normal" }}
@@ -274,14 +273,14 @@ function get_bundle() {
         then
          return 0
         else
-          >&2 echo "failed to get $resource $name with curl https://$server..."
+          >&2 echo "Failed to get $resource $name from $server"
         fi
       done
       sleep 2
     done
 {{ end }}
   else
-    >&2 echo "failed to get $resource $name: can't find kubelet.conf or bootstrap-token"
+    >&2 echo "Failed to get $resource $name: neither kubelet.conf nor bootstrap-token is available"
     bb-bashible-ready-error "Failed to get ${resource} ${name}: kubelet.conf and bootstrap-token are unavailable"
     exit 1
   fi
@@ -314,7 +313,7 @@ function get_pods() {
       then
       return 0
       else
-        >&2 echo "failed to get $resource $name with curl https://$server..."
+        >&2 echo "Failed to list pods in $namespace from $server"
       fi
     done
     sleep 10
@@ -399,7 +398,7 @@ function main() {
     if tmp="$(bb-curl-kube "/api/v1/nodes/$(bb-d8-node-name)" | jq -r '.metadata.labels."node.deckhouse.io/group"')" ; then
       NODE_GROUP="$tmp"
       if [ "${NODE_GROUP}" == "null" ] ; then
-        >&2 echo "failed to get node group. Forgot set label 'node.deckhouse.io/group'"
+        >&2 echo "Node group label is missing. Set 'node.deckhouse.io/group' on this node."
       fi
     fi
   fi
@@ -427,13 +426,13 @@ function main() {
 
     printf '%s\n' "$bashible_bundle" | jq -r '.data."bashible.sh"' > $BOOTSTRAP_DIR/bashible-new.sh
     if [ ! -s $BOOTSTRAP_DIR/bashible-new.sh ] ; then
-      >&2 echo "ERROR: Got empty $BOOTSTRAP_DIR/bashible-new.sh."
+      >&2 echo "ERROR: bashible-new.sh is empty (path: $BOOTSTRAP_DIR/bashible-new.sh)"
       bb-bashible-ready-error "Got empty bashible-new.sh"
       exit 1
     fi
     read -r first_line < $BOOTSTRAP_DIR/bashible-new.sh
     if [[ "$first_line" != '#!/usr/bin/env bash' ]] ; then
-      >&2 echo "ERROR: $BOOTSTRAP_DIR/bashible-new.sh is not a bash script."
+      >&2 echo "ERROR: bashible-new.sh is not a bash script (path: $BOOTSTRAP_DIR/bashible-new.sh)"
       bb-bashible-ready-error "bashible-new.sh is not a bash script"
       exit 1
     fi
@@ -459,7 +458,7 @@ function main() {
   fi
   if [[ "$FIRST_BASHIBLE_RUN" != "yes" ]] && [[ -f "$BASHIBLE_INITIALIZED_FILE" ]] && test -f /etc/kubernetes/kubelet.conf; then
     if bb-node-has-bashible-uninitialized-taint; then
-      echo "WARNING: Node is initialized but bashible-uninitialized taint is still present. Re-applying first-run-finished label..."
+      echo "WARNING: node is initialized but bashible-uninitialized taint is still present, re-applying first-run-finished label"
       bb-label-node-bashible-first-run-finished
     fi
   fi
@@ -540,13 +539,13 @@ function main() {
         bb-event-error-create "$step"
         {{- end }}
         bb-bashible-ready-steps-failed "$step_base"
-        >&2 echo "ERROR: Failed to execute step $step. Retry limit is over."
+        >&2 echo "ERROR: Failed to execute step $step, retry limit reached"
 
         bb-telemetry-end-span "$span_ctx" "$step_base"
 
         return 1
       fi
-      >&2 echo -e "Failed to execute step "$step" ... retry in 10 seconds.\n"
+      >&2 echo "Failed to execute step $step, retrying in 2 seconds"
       sleep 2
       echo ===
       echo === Step: $step
@@ -608,7 +607,7 @@ function main() {
         fi
       done
       if [ "$failed" -gt 0 ]; then
-        >&2 echo "ERROR: parallel-group '$group_name': $failed/${#steps[@]} steps failed"
+        >&2 echo "ERROR: parallel-group '$group_name': $failed of ${#steps[@]} steps failed"
         exit 1
       fi
       echo "=== bashible parallel-group '$group_name' done ==="
@@ -671,7 +670,7 @@ if [ -n "${no_lock-}" ]; then
   main
 else
   (
-    flock -n 200 || { >&2 echo "Can't acquire lockfile /var/lock/bashible."; exit 1; }
+    flock -n 200 || { >&2 echo "Cannot acquire lockfile /var/lock/bashible (another bashible run is in progress)"; exit 1; }
     main
   ) 200>/var/lock/bashible
 fi

--- a/candi/bashible/bb_node_ip.sh.tpl
+++ b/candi/bashible/bb_node_ip.sh.tpl
@@ -57,7 +57,7 @@ if [ -f /etc/kubernetes/kubelet.conf ] ; then
   if node="$(bb-curl-kube "/api/v1/nodes/$(bb-d8-node-name)" 2> /dev/null)" ; then
     echo "$node" | jq -r '([.status.addresses[] | select(.type == "InternalIP") | .address] + [.status.addresses[] | select(.type == "ExternalIP") | .address])[0] // ""' > /var/lib/bashible/discovered-node-ip
   else
-    bb-log-error "Cannot discover node IP from Node object: API server is unreachable"
+    bb-log-error "Cannot discover node IP from Node object: Kubernetes API server is unreachable"
     exit 1
   fi
 fi

--- a/candi/bashible/bb_node_ip.sh.tpl
+++ b/candi/bashible/bb_node_ip.sh.tpl
@@ -23,7 +23,7 @@ function discover_internal_network_cidrs() {
     discovered_internal_network_cidrs="$(ip route show scope link proto kernel dev "${physical_iface}" | awk '{print $1}')"
     echo "$discovered_internal_network_cidrs"
   else
-    echo "Cannot discover internal network CIDRs. Node has more than one interface, and StaticClusterConfiguration internalNetworkCIDRs is not set." >&2
+    echo "Cannot discover internal network CIDRs: node has more than one interface and StaticClusterConfiguration.internalNetworkCIDRs is not set" >&2
     return 1
   fi
 }
@@ -57,7 +57,7 @@ if [ -f /etc/kubernetes/kubelet.conf ] ; then
   if node="$(bb-curl-kube "/api/v1/nodes/$(bb-d8-node-name)" 2> /dev/null)" ; then
     echo "$node" | jq -r '([.status.addresses[] | select(.type == "InternalIP") | .address] + [.status.addresses[] | select(.type == "ExternalIP") | .address])[0] // ""' > /var/lib/bashible/discovered-node-ip
   else
-    bb-log-error "Unable to discover node IP for node object: No access to API server"
+    bb-log-error "Cannot discover node IP from Node object: API server is unreachable"
     exit 1
   fi
 fi

--- a/candi/bashible/bootstrap/02-bootstrap-bashible.sh.tpl
+++ b/candi/bashible/bootstrap/02-bootstrap-bashible.sh.tpl
@@ -68,7 +68,7 @@ function get_bundle() {
       then
        return 0
       else
-        >&2 echo "failed to get $resource $name with curl https://$server..."
+        >&2 echo "Failed to get $resource $name from $server"
       fi
     done
     sleep 10
@@ -88,7 +88,7 @@ while [ "$patch_pending" = true ] ; do
   for server in {{ .clusterMasterKubeAPIEndpoints | join " " }} ; do
     server_addr=$(echo $server | cut -f1 -d":")
     until node_ip="$(ip ro get ${server_addr} | grep -Po '(?<=src )([0-9\.]+)')"; do
-      echo "The network is not ready for connecting to apiserver yet, waiting..."
+      echo "Network is not ready for connecting to $server_addr, waiting"
       sleep 1
     done
 
@@ -107,7 +107,7 @@ while [ "$patch_pending" = true ] ; do
       --data "[{\"op\":\"add\",\"path\":\"/status/bootstrapStatus\", \"value\": {\"description\": \"Use curl -N 'http://${node_ip}:${output_log_port}' to get bootstrap logs.\", \"logsEndpoint\": \"http://${node_ip}:${output_log_port}\"} }]" \
       "https://$server/apis/deckhouse.io/v1alpha2/instances/${machine_name}/status" ; then
 
-      echo "Successfully patched instance ${machine_name} status."
+      echo "Patched instance ${machine_name} status via $server"
       patch_pending=false
 
       break
@@ -115,12 +115,12 @@ while [ "$patch_pending" = true ] ; do
       failure_count=$((failure_count + 1))
 
       if [[ $failure_count -eq $failure_limit ]]; then
-        >&2 echo "Failed to patch instance ${machine_name} status. Number of attempts exceeded. Status patch will be skipped."
+        >&2 echo "Failed to patch instance ${machine_name} status, retry limit reached, skipping status patch"
         patch_pending=false
         break
       fi
 
-      >&2 echo "Failed to patch instance ${machine_name} status. ${failure_count} of ${failure_limit} attempts..."
+      >&2 echo "Failed to patch instance ${machine_name} status (attempt ${failure_count} of ${failure_limit})"
       sleep 10
       continue
     fi
@@ -134,6 +134,6 @@ chmod +x $BOOTSTRAP_DIR/bashible.sh
 
 # Bashible first run
 until bash --noprofile --norc -c /var/lib/bashible/bashible.sh; do
-  echo "Error running bashible script. Retry in 10 seconds."
+  echo "bashible script failed, retrying in 10 seconds"
   sleep 10
 done

--- a/candi/bashible/check_python.sh.tpl
+++ b/candi/bashible/check_python.sh.tpl
@@ -21,6 +21,6 @@ function check_python() {
       return 0
     fi
   done
-  echo "Python not found, exiting..."
+  echo "Python not found"
   return 1
 }

--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -51,10 +51,10 @@ function nodeuser_patch() {
           --data "@${json_file}" >/dev/null; do
       failure_count=$((failure_count + 1))
       if [[ $failure_count -eq $failure_limit ]]; then
-        bb-log-error "Failed to patch NodeUser. Number of attempts exceeded. NodeUser patch will be skipped."
+        bb-log-error "Failed to patch NodeUser ${username}, retry limit reached, skipping patch"
         break
       fi
-      bb-log-error "Failed to patch NodeUser. Retrying..."
+      bb-log-error "Failed to patch NodeUser ${username}, retrying in 10 seconds"
       sleep 10
     done
     rm $json_file
@@ -65,13 +65,12 @@ function nodeuser_patch() {
     while [ "$patch_pending" = true ] ; do
       if [ ${#AVAILABLE_API_SERVERS[@]} -eq 0 ]; then
         read -r -a AVAILABLE_API_SERVERS <<< "$API_SERVERS"
-        bb-log-info "All servers failed once, resetting to original list and retrying"
+        bb-log-info "All API servers failed once, resetting candidate list and retrying"
       fi
-      bb-log-info "Current AVAILABLE_API_SERVERS: ${AVAILABLE_API_SERVERS[*]}"
       for server in "${AVAILABLE_API_SERVERS[@]}"; do
         local server_addr=$(echo $server | cut -f1 -d":")
         until local tcp_endpoint="$(ip ro get ${server_addr} | grep -Po '(?<=src )([0-9\.]+)')"; do
-          bb-log-info "The network is not ready for connecting to apiserver yet, waiting..."
+          bb-log-info "Network is not ready for connecting to $server_addr, waiting"
           sleep 1
         done
 
@@ -85,30 +84,30 @@ function nodeuser_patch() {
           --data "${data}" \
           "https://$server/apis/deckhouse.io/v1/nodeusers/${username}/status" > /dev/null; then
 
-          bb-log-info "Successfully patched NodeUser."
+          bb-log-info "Patched NodeUser ${username} via $server"
           patch_pending=false
           break
         else
 
           AVAILABLE_API_SERVERS=($(printf '%s\n' "${AVAILABLE_API_SERVERS[@]}" | grep -v "^$server$"))
-          bb-log-info "Server $server failed once, removing from current list"
+          bb-log-info "API server $server failed, removing from candidate list"
 
           failure_count=$((failure_count + 1))
 
           if [[ $failure_count -eq $failure_limit ]]; then
-            bb-log-error "Failed to patch NodeUser. Number of attempts exceeded. NodeUser patch will be skipped."
+            bb-log-error "Failed to patch NodeUser ${username}, retry limit reached, skipping patch"
             patch_pending=false
             break
           fi
 
-          bb-log-error "Failed to patch NodeUser via $server. ${failure_count} of ${failure_limit} attempts..."
+          bb-log-error "Failed to patch NodeUser ${username} via $server (attempt ${failure_count} of ${failure_limit})"
           sleep 3
         fi
       done
     done
 
   else
-    bb-log-error "failed to patch NodeUser: can't find kubelet.conf or bootstrap-token"
+    bb-log-error "Failed to patch NodeUser ${username}: neither kubelet.conf nor bootstrap-token is available"
     exit 1
   fi
 }

--- a/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
+++ b/candi/bashible/common-steps/all/000_check_containerd_v2_support.sh.tpl
@@ -26,7 +26,7 @@ can_load_erofs() {
 }
 
 
-# CVE-2025-37999 impacts Linux kernels 6.12.0–6.12.28 and 6.14.0–6.14.6
+# CVE-2025-37999 impacts Linux kernels 6.12.0 to 6.12.28 and 6.14.0 to 6.14.6
 is_kernel_erofs_cve_vulnerable() {
   local full_kv=$(uname -r)
 
@@ -127,7 +127,7 @@ function set_labels() {
 
     ((retries++))
     if [[ $retries -ge $MAX_RETRIES ]]; then
-      bb-log-error "can't set containerd-v2-not-supported label or error annotation on Node."
+      bb-log-error "Failed to set containerd-v2-unsupported label or error annotation on node after $MAX_RETRIES retries"
       return 1
     fi
     sleep 5
@@ -144,26 +144,26 @@ function fail_fast() {
     echo "$errs" | jq -c '.[]' | while read err; do
         err=$(echo $err | sed 's/"//g')
         if [ "$err" == "systemd" ]; then
-          bb-log-error "minimum required version of systemd ${MIN_SYSTEMD}"
+          bb-log-error "systemd ${MIN_SYSTEMD} or newer is required for containerd v2"
         fi
 
         if [ "$err" == "kernel" ]; then
-          bb-log-error "minimum required version of kernel ${MIN_KERNEL}"
+          bb-log-error "Linux kernel ${MIN_KERNEL} or newer is required for containerd v2"
         fi
 
         if [ "$err" == "cgroupv2" ]; then
-          bb-log-error "required cgroupv2 support"
+          bb-log-error "cgroup v2 support is required for containerd v2"
         fi
 
         if [ "$err" == "erofs" ]; then
-          bb-log-error "required erofs kernel module"
+          bb-log-error "erofs kernel module is required for containerd v2"
         fi
 
         if [ "$err" == "kernel_cve_2025_37999" ]; then
-          bb-log-error "Linux kernels 6.12.0–6.12.28 and 6.14.0–6.14.6 have issues with EROFS functionality (CVE-2025-37999). Kernel upgrade required to proceed."
+          bb-log-error "Linux kernels 6.12.0 to 6.12.28 and 6.14.0 to 6.14.6 are affected by CVE-2025-37999 in EROFS. Upgrade the kernel before enabling containerd v2."
         fi
     done
-    bb-log-error "containerd V2 is not supported"
+    bb-log-error "containerd v2 is not supported on this node"
     exit 1
   fi
 }

--- a/candi/bashible/common-steps/all/000_preflight_checks.sh.tpl
+++ b/candi/bashible/common-steps/all/000_preflight_checks.sh.tpl
@@ -17,14 +17,14 @@ if [[ "$FIRST_BASHIBLE_RUN" == "yes" ]]; then
   CONTAINERD_PATH="$(command -v containerd 2>/dev/null || true)"
   if [[ -n "$CONTAINERD_PATH" ]]; then
     if [[ "$CONTAINERD_PATH" != "/opt/deckhouse/bin/containerd" ]]; then
-    bb-log-error "containerd is detected on $HOSTNAME. Deckhouse does not support pre-provisioned containerd installations. Please uninstall containerd and try again."
+    bb-log-error "containerd is already installed on $HOSTNAME. Deckhouse does not support pre-provisioned containerd installations, please uninstall it and retry."
     exit 1
     fi
   fi
 else
   if systemctl list-unit-files containerd.service >/dev/null 2>&1; then
     if systemctl is-enabled containerd >/dev/null 2>&1 || systemctl is-active containerd >/dev/null 2>&1; then
-      bb-log-error "containerd.service is enabled or running on $HOSTNAME. Deckhouse use only containerd-deckhouse.service. Please disable/stop/uninstall containerd.service to avoid further conflicts."
+      bb-log-error "containerd.service is enabled or running on $HOSTNAME. Deckhouse uses containerd-deckhouse.service only, please disable and stop containerd.service to avoid conflicts."
       exit 1
     fi
   fi

--- a/candi/bashible/common-steps/all/001_prefetch_registry_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/001_prefetch_registry_packages.sh.tpl
@@ -28,7 +28,7 @@
 {{- end }}
 
 if ! command -v systemd-run >/dev/null 2>&1 || ! command -v systemctl >/dev/null 2>&1; then
-  bb-log-warning "systemd-run/systemctl not available; skip prefetch — 007 will fetch inline"
+  bb-log-warning "systemd-run or systemctl is not available, skipping prefetch. Step 007 will fetch packages inline."
   return 0 2>/dev/null || exit 0
 fi
 
@@ -36,13 +36,13 @@ fi
 case "$(systemctl is-system-running 2>/dev/null || true)" in
   running|degraded|starting|initializing|maintenance) ;;
   *)
-    bb-log-warning "systemd not in usable state; skip prefetch"
+    bb-log-warning "systemd is not in a usable state, skipping prefetch"
     return 0 2>/dev/null || exit 0
     ;;
 esac
 
 if ! command -v rpp-get >/dev/null 2>&1; then
-  bb-log-warning "rpp-get not yet available; skip prefetch — 007 will fetch inline"
+  bb-log-warning "rpp-get is not yet available, skipping prefetch. Step 007 will fetch packages inline."
   return 0 2>/dev/null || exit 0
 fi
 
@@ -54,7 +54,7 @@ env_file="/run/rpp-prefetch.env"
 #   - inactive/failed  → reset and (re)launch
 case "$(systemctl is-active $unit 2>/dev/null || true)" in
   active|activating)
-    bb-log-info "$unit already running; nothing to do"
+    bb-log-info "$unit is already running, nothing to do"
     return 0 2>/dev/null || exit 0
     ;;
   failed)
@@ -71,7 +71,7 @@ esac
 # persist the RPP auth/context explicitly for the background fetch. Keep the
 # token out of the unit definition by sourcing a root-only env file at runtime.
 if ! (umask 077 && : > "$env_file"); then
-  bb-log-warning "failed to create $env_file; skip prefetch — 007 will fetch inline"
+  bb-log-warning "Failed to create $env_file, skipping prefetch. Step 007 will fetch packages inline."
   return 0 2>/dev/null || exit 0
 fi
 
@@ -107,8 +107,8 @@ if ! systemd-run \
       \"toml-merge:{{ .images.registrypackages.tomlMerge01 }}\" \
       \"pause:{{ .images.registrypackages.pause }}\"" \
     >/dev/null 2>&1; then
-  bb-log-warning "systemd-run failed to launch $unit; 007 will fetch inline"
+  bb-log-warning "systemd-run failed to launch $unit, step 007 will fetch packages inline"
   return 0 2>/dev/null || exit 0
 fi
 
-bb-log-info "$unit launched; subsequent step 007 will wait for it"
+bb-log-info "$unit launched, step 007 will wait for it"

--- a/candi/bashible/common-steps/all/001_waiting_approval_annotations.sh.tpl
+++ b/candi/bashible/common-steps/all/001_waiting_approval_annotations.sh.tpl
@@ -17,7 +17,7 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   WAITING_APPROVAL_MAX_RETRIES=30
   WAITING_APPROVAL_RETRY_SLEEP_SEC=15
 
-  bb-log-info "Setting update.node.deckhouse.io/waiting-for-approval= annotation on our Node..."
+  bb-log-info "Setting update.node.deckhouse.io/waiting-for-approval= annotation on this node"
   attempt=0
   until
     node_data="$(
@@ -32,18 +32,18 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
   do
     attempt=$(( attempt + 1 ))
     if [ "$attempt" -gt "${WAITING_APPROVAL_MAX_RETRIES}" ]; then
-      bb-log-error "Can't set update.node.deckhouse.io/waiting-for-approval= annotation on our Node."
+      bb-log-error "Failed to set update.node.deckhouse.io/waiting-for-approval= annotation on this node"
       exit 1
     fi
     bb-curl-helper-patch-node-metadata "$(bb-d8-node-name)" "annotations" \
       "--resource-version=$(jq -nr --argjson n "$node_data" '$n.resourceVersion')" \
       "update.node.deckhouse.io/waiting-for-approval=" "node.deckhouse.io/configuration-checksum-" \
-      || { bb-log-info "Retry setting update.node.deckhouse.io/waiting-for-approval= annotation on our Node in ${WAITING_APPROVAL_RETRY_SLEEP_SEC}sec..."; sleep "${WAITING_APPROVAL_RETRY_SLEEP_SEC}"; }
+      || { bb-log-info "Failed to set the waiting-for-approval annotation, retrying in ${WAITING_APPROVAL_RETRY_SLEEP_SEC} seconds"; sleep "${WAITING_APPROVAL_RETRY_SLEEP_SEC}"; }
   done
 
-  bb-log-info "Waiting for update.node.deckhouse.io/approved= annotation on our Node..."
+  bb-log-info "Waiting for update.node.deckhouse.io/approved= annotation on this node"
   approval_command="kubectl annotate node $(bb-d8-node-name) update.node.deckhouse.io/approved="
-  waiting_approval_message="Steps are waiting for approval to start. Deckhouse is performing a rolling update. If you want to force an update, use: ${approval_command}"
+  waiting_approval_message="Steps are waiting for approval to start. Deckhouse is performing a rolling update. To force the update, run: ${approval_command}"
   waiting_approval_status_set="no"
   attempt=0
   until
@@ -57,13 +57,11 @@ if [ "$FIRST_BASHIBLE_RUN" == "no" ]; then
     attempt=$(( attempt + 1 ))
     if [ "$attempt" -gt "${WAITING_APPROVAL_MAX_RETRIES}" ]; then
       bb-waiting-approval-timeout "Waiting for approval timed out. ${waiting_approval_message}"
-      bb-log-info "Waiting for approval exceeded retry limit (${WAITING_APPROVAL_MAX_RETRIES}). Continue waiting for approval."
+      bb-log-info "Approval wait exceeded retry limit (${WAITING_APPROVAL_MAX_RETRIES}), still waiting"
       attempt=0
     fi
-    bb-log-info "Steps are waiting for approval to start."
-    bb-log-info "Deckhouse is performing a rolling update. If you want to force an update, use"
-    bb-log-info "${approval_command}"
-    bb-log-info "Retry in ${WAITING_APPROVAL_RETRY_SLEEP_SEC}sec..."
+    bb-log-info "Waiting for approval to start the next steps. Deckhouse is performing a rolling update."
+    bb-log-info "To force the update, run: ${approval_command}"
     sleep "${WAITING_APPROVAL_RETRY_SLEEP_SEC}"
   done
   bb-waiting-approval-not-required

--- a/candi/bashible/common-steps/all/004_create_deckhouse_user.sh.tpl
+++ b/candi/bashible/common-steps/all/004_create_deckhouse_user.sh.tpl
@@ -31,7 +31,7 @@ create_user_and_group() {
     fi
 
     if [ -n "$uid" ] || [ -n "$gid" ]; then
-        bb-log-warning "user or group already exists with different id: uid=${uid}, gid=${gid}"
+        bb-log-warning "User or group already exists with a different id: uid=${uid}, gid=${gid}"
         return
     fi
 

--- a/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
+++ b/candi/bashible/common-steps/all/005_integrate_kubernetes_data_device.sh.tpl
@@ -30,13 +30,13 @@ function get_data_device_secret() {
         then
           return 0
         else
-          >&2 echo "failed to get secret $secret from server $server"
+          >&2 echo "Failed to get secret $secret from $server"
         fi
       done
       sleep 10
     done
   else
-    >&2 echo "failed to get secret $secret: can't find bootstrap-token"
+    >&2 echo "Failed to get secret $secret: bootstrap-token is not available"
     return 1
   fi
 }
@@ -54,7 +54,7 @@ if [ -f /var/lib/bashible/kubernetes_data_device_path ]; then
 else
   DATA_DEVICE="$(get_data_device_secret | jq -re --arg hostname "$(bb-d8-node-name)" '.data[$hostname] // empty' | base64 -d)"
   if [ -z "$DATA_DEVICE" ]; then
-    >&2 echo "failed to get data device path"
+    >&2 echo "Failed to read data device path for node $(bb-d8-node-name) from secret"
     exit 1
   fi
 fi
@@ -91,12 +91,12 @@ fi
 #       }
 */}}
 if ! [ -b "$DATA_DEVICE" ]; then
-  >&2 echo "failed to find $DATA_DEVICE disk. Trying to detect the correct one"
+  >&2 echo "Block device $DATA_DEVICE was not found, trying to autodetect an unused disk"
   DATA_DEVICE=$(lsblk -o path,type,mountpoint,fstype --tree --json | jq -r '.blockdevices[] | select (.path | contains("zram") | not ) | select ( .type == "disk" and .mountpoint == null and .children == null) | .path')
 fi
 
 if [ $(wc -l <<< $DATA_DEVICE) -ne 1 ]; then
-  >&2 echo "failed to detect the correct disk: more than one or no matching disks found: $DATA_DEVICE"
+  >&2 echo "Could not autodetect a single unused disk, candidates: $DATA_DEVICE"
   return 1
 fi
 

--- a/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
+++ b/candi/bashible/common-steps/all/006_check_gpu.sh.tpl
@@ -17,12 +17,12 @@
   {{ if .nodeGroup.gpu }}
 
 if ! command -v /usr/bin/nvidia-container-runtime >/dev/null 2>&1; then
-    bb-log-error "'/usr/bin/nvidia-container-runtime' doesn't exist. It's require for Nvdia GPU nodes."
+    bb-log-error "/usr/bin/nvidia-container-runtime is not installed. It is required on NVIDIA GPU nodes."
     exit 1
 fi
 
 if ! command -v /usr/bin/nvidia-smi; then
-    bb-log-error "'/usr/bin/nvidia-smi' doesn't exist. It's require for Nvdia GPU nodes."
+    bb-log-error "/usr/bin/nvidia-smi is not installed. It is required on NVIDIA GPU nodes."
     exit 1
 fi
 
@@ -33,7 +33,7 @@ function compare() {
   lower_version=$(echo -e "$2\n$1" | sort -V | head -n1)
   if [[ "$lower_version" != "$2" ]]
   then
-    bb-log-error "The installed drivers version $1 doesn't meet the requirements. Update it to at least $2."
+    bb-log-error "NVIDIA driver version $1 is below the required minimum $2, please update the driver"
     exit 1
   fi
 }
@@ -63,15 +63,15 @@ compare $version $required_version
 
 got_capabilities=$(nvidia-smi --query-gpu="compute_cap" --format=csv,noheader | tr -d ' ' | sed '/^$/d')
 if [[ -z "$got_capabilities" ]]; then
-    echo "compute_cap is empty"
+    bb-log-error "nvidia-smi returned an empty compute capability list"
     exit 1
 fi
 
 while IFS= read -r got_capability; do
     if is_valid_greater_than "$got_capability" "6.0"; then
-        echo "compute_cap ${got_capability} is valid"
+        bb-log-info "GPU compute capability $got_capability is supported"
     else
-        echo "compute_cap ${got_capability} is invalid"
+        bb-log-error "GPU compute capability $got_capability is below the required minimum 6.0"
         exit 1
     fi
 done <<< "$got_capabilities"

--- a/candi/bashible/common-steps/all/011_disable_floppy_drive.sh.tpl
+++ b/candi/bashible/common-steps/all/011_disable_floppy_drive.sh.tpl
@@ -27,7 +27,7 @@ if lsmod | grep floppy -q ; then
   elif command -v make-initrd >/dev/null 2>&1; then
     make-initrd
   else
-    bb-log-warning "update-initramfs or make-initrd not found. If you observe the ‘blkid’ hang problem, try to update initramfs without the floppy module."
+    bb-log-warning "Neither update-initramfs nor make-initrd is installed. If blkid hangs on this node, rebuild the initramfs without the floppy module."
     exit 0
   fi
 

--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -19,7 +19,7 @@ _on_containerd_config_changed() {
 
 
 migrate() {
-  bb-log-info "start containerd migration"
+  bb-log-info "Starting containerd migration"
   systemctl stop kubelet.service
   bb-flag-set kubelet-need-restart
   crictl ps -q | xargs -r crictl stop -t 0 && crictl ps -a -q | xargs -r crictl rm -f
@@ -34,7 +34,7 @@ migrate() {
   bb-flag-set reboot
   bb-flag-unset cntrd-major-version-changed
   bb-flag-unset disruption
-  bb-log-info "finish containerd migration"
+  bb-log-info "Finished containerd migration"
 }
 
 bb-event-on 'containerd-config-file-changed' '_on_containerd_config_changed'
@@ -462,13 +462,13 @@ check_additional_configs() {
     for path in ${full_conf_path}/*.toml; do
       if [ "$ctrd_version" = "v1" ]; then
         if bb-ctrd-v1-has-registry-fields "${path}"; then
-          >&2 echo "Failed to merge $path: contains custom registry fields; please configure them in /etc/containerd/registry.d"
+          >&2 echo "Failed to merge $path: it contains custom registry fields, configure them in /etc/containerd/registry.d instead"
           exit 1
         fi
       fi
       if [ "$ctrd_version" = "v2" ]; then
         if bb-ctrd-v2-has-registry-fields "${path}"; then
-          >&2 echo "Failed to merge $path: contains custom registry fields; please configure them in /etc/containerd/registry.d"
+          >&2 echo "Failed to merge $path: it contains custom registry fields, configure them in /etc/containerd/registry.d instead"
           exit 1
         fi
       fi

--- a/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
+++ b/candi/bashible/common-steps/all/034_ctr_import_local_images.sh.tpl
@@ -29,7 +29,7 @@ ctr_import_image() {
 
 
 post-install-import() {
-  bb-log-info "start crt images import"
+  bb-log-info "Importing local images via ctr"
   local PACKAGE="$1"
 
   if [[ "${PACKAGE}" == "pause" ]]; then

--- a/candi/bashible/common-steps/all/035_prefetch_node_images.sh.tpl
+++ b/candi/bashible/common-steps/all/035_prefetch_node_images.sh.tpl
@@ -37,20 +37,20 @@
 {{- if and (eq .nodeGroup.name "master") (or (eq .cri "Containerd") (eq .cri "ContainerdV2")) }}
 
 if ! command -v systemd-run >/dev/null 2>&1 || ! command -v systemctl >/dev/null 2>&1; then
-  bb-log-warning "systemd-run/systemctl not available; skip image prefetch"
+  bb-log-warning "systemd-run or systemctl is not available, skipping image prefetch"
   return 0 2>/dev/null || exit 0
 fi
 
 case "$(systemctl is-system-running 2>/dev/null || true)" in
   running|degraded|starting|initializing|maintenance) ;;
   *)
-    bb-log-warning "systemd not in usable state; skip image prefetch"
+    bb-log-warning "systemd is not in a usable state, skipping image prefetch"
     return 0 2>/dev/null || exit 0
     ;;
 esac
 
 if ! command -v crictl >/dev/null 2>&1; then
-  bb-log-warning "crictl not available; skip image prefetch"
+  bb-log-warning "crictl is not available, skipping image prefetch"
   return 0 2>/dev/null || exit 0
 fi
 
@@ -168,7 +168,7 @@ crit_count=$(printf '%s\n' "$critical_images" | grep -c . || true)
 rest_count=$(printf '%s\n' "$images" | grep -c . || true)
 total_count=$((crit_count + rest_count))
 if [ "${total_count:-0}" -eq 0 ]; then
-  log "$(ts) image prefetch: empty list; nothing to do"
+  log "$(ts) image prefetch: empty list, nothing to do"
   rm -f "$script_file" "$results_file"
   exit 0
 fi
@@ -259,7 +259,7 @@ if ! systemd-run \
     --collect \
     /bin/bash "$script_file" \
     >/dev/null 2>&1; then
-  bb-log-warning "systemd-run failed to launch $unit"
+  bb-log-warning "systemd-run failed to launch $unit, skipping image prefetch"
   rm -f "$script_file"
   return 0 2>/dev/null || exit 0
 fi

--- a/candi/bashible/common-steps/all/063_install_kubelet_forker.sh.tpl
+++ b/candi/bashible/common-steps/all/063_install_kubelet_forker.sh.tpl
@@ -19,7 +19,7 @@ set -e
 # Start sysctl-tuner to set appropriate values to system variables before kubelet start
 if [ -x /opt/deckhouse/bin/sysctl-tuner ]; then
   if ! /opt/deckhouse/bin/sysctl-tuner; then
-    >&2 echo "d8-kubelet-forker [ERROR] sysctl-tuner crashed (abnormal termination) with exit code $? ."
+    >&2 echo "d8-kubelet-forker [ERROR] sysctl-tuner exited with code $?"
     exit 1
   fi
 fi
@@ -33,15 +33,15 @@ until ss -nltp4 | grep -qE "127.0.0.1:10248.*pid=$CHILDREN_PID" && /opt/deckhous
   attempt=$(( attempt + 1 ))
 
   if ! kill -0 $CHILDREN_PID 2>/dev/null; then
-    >&2 echo "d8-kubelet-forker [ERROR] kubelet with PID $CHILDREN_PID is not running."
+    >&2 echo "d8-kubelet-forker [ERROR] kubelet (PID $CHILDREN_PID) is not running"
     exit 1
   fi
 
   if [ "$attempt" -gt "$max_attempts" ]; then
-    >&2 echo "d8-kubelet-forker [ERROR] Could not reach /healthz HTTP-endpoint of kubelet with PID $CHILDREN_PID after $max_attempts attempts. Exiting."
+    >&2 echo "d8-kubelet-forker [ERROR] kubelet (PID $CHILDREN_PID) /healthz did not return 200 after $max_attempts attempts, giving up"
     exit 1
   fi
-  echo "d8-kubelet-forker [INFO] Waiting for HTTP 200 response from /healthz endpoing of kubelet with PID $CHILDREN_PID (attempt $attempt of $max_attempts)..."
+  echo "d8-kubelet-forker [INFO] Waiting for /healthz on kubelet (PID $CHILDREN_PID) to return 200 (attempt $attempt of $max_attempts)"
   sleep 1
 done
 

--- a/candi/bashible/common-steps/all/069_start_kubelet.sh.tpl
+++ b/candi/bashible/common-steps/all/069_start_kubelet.sh.tpl
@@ -19,10 +19,10 @@ function wait-kubelet-client-certificate() {
   until [ -f /var/lib/kubelet/pki/kubelet-client-current.pem ]; do
     attempt=$(( attempt + 1 ))
     if [ "$attempt" -gt "30" ]; then
-      bb-log-error "The file /var/lib/kubelet/pki/kubelet-client-current.pem was not generated in 5 minutes.\nPlease check logs of kubelet: journalctl -u kubelet.service"
+      bb-log-error "kubelet did not generate /var/lib/kubelet/pki/kubelet-client-current.pem in 5 minutes. Check kubelet logs: journalctl -u kubelet.service"
       break
     fi
-    bb-log-info "Waiting till the file /var/lib/kubelet/pki/kubelet-client-current.pem generated (10sec)..."
+    bb-log-info "Waiting for /var/lib/kubelet/pki/kubelet-client-current.pem to appear"
     sleep 10
   done
   {{- else }}
@@ -32,7 +32,7 @@ function wait-kubelet-client-certificate() {
 
 if bb-flag? kubelet-need-restart; then
 
-  bb-log-warning "'kubelet-need-restart' flag was set, restarting kubelet."
+  bb-log-warning "kubelet-need-restart flag is set, restarting kubelet"
   if [ -f /var/lib/kubelet/cpu_manager_state ]; then rm /var/lib/kubelet/cpu_manager_state; fi
   if [ -f /var/lib/kubelet/memory_manager_state ]; then rm /var/lib/kubelet/memory_manager_state; fi
   {{ $kubernetesVersion := .kubernetesVersion | toString }}
@@ -47,7 +47,7 @@ if bb-flag? kubelet-need-restart; then
   systemctl restart "kubelet.service"
   {{ if ne .runType "ClusterBootstrap" }}
   if [[ "${FIRST_BASHIBLE_RUN}" != "yes" ]] && ! bb-flag? reboot; then
-    bb-log-info "Kubelet service was restarted. Sleep 60 seconds to prevent oscillation in Cloud LoadBalancer targets."
+    bb-log-info "kubelet was restarted, sleeping 60 seconds to avoid oscillation in cloud LoadBalancer targets"
     # Issue with oscillating cloud LoadBalancer targets is tracked here.
     # https://github.com/kubernetes/kubernetes/issues/102367
     # Remove the sleep once a solution is devised.
@@ -67,11 +67,11 @@ if systemctl is-active --quiet "kubelet.service"; then
   exit 0
 fi
 
-bb-log-warning "Kubelet service is not running. Starting it..."
+bb-log-warning "kubelet service is not running, starting it"
 if systemctl start "kubelet.service"; then
-  bb-log-info "Kubelet has started."
+  bb-log-info "kubelet started"
   wait-kubelet-client-certificate
 else
-  bb-log-error "Kubelet has not started. Exit"
+  bb-log-error "kubelet failed to start"
   exit 1
 fi

--- a/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
+++ b/candi/bashible/common-steps/all/076_install_d8_shutdown_inhibitor.sh.tpl
@@ -27,7 +27,7 @@
 {{-   $imagePresent = false }}
 {{- end }}
 
-bb-log-warning "package = {{ $inhibitorPackage }}, present = {{ $imagePresent }}"
+bb-log-debug "shutdown inhibitor package={{ $inhibitorPackage }} present={{ $imagePresent }}"
 
 inhibitor_service_name="d8-shutdown-inhibitor.service"
 extra_logind_conf="/etc/systemd/logind.conf.d/99-node-d8-shutdown-inhibitor.conf"
@@ -117,12 +117,12 @@ function inhibitor::enable() {
     return 0
   fi
 
-  bb-log-info "Deckhouse shutdown inhibitor service is disabled. Enable it..."
+  bb-log-info "Enabling Deckhouse shutdown inhibitor service"
   if systemctl enable "${inhibitor_service_name}"; then
-    bb-log-info "Deckhouse shutdown inhibitor was enabled."
+    bb-log-info "Deckhouse shutdown inhibitor service enabled"
   else
     systemctl status "${inhibitor_service_name}"
-    bb-log-error "Deckhouse shutdown inhibitor has not been enabled."
+    bb-log-error "Failed to enable Deckhouse shutdown inhibitor service"
   fi
 }
 
@@ -132,12 +132,12 @@ function inhibitor::disable() {
     return 0
   fi
 
-  bb-log-info "Deckhouse shutdown inhibitor service is enabled. Disable it..."
+  bb-log-info "Disabling Deckhouse shutdown inhibitor service"
   if systemctl disable "${inhibitor_service_name}"; then
-    bb-log-info "Deckhouse shutdown inhibitor was disabled."
+    bb-log-info "Deckhouse shutdown inhibitor service disabled"
   else
     systemctl status "${inhibitor_service_name}"
-    bb-log-error "Deckhouse shutdown inhibitor has not been disabled."
+    bb-log-error "Failed to disable Deckhouse shutdown inhibitor service"
   fi
 }
 
@@ -150,16 +150,16 @@ function inhibitor::start() {
 
   # Do nothing if already started.
   if systemctl is-active --quiet "${inhibitor_service_name}"; then
-    bb-log-warning "Deckhouse shutdown inhibitor service is already running."
+    bb-log-warning "Deckhouse shutdown inhibitor service is already running"
     exit 0
   fi
 
-  bb-log-warning "Deckhouse shutdown inhibitor service is not running. Starting it..."
+  bb-log-warning "Deckhouse shutdown inhibitor service is not running, starting it"
   if systemctl start "${inhibitor_service_name}"; then
-    bb-log-info "Deckhouse shutdown inhibitor has been started."
+    bb-log-info "Deckhouse shutdown inhibitor service started"
   else
     systemctl status "${inhibitor_service_name}"
-    bb-log-error "Deckhouse shutdown inhibitor has not been started. Exit"
+    bb-log-error "Failed to start Deckhouse shutdown inhibitor service"
     exit 1
   fi
 }
@@ -167,18 +167,18 @@ function inhibitor::start() {
 function inhibitor::stop() {
   # Do nothing if already stopped.
   if ! systemctl is-active --quiet "${inhibitor_service_name}"; then
-    bb-log-warning "Deckhouse shutdown inhibitor service is already stopped."
+    bb-log-warning "Deckhouse shutdown inhibitor service is already stopped"
     # Cleanup logind configuration if not done previously.
     bb-event-fire 'd8-shutdown-inhibitor-cleanup'
     return
   fi
 
-  bb-log-warning "Deckhouse shutdown inhibitor service is running. Stop it..."
+  bb-log-warning "Stopping Deckhouse shutdown inhibitor service"
   if systemctl stop "${inhibitor_service_name}"; then
-    bb-log-info "Deckhouse shutdown inhibitor has been stopped."
+    bb-log-info "Deckhouse shutdown inhibitor service stopped"
   else
     systemctl status "${inhibitor_service_name}"
-    bb-log-error "Deckhouse shutdown inhibitor has not been stopped. Exit"
+    bb-log-error "Failed to stop Deckhouse shutdown inhibitor service"
     return
   fi
 

--- a/candi/bashible/common-steps/all/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
+++ b/candi/bashible/common-steps/all/089_manually_unmount_old_csi_mounts_after_kubernetes_1_24.sh.tpl
@@ -34,7 +34,6 @@ return 0
 mount_output="$(mount)"
 
 if ! grep -q '/var/lib/kubelet/plugins/kubernetes.io/csi/pv/' <<< "$mount_output"; then
-  echo 'No mounts of form "/var/lib/kubelet/plugins/kubernetes.io/csi/pv/" present. No-op...'
   disable_systemd_units
   exit 0
 fi

--- a/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
+++ b/candi/bashible/common-steps/all/091_set_virtualization_type.sh.tpl
@@ -41,10 +41,10 @@ node=$(bb-d8-node-name)
 until bb-curl-helper-patch-node-metadata "$node" "annotations" "node.deckhouse.io/virtualization=$virtualization"; do
   attempt=$(( attempt + 1 ))
   if [ "$attempt" -gt "$max_attempts" ]; then
-    bb-log-error "failed to annotate node $node after $max_attempts attempts"
+    bb-log-error "Failed to annotate node $node after $max_attempts attempts"
     exit 1
   fi
-  echo "Waiting for annotate node $node (attempt $attempt of $max_attempts)..."
+  echo "Retrying to set virtualization annotation on node $node (attempt $attempt of $max_attempts)"
   sleep 5
 done
 {{- end  }}

--- a/candi/bashible/common-steps/all/092_set_cgroup_type.sh.tpl
+++ b/candi/bashible/common-steps/all/092_set_cgroup_type.sh.tpl
@@ -21,7 +21,7 @@ fi
 
 node=$(bb-d8-node-name)
 cgroup="$(stat -fc %T /sys/fs/cgroup)" || {
-  bb-log-error "failed to get cgroup version from node $node"
+  bb-log-error "Failed to detect cgroup version on node $node"
   exit 1
 }
 
@@ -33,10 +33,10 @@ max_attempts=5
 until bb-curl-helper-patch-node-metadata "$node" "labels" "node.deckhouse.io/cgroup=$cgroup"; do
   attempt=$(( attempt + 1 ))
   if [ "$attempt" -gt "$max_attempts" ]; then
-    bb-log-error "failed to label node $node after $max_attempts attempts"
+    bb-log-error "Failed to label node $node after $max_attempts attempts"
     exit 1
   fi
-  echo "Waiting for label node $node (attempt $attempt of $max_attempts)..."
+  echo "Retrying to set cgroup label on node $node (attempt $attempt of $max_attempts)"
   sleep 5
 done
 {{- end  }}

--- a/candi/bashible/common-steps/all/095_check_reboot_annotation.sh.tpl
+++ b/candi/bashible/common-steps/all/095_check_reboot_annotation.sh.tpl
@@ -22,7 +22,7 @@ if [[ $REBOOT_ANNOTATION != "null" ]]
       do
         if [[ attempts == 0 ]]
           then
-            >&2 echo "out of attempts. exiting..."
+            >&2 echo "Reboot annotation is set but node did not drain in 30 attempts, giving up"
             exit 1
         fi
         DRAINING_ANNOTATION="$( bb-curl-kube "/api/v1/nodes/$D8_NODE_HOSTNAME" |jq -r '.metadata.annotations."update.node.deckhouse.io/draining"' )"

--- a/candi/bashible/common-steps/all/098_configure_auditd.sh.tpl
+++ b/candi/bashible/common-steps/all/098_configure_auditd.sh.tpl
@@ -20,7 +20,7 @@ _on_audit_rules_changed() {
     augenrules --load
     bb-flag-unset auditd-need-reload
   else
-    bb-log-error "failed to reload auditd rules"
+    bb-log-error "Failed to reload auditd rules"
     exit 1
   fi
 }
@@ -49,7 +49,7 @@ EOF
 EOF
 fi
 if command -v auditctl &>/dev/null; then
-  auditctl -b 65536 || bb-log-warning "failed to configure auditctl backlog, continuing with defaults"
+  auditctl -b 65536 || bb-log-warning "Failed to configure auditctl backlog, continuing with defaults"
 else
   bb-log-info "auditctl is not installed, skipping backlog configuration"
 fi

--- a/candi/bashible/common-steps/all/098_update_node_annotations.sh.tpl
+++ b/candi/bashible/common-steps/all/098_update_node_annotations.sh.tpl
@@ -21,10 +21,10 @@ function add_node_annotation() {
   until bb-curl-helper-patch-node-metadata "$(bb-d8-node-name)" "annotations" "${annotation}"; do
     failure_count=$((failure_count + 1))
     if [[ $failure_count -eq $failure_limit ]]; then
-      bb-log-error "Failed to annotate node $(bb-d8-node-name)"
+      bb-log-error "Failed to set annotation ${annotation} on node $(bb-d8-node-name) after $failure_limit attempts"
       exit 1
     fi
-    bb-log-error "failed to annotate node $(bb-d8-node-name)"
+    bb-log-error "Failed to set annotation ${annotation} on node $(bb-d8-node-name), retrying in 10 seconds"
     sleep 10
   done
 }
@@ -38,10 +38,10 @@ function remove_node_annotation() {
   until bb-curl-helper-patch-node-metadata "$(bb-d8-node-name)" "annotations" "${annotation}-"; do
     failure_count=$((failure_count + 1))
     if [[ $failure_count -eq $failure_limit ]]; then
-      bb-log-error "Failed to annotate node $(bb-d8-node-name)"
+      bb-log-error "Failed to remove annotation ${annotation} from node $(bb-d8-node-name) after $failure_limit attempts"
       exit 1
     fi
-    bb-log-error "failed to annotate node $(bb-d8-node-name)"
+    bb-log-error "Failed to remove annotation ${annotation} from node $(bb-d8-node-name), retrying in 10 seconds"
     sleep 10
   done
 }

--- a/candi/bashible/common-steps/all/099_reboot.sh.tpl
+++ b/candi/bashible/common-steps/all/099_reboot.sh.tpl
@@ -24,7 +24,7 @@ if ! bb-flag? reboot; then
 fi
 
 bb-deckhouse-get-disruptive-update-approval
-bb-log-info "Rebooting machine"
+bb-log-info "Rebooting the machine"
 bb-flag-unset reboot
 
 # Skip the reboot on the very first bashible run to save ~30-40s of provisioning
@@ -35,7 +35,7 @@ bb-flag-unset reboot
 # Watch the first bashible cycle for iptables/kube-proxy/coredns regressions; if
 # anything misbehaves, fall back to the historical `shutdown -r -t 5` path.
 if [ "$FIRST_BASHIBLE_RUN" == "yes" ]; then
-  bb-log-info "Skipping reboot on first bashible run (perf optimization)."
+  bb-log-info "Skipping reboot on first bashible run to speed up provisioning"
   bb-flag-unset disruption
   bb-label-node-bashible-first-run-finished
   touch $BASHIBLE_INITIALIZED_FILE
@@ -62,10 +62,10 @@ attempt=0
 until ! pidof kubelet > /dev/null; do
   attempt=$(( attempt + 1 ))
   if [ "$attempt" -gt "20" ]; then
-    bb-log-error "Can't stop kubelet. Will try to set NotReady status while kubelet is running."
+    bb-log-error "kubelet did not stop in 20 seconds, will set NotReady status with kubelet still running"
     break
   fi
-  bb-log-info "Waiting till kubelet stopped (20sec)..."
+  bb-log-info "Waiting for kubelet to stop"
   sleep 1
 done
 
@@ -74,16 +74,16 @@ attempt=0
 while true; do
   attempt=$(( attempt + 1 ))
   if [[ ${attempt} -gt 3 ]]; then
-    bb-log-warning "Can't update Node status condition to NotReady. Will reboot as is."
+    bb-log-warning "Could not patch node Ready condition to NotReady, rebooting anyway"
     break
   fi
 
-  bb-log-info "Setting node status to NotReady..."
+  bb-log-info "Setting node Ready condition to NotReady"
 
   ready_condition_key=""
   if ! ready_condition_key="$(bb-curl-kube "/api/v1/nodes/$(bb-d8-node-name)" |
        jq -r '.status.conditions | to_entries[] | select(.value.type == "Ready") | .key')"; then
-    bb-log-warning "failed to get ready condition from node"
+    bb-log-warning "Failed to read Ready condition from node status"
     sleep 2
     continue
   fi
@@ -111,7 +111,7 @@ while true; do
     break
   fi
 
-  bb-log-warning "failed to patch node ready condition"
+  bb-log-warning "Failed to patch node Ready condition, retrying in 2 seconds"
   sleep 2
 done
 

--- a/candi/bashible/common-steps/cluster-bootstrap/020_install_registry_igniter.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/020_install_registry_igniter.sh.tpl
@@ -22,17 +22,17 @@ pod_kill_and_wait() {
   echo "Removing pod: ${pod_prefix}"
 
   if [ -z "${pod_prefix}" ]; then
-    echo "Empty prefix, skip"
+    echo "Empty pod prefix, skipping"
     return 0
   fi
 
   if ! command -v crictl > /dev/null 2>&1; then
-    echo "crictl not found, skip"
+    echo "crictl is not installed, skipping pod cleanup"
     return 0
   fi
 
   if ! crictl info > /dev/null 2>&1; then
-    echo "containerd not ready, skip"
+    echo "containerd is not ready, skipping pod cleanup"
     return 0
   fi
 
@@ -43,7 +43,7 @@ pod_kill_and_wait() {
   ' 2>/dev/null)
 
   if [ -z "${pods}" ]; then
-    echo "${pod_prefix}: no pods, skip"
+    echo "${pod_prefix}: no matching pods, nothing to remove"
     return 0
   fi
 
@@ -52,9 +52,9 @@ pod_kill_and_wait() {
     crictl rmp "${pod}" > /dev/null 2>&1 || true
   done
 
-  echo "${pod_prefix}: waiting for removal..."
+  echo "${pod_prefix}: waiting for pods to be removed"
   for ((i=1; i<=max_attempts; i++)); do
-    echo "Attempt: ${i}/${max_attempts}"
+    echo "${pod_prefix}: waiting for removal, attempt ${i} of ${max_attempts}"
     sleep ${sleep_interval}
 
     local remaining_pods=$(crictl pods -o json 2>/dev/null | jq -r --arg PREFIX "${pod_prefix}" '
@@ -64,12 +64,12 @@ pod_kill_and_wait() {
     ' 2>/dev/null)
 
     if [ -z "${remaining_pods}" ]; then
-      echo "${pod_prefix}: successfully removed"
+      echo "${pod_prefix}: removed"
       return 0
     fi
   done
 
-  echo "${pod_prefix}: failed to remove (timeout ${sleep_interval}s * ${max_attempts})"
+  echo "${pod_prefix}: failed to remove pods within ${sleep_interval}s x ${max_attempts}"
   exit 1
 }
 
@@ -311,7 +311,7 @@ start_and_wait() {
     local sleep_interval=1
     local max_attempts=10
 
-    echo "Starting and waiting background process: \${bin_path}"
+    echo "Starting background process: \${bin_path}"
 
     if pgrep -f "\${bin_path}" > /dev/null 2>&1; then
         echo "\${bin_path}: already running"
@@ -321,7 +321,7 @@ start_and_wait() {
     "\${bin_path}" "\${args[@]}" > "\${log_path}" 2>&1 &
 
     for ((i=1; i<=max_attempts; i++)); do
-        echo "Attempt: \${i}/\${max_attempts}"
+        echo "\${bin_path}: waiting for process to come up, attempt \${i} of \${max_attempts}"
         sleep \${sleep_interval}
 
         if pgrep -f "\${bin_path}" > /dev/null 2>&1; then
@@ -330,7 +330,7 @@ start_and_wait() {
         fi
     done
 
-    echo "\${bin_path}: failed to start (timeout \${sleep_interval}s * \${max_attempts})"
+    echo "\${bin_path}: failed to start within \${sleep_interval}s x \${max_attempts}"
     return 1
 }
 
@@ -341,11 +341,11 @@ liveness_probe() {
     local sleep_interval=1
     local max_attempts=20
 
-    echo "Waiting liveness probe: \${address}"
+    echo "Probing liveness of \${address}"
 
     for ((i=1; i<=max_attempts; i++)); do
         if [[ \${i} -ne 1 ]]; then
-            echo "Attempt: \${i}/\${max_attempts}"
+            echo "\${address}: probe attempt \${i} of \${max_attempts}"
             sleep \${sleep_interval}
         fi
 
@@ -356,11 +356,11 @@ liveness_probe() {
         fi
     done
 
-    echo "\${address}: not reachable (timeout \${sleep_interval}s * \${max_attempts})"
+    echo "\${address}: not reachable within \${sleep_interval}s x \${max_attempts}"
     return 1
 }
 
-echo "Starting registry auth..."
+echo "Starting registry auth"
 if ! start_and_wait "${log_path}/auth.log" /opt/deckhouse/bin/ign-auth -logtostderr "${auth_path}/config.yaml"; then
     echo "ERROR: registry auth failed to start, see ${log_path}/auth.log"
     exit 1
@@ -370,7 +370,7 @@ if ! liveness_probe "https://127.0.0.1:5051" "${pki_path}/ca.crt"; then
     exit 1
 fi
 
-echo "Starting registry distribution..."
+echo "Starting registry distribution"
 if ! start_and_wait "${log_path}/distribution.log" /opt/deckhouse/bin/ign-registry serve "${distribution_path}/config.yaml"; then
     echo "ERROR: registry distribution failed to start, see ${log_path}/distribution.log"
     exit 1
@@ -380,7 +380,7 @@ if ! liveness_probe "https://${discovered_node_ip}:5001" "${pki_path}/ca.crt"; t
     exit 1
 fi
 
-echo "All services started successfully, logs: ${log_path}"
+echo "Registry services started, logs are in ${log_path}"
 EOF
 
 # Prepare stop script
@@ -390,7 +390,7 @@ bb-sync-file "${igniter_stop_sh}" - << EOF
 kill_and_wait() {
     local bin_path=\${1}
 
-    echo "Stopping and waiting background process: \${bin_path}"
+    echo "Stopping background process: \${bin_path}"
 
     pkill -f "\${bin_path}" 2>/dev/null || true
 
@@ -398,7 +398,7 @@ kill_and_wait() {
     local max_attempts=10
     for ((i=1; i<=max_attempts; i++)); do
         if [[ \${i} -ne 1 ]]; then
-            echo "Attempt: \${i}/\${max_attempts}"
+            echo "\${bin_path}: waiting for process to exit, attempt \${i} of \${max_attempts}"
             sleep \${sleep_interval}
         fi
 
@@ -408,40 +408,40 @@ kill_and_wait() {
         fi
     done
 
-    echo "\${bin_path}: timeout, sending SIGKILL and wait"
+    echo "\${bin_path}: timeout, sending SIGKILL"
     pkill -9 -f "\${bin_path}" 2>/dev/null || true
 
     local sleep_interval=1
     local max_attempts=5
     for ((i=1; i<=max_attempts; i++)); do
         if [[ \${i} -ne 1 ]]; then
-            echo "Attempt: \${i}/\${max_attempts}"
+            echo "\${bin_path}: waiting for process to exit after SIGKILL, attempt \${i} of \${max_attempts}"
             sleep \${sleep_interval}
         fi
 
         if ! pgrep -f "\${bin_path}" > /dev/null 2>&1; then
-            echo "\${bin_path}: stopped (forced)"
+            echo "\${bin_path}: stopped after SIGKILL"
             return 0
         fi
     done
 
-    echo "\${bin_path}: still running after SIGKILL."
+    echo "\${bin_path}: still running after SIGKILL"
     return 1
 }
 
-echo "Stopping registry distribution..."
+echo "Stopping registry distribution"
 if ! kill_and_wait "/opt/deckhouse/bin/ign-registry"; then
     echo "ERROR: Failed to stop registry distribution, see ${log_path}/distribution.log"
     exit 1
 fi
 
-echo "Stopping registry auth..."
+echo "Stopping registry auth"
 if ! kill_and_wait "/opt/deckhouse/bin/ign-auth"; then
     echo "ERROR: Failed to stop registry auth, see ${log_path}/auth.log"
     exit 1
 fi
 
-echo "All services stopped"
+echo "Registry services stopped"
 EOF
 
 chmod a+x "${igniter_stop_sh}"

--- a/candi/bashible/common-steps/cluster-bootstrap/072_install_control_plane.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/072_install_control_plane.sh.tpl
@@ -115,7 +115,7 @@ if ! bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/kubead
   bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings" \
     -X POST \
     -H "Content-Type: application/json" \
-    --data @- <<'EOF'
+    --data @- >/dev/null <<'EOF'
 {
   "apiVersion": "rbac.authorization.k8s.io/v1",
   "kind": "ClusterRoleBinding",
@@ -163,7 +163,7 @@ bb-curl-helper-patch-node-metadata "$node_name" "labels" "node-role.kubernetes.i
 bb-curl-kube "/api/v1/nodes/${node_name}" \
   -X PATCH \
   -H "Content-Type: application/strategic-merge-patch+json" \
-  --data "$(jq -nc --argjson taints "$node_taints_patch" '{"spec":{"taints":$taints}}')"
+  --data "$(jq -nc --argjson taints "$node_taints_patch" '{"spec":{"taints":$taints}}')" >/dev/null
 __sec rbac_label_taint
 
 # CIS benchmark purposes
@@ -211,7 +211,7 @@ if [[ "${#have_signatures_files[@]}" != "0" ]]; then
   done
 fi
 
-bb-curl-kube "/api/v1/namespaces/kube-system/secrets/d8-pki" -X DELETE || true
+bb-curl-kube "/api/v1/namespaces/kube-system/secrets/d8-pki" -X DELETE >/dev/null || true
 
 # Build secret JSON with base64-encoded PKI files
 pki_data="{}"
@@ -229,7 +229,7 @@ bb-curl-kube "/api/v1/namespaces/kube-system/secrets" \
   -X POST \
   -H "Content-Type: application/json" \
   --data "$(jq -nc --argjson data "$pki_data" \
-    '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"d8-pki","namespace":"kube-system"},"type":"Opaque","data":$data}')"
+    '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"d8-pki","namespace":"kube-system"},"type":"Opaque","data":$data}')" >/dev/null
 __sec pki_upload
 
 # Setup kubectl for root user during bootstrap.
@@ -245,7 +245,7 @@ if ! bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/d8:con
   bb-curl-kube "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings" \
     -X POST \
     -H "Content-Type: application/json" \
-    --data @- <<'EOF'
+    --data @- >/dev/null <<'EOF'
 {
   "apiVersion": "rbac.authorization.k8s.io/v1",
   "kind": "ClusterRoleBinding",

--- a/candi/bashible/common-steps/cluster-bootstrap/073_init_registry_secrets.sh.tpl
+++ b/candi/bashible/common-steps/cluster-bootstrap/073_init_registry_secrets.sh.tpl
@@ -25,20 +25,20 @@ export BB_KUBE_AUTH_TYPE="admin-cert"
 export BB_KUBE_APISERVER_URL=""
 bb-curl-helper-extract-admin-certs
 
-# Create d8-system namespace if it doesn't exist
+# Create d8-system namespace if it does not exist
 bb-curl-kube "/api/v1/namespaces/d8-system" >/dev/null 2>&1 || \
   bb-curl-kube "/api/v1/namespaces" \
     -X POST \
     -H "Content-Type: application/json" \
-    --data '{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"d8-system"}}'
+    --data '{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"d8-system"}}' >/dev/null
 
 # Upload init registry secret
-bb-curl-kube "/api/v1/namespaces/d8-system/secrets/registry-init" -X DELETE || true
+bb-curl-kube "/api/v1/namespaces/d8-system/secrets/registry-init" -X DELETE >/dev/null || true
 
 bb-curl-kube "/api/v1/namespaces/d8-system/secrets" \
   -X POST \
   -H "Content-Type: application/json" \
   --data "$(jq -nc --arg data "$(base64 -w0 < "$INIT_CONFIG_PATH")" \
-    '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"registry-init","namespace":"d8-system"},"type":"Opaque","data":{"config":$data}}')"
+    '{"apiVersion":"v1","kind":"Secret","metadata":{"name":"registry-init","namespace":"d8-system"},"type":"Opaque","data":{"config":$data}}')" >/dev/null
 
 {{- end }}

--- a/candi/bashible/lib.sh.tpl
+++ b/candi/bashible/lib.sh.tpl
@@ -32,7 +32,7 @@ function bb-patch-instance-condition() {
   bb-curl-kube "/apis/deckhouse.io/v1alpha2/instances/${instanceName}/status?fieldManager=${fieldManager}&force=true" \
     -X PATCH \
     -H "Content-Type: application/apply-patch+yaml" \
-    --data-binary @- <<EOF || true
+    --data-binary @- >/dev/null <<EOF || true
 apiVersion: deckhouse.io/v1alpha2
 kind: Instance
 metadata:
@@ -309,10 +309,10 @@ bb-rpp-get-install() {
       echo "$digest" > "$digest_file"
       return 0
     done
-    >&2 echo "rpp-get-install failed (${attempt}/30), retrying in 5 seconds"
+    >&2 echo "Failed to install rpp-get (attempt ${attempt} of 30), retrying in 5 seconds"
     sleep 5
   done
-  >&2 echo "rpp-get-install failed after 30 attempts"
+  >&2 echo "Failed to install rpp-get after 30 attempts"
   rm -f "$tmp"
   return 1
 }
@@ -458,7 +458,7 @@ fetch_bootstrap() {
     -H "Authorization: Bearer $token" \
     --cacert "$BOOTSTRAP_DIR/ca.crt" \
     -o "$out" -w '%{http_code}') || {
-      >&2 echo "Error fetching bootstrap from ${url}"
+      >&2 echo "Failed to fetch bootstrap from ${url}"
       return 3
   }
   case "$code" in
@@ -466,11 +466,11 @@ fetch_bootstrap() {
       jq -er '.bootstrap' "$out"
       ;;
     401)
-      >&2 echo "Bootstrap-token expired."
+      >&2 echo "Bootstrap token expired"
       return 2
       ;;
     *)
-      >&2 echo "HTTP $code: $(head -c 255 "$out" 2>/dev/null)"
+      >&2 echo "Bootstrap request returned HTTP $code: $(head -c 255 "$out" 2>/dev/null)"
       return 1
       ;;
   esac
@@ -497,7 +497,7 @@ get_phase2() {
           return 1
         fi
       else
-        >&2 echo "failed to get bootstrap from ${url} (exit code $rc)"
+        >&2 echo "Failed to get bootstrap from ${url} (exit code $rc)"
       fi
     done
     sleep 10
@@ -518,7 +518,7 @@ function get_pods() {
       then
       return 0
       else
-        >&2 echo "failed to get $resource $name with curl https://$server..."
+        >&2 echo "Failed to list pods in $namespace from $server"
       fi
     done
     sleep 10

--- a/candi/bashible/lib.sh.tpl
+++ b/candi/bashible/lib.sh.tpl
@@ -557,6 +557,6 @@ bb-telemetry-end-span() {
   command -v d8-curl &>/dev/null && curl_cmd=d8-curl
   local endpoint="${BB_TELEMETRY_ENDPOINT:-${OTEL_RELAY_ADDRESS:-http://127.0.0.1:4318}/v1/traces}"
   local payload="{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"bashible\"}}]},\"scopeSpans\":[{\"scope\":{\"name\":\"bashbooster\"},\"spans\":[{\"traceId\":\"${trace_id}\",\"spanId\":\"${span_id}\",\"name\":\"${2}\",\"kind\":1,\"startTimeUnixNano\":\"${start_time}\",\"endTimeUnixNano\":\"${end_time}\"}]}]}]}"
-  $curl_cmd -s -S -X POST -H "Content-Type: application/json" -d "$payload" "$endpoint"
+  $curl_cmd -s -S -X POST -H "Content-Type: application/json" -d "$payload" "$endpoint" 2>/dev/null || true
 }
 {{- end }}

--- a/candi/bashible/preflight/check_deckhouse_user.sh.tpl
+++ b/candi/bashible/preflight/check_deckhouse_user.sh.tpl
@@ -42,5 +42,5 @@ if [ "$uid" != "$EXPECTED_ID" ] || [ "$gid" != "$EXPECTED_ID" ]; then
 fi
 
 if sudo -l -U deckhouse 2>/dev/null | grep -q "(ALL"; then
-    fail "deckhouse user has sudo privileges — this is a security risk"
+    fail "deckhouse user has sudo privileges, this is a security risk"
 fi

--- a/candi/bashible/preflight/check_localhost.sh.tpl
+++ b/candi/bashible/preflight/check_localhost.sh.tpl
@@ -16,6 +16,6 @@
 */}}
 
 if ! getent ahosts localhost | grep -q 127.0.0.1; then
-  echo "localhost domain is not resolved. You should add a line '127.0.0.1 localhost' to this node's /etc/hosts file."
+  echo "The 'localhost' hostname does not resolve. Add the line '127.0.0.1 localhost' to this node's /etc/hosts file."
   exit 1
 fi

--- a/candi/bashible/preflight/check_ports.sh.tpl
+++ b/candi/bashible/preflight/check_ports.sh.tpl
@@ -22,7 +22,7 @@ function check_python() {
         return 0
       fi
     done
-    echo "Python not found, exiting..."
+    echo "Python not found"
     return 1
 }
 
@@ -67,7 +67,7 @@ function check_port() {
     try_connect $1
 
     if [ $? -eq 0 ]; then
-        echo -n "it is already open "; return 1
+        echo -n "port is already open "; return 1
     fi
 
     start_http_server $1 > /dev/null 2>&1 &
@@ -93,7 +93,7 @@ check_python
 echo -n "Checking if kubernetes API port is open (6443) "
 check_port 6443
 if [ $? -ne 0 ]; then
-    echo "Port 6443 is closed, but required for Kubernetes API server to function. Probably control-plane node is protected by firewall rules or another software (like antivirus) and blocks connections."
+    echo "Port 6443 is closed but required for the Kubernetes API server. The control-plane node is likely behind firewall rules or another tool (such as an antivirus) that blocks incoming connections."
     has_error=true
 fi
 echo "SUCCESS"
@@ -101,13 +101,13 @@ echo "SUCCESS"
 echo -n "Checking if Etcd ports are available (2379, 2380) "
 check_port 2379
 if [ $? -ne 0 ]; then
-    echo "Port 2379 is closed, but required for Etcd clients to communicate with it. Probably control-plane node is protected by firewall rules or another software (like antivirus) and blocks connections."
+    echo "Port 2379 is closed but required for etcd client connections. The control-plane node is likely behind firewall rules or another tool (such as an antivirus) that blocks incoming connections."
     has_error=true
 fi
 
 check_port 2380
 if [ $? -ne 0 ]; then
-    echo "Port 2380 is closed, but required for Etcd database server peers communications. Probably control-plane node is protected by firewall rules or another software (like antivirus) and blocks connections."
+    echo "Port 2380 is closed but required for etcd peer communication. The control-plane node is likely behind firewall rules or another tool (such as an antivirus) that blocks incoming connections."
     has_error=true
 fi
 echo "SUCCESS"

--- a/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
+++ b/candi/bashible/preflight/kill_reverse_tunnel.sh.tpl
@@ -89,11 +89,11 @@ if __name__ == '__main__':
     pid = get_pid_for_listen_port('{{.host}}', '{{.port}}')
     print(pid)
     if pid == '':
-        print('Port not fount')
+        print('No process is listening on the requested port')
         exit(0)
     try:
         os.kill(int(pid), signal.SIGKILL)
-    except Exeption as e:
+    except Exception as e:
         print(e)
 
     exit(0)


### PR DESCRIPTION
## Description

Cleanup pass over `candi/bashible/` log output. No bashible logic changed + https://github.com/deckhouse/deckhouse/pull/20471
## Why do we need it, and what problem does it solve?

- Every convergence cycle dumped the full Instance object (with the `conditions` array) into `journalctl` as `bash[NNN]:` lines, because `bb-patch-instance-condition` and related `bb-curl-kube` PATCH/POST calls left their response bodies on stdout. Same for direct PATCH/POST in cluster-bootstrap steps.
- Log strings across `candi/bashible/` were inconsistent: typos, em-dashes and semicolons inside messages, lowercase sentence starts, "retry in 10 seconds" lines that actually slept 2, no-op messages that fired every cycle, awkward grammar.
- Step and parallel-group headers used a 3-line `===` block per step with the full step path, and a different `=== bashible parallel-group '<name>' ... ===` shape for groups. Unified into a single-line `=== Step <basename> ===` / `=== Group <name> ... ===` shape.

*Example of the new logs*

```
=== Step 001_prefetch_registry_packages.sh ===
bash [INFO] rpp-prefetch.service launched, step 007 will wait for it
[bashible-timing] step=001_prefetch_registry_packages.sh dur=0.236s
=== Step 001_waiting_approval_annotations.sh ===
bash [INFO] Setting update.node.deckhouse.io/waiting-for-approval= annotation on this node
bash [INFO] Waiting for update.node.deckhouse.io/approved= annotation on this node
[bashible-timing] step=001_waiting_approval_annotations.sh dur=1.049s
=== Group light-prep start (12 steps) ===
=== Step 003_add_system_proxy.sh ===
=== Step 003_apt_timeout.sh ===
...
[bashible-timing] step=004_install_mandatory_packages.sh dur=1.358s
=== Group light-prep done ===
...
Annotated node zykov-dev-u2-master-0 with node.deckhouse.io/configuration-checksum=482de2c5...
```

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: chore
summary: Stop leaking Instance/Node JSON into bashible journal logs and clean up bashible log strings.
impact_level: low
```