### PR TITLE
[tools] Add d8-static-routing-manager to CSE integrity checks

### DIFF
--- a/tools/build_includes/integrity-check-namespaces-CSE.yaml
+++ b/tools/build_includes/integrity-check-namespaces-CSE.yaml
@@ -30,6 +30,7 @@ namespaces_for_integrity:
     - d8-secrets-store-integration
     - d8-service-with-healthchecks
     - d8-snapshot-controller
+    - d8-static-routing-manager
     - d8-storage-volume-data-manager
     - d8-system
     - d8-upmeter

--- a/tools/integrity_check_namespaces/CSE.yaml
+++ b/tools/integrity_check_namespaces/CSE.yaml
@@ -17,3 +17,4 @@ additionalNamespaces:
   - d8-snapshot-controller
   - d8-storage-volume-data-manager
   - d8-virtualization
+  - d8-static-routing-manager


### PR DESCRIPTION
## Description

Add `d8-static-routing-manager` namespace to CSE integrity check lists in `tools/build_includes/integrity-check-namespaces-CSE.yaml` and `tools/integrity_check_namespaces/CSE.yaml`.

## Why do we need it, and what problem does it solve?

Include the `d8-static-routing-manager` namespace in CSE tests to ensure integrity checks cover this namespace. This resolves potential failures or omissions in CI integrity validation for components deployed in this namespace.

## Checklist

- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: tools
type: chore
summary: Added d8-static-routing-manager to CSE namespace integrity checks
impact_level: low
```