### PR TITLE
[cloud-provider-dvp] wait for VirtualDisk readiness in CreateVolume

### DIFF
--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/api/v1alpha1/deckhousemachine_types.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/api/v1alpha1/deckhousemachine_types.go
@@ -41,6 +41,8 @@ const (
 	DiskMigrationInProgressReason = "DiskMigrationInProgress"
 	DiskMigrationFailedReason     = "DiskMigrationFailed"
 	DiskMigrationCompletedReason  = "DiskMigrationCompleted"
+
+	BootDiskProvisioningFailedReason = "BootDiskProvisioningFailed"
 )
 
 // CPU defines the VM CPU, made of variable number of cores, each getting the Fraction amount of processing time on a physical core.

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -428,6 +428,22 @@ func (r *DeckhouseMachineReconciler) handleVMNotReady(
 	// due to potential conflict or unexpected actions
 	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
 
+	bootDiskName := dvpMachine.Name + "-boot"
+	if bootDisk, err := r.DVP.DiskService.GetDiskByName(ctx, bootDiskName); err == nil {
+		if termErr := dvpapi.TerminalDiskError(bootDisk); termErr != nil {
+			dvpMachine.Status.FailureReason = ptr.To(string(capierrors.CreateMachineError))
+			dvpMachine.Status.FailureMessage = ptr.To(fmt.Sprintf("boot disk provisioning failed: %v", termErr))
+			conditions.Set(dvpMachine, metav1.Condition{
+				Type:               string(infrastructurev1a1.VMReadyCondition),
+				Status:             metav1.ConditionFalse,
+				Reason:             infrastructurev1a1.BootDiskProvisioningFailedReason,
+				Message:            fmt.Sprintf("boot disk provisioning failed: %v", termErr),
+				LastTransitionTime: metav1.Now(),
+			})
+			return ctrl.Result{}, nil
+		}
+	}
+
 	resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine)
 	message := fmt.Sprintf("VM is not ready, state is %s", vm.Status.Phase)
 	if resourceStatus != "" {

--- a/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
+++ b/modules/030-cloud-provider-dvp/images/capdvp-controller-manager/src/internal/controller/deckhousemachine_controller.go
@@ -428,20 +428,35 @@ func (r *DeckhouseMachineReconciler) handleVMNotReady(
 	// due to potential conflict or unexpected actions
 	dvpMachine.Status.Initialization.Provisioned = ptr.To(false)
 
-	bootDiskName := dvpMachine.Name + "-boot"
-	if bootDisk, err := r.DVP.DiskService.GetDiskByName(ctx, bootDiskName); err == nil {
-		if termErr := dvpapi.TerminalDiskError(bootDisk); termErr != nil {
-			dvpMachine.Status.FailureReason = ptr.To(string(capierrors.CreateMachineError))
-			dvpMachine.Status.FailureMessage = ptr.To(fmt.Sprintf("boot disk provisioning failed: %v", termErr))
-			conditions.Set(dvpMachine, metav1.Condition{
-				Type:               string(infrastructurev1a1.VMReadyCondition),
-				Status:             metav1.ConditionFalse,
-				Reason:             infrastructurev1a1.BootDiskProvisioningFailedReason,
-				Message:            fmt.Sprintf("boot disk provisioning failed: %v", termErr),
-				LastTransitionTime: metav1.Now(),
-			})
-			return ctrl.Result{}, nil
+	diskNames := make([]string, 0, 1+len(dvpMachine.Spec.AdditionalDisks))
+	diskNames = append(diskNames, dvpMachine.Name+"-boot")
+	for i := range dvpMachine.Spec.AdditionalDisks {
+		diskNames = append(diskNames, fmt.Sprintf("%s-additional-disk-%d", dvpMachine.Name, i))
+	}
+
+	for _, diskName := range diskNames {
+		disk, err := r.DVP.DiskService.GetDiskByName(ctx, diskName)
+		if err != nil {
+			if !errors.Is(err, dvpapi.ErrNotFound) {
+				logger.V(1).Info("cannot fetch VM disk to probe for terminal error", "disk", diskName, "error", err)
+			}
+			continue
 		}
+		termErr := dvpapi.TerminalDiskError(disk)
+		if termErr == nil {
+			continue
+		}
+		msg := fmt.Sprintf("disk %q provisioning failed: %v", diskName, termErr)
+		dvpMachine.Status.FailureReason = ptr.To(string(capierrors.CreateMachineError))
+		dvpMachine.Status.FailureMessage = ptr.To(msg)
+		conditions.Set(dvpMachine, metav1.Condition{
+			Type:               string(infrastructurev1a1.VMReadyCondition),
+			Status:             metav1.ConditionFalse,
+			Reason:             infrastructurev1a1.BootDiskProvisioningFailedReason,
+			Message:            msg,
+			LastTransitionTime: metav1.Now(),
+		})
+		return ctrl.Result{}, nil
 	}
 
 	resourceStatus := r.collectOwnedResourcesStatus(ctx, dvpMachine)

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/api.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/api.go
@@ -33,6 +33,7 @@ import (
 var (
 	ErrNotFound            = errors.New("not found")
 	ErrDuplicateAttachment = errors.New("duplicate attachment")
+	ErrQuotaExceeded       = errors.New("quota exceeded")
 )
 
 type DVPCloudAPI struct {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
 )
 
 const (
@@ -280,6 +281,15 @@ func (d *DiskService) WaitDiskCreation(ctx context.Context, vmdName string) erro
 		vmd, ok := obj.(*v1alpha2.VirtualDisk)
 		if !ok {
 			return false, fmt.Errorf("expected a VirtualMachineDisk but got a %T", obj)
+		}
+
+		if vmd.Status.Phase == v1alpha2.DiskFailed {
+			for _, cond := range vmd.Status.Conditions {
+				if cond.Type == vdcondition.ReadyType.String() && cond.Status == metav1.ConditionFalse {
+					return false, fmt.Errorf("%s", cond.Message)
+				}
+			}
+			return false, fmt.Errorf("disk %q is in Failed phase", vmdName)
 		}
 
 		return vmd.Status.Phase == v1alpha2.DiskReady, nil

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -284,20 +284,40 @@ func (d *DiskService) WaitDiskCreation(ctx context.Context, vmdName string) erro
 			return false, fmt.Errorf("expected a VirtualMachineDisk but got a %T", obj)
 		}
 
-		if vmd.Status.Phase == v1alpha2.DiskFailed {
-			for _, cond := range vmd.Status.Conditions {
-				if cond.Type == vdcondition.ReadyType.String() && cond.Status == metav1.ConditionFalse {
+		if vmd.Status.Phase == v1alpha2.DiskReady {
+			return true, nil
+		}
+
+		for _, cond := range vmd.Status.Conditions {
+			if cond.Type == vdcondition.ReadyType.String() && cond.Status == metav1.ConditionFalse {
+				if isTerminalDiskErrorReason(vdcondition.ReadyReason(cond.Reason)) {
 					if cond.Reason == vdcondition.QuotaExceeded.String() {
 						return false, fmt.Errorf("%w: %s", ErrQuotaExceeded, cond.Message)
 					}
 					return false, errors.New(cond.Message)
 				}
 			}
+		}
+
+		if vmd.Status.Phase == v1alpha2.DiskFailed {
 			return false, fmt.Errorf("disk %q is in Failed phase", vmdName)
 		}
 
-		return vmd.Status.Phase == v1alpha2.DiskReady, nil
+		return false, nil
 	})
+}
+
+func isTerminalDiskErrorReason(reason vdcondition.ReadyReason) bool {
+	switch reason {
+	case vdcondition.ProvisioningFailed,
+		vdcondition.QuotaExceeded,
+		vdcondition.ImagePullFailed,
+		vdcondition.DatasourceIsNotFound,
+		vdcondition.StorageClassIsNotReady,
+		vdcondition.Lost:
+		return true
+	}
+	return false
 }
 
 func (d *DiskService) WaitDiskDeletion(ctx context.Context, vmdName string) error {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -284,7 +284,7 @@ func (d *DiskService) WaitDiskCreation(ctx context.Context, vmdName string) erro
 			return false, fmt.Errorf("expected a VirtualMachineDisk but got a %T", obj)
 		}
 
-		if vmd.Status.Phase == v1alpha2.DiskReady {
+		if vmd.Status.Phase == v1alpha2.DiskReady || vmd.Status.Phase == v1alpha2.DiskWaitForFirstConsumer {
 			return true, nil
 		}
 

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -276,19 +276,8 @@ func (d *DiskService) WaitDiskCreation(ctx context.Context, vmdName string) erro
 			return true, nil
 		}
 
-		for _, cond := range vmd.Status.Conditions {
-			if cond.Type == vdcondition.ReadyType.String() && cond.Status == metav1.ConditionFalse {
-				if isTerminalDiskErrorReason(vdcondition.ReadyReason(cond.Reason)) {
-					if cond.Reason == vdcondition.QuotaExceeded.String() {
-						return false, fmt.Errorf("%w: %s", ErrQuotaExceeded, cond.Message)
-					}
-					return false, errors.New(cond.Message)
-				}
-			}
-		}
-
-		if vmd.Status.Phase == v1alpha2.DiskFailed {
-			return false, fmt.Errorf("disk %q is in Failed phase", vmdName)
+		if err := TerminalDiskError(vmd); err != nil {
+			return false, err
 		}
 
 		return false, nil

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -306,7 +305,7 @@ func TerminalDiskError(vmd *v1alpha2.VirtualDisk) error {
 				if cond.Reason == vdcondition.QuotaExceeded.String() {
 					return fmt.Errorf("%w: %s", ErrQuotaExceeded, cond.Message)
 				}
-				return errors.New(cond.Message)
+				return fmt.Errorf("%s: %s", cond.Reason, cond.Message)
 			}
 		}
 	}

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -286,7 +287,10 @@ func (d *DiskService) WaitDiskCreation(ctx context.Context, vmdName string) erro
 		if vmd.Status.Phase == v1alpha2.DiskFailed {
 			for _, cond := range vmd.Status.Conditions {
 				if cond.Type == vdcondition.ReadyType.String() && cond.Status == metav1.ConditionFalse {
-					return false, fmt.Errorf("%s", cond.Message)
+					if cond.Reason == vdcondition.QuotaExceeded.String() {
+						return false, fmt.Errorf("%w: %s", ErrQuotaExceeded, cond.Message)
+					}
+					return false, errors.New(cond.Message)
 				}
 			}
 			return false, fmt.Errorf("disk %q is in Failed phase", vmdName)

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk.go
@@ -164,18 +164,6 @@ func (d *DiskService) CreateDiskFromDataSource(
 		return nil, err
 	}
 
-	sc, err := d.GetStorageClass(ctx, diskStorageClass)
-	if err != nil {
-		return nil, err
-	}
-
-	if sc.VolumeBindingMode != nil && *sc.VolumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
-		err = d.WaitDiskCreation(ctx, diskName)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return newDisk, nil
 }
 
@@ -318,6 +306,25 @@ func isTerminalDiskErrorReason(reason vdcondition.ReadyReason) bool {
 		return true
 	}
 	return false
+}
+
+// TerminalDiskError returns a non-nil error if the VirtualDisk is in a terminal failure state,
+// nil if the disk is healthy or still provisioning.
+func TerminalDiskError(vmd *v1alpha2.VirtualDisk) error {
+	for _, cond := range vmd.Status.Conditions {
+		if cond.Type == vdcondition.ReadyType.String() && cond.Status == metav1.ConditionFalse {
+			if isTerminalDiskErrorReason(vdcondition.ReadyReason(cond.Reason)) {
+				if cond.Reason == vdcondition.QuotaExceeded.String() {
+					return fmt.Errorf("%w: %s", ErrQuotaExceeded, cond.Message)
+				}
+				return errors.New(cond.Message)
+			}
+		}
+	}
+	if vmd.Status.Phase == v1alpha2.DiskFailed {
+		return fmt.Errorf("disk %q is in Failed phase", vmd.Name)
+	}
+	return nil
 }
 
 func (d *DiskService) WaitDiskDeletion(ctx context.Context, vmdName string) error {

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/disk_test.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/disk_test.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2025 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/deckhouse/virtualization/api/core/v1alpha2"
+	"github.com/deckhouse/virtualization/api/core/v1alpha2/vdcondition"
+)
+
+const testNamespace = "default"
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := v1alpha2.AddToScheme(s); err != nil {
+		t.Fatalf("v1alpha2.AddToScheme: %v", err)
+	}
+	return s
+}
+
+func newDiskServiceWithDisks(t *testing.T, disks ...*v1alpha2.VirtualDisk) *DiskService {
+	t.Helper()
+	objs := make([]ctrlclient.Object, len(disks))
+	for i, d := range disks {
+		objs[i] = d
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(objs...).
+		Build()
+	return &DiskService{&Service{client: c, namespace: testNamespace}}
+}
+
+func makeVMD(name string, phase v1alpha2.DiskPhase, conditions []metav1.Condition) *v1alpha2.VirtualDisk {
+	return &v1alpha2.VirtualDisk{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels:    map[string]string{diskNameLabel: name},
+		},
+		Status: v1alpha2.VirtualDiskStatus{
+			Phase:      phase,
+			Conditions: conditions,
+		},
+	}
+}
+
+func readyCond(reason vdcondition.ReadyReason, status metav1.ConditionStatus, msg string) metav1.Condition {
+	return metav1.Condition{
+		Type:    vdcondition.ReadyType.String(),
+		Status:  status,
+		Reason:  reason.String(),
+		Message: msg,
+	}
+}
+
+func TestTerminalDiskError(t *testing.T) {
+	tests := []struct {
+		name      string
+		vmd       *v1alpha2.VirtualDisk
+		wantErr   bool
+		isQuota   bool
+		wantInMsg string
+	}{
+		{
+			name:    "provisioning phase, no conditions — no error",
+			vmd:     makeVMD("d", v1alpha2.DiskProvisioning, nil),
+			wantErr: false,
+		},
+		{
+			name: "Ready condition True — no error",
+			vmd: makeVMD("d", v1alpha2.DiskReady, []metav1.Condition{
+				readyCond(vdcondition.Ready, metav1.ConditionTrue, ""),
+			}),
+			wantErr: false,
+		},
+		{
+			name: "non-terminal ReadyReason (Provisioning) with ConditionFalse — no error",
+			vmd: makeVMD("d", v1alpha2.DiskProvisioning, []metav1.Condition{
+				readyCond(vdcondition.Provisioning, metav1.ConditionFalse, "in progress"),
+			}),
+			wantErr: false,
+		},
+		{
+			name: "QuotaExceeded wraps ErrQuotaExceeded",
+			vmd: makeVMD("d", v1alpha2.DiskPending, []metav1.Condition{
+				readyCond(vdcondition.QuotaExceeded, metav1.ConditionFalse, "quota exceeded msg"),
+			}),
+			wantErr:   true,
+			isQuota:   true,
+			wantInMsg: "quota exceeded msg",
+		},
+		{
+			name: "ProvisioningFailed",
+			vmd: makeVMD("d", v1alpha2.DiskPending, []metav1.Condition{
+				readyCond(vdcondition.ProvisioningFailed, metav1.ConditionFalse, "out of space"),
+			}),
+			wantErr:   true,
+			wantInMsg: "out of space",
+		},
+		{
+			name: "Lost",
+			vmd: makeVMD("d", v1alpha2.DiskLost, []metav1.Condition{
+				readyCond(vdcondition.Lost, metav1.ConditionFalse, "pvc lost"),
+			}),
+			wantErr:   true,
+			wantInMsg: "pvc lost",
+		},
+		{
+			name: "ImagePullFailed",
+			vmd: makeVMD("d", v1alpha2.DiskPending, []metav1.Condition{
+				readyCond(vdcondition.ImagePullFailed, metav1.ConditionFalse, "pull failed"),
+			}),
+			wantErr:   true,
+			wantInMsg: "pull failed",
+		},
+		{
+			name: "DatasourceIsNotFound",
+			vmd: makeVMD("d", v1alpha2.DiskPending, []metav1.Condition{
+				readyCond(vdcondition.DatasourceIsNotFound, metav1.ConditionFalse, "datasource gone"),
+			}),
+			wantErr:   true,
+			wantInMsg: "datasource gone",
+		},
+		{
+			name: "StorageClassIsNotReady",
+			vmd: makeVMD("d", v1alpha2.DiskPending, []metav1.Condition{
+				readyCond(vdcondition.StorageClassIsNotReady, metav1.ConditionFalse, "sc not ready"),
+			}),
+			wantErr:   true,
+			wantInMsg: "sc not ready",
+		},
+		{
+			name:      "DiskFailed phase without terminal condition",
+			vmd:       makeVMD("d", v1alpha2.DiskFailed, nil),
+			wantErr:   true,
+			wantInMsg: `"d" is in Failed phase`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := TerminalDiskError(tc.vmd)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.isQuota && !errors.Is(err, ErrQuotaExceeded) {
+					t.Fatalf("expected ErrQuotaExceeded, got: %v", err)
+				}
+				if tc.wantInMsg != "" && !strings.Contains(err.Error(), tc.wantInMsg) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantInMsg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestWaitDiskCreation(t *testing.T) {
+	tests := []struct {
+		name      string
+		disk      *v1alpha2.VirtualDisk
+		ctx       func() context.Context
+		wantErr   bool
+		isQuota   bool
+		isCtxErr  bool
+		wantInMsg string
+	}{
+		{
+			name:    "DiskReady — success",
+			disk:    makeVMD("disk1", v1alpha2.DiskReady, nil),
+			wantErr: false,
+		},
+		{
+			name:    "DiskWaitForFirstConsumer — success",
+			disk:    makeVMD("disk1", v1alpha2.DiskWaitForFirstConsumer, nil),
+			wantErr: false,
+		},
+		{
+			name: "QuotaExceeded — returns ErrQuotaExceeded",
+			disk: makeVMD("disk1", v1alpha2.DiskPending, []metav1.Condition{
+				readyCond(vdcondition.QuotaExceeded, metav1.ConditionFalse, "quota exceeded"),
+			}),
+			wantErr: true,
+			isQuota: true,
+		},
+		{
+			name: "ProvisioningFailed terminal condition",
+			disk: makeVMD("disk1", v1alpha2.DiskPending, []metav1.Condition{
+				readyCond(vdcondition.ProvisioningFailed, metav1.ConditionFalse, "out of space"),
+			}),
+			wantErr:   true,
+			wantInMsg: "out of space",
+		},
+		{
+			name:      "DiskFailed phase",
+			disk:      makeVMD("disk1", v1alpha2.DiskFailed, nil),
+			wantErr:   true,
+			wantInMsg: `"disk1" is in Failed phase`,
+		},
+		{
+			name: "context cancelled while waiting for provisioning disk",
+			disk: makeVMD("disk1", v1alpha2.DiskProvisioning, nil),
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			wantErr:  true,
+			isCtxErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newDiskServiceWithDisks(t, tc.disk)
+
+			ctx := context.Background()
+			if tc.ctx != nil {
+				ctx = tc.ctx()
+			}
+
+			err := svc.WaitDiskCreation(ctx, "disk1")
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.isQuota && !errors.Is(err, ErrQuotaExceeded) {
+					t.Fatalf("expected ErrQuotaExceeded, got: %v", err)
+				}
+				if tc.isCtxErr && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("expected context error, got: %v", err)
+				}
+				if tc.wantInMsg != "" && !strings.Contains(err.Error(), tc.wantInMsg) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantInMsg)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/modules/030-cloud-provider-dvp/images/dvp-common/api/service.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-common/api/service.go
@@ -22,6 +22,7 @@ import (
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -42,39 +43,17 @@ const defaultWaitCheckInterval = time.Second
 type WaitFn func(obj client.Object) (bool, error)
 
 func (s *Service) Wait(ctx context.Context, name string, obj client.Object, waitFn WaitFn) error {
-	var done bool
-	for {
+	return wait.PollUntilContextCancel(ctx, defaultWaitCheckInterval, true, func(ctx context.Context) (bool, error) {
 		err := s.client.Get(ctx, types.NamespacedName{
 			Namespace: s.namespace,
 			Name:      name,
 		}, obj)
 		if err != nil {
 			if !k8serrors.IsNotFound(err) {
-				return err
+				return false, err
 			}
-
-			// obj not found.
-			done, err = waitFn(nil)
-		} else {
-			// obj found.
-			done, err = waitFn(obj)
+			return waitFn(nil)
 		}
-
-		if err != nil {
-			return err
-		}
-
-		if done {
-			return nil
-		}
-
-		timer := time.NewTimer(defaultWaitCheckInterval)
-
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-			timer.Stop()
-			return ctx.Err()
-		}
-	}
+		return waitFn(obj)
+	})
 }

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -127,8 +127,11 @@ func (c *ControllerService) CreateVolume(
 		if disk.Status.Phase == v1alpha2.DiskReady || disk.Status.Phase == v1alpha2.DiskWaitForFirstConsumer {
 			diskCapacity, err := utils.ConvertStringQuantityToInt64(disk.Status.Capacity)
 			if err != nil || diskCapacity <= 0 {
-				// WFFC disks may not have capacity populated yet; fall back to requested size.
-				diskCapacity = requiredSize
+				// WFFC disks may not have Status.Capacity populated yet;
+				// fall back to Spec.PersistentVolumeClaim.Size so the size-mismatch check below stays honest.
+				if size := disk.Spec.PersistentVolumeClaim.Size; size != nil {
+					diskCapacity = size.Value()
+				}
 			}
 			if requiredSize > 0 && diskCapacity > 0 && requiredSize > diskCapacity {
 				return nil, status.Errorf(

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -134,6 +134,10 @@ func (c *ControllerService) CreateVolume(
 				)
 			}
 
+			if err := c.dvpCloudAPI.DiskService.WaitDiskCreation(ctx, disk.Name); err != nil {
+				return nil, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
+			}
+
 			result.Volume.VolumeId = disk.Name
 			result.Volume.CapacityBytes = requiredSize
 			return result, nil
@@ -172,6 +176,10 @@ func (c *ControllerService) CreateVolume(
 	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error from parent DVP cluster while creating disk %s: %v", diskName, err)
+	}
+
+	if err := c.dvpCloudAPI.DiskService.WaitDiskCreation(ctx, disk.Name); err != nil {
+		return nil, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
 	}
 
 	result.Volume.VolumeId = disk.Name

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -135,11 +135,23 @@ func (c *ControllerService) CreateVolume(
 			}
 
 			if err := c.dvpCloudAPI.DiskService.WaitDiskCreation(ctx, disk.Name); err != nil {
+				if errors.Is(err, dvpapi.ErrQuotaExceeded) {
+					return nil, status.Errorf(codes.ResourceExhausted, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
+				}
 				return nil, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
 			}
 
+			readyDisk, err := c.dvpCloudAPI.DiskService.GetDiskByName(ctx, disk.Name)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "error fetching disk %s after provisioning: %v", diskName, err)
+			}
+			actualCapacity, err := utils.ConvertStringQuantityToInt64(readyDisk.Status.Capacity)
+			if err != nil || actualCapacity <= 0 {
+				actualCapacity = requiredSize
+			}
+
 			result.Volume.VolumeId = disk.Name
-			result.Volume.CapacityBytes = requiredSize
+			result.Volume.CapacityBytes = actualCapacity
 			return result, nil
 		}
 
@@ -179,11 +191,23 @@ func (c *ControllerService) CreateVolume(
 	}
 
 	if err := c.dvpCloudAPI.DiskService.WaitDiskCreation(ctx, disk.Name); err != nil {
+		if errors.Is(err, dvpapi.ErrQuotaExceeded) {
+			return nil, status.Errorf(codes.ResourceExhausted, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
+		}
 		return nil, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
 	}
 
+	readyDisk, err := c.dvpCloudAPI.DiskService.GetDiskByName(ctx, disk.Name)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "error fetching disk %s after provisioning: %v", diskName, err)
+	}
+	actualCapacity, err := utils.ConvertStringQuantityToInt64(readyDisk.Status.Capacity)
+	if err != nil || actualCapacity <= 0 {
+		actualCapacity = requiredSize
+	}
+
 	result.Volume.VolumeId = disk.Name
-	result.Volume.CapacityBytes = requiredSize
+	result.Volume.CapacityBytes = actualCapacity
 	return result, nil
 }
 

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -190,6 +190,12 @@ func (c *ControllerService) waitDiskReadyAndGetCapacity(ctx context.Context, dis
 		if errors.Is(err, dvpapi.ErrQuotaExceeded) {
 			return 0, status.Errorf(codes.ResourceExhausted, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
 		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return 0, status.Errorf(codes.DeadlineExceeded, "disk %s provisioning timed out in parent DVP cluster: %v", diskName, err)
+		}
+		if errors.Is(err, context.Canceled) {
+			return 0, status.Errorf(codes.Aborted, "disk %s provisioning canceled in parent DVP cluster: %v", diskName, err)
+		}
 		return 0, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
 	}
 
@@ -269,7 +275,7 @@ func (c *ControllerService) ControllerPublishVolume(
 		waitErr := c.dvpCloudAPI.ComputeService.WaitDiskAttaching(waitCtx, vmBDAName)
 		if waitErr != nil {
 			if errors.Is(waitErr, context.DeadlineExceeded) {
-				return nil, status.Errorf(codes.DeadlineExceeded,
+				return nil, status.Errorf(codes.Internal,
 					"Publish: timeout waiting for vmBDA attachment: disk=%s vm=%s",
 					diskName, vmHostname,
 				)
@@ -299,7 +305,7 @@ func (c *ControllerService) ControllerPublishVolume(
 
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, status.Errorf(
-				codes.DeadlineExceeded,
+				codes.Internal,
 				"Publish: timeout while attaching disk (Kubernetes will retry): disk=%s vm=%s exists=%t attached=%t: %v",
 				diskName, vmHostname, sExists, sAttached, err,
 			)

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -124,56 +124,41 @@ func (c *ControllerService) CreateVolume(
 	if len(disks.Items) == 1 {
 		disk := disks.Items[0]
 
-		capacityStr := disk.Status.Capacity
-		if capacityStr == "" {
-			if requiredSize <= 0 {
+		if disk.Status.Phase == v1alpha2.DiskReady {
+			diskCapacity, err := utils.ConvertStringQuantityToInt64(disk.Status.Capacity)
+			if err != nil {
 				return nil, status.Errorf(
 					codes.Internal,
-					"disk %q exists but capacity is not reported yet (phase=%s) and requested size is %d",
-					disk.Name, disk.Status.Phase, requiredSize,
+					"failed to parse existing disk capacity for %q (capacity=%q): %v",
+					disk.Name, disk.Status.Capacity, err,
 				)
 			}
-
-			if err := c.dvpCloudAPI.DiskService.WaitDiskCreation(ctx, disk.Name); err != nil {
-				if errors.Is(err, dvpapi.ErrQuotaExceeded) {
-					return nil, status.Errorf(codes.ResourceExhausted, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
-				}
-				return nil, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
+			if requiredSize > 0 && diskCapacity > 0 && requiredSize > diskCapacity {
+				return nil, status.Errorf(
+					codes.AlreadyExists,
+					"disk %q already exists with capacity %d bytes, which is smaller than requested %d bytes",
+					disk.Name, diskCapacity, requiredSize,
+				)
 			}
-
-			readyDisk, err := c.dvpCloudAPI.DiskService.GetDiskByName(ctx, disk.Name)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "error fetching disk %s after provisioning: %v", diskName, err)
-			}
-			actualCapacity, err := utils.ConvertStringQuantityToInt64(readyDisk.Status.Capacity)
-			if err != nil || actualCapacity <= 0 {
-				actualCapacity = requiredSize
-			}
-
 			result.Volume.VolumeId = disk.Name
-			result.Volume.CapacityBytes = actualCapacity
+			result.Volume.CapacityBytes = diskCapacity
 			return result, nil
 		}
 
-		diskCapacity, err := utils.ConvertStringQuantityToInt64(capacityStr)
-		if err != nil {
+		if requiredSize <= 0 {
 			return nil, status.Errorf(
 				codes.Internal,
-				"failed to parse existing disk capacity for %q (capacity=%q): %v",
-				disk.Name, capacityStr, err,
+				"disk %q exists but is not ready yet (phase=%s) and requested size is %d",
+				disk.Name, disk.Status.Phase, requiredSize,
 			)
 		}
 
-		if requiredSize > 0 && diskCapacity > 0 && requiredSize > diskCapacity {
-			return nil, status.Errorf(
-				codes.AlreadyExists,
-				"disk %q already exists with capacity %d bytes, which is smaller than requested %d bytes",
-				disk.Name, diskCapacity, requiredSize,
-			)
+		actualCapacity, err := c.waitDiskReadyAndGetCapacity(ctx, disk.Name, requiredSize)
+		if err != nil {
+			return nil, err
 		}
-
 		result.Volume.VolumeId = disk.Name
-		result.Volume.CapacityBytes = diskCapacity
+		result.Volume.CapacityBytes = actualCapacity
 		return result, nil
 	}
 
@@ -190,25 +175,34 @@ func (c *ControllerService) CreateVolume(
 		return nil, status.Errorf(codes.Internal, "error from parent DVP cluster while creating disk %s: %v", diskName, err)
 	}
 
-	if err := c.dvpCloudAPI.DiskService.WaitDiskCreation(ctx, disk.Name); err != nil {
-		if errors.Is(err, dvpapi.ErrQuotaExceeded) {
-			return nil, status.Errorf(codes.ResourceExhausted, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
-		}
-		return nil, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
-	}
-
-	readyDisk, err := c.dvpCloudAPI.DiskService.GetDiskByName(ctx, disk.Name)
+	actualCapacity, err := c.waitDiskReadyAndGetCapacity(ctx, disk.Name, requiredSize)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error fetching disk %s after provisioning: %v", diskName, err)
-	}
-	actualCapacity, err := utils.ConvertStringQuantityToInt64(readyDisk.Status.Capacity)
-	if err != nil || actualCapacity <= 0 {
-		actualCapacity = requiredSize
+		return nil, err
 	}
 
 	result.Volume.VolumeId = disk.Name
 	result.Volume.CapacityBytes = actualCapacity
 	return result, nil
+}
+
+func (c *ControllerService) waitDiskReadyAndGetCapacity(ctx context.Context, diskName string, fallbackSize int64) (int64, error) {
+	if err := c.dvpCloudAPI.DiskService.WaitDiskCreation(ctx, diskName); err != nil {
+		if errors.Is(err, dvpapi.ErrQuotaExceeded) {
+			return 0, status.Errorf(codes.ResourceExhausted, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
+		}
+		return 0, status.Errorf(codes.Internal, "disk %s failed to provision in parent DVP cluster: %v", diskName, err)
+	}
+
+	readyDisk, err := c.dvpCloudAPI.DiskService.GetDiskByName(ctx, diskName)
+	if err != nil {
+		return 0, status.Errorf(codes.Internal, "error fetching disk %s after provisioning: %v", diskName, err)
+	}
+
+	capacity, err := utils.ConvertStringQuantityToInt64(readyDisk.Status.Capacity)
+	if err != nil || capacity <= 0 {
+		return fallbackSize, nil
+	}
+	return capacity, nil
 }
 
 func (c *ControllerService) DeleteVolume(

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -126,12 +126,9 @@ func (c *ControllerService) CreateVolume(
 
 		if disk.Status.Phase == v1alpha2.DiskReady || disk.Status.Phase == v1alpha2.DiskWaitForFirstConsumer {
 			diskCapacity, err := utils.ConvertStringQuantityToInt64(disk.Status.Capacity)
-			if err != nil {
-				return nil, status.Errorf(
-					codes.Internal,
-					"failed to parse existing disk capacity for %q (capacity=%q): %v",
-					disk.Name, disk.Status.Capacity, err,
-				)
+			if err != nil || diskCapacity <= 0 {
+				// WFFC disks may not have capacity populated yet; fall back to requested size.
+				diskCapacity = requiredSize
 			}
 			if requiredSize > 0 && diskCapacity > 0 && requiredSize > diskCapacity {
 				return nil, status.Errorf(
@@ -275,7 +272,7 @@ func (c *ControllerService) ControllerPublishVolume(
 		waitErr := c.dvpCloudAPI.ComputeService.WaitDiskAttaching(waitCtx, vmBDAName)
 		if waitErr != nil {
 			if errors.Is(waitErr, context.DeadlineExceeded) {
-				return nil, status.Errorf(codes.Internal,
+				return nil, status.Errorf(codes.DeadlineExceeded,
 					"Publish: timeout waiting for vmBDA attachment: disk=%s vm=%s",
 					diskName, vmHostname,
 				)
@@ -305,7 +302,7 @@ func (c *ControllerService) ControllerPublishVolume(
 
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, status.Errorf(
-				codes.Internal,
+				codes.DeadlineExceeded,
 				"Publish: timeout while attaching disk (Kubernetes will retry): disk=%s vm=%s exists=%t attached=%t: %v",
 				diskName, vmHostname, sExists, sAttached, err,
 			)

--- a/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
+++ b/modules/030-cloud-provider-dvp/images/dvp-csi-driver/src/pkg/dvp-csi-driver/service/controller.go
@@ -124,7 +124,7 @@ func (c *ControllerService) CreateVolume(
 	if len(disks.Items) == 1 {
 		disk := disks.Items[0]
 
-		if disk.Status.Phase == v1alpha2.DiskReady {
+		if disk.Status.Phase == v1alpha2.DiskReady || disk.Status.Phase == v1alpha2.DiskWaitForFirstConsumer {
 			diskCapacity, err := utils.ConvertStringQuantityToInt64(disk.Status.Capacity)
 			if err != nil {
 				return nil, status.Errorf(


### PR DESCRIPTION
## Description
`CreateVolume` in the DVP CSI driver now waits for the `VirtualDisk` in the parent cluster to reach `Ready` phase before returning success. If provisioning fails (e.g. quota exceeded), the error is propagated back to the nested cluster so the PVC stays in `ProvisioningFailed` with a human-readable message instead of the PV being incorrectly marked as `Bound`.

## Why do we need it, and what problem does it solve?

In a nested Kubernetes cluster running on DVP, creating a PVC via the DVP CSI driver could result in a misleading state: the PV inside the nested cluster was marked `Bound` and the pod was scheduled, but the actual `VirtualDisk` in the
parent cluster was never provisioned (e.g. quota exceeded). The pod would then hang indefinitely unable to start because the disk didn't exist, with no actionable error visible from inside the nested cluster.

Root cause: `CreateVolume` created the `VirtualDisk` object and returned `ProvisioningSucceeded` immediately, without waiting for the disk to actually provision. Async failures in the parent cluster (quota, storage class errors, etc.) were silently swallowed.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [x] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-dvp
type: fix
summary: Made the DVP CSI driver wait for VirtualDisk readiness in CreateVolume so provisioning errors are propagated instead of marking the PV as Bound.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
