### PR TITLE
[docs] Fix CRD version tabs markup and nesting

### DIFF
--- a/docs/documentation/_plugins/render-jsonschema.rb
+++ b/docs/documentation/_plugins/render-jsonschema.rb
@@ -945,9 +945,10 @@ module JSONSchemaRenderer
                  if  input["spec"]["versions"].length > 1 then
                      result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"] + '</font></p>')
                      result.push('<div class="tabs-block">')
+                     result.push('<ul class="tabs__container tabs__container--title">')
                      activeStatus=" active"
                      input["spec"]["versions"].sort{ |a, b| compareAPIVersion(a['name'],b['name']) }.reverse.each do |item|
-                         result.push("<a href='javascript:void(0)' class='tabs__item tabs__item--title tabs__title__%s%s' onclick=\"openTab(event, 'tabs__title__%s', 'tabs__descr__%s', '%s_%s')\">%s</a>" %
+                         result.push("<li href='javascript:void(0)' class='tabs__item tabs__item--title tabs__title__%s%s' onclick=\"openTab(event, 'tabs__title__%s', 'tabs__descr__%s', '%s_%s')\">%s</li>" %
                            [ input["spec"]["names"]["kind"].downcase, activeStatus,
                              input["spec"]["names"]["kind"].downcase,
                              input["spec"]["names"]["kind"].downcase,
@@ -955,7 +956,7 @@ module JSONSchemaRenderer
                              item['name'].downcase ])
                          activeStatus = ""
                      end
-                     result.push('</div>')
+                     result.push('</ul>')
                  end
 
                  activeStatus=" active"
@@ -973,7 +974,7 @@ module JSONSchemaRenderer
                     end
 
                     if input["spec"]["versions"].length > 1 then
-                        result.push("<div id='%s_%s' class='tabs__container tabs__container--descr tabs__content__%s%s'>" %
+                        result.push("<div id='%s_%s' class='tabs__container tabs__container--descr tabs__descr__%s%s'>" %
                             [ input["spec"]["names"]["kind"].downcase, item['name'].downcase,
                             input["spec"]["names"]["kind"].downcase, activeStatus ])
                         activeStatus = ""
@@ -1075,6 +1076,9 @@ module JSONSchemaRenderer
                         result.push("</div>")
                     end
 
+                 end
+                 if input["spec"]["versions"].length > 1 then
+                     result.push('</div>')
                  end
             end
         end

--- a/docs/site/_plugins/render-jsonschema.rb
+++ b/docs/site/_plugins/render-jsonschema.rb
@@ -863,9 +863,10 @@ module JSONSchemaRenderer
                  if  input["spec"]["versions"].length > 1 then
                      result.push('<p><font size="-1">Scope: ' + input["spec"]["scope"] + '</font></p>')
                      result.push('<div class="tabs-block">')
+                     result.push('<ul class="tabs__container tabs__container--title">')
                      activeStatus=" active"
                      input["spec"]["versions"].sort{ |a, b| compareAPIVersion(a['name'],b['name']) }.reverse.each do |item|
-                         result.push("<a href='javascript:void(0)' class='tabs__item tabs__item--title tabs__title__%s%s' onclick=\"openTab(event, 'tabs__title__%s', 'tabs__descr__%s', '%s_%s')\">%s</a>" %
+                         result.push("<li href='javascript:void(0)' class='tabs__item tabs__item--title tabs__title__%s%s' onclick=\"openTab(event, 'tabs__title__%s', 'tabs__descr__%s', '%s_%s')\">%s</li>" %
                            [ input["spec"]["names"]["kind"].downcase, activeStatus,
                              input["spec"]["names"]["kind"].downcase,
                              input["spec"]["names"]["kind"].downcase,
@@ -873,7 +874,7 @@ module JSONSchemaRenderer
                              item['name'].downcase ])
                          activeStatus = ""
                      end
-                     result.push('</div>')
+                     result.push('</ul>')
                  end
 
                  activeStatus=" active"
@@ -891,7 +892,7 @@ module JSONSchemaRenderer
                     end
 
                     if input["spec"]["versions"].length > 1 then
-                        result.push("<div id='%s_%s' class='tabs__container tabs__container--descr tabs__content__%s%s'>" %
+                        result.push("<div id='%s_%s' class='tabs__container tabs__container--descr tabs__descr__%s%s'>" %
                             [ input["spec"]["names"]["kind"].downcase, item['name'].downcase,
                             input["spec"]["names"]["kind"].downcase, activeStatus ])
                         activeStatus = ""
@@ -995,6 +996,9 @@ module JSONSchemaRenderer
                         result.push("</div>")
                     end
 
+                 end
+                 if input["spec"]["versions"].length > 1 then
+                     result.push('</div>')
                  end
             end
         end


### PR DESCRIPTION
## Description

- Replace anchor elements with list items wrapped in an unordered list container for semantically correct tab headers in the multi-version CRD rendering logic
- Fix CSS class name mismatch in description containers, changing tabs__content__ to tabs__descr__ so the tab switching callback correctly targets content panels
- Correct unclosed wrapper div by moving the tabs-block closing tag outside the version iteration loop, ensuring proper HTML nesting when multiple API versions exist

Fixes: #19998 

## Why do we need it, and what problem does it solve?
Fix CRD rendering in the Jekyll plugin.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: fix
summary: Fix CRD version tabs markup and nesting.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
