### PR TITLE
[ci] Fix spellchecker

### DIFF
--- a/.github/workflow_templates/validation.yml
+++ b/.github/workflow_templates/validation.yml
@@ -273,7 +273,7 @@ needs:
   - discover
   - pull_request_info
 if: ${{ needs.discover.outputs.run_doc_changes == 'true' && github.repository == 'deckhouse/deckhouse' }}
-runs-on: ubuntu-24.04
+runs-on: [self-hosted, regular]
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -476,7 +476,7 @@ jobs:
       - discover
       - pull_request_info
     if: ${{ needs.discover.outputs.run_doc_changes == 'true' && github.repository == 'deckhouse/deckhouse' }}
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, regular]
     permissions:
       contents: read
       id-token: write

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ FORMATTING_END = \033[0m
 FOCUS =
 
 MDLINTER_IMAGE = ghcr.io/igorshubovych/markdownlint-cli@sha256:2e22b4979347f70e0768e3fef1a459578b75d7966e4b1a6500712b05c5139476
-SPELLCHECKER_IMAGE = registry.deckhouse.io/base_images/hunspell:1.7.0-r1-alpine@sha256:f419f1dc5b55cd9c0038ece60612549e64333bb0a0e7d4764d45ed94336dec9c
+SPELLCHECKER_IMAGE = registry.deckhouse.ru/base_images/hunspell:1.7.0-r1-alpine@sha256:f419f1dc5b55cd9c0038ece60612549e64333bb0a0e7d4764d45ed94336dec9c
 
 # Explicitly set architecture on arm, since werf currently does not support building of images for any other platform
 # besides linux/amd64 (e.g. relevant for mac m1).

--- a/testing/cloud_layouts/script.d/wait_cluster_ready/test_autoscaler.sh
+++ b/testing/cloud_layouts/script.d/wait_cluster_ready/test_autoscaler.sh
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
       - name: app
-        image: registry.deckhouse.io/base_images@sha256:05fb7868d518fe6c562233e1ee1c9304f6d5142920959e7b2d51acdc49cce0c3
+        image: registry.deckhouse.ru/base_images@sha256:05fb7868d518fe6c562233e1ee1c9304f6d5142920959e7b2d51acdc49cce0c3
         command: ["python3"]
         args: ["-m", "http.server", "8080"]
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## Description
Updates spellcheck CI to work with different source image registry.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: ci
type: chore
summary: Fix spellchecker
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
