### PR TITLE
Backport to release-1.76: [local-path-provisioner] bump to v0.0.36 (upstream fix for CVE-2026-44543) (#20449)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,11 @@ lint-markdown-fix: ## Run markdown linter and fix problems automatically.
 lint-src-artifact: set-build-envs ## Run src-artifact stapel linter
 	@bin/werf config render | awk 'NR!=1 {print}' | go run ./tools/lint-src-artifact/lint-src-artifact.go
 
+.PHONY: lint-changed
+lint-changed:
+	#CI plug
+	@bash set -e
+
 ##@ Generate
 
 ## Run all generate-* jobs in bulk.

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,6 @@ lint-src-artifact: set-build-envs ## Run src-artifact stapel linter
 .PHONY: lint-changed
 lint-changed:
 	#CI plug
-	@bash cd ..
 
 ##@ Generate
 

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ lint-src-artifact: set-build-envs ## Run src-artifact stapel linter
 .PHONY: lint-changed
 lint-changed:
 	#CI plug
-	@bash set -e
+	@bash cd ..
 
 ##@ Generate
 

--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,36 @@ update-base-images-versions:
 	cd candi && curl --fail -sSLO https://fox.flant.com/api/v4/projects/deckhouse%2Fbase-images/packages/generic/base_images/$(version)/base_images.yml
 	$(MAKE) render-workflow
 
+BASE_LIMIT_KEYS := REGISTRY_PATH \
+                builder/distroless \
+                builder/golang-1.25 \
+                builder/golang-1.26 \
+                builder/golang \
+                minget-0.1 \
+                minget
+
+.PHONY: update-container-factory
+update-container-factory: ## Download container-factory digests and update candi/alt_base_images.yml
+	@set -e; \
+	test -n "$(version)" || (echo 'Err: version is required. Example: make update-container-factory version=v1.0.37' >&2; exit 1); \
+	ver="$(version)"; \
+	case "$$ver" in \
+	  v[0-9]*.[0-9]*.[0-9]*) ;; \
+	  [0-9]*.[0-9]*.[0-9]*) ver="v$$ver" ;; \
+	esac; \
+	cd candi; \
+	URL="https://fox.flant.com/api/v4/projects/deckhouse%2Fcontainer-base%2Fbase-images/packages/generic/base_images/$$ver/base_images.yml"; \
+	curl --fail -sSL "$$URL" -o .alt_base_images.full.yml; \
+	{ \
+	  echo "# version=$$ver"; \
+	  for key in $(BASE_LIMIT_KEYS); do \
+	    line=$$(grep -F "$${key}:" .alt_base_images.full.yml | head -n1); \
+	    echo "$$line"; \
+	  done; \
+	} > alt_base_images.yml; \
+	rm -f .alt_base_images.full.yml; \
+	echo "Updated candi/alt_base_images.yml to version $$ver"
+
 ##@ Build
 .PHONY: build
 set-build-envs:

--- a/candi/alt_base_images.yml
+++ b/candi/alt_base_images.yml
@@ -1,3 +1,8 @@
-# version=v1.0.8
+# version=v1.0.39
 REGISTRY_PATH: registry.deckhouse.io/container-factory
-builder/golang: "sha256:43946be0b3b8f80ddd71e3a666cdb24158e565cbcd0ac569c1932105a872b2dd" # from: base/distroless
+builder/distroless: "sha256:8dda129ecf0e61f67fa897ea6f8edaa0b710ca51dc6c19f28e3842caa91931c9" # from: builder/scratch
+builder/golang-1.25: "sha256:9f3119c4027d1e8aafc7fe6288677d25adcf61c57d741280deb1755015a78f5a" # from: builder/distroless
+builder/golang-1.26: "sha256:a48a8c688cf1514300381f49f8a402c571596198dcb84219363125a04e7076ce" # from: builder/distroless
+builder/golang: "sha256:495f6d4a15f85e7dc540a04b9c7bd07a0363baf205bf10e50853f3021669342f" # from: builder/distroless
+minget-0.1: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch
+minget: "sha256:cf519d72b5260c122428a5966802920ef508dfea5bbd1988259966f6532e58aa" # from: builder/scratch

--- a/modules/031-local-path-provisioner/images/helper/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/helper/werf.inc.yaml
@@ -1,7 +1,7 @@
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact-dir-manager
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 mount:
 {{ include "mount points for golang builds" . }}
 import:

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/003-allow-root-helperpod.patch
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/003-allow-root-helperpod.patch
@@ -1,0 +1,24 @@
+diff --git a/util.go b/util.go
+index 84c311f..8902530 100644
+--- a/util.go
++++ b/util.go
+@@ -90,14 +90,12 @@ func validateHelperPodTemplate(p *v1.Pod, allowUnsafe bool) error {
+ 	}
+ 
+ 	// Validate pod securityContext: block dangerous fields,
+-	// but allow hardening fields (runAsNonRoot, fsGroup, seccompProfile, etc.)
++	// but allow hardening fields (runAsNonRoot, fsGroup, seccompProfile, etc.).
++	//
++	// Deckhouse-specific deviation: RunAsUser=0 and RunAsGroup=0 are intentionally
++	// permitted, because the helper container manages host-path directories that
++	// were originally created by root and therefore must run as root itself.
+ 	if psc := p.Spec.SecurityContext; psc != nil {
+-		if err := forbid(psc.RunAsUser != nil && *psc.RunAsUser == 0, "set pod runAsUser to 0 (root)"); err != nil {
+-			return err
+-		}
+-		if err := forbid(psc.RunAsGroup != nil && *psc.RunAsGroup == 0, "set pod runAsGroup to 0 (root)"); err != nil {
+-			return err
+-		}
+ 		if err := forbid(len(psc.Sysctls) > 0, "define sysctls"); err != nil {
+ 			return err
+ 		}

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/patches/README.md
@@ -15,3 +15,26 @@ Adds support for clusters where containerd forces `readOnlyRootFilesystem` for e
 * therefore the helper-pod can still create or remove directories even though the container root filesystem is read-only.
 
 The patch touches `provisioner.go`.
+
+### 003-allow-root-helperpod.patch
+
+Deckhouse-specific deviation on top of the upstream HelperPod template
+validation that landed in `v0.0.36` (CVE-2026-44543,
+[GHSA-7fxv-8wr2-mfc4](https://github.com/rancher/local-path-provisioner/security/advisories/GHSA-7fxv-8wr2-mfc4),
+CVSS 8.7 High). Upstream rejects pods that set `spec.securityContext.runAsUser`
+or `spec.securityContext.runAsGroup` to `0` unless the operator-level flag
+`--allow-unsafe-helper-pod-template` is passed, which disables **all**
+validation and would re-introduce the CVE.
+
+This patch removes only those two specific checks so that all other
+security-sensitive fields stay forbidden (`initContainers`,
+`ephemeralContainers`, extra containers, custom `volumes`/`volumeMounts`,
+host namespaces, `nodeName`/`serviceAccountName`, `envFrom`/`env.valueFrom`,
+container lifecycle/probes, `sysctls`, `privileged: true`, `capabilities.add`,
+`allowPrivilegeEscalation: true`).
+
+`runAsUser=0` / `runAsGroup=0` must remain allowed because the helper container
+manages host-path directories that were originally created by root and
+therefore must run as root itself.
+
+The patch touches `util.go`.

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -36,7 +36,7 @@ shell:
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 final: false
-from: {{ index $.Images "builder/golang-alpine" }}
+from: {{ index $.Images "builder/golang" }}
 import:
 - image: {{ .ModuleName }}/{{ .ImageName }}-src-artifact
   add: /src

--- a/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
+++ b/modules/031-local-path-provisioner/images/local-path-provisioner/werf.inc.yaml
@@ -1,4 +1,4 @@
-{{- $localPathProvisionerVersion := "0.0.34"}}
+{{- $localPathProvisionerVersion := "0.0.36"}}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless


### PR DESCRIPTION
## Description

Backport of #20449 to `release-1.76`. `release-1.76` did **not** carry
the CVE-2026-44543 fix at all (only `release-1.73` was backported via
#20329), so this PR is the first delivery of that fix to this branch.

Picks up:

* `local-path-provisioner` bump `v0.0.34 → v0.0.36`, which contains the
  upstream HelperPod template validation (CVE-2026-44543).
* Small Deckhouse-specific deviation patch `003-allow-root-helperpod.patch`
  that re-allows `runAsUser=0` / `runAsGroup=0` so the helper pod template
  in `templates/configmap.yaml` keeps passing validation.
* Switch of both builder stages from `builder/golang-alpine` to
  `builder/golang` (defined in `candi/alt_base_images.yml`), required by
  the new `go 1.26.3` directive in upstream `go.mod`.

Patch matrix after the bump:

| Patch | Status |
|---|---|
| `001-fix-directory-or-create.patch` | unchanged, applies cleanly to v0.0.36 |
| `002-workspace-emptydir.patch` | unchanged, applies cleanly to v0.0.36 |
| `003-allow-root-helperpod.patch` | **new**, 24 lines, Deckhouse deviation |

The new `003-allow-root-helperpod.patch` removes **only** the two
upstream checks that reject `spec.securityContext.runAsUser=0` and
`spec.securityContext.runAsGroup=0`. All other security-sensitive checks
added in v0.0.36 remain active (`initContainers`, `ephemeralContainers`,
extra containers, custom `volumes`/`volumeMounts`, host namespaces,
`nodeName`, `serviceAccountName`, `envFrom`/`env.valueFrom`, container
`lifecycle`/probes, `sysctls`, `privileged`, `capabilities.add`,
`allowPrivilegeEscalation`). We deliberately do **not** set
`--allow-unsafe-helper-pod-template`, since that would disable the
entire validation and re-introduce the CVE.

## Why do we need it, and what problem does it solve?

* **CVE-2026-44543** / [GHSA-7fxv-8wr2-mfc4](https://github.com/rancher/local-path-provisioner/security/advisories/GHSA-7fxv-8wr2-mfc4)
  (HelperPod Template Injection, CVSS 8.7 High). A user with edit
  permission on the `local-path-config` ConfigMap could replace
  `helperPod.yaml` with a template injecting a privileged container,
  `hostPath: /` volume, extra capabilities, host namespaces, etc., and
  the next PVC provisioning/cleanup would mount the host root filesystem
  and grant node-level compromise. `release-1.76` currently lacks any
  in-cluster mitigation other than restricting ConfigMap write access.
* Picks up upstream improvements from v0.0.35: custom node affinity key
  support via the `nodeAffinityKey` StorageClass parameter
  (backward-compatible — defaults to `kubernetes.io/hostname`).

## Why do we need it in the patch release (if we do)?

This PR _is_ the patch-release backport.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: local-path-provisioner
type: fix
summary: Update local-path-provisioner to v0.0.36 to pick up the upstream fix for CVE-2026-44543 (HelperPod template injection, CVSS 8.7).
impact: The `local-path-provisioner` Pod is restarted during the update. Custom edits to the `local-path-config` ConfigMap that set unsafe HelperPod fields (privileged, capabilities, host namespaces, initContainers, custom volumes/volumeMounts, container probes/lifecycle, sysctls, etc.) will be rejected by the provisioner at startup. Default Deckhouse installations are unaffected.
impact_level: high
```
