### PR TITLE
[user-authz] add pair key ns/name in hook

### DIFF
--- a/modules/140-user-authz/hooks/handle_manage_bindings.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings.go
@@ -140,7 +140,11 @@ func syncBindings(_ context.Context, input *go_hook.HookInput) error {
 		useBindingName := fmt.Sprintf("d8:use:%s:binding:%s", role, binding.Name)
 		for namespace := range namespaces {
 			input.PatchCollector.CreateOrUpdate(createBinding(&binding, role, namespace))
-			expected[useBindingName] = true
+			// Track by (namespace, name): one manage binding fans out to the
+			// same RoleBinding name across many namespaces, so keying by name
+			// alone would keep an orphan alive whenever a namespace drops out
+			// of the binding while any other namespace remains.
+			expected[useBindingKey(namespace, useBindingName)] = true
 		}
 	}
 
@@ -149,12 +153,19 @@ func syncBindings(_ context.Context, input *go_hook.HookInput) error {
 		if err != nil {
 			return fmt.Errorf("failed to iterate over 'useBindings' snapshot: %w", err)
 		}
-		if _, ok := expected[existing.Name]; !ok {
+		if _, ok := expected[useBindingKey(existing.Namespace, existing.Name)]; !ok {
 			input.PatchCollector.Delete("rbac.authorization.k8s.io/v1", "RoleBinding", existing.Namespace, existing.Name)
 		}
 	}
 
 	return nil
+}
+
+// useBindingKey identifies an automated use RoleBinding uniquely. A single
+// manage binding produces RoleBindings with the same name in every target
+// namespace, so reconciliation must compare by namespace and name together.
+func useBindingKey(namespace, name string) string {
+	return namespace + "/" + name
 }
 
 func roleAndNamespacesByBinding(manageRoles []pkg.Snapshot, roleName string) (string, map[string]bool, error) {

--- a/modules/140-user-authz/hooks/handle_manage_bindings_test.go
+++ b/modules/140-user-authz/hooks/handle_manage_bindings_test.go
@@ -82,6 +82,33 @@ var _ = Describe("Modules :: user-authz :: hooks :: handle-manage-bindings ::", 
 		})
 	})
 
+	Context("A namespace drops out of a manage binding", func() {
+		BeforeEach(func() {
+			resources := []string{
+				// Binding "test" now resolves to a single namespace (test-ns).
+				manageModuleRole("d8:manage:permission:module:test:edit", "others", "test-ns"),
+				manageRole("d8:manage:others:manager", "subsystem", "others"),
+				manageBinding("test", "d8:manage:others:manager"),
+				// Leftover use RoleBinding from test2-ns, which no longer
+				// contributes to the binding (its module role lost the
+				// rbac.deckhouse.io/namespace label or was removed).
+				existingUseBinding("d8:use:admin:binding:test", "test2-ns"),
+			}
+			f.BindingContexts.Set(f.KubeStateSet(strings.Join(resources, "\n---\n")))
+			f.RunHook()
+		})
+
+		It("keeps the still-valid binding and deletes the orphan in the dropped namespace", func() {
+			Expect(f).To(ExecuteSuccessfully())
+
+			roleBinding := f.KubernetesResource("RoleBinding", "test-ns", "d8:use:admin:binding:test")
+			Expect(roleBinding.Field("metadata.name").Str).To(Equal("d8:use:admin:binding:test"))
+
+			orphan := f.KubernetesResource("RoleBinding", "test2-ns", "d8:use:admin:binding:test")
+			Expect(orphan).To(BeEmpty())
+		})
+	})
+
 	Context("There`s UseBinding", func() {
 		BeforeEach(func() {
 			resources := []string{
@@ -178,6 +205,37 @@ func manageBinding(name, role string) string {
 			APIGroup: "rbac.authorization.k8s.io/v1",
 			Kind:     "ClusterRole",
 			Name:     role,
+		},
+	}
+	marshaled, _ := yaml.Marshal(&binding)
+	return string(marshaled)
+}
+
+func existingUseBinding(name, namespace string) string {
+	binding := rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "rbac.authorization.k8s.io/v1",
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"heritage":                    "deckhouse",
+				"rbac.deckhouse.io/automated": "true",
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     "test",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "d8:use:role:admin",
 		},
 	}
 	marshaled, _ := yaml.Marshal(&binding)


### PR DESCRIPTION
## Description
Fix reconciliation of automated `use` RoleBindings in the `user-authz` manage-bindings hook. The `expected` set is now keyed by `(namespace, name)` instead of name only.

## Why do we need it, and what problem does it solve?
A single manage binding fans out the same RoleBinding name across many namespaces. Keying only by name meant that when one namespace dropped out of a binding (e.g. the `rbac.deckhouse.io/namespace` label was removed from a module ClusterRole) while another namespace still used it, the orphaned RoleBinding was never deleted. Now per-namespace orphans are cleaned up correctly.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: user-authz
type: fix
summary: Delete orphaned automated use RoleBindings when a namespace drops out of a manage binding.
impact_level: low
```