### PR TITLE
Fix sec scan

### DIFF
--- a/.github/workflow_templates/security-scan-images.yml
+++ b/.github/workflow_templates/security-scan-images.yml
@@ -102,7 +102,22 @@ jobs:
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       baseline_run_id:  ${{ steps.baseline.outputs.run_id }}
     steps:
-{!{ tmpl.Exec "checkout_full_step" $ctx | strings.Indent 6 }!}
+      # IMPORTANT: do NOT checkout the PR head ref here. We deliberately
+      # check out the *base* branch (default for `pull_request_target`),
+      # because:
+      #   1. This job runs CI scripts (`.github/scripts/python/changed_images.py`)
+      #      that must come from trusted code, not from PR-author code. A PR
+      #      from an older branch would otherwise not have the script at all
+      #      (`python3 ... changed_images.py` -> exit 2 "No such file"),
+      #      and a malicious PR could swap the script for anything.
+      #   2. We do not read the PR working tree at all: `images_digests.json`
+      #      is pulled out of the PR's dev image via `regctl`, and the build
+      #      report comes from a downloaded artifact.
+      # fetch-depth: 1 is enough — we only need the script files.
+      - name: Checkout sources (base ref — CI scripts only, not PR code)
+        uses: {!{ index (ds "actions") "actions/checkout" }!}
+        with:
+          fetch-depth: 1
 
       - name: Set PR tag
         id: tag

--- a/.github/workflows/security-scan-images.yml
+++ b/.github/workflows/security-scan-images.yml
@@ -330,14 +330,22 @@ jobs:
       changed_compact:  ${{ steps.diff.outputs.changed_compact }}
       baseline_run_id:  ${{ steps.baseline.outputs.run_id }}
     steps:
-
-      # <template: checkout_full_step>
-      - name: Checkout sources
+      # IMPORTANT: do NOT checkout the PR head ref here. We deliberately
+      # check out the *base* branch (default for `pull_request_target`),
+      # because:
+      #   1. This job runs CI scripts (`.github/scripts/python/changed_images.py`)
+      #      that must come from trusted code, not from PR-author code. A PR
+      #      from an older branch would otherwise not have the script at all
+      #      (`python3 ... changed_images.py` -> exit 2 "No such file"),
+      #      and a malicious PR could swap the script for anything.
+      #   2. We do not read the PR working tree at all: `images_digests.json`
+      #      is pulled out of the PR's dev image via `regctl`, and the build
+      #      report comes from a downloaded artifact.
+      # fetch-depth: 1 is enough — we only need the script files.
+      - name: Checkout sources (base ref — CI scripts only, not PR code)
         uses: actions/checkout@v3.5.2
         with:
-          fetch-depth: 0
-          ref: ${{ needs.pull_request_info.outputs.ref }}
-      # </template: checkout_full_step>
+          fetch-depth: 1
 
       - name: Set PR tag
         id: tag


### PR DESCRIPTION
## Description
Need to get script from main

## Why do we need it, and what problem does it solve?
Need to get script from main


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix sec scan
impact: none
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
