### PR TITLE
[dhctl] add retry optimization

### DIFF
--- a/dhctl/pkg/config/base.go
+++ b/dhctl/pkg/config/base.go
@@ -185,7 +185,7 @@ func ParseConfigFromCluster(
 	var err error
 
 	return metaConfig, log.ProcessCtx(ctx, "common", "Get cluster configuration", func(ctx context.Context) error {
-		return retry.NewLoop("Get cluster configuration from Kubernetes cluster", 10, 5*time.Second).
+		return retry.NewLoop("Get cluster configuration from Kubernetes cluster", 50, 1*time.Second).
 			RunContext(ctx, func() error {
 				metaConfig, err = parseConfigFromCluster(ctx, kubeCl, preparatorProvider, globalOptions)
 				return err
@@ -204,7 +204,7 @@ func ParseConfigInCluster(
 		err        error
 	)
 
-	err = retry.NewSilentLoop("Get cluster configuration from inside Kubernetes cluster", 5, 5*time.Second).
+	err = retry.NewSilentLoop("Get cluster configuration from inside Kubernetes cluster", 25, 1*time.Second).
 		RunContext(ctx, func() error {
 			metaConfig, err = parseConfigFromCluster(ctx, kubeCl, preparatorProvider, globalOptions)
 			return err

--- a/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/delete.go
@@ -56,7 +56,7 @@ func isCAPIClusterUnsupportedErr(err error) bool {
 }
 
 func DeleteValidatingWebhookConfigurations(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete validating webhook configurations", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete validating webhook configurations", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		vwcs, err := kubeCl.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{
 			LabelSelector: "heritage=deckhouse",
 		})
@@ -77,7 +77,7 @@ func DeleteValidatingWebhookConfigurations(ctx context.Context, kubeCl *client.K
 }
 
 func DeleteDeckhouseDeployment(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Deckhouse", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete Deckhouse", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		foregroundPolicy := metav1.DeletePropagationForeground
 		err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Delete(ctx, deckhouseDeploymentName, metav1.DeleteOptions{PropagationPolicy: &foregroundPolicy})
 		if err != nil && !errors.IsNotFound(err) {
@@ -110,7 +110,7 @@ func DeleteClusters(ctx context.Context, kubeCl *client.KubernetesClient) error 
 }
 
 func DeletePDBs(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete pdbs", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete pdbs", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		foregroundPolicy := metav1.DeletePropagationForeground
 		namespaces, err := kubeCl.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -158,7 +158,7 @@ func DeleteD8StorageResources(ctx context.Context, kubeCl *client.KubernetesClie
 }
 
 func DeleteAllD8StorageResources(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Deckhouse Storage CRs", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete Deckhouse Storage CRs", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		for _, cr := range v1alpha1.D8StoragesGVRs() {
 			storageCRs, err := ListD8StorageResources(ctx, kubeCl, cr)
 			if err != nil {
@@ -180,7 +180,7 @@ func DeleteAllD8StorageResources(ctx context.Context, kubeCl *client.KubernetesC
 }
 
 func DeleteStorageClasses(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete StorageClasses", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete StorageClasses", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		list, err := kubeCl.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -203,7 +203,7 @@ func DeleteStorageClasses(ctx context.Context, kubeCl *client.KubernetesClient) 
 }
 
 func DeletePods(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Pods", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete Pods", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		pods, err := kubeCl.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -240,7 +240,7 @@ func DeletePods(ctx context.Context, kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteServices(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete Services", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete Services", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		allServices, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -262,7 +262,7 @@ func DeleteServices(ctx context.Context, kubeCl *client.KubernetesClient) error 
 }
 
 func DeletePVC(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete PersistentVolumeClaims", 45, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete PersistentVolumeClaims", 225, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		volumeClaims, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -280,7 +280,7 @@ func DeletePVC(ctx context.Context, kubeCl *client.KubernetesClient) error {
 }
 
 func WaitForDeckhouseDeploymentDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 30, 5*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for Deckhouse Deployment deletion", 150, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		_, err := kubeCl.AppsV1().Deployments(deckhouseDeploymentNamespace).Get(ctx, deckhouseDeploymentName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			log.InfoLn("Deckhouse Deployment and its dependents are removed")
@@ -322,7 +322,7 @@ func WaitForClustersDeletion(ctx context.Context, kubeCl *client.KubernetesClien
 }
 
 func WaitForServicesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for Services deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for Services deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -349,7 +349,7 @@ func WaitForServicesDeletion(ctx context.Context, kubeCl *client.KubernetesClien
 }
 
 func WaitForPVDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumes deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for PersistentVolumes deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -390,7 +390,7 @@ func WaitForPVDeletion(ctx context.Context, kubeCl *client.KubernetesClient) err
 }
 
 func WaitForPVCDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for PersistentVolumeClaims deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -439,7 +439,7 @@ func checkMachinesAPI(kubeCl *client.KubernetesClient, gv schema.GroupVersion) e
 }
 
 func DeleteMCMMachineDeployments(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete MCM MachineDeployments", 45, 5*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete MCM MachineDeployments", 225, 1*time.Second).RunContext(ctx, func() error {
 		allMachines, err := kubeCl.Dynamic().Resource(sapcloud.MachineGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machines: %v", err)
@@ -481,7 +481,7 @@ func DeleteMCMMachineDeployments(ctx context.Context, kubeCl *client.KubernetesC
 }
 
 func WaitForMCMMachinesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for MCM Machines deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for MCM Machines deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.Dynamic().Resource(sapcloud.MachineGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
@@ -505,7 +505,7 @@ func checkMCMMachinesAPI(kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteMachinesIfResourcesExist(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	err := retry.NewLoop("Get Kubernetes cluster resources for MCM group/version", 5, 5*time.Second).WithShowError(false).
+	err := retry.NewLoop("Get Kubernetes cluster resources for MCM group/version", 25, 1*time.Second).WithShowError(false).
 		RunContext(ctx, func() error {
 			return checkMCMMachinesAPI(kubeCl)
 		})
@@ -530,7 +530,7 @@ func DeleteMachinesIfResourcesExist(ctx context.Context, kubeCl *client.Kubernet
 	}
 
 	// try to remove CAPI machines it needs for static clusters and cluster with cluster api support
-	err = retry.NewLoop("Get Kubernetes cluster resources for CAPI group/version", 5, 5*time.Second).WithShowError(false).
+	err = retry.NewLoop("Get Kubernetes cluster resources for CAPI group/version", 25, 1*time.Second).WithShowError(false).
 		RunContext(ctx, func() error {
 			return checkCAPIMachinesAPI(kubeCl)
 		})
@@ -558,7 +558,7 @@ func checkCAPIMachinesAPI(kubeCl *client.KubernetesClient) error {
 }
 
 func DeleteCAPIMachineDeployments(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete CAPI MachineDeployments", 45, 5*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop("Delete CAPI MachineDeployments", 225, 1*time.Second).RunContext(ctx, func() error {
 		allMachines, err := kubeCl.Dynamic().Resource(capi.MachineGVR).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("get machines: %v", err)
@@ -603,7 +603,7 @@ func DeleteCAPIMachineDeployments(ctx context.Context, kubeCl *client.Kubernetes
 }
 
 func WaitForCAPIMachinesDeletion(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Wait for CAPI Machines deletion", 45, 15*time.Second).WithShowError(false).RunContext(ctx, func() error {
+	return retry.NewLoop("Wait for CAPI Machines deletion", 600, 1*time.Second).WithShowError(false).RunContext(ctx, func() error {
 		resources, err := kubeCl.Dynamic().Resource(capi.MachineGVR).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err

--- a/dhctl/pkg/kubernetes/actions/deckhouse/install.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/install.go
@@ -49,7 +49,7 @@ func prepareDeckhouseDeploymentForUpdate(
 	manifestForUpdate *appsv1.Deployment,
 ) (*appsv1.Deployment, error) {
 	resDeployment := manifestForUpdate
-	err := retry.NewSilentLoop("get deployment", 10, 3*time.Second).RunContext(ctx, func() error {
+	err := retry.NewSilentLoop("get deployment", 30, 1*time.Second).RunContext(ctx, func() error {
 		currentManifestInCluster, err := kubeCl.AppsV1().
 			Deployments(manifestForUpdate.GetNamespace()).
 			Get(ctx, manifestForUpdate.GetName(), metav1.GetOptions{})
@@ -107,7 +107,7 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(
 ) (*actions.ManifestTask, error) {
 	deckhouseDeploymentPresent := false
 
-	err := retry.NewLoop("Get deckhouse manifest", 10, 5*time.Second).RunContext(ctx, func() error {
+	err := retry.NewLoop("Get deckhouse manifest", 50, 1*time.Second).RunContext(ctx, func() error {
 		_, err := kubeCl.AppsV1().Deployments("d8-system").Get(ctx, "deckhouse", metav1.GetOptions{})
 		if err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -159,7 +159,7 @@ func LockDeckhouseQueueBeforeCreatingModuleConfigs(
 }
 
 func UnlockDeckhouseQueueAfterCreatingModuleConfigs(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Unlock Deckhouse controller queue", 15, 5*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop("Unlock Deckhouse controller queue", 75, 1*time.Second).RunContext(ctx, func() error {
 		err := kubeCl.CoreV1().ConfigMaps("d8-system").
 			Delete(ctx, "deckhouse-bootstrap-lock", metav1.DeleteOptions{})
 
@@ -762,7 +762,7 @@ func WaitForReadinessNotOnNode(ctx context.Context, kubeCl *client.KubernetesCli
 					return nil
 				}
 
-				time.Sleep(5 * time.Second)
+				time.Sleep(1 * time.Second)
 			}
 		}
 	})
@@ -791,7 +791,7 @@ func CreateDeckhouseDeploymentManifest(cfg *config.DeckhouseInstaller) *appsv1.D
 }
 
 func WaitForKubernetesAPI(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Waiting for Kubernetes API to become Ready", 45, 5*time.Second).
+	return retry.NewLoop("Waiting for Kubernetes API to become Ready", 225, 1*time.Second).
 		RunContext(ctx, func() error {
 			_, err := kubeCl.Discovery().ServerVersion()
 			if err == nil {

--- a/dhctl/pkg/kubernetes/actions/entity/node.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node.go
@@ -88,7 +88,7 @@ func GetCloudConfig(ctx context.Context, kubeCl *client.KubernetesClient, nodeGr
 			allPassedHosts = strings.Join(apiserverHosts, ",")
 		}
 
-		err := retry.NewSilentLoop(name, 45, 5*time.Second).RunContext(ctx, func() error {
+		err := retry.NewSilentLoop(name, 225, 1*time.Second).RunContext(ctx, func() error {
 			if nodeGroupName == global.MasterNodeGroupName {
 				logger.LogInfoF("Waiting while all API-server endpoints '%s' will be available in bootstrap secret\n", allPassedHosts)
 			}
@@ -150,7 +150,7 @@ func CreateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeG
 	doc := unstructured.Unstructured{}
 	doc.SetUnstructuredContent(data)
 
-	return retry.NewLoop(fmt.Sprintf("Create NodeGroup %q", nodeGroupName), 45, 15*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Create NodeGroup %q", nodeGroupName), 600, 1*time.Second).
 		WithLogger(logger).
 		RunContext(ctx, func() error {
 			res, err := kubeCl.Dynamic().
@@ -192,7 +192,7 @@ func GetNodeGroupDirect(ctx context.Context, kubeCl *client.KubernetesClient, no
 
 func GetNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string) (*unstructured.Unstructured, error) {
 	var ng *unstructured.Unstructured
-	err := retry.NewSilentLoop(fmt.Sprintf("Get NodeGroup %q", nodeGroupName), 45, 15*time.Second).
+	err := retry.NewSilentLoop(fmt.Sprintf("Get NodeGroup %q", nodeGroupName), 600, 1*time.Second).
 		RunContext(ctx, func() error {
 			var err error
 			ng, err = GetNodeGroupDirect(ctx, kubeCl, nodeGroupName)
@@ -218,7 +218,7 @@ func GetNodeGroups(ctx context.Context, kubeCl *client.KubernetesClient) ([]unst
 }
 
 func UpdateNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string, ng *unstructured.Unstructured) error {
-	err := retry.NewLoop(fmt.Sprintf("Update node template in NodeGroup %q", nodeGroupName), 45, 15*time.Second).
+	err := retry.NewLoop(fmt.Sprintf("Update node template in NodeGroup %q", nodeGroupName), 600, 1*time.Second).
 		BreakIf(errors.IsConflict).
 		RunContext(ctx, func() error {
 			_, err := kubeCl.Dynamic().
@@ -310,7 +310,7 @@ func WaitForNodesBecomeReady(ctx context.Context, kubeCl *client.KubernetesClien
 }
 
 func WaitForNodesListBecomeReady(ctx context.Context, kubeCl *client.KubernetesClient, nodes []string, checker hook.NodeChecker) error {
-	return retry.NewLoop("Waiting for nodes to become Ready", 100, 20*time.Second).
+	return retry.NewLoop("Waiting for nodes to become Ready", 2000, 1*time.Second).
 		RunContext(ctx, func() error {
 			desiredReadyNodes := len(nodes)
 			var nodesList corev1.NodeList
@@ -369,7 +369,7 @@ func WaitForNodesListBecomeReady(ctx context.Context, kubeCl *client.KubernetesC
 func GetNodeGroupTemplates(ctx context.Context, kubeCl *client.KubernetesClient) (map[string]map[string]interface{}, error) {
 	nodeTemplates := make(map[string]map[string]interface{})
 
-	err := retry.NewLoop("Get NodeGroups node template settings", 10, 5*time.Second).
+	err := retry.NewLoop("Get NodeGroups node template settings", 50, 1*time.Second).
 		RunContext(ctx, func() error {
 			nodeGroups, err := kubeCl.Dynamic().Resource(nodeGroupResource).List(ctx, metav1.ListOptions{})
 			if err != nil {
@@ -399,7 +399,7 @@ func GetNodeGroupTemplates(ctx context.Context, kubeCl *client.KubernetesClient)
 }
 
 func DeleteNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
-	return retry.NewLoop(fmt.Sprintf("Delete Node %s", nodeName), 45, 10*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Delete Node %s", nodeName), 450, 1*time.Second).
 		RunContext(ctx, func() error {
 			err := kubeCl.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
 			if errors.IsNotFound(err) {
@@ -411,7 +411,7 @@ func DeleteNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName s
 }
 
 func DeleteNodeGroup(ctx context.Context, kubeCl *client.KubernetesClient, nodeGroupName string) error {
-	return retry.NewLoop(fmt.Sprintf("Delete NodeGroup %s", nodeGroupName), 45, 10*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Delete NodeGroup %s", nodeGroupName), 450, 1*time.Second).
 		RunContext(ctx, func() error {
 			err := kubeCl.Dynamic().Resource(nodeGroupResource).Delete(ctx, nodeGroupName, metav1.DeleteOptions{})
 			if errors.IsNotFound(err) {
@@ -441,7 +441,7 @@ func requestNodeExists(ctx context.Context, kubeCl *client.KubernetesClient, nod
 
 func IsNodeExistsInCluster(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string, logger log.Logger) (bool, error) {
 	exists := false
-	err := retry.NewLoop(fmt.Sprintf("Checking node exists %s", nodeName), 5, 2*time.Second).
+	err := retry.NewLoop(fmt.Sprintf("Checking node exists %s", nodeName), 10, 1*time.Second).
 		WithLogger(logger).
 		RunContext(ctx, func() error {
 			var err error
@@ -452,7 +452,7 @@ func IsNodeExistsInCluster(ctx context.Context, kubeCl *client.KubernetesClient,
 	return exists, err
 }
 
-var getMasterNodesIPsDefaultOpts = retry.AttemptsWithWaitOpts(5, 5*time.Second)
+var getMasterNodesIPsDefaultOpts = retry.AttemptsWithWaitOpts(25, 1*time.Second)
 
 func GetMasterNodesIPs(ctx context.Context, kubeProvider kubernetes.KubeClientProviderWithCtx, loopParams retry.Params) ([]NodeIP, error) {
 	selector, err := kubernetes.GetMasterNodeGroupLabelSelector()

--- a/dhctl/pkg/kubernetes/actions/entity/node_user.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user.go
@@ -36,7 +36,7 @@ import (
 	"github.com/deckhouse/deckhouse/dhctl/pkg/util/retry"
 )
 
-var createUpdateNodeUsersDefaultOpts = retry.AttemptsWithWaitOpts(45, 10*time.Second)
+var createUpdateNodeUsersDefaultOpts = retry.AttemptsWithWaitOpts(450, 1*time.Second)
 
 func CreateOrUpdateNodeUser(ctx context.Context, kubeProvider kubernetes.KubeClientProviderWithCtx, nodeUser *v1.NodeUser, loopParams retry.Params) error {
 	nodeUserResource, err := sdk.ToUnstructured(nodeUser)
@@ -67,7 +67,7 @@ func CreateOrUpdateNodeUser(ctx context.Context, kubeProvider kubernetes.KubeCli
 
 func DeleteNodeUser(ctx context.Context, kubeProvider kubernetes.KubeClientProviderWithCtx, name string) error {
 	processName := fmt.Sprintf("Delete NodeUser %s", name)
-	return retry.NewLoop(processName, 45, 10*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(processName, 450, 1*time.Second).RunContext(ctx, func() error {
 		kubeCl, err := kubeProvider.KubeClientCtx(ctx)
 		if err != nil {
 			return err
@@ -95,8 +95,8 @@ func NodeUserExists(ctx context.Context, kubeProvider kubernetes.KubeClientProvi
 
 	err = libretry.NewSilentLoopWithParamsOpts(
 		libretry.WithName("Check NodeUser %q exists", name),
-		libretry.WithAttempts(10),
-		libretry.WithWait(2*time.Second),
+		libretry.WithAttempts(20),
+		libretry.WithWait(1*time.Second),
 	).RunContext(ctx, func() error {
 		timeoutCtx, cancel := defaultTimeoutCtx(ctx)
 		defer cancel()
@@ -132,8 +132,8 @@ type NodeUserPresentsWaiter struct {
 
 func NewNodeUserExistsWaiter(checker NodeUserPresentsChecker, kubeProvider kubernetes.KubeClientProviderWithCtx) *NodeUserPresentsWaiter {
 	params := retry.NewEmptyParams().
-		WithAttempts(50).
-		WithWait(5 * time.Second)
+		WithAttempts(250).
+		WithWait(1 * time.Second)
 
 	return &NodeUserPresentsWaiter{
 		params:       params,

--- a/dhctl/pkg/kubernetes/actions/entity/node_user_test.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user_test.go
@@ -289,7 +289,7 @@ func TestWaitNodeUserPresentOnNodeWithParams(t *testing.T) {
 	}
 
 	assertDefaultParams := func(t *testing.T, w *NodeUserPresentsWaiter) {
-		assertParams(t, w, 50, 5*time.Second)
+		assertParams(t, w, 250, 1*time.Second)
 	}
 
 	t.Run("nil params", func(t *testing.T) {

--- a/dhctl/pkg/kubernetes/actions/manager/deployment.go
+++ b/dhctl/pkg/kubernetes/actions/manager/deployment.go
@@ -33,7 +33,7 @@ import (
 func checkAndRestartDeployment(ctx context.Context, kubeClProvider kubernetes.KubeClientProviderWithCtx, deploymentName string) error {
 	hasDeployment := false
 
-	err := retry.NewLoop(fmt.Sprintf("Check deployment %s/%s exists", global.D8SystemNamespace, deploymentName), 10, 5*time.Second).
+	err := retry.NewLoop(fmt.Sprintf("Check deployment %s/%s exists", global.D8SystemNamespace, deploymentName), 50, 1*time.Second).
 		RunContext(ctx, func() error {
 			kubeCl, err := kubeClProvider.KubeClientCtx(ctx)
 			if err != nil {
@@ -61,7 +61,7 @@ func checkAndRestartDeployment(ctx context.Context, kubeClProvider kubernetes.Ku
 		return nil
 	}
 
-	err = retry.NewLoop(fmt.Sprintf("Restart deployment %s/%s with adding annotation", global.D8SystemNamespace, deploymentName), 10, 5*time.Second).
+	err = retry.NewLoop(fmt.Sprintf("Restart deployment %s/%s with adding annotation", global.D8SystemNamespace, deploymentName), 50, 1*time.Second).
 		RunContext(ctx, func() error {
 			kubeCl, err := kubeClProvider.KubeClientCtx(ctx)
 			if err != nil {

--- a/dhctl/pkg/kubernetes/actions/registrydata/registrydata.go
+++ b/dhctl/pkg/kubernetes/actions/registrydata/registrydata.go
@@ -36,7 +36,7 @@ func GetRegistryData(ctx context.Context, kubeCl *client.KubernetesClient) (*ima
 	conf := &image.RegistryConfig{}
 	var b64dc string
 
-	err := retry.NewLoop("Get registry data from cluster", 45, 5*time.Second).RunContext(ctx, func() error {
+	err := retry.NewLoop("Get registry data from cluster", 225, 1*time.Second).RunContext(ctx, func() error {
 		secret, err := kubeCl.CoreV1().
 			Secrets(d8RppSecretNamespace).
 			Get(ctx, d8RppSecretName, metav1.GetOptions{})

--- a/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
+++ b/dhctl/pkg/kubernetes/actions/resources/cluster_is_bootstrap.go
@@ -46,7 +46,7 @@ type kubeNgGetter struct {
 
 func (n *kubeNgGetter) NodeGroups(ctx context.Context) ([]*v1.NodeGroup, error) {
 	var ngs []unstructured.Unstructured
-	err := retry.NewSilentLoop("get machine failed events", 3, 3*time.Second).RunContext(ctx, func() error {
+	err := retry.NewSilentLoop("get machine failed events", 9, 1*time.Second).RunContext(ctx, func() error {
 		kubeCl, err := n.kubeProvider.KubeClientCtx(ctx)
 		if err != nil {
 			return err
@@ -80,7 +80,7 @@ func (n *kubeNgGetter) NodeGroups(ctx context.Context) ([]*v1.NodeGroup, error) 
 
 func (n *kubeNgGetter) MachineFailedEvents(ctx context.Context) ([]eventsv1.Event, error) {
 	var list *eventsv1.EventList
-	err := retry.NewSilentLoop("get machine failed events", 3, 3*time.Second).RunContext(ctx, func() error {
+	err := retry.NewSilentLoop("get machine failed events", 9, 1*time.Second).RunContext(ctx, func() error {
 		kubeCl, err := n.kubeProvider.KubeClientCtx(ctx)
 		if err != nil {
 			return err
@@ -150,7 +150,7 @@ func (n *clusterIsBootstrapCheck) lastEvents(ctx context.Context, lastTime time.
 
 func (n *clusterIsBootstrapCheck) hasBootstrappedCM(ctx context.Context) (bool, error) {
 	hasCm := false
-	err := retry.NewSilentLoop("get is-bootstrapped cm", 3, 3*time.Second).RunContext(ctx, func() error {
+	err := retry.NewSilentLoop("get is-bootstrapped cm", 9, 1*time.Second).RunContext(ctx, func() error {
 		kubeCl, err := n.kubeProvider.KubeClientCtx(ctx)
 		if err != nil {
 			return err

--- a/dhctl/pkg/kubernetes/actions/resources/resources.go
+++ b/dhctl/pkg/kubernetes/actions/resources/resources.go
@@ -154,7 +154,7 @@ func (c *Creator) ensureRequiredNamespacesExist(ctx context.Context) (map[int]st
 	// or after state is set to "cluster is bootstrapped" (some namespaces will be created by the deckhouse after that)
 	resourcesToSkipInCurrentIteration := make(map[int]struct{})
 
-	err := retry.NewSilentLoop("Ensure that required namespaces exist", 10, 10*time.Second).RunContext(ctx, func() error {
+	err := retry.NewSilentLoop("Ensure that required namespaces exist", 100, 1*time.Second).RunContext(ctx, func() error {
 		for i, res := range c.resources {
 			nsName := res.Object.GetNamespace()
 
@@ -255,7 +255,7 @@ func resourceToGVR(resource *template.Resource, apires metav1.APIResource) (*sch
 
 func (c *Creator) createSingleResource(ctx context.Context, resource *template.Resource, apires metav1.APIResource) error {
 	// Wait up to 10 minutes
-	return retry.NewSilentLoop(fmt.Sprintf("Create %s resources", resource.GVK.String()), 60, 10*time.Second).RunContext(ctx, func() error {
+	return retry.NewSilentLoop(fmt.Sprintf("Create %s resources", resource.GVK.String()), 600, 1*time.Second).RunContext(ctx, func() error {
 		gvr, docCopy := resourceToGVR(resource, apires)
 		namespace := docCopy.GetNamespace()
 		manifestTask := actions.ManifestTask{
@@ -299,7 +299,7 @@ func (c *Creator) invalidateDiscovery() {
 
 func (c *Creator) runSingleMCTask(ctx context.Context, task actions.ModuleConfigTask) error {
 	// Wait up to 10 minutes
-	return retry.NewLoop(task.Title, 60, 5*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(task.Title, 300, 1*time.Second).RunContext(ctx, func() error {
 		return task.Do(c.kubeCl)
 	})
 }

--- a/dhctl/pkg/kubernetes/client/state_cache.go
+++ b/dhctl/pkg/kubernetes/client/state_cache.go
@@ -86,7 +86,7 @@ func (c *StateCache) populateSecret(ctx context.Context) (*v1.Secret, error) {
 	var secret *v1.Secret
 	var lastError error
 
-	err := retry.NewSilentLoop("get cache secret", 3, 2*time.Second).Run(func() error {
+	err := retry.NewSilentLoop("get cache secret", 6, 1*time.Second).Run(func() error {
 		var err error
 
 		secret, err = c.secretsAPI.Get(ctx, c.secretName, metav1.GetOptions{})
@@ -122,7 +122,7 @@ func (c *StateCache) populateSecret(ctx context.Context) (*v1.Secret, error) {
 		preparedLabels[k] = v
 	}
 
-	err = retry.NewSilentLoop("save cache secret", 3, 2*time.Second).Run(func() error {
+	err = retry.NewSilentLoop("save cache secret", 6, 1*time.Second).Run(func() error {
 		var err error
 
 		secretToCreate := &v1.Secret{

--- a/dhctl/pkg/module/controlplane/bootstrap.go
+++ b/dhctl/pkg/module/controlplane/bootstrap.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	createSigDirDefaultOpts = retry.AttemptsWithWaitOpts(10, 10*time.Second)
+	createSigDirDefaultOpts = retry.AttemptsWithWaitOpts(100, 1*time.Second)
 )
 
 type LoopsParams struct {

--- a/dhctl/pkg/operations/bootstrap/bashible/runner.go
+++ b/dhctl/pkg/operations/bootstrap/bashible/runner.go
@@ -39,10 +39,10 @@ const (
 )
 
 var (
-	alreadyRunDefaultOpts      = retry.AttemptsWithWaitOpts(30, 10*time.Second)
-	prepareDefaultOpts         = retry.AttemptsWithWaitOpts(30, 10*time.Second)
-	executeBundleDefaultOpts   = retry.AttemptsWithWaitOpts(10, 10*time.Second)
-	readFileForInfoDefaultOpts = retry.AttemptsWithWaitOpts(10, 3*time.Second)
+	alreadyRunDefaultOpts      = retry.AttemptsWithWaitOpts(300, 1*time.Second)
+	prepareDefaultOpts         = retry.AttemptsWithWaitOpts(300, 1*time.Second)
+	executeBundleDefaultOpts   = retry.AttemptsWithWaitOpts(100, 1*time.Second)
+	readFileForInfoDefaultOpts = retry.AttemptsWithWaitOpts(30, 1*time.Second)
 )
 
 type LoopsParams struct {

--- a/dhctl/pkg/operations/bootstrap/checks.go
+++ b/dhctl/pkg/operations/bootstrap/checks.go
@@ -35,7 +35,7 @@ func CheckPreventBreakAnotherBootstrappedCluster(
 	kubeCl *client.KubernetesClient,
 	config *config.DeckhouseInstaller,
 ) error {
-	return retry.NewSilentLoop("Check to prevent breaking another bootstrapped cluster", 15, 3*time.Second).RunContext(ctx, func() error {
+	return retry.NewSilentLoop("Check to prevent breaking another bootstrapped cluster", 45, 1*time.Second).RunContext(ctx, func() error {
 		var uuidInCluster string
 		cmInCluster, err := kubeCl.CoreV1().ConfigMaps(manifests.ClusterUUIDCmNamespace).Get(ctx, manifests.ClusterUUIDCm, metav1.GetOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
@@ -68,7 +68,7 @@ func WaitForFirstMasterNodeBecomeReady(ctx context.Context, kubeCl *client.Kuber
 	defer span.End()
 
 	var nodeName string
-	err := retry.NewSilentLoop("Get master node name", 45, 3*time.Second).RunContext(ctx, func() error {
+	err := retry.NewSilentLoop("Get master node name", 135, 1*time.Second).RunContext(ctx, func() error {
 		nodes, err := kubeCl.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err

--- a/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
+++ b/dhctl/pkg/operations/bootstrap/cluster-bootstrapper.go
@@ -1064,7 +1064,7 @@ func createResources(
 
 		if len(resourcesToCreate) == 0 {
 			for _, task := range tasks {
-				return retry.NewLoop(task.Title, 60, 5*time.Second).RunContext(ctx, func() error {
+				return retry.NewLoop(task.Title, 300, 1*time.Second).RunContext(ctx, func() error {
 					return task.Do(kubeCl)
 				})
 			}

--- a/dhctl/pkg/operations/bootstrap/deps/check.go
+++ b/dhctl/pkg/operations/bootstrap/deps/check.go
@@ -62,7 +62,7 @@ var (
 		"join", "cat", "ps", "kill",
 	}
 
-	checkDepsDefaultOpts = retry.AttemptsWithWaitOpts(10, 5*time.Second)
+	checkDepsDefaultOpts = retry.AttemptsWithWaitOpts(50, 1*time.Second)
 )
 
 func NewDependenciesChecker(nodeInterface libcon.Interface, loggerProvider log.LoggerProvider) *DependenciesChecker {
@@ -266,7 +266,7 @@ func (c *DependenciesChecker) sshErrorBreakPredicate(err error) bool {
 	}
 	var ee *exec.ExitError
 	if errors.As(err, &ee) && ee.ExitCode() == 255 {
-		c.loggerProvider().WarnF("SSH connection failed (exit 255), retrying in 5 seconds...")
+		c.loggerProvider().WarnF("SSH connection failed (exit 255), retrying in 1 second...")
 		return false
 	}
 

--- a/dhctl/pkg/operations/bootstrap/steps_bashible.go
+++ b/dhctl/pkg/operations/bootstrap/steps_bashible.go
@@ -253,8 +253,8 @@ func prepareMasterNode(ctx context.Context, nodeInterface libcon.Interface, cont
 			extLogger := log.ExternalLoggerProvider(log.GetDefaultLogger())
 			p := retry.NewEmptyParams(
 				retry.WithName("%s", name),
-				retry.WithAttempts(30),
-				retry.WithWait(5*time.Second),
+				retry.WithAttempts(150),
+				retry.WithWait(1*time.Second),
 				retry.WithLogger(extLogger()),
 			)
 			err := retry.NewLoopWithParams(p).RunContext(ctx, func() error {

--- a/dhctl/pkg/operations/bootstrap/steps_deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/steps_deckhouse.go
@@ -111,8 +111,8 @@ func applyPostBootstrapModuleConfigs(
 		extLogger := log.ExternalLoggerProvider(log.GetDefaultLogger())
 		p := retry.NewEmptyParams(
 			retry.WithName("%s", task.Title),
-			retry.WithAttempts(15),
-			retry.WithWait(5*time.Second),
+			retry.WithAttempts(75),
+			retry.WithWait(1*time.Second),
 			retry.WithLogger(extLogger()),
 		)
 		err := retry.NewLoopWithParams(p).

--- a/dhctl/pkg/operations/bootstrap/steps_ssh.go
+++ b/dhctl/pkg/operations/bootstrap/steps_ssh.go
@@ -55,8 +55,8 @@ func readRemoteFileWithRetry(ctx context.Context, nodeInterface libcon.Interface
 	extLogger := log.ExternalLoggerProvider(log.GetDefaultLogger())
 	p := retry.NewEmptyParams(
 		retry.WithName("Read remote file %s", path),
-		retry.WithAttempts(5),
-		retry.WithWait(3*time.Second),
+		retry.WithAttempts(15),
+		retry.WithWait(1*time.Second),
 		retry.WithLogger(extLogger()),
 	)
 	var value string
@@ -86,8 +86,8 @@ func WaitForSSHConnectionOnMaster(ctx context.Context, sshClient libcon.SSHClien
 		extLogger := log.ExternalLoggerProvider(log.GetDefaultLogger())
 
 		if err := availabilityCheck.WithDelaySeconds(1).AwaitAvailability(ctx, retry.NewEmptyParams(
-			retry.WithWait(5*time.Second),
-			retry.WithAttempts(50),
+			retry.WithWait(1*time.Second),
+			retry.WithAttempts(250),
 			retry.WithLogger(extLogger()),
 		)); err != nil {
 			return fmt.Errorf("await master to become available: %v", err)

--- a/dhctl/pkg/operations/commander/helpers.go
+++ b/dhctl/pkg/operations/commander/helpers.go
@@ -105,7 +105,7 @@ func ConstructManagedByCommanderConfigMapTask(ctx context.Context, commanderUUID
 }
 
 func DeleteManagedByCommanderConfigMap(ctx context.Context, kubeCl *client.KubernetesClient) error {
-	return retry.NewLoop("Delete commander-uuid ConfigMap", 20, 5*time.Second).
+	return retry.NewLoop("Delete commander-uuid ConfigMap", 100, 1*time.Second).
 		WithShowError(false).
 		RunContext(ctx, func() error {
 			err := kubeCl.

--- a/dhctl/pkg/operations/converge/context/converge_state.go
+++ b/dhctl/pkg/operations/converge/context/converge_state.go
@@ -59,7 +59,7 @@ func (s *inSecretStateStore) GetState(ctx *Context) (*State, error) {
 		return nil, fmt.Errorf("Could not get kube client: %w", err)
 	}
 
-	err = retry.NewLoop("Get converge state from Kubernetes cluster", 5, 5*time.Second).RunContext(ctx.Ctx(), func() error {
+	err = retry.NewLoop("Get converge state from Kubernetes cluster", 25, 1*time.Second).RunContext(ctx.Ctx(), func() error {
 		c, cancel := ctx.WithTimeout(10 * time.Second)
 		defer cancel()
 
@@ -91,7 +91,7 @@ func (s *inSecretStateStore) Delete(ctx *Context) error {
 	if err != nil {
 		return fmt.Errorf("Could not get kube client: %w", err)
 	}
-	return retry.NewLoop("Cleanup converge state from Kubernetes cluster", 5, 5*time.Second).RunContext(ctx.Ctx(), func() error {
+	return retry.NewLoop("Cleanup converge state from Kubernetes cluster", 25, 1*time.Second).RunContext(ctx.Ctx(), func() error {
 		c, cancel := ctx.WithTimeout(10 * time.Second)
 		defer cancel()
 
@@ -148,7 +148,7 @@ func (s *inSecretStateStore) SetState(convergeCtx *Context, state *State) error 
 		},
 	}
 
-	return retry.NewLoop("Save dhctl converge state", 45, 10*time.Second).
+	return retry.NewLoop("Save dhctl converge state", 450, 1*time.Second).
 		RunContext(
 			convergeCtx.Ctx(),
 			func() error {

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/etcd.go
@@ -35,7 +35,7 @@ import (
 func waitEtcdHasMember(ctx context.Context, client libcon.KubeClient, nodeName string) error {
 	attempt := 0
 
-	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to join etcd", nodeName), 100, 20*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to join etcd", nodeName), 2000, 1*time.Second).RunContext(ctx, func() error {
 		attempt++
 
 		members, err := getEtcdMembers(ctx, client, "")
@@ -65,10 +65,10 @@ func waitEtcdHasMember(ctx context.Context, client libcon.KubeClient, nodeName s
 }
 
 func waitEtcdHasNoMember(ctx context.Context, client libcon.KubeClient, nodeName string) error {
-	const maxAttempts = 45
+	const maxAttempts = 225
 	attempt := 0
 
-	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to leave etcd", nodeName), maxAttempts, 5*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(fmt.Sprintf("Waiting for '%s' to leave etcd", nodeName), maxAttempts, 1*time.Second).RunContext(ctx, func() error {
 		attempt++
 		fieldSelector := fields.OneTermNotEqualSelector("spec.nodeName", nodeName).String()
 

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_destroy_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_destroy_pipeline.go
@@ -139,7 +139,7 @@ func removeControlPlaneRoleFromNode(ctx context.Context, kubeCl *client.Kubernet
 }
 
 func removeLabelsFromNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string, labels []string) error {
-	return retry.NewLoop(fmt.Sprintf("Remove labels from node %s", nodeName), 45, 5*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(fmt.Sprintf("Remove labels from node %s", nodeName), 225, 1*time.Second).RunContext(ctx, func() error {
 		node, err := kubeCl.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
 			if errors.IsNotFound(err) {

--- a/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/controlplane/hook_for_update_pipeline.go
@@ -224,7 +224,7 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 		return fmt.Errorf("failed to wait for the master node '%s' to be listed as etcd cluster member: %w", h.nodeToConverge, err)
 	}
 
-	err = retry.NewLoop("Check Stronghold readiness after node converge", 45, 10*time.Second).RunContext(ctx, func() error {
+	err = retry.NewLoop("Check Stronghold readiness after node converge", 450, 1*time.Second).RunContext(ctx, func() error {
 		ready, err := NewStrongholdReadinessChecker(h.kubeGetter).IsReady(ctx, h.nodeToConverge)
 		if err != nil {
 			return fmt.Errorf("failed to check Stronghold readiness: %w", err)
@@ -240,7 +240,7 @@ func (h *HookForUpdatePipeline) AfterAction(ctx context.Context, runner infrastr
 		return err
 	}
 
-	return retry.NewLoop(fmt.Sprintf("Check control-plane is ready on node '%s'", h.nodeToConverge), 45, 10*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop(fmt.Sprintf("Check control-plane is ready on node '%s'", h.nodeToConverge), 450, 1*time.Second).RunContext(ctx, func() error {
 		ready, err := NewManagerReadinessChecker(h.kubeGetter).IsReady(ctx, h.nodeToConverge)
 		if err != nil {
 			return fmt.Errorf("failed to check the master node '%s' readiness: %w", h.nodeToConverge, err)
@@ -300,7 +300,7 @@ func (h *HookForUpdatePipeline) saveKubernetesDataDevicePath(ctx context.Context
 		},
 	}
 
-	return retry.NewLoop(fmt.Sprintf("Save Kubernetes data device path for node '%s'", h.nodeToConverge), 45, 10*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Save Kubernetes data device path for node '%s'", h.nodeToConverge), 450, 1*time.Second).
 		RunContext(ctx, func() error {
 			return task.CreateOrUpdate(ctx)
 		})

--- a/dhctl/pkg/operations/converge/infrastructure/hook/node.go
+++ b/dhctl/pkg/operations/converge/infrastructure/hook/node.go
@@ -38,7 +38,7 @@ func IsNodeReady(ctx context.Context, checkers []NodeChecker, nodeName, sourceCo
 	title := fmt.Sprintf("Node %s readiness check", nodeName)
 	var lastErr error
 
-	err := retry.NewLoop(title, 30, 10*time.Second).RunContext(ctx, func() error {
+	err := retry.NewLoop(title, 300, 1*time.Second).RunContext(ctx, func() error {
 		for _, check := range checkers {
 			err := log.ProcessCtx(ctx, sourceCommandName, check.Name(), func(ctx context.Context) error {
 				isReady, err := check.IsReady(ctx, nodeName)

--- a/dhctl/pkg/operations/converge/infrastructure/utils/delete.go
+++ b/dhctl/pkg/operations/converge/infrastructure/utils/delete.go
@@ -30,8 +30,8 @@ import (
 func DeleteNodeObjectFromCluster(ctx context.Context, kubeCl *client.KubernetesClient, nodeName string) error {
 	return retry.NewLoop(
 		fmt.Sprintf("Delete node %s", nodeName),
-		10,
-		5*time.Second,
+		50,
+		1*time.Second,
 	).RunContext(ctx, func() error {
 		err := kubeCl.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
 		if err != nil {

--- a/dhctl/pkg/operations/converge/infrastructure/utils/drain.go
+++ b/dhctl/pkg/operations/converge/infrastructure/utils/drain.go
@@ -57,7 +57,7 @@ func TryToDrainNode(ctx context.Context, kubeCl *client.KubernetesClient, nodeNa
 		return nil
 	}
 
-	err := retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 5, 10*time.Second).
+	err := retry.NewLoop(fmt.Sprintf("Drain node '%s'", nodeName), 50, 1*time.Second).
 		RunContext(ctx, func() error {
 			return drainNode(ctx, kubeCl, nodeName, opts)
 		})

--- a/dhctl/pkg/operations/destroy/static/destroyer.go
+++ b/dhctl/pkg/operations/destroy/static/destroyer.go
@@ -537,7 +537,7 @@ func (d *Destroyer) logger() log.Logger {
 	return log.SafeProvideLogger(d.params.LoggerProvider)
 }
 
-var getDestroyMastersDefaultOpts = retry.AttemptsWithWaitOpts(5, 15*time.Second)
+var getDestroyMastersDefaultOpts = retry.AttemptsWithWaitOpts(75, 1*time.Second)
 
 func (d *Destroyer) destroyMasterLoopParams(host session.Host) retry.Params {
 	return retry.SafeCloneOrNewParams(d.params.Loops.DestroyMaster, getDestroyMastersDefaultOpts...).

--- a/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
+++ b/dhctl/pkg/state/infrastructure/before_tofu_state_backup.go
@@ -157,7 +157,7 @@ func (t *TofuMigrationStateBackuper) getBaseInfraSecret(ctx context.Context) (*a
 		return nil, fmt.Errorf("Could not get kube client: %w", err)
 	}
 
-	err = retry.NewLoop("Get base infrastructure state", 15, 5*time.Second).
+	err = retry.NewLoop("Get base infrastructure state", 75, 1*time.Second).
 		WithLogger(t.logger).
 		BreakIf(k8serrors.IsNotFound).
 		RunContext(ctx, func() error {
@@ -183,7 +183,7 @@ func (t *TofuMigrationStateBackuper) isBackupSecretExist(ctx context.Context, na
 	if err != nil {
 		return false, fmt.Errorf("Could not get kube client: %w", err)
 	}
-	err = retry.NewLoop(fmt.Sprintf("Check %s infrastructure backup state exists", name), 15, 5*time.Second).WithLogger(t.logger).
+	err = retry.NewLoop(fmt.Sprintf("Check %s infrastructure backup state exists", name), 75, 1*time.Second).WithLogger(t.logger).
 		RunContext(ctx, func() error {
 			_, err := kubeClient.CoreV1().Secrets(global.D8SystemNamespace).Get(ctx, name, metav1.GetOptions{})
 			if err != nil {
@@ -222,7 +222,7 @@ func (t *TofuMigrationStateBackuper) saveBackupSecret(ctx context.Context, proce
 		return fmt.Errorf("Could not get kube client: %w", err)
 	}
 
-	return retry.NewLoop(fmt.Sprintf("Save %s infrastructure backup state", processPrefix), 15, 5*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Save %s infrastructure backup state", processPrefix), 75, 1*time.Second).
 		WithLogger(t.logger).
 		RunContext(ctx, func() error {
 			var err error
@@ -246,7 +246,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 		return err
 	}
 
-	err = retry.NewLoop("Save base infrastructure backup state for commander", 1, 5*time.Second).
+	err = retry.NewLoop("Save base infrastructure backup state for commander", 5, 1*time.Second).
 		WithLogger(t.logger).
 		RunContext(ctx, func() error {
 			name := baseInfraBackupSecretName + ".terraform.backup"
@@ -270,7 +270,7 @@ func (t *TofuMigrationStateBackuper) saveBackupStatesForCommander(ctx context.Co
 	for ngName, ng := range ngs {
 		err = t.logger.LogProcessCtx(ctx, "default", fmt.Sprintf("Save infrastructure backup node states for commander for node group %s", ngName), func(ctx context.Context) error {
 			for node, st := range ng.State {
-				err := retry.NewLoop(fmt.Sprintf("Save infrastructure backup state for node %s for commander", node), 1, 5*time.Second).
+				err := retry.NewLoop(fmt.Sprintf("Save infrastructure backup state for node %s for commander", node), 5, 1*time.Second).
 					WithLogger(t.logger).
 					RunContext(ctx, func() error {
 						name := "tf-" + node + ".terraform.backup"

--- a/dhctl/pkg/state/infrastructure/state.go
+++ b/dhctl/pkg/state/infrastructure/state.go
@@ -49,7 +49,7 @@ var ErrNoInfrastructureState = errors.New("Infrastructure state was not found in
 
 func GetClusterStateFromCluster(ctx context.Context, kubeCl *client.KubernetesClient) ([]byte, error) {
 	var st []byte
-	err := retry.NewLoop("Get Cluster infrastructure state from Kubernetes cluster", 5, 5*time.Second).
+	err := retry.NewLoop("Get Cluster infrastructure state from Kubernetes cluster", 25, 1*time.Second).
 		RunContext(ctx, func() error {
 			clusterStateSecret, err := kubeCl.CoreV1().Secrets(global.D8SystemNamespace).Get(ctx, manifests.InfrastructureClusterStateName, metav1.GetOptions{})
 			if err != nil {
@@ -68,7 +68,7 @@ func GetClusterStateFromCluster(ctx context.Context, kubeCl *client.KubernetesCl
 
 func GetClusterUUID(ctx context.Context, kubeCl *client.KubernetesClient) (string, error) {
 	var clusterUUID string
-	err := retry.NewLoop("Get Cluster UUID from the Kubernetes cluster", 5, 5*time.Second).
+	err := retry.NewLoop("Get Cluster UUID from the Kubernetes cluster", 25, 1*time.Second).
 		RunContext(ctx, func() error {
 			uuidConfigMap, err := kubeCl.CoreV1().ConfigMaps(global.ConfigsNS).Get(ctx, "d8-cluster-uuid", metav1.GetOptions{})
 			if err != nil {
@@ -105,7 +105,7 @@ func GetNodesStateSecretsFromCluster(ctx context.Context, kubeCl *client.Kuberne
 
 	processName := fmt.Sprintf("Get nodes infrastructure state from Kubernetes cluster for %s", action)
 
-	err = retry.NewLoop(processName, 15, 5*time.Second).RunContext(ctx, func() error {
+	err = retry.NewLoop(processName, 75, 1*time.Second).RunContext(ctx, func() error {
 		timeoutCtx, cancel := defaultRequestTimeoutCtx(ctx)
 		defer cancel()
 
@@ -300,7 +300,7 @@ func SaveNodeInfrastructureState(
 			return err
 		},
 	}
-	return retry.NewLoop(fmt.Sprintf("Save infrastructure state for Node %q", nodeName), 45, 10*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Save infrastructure state for Node %q", nodeName), 450, 1*time.Second).
 		WithLogger(logger).
 		RunContext(ctx, func() error { return task.CreateOrUpdate(ctx) })
 }
@@ -364,7 +364,7 @@ func SaveMasterNodeInfrastructureState(ctx context.Context, kubeCl *client.Kuber
 		},
 	}
 
-	return retry.NewLoop(fmt.Sprintf("Save infrastructure state for master Node %s", nodeName), 45, 10*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Save infrastructure state for master Node %s", nodeName), 450, 1*time.Second).
 		RunContext(
 			ctx,
 			func() error {
@@ -403,7 +403,7 @@ func SaveClusterInfrastructureState(ctx context.Context, kubeCl *client.Kubernet
 		},
 	}
 
-	err := retry.NewLoop("Save Cluster infrastructure state", 45, 10*time.Second).
+	err := retry.NewLoop("Save Cluster infrastructure state", 450, 1*time.Second).
 		RunContext(
 			ctx,
 			func() error {
@@ -423,7 +423,7 @@ func SaveClusterInfrastructureState(ctx context.Context, kubeCl *client.Kubernet
 		return err
 	}
 
-	return retry.NewLoop("Update cloud discovery data", 45, 10*time.Second).RunContext(ctx, func() error {
+	return retry.NewLoop("Update cloud discovery data", 450, 1*time.Second).RunContext(ctx, func() error {
 		_, err = kubeCl.CoreV1().Secrets("kube-system").Patch(
 			ctx,
 			"d8-provider-cluster-configuration",
@@ -436,7 +436,7 @@ func SaveClusterInfrastructureState(ctx context.Context, kubeCl *client.Kubernet
 }
 
 func DeleteInfrastructureState(ctx context.Context, kubeCl *client.KubernetesClient, secretName string) error {
-	return retry.NewLoop(fmt.Sprintf("Delete infrastructure state %s", secretName), 45, 10*time.Second).
+	return retry.NewLoop(fmt.Sprintf("Delete infrastructure state %s", secretName), 450, 1*time.Second).
 		RunContext(ctx, func() error {
 			return kubeCl.CoreV1().Secrets("d8-system").Delete(ctx, secretName, metav1.DeleteOptions{})
 		})

--- a/dhctl/pkg/state/infrastructure/state_saver.go
+++ b/dhctl/pkg/state/infrastructure/state_saver.go
@@ -93,7 +93,7 @@ func (s *ClusterStateSaver) SaveState(ctx context.Context, outputs *infrastructu
 	}
 
 	log.DebugF("Saving intermediate base infra in cluster...\n")
-	err := retry.NewSilentLoop("Save Cluster intermediate infrastructure state", 15, 3*time.Second).Run(
+	err := retry.NewSilentLoop("Save Cluster intermediate infrastructure state", 45, 1*time.Second).Run(
 		func() error {
 			return task.Patch(ctx)
 		},
@@ -168,7 +168,7 @@ func (s *NodeStateSaver) SaveState(ctx context.Context, outputs *infrastructure.
 
 	taskName := fmt.Sprintf("Save intermediate infrastructure state for Node %q", s.nodeName)
 	log.DebugF("Saving intermediate state for node %s in cluster...\n", s.nodeName)
-	err = retry.NewSilentLoop(taskName, 15, 3*time.Second).Run(func() error {
+	err = retry.NewSilentLoop(taskName, 45, 1*time.Second).Run(func() error {
 		return task.PatchOrCreate(ctx)
 	})
 


### PR DESCRIPTION
## Description

Reduced retry wait intervals for dhctl internal operations and increased the number of retry attempts proportionally. The total maximum retry duration is preserved, but checks are performed more frequently.

The change does not restart or directly affect critical cluster components.

## Why do we need it, and what problem does it solve?

Some dhctl operations waited too long between retry attempts. As a result, dhctl could react slowly when an operation had already become successful, but the next retry was scheduled several seconds later.

This change improves dhctl responsiveness by making internal retry loops more granular while keeping the same total retry timeout before failure.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: dhctl
type: fix 
summary: Improved dhctl retry responsiveness without changing the total retry timeout.
impact_level: low
```