### PR TITLE
[dhctl] Fix grammar and spelling in log and user-facing messages

### DIFF
--- a/dhctl/cmd/dhctl/action.go
+++ b/dhctl/cmd/dhctl/action.go
@@ -83,7 +83,7 @@ func (i *actionIniter) init(c *kingpin.ParseContext) error {
 	}
 
 	if i.registerOnShutdown == nil {
-		return fmt.Errorf("Internal error: action initer not initialized. Did not pass register on shutdown")
+		return fmt.Errorf("Internal error: action initer not initialized. The register-on-shutdown callback was not passed")
 	}
 
 	tmpDir := i.params.tmpDirName
@@ -197,7 +197,7 @@ func (i *actionIniter) prepareTmpDirPath(tmpDir string) (string, error) {
 		return "", fmt.Errorf("Tmp dir '%s' cannot be a system directory or user home %v", tmpDir, systemDirs)
 	}
 
-	const breakMsg = "DHCTL can cleanup it dir fully and it can break your system. Do you continue?"
+	const breakMsg = "DHCTL can clean up this directory completely, which can break your system. Do you want to continue?"
 	canceledByUser := fmt.Errorf("Operation cancelled by user")
 
 	inSystemDirs, inSystemDirsAll := fs.IsInSystemDirs(absPath)
@@ -206,7 +206,7 @@ func (i *actionIniter) prepareTmpDirPath(tmpDir string) (string, error) {
 			return "", fmt.Errorf("Tmp dir '%s' cannot be in system directory %v", tmpDir, inSystemDirsAll)
 		}
 
-		msg := fmt.Sprintf("Passed tmp dir '%s' for dhctl in system dir '%v'. %s", tmpDir, inSystemDirsAll, breakMsg)
+		msg := fmt.Sprintf("The tmp dir '%s' passed to dhctl is inside a system dir '%v'. %s", tmpDir, inSystemDirsAll, breakMsg)
 		if !input.NewConfirmation().WithMessage(msg).Ask() {
 			return "", canceledByUser
 		}
@@ -214,10 +214,10 @@ func (i *actionIniter) prepareTmpDirPath(tmpDir string) (string, error) {
 		osTmp := os.TempDir()
 		if absPath == osTmp {
 			if !input.IsTerminal() {
-				return "", fmt.Errorf("Tmp dir '%s' cannot be system tmp %v", tmpDir, osTmp)
+				return "", fmt.Errorf("Tmp dir '%s' cannot be the system tmp dir %v", tmpDir, osTmp)
 			}
 
-			msg := fmt.Sprintf("Passed tmp dir '%s' for dhctl is system tmp dir '%s'. %s", tmpDir, osTmp, breakMsg)
+			msg := fmt.Sprintf("The tmp dir '%s' passed to dhctl is the system tmp dir '%s'. %s", tmpDir, osTmp, breakMsg)
 			if !input.NewConfirmation().WithMessage(msg).Ask() {
 				return "", canceledByUser
 			}

--- a/dhctl/cmd/dhctl/commands/deckhouse.go
+++ b/dhctl/cmd/dhctl/commands/deckhouse.go
@@ -66,7 +66,7 @@ func DefineDeckhouseRemoveDeployment(cmd *kingpin.CmdClause, opts *options.Optio
 			return fmt.Errorf("kubernetes provider is not initialized")
 		}
 
-		return log.ProcessCtx(ctx, "default", "Remove Deckhouse️", func(ctx context.Context) error {
+		return log.ProcessCtx(ctx, "default", "Remove Deckhouse", func(ctx context.Context) error {
 			kube, err := kubeProvider.Client(ctx)
 			if err != nil {
 				return fmt.Errorf("open kubernetes connection: %w", err)
@@ -86,7 +86,7 @@ func DefineDeckhouseCreateDeployment(cmd *kingpin.CmdClause, opts *options.Optio
 	app.DefineKubeFlags(cmd, &opts.Kube)
 
 	var dryRun bool
-	cmd.Flag("dry-run", "Output deployment yaml").BoolVar(&dryRun)
+	cmd.Flag("dry-run", "Output the deployment YAML").BoolVar(&dryRun)
 
 	return cmd.Action(func(c *kingpin.ParseContext) error {
 		ctx := kpcontext.ExtractContext(c)

--- a/dhctl/cmd/dhctl/commands/destroy.go
+++ b/dhctl/cmd/dhctl/commands/destroy.go
@@ -35,13 +35,13 @@ import (
 )
 
 const (
-	destroyApprovalsMessage = `You will be asked for approve multiple times.
-If you understand what you are doing, you can use flag "--yes-i-am-sane-and-i-understand-what-i-am-doing" to skip approvals.
+	destroyApprovalsMessage = `You will be asked for approval multiple times.
+If you understand what you are doing, you can use the flag "--yes-i-am-sane-and-i-understand-what-i-am-doing" to skip approvals.
 `
 	destroyCacheErrorMessage = `Create cache:
 	Error: %v
 
-	Probably that Kubernetes cluster was already deleted.
+	The Kubernetes cluster was probably already deleted.
 	If you want to continue, please delete the cache folder manually.
 `
 )
@@ -76,7 +76,7 @@ func DefineDestroyCommand(cmd *kingpin.CmdClause, opts *options.Options) *kingpi
 			log.InteractiveWarnLn(destroyApprovalsMessage)
 
 			if !input.NewConfirmation().WithYesByDefault().WithMessage("Do you really want to DELETE all cluster resources?").Ask() {
-				return fmt.Errorf("Cleanup cluster resources disallow")
+				return fmt.Errorf("Cluster resource cleanup was not approved")
 			}
 		}
 

--- a/dhctl/cmd/dhctl/commands/edit.go
+++ b/dhctl/cmd/dhctl/commands/edit.go
@@ -36,7 +36,7 @@ func connectionFlags(parent *kingpin.CmdClause, opts *options.Options) {
 }
 
 func baseEditConfigCMD(parent *kingpin.CmdClause, opts *options.Options, name, secret, dataKey string) *kingpin.CmdClause {
-	cmd := parent.Command(name, fmt.Sprintf("Edit %s in Kubernetes cluster.", name))
+	cmd := parent.Command(name, fmt.Sprintf("Edit %s in the Kubernetes cluster.", name))
 	app.DefineEditorConfigFlags(cmd, &opts.Render)
 	app.DefineSanityFlags(cmd, &opts.Global)
 

--- a/dhctl/cmd/dhctl/commands/kube.go
+++ b/dhctl/cmd/dhctl/commands/kube.go
@@ -42,7 +42,7 @@ func DefineTestKubernetesAPIConnectionCommand(cmd *kingpin.CmdClause, opts *opti
 		ctx := kpcontext.ExtractContext(c)
 
 		doneCh := make(chan struct{})
-		tomb.RegisterOnShutdown("wait kubernetes-api-connection to stop", func() {
+		tomb.RegisterOnShutdown("wait for kubernetes-api-connection to stop", func() {
 			<-doneCh
 		})
 
@@ -52,7 +52,7 @@ func DefineTestKubernetesAPIConnectionCommand(cmd *kingpin.CmdClause, opts *opti
 			WithInitParams(client.AppKubernetesInitParams(&opts.Kube))
 
 		proxyClose := func() {
-			log.InteractiveInfoLn("Press Ctrl+C to close proxy connection.")
+			log.InteractiveInfoLn("Press Ctrl+C to close the proxy connection.")
 			ch := make(chan struct{})
 			<-ch
 		}

--- a/dhctl/cmd/dhctl/commands/lock.go
+++ b/dhctl/cmd/dhctl/commands/lock.go
@@ -94,9 +94,9 @@ func DefineReleaseConvergeLockCommand(cmd *kingpin.CmdClause, opts *options.Opti
 
 			c := input.NewConfirmation()
 
-			approve := c.WithMessage(fmt.Sprintf("Do you want to release lock:\n\n%s", info)).Ask()
+			approve := c.WithMessage(fmt.Sprintf("Do you want to release the lock:\n\n%s", info)).Ask()
 			if !approve {
-				return fmt.Errorf("Don't confirm release lock")
+				return fmt.Errorf("Lock release was not confirmed")
 			}
 
 			return nil

--- a/dhctl/cmd/dhctl/commands/session.go
+++ b/dhctl/cmd/dhctl/commands/session.go
@@ -76,7 +76,7 @@ func DefineSessionCommand(cmd *kingpin.CmdClause, opts *options.Options) *kingpi
 
 		apiServerURL := fmt.Sprintf("http://localhost:%s", apiServerPort)
 		if err := localKubeConfig(apiServerURL); err != nil {
-			return fmt.Errorf("error save kubeconfig: %v", err)
+			return fmt.Errorf("save kubeconfig: %v", err)
 		}
 
 		sigChan := make(chan os.Signal, 1)

--- a/dhctl/cmd/dhctl/commands/ssh.go
+++ b/dhctl/cmd/dhctl/commands/ssh.go
@@ -204,7 +204,7 @@ func DefineTestUploadExecCommand(cmd *kingpin.CmdClause, opts *options.Options) 
 		if err != nil {
 			var ee *exec.ExitError
 			if errors.As(err, &ee) {
-				return fmt.Errorf("script '%s' error: %w stderr: %s", ScriptPath, err, string(ee.Stderr))
+				return fmt.Errorf("script '%s' error: %w\nstderr: %s", ScriptPath, err, string(ee.Stderr))
 			}
 			return fmt.Errorf("script '%s' error: %w", ScriptPath, err)
 		}

--- a/dhctl/cmd/dhctl/commands/terraform.go
+++ b/dhctl/cmd/dhctl/commands/terraform.go
@@ -188,7 +188,7 @@ func DefineInfrastructureCheckCommand(cmd *kingpin.CmdClause, opts *options.Opti
 
 		if provider.NeedToUseTofu() && needMigrationToTofu {
 			// todo(log): why do not use logger?
-			fmt.Printf("\nNeed migrate to tofu: %v\n", needMigrationToTofu)
+			fmt.Printf("\nNeed to migrate to tofu: %v\n", needMigrationToTofu)
 		}
 
 		return provider.Cleanup()

--- a/dhctl/cmd/dhctl/main.go
+++ b/dhctl/cmd/dhctl/main.go
@@ -58,7 +58,7 @@ var commandList = []Command{
 	},
 	{
 		Name:       "bootstrap",
-		Help:       "Bootstrap cluster.",
+		Help:       "Bootstrap a cluster.",
 		DefineFunc: bootstrap.DefineBootstrapCommand,
 	},
 	{
@@ -67,13 +67,13 @@ var commandList = []Command{
 	},
 	{
 		Name:       "execute-bashible-bundle",
-		Help:       "Prepare Master node and install Kubernetes.",
+		Help:       "Prepare the master node and install Kubernetes.",
 		DefineFunc: bootstrap.DefineBootstrapExecuteBashibleCommand,
 		Parent:     "bootstrap-phase",
 	},
 	{
 		Name:       "create-resources",
-		Help:       "Create resources in Kubernetes cluster.",
+		Help:       "Create resources in a Kubernetes cluster.",
 		DefineFunc: bootstrap.DefineCreateResourcesCommand,
 		Parent:     "bootstrap-phase",
 	},
@@ -85,35 +85,35 @@ var commandList = []Command{
 	},
 	{
 		Name:       "abort",
-		Help:       "Delete every node, which was created during bootstrap process.",
+		Help:       "Delete every node created during the bootstrap process.",
 		DefineFunc: bootstrap.DefineBootstrapAbortCommand,
 		Parent:     "bootstrap-phase",
 	},
 	{
 		Name:       "base-infra",
-		Help:       "Create base infrastructure for Cloud Kubernetes cluster.",
+		Help:       "Create base infrastructure for a cloud Kubernetes cluster.",
 		DefineFunc: bootstrap.DefineBaseInfrastructureCommand,
 		Parent:     "bootstrap-phase",
 	},
 	{
 		Name:       "exec-post-bootstrap",
-		Help:       "Test scp upload and ssh run uploaded script.",
+		Help:       "Test scp upload and ssh execution of the uploaded script.",
 		DefineFunc: bootstrap.DefineExecPostBootstrapScript,
 		Parent:     "bootstrap-phase",
 	},
 	{
 		Name:       "converge",
-		Help:       "Converge kubernetes cluster.",
+		Help:       "Converge a Kubernetes cluster.",
 		DefineFunc: commands.DefineConvergeCommand,
 	},
 	{
 		Name:       autoConvergeCmd,
-		Help:       "Start service for periodical run converge.",
+		Help:       "Start a service that runs converge periodically.",
 		DefineFunc: commands.DefineAutoConvergeCommand,
 	},
 	{
 		Name:       "converge-migration",
-		Help:       "Migrate state from terraform to opentofu. Starting converge if cluster has not infrastructure changes.",
+		Help:       "Migrate state from terraform to opentofu. Start converge if the cluster has no infrastructure changes.",
 		DefineFunc: commands.DefineConvergeMigrationCommand,
 	},
 	{
@@ -122,7 +122,7 @@ var commandList = []Command{
 	},
 	{
 		Name:       "release",
-		Help:       "Release converge lock fully. It's remove converge lease lock from cluster regardless of owner. Be careful",
+		Help:       "Release the converge lock completely. This removes the converge lease lock from the cluster regardless of owner. Be careful.",
 		DefineFunc: commands.DefineReleaseConvergeLockCommand,
 		Parent:     "lock",
 	},
@@ -186,7 +186,7 @@ var commandList = []Command{
 	},
 	{
 		Name:       "control-plane-manifests",
-		Help:       "Render control-plane manifests and pki.",
+		Help:       "Render control-plane manifests and PKI.",
 		DefineFunc: commands.DefineRenderControlPlaneAndPKI,
 		Parent:     "render",
 	},
@@ -211,13 +211,13 @@ var commandList = []Command{
 	},
 	{
 		Name:       "ssh-connection",
-		Help:       "Test connection via ssh.",
+		Help:       "Test connection via SSH.",
 		DefineFunc: commands.DefineTestSSHConnectionCommand,
 		Parent:     "test",
 	},
 	{
 		Name:       "kubernetes-api-connection",
-		Help:       "Test connection to kubernetes api via ssh or directly.",
+		Help:       "Test connection to the Kubernetes API via SSH or directly.",
 		DefineFunc: commands.DefineTestKubernetesAPIConnectionCommand,
 		Parent:     "test",
 	},
@@ -229,7 +229,7 @@ var commandList = []Command{
 	},
 	{
 		Name:       "upload-exec",
-		Help:       "Test scp upload and ssh run uploaded script.",
+		Help:       "Test scp upload and ssh execution of the uploaded script.",
 		DefineFunc: commands.DefineTestUploadExecCommand,
 		Parent:     "test",
 	},
@@ -246,13 +246,13 @@ var commandList = []Command{
 	},
 	{
 		Name:       "manager",
-		Help:       "Test control plane manager is ready.",
+		Help:       "Test that the control plane manager is ready.",
 		DefineFunc: commands.DefineTestControlPlaneManagerReadyCommand,
 		Parent:     "control-plane",
 	},
 	{
 		Name:       "node",
-		Help:       "Test control plane node is ready.",
+		Help:       "Test that the control plane node is ready.",
 		DefineFunc: commands.DefineTestControlPlaneNodeReadyCommand,
 		Parent:     "control-plane",
 	},
@@ -263,7 +263,7 @@ var commandList = []Command{
 	},
 	{
 		Name:       "create-deployment",
-		Help:       "Install deckhouse after infrastructure is applied successful.",
+		Help:       "Install deckhouse after the infrastructure is applied successfully.",
 		DefineFunc: commands.DefineDeckhouseCreateDeployment,
 		Parent:     "deckhouse",
 	},
@@ -275,7 +275,7 @@ var commandList = []Command{
 	},
 	{
 		Name:       "deployment-ready",
-		Help:       "Wait while deployment is ready.",
+		Help:       "Wait until the deployment is ready.",
 		DefineFunc: commands.DefineWaitDeploymentReadyCommand,
 		Parent:     "deckhouse",
 	},
@@ -304,7 +304,7 @@ func main() {
 		disableCleanupOnInterrupted,
 	})
 
-	kpApp := kingpin.New(app.AppName, "A tool to create Kubernetes cluster and infrastructure.")
+	kpApp := kingpin.New(app.AppName, "A tool to create a Kubernetes cluster and infrastructure.")
 	kpApp.HelpFlag.Short('h')
 	app.GlobalFlags(kpApp, &opts.Global)
 

--- a/dhctl/cmd/dhctl/register.go
+++ b/dhctl/cmd/dhctl/register.go
@@ -67,7 +67,7 @@ func getParentIndex(commandList []Command, name string) (int, error) {
 		}
 	}
 
-	return -1, fmt.Errorf("parrent command %s not found in command list", name)
+	return -1, fmt.Errorf("parent command %s not found in command list", name)
 }
 
 func getNestingDepth(cmd Command, commands []Command) (Command, int) {

--- a/dhctl/pkg/app/app.go
+++ b/dhctl/pkg/app/app.go
@@ -34,15 +34,15 @@ const (
 
 // GlobalFlags registers application-wide flags into cmd, writing into o.
 func GlobalFlags(cmd *kingpin.Application, o *options.GlobalOptions) {
-	cmd.Flag("logger-type", "Format logs output of a dhctl in different ways.").
+	cmd.Flag("logger-type", "Format the log output of dhctl in different ways.").
 		Envar(configEnvName("LOGGER_TYPE")).
 		Default("pretty").
 		EnumVar(&o.LoggerType, "pretty", "json")
-	cmd.Flag("tmp-dir", "Set temporary directory for debug purposes.").
+	cmd.Flag("tmp-dir", "Set the temporary directory for debug purposes.").
 		Envar(configEnvName("TMP_DIR")).
 		Default(o.TmpDir).
 		StringVar(&o.TmpDir)
-	cmd.Flag("do-not-write-debug-log-file", `Skip write debug log into file in tmp-dir`).
+	cmd.Flag("do-not-write-debug-log-file", `Skip writing the debug log to a file in tmp-dir`).
 		Envar(configEnvName("DO_NOT_WRITE_DEBUG_LOG")).
 		Default("false").
 		BoolVar(&o.DoNotWriteDebugLogFile)
@@ -54,11 +54,11 @@ func GlobalFlags(cmd *kingpin.Application, o *options.GlobalOptions) {
 		Envar(configEnvName("PROGRESS_LOG_FILE_PATH")).
 		Default("").
 		StringVar(&o.ProgressFilePath)
-	cmd.Flag("download-dir", "Set directory for downloaded images and it's content").
+	cmd.Flag("download-dir", "Set the directory for downloaded images and their content").
 		Envar(configEnvName("DOWNLOAD_DIR")).
 		Default(o.DownloadDir).
 		StringVar(&o.DownloadDir)
-	cmd.Flag("download-cache-dir", "Set directory for downloaded images layers cache.").
+	cmd.Flag("download-cache-dir", "Set the directory for the downloaded image layers cache.").
 		Envar(configEnvName("DOWNLOAD_CACHE_DIR")).
 		Default(o.DownloadCacheDir).
 		StringVar(&o.DownloadCacheDir)
@@ -82,8 +82,8 @@ func GlobalFlags(cmd *kingpin.Application, o *options.GlobalOptions) {
 // DefineConfigFlags registers --config (required).
 func DefineConfigFlags(cmd *kingpin.CmdClause, o *options.GlobalOptions) {
 	cmd.Flag("config", `Path to a file with bootstrap configuration and declared Kubernetes resources in YAML format.
-It can be go-template file (for only string keys!). Passed data contains next keys:
-  cloudDiscovery - the data discovered by applying infrastructure creation utility and getting its output. It depends on the cloud provider.
+It can be a go-template file (string keys only!). The passed data contains the following keys:
+  cloudDiscovery - the data discovered by running the infrastructure creation utility and getting its output. It depends on the cloud provider.
 `).
 		Required().
 		Envar(configEnvName("CONFIG")).
@@ -92,7 +92,7 @@ It can be go-template file (for only string keys!). Passed data contains next ke
 
 // DefineSanityFlags registers the destructive-action confirmation flag.
 func DefineSanityFlags(cmd *kingpin.CmdClause, o *options.GlobalOptions) {
-	cmd.Flag("yes-i-am-sane-and-i-understand-what-i-am-doing", "You should double check what you are doing here.").
+	cmd.Flag("yes-i-am-sane-and-i-understand-what-i-am-doing", "You should double-check what you are doing here.").
 		Default("false").
 		BoolVar(&o.SanityCheck)
 }

--- a/dhctl/pkg/app/auto-converge.go
+++ b/dhctl/pkg/app/auto-converge.go
@@ -30,7 +30,7 @@ func DefineAutoConvergeFlags(cmd *kingpin.CmdClause, o *options.AutoConvergeOpti
 		Envar(configEnvName("LISTEN_ADDRESS")).
 		StringVar(&o.ListenAddress)
 
-	cmd.Flag("node-name", "Node name where running auto-converger pod").
+	cmd.Flag("node-name", "Name of the node where the auto-converger pod is running").
 		Envar(configEnvName("RUNNING_NODE_NAME")).
 		StringVar(&o.RunningNodeName)
 }

--- a/dhctl/pkg/app/bootstrap.go
+++ b/dhctl/pkg/app/bootstrap.go
@@ -42,14 +42,14 @@ func DefineDeckhouseFlags(cmd *kingpin.CmdClause, o *options.BootstrapOptions) {
 
 // DefinePostBootstrapScriptFlags registers post-bootstrap script flags.
 func DefinePostBootstrapScriptFlags(cmd *kingpin.CmdClause, o *options.BootstrapOptions) {
-	cmd.Flag("post-bootstrap-script-path", `Path to bash (or another interpreted language which installed on master node) script which will execute after bootstrap resources.
-All output of the script will be logged with Info level with prefix 'Post-bootstrap script result:'.
-If you want save to state cache on key 'post-bootstrap-result' you need to out result with prefix 'Result of post-bootstrap script:' in one line.
+	cmd.Flag("post-bootstrap-script-path", `Path to a bash (or other interpreted-language) script installed on the master node, which will be executed after the bootstrap resources.
+All output of the script will be logged at the Info level with the prefix 'Post-bootstrap script result:'.
+If you want to save to the state cache under the key 'post-bootstrap-result', you need to output the result with the prefix 'Result of post-bootstrap script:' on one line.
 Experimental. This feature may be deleted in the future.`).
 		Envar(configEnvName("POST_BOOTSTRAP_SCRIPT_PATH")).
 		StringVar(&o.PostBootstrapScriptPath)
 
-	cmd.Flag("post-bootstrap-script-timeout", "Timeout to execute after bootstrap resources script. Experimental. This feature may be deleted in the future.").
+	cmd.Flag("post-bootstrap-script-timeout", "Timeout for executing the after-bootstrap-resources script. Experimental. This feature may be deleted in the future.").
 		Envar(configEnvName("POST_BOOTSTRAP_SCRIPT_TIMEOUT")).
 		Default(o.PostBootstrapScriptTimeout.String()).
 		DurationVar(&o.PostBootstrapScriptTimeout)
@@ -58,7 +58,7 @@ Experimental. This feature may be deleted in the future.`).
 // DefineResourcesFlags registers --resources / --resources-timeout.
 func DefineResourcesFlags(cmd *kingpin.CmdClause, o *options.BootstrapOptions, isRequired bool) {
 	cmd.Flag("resources", `Path to a file with declared Kubernetes resources in YAML format.
-Deprecated. Please use --config flag multiple repeatedly for logical resources separation.
+Deprecated. Please use the --config flag repeatedly for logical separation of resources.
 `).
 		Envar(configEnvName("RESOURCES")).
 		StringVar(&o.ResourcesPath)
@@ -73,7 +73,7 @@ Deprecated. Please use --config flag multiple repeatedly for logical resources s
 
 // DefineAbortFlags registers --force-abort-from-cache.
 func DefineAbortFlags(cmd *kingpin.CmdClause, o *options.BootstrapOptions) {
-	const help = `Skip 'use dhctl destroy command' error. It force bootstrap abortion from cache.
+	const help = `Skip the 'use dhctl destroy command' error. This forces bootstrap abortion from cache.
 Experimental. This feature may be deleted in the future.`
 	cmd.Flag("force-abort-from-cache", help).
 		Envar(configEnvName("FORCE_ABORT_FROM_CACHE")).

--- a/dhctl/pkg/app/control-plane.go
+++ b/dhctl/pkg/app/control-plane.go
@@ -27,7 +27,7 @@ func DefineControlPlaneFlags(cmd *kingpin.CmdClause, o *options.ControlPlaneOpti
 		Required().
 		StringVar(&o.Hostname)
 
-	ipFlag := cmd.Flag("control-plane-node-ip", "Control plane node ip to check").
+	ipFlag := cmd.Flag("control-plane-node-ip", "Control plane node IP to check").
 		Envar(configEnvName("CONTROL_PLANE_NODE_IP"))
 
 	if ipRequired {

--- a/dhctl/pkg/app/converge.go
+++ b/dhctl/pkg/app/converge.go
@@ -30,7 +30,7 @@ func DefineConvergeExporterFlags(cmd *kingpin.CmdClause, o *options.ConvergeOpti
 	cmd.Flag("listen-address", "Address to expose metrics").
 		Envar(configEnvName("LISTEN_ADDRESS")).
 		StringVar(&o.ListenAddress)
-	cmd.Flag("check-interval", "Period to check infrastructure state converge").
+	cmd.Flag("check-interval", "Period for checking infrastructure state convergence").
 		Envar(configEnvName("CHECK_INTERVAL")).
 		DurationVar(&o.CheckInterval)
 }
@@ -45,7 +45,7 @@ func DefineOutputFlag(cmd *kingpin.CmdClause, o *options.ConvergeOptions) {
 
 // DefineCheckHasTerraformStateBeforeMigrateToTofu registers the migration guard flag.
 func DefineCheckHasTerraformStateBeforeMigrateToTofu(cmd *kingpin.CmdClause, o *options.ConvergeOptions) {
-	cmd.Flag("check-has-terraform-state-before-migrate-to-tofu", "Check cluster has terraform state before migrate state to tofu.").
+	cmd.Flag("check-has-terraform-state-before-migrate-to-tofu", "Check that the cluster has terraform state before migrating the state to tofu.").
 		Default("false").
 		BoolVar(&o.CheckHasTerraformStateBeforeMigrateToTofu)
 }

--- a/dhctl/pkg/app/destroy.go
+++ b/dhctl/pkg/app/destroy.go
@@ -22,7 +22,7 @@ import (
 
 // DefineDestroyResourcesFlags registers --skip-resources.
 func DefineDestroyResourcesFlags(cmd *kingpin.CmdClause, o *options.DestroyOptions) {
-	cmd.Flag("skip-resources", "Do not wait resources deletion (pv, loadbalancers, machines) from the cluster.").
+	cmd.Flag("skip-resources", "Do not wait for deletion of resources (pv, loadbalancers, machines) from the cluster.").
 		Default("false").
 		Envar(configEnvName("SKIP_RESOURCES")).
 		BoolVar(&o.SkipResources)

--- a/dhctl/pkg/app/registry.go
+++ b/dhctl/pkg/app/registry.go
@@ -21,7 +21,7 @@ import (
 )
 
 func DefineImgBundleFlags(cmd *kingpin.CmdClause, o *options.RegistryOptions) {
-	cmd.Flag("img-bundle-path", `Path to the directory with tar or chunk.tar image bundles created by 'd8 mirror pull' command for Local registry mode.`).
+	cmd.Flag("img-bundle-path", `Path to the directory with tar or chunk.tar image bundles created by the 'd8 mirror pull' command for Local registry mode.`).
 		Envar(configEnvName("IMG_BUNDLE_PATH")).
 		StringVar(&o.ImgBundlePath)
 }

--- a/dhctl/pkg/app/render.go
+++ b/dhctl/pkg/app/render.go
@@ -22,7 +22,7 @@ import (
 
 // DefineRenderConfigFlags registers --bundle-dir.
 func DefineRenderConfigFlags(cmd *kingpin.CmdClause, o *options.RenderOptions) {
-	cmd.Flag("bundle-dir", "Directory to render bashible bundle.").
+	cmd.Flag("bundle-dir", "Directory to render the bashible bundle into.").
 		Envar(configEnvName("BUNDLE_DIR")).
 		StringVar(&o.BashibleBundleDir)
 }

--- a/dhctl/pkg/app/terraform.go
+++ b/dhctl/pkg/app/terraform.go
@@ -29,7 +29,7 @@ func DefineCacheFlags(cmd *kingpin.CmdClause, o *options.CacheOptions) {
 		StringVar(&o.Dir)
 
 	cmd.Flag("use-cache", fmt.Sprintf(`Behaviour for using infrastructure state cache. May be:
-	%s - ask user about it (Default)
+	%s - ask the user (Default)
    	%s - use cache
 	%s  - don't use cache
 	`, options.UseStateCacheAsk, options.UseStateCacheYes, options.UseStateCacheNo)).
@@ -37,22 +37,22 @@ func DefineCacheFlags(cmd *kingpin.CmdClause, o *options.CacheOptions) {
 		Default(options.UseStateCacheAsk).
 		EnumVar(&o.UseTfCache, options.UseStateCacheAsk, options.UseStateCacheYes, options.UseStateCacheNo)
 
-	cmd.Flag("kube-cache-store-kubeconfig", "Path to kubernetes config file for storing cache in kubernetes secret").
+	cmd.Flag("kube-cache-store-kubeconfig", "Path to the kubernetes config file for storing the cache in a kubernetes secret").
 		Envar(configEnvName("CACHE_STORE_KUBE_CONFIG")).
 		StringVar(&o.KubeConfig)
-	cmd.Flag("kube-cachestore-kubeconfig-context", "Context from kubernetes config to connect to Kubernetes API. for storing cache in kubernetes secret").
+	cmd.Flag("kube-cachestore-kubeconfig-context", "Context from the kubernetes config to connect to the Kubernetes API, for storing the cache in a kubernetes secret").
 		Envar(configEnvName("CACHE_STORE_KUBE_CONFIG_CONTEXT")).
 		StringVar(&o.KubeConfigContext)
-	cmd.Flag("kube-cachestore-kube-client-from-cluster", "Use in-cluster Kubernetes API access. for storing cache in kubernetes secret").
+	cmd.Flag("kube-cachestore-kube-client-from-cluster", "Use in-cluster Kubernetes API access, for storing the cache in a kubernetes secret").
 		Envar(configEnvName("CACHE_STORE_KUBE_CLIENT_FROM_CLUSTER")).
 		BoolVar(&o.KubeConfigInCluster)
-	cmd.Flag("kube-cachestore-namespace", "Use in-cluster Kubernetes API access. for storing cache in kubernetes secret").
+	cmd.Flag("kube-cachestore-namespace", "Namespace for storing the cache in a kubernetes secret").
 		Envar(configEnvName("CACHE_STORE_KUBE_NAMESPACE")).
 		StringVar(&o.KubeNamespace)
-	cmd.Flag("kube-cachestore-labels", "List labels for cache secrets").
+	cmd.Flag("kube-cachestore-labels", "List of labels for cache secrets").
 		Envar(configEnvName("CACHE_STORE_KUBE_LABELS")).
 		StringMapVar(&o.KubeLabels)
-	cmd.Flag("kube-cachestore-name", "Name for cache secret").
+	cmd.Flag("kube-cachestore-name", "Name of the cache secret").
 		Envar(configEnvName("CACHE_STORE_KUBE_NAME")).
 		StringVar(&o.KubeName)
 }

--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -184,8 +184,8 @@ func ParseConfigFromCluster(
 	var metaConfig *MetaConfig
 	var err error
 
-	return metaConfig, log.ProcessCtx(ctx, "common", "Get Cluster configuration", func(ctx context.Context) error {
-		return retry.NewLoop("Get Cluster configuration from Kubernetes cluster", 10, 5*time.Second).
+	return metaConfig, log.ProcessCtx(ctx, "common", "Get cluster configuration", func(ctx context.Context) error {
+		return retry.NewLoop("Get cluster configuration from Kubernetes cluster", 10, 5*time.Second).
 			RunContext(ctx, func() error {
 				metaConfig, err = parseConfigFromCluster(ctx, kubeCl, preparatorProvider, globalOptions)
 				return err
@@ -204,7 +204,7 @@ func ParseConfigInCluster(
 		err        error
 	)
 
-	err = retry.NewSilentLoop("Get Cluster configuration from inside Kubernetes cluster", 5, 5*time.Second).
+	err = retry.NewSilentLoop("Get cluster configuration from inside Kubernetes cluster", 5, 5*time.Second).
 		RunContext(ctx, func() error {
 			metaConfig, err = parseConfigFromCluster(ctx, kubeCl, preparatorProvider, globalOptions)
 			return err
@@ -458,7 +458,7 @@ func ParseConfigFromData(
 	// init configuration can be empty, but we need default from openapi spec
 	// Note: InitConfiguration can also be provided via ModuleConfig deckhouse (registry settings)
 	if len(metaConfig.InitClusterConfig) == 0 {
-		log.DebugF("Init configuration not found use empty")
+		log.DebugF("Init configuration not found, using empty")
 		doc := `
 apiVersion: deckhouse.io/v1
 kind: InitConfiguration

--- a/dhctl/pkg/config/connection.go
+++ b/dhctl/pkg/config/connection.go
@@ -97,10 +97,10 @@ func ParseConnectionConfig(
 	}
 
 	unmarshallError := func(err error, kind string, docNumber int) string {
-		return fmt.Sprintf("Cannot unmarshal to %s document %d: %v", kind, docNumber, err)
+		return fmt.Sprintf("Cannot unmarshal %s document %d: %v", kind, docNumber, err)
 	}
 
-	log.DebugF("Parsing connection config has %d documents\n", len(docs))
+	log.DebugF("Connection config has %d documents\n", len(docs))
 
 	config := &ConnectionConfig{}
 
@@ -126,7 +126,7 @@ func ParseConnectionConfig(
 			Version: gvk.GroupVersion().String(),
 		}
 
-		log.DebugF("Process validate and parse connection config document %d for index %v\n", i, index)
+		log.DebugF("Validating and parsing connection config document %d for index %v\n", i, index)
 
 		err = schemaStore.ValidateWithIndex(&index, &docData, opts...)
 		if err != nil {
@@ -143,7 +143,7 @@ func ParseConnectionConfig(
 				continue
 			}
 			config.SSHConfig = &sshConfig
-			log.DebugF("SSHConfig added in result config\n")
+			log.DebugF("SSHConfig added to the result config\n")
 		case SSHConfigHostKind:
 			sshHostConfigDocsCount++
 			var sshHost SSHHost
@@ -152,7 +152,7 @@ func ParseConnectionConfig(
 				continue
 			}
 			config.SSHHosts = append(config.SSHHosts, sshHost)
-			log.DebugF("SSHHost added in result config, host in result config %d\n", len(config.SSHHosts))
+			log.DebugF("SSHHost added to the result config, hosts in result config %d\n", len(config.SSHHosts))
 		default:
 			msg := fmt.Sprintf("Unknown kind, expected one of (%q, %q)", SSHConfigKind, SSHConfigHostKind)
 			appendValidationError(msg, i, &gvk, &obj)
@@ -224,7 +224,7 @@ func (p *ConnectionConfigParser) ParseConnectionConfigFromFile() error {
 
 		keysPaths = append(keysPaths, fullPath)
 		if len(key.Passphrase) > 0 {
-			log.DebugF("Passphrase for key %s added in map\n", fullPath)
+			log.DebugF("Passphrase for key %s added to the map\n", fullPath)
 			pathToPassPhrase[fullPath] = key.Passphrase
 		}
 	}

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -81,7 +81,7 @@ func (c *DeckhouseInstaller) GetImageTag(forceVersionTag bool) string {
 	}
 
 	if tag == "" {
-		panic("You are probably using a development image. please use devBranch")
+		panic("You are probably using a development image. Please use devBranch")
 	}
 	return tag
 }
@@ -130,7 +130,7 @@ func PrepareDeckhouseInstallConfig(ctx context.Context, metaConfig *MetaConfig, 
 	}
 
 	if len(metaConfig.DeckhouseConfig.ConfigOverrides) > 0 {
-		return nil, fmt.Errorf("Support for 'configOverrides' was removed. Please use ModuleConfig's instead.")
+		return nil, fmt.Errorf("Support for 'configOverrides' was removed. Please use ModuleConfig instead.")
 	}
 
 	if metaConfig.DeckhouseConfig.ReleaseChannel != "" {
@@ -147,17 +147,17 @@ func PrepareDeckhouseInstallConfig(ctx context.Context, metaConfig *MetaConfig, 
 
 	clusterConfig, err := metaConfig.ClusterConfigYAML()
 	if err != nil {
-		return nil, fmt.Errorf("Marshal cluster config failed: %v", err)
+		return nil, fmt.Errorf("Failed to marshal cluster config: %v", err)
 	}
 
 	providerClusterConfig, err := metaConfig.ProviderClusterConfigYAML()
 	if err != nil {
-		return nil, fmt.Errorf("Marshal provider config failed: %v", err)
+		return nil, fmt.Errorf("Failed to marshal provider config: %v", err)
 	}
 
 	staticClusterConfig, err := metaConfig.StaticClusterConfigYAML()
 	if err != nil {
-		return nil, fmt.Errorf("Marshal static config failed: %v", err)
+		return nil, fmt.Errorf("Failed to marshal static config: %v", err)
 	}
 
 	bundle := DefaultBundle

--- a/dhctl/pkg/config/digests/image.go
+++ b/dhctl/pkg/config/digests/image.go
@@ -24,13 +24,13 @@ type ImagesDigests = map[string]map[string]any
 func GetAllDigests() (ImagesDigests, error) {
 	content, err := imagesDigestsContent()
 	if err != nil {
-		return nil, fmt.Errorf("Could not load images digests: %w", err)
+		return nil, fmt.Errorf("Could not load image digests: %w", err)
 	}
 
 	var digests ImagesDigests
 
 	if err := json.Unmarshal(content, &digests); err != nil {
-		return nil, fmt.Errorf("Could not unmarshal images digests: %w", err)
+		return nil, fmt.Errorf("Could not unmarshal image digests: %w", err)
 	}
 
 	return digests, nil
@@ -44,17 +44,17 @@ func GetImage(section, name string) (string, error) {
 
 	sec, ok := digests[section]
 	if !ok || len(sec) == 0 {
-		return "", fmt.Errorf("Not found images digests section '%s' or empty", section)
+		return "", fmt.Errorf("Image digests section '%s' not found or empty", section)
 	}
 
 	imgRaw, ok := sec[name]
 	if !ok {
-		return "", fmt.Errorf("Not found image '%s' in section '%s'", name, section)
+		return "", fmt.Errorf("Image '%s' not found in section '%s'", name, section)
 	}
 
 	img, ok := imgRaw.(string)
 	if !ok {
-		return "", fmt.Errorf("Image '%s' in section '%s' is not string. It is %T", name, section, imgRaw)
+		return "", fmt.Errorf("Image '%s' in section '%s' is not a string. It is %T", name, section, imgRaw)
 	}
 
 	return img, nil

--- a/dhctl/pkg/config/load.go
+++ b/dhctl/pkg/config/load.go
@@ -322,15 +322,15 @@ func (s *SchemaStore) ValidateWithIndex(index *SchemaIndex, doc *[]byte, opts ..
 			return err
 		}
 		mcName := mc.GetName()
-		log.DebugF("Found module config for validate %s\n", mcName)
+		log.DebugF("Found module config to validate %s\n", mcName)
 		if mc.Spec.Enabled == nil && mcName != "global" {
 			// we need return error because on top level we want filter module configs from modulesources and move into resources
 			// global is special mc without module
-			return fmt.Errorf("Enabled field for module config %s shoud set to true or false", mcName)
+			return fmt.Errorf("Enabled field for module config %s should be set to true or false", mcName)
 		}
 
 		if _, ok := s.modulesCache[mcName]; !ok && mcName != "global" {
-			log.DebugF("Module %s wasn't found. Probably it is module from modulesources. Skip it\n", mc.GetName())
+			log.DebugF("Module %s wasn't found. It is probably a module from modulesources. Skipping it\n", mc.GetName())
 			return ErrSchemaNotFound
 		}
 
@@ -341,25 +341,25 @@ func (s *SchemaStore) ValidateWithIndex(index *SchemaIndex, doc *[]byte, opts ..
 		var ok bool
 		schema, ok = s.moduleConfigsCache[mcName]
 		if !ok {
-			log.DebugF("Schema for module config %s wasn't found. Probably it is module from modulesources. Skip it\n", mc.GetName())
+			log.DebugF("Schema for module config %s wasn't found. It is probably a module from modulesources. Skipping it\n", mc.GetName())
 			return fmt.Errorf("Schema for module config %s not found", mcName)
 		}
 
 		if mc.Spec.Version == 0 {
-			return fmt.Errorf("Version field for module config %s shoud set", mcName)
+			return fmt.Errorf("Version field for module config %s should be set", mcName)
 		}
 
 		var err error
 		docForValidate, err = s.applyConversions(mc)
 		if err != nil {
-			return fmt.Errorf("Setting for validation module config failed: %v", err)
+			return fmt.Errorf("Setting up validation for module config failed: %v", err)
 		}
 	} else {
 		schema = s.getV1alpha1CompatibilitySchema(index)
 	}
 
 	if schema == nil {
-		log.DebugF("No schema for index %s. Skip it\n", index.String())
+		log.DebugF("No schema for index %s. Skipping it\n", index.String())
 		// we need return error because on top level we want filter documents without index and move into resources
 		return ErrSchemaNotFound
 	}
@@ -494,7 +494,7 @@ func (s *SchemaStore) applyConversions(mc ModuleConfig) ([]byte, error) {
 		if err != nil {
 			return []byte{}, fmt.Errorf("error converting to unstructured: %w", err)
 		}
-		log.DebugF("conversion successfully applyed for ModuleConfig %s\n", mc.GetName())
+		log.DebugF("conversion successfully applied for ModuleConfig %s\n", mc.GetName())
 	} else {
 		return yaml.Marshal(mc.Spec.Settings)
 	}

--- a/dhctl/pkg/config/meta.go
+++ b/dhctl/pkg/config/meta.go
@@ -742,7 +742,7 @@ func (m *MetaConfig) EnrichProxyData() (map[string]interface{}, error) {
 func (m *MetaConfig) LoadImagesDigests() error {
 	imagesDigests, err := digests.GetAllDigests()
 	if err != nil {
-		return fmt.Errorf("Cannot get images digests: %w", err)
+		return fmt.Errorf("Cannot get image digests: %w", err)
 	}
 
 	m.Images = imagesDigests
@@ -810,7 +810,7 @@ func (m *MetaConfig) GetReplicasByNodeGroupName(nodeGroupName string) int {
 func getDNSAddress(serviceCIDR string) string {
 	ip, ipnet, err := net.ParseCIDR(serviceCIDR)
 	if err != nil {
-		log.DebugLn("serviceSubnetCIDR is not valid CIDR (should be validated with openapi scheme)")
+		log.DebugLn("serviceSubnetCIDR is not a valid CIDR (should be validated with the openapi schema)")
 		return ""
 	}
 

--- a/dhctl/pkg/config/node_group_configuration.go
+++ b/dhctl/pkg/config/node_group_configuration.go
@@ -44,7 +44,7 @@ func ParseInternalBootstrapNodeGroupConfiguration(ctx context.Context, resources
 
 		index, err := yamlvalidation.ParseIndex(strings.NewReader(doc), yamlvalidation.ParseIndexWithoutCheckValid())
 		if err != nil {
-			log.DebugF("Skip NodeGroupConfiguration probe for doc: %v\n", err)
+			log.DebugF("Skipping NodeGroupConfiguration probe for doc: %v\n", err)
 			continue
 		}
 

--- a/dhctl/pkg/config/registry/config.go
+++ b/dhctl/pkg/config/registry/config.go
@@ -42,8 +42,8 @@ func errUnsupportedCRI(cri constant.CRIType) error {
 
 func errNonStaticClusterMode(mode constant.ModeType) error {
 	return fmt.Errorf(
-		"bootstrap with registry mode '%s' is supported only in static cluster. "+
-			"Please use one of the supported bootstrap modes for non-static cluster: %v",
+		"bootstrap with registry mode '%s' is supported only in a static cluster. "+
+			"Please use one of the supported bootstrap modes for a non-static cluster: %v",
 		mode,
 		[]constant.ModeType{
 			constant.ModeUnmanaged,

--- a/dhctl/pkg/config/validation.go
+++ b/dhctl/pkg/config/validation.go
@@ -65,11 +65,11 @@ type ClusterConfig struct {
 func ValidateResources(configData string, opts ...ValidateOption) error {
 	options := applyOptions(opts...)
 	if !options.commanderMode {
-		panic("ValidateResources operation currently supported only in commander mode")
+		panic("ValidateResources operation is currently supported only in commander mode")
 	}
 
 	if k8sYAML.IsJSONBuffer([]byte(configData)) {
-		return errors.New("got json format, but expected yaml")
+		return errors.New("got JSON format, but expected YAML")
 	}
 
 	docs := input.YAMLSplitRegexp.Split(strings.TrimSpace(configData), -1)
@@ -121,7 +121,7 @@ func ValidateResources(configData string, opts ...ValidateOption) error {
 func ValidateInitConfiguration(configData string, schemaStore *SchemaStore, opts ...ValidateOption) error {
 	options := applyOptions(opts...)
 	if !options.commanderMode {
-		panic("ValidateInitConfiguration operation currently supported only in commander mode")
+		panic("ValidateInitConfiguration operation is currently supported only in commander mode")
 	}
 
 	docs := input.YAMLSplitRegexp.Split(strings.TrimSpace(configData), -1)
@@ -200,7 +200,7 @@ func ValidateClusterConfiguration(
 ) (ClusterConfig, error) {
 	options := applyOptions(opts...)
 	if !options.commanderMode {
-		panic("ValidateClusterConfiguration operation currently supported only in commander mode")
+		panic("ValidateClusterConfiguration operation is currently supported only in commander mode")
 	}
 
 	clusterConfigurationDocs := input.YAMLSplitRegexp.Split(strings.TrimSpace(clusterConfigData), -1)
@@ -299,7 +299,7 @@ func ValidateProviderSpecificClusterConfiguration(
 ) error {
 	options := applyOptions(opts...)
 	if !options.commanderMode {
-		panic("ValidateProviderSpecificClusterConfiguration operation currently supported only in commander mode")
+		panic("ValidateProviderSpecificClusterConfiguration operation is currently supported only in commander mode")
 	}
 
 	if clusterConfig.ClusterType == "Static" {
@@ -389,7 +389,7 @@ func ValidateStaticClusterConfiguration(
 ) error {
 	options := applyOptions(opts...)
 	if !options.commanderMode {
-		panic("ValidateStaticClusterConfiguration operation currently supported only in commander mode")
+		panic("ValidateStaticClusterConfiguration operation is currently supported only in commander mode")
 	}
 
 	docs := input.YAMLSplitRegexp.Split(strings.TrimSpace(staticClusterConfiguration), -1)
@@ -470,7 +470,7 @@ func ValidateClusterSettingsChanges(
 ) error {
 	options := applyOptions(opts...)
 	if !options.commanderMode {
-		panic("ValidateClusterSettingsChanges operation currently supported only in commander mode")
+		panic("ValidateClusterSettingsChanges operation is currently supported only in commander mode")
 	}
 
 	// todo: > bashible

--- a/dhctl/pkg/config/validation_rules.go
+++ b/dhctl/pkg/config/validation_rules.go
@@ -66,7 +66,7 @@ func UpdateReplicasRule(oldRaw, newRaw json.RawMessage) error {
 	}
 
 	if newValue == 0 {
-		return fmt.Errorf("%w: got unacceptable .masterNodeGroup.replicas zero value", ErrValidationRuleFailed)
+		return fmt.Errorf("%w: the .masterNodeGroup.replicas zero value is not acceptable", ErrValidationRuleFailed)
 	}
 
 	if newValue < oldValue && newValue == 1 {
@@ -209,5 +209,5 @@ func ValidateSSHPublicKey(value json.RawMessage) error {
 		return fmt.Errorf("%w: failed to parse public key: %w", ErrValidationRuleFailed, err)
 	}
 
-	return fmt.Errorf("%w: wrong public key format: please, convert it to openssh format using command like ssh-keygen -i -f key.ssh2 > key.pub", ErrValidationRuleFailed)
+	return fmt.Errorf("%w: wrong public key format: please convert it to openssh format using a command like ssh-keygen -i -f key.ssh2 > key.pub", ErrValidationRuleFailed)
 }

--- a/dhctl/pkg/global/errors.go
+++ b/dhctl/pkg/global/errors.go
@@ -20,5 +20,5 @@ import (
 
 var (
 	ErrConvergeInterrupted = errors.New("Interrupted.")
-	ErrNodeGroupChanged    = errors.New("Node group was changed during accept diff.")
+	ErrNodeGroupChanged    = errors.New("Node group was changed during diff acceptance.")
 )

--- a/dhctl/pkg/infrastructure/context.go
+++ b/dhctl/pkg/infrastructure/context.go
@@ -114,7 +114,7 @@ func (f *Context) getCloudProvider(ctx context.Context, metaConfig *config.MetaC
 	getter := f.CloudProviderGetter()
 	if getter == nil {
 		return nil, fmt.Errorf(
-			"Failed to get cloud provider for %s/%s/%s. Cloud providerGetter should set",
+			"Failed to get cloud provider for %s/%s/%s. Cloud provider getter must be set",
 			metaConfig.ClusterPrefix,
 			uuid,
 			metaConfig.ProviderName,

--- a/dhctl/pkg/infrastructure/controller/cluster.go
+++ b/dhctl/pkg/infrastructure/controller/cluster.go
@@ -89,7 +89,7 @@ func (r *ClusterInfra) DestroyCluster(ctx context.Context, autoApprove bool) err
 	}
 
 	if r.globalOptions == nil {
-		log.WarnLn("GlobalOption in nil!")
+		log.WarnLn("GlobalOption is nil!")
 	}
 
 	if r.infrastructureContext == nil {

--- a/dhctl/pkg/infrastructure/controller/nodes.go
+++ b/dhctl/pkg/infrastructure/controller/nodes.go
@@ -72,7 +72,7 @@ func (r *NodeGroupInfrastructureController) DestroyNode(ctx context.Context, nam
 
 	nodeIndex, err := config.GetIndexFromNodeName(name)
 	if err != nil {
-		log.ErrorF("can't extract index from infrastructure state secret (%v), skip %s\n", err, name)
+		log.ErrorF("can't extract index from infrastructure state secret (%v), skipping %s\n", err, name)
 		return nil
 	}
 
@@ -90,7 +90,7 @@ func (r *NodeGroupInfrastructureController) DestroyNode(ctx context.Context, nam
 	}
 
 	if err := infrastructure.DestroyPipeline(ctx, nodeRunner, name); err != nil {
-		return fmt.Errorf("destroing of node %s failed: %v", name, err)
+		return fmt.Errorf("destruction of node %s failed: %v", name, err)
 	}
 
 	return nil

--- a/dhctl/pkg/infrastructure/exec/exec.go
+++ b/dhctl/pkg/infrastructure/exec/exec.go
@@ -165,7 +165,7 @@ func Exec(ctx context.Context, cmd *exec.Cmd, logger log.Logger, isDebug bool) (
 	if err != nil && exitCode != HasChangesExitCode {
 		logger.LogErrorF("Error while process exit code: %v\n", err)
 		if isDebug {
-			err = fmt.Errorf("infrastructure utility has failed in DEBUG mode, search in the output above for an error")
+			err = fmt.Errorf("infrastructure utility has failed in DEBUG mode, search the output above for an error")
 		} else {
 			err = buildExitError(exitCode, &errBuf, stderrAll, stdoutAll)
 		}

--- a/dhctl/pkg/infrastructure/pipeline.go
+++ b/dhctl/pkg/infrastructure/pipeline.go
@@ -500,7 +500,7 @@ func logDebugPlanIfNeed(ctx context.Context, r RunnerInterface, name string, des
 
 	skipMessage := func(f string, args ...any) string {
 		m := fmt.Sprintf(f, args...)
-		return fmt.Sprintf("Skip debug plan for %s: %s", targetsStr, m)
+		return fmt.Sprintf("Skipping debug plan for %s: %s", targetsStr, m)
 	}
 
 	skipDebug := func(f string, args ...any) {
@@ -526,19 +526,19 @@ func logDebugPlanIfNeed(ctx context.Context, r RunnerInterface, name string, des
 	}
 
 	if len(targets) == 0 {
-		skipDebug("pass empty targets with env %s", targetsEnv)
+		skipDebug("got empty targets from env %s", targetsEnv)
 		return
 	}
 
 	if destroy {
-		skipInfo("no out destroy plan, because it is produce only destroy changes")
+		skipInfo("no debug plan output for destroy, because it produces only destroy changes")
 		return
 	}
 
 	executorStep := string(r.GetStep())
 
 	if debugPlanStep != executorStep {
-		skipInfo("passed step %s not match with executor step %s", debugPlanStep, executorStep)
+		skipInfo("passed step %s does not match executor step %s", debugPlanStep, executorStep)
 		return
 	}
 
@@ -569,7 +569,7 @@ func logDebugPlanIfNeed(ctx context.Context, r RunnerInterface, name string, des
 
 	for target, output := range results {
 		fullPretty, forTarget := extractChangesStrings(target, output)
-		log.DebugF("Full debug output plan for %s:\n%s\n", targetStr(target), fullPretty)
+		log.DebugF("Full debug plan output for %s:\n%s\n", targetStr(target), fullPretty)
 		log.InfoF("Changes in plan for %s:\n%s\n", targetStr(target), forTarget)
 	}
 }
@@ -599,13 +599,13 @@ func extractChanges(target string, mapOut map[string]any) string {
 
 	changes, ok := changesRaw.([]any)
 	if !ok {
-		return fmt.Sprintf("Plan resource_changes key is not []any it is %T", changesRaw)
+		return fmt.Sprintf("Plan resource_changes key is not []any, it is %T", changesRaw)
 	}
 
 	for i, changeRaw := range changes {
 		change, ok := changeRaw.(map[string]any)
 		if !ok {
-			msg := fmt.Sprintf("Plan resource_changes key index %d for %s is not map[string]any it is %T", i, target, changesRaw)
+			msg := fmt.Sprintf("Plan resource_changes key index %d for %s is not map[string]any, it is %T", i, target, changesRaw)
 			log.DebugF("%s\n", msg)
 			continue
 		}
@@ -619,7 +619,7 @@ func extractChanges(target string, mapOut map[string]any) string {
 
 		addressStr, ok := address.(string)
 		if !ok {
-			msg := fmt.Sprintf("Plan resource_changes key index %d for %s address is not string it is %T", i, target, address)
+			msg := fmt.Sprintf("Plan resource_changes key index %d for %s address is not a string, it is %T", i, target, address)
 			log.DebugF("%s\n", msg)
 			continue
 		}

--- a/dhctl/pkg/infrastructure/runner.go
+++ b/dhctl/pkg/infrastructure/runner.go
@@ -438,21 +438,21 @@ func (r *Runner) Apply(ctx context.Context) error {
 			return err
 		}
 		if skip {
-			r.logger.LogInfoLn("Skip infrastructure apply.")
+			r.logger.LogInfoLn("Skipping infrastructure apply.")
 			return nil
 		}
 
 		if !govalue.IsNil(r.stateChecker) {
 			err = r.logger.LogProcessCtx(ctx, "default", "infrastructure state check before apply...", func(ctx context.Context) error {
 				if r.statePath == "" {
-					log.InfoF("Infrastructure state path is empty. Skip infrastructure state check.\n")
+					log.InfoF("Infrastructure state path is empty. Skipping infrastructure state check.\n")
 					return nil
 				}
 
 				st, err := os.ReadFile(r.statePath)
 				if err != nil {
 					if os.IsNotExist(err) {
-						log.DebugF("File %s with state not found, Probably call apply with new resource. Skip check.\n", r.statePath)
+						log.DebugF("State file %s not found, probably applying with a new resource. Skipping check.\n", r.statePath)
 						return nil
 					}
 					return err
@@ -574,7 +574,7 @@ func (r *Runner) DebugPlanTarget(ctx context.Context, destroy bool, step, target
 
 	if destroy {
 		log.InfoF(
-			"Skip getting debug plan for destroy: passed step %s; executor step %s; target '%s'\n",
+			"Skipping debug plan for destroy: passed step %s; executor step %s; target '%s'\n",
 			step,
 			executorStep,
 			target,
@@ -584,7 +584,7 @@ func (r *Runner) DebugPlanTarget(ctx context.Context, destroy bool, step, target
 
 	if step != executorStep || target == "" {
 		log.InfoF(
-			"Skip getting debug plan for: passed step %s; executor step %s; target '%s'\n",
+			"Skipping debug plan: passed step %s; executor step %s; target '%s'\n",
 			step,
 			executorStep,
 			target,
@@ -642,7 +642,7 @@ func (r *Runner) GetInfrastructureOutput(ctx context.Context, output string) ([]
 	}
 
 	if r.statePath == "" {
-		return nil, fmt.Errorf("No state found, try to run infastructure apply first")
+		return nil, fmt.Errorf("No state found, try running infrastructure apply first")
 	}
 
 	var result []byte
@@ -676,7 +676,7 @@ func (r *Runner) Destroy(ctx context.Context) error {
 	}
 
 	if r.statePath == "" {
-		return fmt.Errorf("No state found, try to run infrastructure apply first")
+		return fmt.Errorf("No state found, try running infrastructure apply first")
 	}
 
 	if r.changeSettings.AutoDismissChanges {
@@ -698,7 +698,7 @@ func (r *Runner) Destroy(ctx context.Context) error {
 		return 0, err
 	})
 	if err != nil {
-		return fmt.Errorf("Cannot prepare terrafrom destroy plan: %w", err)
+		return fmt.Errorf("Cannot prepare terraform destroy plan: %w", err)
 	}
 
 	if !r.changeSettings.AutoApprove {
@@ -807,7 +807,7 @@ func (r *Runner) Stop() {
 
 func (r *Runner) execInfrastructureUtility(ctx context.Context, executor func(ctx context.Context) (int, error)) (int, error) {
 	if r.checkInfrastructureUtilityIsRunning() {
-		return 0, fmt.Errorf("Infrastructure utility have been already executed.")
+		return 0, fmt.Errorf("Infrastructure utility has already been executed.")
 	}
 
 	r.switchInfrastructureUtilityIsRunning()

--- a/dhctl/pkg/infrastructure/runner_test.go
+++ b/dhctl/pkg/infrastructure/runner_test.go
@@ -349,7 +349,7 @@ func TestConcurrentExec(t *testing.T) {
 		return exec.Plan(ctx, PlanOpts{})
 	})
 
-	require.Equal(t, "Infrastructure utility have been already executed.", err.Error())
+	require.Equal(t, "Infrastructure utility has already been executed.", err.Error())
 }
 
 var destructivelyChanged = &plan.DestructiveChanges{

--- a/dhctl/pkg/infrastructure/terraform/executor.go
+++ b/dhctl/pkg/infrastructure/terraform/executor.go
@@ -141,7 +141,7 @@ func (e *Executor) Apply(ctx context.Context, opts infrastructure.ApplyOpts) err
 
 func (e *Executor) Plan(ctx context.Context, opts infrastructure.PlanOpts) (int, error) {
 	if opts.Target != "" {
-		return 1, fmt.Errorf("Cannot run plan with target '%s' for terraform. It does not support", opts.Target)
+		return 1, fmt.Errorf("Cannot run plan with target '%s' for terraform: targets are not supported", opts.Target)
 	}
 
 	args := []string{
@@ -215,7 +215,7 @@ func (e *Executor) SetExecutorLogger(logger log.Logger) {
 }
 
 func (e *Executor) Stop() {
-	log.DebugF("Interrupt terraform process by pid: %d\n", e.cmd.Process.Pid)
+	log.DebugF("Interrupting terraform process with pid: %d\n", e.cmd.Process.Pid)
 
 	// 1. Terraform exits immediately on SIGTERM, so SIGINT is used here
 	//    to interrupt it gracefully even when main process caught the SIGTERM.

--- a/dhctl/pkg/infrastructure/tofu/executor.go
+++ b/dhctl/pkg/infrastructure/tofu/executor.go
@@ -257,7 +257,7 @@ func (e *Executor) SetExecutorLogger(logger log.Logger) {
 }
 
 func (e *Executor) Stop() {
-	log.DebugF("Interrupt tofu process by pid: %d\n", e.cmd.Process.Pid)
+	log.DebugF("Interrupting tofu process with pid: %d\n", e.cmd.Process.Pid)
 
 	// 1. Tofu exits immediately on SIGTERM, so SIGINT is used here
 	//    to interrupt it gracefully even when main process caught the SIGTERM.

--- a/dhctl/pkg/infrastructureprovider/cloud/fsprovider/di.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/fsprovider/di.go
@@ -37,7 +37,7 @@ func isDir(dir, errPrefix string) error {
 	}
 
 	if !fs.IsDirExists(dir) {
-		return fmt.Errorf("%s dir '%s' is empty or does not exists", errPrefix, dir)
+		return fmt.Errorf("%s dir '%s' is empty or does not exist", errPrefix, dir)
 	}
 
 	return nil
@@ -62,11 +62,11 @@ func isFile(file, errPrefix string) error {
 
 	stat, err := os.Stat(file)
 	if err != nil {
-		return fmt.Errorf("%s file '%s' does not exist or got another fs error: %w", errPrefix, file, err)
+		return fmt.Errorf("%s file '%s' does not exist or another fs error occurred: %w", errPrefix, file, err)
 	}
 
 	if stat.IsDir() {
-		return fmt.Errorf("%s '%s' is not file", errPrefix, file)
+		return fmt.Errorf("%s '%s' is not a file", errPrefix, file)
 	}
 
 	return nil

--- a/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/fsprovider/file_settings_provider.go
@@ -69,7 +69,7 @@ func loadOrGetStore(logger log.Logger, infraVersionsFile string) (settingsStore,
 
 	fileToSettingsStore[infraVersionsFile] = store
 
-	logger.LogDebugF("Providers settings store for terraform versions file %s loaded from file and add to cache\n", infraVersionsFile)
+	logger.LogDebugF("Providers settings store for terraform versions file %s loaded from file and added to cache\n", infraVersionsFile)
 
 	return store, nil
 }
@@ -181,7 +181,7 @@ func loadTerraformVersionFileSettings(filename string, logger log.Logger) (setti
 
 	for name, rawSettings := range infrastructureProviders {
 		if _, ok := noneProviderKeys[name]; ok {
-			logger.LogDebugF("Found not provider name key %s\n", name)
+			logger.LogDebugF("Found non-provider-name key %s\n", name)
 			continue
 		}
 

--- a/dhctl/pkg/infrastructureprovider/cloud/fsprovider/modules.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/fsprovider/modules.go
@@ -87,7 +87,7 @@ func (p *modulesProvider) copyDir(dir string, params cloud.DownloadModulesParams
 	stat, err := os.Stat(sourceDir)
 	if err != nil {
 		if os.IsNotExist(err) && dir == infraModulesDir {
-			p.logger.LogDebugF("Coping loud-providers modules (dir %s) from %s to %s skipped. Not found\n", dir, sourceDir, destinationDir)
+			p.logger.LogDebugF("Copying cloud-providers modules (dir %s) from %s to %s skipped. Not found\n", dir, sourceDir, destinationDir)
 			return nil
 		}
 
@@ -95,20 +95,20 @@ func (p *modulesProvider) copyDir(dir string, params cloud.DownloadModulesParams
 	}
 
 	if !stat.IsDir() {
-		return fmt.Errorf("Coping cloud-providers modules (dir %s) from %s to %s failed is not dir", dir, sourceDir, destinationDir)
+		return fmt.Errorf("Copying cloud-providers modules (dir %s) from %s to %s failed: not a dir", dir, sourceDir, destinationDir)
 	}
 
-	p.logger.LogDebugF("Copy cloud-providers modules (dir %s) from %s to %s\n", dir, sourceDir, destinationDir)
+	p.logger.LogDebugF("Copying cloud-providers modules (dir %s) from %s to %s\n", dir, sourceDir, destinationDir)
 
 	// todo replace with os.CopyFS with go 1.25
 	err = copyFS(destinationDir, os.DirFS(sourceDir), sourceDir)
 	if errors.Is(err, fs.ErrExist) {
-		p.logger.LogDebugF("Coping loud-providers modules (dir %s) from %s to %s skipped. Exists\n", dir, sourceDir, destinationDir)
+		p.logger.LogDebugF("Copying cloud-providers modules (dir %s) from %s to %s skipped. Exists\n", dir, sourceDir, destinationDir)
 		return nil
 	}
 
 	if err != nil {
-		return fmt.Errorf("Coping cloud-providers modules (dir %s) from %s to %s failed: %w", dir, sourceDir, destinationDir, err)
+		return fmt.Errorf("Copying cloud-providers modules (dir %s) from %s to %s failed: %w", dir, sourceDir, destinationDir, err)
 	}
 
 	return nil

--- a/dhctl/pkg/infrastructureprovider/cloud/fsprovider/utils.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/fsprovider/utils.go
@@ -22,7 +22,7 @@ import (
 func checkIsExecFile(path string) error {
 	_, err := exec.LookPath(path)
 	if err != nil {
-		return fmt.Errorf("Failed to check %s of file %s. Is not executable", path, err)
+		return fmt.Errorf("Failed to check %s of file %s. It is not executable", path, err)
 	}
 
 	return nil

--- a/dhctl/pkg/infrastructureprovider/cloud/impl.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/impl.go
@@ -155,7 +155,7 @@ func (p *Provider) OutputExecutor(ctx context.Context, logger log.Logger) (infra
 	executorID := p.executorID()
 
 	if !p.settings.UseOpenTofu() {
-		p.logger.LogDebugF("Create terraform output executor for %s with id %s\n", p.String(), executorID)
+		p.logger.LogDebugF("Creating terraform output executor for %s with id %s\n", p.String(), executorID)
 		return terraform.NewOutputExecutor(terraform.OutputExecutorParams{
 			RunExecutorParams: terraform.RunExecutorParams{
 				RootDir:          rootDir,
@@ -166,7 +166,7 @@ func (p *Provider) OutputExecutor(ctx context.Context, logger log.Logger) (infra
 		}, logger)
 	}
 
-	p.logger.LogDebugF("Create opentofu output executor for %s with id %s\n", p.String(), executorID)
+	p.logger.LogDebugF("Creating opentofu output executor for %s with id %s\n", p.String(), executorID)
 
 	return tofu.NewOutputExecutor(tofu.OutputExecutorParams{
 		RunExecutorParams: tofu.RunExecutorParams{
@@ -243,7 +243,7 @@ func (p *Provider) Executor(ctx context.Context, step infrastructure.Step, logge
 	executorID := p.executorID()
 
 	if !p.settings.UseOpenTofu() {
-		p.logger.LogDebugF("Create terraform executor for %s with step %s with id %s\n", p.String(), step, executorID)
+		p.logger.LogDebugF("Creating terraform executor for %s with step %s with id %s\n", p.String(), step, executorID)
 		return terraform.NewExecutor(terraform.ExecutorParams{
 			WorkingDir: stepDir,
 			PluginsDir: pluginsDir,
@@ -258,7 +258,7 @@ func (p *Provider) Executor(ctx context.Context, step infrastructure.Step, logge
 		}, logger)
 	}
 
-	p.logger.LogDebugF("Create opentofu executor for %s with step %s with id %s\n", p.String(), step, executorID)
+	p.logger.LogDebugF("Creating opentofu executor for %s with step %s with id %s\n", p.String(), step, executorID)
 
 	return tofu.NewExecutor(tofu.ExecutorParams{
 		WorkingDir: stepDir,
@@ -313,7 +313,7 @@ func (p *Provider) logRootDir() {
 		return
 	}
 
-	p.logger.LogDebugF("Entries (%d) which root dir %s have: %s\n", len(entries), p.rootDir, strings.Join(entries, ", "))
+	p.logger.LogDebugF("Entries (%d) that root dir %s has: %s\n", len(entries), p.rootDir, strings.Join(entries, ", "))
 }
 
 func doNotCheckSourceLink(string) error {
@@ -325,7 +325,7 @@ func getVersionsFile(root string) string {
 }
 
 func (p *Provider) createLinkToRootVersionsFileInModule(dir, rootVersionFile string) error {
-	p.logger.LogDebugF("Create link to root versions file %s for module %s for %s\n", rootVersionFile, dir, p.String())
+	p.logger.LogDebugF("Creating link to root versions file %s for module %s for %s\n", rootVersionFile, dir, p.String())
 
 	fullPath := getVersionsFile(dir)
 
@@ -353,7 +353,7 @@ Versions content SHA sum is %s
 	}
 
 	if os.IsNotExist(err) {
-		p.logger.LogDebugF("Root versions file %s for %s not found. Should write\n", versionsRootFile, p.String())
+		p.logger.LogDebugF("Root versions file %s for %s not found. Should be written\n", versionsRootFile, p.String())
 		return true, nil
 	}
 
@@ -382,15 +382,15 @@ Root versions file %s
 	}
 
 	if rewriteRootVersionsFile {
-		p.logger.LogDebugF("Root versions file %s for %s needs to rewrite\n", versionsRootFile, p.String())
+		p.logger.LogDebugF("Root versions file %s for %s needs to be rewritten\n", versionsRootFile, p.String())
 
 		err = os.WriteFile(versionsRootFile, versionContent, 0o644)
 		if err != nil {
 			return fmt.Errorf("Cannot write root versions %s file for %s: %w", versionsRootFile, p.String(), err)
 		}
-		p.logger.LogDebugF("Root versions file %s for %s wrote\n", versionsRootFile, p.String())
+		p.logger.LogDebugF("Root versions file %s for %s written\n", versionsRootFile, p.String())
 	} else {
-		p.logger.LogDebugF("Root versions file %s for %s does not need to rewrite\n", versionsRootFile, p.String())
+		p.logger.LogDebugF("Root versions file %s for %s does not need to be rewritten\n", versionsRootFile, p.String())
 	}
 
 	if err := p.createLinkToRootVersionsFileInModule(stepDir, versionsRootFile); err != nil {
@@ -398,7 +398,7 @@ Root versions file %s
 	}
 
 	if !fsutils.IsDirExists(modulesDir) {
-		p.logger.LogDebugF("Modules dir %s for %s does not exist. Skip create links to root version file\n", modulesDir, p.String())
+		p.logger.LogDebugF("Modules dir %s for %s does not exist. Skipping creation of links to root versions file\n", modulesDir, p.String())
 		return nil
 	}
 
@@ -444,14 +444,14 @@ func (p *Provider) makeRootDir(errPrefix string) error {
 func (p *Provider) downloadModules(ctx context.Context, rootDir string) (string, error) {
 	destination := filepath.Join(rootDir, "modules")
 
-	p.logger.LogDebugF("Create modules destination %s for %s\n", destination, p.String())
+	p.logger.LogDebugF("Creating modules destination %s for %s\n", destination, p.String())
 
 	err := os.MkdirAll(destination, 0o777)
 	if err != nil {
 		return "", fmt.Errorf("Cannot create destination modules dir %s for %s: %w", destination, p.String(), err)
 	}
 
-	p.logger.LogDebugF("Download modules config %s for %s\n", destination, p.String())
+	p.logger.LogDebugF("Downloading modules config %s for %s\n", destination, p.String())
 
 	err = p.di.ModulesProvider.DownloadModules(ctx, DownloadModulesParams{
 		ModulesParams{
@@ -476,7 +476,7 @@ func (p *Provider) downloadPluginVersion(ctx context.Context, rootDir, version s
 	// for windows
 	destinationDir = strings.TrimRight(destinationDir, "\\")
 
-	p.logger.LogDebugF("Create plugins dir destination %s for %s version %s\n", destinationDir, p.String(), version)
+	p.logger.LogDebugF("Creating plugins dir destination %s for %s version %s\n", destinationDir, p.String(), version)
 
 	err := os.MkdirAll(destinationDir, 0o755)
 	if err != nil {
@@ -562,7 +562,7 @@ func (p *Provider) Cleanup() error {
 
 	if p.isDebug {
 		p.logger.LogInfoF(
-			"Cloud %s was not cleaned up because you use debug mode. Root dir is: '%s'. If need cleanup manually.\n",
+			"Cloud %s was not cleaned up because you are using debug mode. Root dir is: '%s'. Clean up manually if needed.\n",
 			p.String(),
 			rootDir,
 		)

--- a/dhctl/pkg/infrastructureprovider/cloud/kubernetes/manifest.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/kubernetes/manifest.go
@@ -28,13 +28,13 @@ func IsManifest(change plan.ChangeOp, kind string, logger log.Logger) bool {
 func extractManifestKind(state map[string]interface{}, logger log.Logger) string {
 	v, ok := state["manifest"]
 	if !ok || v == nil {
-		logger.LogDebugF("State does not have a manifest. Returns empty kind\n")
+		logger.LogDebugF("State does not have a manifest. Returning empty kind\n")
 		return ""
 	}
 
 	mv, ok := v.(map[string]any)
 	if !ok {
-		logger.LogDebugF("manifest is not a map. Returns empty kind\n")
+		logger.LogDebugF("manifest is not a map. Returning empty kind\n")
 		return ""
 	}
 	if kind, ok := mv["kind"].(string); ok {
@@ -42,6 +42,6 @@ func extractManifestKind(state map[string]interface{}, logger log.Logger) string
 		return kind
 	}
 
-	logger.LogDebugF("manifest does not have a kind. Returns empty kind\n")
+	logger.LogDebugF("manifest does not have a kind. Returning empty kind\n")
 	return ""
 }

--- a/dhctl/pkg/infrastructureprovider/cloud/vcd/version.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/vcd/version.go
@@ -101,11 +101,11 @@ func versionConstraintAction(apiVersion string, logger log.Logger, action func(l
 	}
 
 	if versionConstraint.Check(ver) {
-		logger.LogDebugF("Use legacy VCD version %s (%s). Use legacy mode as true\n", ver, versionConstraintStr)
+		logger.LogDebugF("Using legacy VCD version %s (%s). Using legacy mode (true)\n", ver, versionConstraintStr)
 		return action(true)
 	}
 
-	logger.LogDebugF("Use latest VCD version %s (%s)e\n", ver, versionConstraintStr)
+	logger.LogDebugF("Using latest VCD version %s (%s)\n", ver, versionConstraintStr)
 	return action(false)
 }
 

--- a/dhctl/pkg/infrastructureprovider/cloud/versions_content.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/versions_content.go
@@ -42,13 +42,13 @@ func DefaultVersionContentProvider(s settings.ProviderSettings, provider string,
 		return versionContentProvider
 	}
 
-	logger.LogDebugF("No custom version choicer for provider %s. Use default\n", provider)
+	logger.LogDebugF("No custom version choicer for provider %s. Using default\n", provider)
 
 	return func(_ context.Context, settings settings.ProviderSettings, _ *config.MetaConfig, _ log.Logger) ([]byte, string, error) {
 		versions := settings.Versions()
 		l := len(versions)
 		if l != 1 {
-			return nil, "", fmt.Errorf("No one version (%d) found for provider %s", l, provider)
+			return nil, "", fmt.Errorf("Expected exactly one version, but found %d for provider %s", l, provider)
 		}
 
 		v := versions[0]

--- a/dhctl/pkg/infrastructureprovider/cloud/yandex/preparator.go
+++ b/dhctl/pkg/infrastructureprovider/cloud/yandex/preparator.go
@@ -104,7 +104,7 @@ func (p *MetaConfigPreparator) validateNodeGroups(metaConfig *config.MetaConfig)
 	yandexNodeGroups, err := dhctljson.UnmarshalToFromMessageMap[[]nodeGroupSpec](metaConfig.ProviderClusterConfig, "nodeGroups")
 	if err != nil {
 		if errors.Is(err, dhctljson.ErrNotFound) {
-			p.logger.LogDebugLn("nodeGroups not found in provider cluster configuration. Skip validation.")
+			p.logger.LogDebugLn("nodeGroups not found in provider cluster configuration. Skipping validation.")
 			return nil
 		}
 
@@ -125,12 +125,12 @@ func (p *MetaConfigPreparator) validateNodeGroups(metaConfig *config.MetaConfig)
 func (p *MetaConfigPreparator) validateWithNATInstanceLayout(metaConfig *config.MetaConfig) error {
 	// layout was prepared with strcase.ToKebab before calling preparator
 	if metaConfig.Layout != "with-nat-instance" {
-		p.logger.LogDebugF("Skip validate WithNATInstance layout. Got layout %v\n", metaConfig.Layout)
+		p.logger.LogDebugF("Skipping WithNATInstance layout validation. Got layout %v\n", metaConfig.Layout)
 		return nil
 	}
 
 	if !p.validateWithNATLayout {
-		p.logger.LogDebugLn("Skip validate WithNATInstance layout. Validation disabled")
+		p.logger.LogDebugLn("Skipping WithNATInstance layout validation. Validation disabled")
 		return nil
 	}
 

--- a/dhctl/pkg/infrastructureprovider/cloud_provider.go
+++ b/dhctl/pkg/infrastructureprovider/cloud_provider.go
@@ -64,7 +64,7 @@ func CloudProviderGetter(params CloudProviderGetterParams) infrastructure.CloudP
 
 		if metaConfig.ProviderName == "" {
 			return providersCache.GetOrAdd(ctx, clusterUUID, metaConfig, logger, func(_ context.Context, clusterUUID string, _ *config.MetaConfig, l log.Logger) (infrastructure.CloudProvider, error) {
-				l.LogDebugF("Returns DummyCloudProvider because provider name is empty. Probably it is static cluster: %s\n", clusterUUID)
+				l.LogDebugF("Returning DummyCloudProvider because provider name is empty. Probably it is a static cluster: %s\n", clusterUUID)
 				return infrastructure.NewDummyCloudProvider(l), nil
 			})
 		}
@@ -116,7 +116,7 @@ func CloudProviderGetter(params CloudProviderGetterParams) infrastructure.CloudP
 			}
 
 			provider := cloud.NewProvider(p)
-			l.LogDebugF("Cloud %s initialized and added in cache. Root dir is %s\n", provider.String(), provider.RootDir())
+			l.LogDebugF("Cloud %s initialized and added to cache. Root dir is %s\n", provider.String(), provider.RootDir())
 
 			return provider, nil
 		})

--- a/dhctl/pkg/infrastructureprovider/cloud_providers_cache.go
+++ b/dhctl/pkg/infrastructureprovider/cloud_providers_cache.go
@@ -36,7 +36,7 @@ func CleanupProvidersFromDefaultCache(loggerProvider log.LoggerProvider) {
 	logger := log.SafeProvideLogger(loggerProvider)
 
 	for _, provider := range defaultProvidersCache.cloudProvidersCache {
-		logDebugF(logger, "CleanupProvidersFromDefaultCache called. Cleanup provider %s from default cache\n", provider.String())
+		logDebugF(logger, "CleanupProvidersFromDefaultCache called. Cleaning up provider %s from default cache\n", provider.String())
 		if err := provider.Cleanup(); err != nil {
 			logWarnF(logger, "Failed to cleanup provider %s from default cache: %v\n", provider.String(), err)
 		}
@@ -84,14 +84,14 @@ func (c *cloudProvidersMapCache) GetOrAdd(ctx context.Context, clusterUUID strin
 		}
 
 		if govalue.IsNil(provider) {
-			return nil, fmt.Errorf("Do not store nil provider for cluster %s in cache", clusterUUID)
+			return nil, fmt.Errorf("Will not store nil provider for cluster %s in cache", clusterUUID)
 		}
 
 		return provider, nil
 	}
 
 	if metaConfig.ProviderName == "" {
-		logger.LogDebugF("Do not store provider for empty provider for cluster %s probably it is static cluster and do not need any cleanup\n", clusterUUID)
+		logger.LogDebugF("Not storing provider for empty provider for cluster %s, probably it is a static cluster and does not need any cleanup\n", clusterUUID)
 		return create(ctx, clusterUUID, metaConfig, logger)
 	}
 
@@ -101,7 +101,7 @@ func (c *cloudProvidersMapCache) GetOrAdd(ctx context.Context, clusterUUID strin
 	cacheKey := getKey(clusterUUID, metaConfig)
 
 	if c.finalized {
-		return nil, fmt.Errorf("Cache finalized! Do not add provider for cluster wit key %s to finalized cache!", cacheKey)
+		return nil, fmt.Errorf("Cache finalized! Cannot add provider for cluster with key %s to a finalized cache!", cacheKey)
 	}
 
 	c.cloudProvidersCacheMutex.Lock()
@@ -109,7 +109,7 @@ func (c *cloudProvidersMapCache) GetOrAdd(ctx context.Context, clusterUUID strin
 
 	cachedProvider, ok := c.cloudProvidersCache[cacheKey]
 	if ok {
-		logger.LogDebugF("Found existing provider for cluster %s in cache by key %s. Returns from cache\n", cachedProvider.String(), cacheKey)
+		logger.LogDebugF("Found existing provider for cluster %s in cache by key %s. Returning from cache\n", cachedProvider.String(), cacheKey)
 		return cachedProvider, nil
 	}
 
@@ -124,7 +124,7 @@ func (c *cloudProvidersMapCache) GetOrAdd(ctx context.Context, clusterUUID strin
 
 		p, ok := c.cloudProvidersCache[cacheKey]
 		if !ok {
-			l.LogDebugF("Provider with key %s not found. Skip cleaning\n", cacheKey)
+			l.LogDebugF("Provider with key %s not found. Skipping cleanup\n", cacheKey)
 			return
 		}
 
@@ -139,14 +139,14 @@ func (c *cloudProvidersMapCache) GetOrAdd(ctx context.Context, clusterUUID strin
 	provider.AddAfterCleanupFunc("zCloudProviderCacheCleaner", afterCleanup)
 
 	c.cloudProvidersCache[cacheKey] = provider
-	logger.LogDebugF("Store %s in cache with key %s\n", provider.String(), cacheKey)
+	logger.LogDebugF("Storing %s in cache with key %s\n", provider.String(), cacheKey)
 
 	return provider, nil
 }
 
 func (c *cloudProvidersMapCache) Get(clusterUUID string, metaConfig *config.MetaConfig, logger log.Logger) (infrastructure.CloudProvider, bool, error) {
 	if metaConfig.ProviderName == "" {
-		logger.LogDebugF("Do not store provider for cluster %s in cache with empty provider name\n", clusterUUID)
+		logger.LogDebugF("Not storing provider for cluster %s in cache with empty provider name\n", clusterUUID)
 		return nil, false, nil
 	}
 
@@ -156,7 +156,7 @@ func (c *cloudProvidersMapCache) Get(clusterUUID string, metaConfig *config.Meta
 	defer c.finalizedMutex.Unlock()
 
 	if c.finalized {
-		return nil, false, fmt.Errorf("Cache finalized! Do not get provider with key %s to finalized cache!", cacheKey)
+		return nil, false, fmt.Errorf("Cache finalized! Cannot get provider with key %s from a finalized cache!", cacheKey)
 	}
 
 	c.cloudProvidersCacheMutex.Lock()
@@ -173,7 +173,7 @@ func (c *cloudProvidersMapCache) Get(clusterUUID string, metaConfig *config.Meta
 		return nil, false, nil
 	}
 
-	logger.LogDebugF("Found existing provider for cluster %s in cache by key %s. Returns it.\n", provider.String(), cacheKey)
+	logger.LogDebugF("Found existing provider for cluster %s in cache by key %s. Returning it.\n", provider.String(), cacheKey)
 
 	return provider, true, nil
 }
@@ -183,7 +183,7 @@ func (c *cloudProvidersMapCache) IterateOverCache(f CloudProvidersCacheIteratorF
 	defer c.finalizedMutex.Unlock()
 
 	if c.finalized {
-		return fmt.Errorf("Cache finalized! Do not iterate over cache!")
+		return fmt.Errorf("Cache finalized! Cannot iterate over a finalized cache!")
 	}
 
 	c.cloudProvidersCacheMutex.Lock()

--- a/dhctl/pkg/infrastructureprovider/provider_getter_params.go
+++ b/dhctl/pkg/infrastructureprovider/provider_getter_params.go
@@ -114,15 +114,15 @@ func (p *CloudProviderGetterParams) setVersionsContentProviderGetter(di *cloud.P
 	}
 
 	if di.VersionsContentProviderGetter != nil {
-		logger.LogDebugF("fs.GetDI provider our own VersionProviderGetter\n")
+		logger.LogDebugF("fs.GetDI provided our own VersionProviderGetter\n")
 		return nil
 	}
 
 	versionProviderGetter := cloud.DefaultVersionContentProvider
-	logMessage := "Use default VersionProviderGetter\n"
+	logMessage := "Using default VersionProviderGetter\n"
 
 	if p.VersionProviderGetter != nil {
-		logMessage = "Use custom VersionProviderGetter\n"
+		logMessage = "Using custom VersionProviderGetter\n"
 		versionProviderGetter = p.VersionProviderGetter
 	}
 
@@ -139,7 +139,7 @@ func (p *CloudProviderGetterParams) getTmpDir() (string, error) {
 	}
 
 	tmpDir := p.TmpDir
-	logMsg := "Use passed tmp dir."
+	logMsg := "Using passed tmp dir."
 	if tmpDir == "" {
 		tmpDir = options.DefaultTmpDir()
 		logMsg = "CloudProviderGetterParams tmp dir is empty. Using default."
@@ -150,7 +150,7 @@ func (p *CloudProviderGetterParams) getTmpDir() (string, error) {
 		return "", fmt.Errorf("Cannot prepare tmp dir %s: %w", tmpDir, err)
 	}
 
-	logger.LogDebugF("%s Before prepare '%s' Absolute path '%s'\n", logMsg, tmpDir, preparedTmpDir)
+	logger.LogDebugF("%s Before preparation: '%s', absolute path: '%s'\n", logMsg, tmpDir, preparedTmpDir)
 
 	return preparedTmpDir, nil
 }

--- a/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/converge.go
@@ -209,7 +209,7 @@ func (t *taskProviderForCluster) Static(ctx context.Context, metaConfig *config.
 
 	if len(staticClusterConfig) == 0 {
 		// static cluster configuration can be empty because we have auto discovering interfaces
-		log.DebugLn("No static cluster configuration section found. Rewrite with empty data because we have auto discovery")
+		log.DebugLn("No static cluster configuration section found. Rewriting with empty data because we have auto discovery")
 	}
 
 	const secretName = "d8-static-cluster-configuration"

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -312,7 +312,7 @@ func WaitForPVDeletion(ctx context.Context, kubeCl *client.KubernetesClient) err
 			for _, item := range skipPVs {
 				fmt.Fprintf(&skipPVsInfo, "\t\t%s | %s\n", item.Name, item.Status.Phase)
 			}
-			log.InfoF("%d PersistentVolumes provided manually or with reclaimPolicy other than Delete was skipped.\n%s\n", skipPVsCount, strings.TrimSuffix(skipPVsInfo.String(), "\n"))
+			log.InfoF("%d PersistentVolumes provided manually or with a reclaimPolicy other than Delete were skipped.\n%s\n", skipPVsCount, strings.TrimSuffix(skipPVsInfo.String(), "\n"))
 		}
 
 		count := len(filteredResources)

--- a/dhctl/pkg/kubernetes/actions/deckhouse/log.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/log.go
@@ -39,9 +39,9 @@ var (
 	ErrListPods      = errors.New("No Deckhouse pod found.")
 	ErrReadLease     = errors.New("No Deckhouse leader election lease found.")
 	ErrBadLease      = errors.New("Deckhouse leader election lease is malformed.")
-	ErrTimedOut      = errors.New("Time is out waiting for Deckhouse readiness.")
-	ErrRequestFailed = errors.New("Request failed. Probably pod was restarted during installation.")
-	ErrIncorrectNode = errors.New("Deckhouse on wrong node")
+	ErrTimedOut      = errors.New("Timed out waiting for Deckhouse readiness.")
+	ErrRequestFailed = errors.New("Request failed. The pod was probably restarted during installation.")
+	ErrIncorrectNode = errors.New("Deckhouse is on the wrong node")
 )
 
 type logLine struct {
@@ -252,7 +252,7 @@ func (d *LogPrinter) printLogsByLine(ctx context.Context, content []byte) {
 		}
 
 		if isModuleSuccess(line) {
-			log.InfoF("\tModule %q run successfully\n", line.Module)
+			log.InfoF("\tModule %q ran successfully\n", line.Module)
 			_, span := telemetry.StartSpan(ctx, "deckhouse-module."+line.Module)
 			span.SetAttributes(otattribute.String("module", line.Module))
 			span.End()

--- a/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/module_config.go
@@ -72,7 +72,7 @@ func createModuleConfigManifestTask(kubeCl *client.KubernetesClient, mc *config.
 
 			_, err = kubeCl.Dynamic().Resource(config.ModuleConfigGVR).Create(ctx, m, metav1.CreateOptions{})
 			if err != nil {
-				log.DebugF("Do not create mc: %v\n", err)
+				log.DebugF("Not creating mc: %v\n", err)
 			}
 
 			return err
@@ -102,7 +102,7 @@ func createModuleConfigManifestTask(kubeCl *client.KubernetesClient, mc *config.
 				Dynamic().Resource(config.ModuleConfigGVR).
 				Update(ctx, newManifest, metav1.UpdateOptions{})
 			if err != nil {
-				log.InfoF("Do not updating mc: %v\n", err)
+				log.InfoF("Not updating mc: %v\n", err)
 			}
 
 			return err
@@ -150,12 +150,12 @@ func prepareDeckhouseMC(ctx context.Context, mc *config.ModuleConfig, res *Manif
 	// for preventing an updating deckhouse during bootstrap process
 	// for example, we are installing v1.66 tag but in release channel we have v1.67 tag
 
-	log.DebugLn("Found deckhouse mc. Try to prepare...")
+	log.DebugLn("Found deckhouse mc. Trying to prepare...")
 
 	releaseChannel := ""
 	releaseChannelRaw, hasReleaseChannelKey := mc.Spec.Settings["releaseChannel"]
 	if rc, ok := releaseChannelRaw.(string); hasReleaseChannelKey && ok {
-		log.DebugLn("Found releaseChannel in mc deckhouse. Remove it from mc")
+		log.DebugLn("Found releaseChannel in mc deckhouse. Removing it from mc")
 		// we need set releaseChannel after bootstrapping process done
 		// to prevent update during bootstrap
 		delete(mc.Spec.Settings, "releaseChannel")
@@ -163,7 +163,7 @@ func prepareDeckhouseMC(ctx context.Context, mc *config.ModuleConfig, res *Manif
 	}
 
 	if releaseChannel == "" {
-		log.DebugLn("Not found releaseChannel in mc deckhouse. Finish preparing")
+		log.DebugLn("releaseChannel not found in mc deckhouse. Finished preparing")
 		return
 	}
 
@@ -183,43 +183,43 @@ func prepareGlobalMC(ctx context.Context, mc *config.ModuleConfig, res *Manifest
 	// and deckhouse cannot found this secret and cloud permanent nodes will not bootstrap
 	// because deckhouse stuck in error and it cannot create manual-for-bootstrap secrets
 
-	log.DebugLn("Found global mc. Try to prepare...")
+	log.DebugLn("Found global mc. Trying to prepare...")
 
 	var httpsSettings map[string]interface{}
 
 	modulesRaw, hasModules := mc.Spec.Settings["modules"]
 	if !hasModules {
-		log.DebugLn("Not found modules in global mc. Finish preparing")
+		log.DebugLn("modules not found in global mc. Finished preparing")
 		return
 	}
 
 	modules, ok := modulesRaw.(map[string]interface{})
 	if !ok {
-		log.ErrorLn("modules is not map in global mc. Finish preparing")
+		log.ErrorLn("modules is not a map in global mc. Finished preparing")
 		return
 	}
 
 	HTTPSRaw, hasHTTPS := modules["https"]
 	if !hasHTTPS {
-		log.DebugLn("Not found https in global mc. Finish preparing")
+		log.DebugLn("https not found in global mc. Finished preparing")
 		return
 	}
 
 	httpsSettings, ok = HTTPSRaw.(map[string]interface{})
 	if !ok {
-		log.ErrorLn("https is not map in global mc. Finish preparing")
+		log.ErrorLn("https is not a map in global mc. Finished preparing")
 		return
 	}
 
 	if httpsSettings == nil {
-		log.DebugLn("Not found httpsSettings in mc deckhouse. Finish preparing")
+		log.DebugLn("httpsSettings not found in mc deckhouse. Finished preparing")
 		return
 	}
 
-	log.DebugLn("Found https in global mc deckhouse. Remove it from mc")
+	log.DebugLn("Found https in global mc deckhouse. Removing it from mc")
 	delete(modules, "https")
 	if len(modules) == 0 {
-		log.DebugLn("modules in global mc is empty. Remove it from mc")
+		log.DebugLn("modules in global mc is empty. Removing it from mc")
 		delete(mc.Spec.Settings, "modules")
 	}
 

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -334,7 +334,7 @@ func WaitForNodesListBecomeReady(ctx context.Context, kubeCl *client.KubernetesC
 								var err error
 								ready, err = checker.IsReady(ctx, node.Name)
 								if err != nil {
-									log.InfoF("While doing check '%s' node %s has error: %v\n", checker.Name(), node.Name, err)
+									log.InfoF("While performing check '%s', node %s returned an error: %v\n", checker.Name(), node.Name, err)
 								} else if !ready {
 									log.InfoF("Node %s is ready but %s is not ready\n", node.Name, checker.Name())
 								}

--- a/dhctl/pkg/kubernetes/actions/entity/node_user.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user.go
@@ -184,7 +184,7 @@ func (w *NodeUserPresentsWaiter) WaitPresentOnNodes(ctx context.Context, nodeUse
 
 			if len(nodesForClient.Items) == 0 {
 				return fmt.Errorf(
-					"NodeUser '%s' is not present on nodes yet. No any node found for selector '%s'",
+					"NodeUser '%s' is not present on nodes yet. No node found for selector '%s'",
 					nodeUserName,
 					listOpts.LabelSelector,
 				)

--- a/dhctl/pkg/kubernetes/actions/resources/readiness/by_phase.go
+++ b/dhctl/pkg/kubernetes/actions/resources/readiness/by_phase.go
@@ -44,7 +44,7 @@ func (s *ByPhaseChecker) WaitAttemptsBeforeCheck() int {
 
 func (s *ByPhaseChecker) IsReady(_ context.Context, resource *unstructured.Unstructured, resourceName string) (bool, error) {
 	if len(s.phaseValues) == 0 {
-		return false, fmt.Errorf("Internal error. No phase for check defined for resource %s", resourceName)
+		return false, fmt.Errorf("Internal error. No check phase defined for resource %s", resourceName)
 	}
 
 	logger := log.SafeProvideLogger(s.loggerProvider)

--- a/dhctl/pkg/kubernetes/actions/resources/readiness/cast.go
+++ b/dhctl/pkg/kubernetes/actions/resources/readiness/cast.go
@@ -100,6 +100,6 @@ func castErrorFuncForResource(resourceName, additionalMsg string) castErrorFunc 
 			msg = fmt.Sprintf("%s (%s)", msg, additionalMsg)
 		}
 
-		return false, fmt.Errorf("Cannot check resource %s readiness because cannot cast %s to %s", resourceName, msg, kind)
+		return false, fmt.Errorf("Cannot check resource %s readiness because it cannot cast %s to %s", resourceName, msg, kind)
 	}
 }

--- a/dhctl/pkg/kubernetes/actions/resources/readiness/checker.go
+++ b/dhctl/pkg/kubernetes/actions/resources/readiness/checker.go
@@ -39,7 +39,7 @@ type GetCheckerParams struct {
 
 func GetCheckerByGvk(gvk *schema.GroupVersionKind, params GetCheckerParams) (ResourceChecker, error) {
 	if gvk.Empty() {
-		return nil, fmt.Errorf("Cannot get check by gvk: cannot be empty")
+		return nil, fmt.Errorf("Cannot get checker by gvk: gvk cannot be empty")
 	}
 
 	kind := gvk.Kind

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -119,7 +119,7 @@ func (c *Creator) createAll(ctx context.Context) error {
 
 	for indx, resource := range c.resources {
 		if _, shouldSkip := resourcesToSkipInCurrentIteration[indx]; shouldSkip {
-			log.DebugF("Resource %s with index % should skip to create in current iteration because namespace is not existed\n", resource.String())
+			log.DebugF("Resource %s with index % should be skipped from creation in the current iteration because the namespace does not exist\n", resource.String())
 			continue
 		}
 
@@ -162,7 +162,7 @@ func (c *Creator) ensureRequiredNamespacesExist(ctx context.Context) (map[int]st
 				// we can receive empty name space when user want to deploy in 'default' ns
 				// we keep it in our minds and skip verify therese resources because we think that
 				// default namespace always exist
-				log.DebugF("Namespace is empty for resource %s. Skip ns checking\n", res.String())
+				log.DebugF("Namespace is empty for resource %s. Skipping ns check\n", res.String())
 				continue
 			}
 
@@ -173,9 +173,9 @@ func (c *Creator) ensureRequiredNamespacesExist(ctx context.Context) (map[int]st
 					// if ns is existed then we will skip only
 					// if ns is not exists we should skip resource on current iteration and try to create on next iteration
 					resourcesToSkipInCurrentIteration[i] = struct{}{}
-					log.DebugF("Namespace not found but processed for resource %s. Adding skip to create resource in current iteration\n", res.String())
+					log.DebugF("Namespace not found but already processed for resource %s. Skipping resource creation in the current iteration\n", res.String())
 				}
-				log.DebugF("Namespace was processed for resource %s. Skip ns checking\n", res.String())
+				log.DebugF("Namespace was processed for resource %s. Skipping ns check\n", res.String())
 				continue
 			}
 
@@ -403,7 +403,7 @@ func CreateResourcesLoop(
 				)
 			}
 
-			return fmt.Errorf("Creating resources failed after %s waiting", timeout)
+			return fmt.Errorf("Creating resources failed after waiting %s", timeout)
 		case <-ticker.C:
 		}
 		attempt++

--- a/dhctl/pkg/kubernetes/kube.go
+++ b/dhctl/pkg/kubernetes/kube.go
@@ -34,7 +34,7 @@ type LabelSelector struct {
 
 func GetLabelSelector(selectors []LabelSelector) (string, error) {
 	if len(selectors) == 0 {
-		return "", fmt.Errorf("Pass empty label selectors to GetLabelSelector")
+		return "", fmt.Errorf("empty label selectors passed to GetLabelSelector")
 	}
 
 	requirements := make([]labels.Requirement, 0, len(selectors))

--- a/dhctl/pkg/kubernetes/lease/lock.go
+++ b/dhctl/pkg/kubernetes/lease/lock.go
@@ -121,7 +121,7 @@ func (l *LeaseLock) Lock(ctx context.Context, force bool) error {
 func (l *LeaseLock) IsLocked(ctx context.Context, checkStillLocked bool) (bool, error) {
 	kubeClient, err := l.getter.KubeClientCtx(ctx)
 	if err != nil {
-		return false, fmt.Errorf("Could not get kube client: %w", err)
+		return false, fmt.Errorf("could not get kube client: %w", err)
 	}
 	lease, err := kubeClient.CoordinationV1().Leases(l.config.Namespace).Get(ctx, l.config.Name, metav1.GetOptions{})
 	if err != nil {
@@ -129,7 +129,7 @@ func (l *LeaseLock) IsLocked(ctx context.Context, checkStillLocked bool) (bool, 
 			return false, nil
 		}
 
-		return false, fmt.Errorf("Can't get current lease %v", err)
+		return false, fmt.Errorf("can't get current lease: %v", err)
 	}
 
 	if !checkStillLocked {
@@ -164,7 +164,7 @@ func (l *LeaseLock) Unlock(ctx context.Context) {
 		return err
 	})
 	if err != nil {
-		log.Error("Error while Unlock lease %v", err)
+		log.Error("Error while unlocking lease %v", err)
 	}
 
 	l.lease = nil
@@ -212,7 +212,7 @@ func (l *LeaseLock) tryAcquire(ctx context.Context, force bool) (*coordinationv1
 
 	kubeClient, err := l.getter.KubeClientCtx(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get kube client: %w", err)
+		return nil, fmt.Errorf("could not get kube client: %w", err)
 	}
 
 	acquireRetries := l.config.RenewRetries()
@@ -226,7 +226,7 @@ func (l *LeaseLock) tryAcquire(ctx context.Context, force bool) (*coordinationv1
 		if errors.IsAlreadyExists(err) {
 			lease, err = kubeClient.CoordinationV1().Leases(l.config.Namespace).Get(ctx, l.config.Name, metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("%s Can't get current lease %v", prefix, err)
+				return fmt.Errorf("%s Can't get current lease: %v", prefix, err)
 			}
 
 			lease, err = l.tryRenew(ctx, lease, force)
@@ -265,7 +265,7 @@ func (l *LeaseLock) createLease(ctx context.Context) (*coordinationv1.Lease, err
 
 	kubeClient, err := l.getter.KubeClientCtx(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get kube client: %w", err)
+		return nil, fmt.Errorf("could not get kube client: %w", err)
 	}
 
 	return kubeClient.CoordinationV1().Leases(l.config.Namespace).Create(ctx, lease, metav1.CreateOptions{})
@@ -273,11 +273,11 @@ func (l *LeaseLock) createLease(ctx context.Context) (*coordinationv1.Lease, err
 
 func (l *LeaseLock) tryRenew(ctx context.Context, lease *coordinationv1.Lease, force bool) (*coordinationv1.Lease, error) {
 	if lease == nil {
-		return nil, fmt.Errorf("Lease is nil")
+		return nil, fmt.Errorf("lease is nil")
 	}
 
 	if lease.Spec.HolderIdentity == nil {
-		return nil, fmt.Errorf("Lease holder identity is nil")
+		return nil, fmt.Errorf("lease holder identity is nil")
 	}
 
 	if *lease.Spec.HolderIdentity != l.config.Identity {
@@ -293,14 +293,14 @@ func (l *LeaseLock) tryRenew(ctx context.Context, lease *coordinationv1.Lease, f
 		if lease.Spec.RenewTime != nil {
 			renewTime = lease.Spec.RenewTime.Time.String()
 		}
-		log.Warn("Lease finished, try to renew lease", slog.String("identity", l.config.Identity), slog.String("renew_time", renewTime))
+		log.Warn("Lease finished, trying to renew lease", slog.String("identity", l.config.Identity), slog.String("renew_time", renewTime))
 	}
 
 	var newLease *coordinationv1.Lease
 
 	kubeClient, err := l.getter.KubeClientCtx(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Could not get kube client: %w", err)
+		return nil, fmt.Errorf("could not get kube client: %w", err)
 	}
 
 	renewRetries := l.config.RenewRetries()
@@ -407,7 +407,7 @@ func RemoveLease(ctx context.Context, kubeCl *client.KubernetesClient, config *L
 		return err
 	}
 
-	log.Info("Starting remove lease lock")
+	log.Info("Starting to remove lease lock")
 
 	err = retry.NewSilentLoop("release lease", 5, config.RetryWaitDuration).RunContext(ctx, func() error {
 		err := leasesCl.Delete(ctx, lease.Name, metav1.DeleteOptions{})

--- a/dhctl/pkg/kubernetes/lease/lock_test.go
+++ b/dhctl/pkg/kubernetes/lease/lock_test.go
@@ -48,7 +48,7 @@ func TestTryRenewNilLease(t *testing.T) {
 			lease, err := lock.tryRenew(ctx, nil, true)
 			require.Nil(t, lease)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "Lease is nil")
+			require.Contains(t, err.Error(), "lease is nil")
 		})
 	})
 }

--- a/dhctl/pkg/log/deprecated.go
+++ b/dhctl/pkg/log/deprecated.go
@@ -307,7 +307,7 @@ func extractExternalLogger(l Logger) *ExternalLogger {
 	case *DummyLogger:
 		ext = newExternalLogger(newExternalDummyLoggerWrapper(typedLogger))
 	default:
-		panic(fmt.Errorf("Incorrect type %T for extract ExternalLogger", l))
+		panic(fmt.Errorf("Incorrect type %T for extracting ExternalLogger", l))
 	}
 
 	return ext

--- a/dhctl/pkg/log/deprecated_in_memory.go
+++ b/dhctl/pkg/log/deprecated_in_memory.go
@@ -49,7 +49,7 @@ func (m *Match) IsValid() error {
 	}
 
 	if len(m.Prefix) == 0 && len(m.Suffix) == 0 {
-		return fmt.Errorf("Invalid Match: must pass Regex or Prefix or/and Suffix")
+		return fmt.Errorf("Invalid Match: must pass Regex, or Prefix and/or Suffix")
 	}
 
 	return nil

--- a/dhctl/pkg/minget/minget.go
+++ b/dhctl/pkg/minget/minget.go
@@ -41,21 +41,21 @@ func Bytes() ([]byte, error) {
 	stat, err := os.Stat(binaryPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			log.InfoF("%s not exists. Fallback to embedded minget\n", binaryPath)
+			log.InfoF("%s does not exist. Falling back to embedded minget\n", binaryPath)
 		} else {
-			log.WarnF("Failed to stat %s: %v. Fallback to embedded minget", binaryPath, err)
+			log.WarnF("Failed to stat %s: %v. Falling back to embedded minget", binaryPath, err)
 		}
 		return mingetEmbeddedBinary.ReadFile(mingetEmbeddedPath)
 	}
 
 	if stat.IsDir() {
-		log.WarnF("%s stats as directory. Fallback to embedded minget", binaryPath)
+		log.WarnF("%s is a directory. Falling back to embedded minget", binaryPath)
 		return mingetEmbeddedBinary.ReadFile(mingetEmbeddedPath)
 	}
 
 	file, err := os.ReadFile(binaryPath)
 	if err != nil {
-		log.WarnF("Failed to open %s: %v. Fallback to embedded minget", binaryPath, err)
+		log.WarnF("Failed to open %s: %v. Falling back to embedded minget", binaryPath, err)
 		return mingetEmbeddedBinary.ReadFile(mingetEmbeddedPath)
 	}
 

--- a/dhctl/pkg/module/controlplane/bootstrap.go
+++ b/dhctl/pkg/module/controlplane/bootstrap.go
@@ -119,7 +119,7 @@ func (p *BootstrapPreparator) PrepareModule(ctx context.Context) error {
 	}
 
 	if signatureMode == NoSignatureMode {
-		logger.DebugF("Provide no signature mode. Skip prepare signature")
+		logger.DebugF("No signature mode provided. Skipping signature preparation")
 		return nil
 	}
 
@@ -133,11 +133,11 @@ func (p *BootstrapPreparator) Module() string {
 }
 
 func (p *BootstrapPreparator) generateKeysAndUpload(ctx context.Context, signatureMode string) error {
-	p.loggerProvider().DebugF("Got signature mode: %s. Start preparing control-plane signature", signatureMode)
+	p.loggerProvider().DebugF("Got signature mode: %s. Starting to prepare control-plane signature", signatureMode)
 
 	certs, err := tlsutils.GenerateCertificate("signature", "apiserver", tlsutils.CertKeyTypeED25519, 365)
 	if err != nil {
-		return fmt.Errorf("Cannot generate tls certificate: %w", err)
+		return fmt.Errorf("Cannot generate TLS certificate: %w", err)
 	}
 
 	keys, err := p.generateKeys(certs, p.timeNow())
@@ -182,7 +182,7 @@ func (p *BootstrapPreparator) generateKeys(certs *tls.Certificate, now time.Time
 		return nil, fmt.Errorf("Cannot marshal private key JWK: %w", err)
 	}
 
-	logger.DebugF("Generate key for signature")
+	logger.DebugF("Generating key for signature")
 	pubKeyCert, err := x509.ParseCertificate(certs.Certificate[0])
 	if err != nil {
 		return nil, fmt.Errorf("Cannot parse certificate: %w", err)
@@ -193,7 +193,7 @@ func (p *BootstrapPreparator) generateKeys(certs *tls.Certificate, now time.Time
 		return nil, fmt.Errorf("Unexpected public key type %T, expected ed25519.PublicKey", pubKeyCert.PublicKey)
 	}
 
-	logger.DebugF("Generate certificate for signature")
+	logger.DebugF("Generating certificate for signature")
 	pubJWK := jose.JSONWebKey{
 		Key:          pubKey,
 		KeyID:        timeNow,
@@ -217,7 +217,7 @@ func (p *BootstrapPreparator) generateKeys(certs *tls.Certificate, now time.Time
 }
 
 func (p *BootstrapPreparator) encryptionConfig(signatureMode string) ([]byte, error) {
-	p.loggerProvider().DebugF("Generate encryption config")
+	p.loggerProvider().DebugF("Generating encryption config")
 
 	config := EncryptionConfiguration{
 		APIVersion: "apiserver.config.k8s.io/v1",
@@ -260,7 +260,7 @@ func (p *BootstrapPreparator) createSignatureDir(ctx context.Context) error {
 
 	logger := p.loggerProvider()
 
-	logger.DebugF("Create signature dir %s", signaturePath)
+	logger.DebugF("Creating signature dir %s", signaturePath)
 
 	loopParams := retry.SafeCloneOrNewParams(p.loopsParams.CreateSigDir, createSigDirDefaultOpts...).
 		Clone(
@@ -289,7 +289,7 @@ func (p *BootstrapPreparator) uploadSignatureFiles(ctx context.Context, sig *sig
 		return err
 	}
 
-	p.loggerProvider().DebugF("Upload signature files")
+	p.loggerProvider().DebugF("Uploading signature files")
 	files := map[string][]byte{
 		p.signaturePath(privKeyFilename): sig.privateKeyJSON,
 		p.signaturePath(pubKeyFilename):  sig.jwksJSON,

--- a/dhctl/pkg/module/controlplane/config.go
+++ b/dhctl/pkg/module/controlplane/config.go
@@ -55,7 +55,7 @@ func NewSettingsExtractor(cfg *config.MetaConfig, schemaStore SchemaStore, editi
 // if not cse returns NoSignatureMode
 func (e *SettingsExtractor) SignatureMode() (string, error) {
 	if govalue.IsNil(e.cfg) {
-		return "", fmt.Errorf("Internal error: meta config did not pass to control-plane settings extractor")
+		return "", fmt.Errorf("Internal error: meta config was not passed to control-plane settings extractor")
 	}
 
 	logger := e.loggerProvider()
@@ -65,7 +65,7 @@ func (e *SettingsExtractor) SignatureMode() (string, error) {
 	// and after change fix config_test.go (see TODO comments)
 	if !config.IsCSEdition(e.edition) {
 		// TODO fix cse to ee after enable in ee and fe
-		logger.DebugF("Got not cse edition '%s'. Returns no signature mode", e.edition)
+		logger.DebugF("Got non-cse edition '%s'. Returning no signature mode", e.edition)
 		return NoSignatureMode, nil
 	}
 
@@ -76,13 +76,13 @@ func (e *SettingsExtractor) SignatureMode() (string, error) {
 
 	defaultMode := e.findDefaultSignatureMode(schema)
 
-	logger.DebugF("Got ee edition try to extract signature mode")
+	logger.DebugF("Got ee edition, trying to extract signature mode")
 
 	mc := e.cfg.FindModuleConfig(moduleName)
 
 	logAndReturnDefaultMode := func(msg string, args ...any) (string, error) {
 		msg = fmt.Sprintf(msg, args...)
-		logger.DebugF("%s. Returns mode '%s'", msg, defaultMode)
+		logger.DebugF("%s. Returning mode '%s'", msg, defaultMode)
 
 		return defaultMode, nil
 	}
@@ -118,7 +118,7 @@ func (e *SettingsExtractor) findDefaultSignatureMode(schema *spec.Schema) string
 	logger := e.loggerProvider()
 
 	returnDefault := func(msg string) string {
-		logger.DebugF("%s return %s", msg, defaultSignatureMode)
+		logger.DebugF("%s, returning %s", msg, defaultSignatureMode)
 		return defaultSignatureMode
 	}
 
@@ -135,12 +135,12 @@ func (e *SettingsExtractor) findDefaultSignatureMode(schema *spec.Schema) string
 	signatureProps := signature.SchemaProps
 
 	if !signatureProps.Type.Contains("string") {
-		return returnDefault("property apiserver.signature is not string")
+		return returnDefault("property apiserver.signature is not a string")
 	}
 
 	res, ok := signatureProps.Default.(string)
 	if !ok {
-		return returnDefault("property apiserver.signature default is not string")
+		return returnDefault("property apiserver.signature default is not a string")
 	}
 
 	return res

--- a/dhctl/pkg/operations/bootstrap/bashible/runner.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner.go
@@ -95,7 +95,7 @@ func (r *Runner) Prepare(ctx context.Context) error {
 func (r *Runner) AlreadyRun(ctx context.Context) (bool, error) {
 	loopParams := retry.SafeCloneOrNewParams(r.loopsParams.AlreadyRun, alreadyRunDefaultOpts...).
 		Clone(
-			retry.WithName("Checking bashible already ran"),
+			retry.WithName("Checking whether Bashible already ran"),
 			retry.WithLogger(r.loggerProvider()),
 		)
 
@@ -207,13 +207,13 @@ func (r *Runner) ExecuteBundle(ctx context.Context, params ExecuteBundleParams) 
 			// we do not need to restart tunnel because we have HealthMonitor
 			logger := r.loggerProvider()
 
-			logger.DebugF("Stop bashible if need")
+			logger.DebugF("Stopping Bashible if needed")
 
 			if err := r.cleanupPreviousBashibleIfNeed(ctx); err != nil {
 				return err
 			}
 
-			logger.DebugF("Start execute bashible bundle routine")
+			logger.DebugF("Starting Bashible bundle execution routine")
 
 			return r.attemptExecuteBundle(ctx, params, relaySpanUpdater)
 		})
@@ -251,16 +251,16 @@ func (r *Runner) attemptExecuteBundle(
 func (r *Runner) cleanupPreviousBashibleIfNeed(ctx context.Context) error {
 	logger := r.loggerProvider()
 
-	return logger.Process("bootstrap", "Cleanup previous bashible run if need", func() error {
-		logger.DebugF("Gettting bashible pids")
+	return logger.Process("bootstrap", "Clean up previous Bashible run if needed", func() error {
+		logger.DebugF("Getting Bashible PIDs")
 		pids, err := r.getBashiblePIDs(ctx)
 		if err != nil {
 			return err
 		}
 
-		logger.DebugLn("Got bashible pids: %v", pids)
+		logger.DebugLn("Got Bashible PIDs: %v", pids)
 		if len(pids) == 0 {
-			logger.InfoF("Bashible instance not found. Start it!")
+			logger.InfoF("Bashible instance not found. Starting it!")
 			return nil
 		}
 
@@ -293,7 +293,7 @@ func (r *Runner) getBashiblePIDs(ctx context.Context) ([]string, error) {
 
 		parts := strings.SplitN(l, "|", 2)
 		if len(parts) < 2 {
-			logger.DebugLn("Skip ps string without pid")
+			logger.DebugLn("Skipping ps line without PID")
 			continue
 		}
 

--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -35,7 +35,7 @@ func CheckPreventBreakAnotherBootstrappedCluster(
 	kubeCl *client.KubernetesClient,
 	config *config.DeckhouseInstaller,
 ) error {
-	return retry.NewSilentLoop("Check prevent break another bootstrapped", 15, 3*time.Second).RunContext(ctx, func() error {
+	return retry.NewSilentLoop("Check to prevent breaking another bootstrapped cluster", 15, 3*time.Second).RunContext(ctx, func() error {
 		var uuidInCluster string
 		cmInCluster, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Get(ctx, manifests.ClusterUUIDCm, metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
@@ -45,7 +45,7 @@ func CheckPreventBreakAnotherBootstrappedCluster(
 		if err == nil {
 			uuidInCluster = cmInCluster.Data[manifests.ClusterUUIDCmKey]
 			if uuidInCluster == "" {
-				return fmt.Errorf("Cluster UUID config map found, but UUID is empty")
+				return fmt.Errorf("Cluster UUID config map found, but the UUID is empty")
 			}
 		}
 
@@ -54,9 +54,9 @@ func CheckPreventBreakAnotherBootstrappedCluster(
 		}
 
 		if uuidInCluster != config.UUID {
-			return fmt.Errorf(`Cluster UUID's not equal in the cluster (%s) and in the cache (%s).
-Probably you are trying bootstrap cluster on node with previous created cluster.
-Please check hostname.`, uuidInCluster, config.UUID)
+			return fmt.Errorf(`Cluster UUIDs are not equal in the cluster (%s) and in the cache (%s).
+You are probably trying to bootstrap a cluster on a node with a previously created cluster.
+Please check the hostname.`, uuidInCluster, config.UUID)
 		}
 
 		return nil

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-abort.go
@@ -114,7 +114,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 				return nil
 			},
 			func() error {
-				return fmt.Errorf("No UUID found in the cache. Perhaps, the cluster was already bootstrapped.")
+				return fmt.Errorf("No UUID found in the cache. Perhaps the cluster was already bootstrapped.")
 			},
 		)
 	}
@@ -140,7 +140,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 
 	bootstrapState := NewBootstrapState(stateCache)
 
-	err = log.ProcessCtx(ctx, "common", "Choice abort type", func(ctx context.Context) error {
+	err = log.ProcessCtx(ctx, "common", "Choose abort type", func(ctx context.Context) error {
 		ok, err := bootstrapState.IsManifestsCreated(ctx)
 		if err != nil {
 			return err
@@ -171,7 +171,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 				return err
 			}
 
-			logMsg := "Deckhouse installation was not started before. Abort from cache"
+			logMsg := "Deckhouse installation has not started yet. Aborting from cache"
 			if forceAbortFromCache {
 				logMsg = "Force aborting from cache"
 			}
@@ -213,7 +213,7 @@ func (b *ClusterBootstrapper) doRunBootstrapAbort(ctx context.Context, forceAbor
 			return err
 		}
 
-		b.logger.LogInfoLn("Deckhouse installation was started before. Destroy cluster")
+		b.logger.LogInfoLn("Deckhouse installation has already started. Destroying cluster")
 		return nil
 	})
 	if err != nil {

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-post-bootstrap.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-post-bootstrap.go
@@ -44,7 +44,7 @@ func (b *ClusterBootstrapper) ExecPostBootstrap(ctx context.Context) error {
 	}
 
 	if err := cache.InitWithOptions(ctx, wrapper.Client().Check().String(), cache.CacheOptions{InitialState: b.InitialState, ResetInitialState: b.ResetInitialState, Cache: b.Options.Cache}); err != nil {
-		return fmt.Errorf("Can not init cache: %w", err)
+		return fmt.Errorf("Cannot init cache: %w", err)
 	}
 
 	bootstrapState := NewBootstrapState(cache.Global())

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper-resources.go
@@ -31,7 +31,7 @@ import (
 func (b *ClusterBootstrapper) CreateResources(ctx context.Context) error {
 	resourcesToCreate := make(template.Resources, 0)
 	if b.Options.Bootstrap.ResourcesPath != "" {
-		log.WarnLn("--resources flag is deprecated. Please use --config flag multiple repeatedly for logical resources separation")
+		log.WarnLn("--resources flag is deprecated. Please use the --config flag multiple times for logical resource separation")
 		parsedResources, err := template.ParseResources(b.Options.Bootstrap.ResourcesPath, nil)
 		if err != nil {
 			return err
@@ -53,7 +53,7 @@ func (b *ClusterBootstrapper) CreateResources(ctx context.Context) error {
 	log.DebugF("Resources: %s\n", resourcesToCreate.String())
 
 	if len(resourcesToCreate) == 0 {
-		log.WarnLn("Resources to create were not found.")
+		log.WarnLn("No resources to create were found.")
 		return nil
 	}
 

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -73,10 +73,10 @@ const (
 
 	bootstrapAbortInvalidCacheMessage = `Create cache %s:
 	Error: %v
-	Probably that Kubernetes cluster was successfully bootstrapped.
-	Use "dhctl destroy" command to delete the cluster.
+	The Kubernetes cluster was probably bootstrapped successfully.
+	Use the "dhctl destroy" command to delete the cluster.
 `
-	bootstrapPhaseBaseInfraNonCloudMessage = `It is impossible to create base-infrastructure for non-cloud Kubernetes cluster.
+	bootstrapPhaseBaseInfraNonCloudMessage = `It is impossible to create base infrastructure for a non-cloud Kubernetes cluster.
 You have to create it manually.
 `
 	bootstrapAbortCheckMessage = `You will be asked for approval multiple times.
@@ -85,7 +85,7 @@ If you are confident in your actions, you can use the flag "--yes-i-am-sane-and-
 	cacheMessage = `Create cache %s:
 	Error: %v
 
-	Probably that Kubernetes cluster was successfully bootstrapped.
+	The Kubernetes cluster was probably bootstrapped successfully.
 	If you want to continue, please delete the cache folder manually.
 `
 )
@@ -174,7 +174,7 @@ func NewClusterBootstrapper(params *Params) *ClusterBootstrapper {
 
 func (b *ClusterBootstrapper) getCleanupFunc(ctx context.Context, metaConfig *config.MetaConfig) (func(), error) {
 	if b.InfrastructureContext == nil {
-		b.logger.LogDebugF("InfrastructureContext is nil. Skip cleanup.\n")
+		b.logger.LogDebugF("InfrastructureContext is nil. Skipping cleanup.\n")
 		return func() {}, nil
 	}
 
@@ -186,7 +186,7 @@ func (b *ClusterBootstrapper) getCleanupFunc(ctx context.Context, metaConfig *co
 	return func() {
 		err = provider.Cleanup()
 		if err != nil {
-			b.Logger.LogErrorF("Cannot cleanup provider: %v\n", err)
+			b.Logger.LogErrorF("Cannot clean up provider: %v\n", err)
 		}
 	}, nil
 }
@@ -213,14 +213,14 @@ func (b *ClusterBootstrapper) Bootstrap(ctx context.Context) error {
 	defer span.End()
 
 	if b.Options.Bootstrap.PostBootstrapScriptPath != "" {
-		log.DebugF("Have post bootstrap script: %s\n", b.Options.Bootstrap.PostBootstrapScriptPath)
+		log.DebugF("Found post-bootstrap script: %s\n", b.Options.Bootstrap.PostBootstrapScriptPath)
 		if err := ValidateScriptFile(ctx, b.Options.Bootstrap.PostBootstrapScriptPath); err != nil {
 			return err
 		}
 	}
 
 	if b.Options.Bootstrap.ResourcesPath != "" {
-		log.WarnLn("--resources flag is deprecated. Please use --config flag multiple repeatedly for logical resources separation")
+		log.WarnLn("--resources flag is deprecated. Please use the --config flag multiple times for logical resource separation")
 		b.Options.Global.ConfigPaths = append(b.Options.Global.ConfigPaths, b.Options.Bootstrap.ResourcesPath)
 	}
 
@@ -308,7 +308,7 @@ func (b *ClusterBootstrapper) bootstrapLoadConfig(ctx context.Context, bctx *boo
 			confirmation := input.NewConfirmation().
 				WithMessage("Do you really want to bootstrap the cluster on the current host?")
 			if !confirmation.Ask() {
-				return fmt.Errorf("Bootstrap cancelled by user")
+				return fmt.Errorf("Bootstrap canceled by user")
 			}
 		} else {
 			return fmt.Errorf("Static cluster bootstrap requires --ssh-host option when not running in terminal. Please use --ssh-host option or pass --connection-config with SSHHost resource to bootstrap the cluster")
@@ -602,7 +602,7 @@ func (b *ClusterBootstrapper) bootstrapPostInfraPreflights(ctx context.Context, 
 			NodeIP string `json:"nodeIP"`
 		}
 		if err := json.Unmarshal(bctx.metaConfig.ClusterConfig["static"], &static); err != nil {
-			log.DebugF("Static config missed: %s\n", err.Error())
+			log.DebugF("Static config is missing: %s\n", err.Error())
 		}
 		bctx.nodeIP = static.NodeIP
 
@@ -877,11 +877,11 @@ func (b *ClusterBootstrapper) bootstrapFinalize(ctx context.Context, bctx *boots
 		})
 	}
 
-	log.Success("Deckhouse cluster was created successfully!\n")
+	log.Success("Deckhouse cluster created successfully!\n")
 
 	interactive := input.IsTerminal() && !b.Options.Global.ShowProgress
 	if interactive {
-		progressbar.InfoF("%s", "Deckhouse cluster was created successfully! Kubernetes Master Node addresses for SSH:")
+		progressbar.InfoF("%s", "Deckhouse cluster created successfully! Kubernetes master node addresses for SSH:")
 	}
 
 	if bctx.metaConfig.ClusterType == config.CloudClusterType {
@@ -1000,7 +1000,7 @@ func bootstrapAdditionalNodesForCloudCluster(
 		return err
 	}
 
-	return log.ProcessCtx(ctx, "bootstrap", "Waiting for Node Groups are ready", func(ctx context.Context) error {
+	return log.ProcessCtx(ctx, "bootstrap", "Waiting for node groups to become ready", func(ctx context.Context) error {
 		ctx, span := telemetry.StartSpan(ctx, "ClusterBootstrapper.Bootstrap.AdditionalNodesForCloudCluster.WaitForNodesBecomeReady")
 		defer span.End()
 
@@ -1052,7 +1052,7 @@ func createResources(
 
 	tasks := make([]actions.ModuleConfigTask, 0)
 	if result != nil {
-		log.WarnLn("\nThe installation has completed successfully.\nTo finalize bootstraping please add at least one non-master node or remove taints from your master node (if a single node installation).\n")
+		log.WarnLn("\nThe installation has completed successfully.\nTo finalize bootstrapping, please add at least one non-master node or remove the taints from your master node (in the case of a single-node installation).\n")
 
 		tasks = result.ManifestResult.WithResourcesMCTasks
 

--- a/dhctl/pkg/operations/bootstrap/deps/check.go
+++ b/dhctl/pkg/operations/bootstrap/deps/check.go
@@ -51,7 +51,7 @@ type DependenciesChecker struct {
 }
 
 var (
-	ErrMissingDeps    = errors.New("Have missing dependencies")
+	ErrMissingDeps    = errors.New("Some dependencies are missing")
 	ErrShellIsNotBash = errors.New(
 		"Bashible requires /bin/bash as the user's login shell. Please change the user's shell",
 	)
@@ -239,7 +239,7 @@ func (c *DependenciesChecker) depsErrorBreakPredicate(err error) bool {
 	}
 
 	if errors.Is(err, ErrMissingDeps) {
-		c.loggerProvider().DebugF("Has missing deps error. Break cycle")
+		c.loggerProvider().DebugF("Has a missing-dependencies error. Breaking the loop")
 		return true
 	}
 
@@ -252,7 +252,7 @@ func (c *DependenciesChecker) shellErrorBreakPredicate(err error) bool {
 	}
 
 	if errors.Is(err, ErrShellIsNotBash) {
-		c.loggerProvider().DebugF("Has not bash error. Break cycle")
+		c.loggerProvider().DebugF("Has a non-bash shell error. Breaking the loop")
 		return true
 	}
 

--- a/dhctl/pkg/operations/bootstrap/post-script.go
+++ b/dhctl/pkg/operations/bootstrap/post-script.go
@@ -51,12 +51,12 @@ func (e *PostBootstrapScriptExecutor) Execute(ctx context.Context) error {
 	return log.ProcessCtx(ctx, "bootstrap", "Execute post-bootstrap script", func(ctx context.Context) error {
 		resultToSetState, err := e.run(ctx)
 		if err != nil {
-			msg := fmt.Sprintf("Post execution script was failed: %v", err)
+			msg := fmt.Sprintf("Post-bootstrap script failed: %v", err)
 			return errors.New(msg)
 		}
 
 		if err := e.state.SavePostBootstrapScriptResult(ctx, resultToSetState); err != nil {
-			log.ErrorF("Post bootstrap script result was not saved: %v", err)
+			log.ErrorF("Failed to save post-bootstrap script result: %v", err)
 		}
 
 		return nil
@@ -108,7 +108,7 @@ func (e *PostBootstrapScriptExecutor) run(ctx context.Context) (string, error) {
 	script.Sudo()
 
 	if _, err := script.Execute(ctx); err != nil {
-		return "", fmt.Errorf("Running %s done with error: %w", e.path, err)
+		return "", fmt.Errorf("Running %s failed with error: %w", e.path, err)
 	}
 
 	content, err := sshClient.File().DownloadBytes(ctx, outputFile)
@@ -131,13 +131,13 @@ func ValidateScriptFile(ctx context.Context, path string) error {
 	mode := info.Mode()
 
 	if !mode.IsRegular() {
-		return fmt.Errorf("Post bootstrap script should be regular file")
+		return fmt.Errorf("Post-bootstrap script must be a regular file")
 	}
 
 	perm := info.Mode().Perm()
 
 	if perm&0o111 != 0o111 || perm&0o444 != 0o444 {
-		return fmt.Errorf("Post bootstrap script should be readable and executable for user group and other (-r-xr-xr-x)")
+		return fmt.Errorf("Post-bootstrap script must be readable and executable for user, group, and other (-r-xr-xr-x)")
 	}
 
 	return nil

--- a/dhctl/pkg/operations/bootstrap/registry/registry.go
+++ b/dhctl/pkg/operations/bootstrap/registry/registry.go
@@ -73,7 +73,7 @@ func Init(ctx context.Context, params Params) (Stop, error) {
 	}
 
 	logger := params.Logger
-	logger.DebugF("Up bundle registry...")
+	logger.DebugF("Starting bundle registry...")
 
 	reg := newRegistry(bundlePath)
 	if err = reg.start(ctx, logger); err != nil {
@@ -108,7 +108,7 @@ func InitFromConfig(
 
 	bundlePathProvider := func() (string, error) {
 		if imgBundlePath == "" {
-			return "", errors.New("--img-bundle-path is required in Local registry mode, please specify the flag")
+			return "", errors.New("--img-bundle-path is required in Local registry mode; please specify the flag")
 		}
 		return imgBundlePath, nil
 	}

--- a/dhctl/pkg/operations/bootstrap/registry/tunnel.go
+++ b/dhctl/pkg/operations/bootstrap/registry/tunnel.go
@@ -81,7 +81,7 @@ func InitTunnel(ctx context.Context, params TunnelParams) (StopTunnel, error) {
 	}
 
 	logger := params.Logger
-	logger.DebugF("Up bundle registry tunnel...")
+	logger.DebugF("Starting bundle registry tunnel...")
 
 	tunnel := newTunnel(params.GlobalOpts, wrapper.Client())
 	if err := tunnel.start(ctx); err != nil {

--- a/dhctl/pkg/operations/bootstrap/rpp/proxy.go
+++ b/dhctl/pkg/operations/bootstrap/rpp/proxy.go
@@ -264,7 +264,7 @@ func (p *RegistryPackagesProxy) startProxy() error {
 }
 
 func (p *RegistryPackagesProxy) startTunnel(ctx context.Context, sshCl libcon.SSHClient) error {
-	p.debug("Up registry packages proxy tunnel...")
+	p.debug("Starting registry packages proxy tunnel...")
 
 	tunnel, err := p.upSingleTunnel(ctx, sshCl, p.localPort, p.remotePort, true)
 	if err != nil {
@@ -287,7 +287,7 @@ func (p *RegistryPackagesProxy) upSingleTunnel(ctx context.Context, sshCl libcon
 
 	tun := sshCl.ReverseTunnel(addr)
 	if err := tun.Up(); err != nil {
-		return nil, fmt.Errorf("cannot up tunnel for registry packages proxy: %w", err)
+		return nil, fmt.Errorf("cannot bring up tunnel for registry packages proxy: %w", err)
 	}
 
 	if !healthCheck {
@@ -319,5 +319,5 @@ func (p *RegistryPackagesProxy) debug(f string, args ...any) {
 }
 
 func upTunnelError(err error) error {
-	return fmt.Errorf("Cannot up registry packages proxy tunnel: %w", err)
+	return fmt.Errorf("Cannot bring up registry packages proxy tunnel: %w", err)
 }

--- a/dhctl/pkg/operations/bootstrap/steps_bashible.go
+++ b/dhctl/pkg/operations/bootstrap/steps_bashible.go
@@ -126,7 +126,7 @@ func RunBashiblePipeline(ctx context.Context, params *BashiblePipelineParams) er
 	}
 
 	if ready {
-		log.Success("Bashible already run! Skip bashible install\n")
+		log.Success("Bashible has already run! Skipping Bashible installation\n")
 		return nil
 	}
 

--- a/dhctl/pkg/operations/bootstrap/steps_deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/steps_deckhouse.go
@@ -62,13 +62,13 @@ func InstallDeckhouse(
 
 		resManifests, err := deckhouse.CreateDeckhouseManifests(ctx, kubeCl, config, params.BeforeDeckhouseTask)
 		if err != nil {
-			return fmt.Errorf("Deckhouse create manifests: %w", err)
+			return fmt.Errorf("create Deckhouse manifests: %w", err)
 		}
 
 		res.ManifestResult = resManifests
 
 		if err := params.State.SaveManifestsCreated(ctx); err != nil {
-			return fmt.Errorf("Set manifests in cluster flag to cache: %w", err)
+			return fmt.Errorf("set the manifests-in-cluster flag in the cache: %w", err)
 		}
 
 		err = deckhouse.WaitForReadiness(ctx, kubeCl, params.DeckhouseTimeout)
@@ -121,7 +121,7 @@ func RunPostInstallTasks(ctx context.Context, kubeCl *client.KubernetesClient, r
 	defer span.End()
 
 	if result == nil {
-		log.DebugF("Skip post install tasks because result is nil\n")
+		log.DebugF("Skipping post-install tasks because result is nil\n")
 		return nil
 	}
 

--- a/dhctl/pkg/operations/bootstrap/steps_nodes.go
+++ b/dhctl/pkg/operations/bootstrap/steps_nodes.go
@@ -55,7 +55,7 @@ func BootstrapAdditionalMasterNodes(
 	globalOptions *options.GlobalOptions,
 ) error {
 	if metaConfig.MasterNodeGroupSpec.Replicas == 1 {
-		log.DebugF("Skip bootstrap additional master nodes because replicas == 1")
+		log.DebugF("Skipping additional master node bootstrap because replicas == 1")
 		return nil
 	}
 

--- a/dhctl/pkg/operations/bootstrap/steps_ssh.go
+++ b/dhctl/pkg/operations/bootstrap/steps_ssh.go
@@ -76,7 +76,7 @@ func readRemoteFileWithRetry(ctx context.Context, nodeInterface libcon.Interface
 }
 
 func WaitForSSHConnectionOnMaster(ctx context.Context, sshClient libcon.SSHClient) error {
-	return log.ProcessCtx(ctx, "bootstrap", "Wait for SSH on Master become Ready", func(ctx context.Context) error {
+	return log.ProcessCtx(ctx, "bootstrap", "Wait for SSH on master to become ready", func(ctx context.Context) error {
 		availabilityCheck := sshClient.Check()
 		_ = log.ProcessCtx(ctx, "default", "Connection string", func(ctx context.Context) error {
 			log.InfoLn(availabilityCheck.String())

--- a/dhctl/pkg/operations/check/check.go
+++ b/dhctl/pkg/operations/check/check.go
@@ -186,7 +186,7 @@ func checkClusterState(
 func checkAbandonedNodeState(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, nodeGroup *NodeGroupOptions, nodeGroupState *dhctlstate.NodeGroupInfrastructureState, nodeName string, infrastructureContext *infrastructure.Context, opts CheckStateOptions) (int, plan.Plan, *plan.DestructiveChanges, error) {
 	nodeIndex, err := config.GetIndexFromNodeName(nodeName)
 	if err != nil {
-		return plan.HasNoChanges, nil, nil, fmt.Errorf("can't extract index from infrastructure state secret (%v), skip %s", err, nodeName)
+		return plan.HasNoChanges, nil, nil, fmt.Errorf("can't extract index from infrastructure state secret (%v), skipping %s", err, nodeName)
 	}
 
 	cfg := metaConfig
@@ -242,7 +242,7 @@ type NodeStateCheckResult struct {
 func checkNodeState(ctx context.Context, kubeCl *client.KubernetesClient, metaConfig *config.MetaConfig, nodeGroup *NodeGroupOptions, nodeName string, infrastructureContext *infrastructure.Context, opts CheckStateOptions, noout bool) (*NodeStateCheckResult, error) {
 	nodeIndex, err := config.GetIndexFromNodeName(nodeName)
 	if err != nil {
-		return nil, fmt.Errorf("can't extract index from infrastructure state secret (%v), skip %s", err, nodeName)
+		return nil, fmt.Errorf("can't extract index from infrastructure state secret (%v), skipping %s", err, nodeName)
 	}
 
 	pipelineForMaster := nodeGroup.LayoutStep == infrastructure.MasterNodeStep
@@ -364,7 +364,7 @@ func CheckState(
 
 	nodeTemplates, err := entity.GetNodeGroupTemplates(ctx, kubeCl)
 	if err != nil {
-		allErrs = multierror.Append(allErrs, fmt.Errorf("node goups in Kubernetes cluster not found: %w", err))
+		allErrs = multierror.Append(allErrs, fmt.Errorf("node groups in Kubernetes cluster not found: %w", err))
 	}
 
 	// We have no nodeTemplate settings for master nodes

--- a/dhctl/pkg/operations/commander/attach/attacher.go
+++ b/dhctl/pkg/operations/commander/attach/attacher.go
@@ -311,7 +311,7 @@ func (i *Attacher) scan(
 
 		clusterState, err := infrastructurestate.GetClusterStateFromCluster(ctx, kubeClient)
 		if err != nil {
-			return fmt.Errorf("unable get cluster tf state: %w", err)
+			return fmt.Errorf("unable to get cluster tf state: %w", err)
 		}
 
 		if err = stateCache.Save(ctx, "base-infrastructure.tfstate", clusterState); err != nil {

--- a/dhctl/pkg/operations/commander/detach/detacher.go
+++ b/dhctl/pkg/operations/commander/detach/detacher.go
@@ -94,7 +94,7 @@ func (op *Detacher) Detach(ctx context.Context) (err error) {
 
 		if op.OnCheckResult != nil {
 			if err := op.OnCheckResult(ctx, checkRes); err != nil {
-				return fmt.Errorf("oncheckResult callback failed: %w", err)
+				return fmt.Errorf("OnCheckResult callback failed: %w", err)
 			}
 		}
 		return nil

--- a/dhctl/pkg/operations/commander/helpers.go
+++ b/dhctl/pkg/operations/commander/helpers.go
@@ -31,7 +31,7 @@ import (
 )
 
 func NewErrClusterManagedByAnotherCommander(managedByCommanderUUID, requiredCommanderUUID uuid.UUID) error {
-	return fmt.Errorf("cluster managed by another commander %s unable to perform operations from your commander %s", managedByCommanderUUID.String(), requiredCommanderUUID.String())
+	return fmt.Errorf("cluster is managed by another commander %s; unable to perform operations from your commander %s", managedByCommanderUUID.String(), requiredCommanderUUID.String())
 }
 
 func doCheckShouldUpdateCommanderUUID(cm *v1.ConfigMap, requiredCommanderUUID uuid.UUID) (bool, error) {

--- a/dhctl/pkg/operations/converge/auto_converger.go
+++ b/dhctl/pkg/operations/converge/auto_converger.go
@@ -48,11 +48,11 @@ func NewAutoConverger(runner *runner, params AutoConvergerParams) *AutoConverger
 }
 
 func (c *AutoConverger) Start(ctx *convergectx.Context) error {
-	defer log.InfoLn("Stop autoconverger fully")
+	defer log.InfoLn("Stopping autoconverger completely")
 
 	log.InfoLn("Start exporter")
 	log.InfoLn("Address: ", c.params.ListenAddress)
-	log.InfoLn("Checks interval: ", c.params.CheckInterval)
+	log.InfoLn("Check interval: ", c.params.CheckInterval)
 
 	// channels to stop converge loop
 	shutdownAllCh := make(chan struct{})
@@ -66,7 +66,7 @@ func (c *AutoConverger) Start(ctx *convergectx.Context) error {
 
 		err := httpServer.Shutdown(context.TODO())
 		if err != nil {
-			log.ErrorF("Cannot shutdown http server %v", err)
+			log.ErrorF("Cannot shut down http server: %v", err)
 		}
 	})
 
@@ -109,7 +109,7 @@ func (c *AutoConverger) getHTTPServer() *http.Server {
 	indexPageContent := fmt.Sprintf(`<html>
              <head><title>CandI Auto converge</title></head>
              <body>
-             <h1>CandI Auto converge terrform state every %s</h1>
+             <h1>CandI Auto converge terraform state every %s</h1>
              </body>
              </html>`, c.params.CheckInterval.String())
 

--- a/dhctl/pkg/operations/converge/context/client_switcher.go
+++ b/dhctl/pkg/operations/converge/context/client_switcher.go
@@ -139,7 +139,7 @@ func (s *KubeClientSwitcher) SwitchToFirstMaster(ctx context.Context) error {
 			}
 
 			return fmt.Errorf(
-				"Cannot find first control-plane node state or it is empty. Has states for [%s]",
+				"Cannot find first control-plane node state or it is empty. Available states for [%s]",
 				strings.Join(mastersNames, ", "),
 			)
 		}
@@ -182,10 +182,10 @@ func (s *KubeClientSwitcher) SwitchToNotFirstMaster(ctx context.Context) error {
 
 		if len(statesMap) == 0 {
 			if firstMasterState == nil {
-				return fmt.Errorf("Cannot switch to another control-plane, no any states found")
+				return fmt.Errorf("Cannot switch to another control-plane node: no states found")
 			}
 
-			s.warn("Another control-plane nodes states not found. Try to continue with first")
+			s.warn("States for other control-plane nodes not found. Trying to continue with the first one")
 			statesMap[firstMasterState.Name] = firstMasterState.State
 		}
 
@@ -198,7 +198,7 @@ func (s *KubeClientSwitcher) SwitchToNotFirstMaster(ctx context.Context) error {
 }
 
 func (s *KubeClientSwitcher) SwitchClientsToAnotherNodeIfNeed(ctx context.Context, nodeName, ip string) error {
-	const action = "Switch clients when destructive cahange control-plane nodes"
+	const action = "Switch clients on destructive change of control-plane nodes"
 
 	if skip, err := s.isSkipOrLogStart(action, true); err != nil {
 		return err
@@ -214,11 +214,11 @@ func (s *KubeClientSwitcher) SwitchClientsToAnotherNodeIfNeed(ctx context.Contex
 	s.debug("SwitchClientsToAnotherNodeIfNeed sshClient: %v", sshClient)
 	currentHost := session.CurrentHost(sshClient.Session())
 	if currentHost.Host == "" {
-		return fmt.Errorf("Got empty current host")
+		return fmt.Errorf("Got an empty current host")
 	}
 
 	if nodeName != currentHost.Name {
-		s.debug("Skip %s: current host is not deleted host '%s'", action, nodeName)
+		s.debug("Skipping %s: current host is not the deleted host '%s'", action, nodeName)
 		return nil
 	}
 
@@ -252,7 +252,7 @@ func (s *KubeClientSwitcher) SwitchWhenDecreaseMastersIfNeed(ctx context.Context
 	const action = "Switch clients when decrease control-plane nodes"
 
 	logSkip := func(f string, args ...any) {
-		s.debug(fmt.Sprintf("Skip %s: ", action)+f, args...)
+		s.debug(fmt.Sprintf("Skipping %s: ", action)+f, args...)
 	}
 
 	if ngName != global.MasterNodeGroupName {
@@ -279,7 +279,7 @@ func (s *KubeClientSwitcher) SwitchWhenDecreaseMastersIfNeed(ctx context.Context
 	s.debug("SwitchWhenDecreaseMastersIfNeed sshClient: %v", sshClient)
 	currentHost := session.CurrentHost(sshClient.Session())
 	if currentHost.Host == "" {
-		return fmt.Errorf("Got empty current host")
+		return fmt.Errorf("Got an empty current host")
 	}
 
 	needReconnect := false
@@ -332,11 +332,11 @@ type replaceKubeClientParams struct {
 
 func (s *KubeClientSwitcher) replaceKubeClient(ctx context.Context, params replaceKubeClientParams) error {
 	if len(params.state) == 0 {
-		return fmt.Errorf("Empty nodes states for replace client")
+		return fmt.Errorf("Empty node states for replacing client")
 	}
 
 	if params.convergeState == nil {
-		return fmt.Errorf("Internal error. Empty converge state for replace client")
+		return fmt.Errorf("Internal error: empty converge state for replacing client")
 	}
 
 	sshProvider, err := s.ctx.SSHProviderInitializer.GetSSHProvider(ctx)
@@ -374,7 +374,7 @@ func (s *KubeClientSwitcher) replaceKubeClient(ctx context.Context, params repla
 	}
 
 	if len(availableHosts) == 0 {
-		return fmt.Errorf("Cannot switch clients. Got empty available hosts from node states")
+		return fmt.Errorf("Cannot switch clients: no available hosts found in node states")
 	}
 
 	if s.lockRunner != nil {
@@ -388,7 +388,7 @@ func (s *KubeClientSwitcher) replaceKubeClient(ctx context.Context, params repla
 	// also because we will use kube provider
 	// setting kube client not needed
 
-	s.debug("Create new ssh client for replacing kube client")
+	s.debug("Creating new ssh client for replacing kube client")
 
 	sess := session.NewSession(session.Input{
 		User:           params.convergeState.NodeUserCredentials.Name,
@@ -444,7 +444,7 @@ func (s *KubeClientSwitcher) tmpDirForConverger() (string, error) {
 		return "", fmt.Errorf("Failed to create tmp directory for converge: %w", err)
 	}
 
-	s.debug("Temp dir %s created for switch kube client", tmpDir)
+	s.debug("Temp dir %s created for switching kube client", tmpDir)
 	return tmpDir, nil
 }
 
@@ -497,7 +497,7 @@ func (s *KubeClientSwitcher) createNodeUser(ctx context.Context) (*State, error)
 
 	err = entity.NewConvergerNodeUserExistsWaiter(s.ctx).WaitPresentOnNodes(ctx, nodeUserCredentials)
 	if err != nil {
-		return nil, fmt.Errorf("Could not ensure converger user is presented on control plane hosts: %w", err)
+		return nil, fmt.Errorf("Could not ensure converger user is present on control plane hosts: %w", err)
 	}
 
 	convergeState.NodeUserCredentials = nodeUserCredentials
@@ -603,7 +603,7 @@ func (s *KubeClientSwitcher) isSkipOrLogStart(action string, strict bool) (bool,
 
 	if s.switchDisbled(action) {
 		if strict {
-			return true, fmt.Errorf("Internal error. Disable switch to node user passed, but it needs for %s", action)
+			return true, fmt.Errorf("Internal error: disabling switch to node user was requested, but it is needed for %s", action)
 		}
 
 		return true, nil
@@ -687,7 +687,7 @@ func (e *sshIPExtractor) getIPForSSH(ctx context.Context, params *sshIPExtractor
 	addresses, err := infrastructure.GetMasterIPAddressForSSH(ctx, statePath, executor)
 	if err != nil {
 		e.switcher.warn(
-			"Cannot extract ips for node '%s':\n%v\nSkip adding node to ssh client",
+			"Cannot extract IPs for node '%s':\n%v\nSkipping adding node to ssh client",
 			nodeName,
 			err,
 		)
@@ -698,7 +698,7 @@ func (e *sshIPExtractor) getIPForSSH(ctx context.Context, params *sshIPExtractor
 	internal := addresses.Internal
 
 	if sshIP == "" && internal == "" {
-		e.switcher.warn("IPs for node '%s' not found. Skip adding node to ssh client", nodeName)
+		e.switcher.warn("IPs for node '%s' not found. Skipping adding node to ssh client", nodeName)
 		return "", nil
 	}
 
@@ -706,7 +706,7 @@ func (e *sshIPExtractor) getIPForSSH(ctx context.Context, params *sshIPExtractor
 
 	if bastion != "" {
 		e.switcher.debug(
-			"Use node internal ip '%s' for node %s because bastion host '%s' was passed",
+			"Using node internal IP '%s' for node %s because bastion host '%s' was passed",
 			internal,
 			nodeName,
 			bastion,
@@ -715,7 +715,7 @@ func (e *sshIPExtractor) getIPForSSH(ctx context.Context, params *sshIPExtractor
 		return internal, nil
 	}
 
-	e.switcher.debug("Use direct ssh ip '%s' for node %s", sshIP, nodeName)
+	e.switcher.debug("Using direct ssh IP '%s' for node %s", sshIP, nodeName)
 
 	return sshIP, nil
 }
@@ -757,7 +757,7 @@ func (e *sshIPExtractor) prepareState(params *sshIPExtractorParams) (string, err
 
 	statePath := filepath.Join(e.tmpDir, fmt.Sprintf("%s-%s.tfstate", nodeName, e.suffix))
 
-	e.switcher.debug("State path for extracting ip for node %s: %s", nodeName, statePath)
+	e.switcher.debug("State path for extracting IP for node %s: %s", nodeName, statePath)
 
 	err := os.WriteFile(statePath, params.state, 0o644)
 	if err != nil {

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group.go
@@ -120,7 +120,7 @@ func (c *CloudPermanentNodeGroupController) updateNode(ctx *context.Context, nod
 
 	nodeIndex, err := config.GetIndexFromNodeName(nodeName)
 	if err != nil {
-		log.ErrorF("can't extract index from infrastructure state secret (%v), skip %s\n", err, nodeName)
+		log.ErrorF("can't extract index from infrastructure state secret (%v), skipping %s\n", err, nodeName)
 		return nil
 	}
 

--- a/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
+++ b/dhctl/pkg/operations/converge/controller/cloud_permanent_node_group_hook.go
@@ -49,7 +49,7 @@ func (h *HookForDestroyPipeline) BeforeAction(ctx context.Context, runner infras
 
 	err = infra_utils.DeleteNodeObjectFromCluster(ctx, kubeClient, h.nodeToDestroy)
 	if err != nil {
-		return false, fmt.Errorf("failed to delete object node '%s' from cluster: %v\n", h.nodeToDestroy, err)
+		return false, fmt.Errorf("failed to delete node object '%s' from cluster: %v\n", h.nodeToDestroy, err)
 	}
 	return false, nil
 }

--- a/dhctl/pkg/operations/converge/controller/master_node_group.go
+++ b/dhctl/pkg/operations/converge/controller/master_node_group.go
@@ -144,7 +144,7 @@ func (c *MasterNodeGroupController) run(ctx *context.Context) error {
 			return fmt.Errorf("failed to converge with 3 replicas: %w", err)
 		}
 
-		log.DebugF("to multi master scaled. saving state...\n")
+		log.DebugF("scaled to multi-master, saving state...\n")
 
 		c.convergeState.Phase = phases.ScaleToSingleMasterPhase
 
@@ -170,7 +170,7 @@ func (c *MasterNodeGroupController) run(ctx *context.Context) error {
 
 		c.convergeState.Phase = ""
 
-		log.DebugF("to single master scaled. saving state...\n")
+		log.DebugF("scaled to single-master, saving state...\n")
 
 		err = ctx.SetConvergeState(c.convergeState)
 		if err != nil {
@@ -188,7 +188,7 @@ func (c *MasterNodeGroupController) run(ctx *context.Context) error {
 func (c *MasterNodeGroupController) switchClientToNotFirstMaster(ctx *context.Context) error {
 	clientSwitcher := ctx.ClientSwitcher()
 	if govalue.IsNil(clientSwitcher) {
-		log.DebugF("Skip switch client to not first master. Got empty client switcher")
+		log.DebugF("Skipping switch of client to not-first master. Got empty client switcher")
 		return nil
 	}
 
@@ -203,7 +203,7 @@ func (c *MasterNodeGroupController) switchClientToNotFirstMaster(ctx *context.Co
 func (c *MasterNodeGroupController) switchClientToFirstMaster(ctx *context.Context) error {
 	clientSwitcher := ctx.ClientSwitcher()
 	if govalue.IsNil(clientSwitcher) {
-		log.DebugF("Skip switch client to first master. Got empty client switcher")
+		log.DebugF("Skipping switch of client to first master. Got empty client switcher")
 		return nil
 	}
 
@@ -371,7 +371,7 @@ func (c *MasterNodeGroupController) updateNode(ctx *context.Context, nodeName st
 
 	nodeIndex, err := config.GetIndexFromNodeName(nodeName)
 	if err != nil {
-		log.ErrorF("can't extract index from infrastructure state secret (%v), skip %s\n", err, nodeName)
+		log.ErrorF("can't extract index from infrastructure state secret (%v), skipping %s\n", err, nodeName)
 		return nil
 	}
 
@@ -508,16 +508,16 @@ func (c *MasterNodeGroupController) newHookForUpdatePipeline(ctx *context.Contex
 
 func (c *MasterNodeGroupController) deleteNodes(ctx *context.Context, nodesToDeleteInfo []nodeToDeleteInfo) error {
 	if c.desiredReplicas < 1 {
-		return fmt.Errorf(`Cannot delete ALL master nodes. If you want to remove cluster use 'dhctl destroy' command`)
+		return fmt.Errorf(`Cannot delete ALL master nodes. If you want to remove the cluster, use the 'dhctl destroy' command`)
 	}
 
 	needToQuorum := c.totalReplicas()/2 + 1
 
 	noQuorum := c.desiredReplicas < needToQuorum
-	msg := fmt.Sprintf("Desired master replicas count (%d) can break cluster. Need minimum replicas (%d). Do you want to continue?", c.desiredReplicas, needToQuorum)
+	msg := fmt.Sprintf("Desired master replica count (%d) can break the cluster. The minimum number of replicas required is (%d). Do you want to continue?", c.desiredReplicas, needToQuorum)
 	confirm := input.NewConfirmation().WithMessage(msg)
 	if noQuorum && !confirm.Ask() {
-		return fmt.Errorf("Skip delete master nodes")
+		return fmt.Errorf("Skipping deletion of master nodes")
 	}
 
 	title := fmt.Sprintf("Delete Nodes from NodeGroup %s (replicas: %v)", global.MasterNodeGroupName, c.desiredReplicas)

--- a/dhctl/pkg/operations/converge/controller/node_group_controller.go
+++ b/dhctl/pkg/operations/converge/controller/node_group_controller.go
@@ -93,7 +93,7 @@ func (c *NodeGroupController) Run(ctx *context.Context) error {
 		return err
 	}
 
-	log.DebugF("Nodes to delete %d. Starting update nodes\n", len(nodesToDeleteInfo))
+	log.DebugF("Nodes to delete: %d. Starting to update nodes\n", len(nodesToDeleteInfo))
 
 	if err := c.nodeGroup.beforeUpdateNodes(ctx); err != nil {
 		return err
@@ -104,7 +104,7 @@ func (c *NodeGroupController) Run(ctx *context.Context) error {
 		return err
 	}
 
-	log.DebugF("starting delete nodes\n")
+	log.DebugF("starting to delete nodes\n")
 
 	if err := c.switchClientBeforeDeleteNodesIfNeed(ctx, nodesToDeleteInfo); err != nil {
 		return err
@@ -120,7 +120,7 @@ func (c *NodeGroupController) Run(ctx *context.Context) error {
 		return err
 	}
 
-	log.DebugF("Starting converge node template\n")
+	log.DebugF("Starting to converge node template\n")
 
 	if groupSpec != nil {
 		return c.tryUpdateNodeTemplate(ctx, groupSpec.NodeTemplate)
@@ -132,7 +132,7 @@ func (c *NodeGroupController) Run(ctx *context.Context) error {
 func (c *NodeGroupController) switchClientBeforeDeleteNodesIfNeed(ctx *context.Context, nodesToDeleteInfo []nodeToDeleteInfo) error {
 	clientSwitcher := ctx.ClientSwitcher()
 	if govalue.IsNil(clientSwitcher) {
-		log.DebugF("Skip switch client before delete nodes. Got empty switcher\n")
+		log.DebugF("Skipping switch of client before deleting nodes. Got empty switcher\n")
 		return nil
 	}
 
@@ -155,7 +155,7 @@ func (c *NodeGroupController) tryDeleteNodes(ctx *context.Context, nodesToDelete
 	}
 
 	if ctx.ChangesSettings().AutoDismissDestructive {
-		log.DebugLn("Skip delete nodes because destructive operations are disabled")
+		log.DebugLn("Skipping node deletion because destructive operations are disabled")
 		return nil
 	}
 
@@ -199,13 +199,13 @@ func (c *NodeGroupController) deleteRedundantNodes(
 	var allErrs *multierror.Error
 	for _, nodeToDeleteInfo := range nodesToDeleteInfo {
 		if _, ok := c.excludedNodes[nodeToDeleteInfo.name]; ok {
-			log.InfoF("Skip delete excluded node %v\n", nodeToDeleteInfo.name)
+			log.InfoF("Skipping deletion of excluded node %v\n", nodeToDeleteInfo.name)
 			continue
 		}
 
 		nodeIndex, err := config.GetIndexFromNodeName(nodeToDeleteInfo.name)
 		if err != nil {
-			log.ErrorF("can't extract index from infrastructure state secret (%v), skip %s\n", err, nodeToDeleteInfo.name)
+			log.ErrorF("can't extract index from infrastructure state secret (%v), skipping %s\n", err, nodeToDeleteInfo.name)
 			return nil
 		}
 
@@ -266,7 +266,7 @@ func getNodeTemplateDiff(fromNG, fromConfig map[string]any) string {
 	// prevent compare nil and empty map
 	// this case generates diff for gcmp.Diff
 	if len(fromNG) == 0 && len(fromConfig) == 0 {
-		log.DebugF("Node templates does not have keys. Returns no diff\n")
+		log.DebugF("Node templates have no keys. Returning no diff\n")
 		return ""
 	}
 
@@ -293,7 +293,7 @@ func (c *NodeGroupController) tryUpdateNodeTemplate(ctx *context.Context, nodeTe
 
 		diff := getNodeTemplateDiff(templateInCluster, nodeTemplate)
 		if diff == "" {
-			log.DebugF("Node template of the %s NodeGroup is not changed", c.name)
+			log.DebugF("Node template of the %s NodeGroup has not changed", c.name)
 			return nil
 		}
 
@@ -326,12 +326,12 @@ func (c *NodeGroupController) tryUpdateNodeTemplate(ctx *context.Context, nodeTe
 
 func (c *NodeGroupController) tryDeleteNodeGroup(ctx *context.Context) error {
 	if ctx.ChangesSettings().AutoDismissDestructive {
-		log.DebugF("Skip delete %s node group because destructive operations are disabled\n", c.name)
+		log.DebugF("Skipping deletion of %s node group because destructive operations are disabled\n", c.name)
 		return nil
 	}
 
 	if c.name == global.MasterNodeGroupName {
-		log.DebugF("Skip delete %s node group because it is master\n", c.name)
+		log.DebugF("Skipping deletion of %s node group because it is master\n", c.name)
 		return nil
 	}
 
@@ -383,7 +383,7 @@ func (c *NodeGroupController) updateNodes(ctx *context.Context) error {
 
 		err := log.Process("converge", processTitle, func() error {
 			if _, ok := c.excludedNodes[nodeName]; ok {
-				log.InfoF("Skip update excluded node %v\n", nodeName)
+				log.InfoF("Skipping update of excluded node %v\n", nodeName)
 				return nil
 			}
 
@@ -420,7 +420,7 @@ func (c *NodeGroupController) updateNodes(ctx *context.Context) error {
 
 func getNodesToDeleteInfo(desiredReplicas int, state map[string][]byte) ([]nodeToDeleteInfo, error) {
 	if desiredReplicas >= len(state) {
-		log.DebugF("desired replicas >= in state. skip nodes info\n")
+		log.DebugF("desired replicas >= replicas in state. skipping nodes info\n")
 		return nil, nil
 	}
 
@@ -442,7 +442,7 @@ func getNodesToDeleteInfo(desiredReplicas int, state map[string][]byte) ([]nodeT
 		count--
 
 		if count == desiredReplicas {
-			log.DebugF("stopping getting deletes nodes info. count %v\n", count)
+			log.DebugF("stopping collection of nodes-to-delete info. count %v\n", count)
 			break
 		}
 	}

--- a/dhctl/pkg/operations/converge/converger.go
+++ b/dhctl/pkg/operations/converge/converger.go
@@ -112,7 +112,7 @@ func (c *Converger) ConvergeMigration(ctx context.Context) error {
 
 	if !c.CommanderMode {
 		if c.CacheID == "" {
-			return fmt.Errorf("Incorrect cache identity. Need to pass --ssh-host or --kube-client-from-cluster or --kubeconfig")
+			return fmt.Errorf("Incorrect cache identity. You need to pass --ssh-host, --kube-client-from-cluster, or --kubeconfig")
 		}
 
 		err := cache.InitWithOptions(ctx, c.CacheID, cache.CacheOptions{Cache: c.Options.Cache})
@@ -216,7 +216,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 
 	if !c.CommanderMode {
 		if c.CacheID == "" {
-			return nil, fmt.Errorf("Incorrect cache identity. Need to pass --ssh-host or --kube-client-from-cluster or --kubeconfig")
+			return nil, fmt.Errorf("Incorrect cache identity. You need to pass --ssh-host, --kube-client-from-cluster, or --kubeconfig")
 		}
 
 		err := cache.InitWithOptions(ctx, c.CacheID, cache.CacheOptions{Cache: c.Options.Cache})
@@ -402,7 +402,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 	}
 
 	if needAutomaticTofuMigrationForCommander {
-		log.WarnF("Need migrate to opentofu. Switch to migrator\n")
+		log.WarnF("Need to migrate to opentofu. Switching to migrator\n")
 		err = r.RunConvergeMigration(convergeCtx, true)
 	} else {
 		err = r.RunConverge(convergeCtx)
@@ -432,7 +432,7 @@ func (c *Converger) Converge(ctx context.Context) (*ConvergeResult, error) {
 
 func (c *Converger) AutoConverge(ctx context.Context, listenAddress string, checkInterval time.Duration) error {
 	if c.Options == nil || c.Options.AutoConverge.RunningNodeName == "" {
-		return fmt.Errorf("Need to pass running node name. It is may taints infrastructure state while converge")
+		return fmt.Errorf("Need to pass the running node name. It may taint the infrastructure state during converge")
 	}
 
 	convergeCtx := convergectx.NewContext(context.Background(), convergectx.Params{

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/checker.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/checker.go
@@ -46,17 +46,17 @@ func NewChecker(nodeToHostForChecks map[string]string, checkers []hook.NodeCheck
 
 func (c *Checker) IsAllNodesReady(ctx context.Context) error {
 	if c.checkers == nil {
-		log.DebugF("Not passed checkers. Skip. Nodes for check: %v", c.nodeToHostForChecks)
+		log.DebugF("No checkers passed. Skipping. Nodes to check: %v", c.nodeToHostForChecks)
 
 		return nil
 	}
 
 	if len(c.nodeToHostForChecks) == 0 {
-		return fmt.Errorf("do not have nodes for control plane nodes are readinss check")
+		return fmt.Errorf("no nodes provided for the control-plane nodes readiness check")
 	}
 
 	for nodeName := range c.nodeToHostForChecks {
-		if !c.confirm(fmt.Sprintf("Do you want to wait node %s will be ready?", nodeName)) {
+		if !c.confirm(fmt.Sprintf("Do you want to wait for node %s to become ready?", nodeName)) {
 			continue
 		}
 

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_destroy_pipeline.go
@@ -61,7 +61,7 @@ func (h *HookForDestroyPipeline) BeforeAction(ctx context.Context, runner infras
 	// in restart operation we will get error with strict getting
 	outputs, err := infrastructure.GetMasterNodeResultNoStrict(ctx, runner)
 	if err != nil {
-		return false, fmt.Errorf("Get master node pipeline outputs got error: %w", err)
+		return false, fmt.Errorf("failed to get master node pipeline outputs: %w", err)
 	}
 
 	// no need to switch client because we try to switch before delete nodes
@@ -69,7 +69,7 @@ func (h *HookForDestroyPipeline) BeforeAction(ctx context.Context, runner infras
 	masterIP := outputs.MasterIPForSSH
 	if masterIP == "" {
 		h.oldMasterIPForSSH = ""
-		log.InfoF("Got empty master IP for ssh for node %s. Skip removing control-plane from node.\n", h.nodeToDestroy)
+		log.InfoF("Got empty master IP for ssh for node %s. Skipping removal of control-plane from node.\n", h.nodeToDestroy)
 		return false, nil
 	}
 
@@ -87,7 +87,7 @@ func (h *HookForDestroyPipeline) BeforeAction(ctx context.Context, runner infras
 
 	err = infra_utils.DeleteNodeObjectFromCluster(ctx, kubeClient, h.nodeToDestroy)
 	if err != nil {
-		return false, fmt.Errorf("failed to delete object node '%s' from cluster: %v\n", h.nodeToDestroy, err)
+		return false, fmt.Errorf("failed to delete node object '%s' from cluster: %v\n", h.nodeToDestroy, err)
 	}
 
 	return false, nil
@@ -127,7 +127,7 @@ func removeControlPlaneRoleFromNode(ctx context.Context, kubeCl *client.Kubernet
 
 	err = waitEtcdHasNoMember(ctx, kubeCl.KubeClient.(libcon.KubeClient), nodeName)
 	if err != nil {
-		return fmt.Errorf("failed to check etcd has no member '%s': %v", nodeName, err)
+		return fmt.Errorf("failed to check that etcd has no member '%s': %v", nodeName, err)
 	}
 
 	err = infra_utils.TryToDrainNode(ctx, kubeCl, nodeName, infra_utils.GetDrainConfirmation(commanderMode), infra_utils.DrainOptions{Force: true})
@@ -143,7 +143,7 @@ func removeLabelsFromNode(ctx context.Context, kubeCl *client.KubernetesClient, 
 		node, err := kubeCl.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.InfoF("Node '%s' has been deleted. Skip\n", nodeName)
+				log.InfoF("Node '%s' has been deleted. Skipping\n", nodeName)
 				return nil
 			}
 			return err

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -135,7 +135,7 @@ func (h *HookForUpdatePipeline) BeforeAction(ctx context.Context, runner infrast
 	// in restart operation we will get error with strict getting
 	outputs, err := infrastructure.GetMasterNodeResultNoStrict(ctx, runner)
 	if err != nil {
-		return false, fmt.Errorf("Get master node pipeline outputs got error: %w", err)
+		return false, fmt.Errorf("failed to get master node pipeline outputs: %w", err)
 	}
 
 	masterIP := outputs.MasterIPForSSH
@@ -165,7 +165,7 @@ func (h *HookForUpdatePipeline) BeforeAction(ctx context.Context, runner infrast
 
 	err = infra_utils.DeleteNodeObjectFromCluster(ctx, kubeClient, h.nodeToConverge)
 	if err != nil {
-		return false, fmt.Errorf("failed to delete object node '%s' from cluster: %v\n", h.nodeToConverge, err)
+		return false, fmt.Errorf("failed to delete node object '%s' from cluster: %v\n", h.nodeToConverge, err)
 	}
 
 	return false, nil

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/kube-proxy.go
@@ -94,7 +94,7 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 	if len(c.nodesExternalIPs) > 0 {
 		ip, ok := c.nodesExternalIPs[nodeName]
 		if !ok {
-			return false, fmt.Errorf("Not found external ip for node %s", nodeName)
+			return false, fmt.Errorf("No external IP found for node %s", nodeName)
 		}
 
 		sshClient.Session().SetAvailableHosts([]session.Host{{Host: ip, Name: nodeName}})
@@ -110,7 +110,7 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 
 	err = kubeCl.InitContext(ctx, params)
 	if err != nil {
-		return false, fmt.Errorf("open kubernetes connection: %v", err)
+		return false, fmt.Errorf("failed to open kubernetes connection: %v", err)
 	}
 
 	defer func() {
@@ -137,7 +137,7 @@ func (c *KubeProxyChecker) IsReady(ctx context.Context, nodeName string) (bool, 
 
 	uuidInCluster := ns.Data["cluster-uuid"]
 	if c.clusterUUID != "" && c.clusterUUID != uuidInCluster {
-		return false, fmt.Errorf("Incorrect cluster uuid. In cluster %s != %s passed.", uuidInCluster, c.clusterUUID)
+		return false, fmt.Errorf("Incorrect cluster UUID: cluster has %s, but %s was passed.", uuidInCluster, c.clusterUUID)
 	}
 
 	return true, nil
@@ -154,7 +154,7 @@ func (c *KubeProxyChecker) printNs(cm *corev1.ConfigMap) {
 
 	yamlRepr, err := yaml.Marshal(cm)
 	if err != nil {
-		log.ErrorF("ConfigMap marshal error %v\n", err)
+		log.ErrorF("ConfigMap marshal error: %v\n", err)
 		return
 	}
 

--- a/dhctl/pkg/operations/converge/infrastructure/hook/node.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/node.go
@@ -61,7 +61,7 @@ func IsNodeReady(ctx context.Context, checkers []NodeChecker, nodeName, sourceCo
 		return nil
 	})
 	if err != nil {
-		return false, fmt.Errorf("Node %s is not ready. last error: %v/%v", nodeName, err, lastErr)
+		return false, fmt.Errorf("Node %s is not ready. Last error: %v/%v", nodeName, err, lastErr)
 	}
 
 	return true, nil

--- a/dhctl/pkg/operations/converge/infrastructure/utils/delete.go
+++ b/dhctl/pkg/operations/converge/infrastructure/utils/delete.go
@@ -36,7 +36,7 @@ func DeleteNodeObjectFromCluster(ctx context.Context, kubeCl *client.KubernetesC
 		err := kubeCl.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.InfoF("Node '%s' already deleted. Skip\n", nodeName)
+				log.InfoF("Node '%s' already deleted. Skipping\n", nodeName)
 				return nil
 			}
 			return err

--- a/dhctl/pkg/operations/converge/infrastructure/utils/drain.go
+++ b/dhctl/pkg/operations/converge/infrastructure/utils/drain.go
@@ -53,7 +53,7 @@ func GetDrainConfirmation(commanderMode bool) func(string) bool {
 func TryToDrainNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string, confirm func(string) bool, opts DrainOptions) error {
 	// todo it is deeper for pass from command root, use app package directly
 	if app.SkipDrainingNodes() {
-		log.InfoF("Skipping draining node %s because draining disabled by env\n", nodeName)
+		log.InfoF("Skipping draining node %s because draining is disabled by env\n", nodeName)
 		return nil
 	}
 
@@ -63,8 +63,8 @@ func TryToDrainNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeNa
 		})
 	if err != nil {
 		if goerrors.Is(err, kubedrain.ErrDrainTimeout) {
-			if confirm("Cannot drain node, because process was timeout. Do we continue without full-fledged drain?") {
-				log.WarnLn("Continue without full-fledged drain")
+			if confirm("Cannot drain the node because the process timed out. Continue without a full-fledged drain?") {
+				log.WarnLn("Continuing without a full-fledged drain")
 				return nil
 			}
 

--- a/dhctl/pkg/operations/converge/lock/lock.go
+++ b/dhctl/pkg/operations/converge/lock/lock.go
@@ -90,13 +90,13 @@ func (r *InLockRunner) Run(ctx context.Context, action func() error) error {
 	}
 
 	defer func() {
-		log.DebugLn("Start unlock converge from Run")
+		log.DebugLn("Starting converge unlock from Run")
 		if r.unlockConverge != nil {
 			r.unlockConverge(true)
 			return
 		}
 
-		log.DebugLn("unlockConverge is nil. Skip")
+		log.DebugLn("unlockConverge is nil. Skipping")
 	}()
 
 	log.DebugLn("lock for Run method was set. Start action")
@@ -168,7 +168,7 @@ func GetLockLeaseConfig(identity, sshUser string) *lease.LeaseLockConfig {
 		RetryWaitDuration:    3 * time.Second,
 		AdditionalUserInfo:   additionalInfo,
 		OnRenewError: func(renewErr error) {
-			log.WarnF("Lease renew was failed. Send SIGINT and shutdown: %v\n", renewErr)
+			log.WarnF("Lease renewal failed. Sending SIGINT and shutting down: %v\n", renewErr)
 			p, err := os.FindProcess(os.Getpid())
 			if err != nil {
 				log.ErrorF("Cannot find pid: %v", err)
@@ -210,11 +210,11 @@ func lockLease(
 	config *lease.LeaseLockConfig,
 	forceLock bool,
 ) (func(fullUnlock bool), error) {
-	log.DebugLn("Create converge lock and mutex")
+	log.DebugLn("Creating converge lock and mutex")
 	mutex := &sync.Mutex{}
 	leaseLock := lease.NewLeaseLock(getter, *config)
 
-	log.DebugLn("Try to lock converge")
+	log.DebugLn("Trying to lock converge")
 	err := leaseLock.Lock(ctx, forceLock)
 	if err != nil {
 		return nil, err
@@ -225,18 +225,18 @@ func lockLease(
 		mutex.Lock()
 		defer mutex.Unlock()
 
-		log.DebugLn("Try to release converge lock. Is it %v", leaseLock == nil)
+		log.DebugLn("Trying to release converge lock. Is it nil:", leaseLock == nil)
 
 		if leaseLock == nil {
-			log.DebugLn("Lock was released. Skip")
+			log.DebugLn("Lock was already released. Skipping")
 			return
 		}
 
 		if fullUnlock {
-			log.DebugLn("Try to full release...")
+			log.DebugLn("Trying to fully release...")
 			leaseLock.Unlock(ctx)
 		} else {
-			log.DebugLn("Try to stop autorenew only...")
+			log.DebugLn("Trying to stop auto-renew only...")
 			leaseLock.StopAutoRenew()
 		}
 
@@ -244,6 +244,6 @@ func lockLease(
 		log.DebugLn("Lock was released")
 	}
 
-	log.DebugLn("Lock converge successful")
+	log.DebugLn("Converge locked successfully")
 	return unlockConverge, nil
 }

--- a/dhctl/pkg/operations/converge/runner.go
+++ b/dhctl/pkg/operations/converge/runner.go
@@ -349,29 +349,29 @@ func (r *runner) convergeMigration(ctx *context.Context, checkHasTerraformStateB
 		}
 
 		if !hasTerraFormState {
-			log.InfoLn("Cluster do not have terraform state. Skipping migration")
+			log.InfoLn("Cluster does not have terraform state. Skipping migration")
 			return nil
 		}
 
 		commanderError := ""
 		if ctx.CommanderMode() {
-			commanderError = " For fix to migrate to opentofy please " +
-				"detach cluster from commander, converge on previous installer version manually and attach cluster to commander. " +
-				"Show complete guide in D8NeedMigrateStateToOpenTofu alert"
+			commanderError = " To migrate to opentofu, please " +
+				"detach the cluster from commander, converge on the previous installer version manually, and attach the cluster to commander again. " +
+				"See the complete guide in the D8NeedMigrateStateToOpenTofu alert"
 		}
 
 		if stats.Cluster.Status != check.OKStatus {
-			return fmt.Errorf("Cluster state has no ok status.%s", commanderError)
+			return fmt.Errorf("Cluster state does not have an OK status.%s", commanderError)
 		}
 
 		for _, node := range stats.Node {
 			if node.Status != check.OKStatus {
-				return fmt.Errorf("Node %s state has no ok status.%s", node.Name, commanderError)
+				return fmt.Errorf("Node %s state does not have an OK status.%s", node.Name, commanderError)
 			}
 		}
 	}
 
-	log.DebugLn("Start backup infrastructure states")
+	log.DebugLn("Starting backup of infrastructure states")
 
 	var commanderMode *infrastructurestate.TofuBackupCommanderMode
 	if ctx.CommanderMode() {
@@ -387,7 +387,7 @@ func (r *runner) convergeMigration(ctx *context.Context, checkHasTerraformStateB
 		return err
 	}
 
-	log.DebugLn("End backup infrastructure states")
+	log.DebugLn("Finished backup of infrastructure states")
 
 	if err := r.updateClusterState(ctx, metaConfig); err != nil {
 		return err
@@ -402,7 +402,7 @@ func (r *runner) convergeMigration(ctx *context.Context, checkHasTerraformStateB
 		return err
 	}
 
-	log.DebugLn("Restart infrastructure manager deployments")
+	log.DebugLn("Restarting infrastructure manager deployments")
 
 	err = manager.RestartStateExporter(ctx.Ctx(), ctx.KubeProvider())
 	if err != nil {
@@ -415,7 +415,7 @@ func (r *runner) convergeMigration(ctx *context.Context, checkHasTerraformStateB
 			return err
 		}
 	} else {
-		log.InfoF("Skip restarting autoconverger\n")
+		log.InfoF("Skipping restart of autoconverger\n")
 	}
 
 	log.DebugLn("Restarting infrastructure manager deployments finished")
@@ -425,7 +425,7 @@ func (r *runner) convergeMigration(ctx *context.Context, checkHasTerraformStateB
 
 func (r *runner) converge(ctx *context.Context) error {
 	log.DebugF("Converge start\n")
-	defer log.DebugF("Converge finisher\n")
+	defer log.DebugF("Converge finished\n")
 	metaConfig, err := ctx.MetaConfig()
 	if err != nil {
 		return err
@@ -438,7 +438,7 @@ func (r *runner) converge(ctx *context.Context) error {
 			return err
 		}
 	} else {
-		log.InfoLn("Skip converge base infrastructure")
+		log.InfoLn("Skipping converge of base infrastructure")
 	}
 
 	kubeClientSwitched := false
@@ -460,7 +460,7 @@ func (r *runner) converge(ctx *context.Context) error {
 			return err
 		}
 	} else {
-		log.InfoLn("Skip converge nodes")
+		log.InfoLn("Skipping converge of nodes")
 	}
 
 	if !r.isSkip(phases.DeckhouseConfigurationPhase) {
@@ -469,7 +469,7 @@ func (r *runner) converge(ctx *context.Context) error {
 			return err
 		}
 	} else {
-		log.InfoLn("Skip converge deckhouse configuration")
+		log.InfoLn("Skipping converge of deckhouse configuration")
 	}
 
 	if kubeClientSwitched {

--- a/dhctl/pkg/operations/destroy/destroy_provider.go
+++ b/dhctl/pkg/operations/destroy/destroy_provider.go
@@ -54,7 +54,7 @@ func (f *infraDestroyerProvider) Cloud(context.Context, *config.MetaConfig) (inf
 	}
 
 	if govalue.IsNil(f.cloudStateProvider) {
-		return nil, fmt.Errorf("Cloud state provider should provided to infraDestroyerProvider")
+		return nil, fmt.Errorf("Cloud state provider should be provided to infraDestroyerProvider")
 	}
 
 	stateLoader, clusterInfra, err := f.cloudStateProvider()
@@ -63,11 +63,11 @@ func (f *infraDestroyerProvider) Cloud(context.Context, *config.MetaConfig) (inf
 	}
 
 	if govalue.IsNil(stateLoader) {
-		return nil, fmt.Errorf("Cloud state loader should provided from cloudStateProvider")
+		return nil, fmt.Errorf("Cloud state loader should be provided by cloudStateProvider")
 	}
 
 	if govalue.IsNil(clusterInfra) {
-		return nil, fmt.Errorf("Cluster infrastructure should provided from cloudStateProvider")
+		return nil, fmt.Errorf("Cluster infrastructure should be provided by cloudStateProvider")
 	}
 
 	return cloud.NewDestroyer(&cloud.DestroyerParams{
@@ -90,7 +90,7 @@ func (f *infraDestroyerProvider) Static(context.Context, *config.MetaConfig) (in
 	}
 
 	if govalue.IsNil(f.sshClientProvider) {
-		return nil, fmt.Errorf("SSH client provider should provided to infraDestroyerProvider")
+		return nil, fmt.Errorf("SSH client provider should be provided to infraDestroyerProvider")
 	}
 
 	return static.NewDestroyer(&static.DestroyerParams{
@@ -112,19 +112,19 @@ func (f *infraDestroyerProvider) Incorrect(_ context.Context, metaConfig *config
 
 func (f *infraDestroyerProvider) checkGeneralParams() error {
 	if govalue.IsNil(f.stateCache) {
-		return fmt.Errorf("State cache should provided to infraDestroyerProvider")
+		return fmt.Errorf("State cache should be provided to infraDestroyerProvider")
 	}
 
 	if govalue.IsNil(f.kubeProvider) {
-		return fmt.Errorf("Kubernetes provider should provided to infraDestroyerProvider")
+		return fmt.Errorf("Kubernetes provider should be provided to infraDestroyerProvider")
 	}
 
 	if govalue.IsNil(f.phasesActionProvider) {
-		return fmt.Errorf("Phases action provider should provided to infraDestroyerProvider")
+		return fmt.Errorf("Phases action provider should be provided to infraDestroyerProvider")
 	}
 
 	if f.tmpDir == "" {
-		return fmt.Errorf("Temp directory should provided to infraDestroyerProvider")
+		return fmt.Errorf("Temp directory should be provided to infraDestroyerProvider")
 	}
 
 	// wait params can be nil

--- a/dhctl/pkg/operations/destroy/kubecl.go
+++ b/dhctl/pkg/operations/destroy/kubecl.go
@@ -38,7 +38,7 @@ func newKubeClientProvider(kubeProvider libcon.KubeProvider, sshProvider libcon.
 
 func (p *kubeClientProvider) KubeClientCtx(ctx context.Context) (*client.KubernetesClient, error) {
 	if p.kubeProvider == nil {
-		return nil, fmt.Errorf("kube provider in nil")
+		return nil, fmt.Errorf("kube provider is nil")
 	}
 	kubeCl, err := p.kubeProvider.Client(ctx)
 	if err != nil {
@@ -50,13 +50,13 @@ func (p *kubeClientProvider) KubeClientCtx(ctx context.Context) (*client.Kuberne
 func (p *kubeClientProvider) Cleanup(ctx context.Context, stopSSH bool) {
 	err := p.kubeProvider.Cleanup(ctx)
 	if err != nil {
-		log.WarnF("failed to cleanup kube provider: %v", err)
+		log.WarnF("failed to clean up kube provider: %v", err)
 	}
 
 	if stopSSH {
 		err := p.sshProvider.Cleanup(ctx)
 		if err != nil {
-			log.WarnF("failed to cleanup ssh provider: %v", err)
+			log.WarnF("failed to clean up ssh provider: %v", err)
 		}
 	}
 }

--- a/dhctl/pkg/operations/destroy/static/destroyer.go
+++ b/dhctl/pkg/operations/destroy/static/destroyer.go
@@ -109,7 +109,7 @@ func (d *Destroyer) Prepare(ctx context.Context) error {
 
 	if err != nil {
 		if !errors.Is(err, errNotFoundCredentials) {
-			return fmt.Errorf("Error while getting node user from cache: %w", err)
+			return fmt.Errorf("Error getting node user from cache: %w", err)
 		}
 
 		d.nodesWithCredentials, err = d.createAndSaveCredentials(ctx, logger)
@@ -117,7 +117,7 @@ func (d *Destroyer) Prepare(ctx context.Context) error {
 			return err
 		}
 	} else {
-		logger.LogDebugLn("Found existing nodes with credentials. Saved to destroyer and skipping creating")
+		logger.LogDebugLn("Found existing nodes with credentials. Saved to destroyer and skipping creation")
 	}
 
 	return d.waitNodeUserExists(ctx)
@@ -134,7 +134,7 @@ func (d *Destroyer) CleanupBeforeDestroy(ctx context.Context) error {
 
 func (d *Destroyer) DestroyCluster(ctx context.Context, autoApprove bool) error {
 	if govalue.IsNil(d.params.SSHClientProvider) {
-		return errors.New("Internal error. SSH provider did not pass")
+		return errors.New("Internal error. SSH provider was not passed")
 	}
 
 	return d.params.PhasedActionProvider().Run(ctx, phases.AllNodesPhase, true, func() (phases.DefaultContextType, error) {
@@ -150,7 +150,7 @@ func (d *Destroyer) DestroyCluster(ctx context.Context, autoApprove bool) error 
 func (d *Destroyer) destroyCluster(ctx context.Context, autoApprove bool) error {
 	if !autoApprove {
 		if !input.NewConfirmation().WithMessage("Do you really want to cleanup control-plane nodes?").Ask() {
-			return fmt.Errorf("Cleanup master nodes disallow")
+			return fmt.Errorf("Cleaning up master nodes is not allowed")
 		}
 	}
 
@@ -308,7 +308,7 @@ func (d *Destroyer) processStaticHost(ctx context.Context, sshClient libcon.SSHC
 
 func (d *Destroyer) switchToNodeUser(ctx context.Context, sshProvider libcon.SSHProvider, settings *session.Session) (libcon.SSHClient, error) {
 	if d.nodesWithCredentials == nil {
-		return nil, fmt.Errorf("Internal error. No nodes with credentials in destroyer. Probably Prepare did not call or try destroy when abort")
+		return nil, fmt.Errorf("Internal error. No nodes with credentials in destroyer. Probably Prepare was not called, or destroy was attempted during an abort")
 	}
 
 	if d.params.TmpDir == "" {
@@ -404,15 +404,15 @@ func (d *Destroyer) switchToNodeUser(ctx context.Context, sshProvider libcon.SSH
 
 func (d *Destroyer) waitNodeUserExists(ctx context.Context) error {
 	if d.params.PhasedActionProvider == nil {
-		return fmt.Errorf("Internal error. PhasedActionProvider not initialized. Probably you try to destroy when need abort")
+		return fmt.Errorf("Internal error. PhasedActionProvider not initialized. Probably you tried to destroy when an abort was needed")
 	}
 
 	if d.nodesWithCredentials == nil {
-		return fmt.Errorf("Internal error. nodesWithCredentials not initialized. Probably you try to destroy when need abort")
+		return fmt.Errorf("Internal error. nodesWithCredentials not initialized. Probably you tried to destroy when an abort was needed")
 	}
 
 	if len(d.nodesWithCredentials.IPs) == 0 {
-		return fmt.Errorf("Internal error. nodesWithCredentials ips is empty")
+		return fmt.Errorf("Internal error. nodesWithCredentials IPs are empty")
 	}
 
 	logger := d.logger()
@@ -462,7 +462,7 @@ func (d *Destroyer) createNodeUserCredentials(ctx context.Context, ips []entity.
 
 func (d *Destroyer) createAndSaveCredentials(ctx context.Context, logger log.Logger) (*NodesWithCredentials, error) {
 	if d.params.PhasedActionProvider == nil {
-		return nil, fmt.Errorf("Internal error. PhasedActionProvider not initialized. Probably you try to destroy when need abort")
+		return nil, fmt.Errorf("Internal error. PhasedActionProvider not initialized. Probably you tried to destroy when an abort was needed")
 	}
 
 	nodeIPs, err := entity.GetMasterNodesIPs(ctx, d.params.KubeProvider, d.params.Loops.GetMastersIPs)

--- a/dhctl/pkg/operations/destroy/static/state.go
+++ b/dhctl/pkg/operations/destroy/static/state.go
@@ -27,7 +27,7 @@ const (
 	nodeUserExistsKey = "node-user-exists"
 )
 
-var errNotFoundCredentials = errors.New("Not found node user credentials")
+var errNotFoundCredentials = errors.New("node user credentials not found")
 
 type State struct {
 	cache state.Cache

--- a/dhctl/pkg/operations/edit.go
+++ b/dhctl/pkg/operations/edit.go
@@ -54,7 +54,7 @@ func Edit(data []byte, globalOptions *options.GlobalOptions, opts EditOptions) (
 
 	err = os.WriteFile(tmpFile.Name(), data, 0o600)
 	if err != nil {
-		log.ErrorF("can't write write cluster configuration to the file %s: %s\n", tmpFile.Name(), err)
+		log.ErrorF("can't write cluster configuration to the file %s: %s\n", tmpFile.Name(), err)
 		return nil, err
 	}
 

--- a/dhctl/pkg/operations/exporter.go
+++ b/dhctl/pkg/operations/exporter.go
@@ -215,7 +215,7 @@ func (c *ConvergeExporter) registerMetrics() {
 //
 //nolint:gocritic
 func (c *ConvergeExporter) Start(ctx context.Context) {
-	log.InfoLn("Start exporter")
+	log.InfoLn("Starting exporter")
 	log.InfoLn("Address: ", c.ListenAddress)
 	log.InfoLn("Metrics path: ", c.MetricsPath)
 	log.InfoLn("Checks interval: ", c.CheckInterval)
@@ -264,7 +264,7 @@ func (c *ConvergeExporter) convergeLoop(ctx context.Context) {
 		case <-ticker.C:
 			c.recordStatistic(c.getStatistic(ctx, clearTmp))
 		case <-ctx.Done():
-			log.ErrorLn("Stop exporter...")
+			log.ErrorLn("Stopping exporter...")
 			return
 		}
 	}
@@ -354,7 +354,7 @@ func (c *ConvergeExporter) recordStatistic(statistic *check.Statistics, hasTerra
 		}
 
 		c.GaugeMetrics["cluster_status"].WithLabelValues(status).Set(0)
-		log.InfoF("Cluster status: clean %s status\n", status)
+		log.InfoF("Cluster status: clearing %s status\n", status)
 	}
 
 	newExistedEntities := newPreviouslyExistedEntities()
@@ -368,7 +368,7 @@ func (c *ConvergeExporter) recordStatistic(statistic *check.Statistics, hasTerra
 				continue
 			}
 			c.GaugeMetrics["node_status"].WithLabelValues(status, node.Group, node.Name).Set(0)
-			log.InfoF("%v/%v: clean node status %v\n", node.Group, node.Name, status)
+			log.InfoF("%v/%v: clearing node status %v\n", node.Group, node.Name, status)
 		}
 	}
 
@@ -380,7 +380,7 @@ func (c *ConvergeExporter) recordStatistic(statistic *check.Statistics, hasTerra
 				continue
 			}
 			c.GaugeMetrics["node_template_status"].WithLabelValues(status, template.Name).Set(0)
-			log.InfoF("%v: node template clean status %v\n", template.Name, status)
+			log.InfoF("%v: clearing node template status %v\n", template.Name, status)
 		}
 	}
 
@@ -391,7 +391,7 @@ func (c *ConvergeExporter) recordStatistic(statistic *check.Statistics, hasTerra
 		}
 		for _, status := range nodeStatuses {
 			c.GaugeMetrics["node_status"].WithLabelValues(status, nodeGroup, nodeName).Set(0)
-			log.InfoF("%v/%v: clean missing node status %v\n", nodeGroup, nodeName, status)
+			log.InfoF("%v/%v: clearing missing node status %v\n", nodeGroup, nodeName, status)
 		}
 	}
 

--- a/dhctl/pkg/operations/nodebootstrap.go
+++ b/dhctl/pkg/operations/nodebootstrap.go
@@ -235,7 +235,7 @@ func ParallelBootstrapAdditionalNodes(
 	}
 
 	if err := nodesCheckErrors.ErrorOrNil(); err != nil {
-		return nil, fmt.Errorf("Check existing nodes in cluster error: %w", err)
+		return nil, fmt.Errorf("error checking existing nodes in cluster: %w", err)
 	}
 
 	if len(nodesIndexToCreate) > 1 && !saveLogToBuffer {
@@ -501,7 +501,7 @@ func checkNodeResourceExistsInClusterDuringBootstrap(ctx context.Context, params
 
 	hasState, err := infrastructurestate.HasNodeStateInCluster(ctx, kubeCl, params.node)
 	if err != nil {
-		return fmt.Errorf("Cannot check that state in cluster for %s: %w", nodeName, err)
+		return fmt.Errorf("Cannot check state in cluster for %s: %w", nodeName, err)
 	}
 
 	if hasState {
@@ -516,13 +516,13 @@ func checkNodeResourceExistsInClusterDuringBootstrap(ctx context.Context, params
 		// - client fix cloud issue (like extend quota)
 		// - vm started and registered
 		// - client restart bootstrap
-		logger.LogDebugF("Has node state in cluster for '%s'. Skip checking node resource in cluster\n", nodeName)
+		logger.LogDebugF("Has node state in cluster for '%s'. Skipping node resource check in cluster\n", nodeName)
 		return nil
 	}
 
 	nodeExists, err := entity.IsNodeExistsInCluster(ctx, kubeCl, nodeName, logger)
 	if err != nil {
-		return fmt.Errorf("Cannot check that node resource exists for %s: %w", nodeName, err)
+		return fmt.Errorf("Cannot check whether node resource exists for %s: %w", nodeName, err)
 	}
 
 	if nodeExists {

--- a/dhctl/pkg/operations/phases/wrappers.go
+++ b/dhctl/pkg/operations/phases/wrappers.go
@@ -122,7 +122,7 @@ func (a *phaseActionWithError[OperationPhaseDataT]) Run(ctx context.Context, pha
 }
 
 func (a *phaseActionWithError[OperationPhaseDataT]) CompleteSub(phase OperationSubPhase) error {
-	return fmt.Errorf("SubPhase '%s' cannot be complete: %w", phase, a.err)
+	return fmt.Errorf("SubPhase '%s' cannot be completed: %w", phase, a.err)
 }
 
 type (
@@ -305,7 +305,7 @@ func (p *PipelineWithStateCache[OperationPhaseDataT]) initPipeline(ctx context.C
 	}
 
 	if err := p.phaseContext.InitPipeline(ctx, p.stateCache); err != nil {
-		return p.wrapError(fmt.Errorf("cannot init pipline: %w", err))
+		return p.wrapError(fmt.Errorf("cannot init pipeline: %w", err))
 	}
 
 	return nil

--- a/dhctl/pkg/operations/secretedit.go
+++ b/dhctl/pkg/operations/secretedit.go
@@ -118,7 +118,7 @@ func SecretEdit(
 					}
 
 					if editOpts.SanityCheck {
-						log.InfoLn("Remove allow-unsafe annotation")
+						log.InfoLn("Removing allow-unsafe annotation")
 						removeUnsafeAnnotation(config)
 
 						_, err = kubeCl.CoreV1().

--- a/dhctl/pkg/preflight/checks/cidr_intersection_static.go
+++ b/dhctl/pkg/preflight/checks/cidr_intersection_static.go
@@ -112,7 +112,7 @@ func cidrIntersects(cidr1, cidr2 string) error {
 	}
 
 	if ipNet1.Contains(ipNet2.IP) || ipNet2.Contains(ipNet1.IP) {
-		return fmt.Errorf("CIDRs %s and %s are intersects", cidr1, cidr2)
+		return fmt.Errorf("CIDRs %s and %s intersect", cidr1, cidr2)
 	}
 
 	return nil

--- a/dhctl/pkg/preflight/checks/cidr_intersection_test.go
+++ b/dhctl/pkg/preflight/checks/cidr_intersection_test.go
@@ -98,7 +98,7 @@ func TestCidrIntersects(t *testing.T) {
 			cidr1:       "10.0.0.0/8",
 			cidr2:       "10.0.1.0/24",
 			expectError: true,
-			errorMsg:    "CIDRs 10.0.0.0/8 and 10.0.1.0/24 are intersects",
+			errorMsg:    "CIDRs 10.0.0.0/8 and 10.0.1.0/24 intersect",
 		},
 		{
 			cidr1:       "10.0.0.0/8",
@@ -167,7 +167,7 @@ func TestCheckCidrIntersection(t *testing.T) {
 				},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "are intersects")
+				return assert.ErrorContains(t, err, "intersect")
 			},
 		},
 		{
@@ -269,7 +269,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 				},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "are intersects")
+				return assert.ErrorContains(t, err, "intersect")
 			},
 		},
 		{
@@ -284,7 +284,7 @@ func TestCheckCidrIntersectionStatic(t *testing.T) {
 				},
 			}},
 			wantErr: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.ErrorContains(t, err, "are intersects")
+				return assert.ErrorContains(t, err, "intersect")
 			},
 		},
 		{

--- a/dhctl/pkg/preflight/checks/cloud_api_access.go
+++ b/dhctl/pkg/preflight/checks/cloud_api_access.go
@@ -195,8 +195,8 @@ var cloudAPIConfigsProviders = map[string]func(providerClusterConfig []byte) (*c
 }
 
 func wrapTunnelErr(err error) error {
-	return fmt.Errorf(`cannot setup tunnel to control-plane host: %w.
-Please check connectivity to control-plane host and that the sshd config parameters 'AllowTcpForwarding' is set to 'yes' and 'DisableForwarding' is set to 'no' on the control-plane node.`, err)
+	return fmt.Errorf(`cannot set up tunnel to the control-plane host: %w.
+Please check connectivity to the control-plane host and that the sshd config parameters 'AllowTcpForwarding' is set to 'yes' and 'DisableForwarding' is set to 'no' on the control-plane node.`, err)
 }
 
 func CloudAPIAccess(meta *config.MetaConfig, sshProvider libcon.SSHProvider, legacyMode bool) preflight.Check {

--- a/dhctl/pkg/preflight/checks/python.go
+++ b/dhctl/pkg/preflight/checks/python.go
@@ -47,7 +47,7 @@ func (PythonCheck) RetryPolicy() preflight.RetryPolicy {
 func (c PythonCheck) Run(ctx context.Context) error {
 	pythonBinary, err := detectPythonBinary(ctx, c.NodeInterface)
 	if err != nil {
-		return fmt.Errorf("Detect Python binary name: %w", err)
+		return fmt.Errorf("detecting Python binary name: %w", err)
 	}
 
 	requiredPythonModules := [][]string{
@@ -96,7 +96,7 @@ func detectPythonBinary(ctx context.Context, nodeInterface libcon.Interface) (st
 	}
 
 	return "", fmt.Errorf(
-		"Python was not found under any of expected names (%s), please install Python 2 or 3 on the node",
+		"Python was not found under any of the expected names (%s), please install Python 2 or 3 on the node",
 		strings.Join(possibleBinaries, ", "),
 	)
 }

--- a/dhctl/pkg/preflight/checks/python_test.go
+++ b/dhctl/pkg/preflight/checks/python_test.go
@@ -100,7 +100,7 @@ func TestCheckPythonAndItsModules(t *testing.T) {
 					mni.On("Command", "command", []string{"-v", binary}).Return(cmd)
 				}
 			},
-			expectedError: "Python was not found under any of expected names",
+			expectedError: "Python was not found under any of the expected names",
 		},
 		{
 			name: "python available but missing required modules",
@@ -198,7 +198,7 @@ func TestDetectPythonBinary(t *testing.T) {
 					mni.On("Command", "command", []string{"-v", binary}).Return(cmd)
 				}
 			},
-			expectedError: "Python was not found under any of expected names",
+			expectedError: "Python was not found under any of the expected names",
 		},
 	}
 

--- a/dhctl/pkg/preflight/checks/registry_auth.go
+++ b/dhctl/pkg/preflight/checks/registry_auth.go
@@ -125,12 +125,12 @@ func getAuthRealmAndService(ctx context.Context, metaConfig *config.MetaConfig, 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return authURL, registryService, fmt.Errorf("cannot auth in registry. %w", err)
+		return authURL, registryService, fmt.Errorf("cannot authenticate in registry. %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
-		return authURL, registryService, fmt.Errorf("%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\nCheck if container registry address is correct", ErrAuthRegistryFailed)
+		return authURL, registryService, fmt.Errorf("%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\nCheck that the container registry address is correct", ErrAuthRegistryFailed)
 	}
 	wwwAuthHeader := resp.Header.Get("WWW-Authenticate")
 
@@ -140,7 +140,7 @@ func getAuthRealmAndService(ctx context.Context, metaConfig *config.MetaConfig, 
 
 	realmMatches := realmRe.FindStringSubmatch(wwwAuthHeader)
 	if len(realmMatches) == 0 {
-		return authURL, registryService, fmt.Errorf("couldn't find bearer realm parameter, consider enabling bearer token auth in your registry, returned header:%s. %w", wwwAuthHeader, ErrAuthRegistryFailed)
+		return authURL, registryService, fmt.Errorf("couldn't find the bearer realm parameter; consider enabling bearer token auth in your registry. Returned header: %s. %w", wwwAuthHeader, ErrAuthRegistryFailed)
 	}
 	authURL = realmMatches[1]
 
@@ -171,12 +171,12 @@ func checkBasicRegistryAuth(ctx context.Context, metaConfig *config.MetaConfig, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("cannot request to registry. %w", err)
+		return fmt.Errorf("cannot send request to registry. %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
-		return fmt.Errorf("%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\nCheck if container registry address is correct", ErrAuthRegistryFailed)
+		return fmt.Errorf("%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\nCheck that the container registry address is correct", ErrAuthRegistryFailed)
 	}
 
 	return checkResponseError(resp)
@@ -195,7 +195,7 @@ func checkTokenRegistryAuth(ctx context.Context, metaConfig *config.MetaConfig, 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("cannot auth in registry. %w", err)
+		return fmt.Errorf("cannot authenticate in registry. %w", err)
 	}
 	defer resp.Body.Close()
 

--- a/dhctl/pkg/preflight/checks/registry_proxy.go
+++ b/dhctl/pkg/preflight/checks/registry_proxy.go
@@ -93,8 +93,8 @@ func (c RegistryProxyCheck) Run(ctx context.Context) error {
 
 	tun, err := utils.SetupSSHTunnelToProxyAddr(ctx, wrapper.Client(), proxyURL, c.LegacyMode)
 	if err != nil {
-		return fmt.Errorf(`Cannot setup tunnel to control-plane host: %w.
-Please check connectivity to control-plane host and that the sshd config parameters 'AllowTcpForwarding' is set to 'yes' and 'DisableForwarding' is set to 'no' on the control-plane node.`, err)
+		return fmt.Errorf(`Cannot set up tunnel to the control-plane host: %w.
+Please check connectivity to the control-plane host and that the sshd config parameters 'AllowTcpForwarding' is set to 'yes' and 'DisableForwarding' is set to 'no' on the control-plane node.`, err)
 	}
 	defer tun.Stop()
 
@@ -115,7 +115,7 @@ Please check connectivity to control-plane host and that the sshd config paramet
 	httpCl := utils.BuildHTTPClientWithLocalhostProxy(proxyURL)
 	resp, err := httpCl.Do(req)
 	if err != nil {
-		return fmt.Errorf(`Container registry API connectivity check was failed with error: %w.
+		return fmt.Errorf(`Container registry API connectivity check failed with error: %w.
 Please check connectivity from the control-plane node to the proxy and from the proxy to the container registry.`, err)
 	}
 
@@ -130,7 +130,7 @@ func checkResponseIsFromDockerRegistry(resp *http.Response) error {
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusUnauthorized {
 		return fmt.Errorf(
 			"%w: got %d status code from the container registry API, this is not a valid registry API response.\n"+
-				"Check if container registry address is correct and if there is any reverse proxies that might be misconfigured.",
+				"Check that the container registry address is correct and that there are no misconfigured reverse proxies.",
 			ErrRegistryUnreachable,
 			resp.StatusCode,
 		)
@@ -139,7 +139,7 @@ func checkResponseIsFromDockerRegistry(resp *http.Response) error {
 	if resp.Header.Get("Docker-Distribution-API-Version") != "registry/2.0" {
 		return fmt.Errorf(
 			"%w: expected Docker-Distribution-API-Version=registry/2.0 header in response from registry.\n"+
-				"Check if container registry address is correct and if there is any reverse proxies that might be misconfigured",
+				"Check that the container registry address is correct and that there are no misconfigured reverse proxies",
 			ErrRegistryUnreachable,
 		)
 	}

--- a/dhctl/pkg/preflight/checks/ssh_credential.go
+++ b/dhctl/pkg/preflight/checks/ssh_credential.go
@@ -55,7 +55,7 @@ func (c *SSHCredentialCheck) Run(ctx context.Context) error {
 		return nil
 	}
 	if err := wrapper.Client().Check().CheckAvailability(ctx); err != nil {
-		return fmt.Errorf("ssh %w. Please check ssh credential and try again. Error: %w", ErrAuthSSHFailed, err)
+		return fmt.Errorf("ssh %w. Please check your ssh credentials and try again. Error: %w", ErrAuthSSHFailed, err)
 	}
 	return nil
 }

--- a/dhctl/pkg/server/pkg/interceptors/interceptors.go
+++ b/dhctl/pkg/server/pkg/interceptors/interceptors.go
@@ -84,17 +84,17 @@ func UnaryParallelTasksLimiter(sem chan struct{}, prefix string) grpc.UnaryServe
 		}
 
 		log := logger.L(ctx)
-		log.Info("limiter tries to start operation", slog.Int("concurrent_operation", len(sem)))
+		log.Info("limiter trying to start an operation", slog.Int("concurrent_operation", len(sem)))
 		timeout := time.After(5 * time.Minute)
 		select {
 		case <-timeout:
-			log.Info("limiter couldn't start operation due to timeout", slog.Int("concurrent_operation", len(sem)))
-			return nil, status.Error(codes.ResourceExhausted, "too many dhctl operation has already started")
+			log.Info("limiter couldn't start an operation due to timeout", slog.Int("concurrent_operation", len(sem)))
+			return nil, status.Error(codes.ResourceExhausted, "too many dhctl operations have already started")
 		case sem <- struct{}{}:
-			log.Info("limiter started operation", slog.Int("concurrent_operation", len(sem)))
+			log.Info("limiter started an operation", slog.Int("concurrent_operation", len(sem)))
 			defer func() {
 				<-sem
-				log.Info("limiter finished operation", slog.Int("concurrent_operation", len(sem)))
+				log.Info("limiter finished an operation", slog.Int("concurrent_operation", len(sem)))
 			}()
 
 			return handler(ctx, req)
@@ -109,17 +109,17 @@ func StreamParallelTasksLimiter(sem chan struct{}, prefix string) grpc.StreamSer
 		}
 
 		log := logger.L(ss.Context())
-		log.Info("limiter tries to start operation", slog.Int("concurrent_operation", len(sem)))
+		log.Info("limiter trying to start an operation", slog.Int("concurrent_operation", len(sem)))
 		timeout := time.After(resourceExhaustedTimeout)
 		select {
 		case <-timeout:
-			log.Info("limiter couldn't start operation due to timeout", slog.Int("concurrent_operation", len(sem)))
-			return status.Error(codes.ResourceExhausted, "too many dhctl operations has already started")
+			log.Info("limiter couldn't start an operation due to timeout", slog.Int("concurrent_operation", len(sem)))
+			return status.Error(codes.ResourceExhausted, "too many dhctl operations have already started")
 		case sem <- struct{}{}:
-			log.Info("limiter started operation", slog.Int("concurrent_operation", len(sem)))
+			log.Info("limiter started an operation", slog.Int("concurrent_operation", len(sem)))
 			defer func() {
 				<-sem
-				log.Info("limiter finished operation", slog.Int("concurrent_operation", len(sem)))
+				log.Info("limiter finished an operation", slog.Int("concurrent_operation", len(sem)))
 			}()
 
 			return handler(srv, ss)

--- a/dhctl/pkg/server/rpc/dhctl/service.go
+++ b/dhctl/pkg/server/rpc/dhctl/service.go
@@ -177,7 +177,7 @@ func (b *fsmPhaseSwitcher[T, OperationPhaseDataT]) switchPhase(ctx context.Conte
 		select {
 		case switchErr, ok = <-b.next:
 			if !ok {
-				return fmt.Errorf("server stopped, cancel task")
+				return fmt.Errorf("server stopped, canceling task")
 			}
 		case <-ctx.Done():
 			switchErr = fmt.Errorf("%w: %w", phases.ErrStopOperationCondition, ctx.Err())

--- a/dhctl/pkg/server/server/proxy.go
+++ b/dhctl/pkg/server/server/proxy.go
@@ -143,7 +143,7 @@ func (d *StreamDirector) Director() proxy.StreamDirector {
 
 		d.writeLogs(log, stdOutReader, stdErrReader)
 
-		log.Info("dhctl instance will start with next command arguments", slog.String("cmd", strings.Join(cmd.Args, " ")))
+		log.Info("dhctl instance will start with the following command arguments", slog.String("cmd", strings.Join(cmd.Args, " ")))
 
 		err = cmd.Start()
 		if err != nil {

--- a/dhctl/pkg/state/cache/init.go
+++ b/dhctl/pkg/state/cache/init.go
@@ -48,7 +48,7 @@ func choiceCache(ctx context.Context, identity string, opts CacheOptions) (state
 	log.InfoF("State cache directory: %s\n", tmpDir)
 
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
-		return nil, fmt.Errorf("Can't create cache directory: %w", err)
+		return nil, fmt.Errorf("Cannot create cache directory: %w", err)
 	}
 
 	if cacheOpts.KubeNamespace == "" {
@@ -58,7 +58,7 @@ func choiceCache(ctx context.Context, identity string, opts CacheOptions) (state
 		return cache.NewStateCache(tmpDir)
 	}
 
-	log.DebugLn("Use kubernetes state cache")
+	log.DebugLn("Using Kubernetes state cache")
 
 	kubeCl := client.NewKubernetesClient()
 	err := kubeCl.Init(&client.KubernetesInitParams{

--- a/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
+++ b/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
@@ -100,7 +100,7 @@ func (t *TofuMigrationStateBackuper) doBackupStates(ctx context.Context) error {
 			return err
 		}
 	} else {
-		t.logger.LogInfoF("Backup secret %s for base infrastructure state exists. Skip backup.\n", baseInfraBackupSecretName)
+		t.logger.LogInfoF("Backup secret %s for base infrastructure state exists. Skipping backup.\n", baseInfraBackupSecretName)
 	}
 
 	kubeClient, err := t.kubeProvider.KubeClientCtx(ctx)
@@ -115,7 +115,7 @@ func (t *TofuMigrationStateBackuper) doBackupStates(ctx context.Context) error {
 
 	for _, secret := range secrets {
 		if len(secret.Labels) > 0 && secret.Labels[tofuBackupLabelKey] == "true" {
-			t.logger.LogInfoF("Skip backup secret %s\n", secret.Name)
+			t.logger.LogInfoF("Skipping backup secret %s\n", secret.Name)
 			continue
 		}
 
@@ -126,7 +126,7 @@ func (t *TofuMigrationStateBackuper) doBackupStates(ctx context.Context) error {
 		}
 
 		if exists {
-			t.logger.LogInfoF("Backup secret %s for base infrastructure state exists. Skip backup.\n", nodeBackupSecretName)
+			t.logger.LogInfoF("Backup secret %s for base infrastructure state exists. Skipping backup.\n", nodeBackupSecretName)
 			continue
 		}
 
@@ -237,7 +237,7 @@ func (t *TofuMigrationStateBackuper) saveBackupSecret(ctx context.Context, proce
 
 func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Context) error {
 	if t.commanderMode == nil {
-		t.logger.LogInfoF("Skip save backup for commander mode because is not commander\n")
+		t.logger.LogInfoF("Skipping backup save for commander mode because this is not the commander\n")
 		return nil
 	}
 
@@ -256,7 +256,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 				return err
 			}
 			if ok {
-				t.logger.LogInfoF("Skip base infrastructure backup state for commander. Exists\n")
+				t.logger.LogInfoF("Skipping base infrastructure backup state for commander. Already exists\n")
 				return nil
 			}
 
@@ -268,9 +268,9 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 	}
 
 	for ngName, ng := range ngs {
-		err = t.logger.LogProcessCtx(ctx, "default", fmt.Sprintf("Save infrastructure backup nodes states for commander for node group %s", ngName), func(ctx context.Context) error {
+		err = t.logger.LogProcessCtx(ctx, "default", fmt.Sprintf("Save infrastructure backup node states for commander for node group %s", ngName), func(ctx context.Context) error {
 			for node, st := range ng.State {
-				err := retry.NewLoop(fmt.Sprintf("Save infrastructure backup state for node %s states for commander", node), 1, 5*time.Second).
+				err := retry.NewLoop(fmt.Sprintf("Save infrastructure backup state for node %s for commander", node), 1, 5*time.Second).
 					WithLogger(t.logger).
 					RunContext(ctx, func() error {
 						name := "tf-" + node + ".terraform.backup"
@@ -280,7 +280,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 							return err
 						}
 						if ok {
-							t.logger.LogInfoF("Skip node %s infrastructure backup state for commander. Exists\n", node)
+							t.logger.LogInfoF("Skipping node %s infrastructure backup state for commander. Already exists\n", node)
 							return nil
 						}
 

--- a/dhctl/pkg/state/infrastructure/state.go
+++ b/dhctl/pkg/state/infrastructure/state.go
@@ -45,7 +45,7 @@ const (
 	infraStateSecretNodeNameLabelKey  = "node.deckhouse.io/node-name"
 )
 
-var ErrNoInfrastructureState = errors.New("Infrastructure state is not found in outputs.")
+var ErrNoInfrastructureState = errors.New("Infrastructure state was not found in outputs.")
 
 func GetClusterStateFromCluster(ctx context.Context, kubeCl *client.KubernetesClient) ([]byte, error) {
 	var st []byte
@@ -119,17 +119,17 @@ func GetNodesStateSecretsFromCluster(ctx context.Context, kubeCl *client.Kuberne
 
 			name := nodeState.Labels[infraStateSecretNodeNameLabelKey]
 			if name == "" {
-				return fmt.Errorf("Cannot determine Node name for %q secret", secretName)
+				return fmt.Errorf("Cannot determine Node name for secret %q", secretName)
 			}
 
 			if _, ok := nodeState.Labels[global.InfrastructureStateBackupLabelKey]; ok {
-				log.DebugF("Found backup state secret %s for node: %s. Skip.\n", secretName, name)
+				log.DebugF("Found backup state secret %s for node: %s. Skipping.\n", secretName, name)
 				continue
 			}
 
 			nodeGroup := nodeState.Labels[infraStateSecretNodeGroupLabelKey]
 			if nodeGroup == "" {
-				return fmt.Errorf("can't determine NodeGroup for %q secret", nodeState.GetName())
+				return fmt.Errorf("Cannot determine NodeGroup for secret %q", nodeState.GetName())
 			}
 			secrets = append(secrets, &nodeState)
 		}
@@ -169,12 +169,12 @@ func (p HasNodeStateInClusterParams) String() string {
 func HasNodeStateInCluster(ctx context.Context, kubeCl *client.KubernetesClient, params HasNodeStateInClusterParams) (bool, error) {
 	nodeName := params.Name
 	if nodeName == "" {
-		return false, fmt.Errorf("HasNodeStateInCluster: internal error. node name not passed")
+		return false, fmt.Errorf("HasNodeStateInCluster: internal error. node name was not passed")
 	}
 
 	nodeGroup := params.NodeGroup
 	if nodeGroup == "" {
-		return false, fmt.Errorf("HasNodeStateInCluster: internal error. node group not passed for %s", nodeName)
+		return false, fmt.Errorf("HasNodeStateInCluster: internal error. node group was not passed for %s", nodeName)
 	}
 
 	selectors := []kubernetes.LabelSelector{
@@ -230,7 +230,7 @@ func GetMasterNodesStateFromCluster(ctx context.Context, kubeProvider kubernetes
 
 	states, ok := statesForNgMap[global.MasterNodeGroupName]
 	if !ok {
-		return nil, fmt.Errorf("GetMasterNodesStateFromCluster: states for master node group not found")
+		return nil, fmt.Errorf("GetMasterNodesStateFromCluster: states for the master node group were not found")
 	}
 
 	return states.State, nil
@@ -244,12 +244,12 @@ func extractNodesStatesFromSecrets(secrets []*v1.Secret) (map[string]state.NodeG
 
 		name := nodeState.Labels[infraStateSecretNodeNameLabelKey]
 		if name == "" {
-			return nil, fmt.Errorf("Cannot determine Node name for %q secret", secretName)
+			return nil, fmt.Errorf("Cannot determine Node name for secret %q", secretName)
 		}
 
 		nodeGroup := nodeState.Labels[infraStateSecretNodeGroupLabelKey]
 		if nodeGroup == "" {
-			return nil, fmt.Errorf("Cannot determine NodeGroup for %q secret", secretName)
+			return nil, fmt.Errorf("Cannot determine NodeGroup for secret %q", secretName)
 		}
 
 		if _, ok := extractedState[nodeGroup]; !ok {

--- a/dhctl/pkg/state/infrastructure/state_saver.go
+++ b/dhctl/pkg/state/infrastructure/state_saver.go
@@ -92,7 +92,7 @@ func (s *ClusterStateSaver) SaveState(ctx context.Context, outputs *infrastructu
 		},
 	}
 
-	log.DebugF("Intermediate save base infra in cluster...\n")
+	log.DebugF("Saving intermediate base infra in cluster...\n")
 	err := retry.NewSilentLoop("Save Cluster intermediate infrastructure state", 15, 3*time.Second).Run(
 		func() error {
 			return task.Patch(ctx)
@@ -167,7 +167,7 @@ func (s *NodeStateSaver) SaveState(ctx context.Context, outputs *infrastructure.
 	}
 
 	taskName := fmt.Sprintf("Save intermediate infrastructure state for Node %q", s.nodeName)
-	log.DebugF("Intermediate save state for node %s in cluster...\n", s.nodeName)
+	log.DebugF("Saving intermediate state for node %s in cluster...\n", s.nodeName)
 	err = retry.NewSilentLoop(taskName, 15, 3*time.Second).Run(func() error {
 		return task.PatchOrCreate(ctx)
 	})

--- a/dhctl/pkg/state/infrastructure/state_version.go
+++ b/dhctl/pkg/state/infrastructure/state_version.go
@@ -23,7 +23,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/input"
 )
 
-const opentofuConvertationMsg = "Terraform state detected while opentofu state was expected. Do you want to apply migration? Use with caution, and only if there are no changes in the execution plan!"
+const opentofuConvertationMsg = "Terraform state detected while opentofu state was expected. Do you want to apply the migration? Use with caution, and only if there are no changes in the execution plan!"
 
 var ErrTerraformState = errors.New("Cannot converge state because state is terraform, not opentofu")
 

--- a/dhctl/pkg/template/bundle.go
+++ b/dhctl/pkg/template/bundle.go
@@ -137,13 +137,13 @@ func PrepareBashibleBundle(
 	}
 
 	firstRunFileFlag := filepath.Join(templateController.TmpDir, bashibleDir, "first_run")
-	log.DebugF("Create %q\n", firstRunFileFlag)
+	log.DebugF("Creating %q\n", firstRunFileFlag)
 	if err := fs.CreateEmptyFile(firstRunFileFlag); err != nil {
 		return err
 	}
 
 	devicePathFile := filepath.Join(templateController.TmpDir, bashibleDir, "kubernetes_data_device_path")
-	log.InfoF("Create %q\n", devicePathFile)
+	log.InfoF("Creating %q\n", devicePathFile)
 
 	return fs.CreateFileWithContent(devicePathFile, devicePath)
 }

--- a/dhctl/pkg/template/preflight.go
+++ b/dhctl/pkg/template/preflight.go
@@ -31,21 +31,21 @@ var (
 )
 
 func RenderAndSavePreflightCheckPortsScript(globalOptions *options.GlobalOptions) (string, error) {
-	log.DebugLn("Start render check ports script")
+	log.DebugLn("Rendering check ports script")
 	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkPortsScriptPath)
 
 	return RenderAndSaveTemplate("check_ports.sh", scriptPath, map[string]interface{}{})
 }
 
 func RenderAndSavePreflightCheckDeckhouseUserScript(globalOptions *options.GlobalOptions) (string, error) {
-	log.DebugLn("Start render check user script")
+	log.DebugLn("Rendering check user script")
 	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkDeckhouseUserScriptPath)
 
 	return RenderAndSaveTemplate("check_deckhouse_user.sh", scriptPath, map[string]interface{}{})
 }
 
 func RenderAndSavePreflightCheckLocalhostScript(globalOptions *options.GlobalOptions) (string, error) {
-	log.DebugLn("Start render check localhost script")
+	log.DebugLn("Rendering check localhost script")
 	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkLocalhostScriptPath)
 
 	return RenderAndSaveTemplate(
@@ -56,7 +56,7 @@ func RenderAndSavePreflightCheckLocalhostScript(globalOptions *options.GlobalOpt
 }
 
 func RenderAndSavePreflightReverseTunnelOpenScript(url string, globalOptions *options.GlobalOptions) (string, error) {
-	log.DebugLn("Start render proxy reverse tunnel open script")
+	log.DebugLn("Rendering proxy reverse tunnel open script")
 	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", checkProxyRevTunnelOpenScriptPath)
 
 	return RenderAndSaveTemplate(
@@ -69,7 +69,7 @@ func RenderAndSavePreflightReverseTunnelOpenScript(url string, globalOptions *op
 }
 
 func RenderAndSaveKillReverseTunnelScript(host, port string, globalOptions *options.GlobalOptions) (string, error) {
-	log.DebugLn("Start render kill reverse tunnel script")
+	log.DebugLn("Rendering kill reverse tunnel script")
 	scriptPath := filepath.Join(globalOptions.CandiDir, "bashible", killReverseTunnelPath)
 
 	return RenderAndSaveTemplate(
@@ -87,7 +87,7 @@ func RenderAndSavePreflightCheckScript(
 	params map[string]interface{},
 	globalOptions *options.GlobalOptions,
 ) (string, error) {
-	log.DebugLn("Start render check localhost script")
+	log.DebugLn("Rendering check localhost script")
 	path := filepath.Join(globalOptions.CandiDir, "bashible", preflightScriptDirPath)
 
 	return RenderAndSaveTemplate(

--- a/dhctl/pkg/template/template.go
+++ b/dhctl/pkg/template/template.go
@@ -41,7 +41,7 @@ func RenderAndSaveTemplate(outFileName, templatePath string, data map[string]int
 		}
 		cnt := res.Bytes()
 		content = string(cnt)
-		log.DebugF("Render and save template content:\n%s", content)
+		log.DebugF("Rendering and saving template content:\n%s", content)
 	}
 
 	outFile, err := os.CreateTemp(os.TempDir(), fmt.Sprintf("*-%s", outFileName))
@@ -51,7 +51,7 @@ func RenderAndSaveTemplate(outFileName, templatePath string, data map[string]int
 
 	defer func() {
 		if err := outFile.Close(); err != nil {
-			log.ErrorF("Cannot close rendered %s %s:%v", outFileName, outFile.Name(), err)
+			log.ErrorF("Cannot close rendered %s %s: %v", outFileName, outFile.Name(), err)
 		}
 	}()
 

--- a/dhctl/pkg/terminal/ask-password.go
+++ b/dhctl/pkg/terminal/ask-password.go
@@ -45,7 +45,7 @@ func AskPassword(prompt string) ([]byte, error) {
 	fd := int(os.Stdin.Fd())
 
 	if !terminal.IsTerminal(fd) {
-		return nil, fmt.Errorf("stdin is not a terminal, error reading password")
+		return nil, fmt.Errorf("stdin is not a terminal, cannot read password")
 	}
 
 	log.InfoF(prompt)

--- a/dhctl/pkg/util/cache/cache.go
+++ b/dhctl/pkg/util/cache/cache.go
@@ -146,7 +146,7 @@ func (s *StateCache) CleanWithExceptions(ctx context.Context, excludeKeys ...str
 		return nil
 	})
 	if err != nil {
-		log.WarnF("Can't getting keys to remove: %s ...\n", err)
+		log.WarnF("Can't get keys to remove: %s ...\n", err)
 		return
 	}
 

--- a/dhctl/pkg/util/fs/dir.go
+++ b/dhctl/pkg/util/fs/dir.go
@@ -84,7 +84,7 @@ func FileExistsInDirAndParentsDirs(dir, fileName string) (string, error) {
 	}
 
 	if !IsDirExists(dir) {
-		return "", fmt.Errorf("'%s' is not a directory or does not exists", dir)
+		return "", fmt.Errorf("'%s' is not a directory or does not exist", dir)
 	}
 
 	parentDir := dir

--- a/dhctl/pkg/util/image/image.go
+++ b/dhctl/pkg/util/image/image.go
@@ -108,7 +108,7 @@ func RegistryConfigFromDockerConfig(dc *dockerConfig, scheme, registry string) (
 
 	_, ok := dc.Auths[baseRegistry]
 	if !ok {
-		return nil, fmt.Errorf("docker config doesn't contains %s registry credentials", registry)
+		return nil, fmt.Errorf("docker config doesn't contain %s registry credentials", registry)
 	}
 	rc := &RegistryConfig{
 		scheme:   scheme,

--- a/dhctl/pkg/util/image/image_test.go
+++ b/dhctl/pkg/util/image/image_test.go
@@ -130,7 +130,7 @@ func TestRegistryConfigFromDockerConfig(t *testing.T) {
 				registry:      "registry.io",
 				scheme:        "HTTPS",
 				wantErr:       true,
-				err:           "docker config doesn't contains registry.io registry credentials",
+				err:           "docker config doesn't contain registry.io registry credentials",
 			},
 			{
 				title: "Invalid auth, failure",

--- a/dhctl/pkg/util/image/prepare.go
+++ b/dhctl/pkg/util/image/prepare.go
@@ -30,7 +30,7 @@ func PrepareFiles(path string) error {
 		return err
 	}
 	if !pathStat.IsDir() {
-		return fmt.Errorf("%s isn't directory", path)
+		return fmt.Errorf("%s isn't a directory", path)
 	}
 
 	bashiblePath := filepath.Join(path, "candi", "bashible")

--- a/dhctl/pkg/util/registryutil/registry.go
+++ b/dhctl/pkg/util/registryutil/registry.go
@@ -47,7 +47,7 @@ func NewRegistryTransport(scheme, ca string) (*http.Transport, error) {
 
 	certPool, err := x509.SystemCertPool()
 	if err != nil {
-		log.WarnF("Cannot get system CAs pool, fallback to custom CA pool only: %v\n", err)
+		log.WarnF("Cannot get system CAs pool, falling back to custom CA pool only: %v\n", err)
 		certPool = x509.NewCertPool()
 	}
 	if certPool == nil {

--- a/dhctl/pkg/util/retry/retry.go
+++ b/dhctl/pkg/util/retry/retry.go
@@ -303,7 +303,7 @@ func (l *Loop) run(ctx context.Context, task func() error) error {
 			}
 
 			if l.breakPredicate != nil && l.breakPredicate(err) {
-				l.logger.LogDebugF(l.prefix+"Client break loop with %v\n", err)
+				l.logger.LogDebugF(l.prefix+"Client broke the loop with %v\n", err)
 				return err
 			}
 

--- a/dhctl/pkg/util/tomb/tomb.go
+++ b/dhctl/pkg/util/tomb/tomb.go
@@ -152,7 +152,7 @@ func printGorutinesStackTrace(shouldAlwaysPrint bool, msg string) {
 	l := runtime.Stack(buf, true)
 	buf = buf[:l]
 	if shouldAlwaysPrint || input.IsTerminal() {
-		log.InfoF("\n%sGorutines stack for debug:\n%s\n", msg, string(buf))
+		log.InfoF("\n%sGoroutines stack for debug:\n%s\n", msg, string(buf))
 	}
 
 	buf = nil
@@ -218,7 +218,7 @@ func graceShutdownForSignal(interruptCh <-chan os.Signal, exitCode int, s os.Sig
 	go func() {
 		<-interruptCh
 
-		printGorutinesStackTrace(false, "Killed by signal twice. Probably dhctl have problems. ")
+		printGorutinesStackTrace(false, "Killed by signal twice. Probably dhctl has problems. ")
 
 		log.ErrorLn("Killed by signal twice.")
 		os.Exit(1)


### PR DESCRIPTION
## Description

Grammar, spelling, and phrasing fixes across dhctl's human-readable messages — log lines (`log.*`), interactive prompts/confirmations, error messages (`fmt.Errorf`), operation/phase titles, and CLI flag help texts. Only message strings were touched; variable names, flags, interfaces, and format verbs (`%s/%d/%v/%w`) were left unchanged.

Examples:
- `Cannot drain node, because process was timeout. Do we continue without full-fledged drain?` → `Cannot drain the node because the process timed out. Continue without a full-fledged drain?`
- `%s not exists. Fallback to embedded minget` → `%s does not exist. Falling back to embedded minget`
- `Lease renew was failed.` → `Lease renewal failed.`
- spelling: `applyed`→`applied`, `Gorutines`→`Goroutines`, `terrform`/`infastructure`/`opentofy`/`pipline`/`parrent`, doubled `write write`.

Also dropped a dangling `%v` in `lock.go` where `log.DebugLn` (Println-style, not a format function) printed the verb literally.

## Why do we need it, and what problem does it solve?

dhctl's output was often grammatically incorrect and inconsistent, which looks unpolished and can confuse users reading logs and prompts. This makes the messages read like fluent technical English without changing behavior.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

Note: text-only message changes. Verified locally with `go build ./...` and `go vet ./...` (clean) and the affected package tests pass; no behavior changes.

## Changelog entries

```changes
section: dhctl
type: chore
summary: Fix grammar and spelling in dhctl log and user-facing messages.
impact_level: low
```
