### PR TITLE
[cloud-provider-yandex] set volume-expansion-mode to online

### DIFF
--- a/helm_lib/Chart.lock
+++ b/helm_lib/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: deckhouse_lib_helm
   repository: https://deckhouse.github.io/lib-helm
-  version: 1.72.0
-digest: sha256:f726180e4e40570dbeb4ed1cf000fe1a971458e68272a246745ce8c00ccf2e36
-generated: "2026-05-25T13:33:58.23687+03:00"
+  version: 1.72.1
+digest: sha256:4df5f84c3d43ad64ee5d4764500a86e07914a665b50eedc560c620b3be8a9280
+generated: "2026-06-10T16:26:31.212968+03:00"

--- a/helm_lib/Chart.yaml
+++ b/helm_lib/Chart.yaml
@@ -5,5 +5,5 @@ version: 0.1.0
 description: Helm helpers
 dependencies:
   - name: deckhouse_lib_helm
-    version: "1.72.0"
+    version: "1.72.1"
     repository: https://deckhouse.github.io/lib-helm

--- a/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
+++ b/helm_lib/charts/deckhouse_lib_helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 description: Helm utils template definitions for Deckhouse modules.
 name: deckhouse_lib_helm
 type: library
-version: 1.72.0
+version: 1.72.1

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
@@ -14,17 +14,8 @@
     {{- end }}
   {{- end }}
 
-  {{- $volume_expansion_mode_online := false -}}
-  {{- range $module_name := list "cloud-provider-yandex"}}
-    {{- if has $module_name $context.Values.global.enabledModules }}
-      {{- $volume_expansion_mode_online = true }}
-    {{- end }}
-  {{- end }}
-
   {{- if $volume_expansion_mode_offline }}
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
-  {{- else if $volume_expansion_mode_online }}
-    {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "online" }}
   {{- end }}
 
   {{- if $context.Values.global.discovery.defaultStorageClass }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
@@ -14,8 +14,17 @@
     {{- end }}
   {{- end }}
 
+  {{- $volume_expansion_mode_online := false -}}
+  {{- range $module_name := list "cloud-provider-yandex"}}
+    {{- if has $module_name $context.Values.global.enabledModules }}
+      {{- $volume_expansion_mode_online = true }}
+    {{- end }}
+  {{- end }}
+
   {{- if $volume_expansion_mode_offline }}
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
+  {{- else if $volume_expansion_mode_online }}
+    {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "online" }}
   {{- end }}
 
   {{- if $context.Values.global.discovery.defaultStorageClass }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
@@ -8,7 +8,7 @@
   {{- $annotations := dict -}}
 
   {{- $volume_expansion_mode_offline := false -}}
-  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-yandex" "cloud-provider-vsphere" "cloud-provider-vcd"}}
+  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-vsphere" "cloud-provider-vcd"}}
     {{- if has $module_name $context.Values.global.enabledModules }}
       {{- $volume_expansion_mode_offline = true }}
     {{- end }}
@@ -17,7 +17,7 @@
   {{- if $volume_expansion_mode_offline }}
     {{- $_ := set $annotations "storageclass.deckhouse.io/volume-expansion-mode" "offline" }}
   {{- end }}
-
+  
   {{- if $context.Values.global.discovery.defaultStorageClass }}
     {{- if eq $context.Values.global.discovery.defaultStorageClass $sc_name }}
       {{- $_ := set $annotations "storageclass.kubernetes.io/is-default-class" "true" }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
@@ -8,7 +8,7 @@
   {{- $annotations := dict -}}
 
   {{- $volume_expansion_mode_offline := false -}}
-  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-vsphere" "cloud-provider-vcd"}}
+  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-yandex" "cloud-provider-vsphere" "cloud-provider-vcd"}}
     {{- if has $module_name $context.Values.global.enabledModules }}
       {{- $volume_expansion_mode_offline = true }}
     {{- end }}

--- a/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
+++ b/helm_lib/charts/deckhouse_lib_helm/templates/_module_storage_class.tpl
@@ -8,7 +8,7 @@
   {{- $annotations := dict -}}
 
   {{- $volume_expansion_mode_offline := false -}}
-  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-yandex" "cloud-provider-vsphere" "cloud-provider-vcd"}}
+  {{- range $module_name := list "cloud-provider-azure" "cloud-provider-vsphere" "cloud-provider-vcd"}}
     {{- if has $module_name $context.Values.global.enabledModules }}
       {{- $volume_expansion_mode_offline = true }}
     {{- end }}

--- a/modules/030-cloud-provider-yandex/template_tests/module_test.go
+++ b/modules/030-cloud-provider-yandex/template_tests/module_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Module :: cloud-provider-yandex :: helm template ::", func() {
 			Expect(csiSSDSCNonReplicated.Exists()).To(BeTrue())
 
 			Expect(csiHDDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: online
+storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 
@@ -456,7 +456,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 
 			Expect(csiHDDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 			Expect(csiSSDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: online
+storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 		})
@@ -485,7 +485,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 
 			Expect(csiHDDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 			Expect(csiSSDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: online
+storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 		})
@@ -511,7 +511,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 			Expect(csiSSDSCNonReplicated.Exists()).To(BeTrue())
 
 			Expect(csiHDDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: online
+storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 			Expect(csiSSDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())

--- a/modules/030-cloud-provider-yandex/template_tests/module_test.go
+++ b/modules/030-cloud-provider-yandex/template_tests/module_test.go
@@ -417,7 +417,7 @@ var _ = Describe("Module :: cloud-provider-yandex :: helm template ::", func() {
 			Expect(csiSSDSCNonReplicated.Exists()).To(BeTrue())
 
 			Expect(csiHDDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
+storageclass.deckhouse.io/volume-expansion-mode: online
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 
@@ -456,7 +456,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 
 			Expect(csiHDDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 			Expect(csiSSDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
+storageclass.deckhouse.io/volume-expansion-mode: online
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 		})
@@ -485,7 +485,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 
 			Expect(csiHDDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 			Expect(csiSSDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
+storageclass.deckhouse.io/volume-expansion-mode: online
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 		})
@@ -511,7 +511,7 @@ storageclass.kubernetes.io/is-default-class: "true"
 			Expect(csiSSDSCNonReplicated.Exists()).To(BeTrue())
 
 			Expect(csiHDDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
+storageclass.deckhouse.io/volume-expansion-mode: online
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 			Expect(csiSSDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())

--- a/modules/030-cloud-provider-yandex/template_tests/module_test.go
+++ b/modules/030-cloud-provider-yandex/template_tests/module_test.go
@@ -417,7 +417,6 @@ var _ = Describe("Module :: cloud-provider-yandex :: helm template ::", func() {
 			Expect(csiSSDSCNonReplicated.Exists()).To(BeTrue())
 
 			Expect(csiHDDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 
@@ -456,7 +455,6 @@ storageclass.kubernetes.io/is-default-class: "true"
 
 			Expect(csiHDDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 			Expect(csiSSDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 		})
@@ -485,7 +483,6 @@ storageclass.kubernetes.io/is-default-class: "true"
 
 			Expect(csiHDDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())
 			Expect(csiSSDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 		})
@@ -511,7 +508,6 @@ storageclass.kubernetes.io/is-default-class: "true"
 			Expect(csiSSDSCNonReplicated.Exists()).To(BeTrue())
 
 			Expect(csiHDDSC.Field("metadata.annotations").String()).To(MatchYAML(`
-storageclass.deckhouse.io/volume-expansion-mode: offline
 storageclass.kubernetes.io/is-default-class: "true"
 `))
 			Expect(csiSSDSC.Field(`metadata.annotations.storageclass\.kubernetes\.io/is-default-class`).Exists()).To(BeFalse())


### PR DESCRIPTION
## Description
Remove `cloud-provider-yandex` from the list of providers with `offline` volume expansion mode in `helm_lib_module_storage_class_annotations`.
StorageClasses for Yandex Cloud will now have `storageclass.deckhouse.io/volume-expansion-mode: online`.

## Why do we need it, and what problem does it solve?
The `offline` annotation incorrectly signals that PVC resize requires pod restart on Yandex Cloud.
In reality, the Yandex CSI driver (`yandex.csi.flant.com`) supports `NodeExpandVolume` on a mounted volume — filesystem resize completes without stopping or restarting the pod.

Tested manually on Deckhouse CE v1.75.9:
- PVC resized from 10Gi → 20Gi while pod was running
- Pod UID before and after: identical
- restartCount before and after: 0
- Filesystem expanded from 9.7G → 19.6G without pod restart
- `FileSystemResizeSuccessful` event confirmed

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: fix
summary: Fixed the volume-expansion-mode annotation so Yandex CSI supports online PVC resize.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
