### PR TITLE
[deckhouse] add queue head info metric and critical label for severity-tiered alerting 

### DIFF
--- a/docs/documentation/_data/deckhouse-alerts.yml
+++ b/docs/documentation/_data/deckhouse-alerts.yml
@@ -934,16 +934,67 @@ alerts:
       module: deckhouse
       edition: ce
       description: |
-        Deckhouse cannot finish processing of the `{{ $labels.queue }}` queue, which currently has {{ $value }} pending task(s).
+        The module queue head has remained unchanged for more than 10 minutes.
 
-        To investigate the issue, check the logs by running the following command:
+        Affected queue:
+
+        - Module: `{{ $labels.module }}`
+        - Task type: `{{ $labels.task_type }}`
+        - Hook: `{{ $labels.hook }}`
+
+        To investigate the issue, check the logs of the `deckhouse` controller pods:
 
         ```bash
         d8 k -n d8-system logs -f -l app=deckhouse
         ```
       summary: |
-        The {{ $labels.queue }} Deckhouse queue is stuck with {{ $value }} pending task(s).
-      severity: "7"
+        Module queue {{ $labels.module }} (type {{ $labels.task_type }}, hook {{ $labels.hook }}) is hung.
+      severity: "6"
+      markupFormat: markdown
+    - name: D8DeckhouseQueueIsHungCritical
+      sourceFile: modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+      moduleUrl: 002-deckhouse
+      module: deckhouse
+      edition: ce
+      description: |
+        The critical module queue head has remained unchanged for more than 10 minutes.
+
+        Affected queue:
+
+        - Module: `{{ $labels.module }}`
+        - Task type: `{{ $labels.task_type }}`
+        - Hook: `{{ $labels.hook }}`
+
+        To investigate the issue, check the logs of the `deckhouse` controller pods:
+
+        ```bash
+        d8 k -n d8-system logs -f -l app=deckhouse
+        ```
+      summary: |
+        Critical module queue {{ $labels.module }} (type {{ $labels.task_type }}, hook {{ $labels.hook }}) is hung.
+      severity: "4"
+      markupFormat: markdown
+    - name: D8DeckhouseQueueIsHungGlobal
+      sourceFile: modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+      moduleUrl: 002-deckhouse
+      module: deckhouse
+      edition: ce
+      description: |
+        The global/parallel task head has remained unchanged for more than 10 minutes.
+
+        Affected task:
+
+        - Task type: `{{ $labels.task_type }}`
+        - Hook: `{{ $labels.hook }}`
+
+        To investigate the issue, check the logs of the `deckhouse` controller pods:
+
+        ```bash
+        d8 k -n d8-system logs -f -l app=deckhouse
+        ```
+      summary: |
+        Global/Parallel task {{ $labels.task_type }} (hook {{ $labels.hook }}) is hung.
+      severity: "4"
       markupFormat: markdown
     - name: D8DeckhouseSelfTargetAbsent
       sourceFile: modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml

--- a/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
+++ b/modules/002-deckhouse/monitoring/prometheus-rules/deckhouse.yaml
@@ -165,11 +165,21 @@
 
         This alert often indicates that the Deckhouse Pod is experiencing connectivity issues with the Internet.
 
+  - record: d8:deckhouse_queue_is_hung:with_head
+    expr: |
+      (max by (pod, instance, queue) (
+        min_over_time(deckhouse_tasks_queue_length{queue!~"main-subqueue-kubernetes-.*|/modules/upmeter/update_selector.*|/modules/secret-copier|/modules/deckhouse/update_deckhouse_image"}[__SCRAPE_INTERVAL_X_3__])
+      ) != 0)
+      * on(pod, instance, queue) group_left(module, task_type, hook)
+        max by (pod, instance, queue, module, task_type, hook) (deckhouse_tasks_queue_head_info)
+
   - alert: D8DeckhouseQueueIsHung
-    expr: max by (pod, instance, queue) (min_over_time(deckhouse_tasks_queue_length{queue!~"main-subqueue-kubernetes-.*|/modules/upmeter/update_selector.*|/modules/secret-copier|/modules/deckhouse/update_deckhouse_image"}[__SCRAPE_INTERVAL_X_3__])) != 0
+    expr: |
+      d8:deckhouse_queue_is_hung:with_head
+      * on(module) group_left() max by (module) (deckhouse_mm_module_info{critical="false", module!=""})
     for: 10m
     labels:
-      severity_level: "7"
+      severity_level: "6"
       tier: cluster
       d8_module: deckhouse
       d8_component: deckhouse
@@ -178,12 +188,80 @@
       plk_markup_format: "markdown"
       plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
       plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
-      plk_labels_as_annotations: "instance,pod"
-      summary: The `{{ $labels.queue }}` Deckhouse queue is stuck with {{ $value }} pending task(s).
+      plk_labels_as_annotations: "module,task_type,hook"
+      summary: Module queue `{{ $labels.module }}` (type `{{ $labels.task_type }}`, hook `{{ $labels.hook }}`) is hung.
       description: |
-        Deckhouse cannot finish processing of the `{{ $labels.queue }}` queue, which currently has {{ $value }} pending task(s).
+        The module queue head has remained unchanged for more than 10 minutes.
 
-        To investigate the issue, check the logs by running the following command:
+        Affected queue:
+
+        - Module: `{{ $labels.module }}`
+        - Task type: `{{ $labels.task_type }}`
+        - Hook: `{{ $labels.hook }}`
+
+        To investigate the issue, check the logs of the `deckhouse` controller pods:
+
+        ```bash
+        d8 k -n d8-system logs -f -l app=deckhouse
+        ```
+
+  - alert: D8DeckhouseQueueIsHungCritical
+    expr: |
+      d8:deckhouse_queue_is_hung:with_head
+      * on(module) group_left() max by (module) (deckhouse_mm_module_info{critical="true", module!=""})
+    for: 10m
+    labels:
+      severity_level: "4"
+      tier: cluster
+      d8_module: deckhouse
+      d8_component: deckhouse
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_labels_as_annotations: "module,task_type,hook"
+      summary: Critical module queue `{{ $labels.module }}` (type `{{ $labels.task_type }}`, hook `{{ $labels.hook }}`) is hung.
+      description: |
+        The critical module queue head has remained unchanged for more than 10 minutes.
+
+        Affected queue:
+
+        - Module: `{{ $labels.module }}`
+        - Task type: `{{ $labels.task_type }}`
+        - Hook: `{{ $labels.hook }}`
+
+        To investigate the issue, check the logs of the `deckhouse` controller pods:
+
+        ```bash
+        d8 k -n d8-system logs -f -l app=deckhouse
+        ```
+
+  - alert: D8DeckhouseQueueIsHungGlobal
+    expr: |
+      d8:deckhouse_queue_is_hung:with_head{module=""}
+    for: 10m
+    labels:
+      severity_level: "4"
+      tier: cluster
+      d8_module: deckhouse
+      d8_component: deckhouse
+    annotations:
+      plk_protocol_version: "1"
+      plk_markup_format: "markdown"
+      plk_create_group_if_not_exists__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_grouped_by__d8_deckhouse_malfunctioning: "D8DeckhouseMalfunctioning,tier=cluster,prometheus=deckhouse,kubernetes=~kubernetes"
+      plk_labels_as_annotations: "module,task_type,hook"
+      summary: Global/Parallel task `{{ $labels.task_type }}` (hook `{{ $labels.hook }}`) is hung.
+      description: |
+        The global/parallel task head has remained unchanged for more than 10 minutes.
+
+        Affected task:
+
+        - Task type: `{{ $labels.task_type }}`
+        - Hook: `{{ $labels.hook }}`
+
+        To investigate the issue, check the logs of the `deckhouse` controller pods:
 
         ```bash
         d8 k -n d8-system logs -f -l app=deckhouse


### PR DESCRIPTION
## Description

Changes in addon-operator:
1. **New metric** `deckhouse_tasks_queue_head_info` with labels `queue`, `module`, `task_type`, `hook` — shows what task is at the head of each non-empty queue.
2. **New label** `critical` on `deckhouse_mm_module_info` — value from `BasicModule.GetCritical()`.

## Why do we need it, and what problem does it solve?

`deckhouse_tasks_queue_length` exposes only `queue` — no visibility into which task/module/hook is at the head of a hung queue. Severity is always "7" regardless of module criticality. `deckhouse_mm_module_info` lacks a `critical` label.

This change enables severity-tiered alerting based on module criticality: critical module queues (e.g., `cni-cilium`) get severity 4, non-critical (e.g., `console`) get severity 6, and global/parallel task hangs get severity 4. Operators get immediate signal about what is stuck and how important it is.

## Example

### `critical` label on `deckhouse_mm_module_info`

Critical modules (26 total):

```
deckhouse_mm_module_info{critical="true",enabled="true",module="chrony"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="cloud-provider-dvp"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="cni-cilium"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="control-plane-manager"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="deckhouse"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="kube-dns"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="local-path-provisioner"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="node-manager"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="registry"} 1
deckhouse_mm_module_info{critical="true",enabled="true",module="registry-packages-proxy"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="cloud-provider-aws"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="cloud-provider-azure"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="cloud-provider-gcp"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="cloud-provider-openstack"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="cloud-provider-vsphere"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="cni-flannel"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="kube-proxy"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="terraform-manager"} 1
deckhouse_mm_module_info{critical="true",enabled="false",module="user-authn"} 1
```

Non-critical enabled modules (29 total):

```
deckhouse_mm_module_info{critical="false",enabled="true",module="admission-policy-engine"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="cert-manager"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="console"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="documentation"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="ingress-nginx"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="monitoring-deckhouse"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="monitoring-kubernetes"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="prometheus"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="upmeter"} 1
deckhouse_mm_module_info{critical="false",enabled="true",module="user-authz"} 1
```

Verified on dev cluster: 26 modules with `critical="true"`, 41 with `critical="false"`.

### `deckhouse_tasks_queue_head_info` — startup phase (non-empty queues)

Captured during a deckhouse pod restart. All queue head changes were correctly reflected as the startup progressed:

**Global hook task (module=""):**
```
deckhouse_tasks_queue_head_info{hook="discovery/kubernetes_version.go",module="",queue="main",task_type="GlobalHookEnableKubernetesBindings"} 1
```

**Parallel module run (ParallelModuleRun normalised to module=""):**
```
deckhouse_tasks_queue_head_info{hook="",module="",queue="main",task_type="ParallelModuleRun"} 1
```

**Module run tasks (module=<name>):**
```
deckhouse_tasks_queue_head_info{hook="",module="control-plane-manager",queue="parallel_queue_0",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="node-manager",queue="parallel_queue_1",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="admission-policy-engine",queue="parallel_queue_9",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="cert-manager",queue="parallel_queue_7",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="console",queue="parallel_queue_0",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="ingress-nginx",queue="parallel_queue_5",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="monitoring-custom",queue="parallel_queue_5",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="upmeter",queue="parallel_queue_2",task_type="ModuleRun"} 1
deckhouse_tasks_queue_head_info{hook="",module="user-authz",queue="parallel_queue_14",task_type="ModuleRun"} 1
```

**Module hook tasks (hook=<path>):**
```
deckhouse_tasks_queue_head_info{hook="300-prometheus/hooks/disk_metrics.go",module="prometheus",queue="/modules/prometheus/disk_metrics",task_type="ModuleHookRun"} 1
deckhouse_tasks_queue_head_info{hook="402-ingress-nginx/hooks/safe_daemonset_update.go",module="ingress-nginx",queue="/modules/ingress-nginx/safe_daemonset_update",task_type="ModuleHookRun"} 1
```

### `deckhouse_tasks_queue_head_info` — steady state (all queues empty)

```
# No series produced — all queues are empty
deckhouse_tasks_queue_head_info  →  (no results)
```

Verified on dev cluster: metric correctly produces series only for non-empty queues, and they expire within one scrape interval after the queue drains.

### Recording rule `d8:deckhouse_queue_is_hung:with_head`

During a running `ConvergeModules` task on the `main` queue:

```
d8:deckhouse_queue_is_hung:with_head{queue="main",module="",task_type="ConvergeModules",hook=""} 1
```

The recording rule correctly joins `deckhouse_tasks_queue_length` with `deckhouse_tasks_queue_head_info` on the `queue` label and uses `min_over_time(..., __SCRAPE_INTERVAL_X_3__)` to avoid flapping on short-lived queue spikes.

## Checklist
- [x] Unit tests pass 
- [ ] Alert rules in deckhouse (separate PR).
- [ ] Documentation updated.
- [x] Deployed to dev cluster, `critical` label and `tasks_queue_head_info` verified.

## Changelog entries

```changes
section: deckhouse
type: feature
summary: Rework D8DeckhouseQueueIsHung alert with queue head info and severity based on module criticality.
```