### PR TITLE
[docs] Sort global CRDs alphabetically

### DIFF
--- a/docs/documentation/pages/reference/api/CR.md
+++ b/docs/documentation/pages/reference/api/CR.md
@@ -3,17 +3,14 @@ title: "Custom Resources"
 permalink: en/reference/api/cr.html
 ---
 
+{{ site.data.schemas.crds.application | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackage | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackageversion | format_crd: "global" }}
+
 {{ site.data.schemas.crds.cluster_configuration | format_cluster_configuration }}
 
 {{ site.data.schemas.crds.cni-migration | format_crd: "global" }}
 {{ site.data.schemas.crds.cni-node-migration | format_crd: "global" }}
-
-{{ site.data.schemas.crds.packagerepository | format_crd: "global" }}
-{{ site.data.schemas.crds.applicationpackage | format_crd: "global" }}
-{{ site.data.schemas.crds.application | format_crd: "global" }}
-{{ site.data.schemas.crds.applicationpackageversion | format_crd: "global" }}
-{{ site.data.schemas.crds.packagerepositoryoperation | format_crd: "global" }}
-
 {{ site.data.schemas.crds.deckhouse-release | format_crd: "global" }}
 
 {{ site.data.schemas.crds.init_configuration | format_cluster_configuration }}
@@ -27,7 +24,10 @@ permalink: en/reference/api/cr.html
 {{ site.data.schemas.crds.module-source | format_crd: "global" }}
 {{ site.data.schemas.crds.module-update-policy | format_crd: "global" }}
 
-{{ site.data.schemas.crds.static_cluster_configuration | format_cluster_configuration }}
+{{ site.data.schemas.crds.packagerepository | format_crd: "global" }}
+{{ site.data.schemas.crds.packagerepositoryoperation | format_crd: "global" }}
 
 {{ site.data.schemas.crds.ssh_configuration | format_cluster_configuration }}
 {{ site.data.schemas.crds.ssh_host_configuration | format_cluster_configuration }}
+
+{{ site.data.schemas.crds.static_cluster_configuration | format_cluster_configuration }}

--- a/docs/documentation/pages/reference/api/CR_RU.md
+++ b/docs/documentation/pages/reference/api/CR_RU.md
@@ -5,17 +5,14 @@ lang: ru
 search: global custom resources, global configuration, global parameters, глобальные настройки, настройки платформы, глобальные параметры
 ---
 
+{{ site.data.schemas.crds.application | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackage | format_crd: "global" }}
+{{ site.data.schemas.crds.applicationpackageversion | format_crd: "global" }}
+
 {{ site.data.schemas.crds.cluster_configuration | format_cluster_configuration }}
 
 {{ site.data.schemas.crds.cni-migration | format_crd: "global" }}
 {{ site.data.schemas.crds.cni-node-migration | format_crd: "global" }}
-
-{{ site.data.schemas.crds.packagerepository | format_crd: "global" }}
-{{ site.data.schemas.crds.applicationpackage | format_crd: "global" }}
-{{ site.data.schemas.crds.application | format_crd: "global" }}
-{{ site.data.schemas.crds.applicationpackageversion | format_crd: "global" }}
-{{ site.data.schemas.crds.packagerepositoryoperation | format_crd: "global" }}
-
 {{ site.data.schemas.crds.deckhouse-release | format_crd: "global" }}
 
 {{ site.data.schemas.crds.init_configuration | format_cluster_configuration }}
@@ -29,7 +26,10 @@ search: global custom resources, global configuration, global parameters, гло
 {{ site.data.schemas.crds.module-source | format_crd: "global" }}
 {{ site.data.schemas.crds.module-update-policy | format_crd: "global" }}
 
-{{ site.data.schemas.crds.static_cluster_configuration | format_cluster_configuration }}
+{{ site.data.schemas.crds.packagerepository | format_crd: "global" }}
+{{ site.data.schemas.crds.packagerepositoryoperation | format_crd: "global" }}
 
 {{ site.data.schemas.crds.ssh_configuration | format_cluster_configuration }}
 {{ site.data.schemas.crds.ssh_host_configuration | format_cluster_configuration }}
+
+{{ site.data.schemas.crds.static_cluster_configuration | format_cluster_configuration }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

Alphabetically sorted location of global CRDs on the Custom Resources page.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: fix
summary: Alphabetically sorted location of global CRDs on the Custom Resources page.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
