### PR TITLE
[cotrol-plane-manager] Fix error from validating root certs function during regeneration

### DIFF
--- a/go_lib/controlplane/pki/certs.go
+++ b/go_lib/controlplane/pki/certs.go
@@ -59,7 +59,7 @@ func createRootCertIfNotExists(cfg config, spec rootCertSpec, rep *PKIApplyRepor
 	oldCert, oldKey, err := readCertAndKey(cfg.pkiDir, spec.BaseName)
 	newCertCfg := spec.BuildConfig(cfg)
 	if err == nil {
-		if err := validateCert(oldCert, newCertCfg); err != nil {
+		if err := validateRootCert(oldCert, newCertCfg); err != nil {
 			return nil, nil, &CertValidationError{
 				BaseName: spec.BaseName,
 				Reason:   err.Error(),

--- a/go_lib/controlplane/pki/certs_test.go
+++ b/go_lib/controlplane/pki/certs_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/constants"
 )
 
 func TestCreateRootCertIfNotExists_CreatesNew(t *testing.T) {
@@ -126,6 +128,49 @@ func TestCreateLeafCertIfNotExists_SkipsValid(t *testing.T) {
 	cert2, _, err := readCertAndKey(dir, "apiserver")
 	require.NoError(t, err)
 	assert.Equal(t, cert1.SerialNumber, cert2.SerialNumber)
+}
+
+func TestCreateRootCertIfNotExists_ReusesExistingOnAlgorithmChange(t *testing.T) {
+	dir := t.TempDir()
+	spec := getRootCertSpec(CACertName)
+
+	var rep PKIApplyReport
+	cert1, _, err := createRootCertIfNotExists(makeTestConfig(t, dir, WithEncryptionAlgorithmType(constants.EncryptionAlgorithmRSA2048)), spec, &rep)
+	require.NoError(t, err)
+	assert.Equal(t, PKIActionWrittenCreated, rep.Entries[0].Action)
+
+	// Simulate user changing encryptionAlgorithm in cluster-configuration.
+	// CA must be reused as-is — it is never rotated on algorithm change.
+	rep = PKIApplyReport{}
+	cert2, _, err := createRootCertIfNotExists(makeTestConfig(t, dir, WithEncryptionAlgorithmType(constants.EncryptionAlgorithmECDSAP384)), spec, &rep)
+	require.NoError(t, err, "CA must be reused when encryptionAlgorithm changes")
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionUnchanged, rep.Entries[0].Action)
+	assert.Equal(t, cert1.SerialNumber, cert2.SerialNumber, "CA serial number must not change")
+}
+
+func TestCreateLeafCertIfNotExists_RegeneratesOnAlgorithmChange(t *testing.T) {
+	dir := t.TempDir()
+	caCert, caKey := makeTestCACert(t, "kubernetes")
+	spec := getLeafCertSpec(ApiserverCertName)
+
+	var rep PKIApplyReport
+	err := createLeafCertIfNotExists(makeTestConfig(t, dir, WithEncryptionAlgorithmType(constants.EncryptionAlgorithmRSA2048)), spec, caCert, caKey, &rep)
+	require.NoError(t, err)
+	cert1, _, err := readCertAndKey(dir, "apiserver")
+	require.NoError(t, err)
+
+	// Simulate user changing encryptionAlgorithm in cluster-configuration.
+	// Leaf cert must be regenerated with the new algorithm.
+	rep = PKIApplyReport{}
+	err = createLeafCertIfNotExists(makeTestConfig(t, dir, WithEncryptionAlgorithmType(constants.EncryptionAlgorithmECDSAP384)), spec, caCert, caKey, &rep)
+	require.NoError(t, err)
+	require.Len(t, rep.Entries, 1)
+	assert.Equal(t, PKIActionWrittenRegenerated, rep.Entries[0].Action)
+
+	cert2, _, err := readCertAndKey(dir, "apiserver")
+	require.NoError(t, err)
+	assert.NotEqual(t, cert1.SerialNumber, cert2.SerialNumber, "leaf cert must be regenerated with new algorithm")
 }
 
 func TestCreateLeafCertIfNotExists_RegeneratesInvalid(t *testing.T) {

--- a/go_lib/controlplane/pki/signature/regular_renewer_test.go
+++ b/go_lib/controlplane/pki/signature/regular_renewer_test.go
@@ -510,9 +510,5 @@ func TestRegularAPIServerChecksumPaths(t *testing.T) {
 }
 
 func renewSignatureCerts(tmpDir string, k8sInterface kubernetes.Interface) error {
-	r := RegularRenewer{
-		kubernetesPkiPath: tmpDir,
-	}
-
-	return r.Renew(k8sInterface)
+	return NewRegularSignatureRenewer(tmpDir).Renew(k8sInterface)
 }

--- a/go_lib/controlplane/pki/testhelpers_test.go
+++ b/go_lib/controlplane/pki/testhelpers_test.go
@@ -36,7 +36,13 @@ import (
 func makeTestConfig(t *testing.T, dir string, opts ...configOption) config {
 	t.Helper()
 	opts = append([]configOption{WithPKIDir(dir)}, opts...)
-	cfg, err := newConfig("test-node", "cluster.local", net.ParseIP("10.0.0.1"), "10.96.0.0/12", opts...)
+	cfg, err := newConfig(
+		"test-node",
+		"cluster.local",
+		net.ParseIP("10.0.0.1"),
+		"10.96.0.0/12",
+		opts...,
+	)
 	require.NoError(t, err)
 	return *cfg
 }

--- a/go_lib/controlplane/pki/testhelpers_test.go
+++ b/go_lib/controlplane/pki/testhelpers_test.go
@@ -30,16 +30,17 @@ import (
 )
 
 // makeTestConfig returns a minimal valid config pointing to dir.
-// It uses pki2-internal symbols (newConfig, WithPKIDir) and therefore cannot
+// Extra options (e.g. WithEncryptionAlgorithmType) can be passed to override defaults.
+// It uses pki-internal symbols (newConfig, WithPKIDir) and therefore cannot
 // be placed in a shared test package.
-func makeTestConfig(t *testing.T, dir string) config {
+func makeTestConfig(t *testing.T, dir string, opts ...configOption) config {
 	t.Helper()
 	cfg, err := newConfig(
 		"test-node",
 		"cluster.local",
 		net.ParseIP("10.0.0.1"),
 		"10.96.0.0/12",
-		WithPKIDir(dir),
+		append([]configOption{WithPKIDir(dir)}, opts...)...,
 	)
 	require.NoError(t, err)
 	return *cfg

--- a/go_lib/controlplane/pki/testhelpers_test.go
+++ b/go_lib/controlplane/pki/testhelpers_test.go
@@ -35,13 +35,8 @@ import (
 // be placed in a shared test package.
 func makeTestConfig(t *testing.T, dir string, opts ...configOption) config {
 	t.Helper()
-	cfg, err := newConfig(
-		"test-node",
-		"cluster.local",
-		net.ParseIP("10.0.0.1"),
-		"10.96.0.0/12",
-		append([]configOption{WithPKIDir(dir)}, opts...)...,
-	)
+	opts = append([]configOption{WithPKIDir(dir)}, opts...)
+	cfg, err := newConfig("test-node", "cluster.local", net.ParseIP("10.0.0.1"), "10.96.0.0/12", opts...)
 	require.NoError(t, err)
 	return *cfg
 }

--- a/go_lib/controlplane/pki/validate.go
+++ b/go_lib/controlplane/pki/validate.go
@@ -47,10 +47,8 @@ func validateCert(oldCert *x509.Certificate, newCertCfg certConfig) error {
 	return nil
 }
 
-// validateRootCert checks whether an existing root CA certificate is still fit for use.
-// Unlike validateCert, it does NOT check the encryption algorithm, because root CA certificates
-// are never rotated on algorithm changes — they are only created during initial cluster bootstrap.
-// Changing encryptionAlgorithm in cluster configuration only affects leaf certificate re-issuance.
+// validateRootCert is like validateCert but skips the encryption algorithm check,
+// because root CA certificates are never rotated on algorithm changes.
 func validateRootCert(oldCert *x509.Certificate, newCertCfg certConfig) error {
 	if certificateExpiresSoon(oldCert, 30*24*time.Hour) {
 		return fmt.Errorf("expired at %s", oldCert.NotAfter.UTC().Format(time.RFC3339))

--- a/go_lib/controlplane/pki/validate.go
+++ b/go_lib/controlplane/pki/validate.go
@@ -47,6 +47,22 @@ func validateCert(oldCert *x509.Certificate, newCertCfg certConfig) error {
 	return nil
 }
 
+// validateRootCert checks whether an existing root CA certificate is still fit for use.
+// Unlike validateCert, it does NOT check the encryption algorithm, because root CA certificates
+// are never rotated on algorithm changes — they are only created during initial cluster bootstrap.
+// Changing encryptionAlgorithm in cluster configuration only affects leaf certificate re-issuance.
+func validateRootCert(oldCert *x509.Certificate, newCertCfg certConfig) error {
+	if certificateExpiresSoon(oldCert, 30*24*time.Hour) {
+		return fmt.Errorf("expired at %s", oldCert.NotAfter.UTC().Format(time.RFC3339))
+	}
+
+	if !certificateSubjectAndSansIsEqual(oldCert, newCertCfg) {
+		return fmt.Errorf("subject or SANs mismatch")
+	}
+
+	return nil
+}
+
 func certificateExpiresSoon(cert *x509.Certificate, durationLeft time.Duration) bool {
 	return pkiutil.CertificateExpiresSoon(cert, durationLeft)
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Fixed the certificate regeneration case: only non-root certificates are regenerated according to the documented behavior. Also no more error from validating root certs function.

Added a tests covering this case.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
To get rid of error from validating root certs function.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: fix
summary: Fixed an error in the root certificate validation function.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
