### PR TITLE
[monitoring-kubernetes]fix regexp for relable oom-kills

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/propagated-ebpf-exporter.yaml
+++ b/modules/340-monitoring-kubernetes/monitoring/prometheus-rules/kubernetes/propagated-ebpf-exporter.yaml
@@ -23,5 +23,5 @@
     expr: |-
       max by (namespace, pod, container) (
         kube_pod_container_info * on (uid) group_left
-        max by (uid) (label_replace(ebpf_exporter_oom_kills{cgroup_path=~".*burstable.*"}, "uid", "$1", "cgroup_path", ".+burstable/pod(.*)"))
+        max by (uid) (label_replace(ebpf_exporter_oom_kills{cgroup_path=~".*burstable.*"}, "uid", "$1", "cgroup_path", ".+burstable/pod([a-f0-9-]+)"))
       )


### PR DESCRIPTION
## Description

If the group has the form /sys/fs/cgroup/kubepods/burstable/pod<uid>/<container-uid>, then relabel doesn't work because the uid will contain extra information due to the greedy regular expression.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: monitoring-kubernetes
type: fix
summary: fix relabel regex for oom-kills
impact: monitoring-kubernetes
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
