### PR TITLE
[global][candi] Fix default k8s version to 1.34

### DIFF
--- a/candi/version_map.yml
+++ b/candi/version_map.yml
@@ -44,7 +44,6 @@ k8s:
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
   "1.33":
-    default: true
     status: available
     patch: 12
     bashible: *bashible
@@ -58,6 +57,7 @@ k8s:
       snapshotter: v8.1.1
       livenessprobe: v2.15.0
   "1.34":
+    default: true
     status: available
     patch: 8
     bashible: *bashible


### PR DESCRIPTION
## Description
Automatic k8s version is changed to 1.34 from 1.33

## Why do we need it, and what problem does it solve?
Fix for the k8s upgrade.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Changed the automatic Kubernetes version from 1.33 to 1.34.
impact: Automatic k8s version is changed to 1.34 from 1.33, automatic setting will result in upgrade.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
