### PR TITLE
[node-manager] Add RBAC rules for node-manager (#19720)

### DIFF
--- a/modules/040-node-manager/crds/mcm.yaml
+++ b/modules/040-node-manager/crds/mcm.yaml
@@ -228,6 +228,7 @@ spec:
 
 ---
 
+# Not used by Deckhouse, required because MCM lists this resource.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -317,6 +318,7 @@ spec:
 
 ---
 
+# Not used by Deckhouse, required because MCM lists this resource.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
+++ b/modules/040-node-manager/templates/machine-controller-manager/rbac-for-us.yaml
@@ -23,6 +23,7 @@ rules:
    - azuremachineclasses
    - gcpmachineclasses
    - openstackmachineclasses
+   # Not used by Deckhouse, required because MCM lists these resources.
    - alicloudmachineclasses
    - packetmachineclasses
    - vspheremachineclasses
@@ -34,6 +35,7 @@ rules:
    - azuremachineclasses/status
    - gcpmachineclasses/status
    - openstackmachineclasses/status
+   # Not used by Deckhouse, required because MCM accesses these status resources.
    - alicloudmachineclasses/status
    - packetmachineclasses/status
    - vspheremachineclasses/status

--- a/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/040-node-manager/templates/user-authz-cluster-roles.yaml
@@ -1,16 +1,66 @@
 ---
+# Access level: SuperAdmin.
+# Full access to all resources.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    user-authz.deckhouse.io/access-level: User
-  name: d8:user-authz:node-manager:user
+    user-authz.deckhouse.io/access-level: SuperAdmin
+  name: d8:user-authz:node-manager:super-admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+# Access level: ClusterAdmin.
+# Includes User, PrivilegedUser, Editor, Admin, and ClusterEditor permissions.
+# Full access:
+# - node-manager deckhouse.io resources (instances, nodegroups, nodegroupconfigurations, nodeusers, sshcredentials, staticinstances)
+# Read access:
+# - Node Feature Discovery resources
+# - Machine Controller Manager resources
+# - Cluster API resources
+# - node-manager infrastructure resources
+# Write access:
+# - cluster-autoscaler and fencing-agent configuration resources
+# Node write access:
+# - Kubernetes Node resources (update, patch)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: ClusterAdmin
+  name: d8:user-authz:node-manager:cluster-admin
   {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
 rules:
 - apiGroups:
   - deckhouse.io
   resources:
+  - instances
   - nodegroups
+  - nodegroupconfigurations
+  - nodeusers
+  - sshcredentials
+  - staticinstances
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturegroups
+  - nodefeaturerules
   verbs:
   - get
   - list
@@ -33,17 +83,80 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - machine.sapcloud.io
+  resources:
+  - machinedeployments/scale
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machinedeployments
+  - machinedrainrules
+  - machinehealthchecks
+  - machinepools
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - cluster.x-k8s.io
   resources:
   - machines
   - machinesets
   - machinedeployments
+  - machinepools
+  - machinehealthchecks
+  - clusters
+  - machinedeployments/scale
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - deckhousecontrolplanes
+  - staticclusters
+  - staticmachines
+  - staticmachinetemplates
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vcdmachinetemplates
+  - huaweicloudmachinetemplates
+  - dynamixmachinetemplates
+  - zvirtmachinetemplates
+  - deckhousemachinetemplates
+  - staticmachinetemplates
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
 ---
+# Access level: ClusterEditor.
+# Includes User, PrivilegedUser, Editor, and Admin permissions.
+# Adds write access to public node-manager resources (instances, nodegroups, nodegroupconfigurations, staticinstances).
+# Adds read access to nodegroupconfigurations and staticinstances.
+# Adds update and patch access to Kubernetes Node resources.
+# Allowed public resource verbs: create, update, patch, delete, deletecollection.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -55,43 +168,86 @@ rules:
 - apiGroups:
   - deckhouse.io
   resources:
+  - nodegroupconfigurations
+  - staticinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - instances
+  - nodegroups
+  - nodegroupconfigurations
+  - staticinstances
+  verbs:
+  - create
+  - update
+  - patch
+  - delete
+  - deletecollection
+---
+# Access level: Admin.
+# Includes User, PrivilegedUser, and Editor permissions.
+# Uses node-manager read access from User.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Admin
+  name: d8:user-authz:node-manager:admin
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules: []
+---
+# Access level: Editor.
+# Includes User and PrivilegedUser permissions.
+# Uses node-manager read access from User.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: Editor
+  name: d8:user-authz:node-manager:editor
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules: []
+---
+# Access level: PrivilegedUser.
+# Includes User permissions.
+# Uses node-manager read access from User.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: PrivilegedUser
+  name: d8:user-authz:node-manager:privileged-user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules: []
+---
+# Access level: User.
+# Read access:
+# - public node-manager resources (instances, nodegroups)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    user-authz.deckhouse.io/access-level: User
+  name: d8:user-authz:node-manager:user
+  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
+rules:
+- apiGroups:
+  - deckhouse.io
+  resources:
+  - instances
   - nodegroups
   verbs:
   - get
   - list
   - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    user-authz.deckhouse.io/access-level: ClusterAdmin
-  name: d8:user-authz:node-manager:cluster-admin
-  {{- include "helm_lib_module_labels" (list .) | nindent 2 }}
-rules:
-- apiGroups:
-  - machine.sapcloud.io
-  resources:
-  - openstackmachineclasses
-  - awsmachineclasses
-  - azuremachineclasses
-  - vspheremachineclasses
-  - gcpmachineclasses
-  - alicloudmachineclasses
-  - yandexmachineclasses
-  - packetmachineclasses
-  - machines
-  - machinesets
-  - machinedeployments
-  verbs:
-  - patch
-  - update
-- apiGroups:
-  - cluster.x-k8s.io
-  resources:
-  - machines
-  - machinesets
-  - machinedeployments
-  verbs:
-  - patch
-  - update


### PR DESCRIPTION
## Description

backport https://github.com/deckhouse/deckhouse/pull/19720

Adds module-scoped RBAC v1 extension for node-manager
Also removes unused `alicloudmachineclasses` and `packetmachineclasses` MCM CRDs and related controller RBAC rules.

## Why do we need it, and what problem does it solve?

The change provides explicit user-authz RBAC rules for node-manager resources according to the access-level model.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: node-manager
type: fix
summary: Add RBAC rules for node-manager
impact: 
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
