### PR TITLE
[node-manager] Fencing-agent: Fix bug when starting watchdog

### DIFF
--- a/modules/040-node-manager/images/fencing-agent/src/cmd/main.go
+++ b/modules/040-node-manager/images/fencing-agent/src/cmd/main.go
@@ -44,6 +44,7 @@ const (
 	Watchdog             = "Watchdog"
 	fencingNodeLabel     = "node-manager.deckhouse.io/fencing-enabled"
 	fencingNodeLabelMode = "node-manager.deckhouse.io/fencing-mode"
+	version              = "0.1.1"
 )
 
 func main() {
@@ -51,6 +52,8 @@ func main() {
 	cfg.MustLoad()
 
 	log := logger.NewLogger(cfg.LogLevel)
+
+	log.Info("Starting fencing-agent", version)
 
 	err := AppRun(cfg, log)
 	if err != nil {
@@ -118,9 +121,7 @@ func AppRun(cfg config.Config, log *log.Logger) error {
 		defer kubeClient.StopInformer()
 
 		softdog := watchdog.New(cfg.Watchdog.Device)
-
 		fallback := usecase.NewFallback(log, kubeClient)
-
 		fencingAgent := usecase.NewHealthMonitor(
 			kubeClient,
 			mblist,
@@ -134,13 +135,13 @@ func AppRun(cfg config.Config, log *log.Logger) error {
 		if err != nil {
 			return fmt.Errorf("failed to start health monitor: %w", err)
 		}
+
 		defer fencingAgent.Stop()
 	} else {
 		log.Info("Notify mode enabled, no fencing will be performed")
 	}
 
 	nodesGetter := usecase.NewGetNodes(mblist)
-
 	grpcSrv := grpc.NewServer(log, eventBus, nodesGetter)
 
 	grpcSrvRunner, err := grpc.NewRunner(cfg.GRPC, log, grpcSrv)

--- a/modules/040-node-manager/images/fencing-agent/src/cmd/main.go
+++ b/modules/040-node-manager/images/fencing-agent/src/cmd/main.go
@@ -44,20 +44,19 @@ const (
 	Watchdog             = "Watchdog"
 	fencingNodeLabel     = "node-manager.deckhouse.io/fencing-enabled"
 	fencingNodeLabelMode = "node-manager.deckhouse.io/fencing-mode"
-	version              = "0.1.1"
 )
 
 func main() {
 	var cfg config.Config
 	cfg.MustLoad()
 
-	log := logger.NewLogger(cfg.LogLevel)
+	l := logger.NewLogger(cfg.LogLevel)
 
-	log.Info("Starting fencing-agent", version)
+	l.Info("Starting fencing-agent")
 
-	err := AppRun(cfg, log)
+	err := AppRun(cfg, l)
 	if err != nil {
-		log.Error("failed to run application", sl.Err(err))
+		l.Error("failed to run application", sl.Err(err))
 		os.Exit(1)
 	}
 }

--- a/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
@@ -233,7 +233,7 @@ func (c *Client) StartInformer(ctx context.Context) error {
 	/* avoid race condition on maintenance annotations */
 	node, err := c.informerFactory.Core().V1().Nodes().Lister().Get(c.nodeName)
 	if err != nil {
-		c.Logger.Warn("failed to get node's maintenance annotations")
+		c.Logger.Warn("failed to get node info while start informer")
 		return nil
 	}
 

--- a/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
@@ -229,6 +229,12 @@ func (c *Client) StartInformer(ctx context.Context) error {
 		return fmt.Errorf("failed to sync node informer cache")
 	}
 	c.Logger.Info("node informer cache synced successfully")
+
+	node, err := c.informerFactory.Core().V1().Nodes().Lister().Get(c.nodeName)
+	if err == nil {
+		c.checkMaintenanceAnnotations(node)
+	}
+
 	return nil
 }
 

--- a/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/adapters/kubeclient/kubeclient.go
@@ -230,10 +230,14 @@ func (c *Client) StartInformer(ctx context.Context) error {
 	}
 	c.Logger.Info("node informer cache synced successfully")
 
+	/* avoid race condition on maintenance annotations */
 	node, err := c.informerFactory.Core().V1().Nodes().Lister().Get(c.nodeName)
-	if err == nil {
-		c.checkMaintenanceAnnotations(node)
+	if err != nil {
+		c.Logger.Warn("failed to get node's maintenance annotations")
+		return nil
 	}
+
+	c.checkMaintenanceAnnotations(node)
 
 	return nil
 }

--- a/modules/040-node-manager/images/fencing-agent/src/internal/usecase/health_monitor.go
+++ b/modules/040-node-manager/images/fencing-agent/src/internal/usecase/health_monitor.go
@@ -87,9 +87,15 @@ func NewHealthMonitor(
 
 func (h *HealthMonitor) Start(ctx context.Context, watchdogTimeout int) error {
 	timeout := time.Duration(watchdogTimeout/2-1) * time.Second
-	if err := h.startWatchdogBackoff(ctx); err != nil {
-		return err
+
+	if !h.watcher.IsMaintenanceMode() {
+		if err := h.startWatchdogBackoff(ctx); err != nil {
+			return err
+		}
+	} else {
+		h.logger.Info("node is in maintenance mode at startup, skipping initial watchdog arming")
 	}
+
 	go func() {
 		ticker := time.NewTicker(timeout)
 		defer ticker.Stop()

--- a/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
@@ -47,6 +47,25 @@ spec:
     WD="/dev/watchdog"
     MODE="{{ $mode }}"
 
+    ensure_dev() {
+      if [ -e "${WD}" ]; then
+        chown 64535:root "${WD}"
+        chmod 0660 "${WD}"
+        return 0
+      fi
+
+      local minor
+      minor=$(awk '/watchdog$/{print $1}' /proc/misc 2>/dev/null)
+      if [ -n "${minor}" ]; then
+        mknod "${WD}" c 10 "${minor}"
+        chown 64535:root "${WD}"
+        chmod 0660 "${WD}"
+        return 0
+      fi
+
+      return 1
+    }
+
     start_wd() {
       if [ "${MODE}" = "Notify" ]; then
         echo "[NOTIFY] Would run: modprobe softdog soft_margin={{ $timeout }} soft_panic=1"
@@ -54,14 +73,17 @@ spec:
       fi
 
       if lsmod | grep -qw softdog; then
-        if [ -e "${WD}" ]; then
-          ls -lha /dev/watchdog* 2>/dev/null
+        if ensure_dev; then
+          echo "softdog already loaded, device permissions fixed"
+          return 0
         fi
-        rmmod softdog || true
+        echo "softdog loaded but device missing and /proc/misc has no entry, reloading"
+        rmmod softdog 2>/dev/null || true
         sleep 1
-      elif [ -e "${WD}" ]; then
-        ls -lha /dev/watchdog* 2>/dev/null
-        rm -f "${WD}"
+        if lsmod | grep -qw softdog; then
+          echo "ERROR: cannot unload softdog (module in use)" >&2
+          exit 1
+        fi
       fi
 
       modprobe softdog soft_margin={{ $timeout }} soft_panic=1
@@ -72,13 +94,10 @@ spec:
         retries=$((retries + 1))
       done
 
-      if [ ! -e "${WD}" ]; then
+      if ! ensure_dev; then
         echo "ERROR: ${WD} was not created after modprobe softdog" >&2
         exit 1
       fi
-
-      chown 64535:root "${WD}"
-      chmod 0660 "${WD}"
     }
 
     stop_wd() {

--- a/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
@@ -48,16 +48,37 @@ spec:
     MODE="{{ $mode }}"
 
     start_wd() {
-      if [ -e "${WD}" ]; then
-        ls -lha /dev/watchdog* 2>/dev/null
-        rm -rf "${WD}"
-      fi
-
       if [ "${MODE}" = "Notify" ]; then
         echo "[NOTIFY] Would run: modprobe softdog soft_margin={{ $timeout }} soft_panic=1"
-      else
-        modprobe softdog soft_margin={{ $timeout }} soft_panic=1
+        return 0
       fi
+
+      if lsmod | grep -qw softdog; then
+        if [ -e "${WD}" ]; then
+          ls -lha /dev/watchdog* 2>/dev/null
+        fi
+        rmmod softdog || true
+        sleep 1
+      elif [ -e "${WD}" ]; then
+        ls -lha /dev/watchdog* 2>/dev/null
+        rm -f "${WD}"
+      fi
+
+      modprobe softdog soft_margin={{ $timeout }} soft_panic=1
+
+      local retries=0
+      while [ ! -e "${WD}" ] && [ "${retries}" -lt 10 ]; do
+        sleep 0.5
+        retries=$((retries + 1))
+      done
+
+      if [ ! -e "${WD}" ]; then
+        echo "ERROR: ${WD} was not created after modprobe softdog" >&2
+        exit 1
+      fi
+
+      chown 64535:root "${WD}"
+      chmod 0660 "${WD}"
     }
 
     stop_wd() {

--- a/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
+++ b/modules/040-node-manager/templates/fencing-agent/nodegroupconfiguration.yaml
@@ -22,7 +22,7 @@ spec:
     bb-event-on 'nodegroup-watchdog-service-changed' '_nodegroup_watchdog_service'
     function _nodegroup_watchdog_service() {
       systemctl daemon-reload
-      systemctl restart nodegroup-watchdog.service
+      systemctl reload-or-restart nodegroup-watchdog.service
       systemctl enable --now nodegroup-watchdog.service
     }
 
@@ -36,6 +36,7 @@ spec:
     RemainAfterExit=yes
     ExecStart=/opt/deckhouse/bin/nodegroup-watchdog.sh start
     ExecStop=/opt/deckhouse/bin/nodegroup-watchdog.sh stop
+    ExecReload=/opt/deckhouse/bin/nodegroup-watchdog.sh start
 
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
## Description
Add softdog module handling improvements and maintenance mode guard in watchdog setup: 
- fix fencing-agent crash on nodes in maintenance mode 
- harden softdog device setup in NodeGroupConfiguration script.

## Why do we need it, and what problem does it solve?
When a node is in maintenance mode (e.g. during a Deckhouse update with update.node.deckhouse.io/approved annotation), the fencing-agent pod starts and unconditionally tries to open /dev/watchdog in HealthMonitor.Start(). This fails with permission denied after 5 retries and crashes the pod, even though the agent should simply skip watchdog arming during maintenance.

Two independent issues are fixed:

1. health_monitor.go: Start() now checks IsMaintenanceMode() before attempting to arm the watchdog. If the node is in maintenance, arming is skipped. The existing periodic check() loop already handles arming after maintenance ends — no new logic needed there.
2. nodegroupconfiguration.yaml: The start_wd() function had a bug where rm -rf /dev/watchdog followed by modprobe softdog would silently fail if softdog was already loaded (modprobe is a no-op for an already-loaded module, so the device node is never recreated). The fix properly unloads softdog before reloading, waits for the device to appear, and explicitly sets ownership (chown 64535:root) and permissions (chmod 0660) instead of relying solely on udev rule timing.

## Why do we need it in the patch release (if we do)?
The fencing-agent pod crashes in a restart loop on any node that enters maintenance mode while fencing is enabled. This affects all clusters with spec.fencing.mode: Watchdog configured on a NodeGroup. The pod cannot recover until maintenance ends AND the pod is restarted again, leaving the node without fencing protection.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: node-manager
type: fix
summary: Fix fencing-agent crash when starting on a node in maintenance mode.
impact: |
  Nodes in maintenance mode could previously cause the fencing-agent to crash while attempting to arm the watchdog. The agent now skips watchdog arming during maintenance and resumes it automatically afterwards.
impact_level: high
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
