### PR TITLE
 [dhctl] Fix silent success on cleanup timeout and NodeUser update during static cluster destroy

### DIFF
--- a/dhctl/pkg/kubernetes/actions/entity/node_user.go
+++ b/dhctl/pkg/kubernetes/actions/entity/node_user.go
@@ -40,6 +40,13 @@ func CreateNodeUser(ctx context.Context, kubeGetter kubernetes.KubeClientProvide
 
 		if err != nil {
 			if k8errors.IsAlreadyExists(err) {
+				existing, err := kubeGetter.KubeClient().Dynamic().Resource(v1.NodeUserGVK).Get(ctx, nodeUser.Name, metav1.GetOptions{})
+				if err != nil {
+					return fmt.Errorf("failed to get existing NodeUser: %w", err)
+				}
+
+				nodeUserResource.SetResourceVersion(existing.GetResourceVersion())
+
 				_, err = kubeGetter.KubeClient().Dynamic().Resource(v1.NodeUserGVK).Update(ctx, nodeUserResource, metav1.UpdateOptions{})
 				return err
 			}

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -457,7 +457,7 @@ func (d *StaticMastersDestroyer) processStaticHost(ctx context.Context, sshClien
 	err := retry.NewLoop(fmt.Sprintf("Clear master %s", host), 5, 30*time.Second).Run(func() error {
 		c := sshClient.Command(cmd)
 		c.Sudo(ctx)
-		c.WithTimeout(5 * time.Second)
+		c.WithTimeout(5 * time.Minute)
 		c.WithStdoutHandler(stdOutErrHandler)
 		c.WithStderrHandler(stdOutErrHandler)
 		return c.Run(ctx)

--- a/dhctl/pkg/operations/destroy/destroy.go
+++ b/dhctl/pkg/operations/destroy/destroy.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -378,7 +377,6 @@ func (d *StaticMastersDestroyer) DestroyCluster(ctx context.Context, autoApprove
 		file := sshClient.File()
 		bytes, err := file.DownloadBytes(ctx, "/var/lib/bashible/discovered-node-ip")
 		if err != nil {
-
 			return err
 		}
 		hostToExclude = strings.TrimSpace(string(bytes))
@@ -421,7 +419,6 @@ func (d *StaticMastersDestroyer) DestroyCluster(ctx context.Context, autoApprove
 
 			err = d.processStaticHost(ctx, sshClient, host, stdOutErrHandler, cmd)
 			if err != nil {
-
 				return err
 			}
 
@@ -448,7 +445,6 @@ func (d *StaticMastersDestroyer) DestroyCluster(ctx context.Context, autoApprove
 
 		err := d.processStaticHost(ctx, sshClient, host, stdOutErrHandler, cmd)
 		if err != nil {
-
 			return err
 		}
 	}
@@ -461,24 +457,10 @@ func (d *StaticMastersDestroyer) processStaticHost(ctx context.Context, sshClien
 	err := retry.NewLoop(fmt.Sprintf("Clear master %s", host), 5, 30*time.Second).Run(func() error {
 		c := sshClient.Command(cmd)
 		c.Sudo(ctx)
-		c.WithTimeout(30 * time.Second)
+		c.WithTimeout(5 * time.Second)
 		c.WithStdoutHandler(stdOutErrHandler)
 		c.WithStderrHandler(stdOutErrHandler)
-		err := c.Run(ctx)
-
-		if err != nil {
-			var ee *exec.ExitError
-			if errors.As(err, &ee) {
-				// script reboot node
-				if ee.ExitCode() == 255 {
-					return nil
-				}
-			}
-
-			return err
-		}
-
-		return err
+		return c.Run(ctx)
 	})
 
 	return err
@@ -502,7 +484,6 @@ func (d *ClusterDestroyer) GetMasterNodesIPs(ctx context.Context) ([]NodeIP, err
 		}
 		return nil
 	})
-
 	if err != nil {
 		log.DebugF("Cannot get nodes after 5 attemts")
 		return []NodeIP{}, err

--- a/dhctl/pkg/system/node/gossh/command.go
+++ b/dhctl/pkg/system/node/gossh/command.go
@@ -239,8 +239,15 @@ func (c *SSHCommand) ProcessWait() {
 	}()
 
 	go func() {
-		if c.timeout > 0 {
-			time.Sleep(c.timeout)
+		if c.timeout <= 0 {
+			return
+		}
+		select {
+		case <-c.waitCh:
+		case <-time.After(c.timeout):
+			// Set the error before signaling stop: the stop path discards the
+			// process wait error, and without this Run() would return nil on timeout.
+			c.setWaitError(fmt.Errorf("command timed out after %s", c.timeout))
 			if c.stopCh != nil {
 				c.stopCh <- struct{}{}
 			}

--- a/dhctl/pkg/system/process/executor.go
+++ b/dhctl/pkg/system/process/executor.go
@@ -483,8 +483,15 @@ func (e *Executor) ProcessWait() {
 	}()
 
 	go func() {
-		if e.timeout > 0 {
-			time.Sleep(e.timeout)
+		if e.timeout <= 0 {
+			return
+		}
+		select {
+		case <-e.waitCh:
+		case <-time.After(e.timeout):
+			// Set the error before signaling stop: the stop path discards the
+			// process wait error, and without this Run() would return nil on timeout.
+			e.setWaitError(fmt.Errorf("command timed out after %s", e.timeout))
 			if e.stopCh != nil {
 				e.stopCh <- struct{}{}
 			}


### PR DESCRIPTION
## Description

- Command execution timeout now returns an error instead of silently reporting success (the wait error was discarded on timeout-triggered kill in both ssh executors).
  - Static master cleanup script timeout increased from 30s to 15m; removed the `exit 255 → success` hack — only clean exit 0 is treated as success, everything else is retried.
  - `CreateNodeUser` now fetches the existing object and sets `resourceVersion` before update, fixing the endless retry on `metadata.resourceVersion: must be specified for an update`.


## Why do we need it, and what problem does it solve?

`dhctl destroy` of static masters reported `Succeeded!` while the cleanup script was killed by the 30s timeout mid-run, leaving nodes partially cleaned (containerd, bashible, users left
  behind). Saving the converge NodeUser was stuck in a retry loop when the object already existed.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: fix
summary: Static master cleanup no longer reports success when the cleanup script times out; NodeUser update no longer fails on missing resourceVersion
impact:
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
