### PR TITLE
[dhctl] fix: ignore curl error, if cannot send spans to dhctl otel proxy

### DIFF
--- a/candi/bashible/lib.sh.tpl
+++ b/candi/bashible/lib.sh.tpl
@@ -557,6 +557,6 @@ bb-telemetry-end-span() {
   command -v d8-curl &>/dev/null && curl_cmd=d8-curl
   local endpoint="${BB_TELEMETRY_ENDPOINT:-${OTEL_RELAY_ADDRESS:-http://127.0.0.1:4318}/v1/traces}"
   local payload="{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"bashible\"}}]},\"scopeSpans\":[{\"scope\":{\"name\":\"bashbooster\"},\"spans\":[{\"traceId\":\"${trace_id}\",\"spanId\":\"${span_id}\",\"name\":\"${2}\",\"kind\":1,\"startTimeUnixNano\":\"${start_time}\",\"endTimeUnixNano\":\"${end_time}\"}]}]}]}"
-  $curl_cmd -s -S -X POST -H "Content-Type: application/json" -d "$payload" "$endpoint"
+  $curl_cmd -s -S -X POST -H "Content-Type: application/json" -d "$payload" "$endpoint" 2>/dev/null || true
 }
 {{- end }}


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

If DHCTL_TRACE enabled, sometimes reverse tunnel for opentelemetry in dhctl could be broken, and if it so - running steps can be canceled. 
Added silence and ommiting for this scenario.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: chore
summary: Fix run-step logic execution with omitting curl to dhctl opentelemetry from bashible
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
