### PR TITLE
[extended-monitoring] add aws region for image-available-exporter

### DIFF
--- a/modules/340-extended-monitoring/openapi/config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/config-values.yaml
@@ -33,7 +33,7 @@ properties:
         x-examples:
         - eu-central-1
         description: |
-          AWS region for ECR authentication (passed as --aws-region to image-availability-exporter).
+          AWS region for ECR authentication.
       ignoredImages:
         type: array
         x-examples:

--- a/modules/340-extended-monitoring/openapi/config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/config-values.yaml
@@ -28,6 +28,12 @@ properties:
           Default registry to use when an image name is not fully qualified.
           
           If not set, index.docker.io is used by default.
+      awsRegion:
+        type: string
+        x-examples:
+        - eu-central-1
+        description: |
+          AWS region for ECR authentication (passed as --aws-region to image-availability-exporter).
       ignoredImages:
         type: array
         x-examples:

--- a/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
@@ -23,7 +23,7 @@ properties:
           Если не задан, то используется index.docker.io
       awsRegion:
         description: |
-          AWS-регион для аутентификации в ECR (передаётся в image-availability-exporter как --aws-region).
+          AWS-регион для аутентификации в ECR.
       ignoredImages:
         description: |
           Список образов, для которых нужно пропустить проверку, например `alpine:3.12` или `quay.io/test/test:v1.1`.

--- a/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
+++ b/modules/340-extended-monitoring/openapi/doc-ru-config-values.yaml
@@ -21,6 +21,9 @@ properties:
           Используется если в образе не указан registry.
           
           Если не задан, то используется index.docker.io
+      awsRegion:
+        description: |
+          AWS-регион для аутентификации в ECR (передаётся в image-availability-exporter как --aws-region).
       ignoredImages:
         description: |
           Список образов, для которых нужно пропустить проверку, например `alpine:3.12` или `quay.io/test/test:v1.1`.

--- a/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
+++ b/modules/340-extended-monitoring/templates/image-availability-exporter/deployment.yaml
@@ -70,6 +70,9 @@ spec:
         # Among known inexisting images, there is the one from Upmeter probe where we don't want a container to start.
         - --check-interval={{ .Values.extendedMonitoring.imageAvailability.imageCheckInterval }}
         - --default-registry={{ .Values.extendedMonitoring.imageAvailability.defaultRegistry }}
+        {{- if .Values.extendedMonitoring.imageAvailability.awsRegion }}
+        - --aws-region={{ .Values.extendedMonitoring.imageAvailability.awsRegion }}
+        {{- end }}
         {{- $ignoredImages := list ".*upmeter-nonexistent.*" }}
         {{- if .Values.extendedMonitoring.imageAvailability.ignoredImages }}
           {{- $ignoredImages = concat $ignoredImages .Values.extendedMonitoring.imageAvailability.ignoredImages }}


### PR DESCRIPTION
## Description

The region parameter has been added to the image-availability in the AWS

## Why do we need it, and what problem does it solve?

If a cluster and registry in different regions fail authorization

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section:  extended-monitoring
type: feature
summary: The region parameter has been added to the module in the AWS
impact: image-available-exporter
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
