### PR TITLE
[candi] Set PDPL level for d8-dhctl-converger on Astra Linux

### DIFF
--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -299,6 +299,18 @@ function main() {
         nodeuser_add_error "${user_name}" "${error_message}"
         continue
       fi
+
+      # d8-dhctl-converger is also used to destroy static masters, on Astra Linux it needs
+      # an elevated PDPL level to be able to perform privileged operations.
+      if [[ "$user_name" == "d8-dhctl-converger" ]] && [[ $(bb-is-bundle) == "astra" ]]; then
+        error_message=$(pdpl-user -i 63 d8-dhctl-converger 2>&1)
+        if bb-error?
+        then
+          bb-log-error "Error setting PDPL level for user '$user_name': ${error_message}"
+          nodeuser_add_error "${user_name}" "${error_message}"
+          continue
+        fi
+      fi
     fi
     nodeuser_clear_error "${user_name}"
   done

--- a/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
+++ b/candi/bashible/common-steps/all/000_add_node_users.sh.tpl
@@ -303,12 +303,16 @@ function main() {
       # d8-dhctl-converger is also used to destroy static masters, on Astra Linux it needs
       # an elevated PDPL level to be able to perform privileged operations.
       if [[ "$user_name" == "d8-dhctl-converger" ]] && [[ $(bb-is-bundle) == "astra" ]]; then
-        error_message=$(pdpl-user -i 63 d8-dhctl-converger 2>&1)
-        if bb-error?
-        then
-          bb-log-error "Error setting PDPL level for user '$user_name': ${error_message}"
-          nodeuser_add_error "${user_name}" "${error_message}"
-          continue
+        if type pdpl-user >/dev/null 2>&1; then
+          error_message=$(pdpl-user -i 63 d8-dhctl-converger 2>&1)
+          if bb-error?
+          then
+            bb-log-error "Error setting PDPL level for user '$user_name': ${error_message}"
+            nodeuser_add_error "${user_name}" "${error_message}"
+            continue
+          fi
+        else
+          bb-log-warning "pdpl-user command not found, skipping PDPL level setup for user '$user_name'"
         fi
       fi
     fi


### PR DESCRIPTION
## Description

Run `pdpl-user -i 63 d8-dhctl-converger` after the user is created when the node bundle is `astra`. Required so the converger user can destroy static master nodes on Astra Linux.

## Why do we need it, and what problem does it solve?

Required so the converger user can destroy static master nodes on Astra Linux.


## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Set PDPL level for d8-dhctl-converger on Astra Linux
impact:
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
