### PR TITLE
[docs] Document scheduler graceful shutdown patch

### DIFF
--- a/modules/000-common/images/kubernetes/patches/README.md
+++ b/modules/000-common/images/kubernetes/patches/README.md
@@ -78,7 +78,7 @@ Patch enhances the observability of stale ServiceAccount tokens by adding namesp
 Why it is needed:
 Previously, the `serviceaccount_stale_tokens_total` metric was a simple counter without any labels. While it indicated that some clients were using outdated tokens (past their warnafter threshold), it provided no information about which ServiceAccounts were responsible
 
-### 012-fix-scheduler-node-graceful-shutdown.patch
+### fix-scheduler-node-graceful-shutdown.patch
 
 Patch prevents the scheduler from placing new pods on nodes that are in graceful shutdown.
 

--- a/modules/000-common/images/kubernetes/patches/README.md
+++ b/modules/000-common/images/kubernetes/patches/README.md
@@ -84,3 +84,5 @@ Patch prevents the scheduler from placing new pods on nodes that are in graceful
 
 Why it is needed:
 During graceful node shutdown, kubelet reports the shutdown state through the `NodeReady` condition. The scheduler must treat such nodes as unschedulable and react to `NodeReady` condition updates so pods can be queued again when the shutdown state is cleared.
+
+> Upstream PR https://github.com/kubernetes/kubernetes/pull/139249

--- a/modules/000-common/images/kubernetes/patches/README.md
+++ b/modules/000-common/images/kubernetes/patches/README.md
@@ -77,3 +77,10 @@ Patch enhances the observability of stale ServiceAccount tokens by adding namesp
 
 Why it is needed:
 Previously, the `serviceaccount_stale_tokens_total` metric was a simple counter without any labels. While it indicated that some clients were using outdated tokens (past their warnafter threshold), it provided no information about which ServiceAccounts were responsible
+
+### 012-fix-scheduler-node-graceful-shutdown.patch
+
+Patch prevents the scheduler from placing new pods on nodes that are in graceful shutdown.
+
+Why it is needed:
+During graceful node shutdown, kubelet reports the shutdown state through the `NodeReady` condition. The scheduler must treat such nodes as unschedulable and react to `NodeReady` condition updates so pods can be queued again when the shutdown state is cleared.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Updates `modules/000-common/images/kubernetes/patches/README.md` with documentation for `fix-scheduler-node-graceful-shutdown.patch`.

The new entry explains that the patch prevents the Kubernetes scheduler from placing new Pods on nodes that are in graceful shutdown, and notes that scheduler behavior depends on `NodeReady` condition updates reported by `kubelet`.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: chore
summary: Document the Kubernetes scheduler graceful shutdown patch in the patch inventory.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
