### PR TITLE
[deckhouse-controller] cluster configuration stuck bug fix

### DIFF
--- a/deckhouse-controller/cmd/deckhouse-controller/main.go
+++ b/deckhouse-controller/cmd/deckhouse-controller/main.go
@@ -176,6 +176,25 @@ func main() {
 		dhctlOpts.Kube.InCluster = envBoolOr("DECKHOUSE_KUBE_CONFIG_IN_CLUSTER", true)
 		dhctlOpts.Global.TmpDir = envOr("DECKHOUSE_TMP_DIR", os.TempDir())
 
+		// Pin the dhctl content directories to the deckhouse image layout
+		// (/deckhouse/...). The legacy kingpin entrypoint relied on
+		// dhctl/pkg/config package globals that defaulted to these absolute
+		// paths, so commands like `cluster-configuration` and
+		// `cloud-discovery-data` found their schemas under /deckhouse/candi.
+		// options.New() instead calls NewGlobalOptions(), which auto-detects
+		// these dirs relative to the current working directory and otherwise
+		// points them at a download dir under TmpDir (/tmp/dhctl/deckhouse/...).
+		// That directory does not exist in the deckhouse image, so config
+		// parsing failed with "init configuration index not found". Restore the
+		// previous behavior by setting the image paths explicitly.
+		dhctlOpts.Global.DeckhouseDir = options.DefaultDeckhouseDir
+		dhctlOpts.Global.CandiDir = options.DefaultCandiDir
+		dhctlOpts.Global.ModulesDir = options.DefaultModulesDir
+		dhctlOpts.Global.GlobalHooksModule = options.DefaultGlobalHooksModule
+		dhctlOpts.Global.InfrastructureVersions = options.DefaultInfrastructureVersions
+		dhctlOpts.Global.VersionMap = options.DefaultVersionMap
+		dhctlOpts.Global.NeedDownload = false
+
 		dhctlcli.RegisterCobraBridges(rootCmd, fileName, dhctlOpts)
 	}
 

--- a/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
+++ b/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
@@ -33,11 +33,8 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
-	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 )
 
@@ -150,11 +147,10 @@ func clusterConfigurationStdinFromCluster(opts *options.Options) func() error {
 
 		ctx := context.Background()
 
-		kubeCl, cleanup, err := newKubeClient(ctx, opts)
+		kubeCl, err := newKubeClient(ctx, opts)
 		if err != nil {
 			return err
 		}
-		defer cleanup(ctx)
 
 		secret, err := kubeCl.CoreV1().Secrets(clusterConfigurationSecretNS).
 			Get(ctx, clusterConfigurationSecretName, metav1.GetOptions{})

--- a/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
+++ b/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
@@ -145,6 +145,13 @@ func clusterConfigurationStdinFromCluster(opts *options.Options) func() error {
 			return nil
 		}
 
+		// A human is viewing the config interactively, so default to YAML.
+		// An explicit -o/--output (or DHCTL_CLI_OUTPUT, applied by kingpin)
+		// still wins.
+		if !outputFlagPresent(os.Args) {
+			opts.Render.ParseOutput = "yaml"
+		}
+
 		ctx := context.Background()
 
 		kubeCl, err := newKubeClient(ctx, opts)
@@ -202,6 +209,20 @@ func parseFileFlagPresent(args []string) bool {
 		case a == "-f", a == "--file":
 			return true
 		case strings.HasPrefix(a, "--file="), strings.HasPrefix(a, "-f="):
+			return true
+		}
+	}
+	return false
+}
+
+// outputFlagPresent reports whether the args contain the parse commands'
+// --output/-o flag in any of its accepted spellings.
+func outputFlagPresent(args []string) bool {
+	for _, a := range args {
+		switch {
+		case a == "-o", a == "--output":
+			return true
+		case strings.HasPrefix(a, "--output="), strings.HasPrefix(a, "-o="):
 			return true
 		}
 	}

--- a/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
+++ b/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
@@ -181,40 +181,17 @@ func clusterConfigurationStdinFromCluster(opts *options.Options) func() error {
 }
 
 // newKubeClient builds a Kubernetes client from the deckhouse-controller's
-// dhctl options. It mirrors the client setup used by the edit commands so that
-// in-cluster (the deckhouse pod) and kubeconfig-based access behave the same.
-func newKubeClient(ctx context.Context, opts *options.Options) (*client.KubernetesClient, func(context.Context), error) {
-	logger := log.GetDefaultLogger()
-	loggerProvider := log.ExternalLoggerProvider(logger)
-	params := app.ProviderParams(&opts.Global, loggerProvider)
-
-	sshProviderInitializer, kubeProvider, err := providerinitializer.GetProviders(
-		ctx,
-		params,
-		providerinitializer.WithKubeFlagsDefined(opts.Kube.IsDefined()),
-		providerinitializer.WithKubeConfig(opts.Kube.Config, opts.Kube.ConfigContext, opts.Kube.InCluster),
-		providerinitializer.WithRequiredKubeProvider(),
-	)
-	if err != nil {
-		return nil, nil, err
+// dhctl kube options. deckhouse-controller runs in-cluster
+// (DECKHOUSE_KUBE_CONFIG_IN_CLUSTER defaults to true), so this resolves to the
+// pod's service-account credentials; it also honors an explicit kubeconfig.
+// Unlike the edit commands' provider initializer, it never sets up SSH — this
+// path only needs read access to a Secret.
+func newKubeClient(ctx context.Context, opts *options.Options) (*client.KubernetesClient, error) {
+	kubeCl := client.NewKubernetesClient()
+	if err := kubeCl.InitContext(ctx, client.AppKubernetesInitParams(&opts.Kube)); err != nil {
+		return nil, fmt.Errorf("initialize kubernetes client: %w", err)
 	}
-	if kubeProvider == nil {
-		return nil, nil, fmt.Errorf("kubernetes provider is not initialized")
-	}
-
-	kube, err := kubeProvider.Client(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cleanup := func(c context.Context) {
-		//nolint: errcheck
-		if sshProviderInitializer != nil {
-			sshProviderInitializer.Cleanup(c)
-		}
-	}
-
-	return &client.KubernetesClient{KubeClient: kube}, cleanup, nil
+	return kubeCl, nil
 }
 
 // parseFileFlagPresent reports whether the args contain the parse commands'

--- a/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
+++ b/deckhouse-controller/internal/dhctlcli/cobra_bridge.go
@@ -24,13 +24,27 @@
 package dhctlcli
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/alecthomas/kingpin.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/deckhouse/deckhouse/dhctl/pkg/app"
 	"github.com/deckhouse/deckhouse/dhctl/pkg/app/options"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/system/providerinitializer"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
+)
+
+const (
+	clusterConfigurationSecretNS   = "kube-system"
+	clusterConfigurationSecretName = "d8-cluster-configuration"
+	clusterConfigurationSecretKey  = "cluster-configuration.yaml"
 )
 
 // RegisterCobraBridges adds cobra wrappers for the kingpin-based dhctl
@@ -43,6 +57,7 @@ func RegisterCobraBridges(rootCmd *cobra.Command, fileName string, opts *options
 		"edit",
 		"Change configuration files in Kubernetes cluster conveniently and safely.",
 		fileName,
+		nil,
 		func(kpApp *kingpin.Application) {
 			editCmd := kpApp.Command("edit", "Change configuration files in Kubernetes cluster conveniently and safely.")
 			DefineEditCommands(editCmd, opts /* wConnFlags */, true)
@@ -53,6 +68,10 @@ func RegisterCobraBridges(rootCmd *cobra.Command, fileName string, opts *options
 		"cluster-configuration",
 		"Parse configuration and print it.",
 		fileName,
+		// When invoked interactively (a TTY) with neither --file nor piped
+		// stdin, read the cluster-configuration straight from the cluster so
+		// the command prints the current config instead of blocking on stdin.
+		clusterConfigurationStdinFromCluster(opts),
 		func(kpApp *kingpin.Application) {
 			DefineCommandParseClusterConfiguration(
 				kpApp.Command("cluster-configuration", "Parse configuration and print it."),
@@ -65,6 +84,7 @@ func RegisterCobraBridges(rootCmd *cobra.Command, fileName string, opts *options
 		"cloud-discovery-data",
 		"Parse cloud discovery data and print it.",
 		fileName,
+		nil,
 		func(kpApp *kingpin.Application) {
 			DefineCommandParseCloudDiscoveryData(
 				kpApp.Command("cloud-discovery-data", "Parse cloud discovery data and print it."),
@@ -80,7 +100,11 @@ func RegisterCobraBridges(rootCmd *cobra.Command, fileName string, opts *options
 // We must DisableFlagParsing so that cobra does not steal --help (kingpin
 // prints its own usage for these subcommands) or fail on dhctl-style flags
 // that cobra knows nothing about.
-func newDhctlBridge(name, short, fileName string, register func(*kingpin.Application)) *cobra.Command {
+//
+// preRun, when non-nil, runs before the kingpin Application is parsed. It is
+// used to prime stdin for commands that should read from the cluster when no
+// explicit input is given.
+func newDhctlBridge(name, short, fileName string, preRun func() error, register func(*kingpin.Application)) *cobra.Command {
 	return &cobra.Command{
 		Use:                name,
 		Short:              short,
@@ -90,6 +114,13 @@ func newDhctlBridge(name, short, fileName string, register func(*kingpin.Applica
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if preRun != nil {
+				if err := preRun(); err != nil {
+					fmt.Fprintf(os.Stderr, "%s: %s\n", name, err)
+					return err
+				}
+			}
+
 			kpApp := kingpin.New(fileName, "")
 			register(kpApp)
 			if _, err := kpApp.Parse(os.Args[1:]); err != nil {
@@ -101,4 +132,105 @@ func newDhctlBridge(name, short, fileName string, register func(*kingpin.Applica
 			return nil
 		},
 	}
+}
+
+// clusterConfigurationStdinFromCluster returns a preRun that feeds the
+// in-cluster d8-cluster-configuration secret to the `cluster-configuration`
+// parse command via stdin.
+//
+// It only fires when the user provided no input source: no --file flag (or
+// DHCTL_CLI_FILE env) and stdin is an interactive terminal rather than a pipe.
+// In every other case it is a no-op, preserving the original behavior of
+// reading --file or piped stdin.
+func clusterConfigurationStdinFromCluster(opts *options.Options) func() error {
+	return func() error {
+		if parseFileFlagPresent(os.Args) || os.Getenv("DHCTL_CLI_FILE") != "" || !input.IsTerminal() {
+			return nil
+		}
+
+		ctx := context.Background()
+
+		kubeCl, cleanup, err := newKubeClient(ctx, opts)
+		if err != nil {
+			return err
+		}
+		defer cleanup(ctx)
+
+		secret, err := kubeCl.CoreV1().Secrets(clusterConfigurationSecretNS).
+			Get(ctx, clusterConfigurationSecretName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("get %s secret: %w", clusterConfigurationSecretName, err)
+		}
+
+		data, ok := secret.Data[clusterConfigurationSecretKey]
+		if !ok || len(data) == 0 {
+			return fmt.Errorf("secret %s has no %q key", clusterConfigurationSecretName, clusterConfigurationSecretKey)
+		}
+
+		// Hand the secret bytes to the parse action via stdin without touching
+		// disk (the data is sensitive). The mirrored parse function reads
+		// os.Stdin when no --file is set.
+		r, w, err := os.Pipe()
+		if err != nil {
+			return err
+		}
+		os.Stdin = r
+		go func() {
+			_, _ = w.Write(data)
+			_ = w.Close()
+		}()
+
+		return nil
+	}
+}
+
+// newKubeClient builds a Kubernetes client from the deckhouse-controller's
+// dhctl options. It mirrors the client setup used by the edit commands so that
+// in-cluster (the deckhouse pod) and kubeconfig-based access behave the same.
+func newKubeClient(ctx context.Context, opts *options.Options) (*client.KubernetesClient, func(context.Context), error) {
+	logger := log.GetDefaultLogger()
+	loggerProvider := log.ExternalLoggerProvider(logger)
+	params := app.ProviderParams(&opts.Global, loggerProvider)
+
+	sshProviderInitializer, kubeProvider, err := providerinitializer.GetProviders(
+		ctx,
+		params,
+		providerinitializer.WithKubeFlagsDefined(opts.Kube.IsDefined()),
+		providerinitializer.WithKubeConfig(opts.Kube.Config, opts.Kube.ConfigContext, opts.Kube.InCluster),
+		providerinitializer.WithRequiredKubeProvider(),
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if kubeProvider == nil {
+		return nil, nil, fmt.Errorf("kubernetes provider is not initialized")
+	}
+
+	kube, err := kubeProvider.Client(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cleanup := func(c context.Context) {
+		//nolint: errcheck
+		if sshProviderInitializer != nil {
+			sshProviderInitializer.Cleanup(c)
+		}
+	}
+
+	return &client.KubernetesClient{KubeClient: kube}, cleanup, nil
+}
+
+// parseFileFlagPresent reports whether the args contain the parse commands'
+// --file/-f flag in any of its accepted spellings.
+func parseFileFlagPresent(args []string) bool {
+	for _, a := range args {
+		switch {
+		case a == "-f", a == "--file":
+			return true
+		case strings.HasPrefix(a, "--file="), strings.HasPrefix(a, "-f="):
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: deckhouse-controller
type: fix
summary: cluster configuration bug fix
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
