### PR TITLE
[docs] Remove console module edition restrictions

### DIFF
--- a/docs/documentation/_data/modules/modules-addition.json
+++ b/docs/documentation/_data/modules/modules-addition.json
@@ -229,18 +229,8 @@
       "se-plus",
       "ee"
     ],
-    "editionsWithRestrictions": [
-      "ce",
-      "be"
-    ],
-    "editionsWithRestrictionsComments": {
-      "all": {
-        "en": "The system part of Deckhouse is read-only in the web UI",
-        "ru": "Системная часть Deckhouse доступна в веб-интерфейсе только для чтения"
-      }
-    },
     "external": "true",
-    "path": "/modules/console/stable/"
+    "path": "/modules/console/"
   },
   "csi-ceph": {
     "editions": [

--- a/docs/site/backends/docs-builder-template/data/modules_all.json
+++ b/docs/site/backends/docs-builder-template/data/modules_all.json
@@ -105,16 +105,6 @@
       "cse-lite",
       "cse-pro"
     ],
-    "editionsWithRestrictions": [
-      "ce",
-      "be"
-    ],
-    "editionsWithRestrictionsComments": {
-      "all": {
-        "en": "The system part of Deckhouse is read-only in the web UI",
-        "ru": "Системная часть Deckhouse доступна в веб-интерфейсе только для чтения"
-      }
-    },
     "external": "true",
     "path": "/modules/console/",
     "tags": [


### PR DESCRIPTION
## Description

Remove console module edition restrictions in the documentation.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: docs
type: chore
summary: Remove console module edition restrictions in the documentation.
impact_level: low
```
