### PR TITLE
[istio] Custom annotations for Ingress Controller

### DIFF
--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -46,6 +46,9 @@ spec:
     metadata:
       annotations:
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
+        {{- with $.Values.istio.alliance.ingressGateway.daemonSetAnnotations }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
       labels:
         app: ingressgateway
         sidecar.istio.io/inject: "false"

--- a/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
+++ b/ee/modules/110-istio/templates/alliance/ingressgateway/daemonset.yaml
@@ -46,7 +46,7 @@ spec:
     metadata:
       annotations:
         {{ include "helm_lib_prevent_ds_eviction_annotation" . | nindent 8 }}
-        {{- with $.Values.istio.alliance.ingressGateway.daemonSetAnnotations }}
+        {{- with $.Values.istio.alliance.ingressGateway.gatewayPodAnnotations }}
         {{- . | toYaml | nindent 8 }}
         {{- end }}
       labels:

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -135,7 +135,7 @@ properties:
               - cse-pro
             example:
               yandex.cpi.flant.com/listener-subnet-id: xyz-123
-          daemonSetAnnotations:
+          gatewayPodAnnotations:
             type: object
             additionalProperties:
               type: string

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -135,6 +135,16 @@ properties:
               - cse-pro
             example:
               yandex.cpi.flant.com/listener-subnet-id: xyz-123
+          daemonSetAnnotations:
+            type: object
+            additionalProperties:
+              type: string
+            description: Additional annotations for ingressgateway DaemonSet pods.
+            x-doc-d8Editions:
+              - ee
+              - cse-pro
+            example:
+              checksum/config: xyz-123
           nodeSelector:
             type: object
             additionalProperties:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -48,7 +48,7 @@ properties:
               Дополнительные аннотации для сервиса ingressgateway.
 
               Полезно, например, для настройки локального LB в Yandex Cloud (аннотация `yandex.cpi.flant.com/listener-subnet-id`).
-          daemonSetAnnotations:
+          gatewayPodAnnotations:
             description: |
               Дополнительные аннотации для подов DaemonSet'а ingressgateway.
           nodeSelector:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -48,6 +48,9 @@ properties:
               Дополнительные аннотации для сервиса ingressgateway.
 
               Полезно, например, для настройки локального LB в Yandex Cloud (аннотация `yandex.cpi.flant.com/listener-subnet-id`).
+          daemonSetAnnotations:
+            description: |
+              Дополнительные аннотации для подов DaemonSet'а ingressgateway.
           nodeSelector:
             description: |
               Селектор для DaemonSet'а ingressgateway.

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -371,6 +371,9 @@ neighbour-0:
   clusterUUID: r-e-m-o-t-e
   rootCA: ---ROOT CA---
 `)
+			f.ValuesSetFromYaml("istio.alliance.ingressGateway.daemonSetAnnotations", `
+test.deckhouse.io/annotation: test-value
+`)
 			f.HelmRender()
 		})
 
@@ -403,7 +406,9 @@ neighbour-0:
 			Expect(f.KubernetesGlobalResource("ClusterRole", "d8:istio:alliance:metadata-exporter").Exists()).To(BeTrue())
 			Expect(f.KubernetesGlobalResource("ClusterRoleBinding", "d8:istio:alliance:metadata-exporter").Exists()).To(BeTrue())
 
-			Expect(f.KubernetesResource("DaemonSet", "d8-istio", "ingressgateway").Exists()).To(BeTrue())
+			ingressgatewayDaemonSet := f.KubernetesResource("DaemonSet", "d8-istio", "ingressgateway")
+			Expect(ingressgatewayDaemonSet.Exists()).To(BeTrue())
+			Expect(ingressgatewayDaemonSet.Field("spec.template.metadata.annotations.test\\.deckhouse\\.io/annotation").String()).To(Equal("test-value"))
 			Expect(f.KubernetesResource("VerticalPodAutoscaler", "d8-istio", "ingressgateway").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Gateway", "d8-istio", "ingressgateway").Exists()).To(BeTrue())
 			Expect(f.KubernetesResource("Service", "d8-istio", "ingressgateway").Exists()).To(BeTrue())

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -371,7 +371,7 @@ neighbour-0:
   clusterUUID: r-e-m-o-t-e
   rootCA: ---ROOT CA---
 `)
-			f.ValuesSetFromYaml("istio.alliance.ingressGateway.daemonSetAnnotations", `
+			f.ValuesSetFromYaml("istio.alliance.ingressGateway.gatewayPodAnnotations", `
 test.deckhouse.io/annotation: test-value
 `)
 			f.HelmRender()


### PR DESCRIPTION
## Description
This change adds support for custom annotations on ingressgateway pods via the `istio.alliance.ingressGateway.gatewayPodAnnotations` module setting.

The parameter accepts arbitrary key-value annotations that are applied to the pods created by the alliance ingressgateway DaemonSet. This lets cluster administrators customize ingressgateway pod behavior and integrate with external systems without changing module templates.

Typical use cases include:

annotations for cluster-autoscaler, monitoring, or security policies;
annotations read by controllers and admission webhooks at the Pod level;
other operational metadata that must live on ingressgateway pods rather than on the DaemonSet object or Service.
The feature is available in EE and CSE Pro editions and applies to the ingressgateway deployed when federation or multicluster is enabled and an ingress gateway is required for cross-cluster traffic.

Cluster impact: changing `gatewayPodAnnotations` triggers a rolling update of the ingressgateway DaemonSet, which recreates ingressgateway pods. It does not affect the control plane, Prometheus, or other ingress controllers (such as `IngressIstioController`).

## Why do we need it, and what problem does it solve?
Today, alliance ingressgateway configuration supports only Service annotations (`serviceAnnotations`), for example to configure a cloud Load Balancer. There is no way to set custom annotations on ingressgateway pods through module configuration.

Because of that, administrators cannot attach required pod-level annotations via `ModuleConfig` and must work around the limitation manually or wait for template changes.

This matters because many Kubernetes mechanisms operate on Pod annotations, not on DaemonSet metadata. The same approach is already used elsewhere in Deckhouse (for example, `controllerPodsAdditionalAnnotations` in ingress-nginx).

The new parameter closes this gap and provides a consistent way to customize alliance ingressgateway pods through the `istio` module configuration.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: feature
summary: Added support for custom annotations on the Istio Ingress Gateway controller.
impact_level: default
```
