### PR TITLE
[docs] Normalise relative URL for index pages

### DIFF
--- a/docs/documentation/_layouts/default.html
+++ b/docs/documentation/_layouts/default.html
@@ -7,7 +7,7 @@
   {% else %}
   <meta name="page:versioned" content="true">
   {% endif %}
-  <meta name="page:url:relative" content="./{{ page.url | remove_first: "/" | regex_replace: '^(ru/|en/)', '' }}">
+  <meta name="page:url:relative" content="./{{ page.url | remove_first: "/" | regex_replace: '^(ru/|en/)', '' | regex_replace_once: '/index.html$', '/' }}">
   {%- if page.anchors_disabled == true %}
     <script>
         window.anchors_disabled = true;


### PR DESCRIPTION
## Description

Normalise relative URL for index pages:
- Strip trailing index filename from the relative URL meta tag by appending a regex substitution that converts explicit index paths to directory-style trailing slashes
- Ensures consistent language-switching and versioned link resolution when the canonical page is a directory index


## Why do we need it, and what problem does it solve?
Fix URL in search result.

## Changelog entries
```changes
section: docs
type: chore
summary: Normalise relative URL for index pages.
impact_level: low
```
