### PR TITLE
[istio] JWKS extra root CA implementation

### DIFF
--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -396,6 +396,15 @@ properties:
       root:
         type: string
         description: The root certificate in PEM format if `cert` is an intermediate certificate.
+  jwksResolverExtraRootCA:
+    type: string
+    description: |
+      An additional root certificate in PEM format. It is used by istiod when resolving JWKS URIs over HTTPS.
+    x-examples:
+    - |
+      -----BEGIN CERTIFICATE-----
+      MIIDXTCCAkWgAwIBAgIJAN...
+      -----END CERTIFICATE-----
   controlPlane:
     type: object
     description: istiod specific settings.

--- a/modules/110-istio/openapi/config-values.yaml
+++ b/modules/110-istio/openapi/config-values.yaml
@@ -396,7 +396,7 @@ properties:
       root:
         type: string
         description: The root certificate in PEM format if `cert` is an intermediate certificate.
-  jwksResolverExtraRootCA:
+  jwksResolverAdditionalRootCA:
     type: string
     description: |
       An additional root certificate in PEM format. It is used by istiod when resolving JWKS URIs over HTTPS.

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -180,6 +180,9 @@ properties:
         description: Цепочка сертификатов в формате PEM на случай, если `cert` — промежуточный сертификат.
       root:
         description: Корневой сертификат в формате PEM на случай, если `cert` — промежуточный сертификат.
+  jwksResolverExtraRootCA:
+    description: |
+      Дополнительный корневой сертификат в формате PEM. Используется компонентом istiod при получении JWKS URI по HTTPS.
   controlPlane:
     description: Настройки для компонента istiod.
     properties:

--- a/modules/110-istio/openapi/doc-ru-config-values.yaml
+++ b/modules/110-istio/openapi/doc-ru-config-values.yaml
@@ -180,7 +180,7 @@ properties:
         description: Цепочка сертификатов в формате PEM на случай, если `cert` — промежуточный сертификат.
       root:
         description: Корневой сертификат в формате PEM на случай, если `cert` — промежуточный сертификат.
-  jwksResolverExtraRootCA:
+  jwksResolverAdditionalRootCA:
     description: |
       Дополнительный корневой сертификат в формате PEM. Используется компонентом istiod при получении JWKS URI по HTTPS.
   controlPlane:

--- a/modules/110-istio/openapi/openapi-case-tests.yaml
+++ b/modules/110-istio/openapi/openapi-case-tests.yaml
@@ -38,6 +38,10 @@ positive:
         enabled: true
       dataPlane:
         trafficRedirectionSetupMode: CNIPlugin
+    - jwksResolverAdditionalRootCA: |
+        -----BEGIN CERTIFICATE-----
+        MIIDXTCCAkWgAwIBAgIJAN...
+        -----END CERTIFICATE-----
     - dataPlane:
         extensionProviders:
         - name: authservice-grpc

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -70,6 +70,12 @@ const istioValues = `
       applicationNamespaces: []
       globalVersion: "1.21.6"
       versionMap:
+        "1.27.9":
+          revision: "v1x27x9"
+          fullVersion: "1.27.9"
+          imageSuffix: "V1x27x9"
+          supportsAmbient: true
+          supportsOperator: false
         "1.25.2":
           revision: "v1x25x2"
           fullVersion: "1.25.2"
@@ -159,6 +165,10 @@ const istioValues = `
               max: "1Gi"
               min: "64Mi"
 `
+
+const jwksResolverExtraRootCA = `-----BEGIN CERTIFICATE-----
+MIIDXTCCAkWgAwIBAgIJAN...
+-----END CERTIFICATE-----`
 
 func getSubdirs(dir string) ([]string, error) {
 	var subdirs []string
@@ -376,6 +386,33 @@ var _ = Describe("Module :: istio :: helm template :: main", func() {
 			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.name").String()).To(Equal(`authservice-grpc`))
 			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.service").String()).To(Equal(`authservice.d8-istio.svc.cluster.local`))
 			Expect(iopV21.Field("spec.meshConfig.extensionProviders.1.envoyExtAuthzGrpc.port").Int()).To(Equal(int64(10003)))
+		})
+	})
+
+	Context("JWKS resolver extra root CA is configured", func() {
+		BeforeEach(func() {
+			f.ValuesSetFromYaml("global", globalValues)
+			f.ValuesSet("global.modulesImages", GetModulesImages())
+			f.ValuesSetFromYaml("istio", istioValues)
+			f.ValuesSetFromYaml("istio.internal.versionsToInstall", `["1.21.6","1.25.2","1.27.9"]`)
+			f.ValuesSet("istio.jwksResolverAdditionalRootCA", jwksResolverAdditionalRootCA)
+			f.HelmRender()
+		})
+
+		It("passes the certificate to pilot configuration for supported Istio versions", func() {
+			Expect(f.RenderError).ShouldNot(HaveOccurred())
+
+			iopV21 := f.KubernetesResource("IstioOperator", "d8-istio", "v1x21x6")
+			istioV25 := f.KubernetesResource("Istio", "d8-istio", "v1x25x2")
+			jwksExtraRootCAV27 := f.KubernetesResource("ConfigMap", "d8-istio", "pilot-jwks-extra-cacerts-v1x27x9")
+
+			Expect(iopV21.Exists()).To(BeTrue())
+			Expect(istioV25.Exists()).To(BeTrue())
+			Expect(jwksExtraRootCAV27.Exists()).To(BeTrue())
+
+			Expect(iopV21.Field("spec.values.pilot.jwksResolverExtraRootCA").String()).To(Equal(jwksResolverAdditionalRootCA))
+			Expect(istioV25.Field("spec.values.pilot.jwksResolverExtraRootCA").String()).To(Equal(jwksResolverAdditionalRootCA))
+			Expect(jwksExtraRootCAV27.Field("data.extra\\.pem").String()).To(Equal(jwksResolverAdditionalRootCA))
 		})
 	})
 

--- a/modules/110-istio/template_tests/module_test.go
+++ b/modules/110-istio/template_tests/module_test.go
@@ -166,7 +166,7 @@ const istioValues = `
               min: "64Mi"
 `
 
-const jwksResolverExtraRootCA = `-----BEGIN CERTIFICATE-----
+const jwksResolverAdditionalRootCA = `-----BEGIN CERTIFICATE-----
 MIIDXTCCAkWgAwIBAgIJAN...
 -----END CERTIFICATE-----`
 

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -204,7 +204,7 @@ spec:
 
     pilot:
       autoscaleEnabled: false
-  {{- with $.Values.istio.jwksResolverExtraRootCA }}
+  {{- with $.Values.istio.jwksResolverAdditionalRootCA }}
       jwksResolverExtraRootCA: |-
 {{ . | indent 8 }}
   {{- end }}

--- a/modules/110-istio/templates/control-plane/iop.yaml
+++ b/modules/110-istio/templates/control-plane/iop.yaml
@@ -204,6 +204,10 @@ spec:
 
     pilot:
       autoscaleEnabled: false
+  {{- with $.Values.istio.jwksResolverExtraRootCA }}
+      jwksResolverExtraRootCA: |-
+{{ . | indent 8 }}
+  {{- end }}
       env:
         PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: false
         PILOT_ENABLE_GATEWAY_API_GATEWAYCLASS_CONTROLLER: false

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -173,6 +173,10 @@ spec:
       cni:
         enabled: {{ eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
       enabled: true
+  {{- with $.Values.istio.jwksResolverExtraRootCA }}
+      jwksResolverExtraRootCA: |-
+{{ . | indent 8 }}
+  {{- end }}
       env:
         ISTIO_MULTIROOT_MESH: "true"
         ENABLE_ENHANCED_RESOURCE_SCOPING: "true"

--- a/modules/110-istio/templates/control-plane/istios.yaml
+++ b/modules/110-istio/templates/control-plane/istios.yaml
@@ -173,7 +173,7 @@ spec:
       cni:
         enabled: {{ eq $.Values.istio.dataPlane.trafficRedirectionSetupMode "CNIPlugin" }}
       enabled: true
-  {{- with $.Values.istio.jwksResolverExtraRootCA }}
+  {{- with $.Values.istio.jwksResolverAdditionalRootCA }}
       jwksResolverExtraRootCA: |-
 {{ . | indent 8 }}
   {{- end }}

--- a/modules/110-istio/templates/control-plane/jwks-extra-root-ca.yaml
+++ b/modules/110-istio/templates/control-plane/jwks-extra-root-ca.yaml
@@ -1,5 +1,5 @@
-{{- with $.Values.istio.jwksResolverExtraRootCA }}
-  {{- $jwksResolverExtraRootCA := . }}
+{{- with $.Values.istio.jwksResolverAdditionalRootCA }}
+  {{- $jwksResolverAdditionalRootCA := . }}
   {{- range $version := $.Values.istio.internal.versionsToInstall }}
     {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
     {{- if not (get $versionInfo "supportsOperator") }}
@@ -12,7 +12,7 @@ metadata:
   namespace: d8-{{ $.Chart.Name }}
   {{- include "helm_lib_module_labels" (list $ (dict "app" "istiod" "istio.io/rev" $revision "operator.istio.io/component" "Pilot")) | nindent 2 }}
 data:
-  extra.pem: {{ $jwksResolverExtraRootCA | quote }}
+  extra.pem: {{ $jwksResolverAdditionalRootCA | quote }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/modules/110-istio/templates/control-plane/jwks-extra-root-ca.yaml
+++ b/modules/110-istio/templates/control-plane/jwks-extra-root-ca.yaml
@@ -1,0 +1,18 @@
+{{- with $.Values.istio.jwksResolverExtraRootCA }}
+  {{- $jwksResolverExtraRootCA := . }}
+  {{- range $version := $.Values.istio.internal.versionsToInstall }}
+    {{- $versionInfo := get $.Values.istio.internal.versionMap $version }}
+    {{- if not (get $versionInfo "supportsOperator") }}
+      {{- $revision := get $versionInfo "revision" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pilot-jwks-extra-cacerts-{{ $revision }}
+  namespace: d8-{{ $.Chart.Name }}
+  {{- include "helm_lib_module_labels" (list $ (dict "app" "istiod" "istio.io/rev" $revision "operator.istio.io/component" "Pilot")) | nindent 2 }}
+data:
+  extra.pem: {{ $jwksResolverExtraRootCA | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description
Adds a module configuration option for providing an additional trusted root CA certificate for Istio JWKS resolution.

When configured, istiod uses this certificate while resolving JWKS URIs over HTTPS. The setting is supported for Istio 1.21, 1.25, and the operator-free 1.27 control plane path.

Changing this option affects Istio control plane configuration and may require istiod rollout/reconciliation for the new certificate to take effect.

## Why do we need it, and what problem does it solve?
Some environments expose JWKS endpoints with TLS certificates signed by private or custom certificate authorities. Without an additional trusted root CA, istiod cannot validate those HTTPS endpoints and may fail to fetch JWKS, which can break JWT-based authentication policies.

This change allows users to provide the required trusted CA through the Istio module configuration, enabling JWKS resolution for private PKI-backed endpoints without weakening TLS verification.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: istio
type: feature
summary: Added support for an extra root CA for JWKS fetching in Istio.
impact_level: default
```