### PR TITLE
[docs] Fix slow page load on large DOM pages (with large OpenAPI schemas)

### DIFF
--- a/docs/site/assets/js/customscripts.js
+++ b/docs/site/assets/js/customscripts.js
@@ -38,7 +38,33 @@ document.addEventListener("DOMContentLoaded", function () {
    */
   if ((typeof anchors !== 'undefined') && (typeof anchors.add !== 'undefined') && (window.anchors_disabled != true)) {
     anchors.add('h2,h3,h4,h5');
-    anchors.add('.anchored');
+    // Skip adding anchors to .anchored elements (CRD properties) on CR/CRD pages —
+    // they already have id/data-anchor-id set in HTML, and running anchors.add()
+    // on 10k+ elements causes multi-second style recalculations.
+    if (!document.querySelector('meta[name="page:anchors-skip-props"]')) {
+      anchors.add('.anchored');
+    } else {
+      // Lightweight replacement for AnchorJS on CR/CRD pages.
+      // Instead of iterating all 10k+ elements upfront, inject one <a> per element
+      // lazily on mouseenter via a single delegated listener.
+      document.addEventListener('mouseenter', function (e) {
+        if (!(e.target instanceof Element)) return;
+        const propName = e.target.closest('.resources__prop_name.anchored');
+        if (!propName || propName.querySelector('.anchorjs-link')) return;
+        const id = propName.id || propName.getAttribute('data-anchor-id');
+        if (!id) return;
+        const base = window.location.pathname + window.location.search;
+        const a = document.createElement('a');
+        a.className = 'anchorjs-link';
+        a.setAttribute('aria-label', 'Anchor');
+        a.setAttribute('data-anchorjs-icon', (typeof anchors !== 'undefined') ? anchors.options.icon : '');
+        a.style.font = '1em/1 anchorjs-icons';
+        a.style.paddingLeft = '0.375em';
+        a.style.display = 'inline';
+        a.href = base + '#' + id;
+        propName.appendChild(a);
+      }, true);
+    }
   }
 });
 

--- a/docs/site/assets/js/navigation.js
+++ b/docs/site/assets/js/navigation.js
@@ -6,21 +6,33 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const sidebarAndToc = document.querySelectorAll('.sidebar__wrapper-inner');
+    const header = document.querySelector('header');
     let lastScroll = window.scrollY;
+    let rafPending = false;
+
+    // navigationContainer.offsetHeight is stable (doesn't depend on page content),
+    // but reading it forces a full reflow on large DOMs. We prime the cache on the
+    // 'load' event (after first paint) and use 0 as a safe fallback until then.
+    let cachedNavigationHeight = 0;
+    window.addEventListener('load', () => {
+        cachedNavigationHeight = navigationContainer.offsetHeight;
+        const newTop = updateTop();
+        scrollHandler(newTop);
+    }, { once: true });
 
     function applyHeaderOffsets() {
-        const header = document.querySelector('header');
-        const headerHeight = header.getBoundingClientRect().height;
+        // Read all layout properties first, before any writes, to avoid forced reflow.
+        const headerHeight = header ? header.getBoundingClientRect().height : 0;
+        // Write phase: apply styles after all reads are done.
         navigationContainer.style.top = `${headerHeight}px`;
         sidebarAndToc.forEach(e => {
             e.style.top = `${headerHeight}px`;
         });
-        return headerHeight;
+        return { headerHeight, navigationHeight: cachedNavigationHeight };
     }
 
     function updateTop() {
-        const headerHeight = applyHeaderOffsets();
-        const navigationHeight = navigationContainer.offsetHeight;
+        const { headerHeight, navigationHeight } = applyHeaderOffsets();
         return headerHeight + navigationHeight;
     }
 
@@ -96,11 +108,17 @@ document.addEventListener('DOMContentLoaded', () => {
     scrollHandler(initTop);
 
     window.addEventListener('scroll', () => {
-        const newTop = updateTop();
-        scrollHandler(newTop)
+        if (rafPending) return;
+        rafPending = true;
+        requestAnimationFrame(() => {
+            rafPending = false;
+            const newTop = updateTop();
+            scrollHandler(newTop);
+        });
     });
 
     window.addEventListener('resize', () => {
+        cachedNavigationHeight = navigationContainer.offsetHeight;
         const newTop = updateTop();
         scrollHandler(newTop)
     });

--- a/docs/site/backends/docs-builder-template/layouts/_partials/head.html
+++ b/docs/site/backends/docs-builder-template/layouts/_partials/head.html
@@ -61,3 +61,7 @@
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image">
+{{- $baseName := strings.ToUpper .File.TranslationBaseName -}}
+{{- if or (eq $baseName "CR") (eq $baseName "CRD") }}
+<meta name="page:anchors-skip-props" content="true">
+{{- end }}


### PR DESCRIPTION
## Description

Fix slow page load on large DOM pages, e.g. with large OpenAPI schemas).

## Why do we need it, and what problem does it solve?

Pages with 10k+ CRD properties were taking
several seconds to become interactive due to two JS bottlenecks.

navigation.js: reading offsetHeight after writing style.top forced a full synchronous may reflow on a 100k-node DOM on every scroll event. Fix by caching header/navigationHeight, separating read/write phases, and throttling scroll handler via requestAnimationFrame.

customscripts.js: anchors.add('.anchored') iterated all (possibly 10k+) property elements at DOMContentLoaded, causing >2s style recalculation. On CR/CRD pages (detected via <meta name="page:anchors-skip-props"> injected by head.html), skip the bulk anchors.add() and instead inject the anchor <a> lazily on mouseenter per element.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: docs
type: chore
summary: Fix slow page load on large DOM pages (with large OpenAPI schemas).
impact_level: low
```
