### PR TITLE
[docs] Describe OS image update procedure for clusters

### DIFF
--- a/docs/documentation/pages/admin/configuration/integrations/virtualization/dvp/CONFIGURATION_AND_LAYOUT_RU.md
+++ b/docs/documentation/pages/admin/configuration/integrations/virtualization/dvp/CONFIGURATION_AND_LAYOUT_RU.md
@@ -130,3 +130,42 @@ provider:
   kubeconfigDataBase64: ZXhhbXBsZQo=
   namespace: default
 ```
+
+### Обновление образа ОС
+
+При создании узлов DKP использует образ ОС, указанный в конфигурации кластера или инстанс-класса.
+
+При обновлении ОС не изменяйте существующий образ без изменения его имени. В этом случае значение образа в конфигурации DKP не изменится, и узлы не будут автоматически переведены на обновлённый образ.
+
+Рекомендуемый порядок действий:
+
+1. Создайте новый образ ОС с новым именем.
+1. Укажите новый образ в конфигурации DKP.
+1. Пересоздайте узлы, которые должны использовать новый образ.
+1. Удалите старый образ после завершения миграции всех узлов.
+
+Например, вместо изменения образа с прежним именем:
+
+```yaml
+rootDisk:
+  image:
+    kind: ClusterVirtualImage
+    name: ubuntu-24-04
+```
+
+создайте новый образ и укажите его в конфигурации:
+
+```yaml
+rootDisk:
+  image:
+    kind: ClusterVirtualImage
+    name: ubuntu-24-04-20260204
+```
+
+**Для CloudPermanent-узлов** измените значение поля [`rootDisk.image.name`](/modules/cloud-provider-dvp/cluster_configuration.html#dvpclusterconfiguration-masternodegroup-instanceclass-rootdisk-image) в [DVPClusterConfiguration](/modules/cloud-provider-dvp/cluster_configuration.html#dvpclusterconfiguration) и выполните:
+
+```shell
+dhctl converge
+```
+
+**Для CloudEphemeral-узлов** измените значение поля [`rootDisk.image.name`](/modules/cloud-provider-dvp/cr.html#dvpinstanceclass-v1alpha1-spec-rootdisk-image-name) в используемом ресурсе [DVPInstanceClass](/modules/cloud-provider-dvp/cr.html#dvpinstanceclass), после чего пересоздайте узлы соответствующей группы.


### PR DESCRIPTION
## Description
Describe OS image update procedure for clusters.


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Describe OS image update procedure for clusters.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
