### PR TITLE
[deckhouse] fix image extraction to respect opaque whiteouts

### DIFF
--- a/deckhouse-controller/internal/registry/service.go
+++ b/deckhouse-controller/internal/registry/service.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	crv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -109,7 +108,7 @@ func (s *Service) GetImageReader(ctx context.Context, remote Remote, packageName
 		slog.String("digest", digest.String()),
 		slog.Int64("size", size))
 
-	return mutate.Extract(img), nil
+	return cr.Extract(img)
 }
 
 // GetImageDigest downloads package image and returns its digest
@@ -222,7 +221,10 @@ func (s *Service) Download(ctx context.Context, remote Remote, out, packageName,
 
 // download copies tar to path
 func (s *Service) download(_ context.Context, img crv1.Image, output string) error {
-	rc := mutate.Extract(img)
+	rc, err := cr.Extract(img)
+	if err != nil {
+		return fmt.Errorf("extract image: %w", err)
+	}
 	defer rc.Close()
 
 	if err := os.MkdirAll(output, 0o700); err != nil {

--- a/deckhouse-controller/internal/registry/service_test.go
+++ b/deckhouse-controller/internal/registry/service_test.go
@@ -15,9 +15,19 @@
 package registry
 
 import (
+	"archive/tar"
+	"bytes"
+	"context"
 	"encoding/base64"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -82,4 +92,53 @@ func TestBuildRemote_ModuleSource_LoginPasswordNotApplicable(t *testing.T) {
 	assert.Equal(t, existingDockerCfg, got.DockerConfig)
 	assert.Empty(t, got.Login)
 	assert.Empty(t, got.Password)
+}
+
+// reproLayer builds a tar layer; a non-empty opaqueDir adds an AUFS opaque
+// whiteout marker on that directory ("remove everything in it from lower layers").
+func reproLayer(t *testing.T, files map[string]string, opaqueDir string) v1.Layer {
+	t.Helper()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if opaqueDir != "" {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: opaqueDir + "/", Typeflag: tar.TypeDir, Mode: 0o755}))
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: opaqueDir + "/.wh..wh..opq", Mode: 0o644}))
+	}
+	for name, body := range files {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(body))}))
+		_, err := io.WriteString(tw, body)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+
+	data := buf.Bytes()
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	})
+	require.NoError(t, err)
+	return layer
+}
+
+// TestServiceDownload_OpaqueWhiteout pins the fix for go-containerregistry#2029:
+// download() must drop files removed via an opaque whiteout, not resurrect them.
+// Lower layer holds test/hello.txt; the upper layer does `rm -rf /test` (opaque
+// whiteout) and re-adds test/hello2.txt — only hello2.txt must land on disk.
+func TestServiceDownload_OpaqueWhiteout(t *testing.T) {
+	lower := reproLayer(t, map[string]string{"test/hello.txt": "old"}, "")
+	upper := reproLayer(t, map[string]string{"test/hello2.txt": "new"}, "test")
+
+	img, err := mutate.AppendLayers(empty.Image, lower, upper)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	require.NoError(t, (&Service{}).download(context.Background(), img, dir))
+
+	// File deleted by the opaque whiteout must not reappear.
+	assert.NoFileExists(t, filepath.Join(dir, "test", "hello.txt"))
+
+	// Recreated file must be present with its current content.
+	got, err := os.ReadFile(filepath.Join(dir, "test", "hello2.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
 }


### PR DESCRIPTION
## Description

Switch OCI image extraction in deckhouse-controller's registry service
(`internal/registry/service.go` — package/module image download and unpack to disk)
from go-containerregistry's `mutate.Extract` to `cr.Extract`, which flattens the image
via `ocitools.Squash`. `mutate.Extract` does not apply opaque whiteouts, so files
deleted across layers leak into the extracted filesystem. 

## Why do we need it, and what problem does it solve?

Fixes a correctness bug: when an image deletes a directory and recreates it across
layers (`rm -rf /dir && mkdir /dir` — an opaque whiteout `.wh..wh..opq`),
`mutate.Extract` keeps the deleted files, producing a corrupted on-disk package/module
layout. Root cause is upstream google/go-containerregistry#2029. `cr.Extract`
(`ocitools.Squash`) honors opaque whiteouts and is already the standard extraction
path used elsewhere in the controller (module downloads, release checks).

### Testing

Added `TestServiceDownload_OpaqueWhiteout` (`deckhouse-controller/internal/registry/service_test.go`).
It builds an in-memory two-layer image reproducing go-containerregistry#2029 — the lower layer has
`test/hello.txt`, the upper layer removes `/test` via an opaque whiteout (`.wh..wh..opq`) and re-adds
`test/hello2.txt` — then runs the real `Service.download()` into a temp dir and asserts:

- `test/hello.txt` (deleted via the opaque whiteout) is **not** written to disk;
- `test/hello2.txt` is present with its current content.

Verified as a regression guard: the test **fails on the pre-fix `mutate.Extract`** (the deleted file
resurfaces) and **passes with `cr.Extract`**.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse
type: fix 
summary: Fixed image extraction to respect opaque whiteouts.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
