### PR TITLE
[node-controller] add leader election

### DIFF
--- a/modules/040-node-manager/images/node-controller/src/cmd/main.go
+++ b/modules/040-node-manager/images/node-controller/src/cmd/main.go
@@ -68,6 +68,7 @@ func main() {
 	var webhookPort int
 	var disabledControllers string
 	var maxConcurrentReconcilesRaw string
+	var leaderElect bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":4291", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":4292", "The address the probe endpoint binds to.")
@@ -75,6 +76,7 @@ func main() {
 	flag.StringVar(&logOptions.Format, "logging-format", logOptions.Format, "Logging format (text or json)")
 	flag.StringVar(&disabledControllers, "disable-controllers", "", "Comma-separated list of controllers to disable")
 	flag.StringVar(&maxConcurrentReconcilesRaw, "max-concurrent-reconciles", "10", "Maximum number of concurrent reconciles per controller. Format: N or N,controller1=M,controller2=K")
+	flag.BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager")
 
 	logs.AddGoFlags(flag.CommandLine)
 
@@ -104,6 +106,10 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		Cache:                  cacheOpts,
 		Client:                 clientOpts,
+
+		LeaderElection:          leaderElect,
+		LeaderElectionID:        "node-controller.deckhouse.io",
+		LeaderElectionNamespace: os.Getenv("POD_NAMESPACE"),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/modules/040-node-manager/templates/node-controller/deployment.yaml
+++ b/modules/040-node-manager/templates/node-controller/deployment.yaml
@@ -36,7 +36,7 @@ metadata:
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "node-controller")) | nindent 2 }}
 spec:
-  maxUnavailable: 1
+  maxUnavailable: {{ include "helm_lib_is_ha_to_value" (list . 1 0) }}
   selector:
     matchLabels:
       app: node-controller
@@ -48,7 +48,7 @@ metadata:
   namespace: d8-cloud-instance-manager
   {{- include "helm_lib_module_labels" (list . (dict "app" "node-controller")) | nindent 2 }}
 spec:
-  replicas: 1
+  replicas: {{ include "helm_lib_is_ha_to_value" (list . 2 1) }}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -82,6 +82,7 @@ spec:
         - --health-probe-bind-address=0.0.0.0:4292
         - --webhook-port=4290
         - --max-concurrent-reconciles=10
+        - --leader-elect={{ include "helm_lib_is_ha_to_value" (list . "true" "false") }}
         - -v=4
         livenessProbe:
           httpGet:

--- a/modules/040-node-manager/templates/node-controller/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/node-controller/rbac-for-us.yaml
@@ -190,6 +190,9 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Description

Adds leader election support investigation for node-controller high availability.

The changes introduce validation of controller-runtime leader election behavior and evaluate how node-controller can operate with multiple replicas using Kubernetes Lease objects.

The change does not modify reconciliation logic and does not restart critical cluster components.

## Why do we need it, and what problem does it solve?

Node-controller is a critical component and should support high availability deployment.

This change validates controller-runtime leader election behavior, failover scenarios, and ensures that only a single active controller instance performs reconciliation while standby replicas remain passive.

The investigation allows enabling multiple node-controller replicas without creating duplicate reconciliation loops or split-brain scenarios.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: node-manager
type: feature 
summary: Add leader election support investigation for node-controller HA
impact_level: low
```