### PR TITLE
[control-plane-manager] Automatic renewal of kube-apiserver signature keys

### DIFF
--- a/go_lib/controlplane/pki/io.go
+++ b/go_lib/controlplane/pki/io.go
@@ -68,7 +68,7 @@ func writeCert(pkiDir, name string, cert *x509.Certificate) error {
 		return fmt.Errorf("couldn't create directory %q: %w", filepath.Dir(certificatePath), err)
 	}
 
-	return writeFileAtomically(certificatePath, pkiutil.EncodeCertificate(cert), 0o600)
+	return pkiutil.WriteFileAtomically(certificatePath, pkiutil.EncodeCertificate(cert), 0o600)
 }
 
 func writeKey(pkiDir, name string, key crypto.Signer) error {
@@ -83,7 +83,7 @@ func writeKey(pkiDir, name string, key crypto.Signer) error {
 		return fmt.Errorf("unable to marshal private key to PEM: %w", err)
 	}
 
-	return writeFileAtomically(privateKeyPath, encoded, 0o600)
+	return pkiutil.WriteFileAtomically(privateKeyPath, encoded, 0o600)
 }
 
 // writeSAPublicKey encodes the public part of key in PKIX PEM format and writes it to sa.pub.
@@ -100,49 +100,9 @@ func writeSAPublicKey(pkiDir string, key crypto.Signer) error {
 		Bytes: pubKeyDER,
 	})
 
-	if err := writeFileAtomically(filepath.Join(pkiDir, "sa.pub"), publicKeyPEM, 0o600); err != nil {
+	if err := pkiutil.WriteFileAtomically(filepath.Join(pkiDir, "sa.pub"), publicKeyPEM, 0o600); err != nil {
 		return fmt.Errorf("unable to write SA public key: %w", err)
 	}
 
 	return nil
-}
-
-// writeFileAtomically writes data to dst atomically using a write-fsync-rename sequence:
-//  1. A temp file is created in the same directory as dst (same filesystem, so rename is atomic).
-//  2. Data is written and fsynced to ensure it reaches disk before the rename.
-//  3. The temp file is renamed to dst, which is an atomic operation on POSIX systems.
-//
-// This guarantees that dst is never left in a partially written state,
-// even if the process crashes mid-write.
-func writeFileAtomically(dst string, data []byte, perm os.FileMode) error {
-	dstDir := filepath.Dir(dst)
-	base := filepath.Base(dst)
-
-	tmpFile, err := os.CreateTemp(dstDir, "."+base+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("couldn't create temp file in %q: %w", dstDir, err)
-	}
-
-	tmpPath := tmpFile.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
-
-	if _, err := tmpFile.Write(data); err != nil {
-		_ = tmpFile.Close()
-		return fmt.Errorf("couldn't write to temp file: %w", err)
-	}
-
-	if err := tmpFile.Sync(); err != nil {
-		_ = tmpFile.Close()
-		return fmt.Errorf("couldn't sync temp file: %w", err)
-	}
-
-	if err := tmpFile.Close(); err != nil {
-		return fmt.Errorf("couldn't close temp file: %w", err)
-	}
-
-	if err := os.Chmod(tmpPath, perm); err != nil {
-		return fmt.Errorf("couldn't chmod temp file: %w", err)
-	}
-
-	return os.Rename(tmpPath, dst)
 }

--- a/go_lib/controlplane/pki/signature/expiration.go
+++ b/go_lib/controlplane/pki/signature/expiration.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signature
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+// ActiveKeyExpiration returns the NotAfter of the active signing key certificate.
+func ActiveKeyExpiration(pkiDir string) (time.Time, error) {
+	privData, err := os.ReadFile(filepath.Join(pkiDir, SignaturePrivateJWK))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read private jwk: %w", err)
+	}
+	var privJWK jose.JSONWebKey
+	if err := json.Unmarshal(privData, &privJWK); err != nil {
+		return time.Time{}, fmt.Errorf("parse private jwk: %w", err)
+	}
+	jwksData, err := os.ReadFile(filepath.Join(pkiDir, SignaturePublicJWKS))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("read jwks: %w", err)
+	}
+	var jwks jose.JSONWebKeySet
+	if err := json.Unmarshal(jwksData, &jwks); err != nil {
+		return time.Time{}, fmt.Errorf("parse jwks: %w", err)
+	}
+	for _, key := range jwks.Keys {
+		if key.KeyID == privJWK.KeyID && len(key.Certificates) > 0 {
+			return key.Certificates[0].NotAfter, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("active key %q with certificate not found in JWKS", privJWK.KeyID)
+}
+
+// SignatureFilesChecksum returns a stable hash of the on-disk signature key files, which is used to detect files changes.
+func SignatureFilesChecksum(pkiDir string) (string, error) {
+	h := sha256.New()
+	for _, name := range []string{SignaturePrivateJWK, SignaturePublicJWKS} {
+		data, err := os.ReadFile(filepath.Join(pkiDir, name))
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", name, err)
+		}
+		_, _ = h.Write(data)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}

--- a/go_lib/controlplane/pki/signature/regular_renewer.go
+++ b/go_lib/controlplane/pki/signature/regular_renewer.go
@@ -36,6 +36,7 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/util/pkiutil"
 )
@@ -78,6 +79,14 @@ func (s *RegularRenewer) WithLeftDaysToRenew(days int) *RegularRenewer {
 }
 
 func (s *RegularRenewer) Renew(k8sInterface kubernetes.Interface) error {
+	// On a 409 (another node updated d8-pki first), RetryOnConflict re-runs renewOnce, which re-reads secret and re-evaluates active key expiry.
+	// Winner writes the active key, so renewOnce becomes a sync-only no-op.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return s.renewOnce(k8sInterface)
+	})
+}
+
+func (s *RegularRenewer) renewOnce(k8sInterface kubernetes.Interface) error {
 	pkiDir := s.kubernetesPkiPath
 	logger.Info("renew signature certs", slog.String("pki_dir", pkiDir))
 	jwkPath := filepath.Join(pkiDir, SignaturePrivateJWK)

--- a/go_lib/controlplane/pki/signature/regular_renewer.go
+++ b/go_lib/controlplane/pki/signature/regular_renewer.go
@@ -56,9 +56,6 @@ const (
 	TLSCertificateOUField = "apiserver"
 	// DefaultCertificateTTL is the number of days generated certificates will be considered valid.
 	DefaultCertificateTTL = 365
-	// SignatureRenewalDays is the number of days before expiry at which the signature cert is renewed.
-	SignatureRenewalDays      = 60
-	SignatureRenewalThreshold = SignatureRenewalDays * 24 * time.Hour
 )
 
 type RegularRenewer struct {
@@ -69,7 +66,7 @@ type RegularRenewer struct {
 func NewRegularSignatureRenewer(kubernetesPkiPath string) *RegularRenewer {
 	return &RegularRenewer{
 		kubernetesPkiPath: kubernetesPkiPath,
-		leftDaysToRenew:   SignatureRenewalDays,
+		leftDaysToRenew:   60,
 	}
 }
 

--- a/go_lib/controlplane/pki/signature/regular_renewer.go
+++ b/go_lib/controlplane/pki/signature/regular_renewer.go
@@ -56,6 +56,9 @@ const (
 	TLSCertificateOUField = "apiserver"
 	// DefaultCertificateTTL is the number of days generated certificates will be considered valid.
 	DefaultCertificateTTL = 365
+	// SignatureRenewalDays is the number of days before expiry at which the signature cert is renewed.
+	SignatureRenewalDays      = 60
+	SignatureRenewalThreshold = SignatureRenewalDays * 24 * time.Hour
 )
 
 type RegularRenewer struct {
@@ -66,7 +69,7 @@ type RegularRenewer struct {
 func NewRegularSignatureRenewer(kubernetesPkiPath string) *RegularRenewer {
 	return &RegularRenewer{
 		kubernetesPkiPath: kubernetesPkiPath,
-		leftDaysToRenew:   60,
+		leftDaysToRenew:   SignatureRenewalDays,
 	}
 }
 
@@ -266,10 +269,10 @@ func generateNewSignatureCerts(filePath string, k8sInterface kubernetes.Interfac
 
 func replaceSignatureFiles(filePath string, jwkData, jwksData []byte) error {
 	logger.Info("replace signature files on disk")
-	if err := os.WriteFile(filepath.Join(filePath, SignaturePublicJWKS), jwksData, 0o600); err != nil {
+	if err := pkiutil.WriteFileAtomically(filepath.Join(filePath, SignaturePublicJWKS), jwksData, 0o600); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(filePath, SignaturePrivateJWK), jwkData, 0o600); err != nil {
+	if err := pkiutil.WriteFileAtomically(filepath.Join(filePath, SignaturePrivateJWK), jwkData, 0o600); err != nil {
 		return err
 	}
 	return nil

--- a/go_lib/controlplane/pki/signature/regular_renewer_test.go
+++ b/go_lib/controlplane/pki/signature/regular_renewer_test.go
@@ -510,7 +510,5 @@ func TestRegularAPIServerChecksumPaths(t *testing.T) {
 }
 
 func renewSignatureCerts(tmpDir string, k8sInterface kubernetes.Interface) error {
-	r := NewRegularSignatureRenewer(tmpDir).WithLeftDaysToRenew(60)
-
-	return r.Renew(k8sInterface)
+	return NewRegularSignatureRenewer(tmpDir).Renew(k8sInterface)
 }

--- a/go_lib/controlplane/pki/signature/regular_renewer_test.go
+++ b/go_lib/controlplane/pki/signature/regular_renewer_test.go
@@ -510,5 +510,7 @@ func TestRegularAPIServerChecksumPaths(t *testing.T) {
 }
 
 func renewSignatureCerts(tmpDir string, k8sInterface kubernetes.Interface) error {
-	return NewRegularSignatureRenewer(tmpDir).Renew(k8sInterface)
+	r := NewRegularSignatureRenewer(tmpDir).WithLeftDaysToRenew(60)
+
+	return r.Renew(k8sInterface)
 }

--- a/go_lib/controlplane/pki/validate.go
+++ b/go_lib/controlplane/pki/validate.go
@@ -61,7 +61,7 @@ func validateRootCert(oldCert *x509.Certificate, newCertCfg certConfig) error {
 	return nil
 }
 
-func certificateExpiresSoon(cert *x509.Certificate, durationLeft time.Duration) bool {
+func certificateExpiresSoon(cert *x509.Certificate, durationLeft time.Duration) bool { //nolint:unparam
 	return pkiutil.CertificateExpiresSoon(cert, durationLeft)
 }
 

--- a/go_lib/controlplane/util/pkiutil/io.go
+++ b/go_lib/controlplane/util/pkiutil/io.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
+	"os"
 	"path/filepath"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -66,6 +67,46 @@ func loadCert(path string) (*x509.Certificate, error) {
 	// Safely pick the first one because the sender's certificate must come first in the list.
 	// For details, see: https://www.rfc-editor.org/rfc/rfc4346#section-7.4.2
 	return certs[0], nil
+}
+
+// WriteFileAtomically writes data to dst atomically using a write-fsync-rename sequence:
+//  1. A temp file is created in the same directory as dst (same filesystem, so rename is atomic).
+//  2. Data is written and fsynced to ensure it reaches disk before the rename.
+//  3. The temp file is renamed to dst, which is an atomic operation on POSIX systems.
+//
+// This guarantees that dst is never left in a partially written state,
+// even if the process crashes mid-write.
+func WriteFileAtomically(dst string, data []byte, perm os.FileMode) error {
+	dstDir := filepath.Dir(dst)
+	base := filepath.Base(dst)
+
+	tmpFile, err := os.CreateTemp(dstDir, "."+base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("couldn't create temp file in %q: %w", dstDir, err)
+	}
+
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("couldn't write to temp file: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("couldn't sync temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("couldn't close temp file: %w", err)
+	}
+
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("couldn't chmod temp file: %w", err)
+	}
+
+	return os.Rename(tmpPath, dst)
 }
 
 func loadKey(path string) (crypto.Signer, error) {

--- a/modules/040-control-plane-manager/crds/control_plane_operations.yaml
+++ b/modules/040-control-plane-manager/crds/control_plane_operations.yaml
@@ -119,6 +119,7 @@ spec:
                   - `JoinEtcdCluster`: Joins a new member to the etcd cluster.
                   - `WaitPodReady`: Waits for the component static pod to become `Ready` after a restart.
                   - `CertObserve`: Collects the current certificate expiration dates for the component and publishes them to `status.observedState`.
+                  - `RenewSignature`: Re-issues the signature key for the kube-apiserver.
                 items:
                   description: |-
                     Name of a single step performed within an operation.
@@ -131,6 +132,7 @@ spec:
                   - JoinEtcdCluster
                   - WaitPodReady
                   - CertObserve
+                  - RenewSignature
                   type: string
                 minItems: 1
                 type: array

--- a/modules/040-control-plane-manager/crds/doc-ru-control_plane_operations.yaml
+++ b/modules/040-control-plane-manager/crds/doc-ru-control_plane_operations.yaml
@@ -33,6 +33,7 @@ spec:
                     * `JoinEtcdCluster` — присоединение нового члена к etcd-кластеру;
                     * `WaitPodReady` — ожидание готовности статического пода после перезагрузки;
                     * `CertObserve` — сбор данных о текущих сроках действия сертификатов компонента и их публикация в `status.observedState`.
+                    * `RenewSignature` — перевыпуск ключа подписи для kube-apiserver (CSE).
                   items:
                     description: |
                       Имя этапа операции.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/controlplaneoperation_conditions.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/controlplaneoperation_conditions.go
@@ -33,6 +33,7 @@ const (
 	CPOConditionEtcdClusterJoined    = "EtcdClusterJoined"
 	CPOConditionPodReady             = "PodReady"
 	CPOConditionCertificatesObserved = "CertificatesObserved"
+	CPOConditionSignatureRenewed     = "SignatureRenewed"
 )
 
 const (
@@ -79,6 +80,8 @@ func StepConditionType(step StepName) string {
 		return CPOConditionPodReady
 	case StepCertObserve:
 		return CPOConditionCertificatesObserved
+	case StepRenewSignature:
+		return CPOConditionSignatureRenewed
 	default:
 		return string(step)
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/controlplaneoperation_types.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/controlplaneoperation_types.go
@@ -32,7 +32,7 @@ import (
 //   - WaitPodReady     — waits for the component static pod to become Ready after restart.
 //   - CertObserve      — collects current certificate expiration dates for the component and publishes them to status.observedState.
 //
-// +kubebuilder:validation:Enum=Backup;SyncCA;RenewPKICerts;RenewKubeconfigs;SyncManifests;JoinEtcdCluster;WaitPodReady;CertObserve
+// +kubebuilder:validation:Enum=Backup;SyncCA;RenewPKICerts;RenewKubeconfigs;SyncManifests;JoinEtcdCluster;WaitPodReady;CertObserve;RenewSignature
 type StepName string
 
 const (

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/controlplaneoperation_types.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/api/v1alpha1/controlplaneoperation_types.go
@@ -44,6 +44,7 @@ const (
 	StepJoinEtcdCluster  StepName = "JoinEtcdCluster"
 	StepWaitPodReady     StepName = "WaitPodReady"
 	StepCertObserve      StepName = "CertObserve"
+	StepRenewSignature   StepName = "RenewSignature"
 )
 
 // OperationComponent identifies the control plane component the operation targets.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/config/crd/bases/control-plane.deckhouse.io_controlplaneoperations.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/config/crd/bases/control-plane.deckhouse.io_controlplaneoperations.yaml
@@ -138,6 +138,7 @@ spec:
                   - JoinEtcdCluster
                   - WaitPodReady
                   - CertObserve
+                  - RenewSignature
                   type: string
                 minItems: 1
                 type: array

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/checksum/checksum.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/checksum/checksum.go
@@ -76,6 +76,12 @@ type componentFieldMap struct {
 	pkiChecksumDependsOn []string
 }
 
+// pkiChecksumExcludedKeys are d8-pki keys that are not included in the pkiChecksum calculation.
+var pkiChecksumExcludedKeys = map[string]struct{}{
+	"signature-private": {},
+	"signature-public":  {},
+}
+
 // ExtraFileKeysForPodComponent returns secret keys for extra files mounted with the static pod
 // (extra-file-* subset of componentChecksumDeps). Unknown podComponent yields nil.
 func ExtraFileKeysForPodComponent(podComponent string) []string {
@@ -143,10 +149,18 @@ func collectDependencyData(secretData map[string][]byte, component string) ([]st
 	return sortedKeysFromSlice(fieldMap.configChecksumDependsOn, secretData), nil
 }
 
-// PKIChecksum calculates the total checksum of all the keys of the pki secret based only on the values in the secret.
+// PKIChecksum calculates the total checksum of all the keys (except pkiChecksumExcludedKeys) of the pki secret based only on the values in the secret.
 // Keys names are ignored for the checksum calculation.
 func PKIChecksum(pkiSecretData map[string][]byte) (string, error) {
-	return hashKeys(pkiSecretData, sortedKeysFromMap(pkiSecretData)), nil
+	all := sortedKeysFromMap(pkiSecretData)
+	keys := make([]string, 0, len(all))
+	for _, k := range all {
+		if _, skip := pkiChecksumExcludedKeys[k]; skip {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	return hashKeys(pkiSecretData, keys), nil
 }
 
 // ComponentPKIChecksum calculates the pkiChecksum for a component based on certSANs and encryption-algorithm keys.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
@@ -84,7 +84,8 @@ const (
 	KubeconfigRenewalIDAnnotationKey = "control-plane.deckhouse.io/kubeconfig-renewal-id"
 	SignatureRenewalIDAnnotationKey  = "control-plane.deckhouse.io/signature-renewal-id"
 	SignatureExpirationKey           = "signature"
-	SignatureRenewalThreshold        = 60 * 24 * time.Hour
+	SignatureRenewalDays             = 60
+	SignatureRenewalThreshold        = SignatureRenewalDays * 24 * time.Hour
 	CertRenewalThreshold             = 30 * 24 * time.Hour
 )
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
@@ -88,6 +88,14 @@ const (
 	CertRenewalThreshold             = 30 * 24 * time.Hour
 )
 
+var SignatureBuildEnabled = "false"
+
+// SignatureEnabled reports whether the signature feature is built into this binary (CSE only).
+// Flag is overridden by an ldflag in the CSE build (see werf.inc.yaml).
+func SignatureEnabled() bool {
+	return strings.ToLower(SignatureBuildEnabled) == "true"
+}
+
 // ToRelativePath returns path without leading slash for using in tmp directory sync
 func ToRelativePath(absolutePath string) string {
 	return strings.TrimPrefix(absolutePath, "/")

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/constants/constants.go
@@ -82,6 +82,9 @@ const (
 	// Cert renewal
 	CertRenewalIDAnnotationKey       = "control-plane.deckhouse.io/cert-renewal-id"
 	KubeconfigRenewalIDAnnotationKey = "control-plane.deckhouse.io/kubeconfig-renewal-id"
+	SignatureRenewalIDAnnotationKey  = "control-plane.deckhouse.io/signature-renewal-id"
+	SignatureExpirationKey           = "signature"
+	SignatureRenewalThreshold        = 60 * 24 * time.Hour
 	CertRenewalThreshold             = 30 * 24 * time.Hour
 )
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-configuration/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-configuration/controller_test.go
@@ -92,7 +92,7 @@ func (suite *ControllerTestSuite) reconcile() {
 
 func (suite *ControllerTestSuite) getControlPlaneNode() *controlplanev1alpha1.ControlPlaneNode {
 	cpn := &controlplanev1alpha1.ControlPlaneNode{}
-	err := suite.client.Get(suite.ctx, client.ObjectKey{Name: testNodeName}, cpn)
+	err := suite.client.Get(suite.ctx, client.ObjectKey{Name: testNodeName, Namespace: constants.KubeSystemNamespace}, cpn)
 	require.NoError(suite.T(), err, "ControlPlaneNode should exist")
 	return cpn
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
@@ -188,6 +188,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	currentOps, err = r.ensureSignatureRenewalExists(ctx, cpn, states, currentOps, logger)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	if err := r.ensureObserveOperations(ctx, cpn, currentOps, logger); err != nil {
 		return reconcile.Result{}, err
@@ -815,6 +819,66 @@ func (r *Reconciler) ensureObserveOperations(ctx context.Context, cpn *controlpl
 	return nil
 }
 
+// createRenewalOperation builds, creates a renewal CPO for a component.
+func (r *Reconciler) createRenewalOperation(
+	ctx context.Context,
+	cpn *controlplanev1alpha1.ControlPlaneNode,
+	state componentState,
+	steps []controlplanev1alpha1.StepName,
+	ops []controlplanev1alpha1.ControlPlaneOperation,
+	reason string,
+	logger *log.Logger,
+) ([]controlplanev1alpha1.ControlPlaneOperation, error) {
+	op := operationBase(cpn, state.component, steps)
+	op.ObjectMeta.GenerateName = operationGenerateNamePrefix(state)
+	op.Spec.DesiredConfigChecksum = state.spec.Config
+	op.Spec.DesiredPKIChecksum = state.spec.PKI
+	op.Spec.DesiredCAChecksum = state.specCA
+	if err := r.client.Create(ctx, op); err != nil {
+		return nil, fmt.Errorf("create %s for %s: %w", reason, state.component, err)
+	}
+	logger.Info(reason+" created", slog.String("operation", op.Name))
+	return append(ops, *op), nil
+}
+
+// ensureSignatureRenewalExists creates a kube-apiserver signature-rotation CPO when the active signature key expires within SignatureRenewalThreshold.
+func (r *Reconciler) ensureSignatureRenewalExists(
+	ctx context.Context,
+	cpn *controlplanev1alpha1.ControlPlaneNode,
+	states []componentState,
+	ops []controlplanev1alpha1.ControlPlaneOperation,
+	logger *log.Logger,
+) ([]controlplanev1alpha1.ControlPlaneOperation, error) {
+	for _, state := range states {
+		var err error
+		if state.component != controlplanev1alpha1.OperationComponentKubeAPIServer {
+			continue
+		}
+		if !componentStateInSync(state) {
+			continue
+		}
+		sigExp, ok := certDatesForComponent(cpn, state.component)[constants.SignatureExpirationKey]
+		if !ok || sigExp.IsZero() || time.Until(sigExp.Time) >= constants.SignatureRenewalThreshold {
+			continue
+		}
+
+		if existing := findActiveOperation(ops, func(op *controlplanev1alpha1.ControlPlaneOperation) bool {
+			return op.Spec.Component == state.component
+		}); existing != nil {
+			logger.Debug("active operation exists for component, skip signature renewal operation creation",
+				slog.String("operation", existing.Name),
+				slog.String("component", string(state.component)))
+			continue
+		}
+
+		ops, err = r.createRenewalOperation(ctx, cpn, state, signatureRenewalSteps(), ops, "signature renewal", logger)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ops, nil
+}
+
 // applyCertDatesAndTimestamp copies certificate expiration dates from ObservedState into CPN status and updates per-component LastCertObserveTime.
 func applyCertDatesAndTimestamp(cpn *controlplanev1alpha1.ControlPlaneNode, component controlplanev1alpha1.OperationComponent, observed controlplanev1alpha1.ObservedComponentState, observedAt metav1.Time) {
 	compStatus := cpn.Status.Components.Component(component)
@@ -851,6 +915,7 @@ func (r *Reconciler) ensureCertRenewalExists(
 	logger *log.Logger,
 ) ([]controlplanev1alpha1.ControlPlaneOperation, error) {
 	for _, state := range states {
+		var err error
 		if !componentStateInSync(state) {
 			continue
 		}
@@ -860,7 +925,7 @@ func (r *Reconciler) ensureCertRenewalExists(
 			continue
 		}
 
-		minExpiry := minExpirationDate(dates)
+		minExpiry := minExpirationDateExcluding(dates, constants.SignatureExpirationKey)
 		if minExpiry.IsZero() || time.Until(minExpiry) >= constants.CertRenewalThreshold {
 			continue
 		}
@@ -874,20 +939,10 @@ func (r *Reconciler) ensureCertRenewalExists(
 			continue
 		}
 
-		op := operationBase(cpn, state.component, certRenewalSteps(state.component))
-		op.ObjectMeta.GenerateName = operationGenerateNamePrefix(state)
-		op.Spec.DesiredConfigChecksum = state.spec.Config
-		op.Spec.DesiredPKIChecksum = state.spec.PKI
-		op.Spec.DesiredCAChecksum = state.specCA
-
-		if err := r.client.Create(ctx, op); err != nil {
-			return nil, fmt.Errorf("create cert renewal for %s: %w", state.component, err)
+		ops, err = r.createRenewalOperation(ctx, cpn, state, certRenewalSteps(state.component), ops, "cert renewal", logger)
+		if err != nil {
+			return nil, err
 		}
-		ops = append(ops, *op)
-		logger.Info("cert renewal created",
-			slog.String("operation", op.Name),
-			slog.String("component", string(state.component)),
-			slog.String("minExpiry", minExpiry.Format(time.RFC3339)))
 	}
 
 	return ops, nil
@@ -918,6 +973,17 @@ func certRenewalSteps(component controlplanev1alpha1.OperationComponent) []contr
 	}
 }
 
+// signatureRenewalSteps is the pipeline for a kube-apiserver signature-key rotation.
+func signatureRenewalSteps() []controlplanev1alpha1.StepName {
+	return []controlplanev1alpha1.StepName{
+		controlplanev1alpha1.StepBackup,
+		controlplanev1alpha1.StepRenewSignature,
+		controlplanev1alpha1.StepSyncManifests,
+		controlplanev1alpha1.StepWaitPodReady,
+		controlplanev1alpha1.StepCertObserve,
+	}
+}
+
 // certDatesForComponent returns cert expiration dates from CPN status for a given component.
 func certDatesForComponent(cpn *controlplanev1alpha1.ControlPlaneNode, component controlplanev1alpha1.OperationComponent) map[string]metav1.Time {
 	compStatus := cpn.Status.Components.Component(component)
@@ -931,6 +997,24 @@ func certDatesForComponent(cpn *controlplanev1alpha1.ControlPlaneNode, component
 func minExpirationDate(dates map[string]metav1.Time) time.Time {
 	var min time.Time
 	for _, t := range dates {
+		if min.IsZero() || t.Time.Before(min) {
+			min = t.Time
+		}
+	}
+	return min
+}
+
+// minExpirationDateExcluding returns the earliest expiration, ignoring the given keys.
+func minExpirationDateExcluding(dates map[string]metav1.Time, exclude ...string) time.Time {
+	skip := make(map[string]struct{}, len(exclude))
+	for _, k := range exclude {
+		skip[k] = struct{}{}
+	}
+	var min time.Time
+	for k, t := range dates {
+		if _, ok := skip[k]; ok {
+			continue
+		}
 		if min.IsZero() || t.Time.Before(min) {
 			min = t.Time
 		}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
@@ -869,9 +869,9 @@ func (r *Reconciler) ensureSignatureRenewalExists(
 		}
 
 		if existing := findActiveOperation(ops, func(op *controlplanev1alpha1.ControlPlaneOperation) bool {
-			return op.Spec.Component == state.component
+			return op.Spec.Component == state.component && op.HasStep(controlplanev1alpha1.StepRenewSignature)
 		}); existing != nil {
-			logger.Debug("active operation exists for component, skip signature renewal operation creation",
+			logger.Debug("active signature renewal operation exists for component, skip signature renewal operation creation",
 				slog.String("operation", existing.Name),
 				slog.String("component", string(state.component)))
 			continue
@@ -937,9 +937,9 @@ func (r *Reconciler) ensureCertRenewalExists(
 		}
 
 		if existing := findActiveOperation(ops, func(op *controlplanev1alpha1.ControlPlaneOperation) bool {
-			return op.Spec.Component == state.component
+			return op.Spec.Component == state.component && op.HasStep(controlplanev1alpha1.StepRenewPKICerts)
 		}); existing != nil {
-			logger.Debug("active operation exists for component, skip cert renewal creation",
+			logger.Debug("active cert renewal operation exists for component, skip cert renewal creation",
 				slog.String("operation", existing.Name),
 				slog.String("component", string(state.component)))
 			continue

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
@@ -288,13 +288,6 @@ func buildComponentStates(cpn *controlplanev1alpha1.ControlPlaneNode) []componen
 	return result
 }
 
-// componentStateInSync reports whether a component state is in sync with the desired spec/status checksums.
-func componentStateInSync(state componentState) bool {
-	return state.spec.Config == state.status.Config &&
-		(!state.hasPKI || state.spec.PKI == state.status.PKI) &&
-		state.specCA == state.status.CA
-}
-
 // ensureOperationsExist creates operations (CPOs) for components where spec != status.
 func (r *Reconciler) ensureOperationsExist(
 	ctx context.Context,
@@ -860,9 +853,6 @@ func (r *Reconciler) ensureSignatureRenewalExists(
 		if state.component != controlplanev1alpha1.OperationComponentKubeAPIServer {
 			continue
 		}
-		if !componentStateInSync(state) {
-			continue
-		}
 		sigExp, ok := certDatesForComponent(cpn, state.component)[constants.SignatureExpirationKey]
 		if !ok || sigExp.IsZero() || time.Until(sigExp.Time) >= constants.SignatureRenewalThreshold {
 			continue
@@ -922,10 +912,6 @@ func (r *Reconciler) ensureCertRenewalExists(
 ) ([]controlplanev1alpha1.ControlPlaneOperation, error) {
 	for _, state := range states {
 		var err error
-		if !componentStateInSync(state) {
-			continue
-		}
-
 		dates := certDatesForComponent(cpn, state.component)
 		if len(dates) == 0 {
 			continue

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller.go
@@ -188,9 +188,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	currentOps, err = r.ensureSignatureRenewalExists(ctx, cpn, states, currentOps, logger)
-	if err != nil {
-		return reconcile.Result{}, err
+	if constants.SignatureEnabled() {
+		currentOps, err = r.ensureSignatureRenewalExists(ctx, cpn, states, currentOps, logger)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	if err := r.ensureObserveOperations(ctx, cpn, currentOps, logger); err != nil {
@@ -463,6 +465,10 @@ func determineSteps(state componentState, pkiChanged, caChanged bool) []controlp
 				controlplanev1alpha1.StepRenewPKICerts,
 				controlplanev1alpha1.StepRenewKubeconfigs,
 			)
+		}
+		// CSE only, first deploy/join (status.Config still empty)
+		if constants.SignatureEnabled() && state.status.Config == "" {
+			steps = append(steps, controlplanev1alpha1.StepRenewSignature)
 		}
 		steps = append(steps,
 			controlplanev1alpha1.StepSyncManifests,

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-node/controller_test.go
@@ -290,6 +290,9 @@ func (suite *ControllerTestSuite) parseManifests(data string) []client.Object {
 			cpn := &controlplanev1alpha1.ControlPlaneNode{}
 			require.NoError(suite.T(), yaml.Unmarshal([]byte(manifest), cpn),
 				"failed to unmarshal ControlPlaneNode")
+			if cpn.Namespace == "" {
+				cpn.Namespace = constants.KubeSystemNamespace
+			}
 			objs = append(objs, cpn)
 		default:
 			suite.T().Logf("unknown kind: %s, skipping", metaType.Kind)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/annotations.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/annotations.go
@@ -29,6 +29,7 @@ type checksumAnnotations struct {
 	CAChecksum          string
 	CertRenewalID       string
 	KubeconfigRenewalID string
+	SignatureRenewalID  string
 }
 
 func checksumAnnotationsFromSpec(spec controlplanev1alpha1.ControlPlaneOperationSpec) checksumAnnotations {
@@ -57,6 +58,9 @@ func desiredChecksumAnnotations(spec checksumAnnotations) map[string]string {
 	if spec.KubeconfigRenewalID != "" {
 		result[constants.KubeconfigRenewalIDAnnotationKey] = spec.KubeconfigRenewalID
 	}
+	if spec.SignatureRenewalID != "" {
+		result[constants.SignatureRenewalIDAnnotationKey] = spec.SignatureRenewalID
+	}
 
 	return result
 }
@@ -70,7 +74,9 @@ func buildSyncManifestAnnotations(op *controlplanev1alpha1.ControlPlaneOperation
 	if stepWasRenewed(op, controlplanev1alpha1.StepRenewKubeconfigs) {
 		annotations.KubeconfigRenewalID = op.Name
 	}
-
+	if stepWasRenewed(op, controlplanev1alpha1.StepRenewSignature) {
+		annotations.SignatureRenewalID = op.Name
+	}
 	return annotations
 }
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/backup.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/backup.go
@@ -101,6 +101,10 @@ func backupFilesForComponent(component controlplanev1alpha1.OperationComponent, 
 		files = append(files, filepath.Join(constants.KubernetesPkiPath, relPath))
 	}
 
+	for _, name := range deps.SignatureFiles {
+		files = append(files, filepath.Join(constants.KubernetesPkiPath, name))
+	}
+
 	for _, kf := range deps.KubeconfigFiles {
 		files = append(files, filepath.Join(kubeconfigDir, string(kf)))
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/component_meta.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/component_meta.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/kubeconfig"
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki/signature"
 
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
 	"control-plane-manager/internal/checksum"
@@ -30,6 +31,7 @@ import (
 type componentDependencies struct {
 	CertTree            map[pki.RootCertName][]pki.LeafCertName
 	CAFiles             []string
+	SignatureFiles      []string
 	KubeconfigFiles     []kubeconfig.File
 	ExtraFileKeys       []string
 	NeedsRootKubeconfig bool
@@ -69,6 +71,10 @@ var componentDepsRegistry = map[controlplanev1alpha1.OperationComponent]componen
 			string(pki.FrontProxyCACertName) + ".key",
 			"sa.pub",
 			"sa.key",
+		},
+		SignatureFiles: []string{
+			signature.SignaturePrivateJWK,
+			signature.SignaturePublicJWKS,
 		},
 		ExtraFileKeys:       checksum.ExtraFileKeysForPodComponent(controlplanev1alpha1.OperationComponentKubeAPIServer.PodComponentName()),
 		KubeconfigFiles:     []kubeconfig.File{kubeconfig.Admin, kubeconfig.SuperAdmin},

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
@@ -83,12 +83,13 @@ func Register(mgr manager.Manager, metricsStorage metricsstorage.Storage) error 
 	// Inject Reconciler-level deps into steps that need them.
 	r.steps[controlplanev1alpha1.StepWaitPodReady].(*waitPodReadyStep).waitForPod = r.waitForPod
 
-	kubeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		return fmt.Errorf("cannot create kube client for etcd key signature renewer: %w", err)
+	if constants.SignatureEnabled() {
+		kubeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+		if err != nil {
+			return fmt.Errorf("cannot create kube client for signature renewer: %w", err)
+		}
+		r.steps[controlplanev1alpha1.StepRenewSignature].(*renewSignatureStep).kubeClient = kubeClient
 	}
-
-	r.steps[controlplanev1alpha1.StepRenewSignature].(*renewSignatureStep).kubeClient = kubeClient
 
 	// harden admin kubeconfig perms and align root kubeconfig symlink during controller startup.
 	r.enforceNodePolicy(r.log)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
@@ -27,7 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,15 +83,15 @@ func Register(mgr manager.Manager, metricsStorage metricsstorage.Storage) error 
 	// Inject Reconciler-level deps into steps that need them.
 	r.steps[controlplanev1alpha1.StepWaitPodReady].(*waitPodReadyStep).waitForPod = r.waitForPod
 
+	kubeClient, err := kubernetes.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return fmt.Errorf("cannot create kube client for etcd key signature renewer: %w", err)
+	}
+
+	r.steps[controlplanev1alpha1.StepRenewSignature].(*renewSignatureStep).kubeClient = kubeClient
+
 	// harden admin kubeconfig perms and align root kubeconfig symlink during controller startup.
 	r.enforceNodePolicy(r.log)
-
-	// todo reconcile normal way not in start controller
-	// todo refact to use controller runtime client
-	// instead of client-go
-	if err := r.renewSignatureKeysIfNeed(mgr.GetConfig()); err != nil {
-		return err
-	}
 
 	nodeLabelPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{
 		MatchLabels: map[string]string{
@@ -228,20 +227,6 @@ func (r *Reconciler) enforceNodePolicy(logger *log.Logger) {
 	if err := updateRootKubeconfig(r.node.KubeconfigDir, r.node.HomeDir, r.node.NodeAdminKubeconfig); err != nil {
 		logger.Warn("failed to enforce root kubeconfig symlink", log.Err(err))
 	}
-}
-
-// TODO Move to normal reconciler, not on start only
-func (r *Reconciler) renewSignatureKeysIfNeed(kubeConfig *rest.Config) error {
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-	if err != nil {
-		return fmt.Errorf("cannot create kube client for etcd key signature renewer: %w", err)
-	}
-
-	if err := getEtcdKeySignatureRenewer().Renew(kubeClient); err != nil {
-		return fmt.Errorf("cannot renew signature keys for etcd key: %w", err)
-	}
-
-	return nil
 }
 
 func (r *Reconciler) ensureOperationStartedAt(ctx context.Context, op *controlplanev1alpha1.ControlPlaneOperation, now time.Time) error {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
@@ -25,7 +25,7 @@ import (
 func getEtcdKeySignatureRenewer() signature.Renewer {
 	if constants.SignatureEnabled() {
 		return signature.NewRegularSignatureRenewer(constants.KubernetesPkiPath).
-			WithLeftDaysToRenew(60)
+			WithLeftDaysToRenew(signature.SignatureRenewalDays)
 	}
 
 	return signature.NewNoSignatureRenewer()

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
@@ -17,21 +17,13 @@ limitations under the License.
 package controlplaneoperation
 
 import (
-	"strings"
-
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki/signature"
 
 	"control-plane-manager/internal/constants"
 )
 
-var SignatureEnabled = "true"
-
-func signatureEnabled() bool {
-	return strings.ToLower(SignatureEnabled) == "true"
-}
-
 func getEtcdKeySignatureRenewer() signature.Renewer {
-	if signatureEnabled() {
+	if constants.SignatureEnabled() {
 		return signature.NewRegularSignatureRenewer(constants.KubernetesPkiPath).
 			WithLeftDaysToRenew(60)
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
@@ -26,8 +26,12 @@ import (
 
 var SignatureEnabled = "true"
 
+func signatureEnabled() bool {
+	return strings.ToLower(SignatureEnabled) == "true"
+}
+
 func getEtcdKeySignatureRenewer() signature.Renewer {
-	if strings.ToLower(SignatureEnabled) == "true" {
+	if signatureEnabled() {
 		return signature.NewRegularSignatureRenewer(constants.KubernetesPkiPath).
 			WithLeftDaysToRenew(60)
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/etcd_key_signature.go
@@ -25,7 +25,7 @@ import (
 func getEtcdKeySignatureRenewer() signature.Renewer {
 	if constants.SignatureEnabled() {
 		return signature.NewRegularSignatureRenewer(constants.KubernetesPkiPath).
-			WithLeftDaysToRenew(signature.SignatureRenewalDays)
+			WithLeftDaysToRenew(constants.SignatureRenewalDays)
 	}
 
 	return signature.NewNoSignatureRenewer()

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -82,11 +82,12 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 	return state, true, errors.Join(readErrs...)
 }
 
-func observeSignatureExpiration(pkiDir string, logger *log.Logger) (metav1.Time, bool) {
+// observeSignatureExpiration reads the active signature keys expiry from disk.
+// Returns an error when the key files are missing or unreadable
+func observeSignatureExpiration(pkiDir string) (metav1.Time, error) {
 	exp, err := signature.ActiveKeyExpiration(pkiDir)
 	if err != nil {
-		logger.Info("no active signature key to observe", "error", err)
-		return metav1.Time{}, false
+		return metav1.Time{}, err
 	}
-	return metav1.NewTime(exp), true
+	return metav1.NewTime(exp), nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/kubeconfig"
 	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki"
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki/signature"
 	"github.com/deckhouse/deckhouse/pkg/log"
 
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
@@ -79,4 +80,16 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 		state.CertificatesExpirationTime = certExpiry
 	}
 	return state, true, errors.Join(readErrs...)
+}
+
+func observeSignatureExpiration(component controlplanev1alpha1.OperationComponent, pkiDir string, logger *log.Logger) (metav1.Time, bool) {
+	if !signatureEnabled() || component != controlplanev1alpha1.OperationComponentKubeAPIServer {
+		return metav1.Time{}, false
+	}
+	exp, err := signature.ActiveKeyExpiration(pkiDir)
+	if err != nil {
+		logger.Info("no active signature key to observe", "error", err)
+		return metav1.Time{}, false
+	}
+	return metav1.NewTime(exp), true
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/observer.go
@@ -82,10 +82,7 @@ func observeCertExpirationsForStaticPod(component controlplanev1alpha1.Operation
 	return state, true, errors.Join(readErrs...)
 }
 
-func observeSignatureExpiration(component controlplanev1alpha1.OperationComponent, pkiDir string, logger *log.Logger) (metav1.Time, bool) {
-	if !signatureEnabled() || component != controlplanev1alpha1.OperationComponentKubeAPIServer {
-		return metav1.Time{}, false
-	}
+func observeSignatureExpiration(pkiDir string, logger *log.Logger) (metav1.Time, bool) {
 	exp, err := signature.ActiveKeyExpiration(pkiDir)
 	if err != nil {
 		logger.Info("no active signature key to observe", "error", err)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -22,7 +22,10 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki/signature"
 	"github.com/deckhouse/deckhouse/pkg/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
 	"control-plane-manager/internal/checksum"
@@ -39,6 +42,7 @@ var (
 	_ Step = (*joinEtcdClusterStep)(nil)
 	_ Step = (*waitPodReadyStep)(nil)
 	_ Step = (*certObserveStep)(nil)
+	_ Step = (*renewSignatureStep)(nil)
 )
 
 // StepOutcome is the terminal state when Step.Execute finishes.
@@ -74,6 +78,7 @@ func defaultSteps() map[controlplanev1alpha1.StepName]Step {
 		controlplanev1alpha1.StepJoinEtcdCluster:  &joinEtcdClusterStep{},
 		controlplanev1alpha1.StepWaitPodReady:     &waitPodReadyStep{},
 		controlplanev1alpha1.StepCertObserve:      &certObserveStep{},
+		controlplanev1alpha1.StepRenewSignature:   &renewSignatureStep{},
 	}
 }
 
@@ -283,10 +288,19 @@ type certObserveStep struct{}
 func (c *certObserveStep) Execute(_ context.Context, env *StepEnv, logger *log.Logger) (StepResult, error) {
 	kubeconfigDir := env.Node.KubeconfigDir
 	component := env.State.Raw().Spec.Component
+
 	observedState, ok, err := observeCertExpirationsForStaticPod(component, kubeconfigDir, logger)
 	if !ok {
 		logger.Warn("CertObserve skipped: not a static pod component")
 		return StepResult{Outcome: OutcomeCompleted}, nil
+	}
+
+	signatureExpiry, ok := observeSignatureExpiration(component, constants.KubernetesPkiPath, logger)
+	if ok {
+		if observedState.CertificatesExpirationTime == nil {
+			observedState.CertificatesExpirationTime = map[string]metav1.Time{}
+		}
+		observedState.CertificatesExpirationTime[constants.SignatureExpirationKey] = signatureExpiry
 	}
 
 	// Persist whatever was read successfully before surfacing the error
@@ -306,4 +320,35 @@ func (c *certObserveStep) Execute(_ context.Context, env *StepEnv, logger *log.L
 
 	logger.Info("observed certificate expiration", slog.Int("certificates", len(observedState.CertificatesExpirationTime)))
 	return StepResult{Outcome: OutcomeCompleted}, nil
+}
+
+type renewSignatureStep struct {
+	kubeClient kubernetes.Interface
+}
+
+func (c *renewSignatureStep) Execute(_ context.Context, env *StepEnv, logger *log.Logger) (StepResult, error) {
+	if env.State.Raw().Spec.Component != controlplanev1alpha1.OperationComponentKubeAPIServer {
+		return StepResult{Outcome: OutcomeCompleted}, nil
+	}
+	if c.kubeClient == nil {
+		return StepResult{}, fmt.Errorf("renewSignatureStep: kubeClient not injected")
+	}
+
+	before, _ := signature.SignatureFilesChecksum(constants.KubernetesPkiPath)
+
+	if err := getEtcdKeySignatureRenewer().Renew(c.kubeClient); err != nil {
+		logger.Error("failed to renew signature keys", log.Err(err))
+		return StepResult{}, fmt.Errorf("renew signature keys: %w", err)
+	}
+
+	after, err := signature.SignatureFilesChecksum(constants.KubernetesPkiPath)
+	if err != nil {
+		logger.Error("failed to get signature files checksum", log.Err(err))
+		return StepResult{Outcome: OutcomeCompleted, Message: controlplanev1alpha1.CPOStepResultNotRenewed}, nil
+	}
+	if before != after {
+		logger.Info("signature keys rotated on disk")
+		return StepResult{Outcome: OutcomeCompleted, Message: controlplanev1alpha1.CPOStepResultRenewed}, nil
+	}
+	return StepResult{Outcome: OutcomeCompleted, Message: controlplanev1alpha1.CPOStepResultNotRenewed}, nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -18,6 +18,7 @@ package controlplaneoperation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -297,7 +298,10 @@ func (c *certObserveStep) Execute(_ context.Context, env *StepEnv, logger *log.L
 	}
 
 	if constants.SignatureEnabled() && component == controlplanev1alpha1.OperationComponentKubeAPIServer {
-		if signatureExpiry, ok := observeSignatureExpiration(constants.KubernetesPkiPath, logger); ok {
+		signatureExpiry, sigErr := observeSignatureExpiration(constants.KubernetesPkiPath)
+		if sigErr != nil {
+			err = errors.Join(err, fmt.Errorf("signature key: %w", sigErr))
+		} else {
 			if observedState.CertificatesExpirationTime == nil {
 				observedState.CertificatesExpirationTime = map[string]metav1.Time{}
 			}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -22,10 +22,11 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki/signature"
-	"github.com/deckhouse/deckhouse/pkg/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/pki/signature"
+	"github.com/deckhouse/deckhouse/pkg/log"
 
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
 	"control-plane-manager/internal/checksum"
@@ -295,12 +296,13 @@ func (c *certObserveStep) Execute(_ context.Context, env *StepEnv, logger *log.L
 		return StepResult{Outcome: OutcomeCompleted}, nil
 	}
 
-	signatureExpiry, ok := observeSignatureExpiration(component, constants.KubernetesPkiPath, logger)
-	if ok {
-		if observedState.CertificatesExpirationTime == nil {
-			observedState.CertificatesExpirationTime = map[string]metav1.Time{}
+	if constants.SignatureEnabled() && component == controlplanev1alpha1.OperationComponentKubeAPIServer {
+		if signatureExpiry, ok := observeSignatureExpiration(constants.KubernetesPkiPath, logger); ok {
+			if observedState.CertificatesExpirationTime == nil {
+				observedState.CertificatesExpirationTime = map[string]metav1.Time{}
+			}
+			observedState.CertificatesExpirationTime[constants.SignatureExpirationKey] = signatureExpiry
 		}
-		observedState.CertificatesExpirationTime[constants.SignatureExpirationKey] = signatureExpiry
 	}
 
 	// Persist whatever was read successfully before surfacing the error
@@ -327,6 +329,10 @@ type renewSignatureStep struct {
 }
 
 func (c *renewSignatureStep) Execute(_ context.Context, env *StepEnv, logger *log.Logger) (StepResult, error) {
+	if !constants.SignatureEnabled() {
+		return StepResult{Outcome: OutcomeCompleted, Message: controlplanev1alpha1.CPOStepResultNotRenewed}, nil
+	}
+
 	if env.State.Raw().Spec.Component != controlplanev1alpha1.OperationComponentKubeAPIServer {
 		return StepResult{Outcome: OutcomeCompleted}, nil
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/approver_test.go
@@ -209,7 +209,8 @@ func TestNewApprover_PartitionAndOrder(t *testing.T) {
 func newOperation(name, node string, component controlplanev1alpha1.OperationComponent, approved bool) controlplanev1alpha1.ControlPlaneOperation {
 	return controlplanev1alpha1.ControlPlaneOperation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: constants.KubeSystemNamespace,
 			Labels: map[string]string{
 				constants.ControlPlaneNodeNameLabelKey: node,
 			},

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/operations-approver/controller_test.go
@@ -92,12 +92,12 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var updated1 controlplanev1alpha1.ControlPlaneOperation
-		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-api-1"}, &updated1))
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-api-1", Namespace: constants.KubeSystemNamespace}, &updated1))
 		// First one should be approved (limit is 1)
 		require.True(t, updated1.Spec.Approved)
 
 		var updated2 controlplanev1alpha1.ControlPlaneOperation
-		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-api-2"}, &updated2))
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-api-2", Namespace: constants.KubeSystemNamespace}, &updated2))
 		// Second one should NOT be approved because limit is 1 (based only on 2 masters), despite 5 arbiters
 		require.False(t, updated2.Spec.Approved)
 	})
@@ -116,7 +116,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var updated controlplanev1alpha1.ControlPlaneOperation
-		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-etcd"}, &updated))
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "op-etcd", Namespace: constants.KubeSystemNamespace}, &updated))
 		require.True(t, updated.Spec.Approved)
 	})
 
@@ -142,11 +142,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var etcdUpdated controlplanev1alpha1.ControlPlaneOperation
-		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "zzz-etcd"}, &etcdUpdated))
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "zzz-etcd", Namespace: constants.KubeSystemNamespace}, &etcdUpdated))
 		require.True(t, etcdUpdated.Spec.Approved)
 
 		var apiUpdated controlplanev1alpha1.ControlPlaneOperation
-		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "aaa-apiserver"}, &apiUpdated))
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "aaa-apiserver", Namespace: constants.KubeSystemNamespace}, &apiUpdated))
 		require.False(t, apiUpdated.Spec.Approved)
 	})
 
@@ -165,7 +165,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 
 		var updated controlplanev1alpha1.ControlPlaneOperation
-		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "etcd-next"}, &updated))
+		require.NoError(t, cl.Get(ctx, client.ObjectKey{Name: "etcd-next", Namespace: constants.KubeSystemNamespace}, &updated))
 		require.False(t, updated.Spec.Approved)
 	})
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
@@ -34,9 +34,9 @@ shell:
   install:
     - cd /src/cmd/control-plane-manager
     {{ if eq $.Env "CSE"}}
-    - export ETCD_SIGN_ENABLED="-X control-plane-manager/internal/controllers/control-plane-operation.SignatureEnabled=true"
+    - export ETCD_SIGN_ENABLED="-X control-plane-manager/internal/constants.SignatureBuildEnabled=true"
     {{ else }}
-    - export ETCD_SIGN_ENABLED="-X control-plane-manager/internal/controllers/control-plane-operation.SignatureEnabled=false"
+    - export ETCD_SIGN_ENABLED="-X control-plane-manager/internal/constants.SignatureBuildEnabled=false"
     {{ end }}
     - GOPROXY=$(cat /run/secrets/GOPROXY) GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $BUILD_TAGS -ldflags="-s -w $ETCD_SIGN_ENABLED" -o /control-plane-manager .
 ---


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
`control-plane-manager` now monitors the expiration of the active etcd/kube-apiserver signature signing key and automatically rotates it before it expires.

A new Observer cpo reads the `NotAfter` date from the on-disk JWK/JWKS files and stores it in `ControlPlaneNode` status under `CertificatesExpirationTime["signature"]`. 
The `control-plane-node` controller then checks this value on every reconcile: if the key is within the 60-day `SignatureRenewalThreshold`,it creates a dedicated `ControlPlaneOperation` for the `kube-apiserver` component that runs the new `renewSignature` step.

Two helpers are added to `go_lib/controlplane/pki/signature`:
- `ActiveKeyExpiration` – returns the `NotAfter` of the active signing key certificate.
- `SignatureFilesChecksum` – computes a stable SHA-256 hash of the on-disk signature key files used to detect whether rotation actually changed the files on disk.

This feature is CSE-only
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
Previously, the signature key was rotated only as a side-effect of a regular `kube-apiserver` config update (when the `config` checksum was empty). There was no proactive tracking of the key's expiration date. As a result, a cluster with no pending config changes could silently reach signature-key expiry, causing authentication failures
for workloads that rely on signed tokens.

This change makes key rotation fully automatic: the controller detects the approaching expiry and schedules a rotation `ControlPlaneOperation` independently of any config drift, eliminating the need for manual operator intervention.
## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Automatically rotate the kube-apiserver signature key before expiration (CSE only)
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
