### PR TITLE
Fix reproducibility check

### DIFF
--- a/.github/scripts/python/reproducibility_check.py
+++ b/.github/scripts/python/reproducibility_check.py
@@ -55,22 +55,6 @@ def entry_lines(entry: dict) -> list:
 # a global meta-image, not a module (e.g. 'dev/install', 'base/vex').
 _NON_MODULE_PREFIXES = {"dev", "base"}
 
-# Images whose content is intentionally non-reproducible across runs and must
-# be skipped from the digest comparison:
-#
-# * release-channel-version / release-channel-version-prebuild
-#   .werf/werf-release-channel.yaml bakes the current Deckhouse version
-#   string, the per-tag CHANGELOG snippet, and the kubernetesVersions list
-#   into version.json/changelog.yaml. Even on the same commit these inputs
-#   can shift between runs (CHANGELOG additions on other branches, k8s
-#   version bumps), making the manifest digest unstable. The image is a
-#   pure metadata payload (no code), so it does not represent a build
-#   reproducibility risk and is excluded from the check.
-_IGNORED_IMAGES = {
-    "release-channel-version",
-    "release-channel-version-prebuild",
-}
-
 
 def split_module(image_name: str) -> tuple:
     """Return (module, image_subname) for table display.
@@ -97,13 +81,8 @@ def main(argv: list) -> int:
     baseline_images = load_report(baseline_path).get("Images") or {}
     rerun_images    = load_report(rerun_path).get("Images") or {}
 
-    all_names = sorted(set(baseline_images) | set(rerun_images))
-    ignored = sorted(n for n in all_names if n in _IGNORED_IMAGES)
-
     mismatched = []
-    for name in all_names:
-        if name in _IGNORED_IMAGES:
-            continue
+    for name in sorted(set(baseline_images) | set(rerun_images)):
         b_digest = baseline_images.get(name, {}).get("DockerImageDigest", "")
         r_digest = rerun_images.get(name, {}).get("DockerImageDigest", "")
         if b_digest != r_digest:
@@ -114,13 +93,10 @@ def main(argv: list) -> int:
     print(f"Baseline: {baseline_path}")
     print(f"Rerun:    {rerun_path}")
     print(f"Images in baseline: {len(baseline_images)}; in rerun: {len(rerun_images)}")
-    if ignored:
-        print(f"Ignored (non-reproducible by design): {', '.join(ignored)}")
     print()
 
-    compared = len(all_names) - len(ignored)
     if not mismatched:
-        print(f"OK: all {compared} compared image digests match. Build is reproducible.")
+        print(f"OK: all {len(baseline_images)} image digests match. Build is reproducible.")
         return 0
 
     print(f"Digest mismatch: {len(mismatched)} image(s) differ.")

--- a/.github/workflow_templates/reproducibility-check.yml
+++ b/.github/workflow_templates/reproducibility-check.yml
@@ -35,8 +35,8 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: 'Git commit SHA to verify reproducibility for'
-        required: true
+        description: 'PR commit SHA that already has a successful build-and-test_dev.yml run (empty = newest main commit with a successful build)'
+        required: false
         type: string
 
 env:
@@ -75,23 +75,56 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Trigger fully determines which build workflow holds the baseline:
-            //   schedule          -> 'main' commit, baseline in build-and-test_main.yml
-            //   workflow_dispatch -> arbitrary commit (treated as dev/PR), baseline in build-and-test_dev.yml
+            if (eventName !== 'schedule' && eventName !== 'workflow_dispatch') {
+              return core.setFailed(`Unsupported event: ${eventName}`);
+            }
+
+            const inputSha = ((context.payload.inputs || {}).commit_sha || '').trim();
+
+            // Baseline selection:
+            //   schedule, or manual run WITHOUT a commit -> newest 'main' commit that
+            //     HAS a successful build (baseline in build-and-test_main.yml)
+            //   manual run WITH a commit                 -> that exact commit, treated
+            //     as a dev/PR build (baseline in build-and-test_dev.yml)
+            const useMainBaseline = (eventName === 'schedule') || !inputSha;
+
             let sha = '';
             let baselineKind = '';
             let baselineWorkflowId = '';
-            if (eventName === 'schedule') {
-              const r = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
-              sha = r.data.commit.sha;
+            let baseline = null;
+            if (useMainBaseline) {
               baselineKind = 'main';
               baselineWorkflowId = 'build-and-test_main.yml';
-              core.notice(`Schedule run: using latest 'main' commit ${sha}, baseline workflow=${baselineWorkflowId}`);
-            } else if (eventName === 'workflow_dispatch') {
-              sha = ((context.payload.inputs || {}).commit_sha || '').trim();
-              if (!sha) {
-                return core.setFailed(`'commit_sha' input is required for manual runs`);
+              if (eventName === 'workflow_dispatch') {
+                core.notice(`Manual run without commit_sha: falling back to newest successful 'main' build.`);
               }
+              // Do NOT pin to HEAD of 'main': the latest commit's build may still
+              // be running, may have failed, or may not be queued yet. Instead pick
+              // the most recent SUCCESSFUL build-and-test_main.yml run on 'main' and
+              // use its head commit. listWorkflowRuns returns runs newest-first, so
+              // the first success is the freshest 'main' commit with a usable
+              // build_report_FE artifact.
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: baselineWorkflowId,
+                branch: 'main',
+                status: 'success',
+                per_page: 30,
+              });
+              baseline = (runs.data.workflow_runs || [])[0];
+              if (!baseline) {
+                return core.setFailed(
+                  `No successful '${baselineWorkflowId}' run found on 'main'. ` +
+                  `Reproducibility check requires an existing baseline build_report_FE artifact.`
+                );
+              }
+              sha = baseline.head_sha;
+              core.notice(
+                `Using newest successful 'main' build for commit ${sha} ` +
+                `(run ${baseline.id}, ${baseline.html_url})`
+              );
+            } else {
+              sha = inputSha;
               try {
                 const r = await github.rest.repos.getCommit({ owner, repo, ref: sha });
                 sha = r.data.sha;
@@ -101,27 +134,25 @@ jobs:
               baselineKind = 'dev';
               baselineWorkflowId = 'build-and-test_dev.yml';
               core.notice(`Manual run: using commit ${sha}, baseline workflow=${baselineWorkflowId}`);
-            } else {
-              return core.setFailed(`Unsupported event: ${eventName}`);
-            }
 
-            // Locate the latest successful baseline run for this SHA in the chosen workflow.
-            // API supports a server-side head_sha filter, so we only fetch matching runs.
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner, repo,
-              workflow_id: baselineWorkflowId,
-              head_sha: sha,
-              status: 'success',
-              per_page: 10,
-            });
-            // Runs are returned newest-first; pick the most recent success.
-            const baseline = (runs.data.workflow_runs || [])[0];
-            if (!baseline) {
-              return core.setFailed(
-                `No successful '${baselineWorkflowId}' run found for SHA ${sha}. ` +
-                `Reproducibility check requires an existing baseline build_report_FE artifact. ` +
-                `Ensure the regular build pipeline has completed for this commit first.`
-              );
+              // Locate the latest successful baseline run for this exact SHA.
+              // API supports a server-side head_sha filter, so we only fetch matching runs.
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: baselineWorkflowId,
+                head_sha: sha,
+                status: 'success',
+                per_page: 10,
+              });
+              // Runs are returned newest-first; pick the most recent success.
+              baseline = (runs.data.workflow_runs || [])[0];
+              if (!baseline) {
+                return core.setFailed(
+                  `No successful '${baselineWorkflowId}' run found for SHA ${sha}. ` +
+                  `Reproducibility check requires an existing baseline build_report_FE artifact. ` +
+                  `Ensure the regular build pipeline has completed for this commit first.`
+                );
+              }
             }
 
             // For dev mode we need the PR number to reconstruct CI_COMMIT_REF_SLUG = prN.

--- a/.github/workflow_templates/reproducibility-check.yml
+++ b/.github/workflow_templates/reproducibility-check.yml
@@ -64,6 +64,7 @@ jobs:
       baseline_run_url: ${{ steps.resolve.outputs.baseline_run_url }}
       baseline_workflow: ${{ steps.resolve.outputs.baseline_workflow }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
+      ci_commit_ref_name: ${{ steps.resolve.outputs.ci_commit_ref_name }}
     steps:
       - name: Resolve target SHA and locate baseline
         id: resolve
@@ -155,11 +156,20 @@ jobs:
               }
             }
 
-            // For dev mode we need the PR number to reconstruct CI_COMMIT_REF_SLUG = prN.
-            // Prefer the PR attached to the baseline run itself: it is always the exact PR
-            // on which this SHA was built. Fall back to commit-associated PRs only if the
-            // run object has no pull_requests payload (e.g. older runs, edge cases).
+            // For dev mode we reconstruct the exact CI_COMMIT_* context the baseline
+            // build-and-test_dev.yml run used, so the rerun produces identical digests:
+            //   CI_COMMIT_REF_SLUG = prN  (always)
+            //   CI_COMMIT_REF_NAME = PR head branch name for internal PRs, prN for forks
+            // (this mirrors git_info_job in ci_templates/helper_jobs.yml).
+            // CI_COMMIT_REF_NAME is baked into release-channel-version(-prebuild) via
+            // .werf/werf-release-channel.yaml, so an incorrect value makes those images
+            // look non-reproducible even on the same commit.
+            //
+            // We need the PR number first. Prefer the PR attached to the baseline run
+            // itself: it is always the exact PR this SHA was built on. Fall back to
+            // commit-associated PRs only if the run object has no pull_requests payload.
             let prNumber = '';
+            let ciCommitRefName = '';
             if (baselineKind === 'dev') {
               const runPr = (baseline.pull_requests || [])[0];
               if (runPr && runPr.number) {
@@ -179,6 +189,26 @@ jobs:
                   );
                 }
               }
+
+              // Reconstruct CI_COMMIT_REF_NAME exactly like git_info_job:
+              //   refName = (prRepo === targetRepo) ? pr.head.ref : `pr${number}`
+              const targetRepo = `${owner}/${repo}`;
+              try {
+                const pr = (await github.rest.pulls.get({
+                  owner, repo, pull_number: Number(prNumber),
+                })).data;
+                const prRepo = (pr.head && pr.head.repo) ? pr.head.repo.full_name : '';
+                const prRef  = (pr.head && pr.head.ref)  ? pr.head.ref            : '';
+                ciCommitRefName = (prRepo === targetRepo && prRef) ? prRef : `pr${prNumber}`;
+                core.notice(
+                  `dev baseline: CI_COMMIT_REF_NAME='${ciCommitRefName}' ` +
+                  `(PR head '${prRepo}:${prRef}', target '${targetRepo}')`
+                );
+              } catch (e) {
+                return core.setFailed(
+                  `Failed to fetch PR #${prNumber} to reconstruct CI_COMMIT_REF_NAME: ${e.message}`
+                );
+              }
             }
 
             core.notice(`Baseline run: ${baseline.html_url} (workflow=${baselineKind}, id=${baseline.id})`);
@@ -187,6 +217,7 @@ jobs:
             core.setOutput('baseline_run_url', baseline.html_url);
             core.setOutput('baseline_workflow', baselineKind);
             core.setOutput('pr_number', prNumber);
+            core.setOutput('ci_commit_ref_name', ciCommitRefName);
 
   # Synthetic git_info: build_template reads needs.git_info.outputs.*. We
   # construct the values from the resolved target SHA and baseline workflow kind
@@ -208,20 +239,31 @@ jobs:
           SHA: ${{ needs.resolve_target.outputs.sha }}
           WF: ${{ needs.resolve_target.outputs.baseline_workflow }}
           PR_NUMBER: ${{ needs.resolve_target.outputs.pr_number }}
+          REF_NAME: ${{ needs.resolve_target.outputs.ci_commit_ref_name }}
         run: |
+          # Reproduce the baseline build's CI_COMMIT_* context. In the real builds
+          # (git_info_job, ci_templates/helper_jobs.yml):
+          #   main: ref_slug = ref_name = branch = "main"
+          #   dev:  ref_slug = "prN"; ref_name = branch = PR head branch (internal)
+          #         or "prN" (fork). ref_name is resolved upstream in resolve_target.
           if [[ "$WF" == "main" ]]; then
-            REF="main"
+            REF_SLUG="main"
+            REF_NAME="main"
           elif [[ "$WF" == "dev" ]]; then
-            REF="pr${PR_NUMBER}"
+            REF_SLUG="pr${PR_NUMBER}"
+            if [[ -z "$REF_NAME" ]]; then
+              echo "::error::ci_commit_ref_name is empty in dev mode"
+              exit 1
+            fi
           else
             echo "::error::Unknown baseline_workflow: '$WF'"
             exit 1
           fi
           {
             echo "ci_commit_tag="
-            echo "ci_commit_branch=${REF}"
-            echo "ci_commit_ref_name=${REF}"
-            echo "ci_commit_ref_slug=${REF}"
+            echo "ci_commit_branch=${REF_NAME}"
+            echo "ci_commit_ref_name=${REF_NAME}"
+            echo "ci_commit_ref_slug=${REF_SLUG}"
             echo "github_sha=${SHA}"
           } >> $GITHUB_OUTPUT
 

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -39,8 +39,8 @@ on:
   workflow_dispatch:
     inputs:
       commit_sha:
-        description: 'Git commit SHA to verify reproducibility for'
-        required: true
+        description: 'PR commit SHA that already has a successful build-and-test_dev.yml run (empty = newest main commit with a successful build)'
+        required: false
         type: string
 
 env:
@@ -95,23 +95,56 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Trigger fully determines which build workflow holds the baseline:
-            //   schedule          -> 'main' commit, baseline in build-and-test_main.yml
-            //   workflow_dispatch -> arbitrary commit (treated as dev/PR), baseline in build-and-test_dev.yml
+            if (eventName !== 'schedule' && eventName !== 'workflow_dispatch') {
+              return core.setFailed(`Unsupported event: ${eventName}`);
+            }
+
+            const inputSha = ((context.payload.inputs || {}).commit_sha || '').trim();
+
+            // Baseline selection:
+            //   schedule, or manual run WITHOUT a commit -> newest 'main' commit that
+            //     HAS a successful build (baseline in build-and-test_main.yml)
+            //   manual run WITH a commit                 -> that exact commit, treated
+            //     as a dev/PR build (baseline in build-and-test_dev.yml)
+            const useMainBaseline = (eventName === 'schedule') || !inputSha;
+
             let sha = '';
             let baselineKind = '';
             let baselineWorkflowId = '';
-            if (eventName === 'schedule') {
-              const r = await github.rest.repos.getBranch({ owner, repo, branch: 'main' });
-              sha = r.data.commit.sha;
+            let baseline = null;
+            if (useMainBaseline) {
               baselineKind = 'main';
               baselineWorkflowId = 'build-and-test_main.yml';
-              core.notice(`Schedule run: using latest 'main' commit ${sha}, baseline workflow=${baselineWorkflowId}`);
-            } else if (eventName === 'workflow_dispatch') {
-              sha = ((context.payload.inputs || {}).commit_sha || '').trim();
-              if (!sha) {
-                return core.setFailed(`'commit_sha' input is required for manual runs`);
+              if (eventName === 'workflow_dispatch') {
+                core.notice(`Manual run without commit_sha: falling back to newest successful 'main' build.`);
               }
+              // Do NOT pin to HEAD of 'main': the latest commit's build may still
+              // be running, may have failed, or may not be queued yet. Instead pick
+              // the most recent SUCCESSFUL build-and-test_main.yml run on 'main' and
+              // use its head commit. listWorkflowRuns returns runs newest-first, so
+              // the first success is the freshest 'main' commit with a usable
+              // build_report_FE artifact.
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: baselineWorkflowId,
+                branch: 'main',
+                status: 'success',
+                per_page: 30,
+              });
+              baseline = (runs.data.workflow_runs || [])[0];
+              if (!baseline) {
+                return core.setFailed(
+                  `No successful '${baselineWorkflowId}' run found on 'main'. ` +
+                  `Reproducibility check requires an existing baseline build_report_FE artifact.`
+                );
+              }
+              sha = baseline.head_sha;
+              core.notice(
+                `Using newest successful 'main' build for commit ${sha} ` +
+                `(run ${baseline.id}, ${baseline.html_url})`
+              );
+            } else {
+              sha = inputSha;
               try {
                 const r = await github.rest.repos.getCommit({ owner, repo, ref: sha });
                 sha = r.data.sha;
@@ -121,27 +154,25 @@ jobs:
               baselineKind = 'dev';
               baselineWorkflowId = 'build-and-test_dev.yml';
               core.notice(`Manual run: using commit ${sha}, baseline workflow=${baselineWorkflowId}`);
-            } else {
-              return core.setFailed(`Unsupported event: ${eventName}`);
-            }
 
-            // Locate the latest successful baseline run for this SHA in the chosen workflow.
-            // API supports a server-side head_sha filter, so we only fetch matching runs.
-            const runs = await github.rest.actions.listWorkflowRuns({
-              owner, repo,
-              workflow_id: baselineWorkflowId,
-              head_sha: sha,
-              status: 'success',
-              per_page: 10,
-            });
-            // Runs are returned newest-first; pick the most recent success.
-            const baseline = (runs.data.workflow_runs || [])[0];
-            if (!baseline) {
-              return core.setFailed(
-                `No successful '${baselineWorkflowId}' run found for SHA ${sha}. ` +
-                `Reproducibility check requires an existing baseline build_report_FE artifact. ` +
-                `Ensure the regular build pipeline has completed for this commit first.`
-              );
+              // Locate the latest successful baseline run for this exact SHA.
+              // API supports a server-side head_sha filter, so we only fetch matching runs.
+              const runs = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
+                workflow_id: baselineWorkflowId,
+                head_sha: sha,
+                status: 'success',
+                per_page: 10,
+              });
+              // Runs are returned newest-first; pick the most recent success.
+              baseline = (runs.data.workflow_runs || [])[0];
+              if (!baseline) {
+                return core.setFailed(
+                  `No successful '${baselineWorkflowId}' run found for SHA ${sha}. ` +
+                  `Reproducibility check requires an existing baseline build_report_FE artifact. ` +
+                  `Ensure the regular build pipeline has completed for this commit first.`
+                );
+              }
             }
 
             // For dev mode we need the PR number to reconstruct CI_COMMIT_REF_SLUG = prN.

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -84,6 +84,7 @@ jobs:
       baseline_run_url: ${{ steps.resolve.outputs.baseline_run_url }}
       baseline_workflow: ${{ steps.resolve.outputs.baseline_workflow }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
+      ci_commit_ref_name: ${{ steps.resolve.outputs.ci_commit_ref_name }}
     steps:
       - name: Resolve target SHA and locate baseline
         id: resolve
@@ -175,11 +176,20 @@ jobs:
               }
             }
 
-            // For dev mode we need the PR number to reconstruct CI_COMMIT_REF_SLUG = prN.
-            // Prefer the PR attached to the baseline run itself: it is always the exact PR
-            // on which this SHA was built. Fall back to commit-associated PRs only if the
-            // run object has no pull_requests payload (e.g. older runs, edge cases).
+            // For dev mode we reconstruct the exact CI_COMMIT_* context the baseline
+            // build-and-test_dev.yml run used, so the rerun produces identical digests:
+            //   CI_COMMIT_REF_SLUG = prN  (always)
+            //   CI_COMMIT_REF_NAME = PR head branch name for internal PRs, prN for forks
+            // (this mirrors git_info_job in ci_templates/helper_jobs.yml).
+            // CI_COMMIT_REF_NAME is baked into release-channel-version(-prebuild) via
+            // .werf/werf-release-channel.yaml, so an incorrect value makes those images
+            // look non-reproducible even on the same commit.
+            //
+            // We need the PR number first. Prefer the PR attached to the baseline run
+            // itself: it is always the exact PR this SHA was built on. Fall back to
+            // commit-associated PRs only if the run object has no pull_requests payload.
             let prNumber = '';
+            let ciCommitRefName = '';
             if (baselineKind === 'dev') {
               const runPr = (baseline.pull_requests || [])[0];
               if (runPr && runPr.number) {
@@ -199,6 +209,26 @@ jobs:
                   );
                 }
               }
+
+              // Reconstruct CI_COMMIT_REF_NAME exactly like git_info_job:
+              //   refName = (prRepo === targetRepo) ? pr.head.ref : `pr${number}`
+              const targetRepo = `${owner}/${repo}`;
+              try {
+                const pr = (await github.rest.pulls.get({
+                  owner, repo, pull_number: Number(prNumber),
+                })).data;
+                const prRepo = (pr.head && pr.head.repo) ? pr.head.repo.full_name : '';
+                const prRef  = (pr.head && pr.head.ref)  ? pr.head.ref            : '';
+                ciCommitRefName = (prRepo === targetRepo && prRef) ? prRef : `pr${prNumber}`;
+                core.notice(
+                  `dev baseline: CI_COMMIT_REF_NAME='${ciCommitRefName}' ` +
+                  `(PR head '${prRepo}:${prRef}', target '${targetRepo}')`
+                );
+              } catch (e) {
+                return core.setFailed(
+                  `Failed to fetch PR #${prNumber} to reconstruct CI_COMMIT_REF_NAME: ${e.message}`
+                );
+              }
             }
 
             core.notice(`Baseline run: ${baseline.html_url} (workflow=${baselineKind}, id=${baseline.id})`);
@@ -207,6 +237,7 @@ jobs:
             core.setOutput('baseline_run_url', baseline.html_url);
             core.setOutput('baseline_workflow', baselineKind);
             core.setOutput('pr_number', prNumber);
+            core.setOutput('ci_commit_ref_name', ciCommitRefName);
 
   # Synthetic git_info: build_template reads needs.git_info.outputs.*. We
   # construct the values from the resolved target SHA and baseline workflow kind
@@ -228,20 +259,31 @@ jobs:
           SHA: ${{ needs.resolve_target.outputs.sha }}
           WF: ${{ needs.resolve_target.outputs.baseline_workflow }}
           PR_NUMBER: ${{ needs.resolve_target.outputs.pr_number }}
+          REF_NAME: ${{ needs.resolve_target.outputs.ci_commit_ref_name }}
         run: |
+          # Reproduce the baseline build's CI_COMMIT_* context. In the real builds
+          # (git_info_job, ci_templates/helper_jobs.yml):
+          #   main: ref_slug = ref_name = branch = "main"
+          #   dev:  ref_slug = "prN"; ref_name = branch = PR head branch (internal)
+          #         or "prN" (fork). ref_name is resolved upstream in resolve_target.
           if [[ "$WF" == "main" ]]; then
-            REF="main"
+            REF_SLUG="main"
+            REF_NAME="main"
           elif [[ "$WF" == "dev" ]]; then
-            REF="pr${PR_NUMBER}"
+            REF_SLUG="pr${PR_NUMBER}"
+            if [[ -z "$REF_NAME" ]]; then
+              echo "::error::ci_commit_ref_name is empty in dev mode"
+              exit 1
+            fi
           else
             echo "::error::Unknown baseline_workflow: '$WF'"
             exit 1
           fi
           {
             echo "ci_commit_tag="
-            echo "ci_commit_branch=${REF}"
-            echo "ci_commit_ref_name=${REF}"
-            echo "ci_commit_ref_slug=${REF}"
+            echo "ci_commit_branch=${REF_NAME}"
+            echo "ci_commit_ref_name=${REF_NAME}"
+            echo "ci_commit_ref_slug=${REF_SLUG}"
             echo "github_sha=${SHA}"
           } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

Fixes to the weekly build reproducibility check workflow (`reproducibility-check.yml`)
and its comparison script.
1. **Scheduled run no longer pins to `main` HEAD.** Previously the run took the
   absolute latest `main` commit via `getBranch` and required a successful
   `build-and-test_main.yml` run for that exact SHA. The HEAD commit is usually
   still building / failed / not yet queued, so the run failed immediately with
   `No successful 'build-and-test_main.yml' run found for SHA ...`. Now it lists
   successful `build-and-test_main.yml` runs on `main` (newest-first) and uses the
   head commit of the most recent success — the freshest `main` commit that
   actually has a usable `build_report_FE` artifact.
2. **Manual run without a commit is allowed and mirrors the scheduled run.** The
   `commit_sha` input is now `required: false`. Empty input → same "newest
   successful main build" path as the schedule; a non-empty input keeps the
   dev-style behaviour (baseline from `build-and-test_dev.yml` for that exact PR
   commit). The input description now states explicitly that it expects a PR commit
   that already has a successful `build-and-test_dev.yml` run.
3. **Correctly reproduce `CI_COMMIT_REF_NAME` for dev baselines.** The synthetic
   `git_info` job used `CI_COMMIT_REF_NAME = prN`, but the real `build-and-test_dev.yml`
   build (via `git_info_job`) uses the PR head branch name for internal PRs (only
   forks get `prN`). `CI_COMMIT_REF_NAME` is baked into
   `release-channel-version`/`release-channel-version-prebuild` through
   `.werf/werf-release-channel.yaml` (`export version="..."` + `version.json`), so the
   mismatch made those two images always look non-reproducible (false positive).
   `resolve_target` now reconstructs the value exactly like `git_info_job`
   (`refName = (prRepo === targetRepo) ? pr.head.ref : prN`) and the synthetic
   `git_info` splits `ref_name`/`ref_slug` accordingly (`ref_slug` stays `prN`).
4. **Digest comparison no longer skips any image.** Removed the `_IGNORED_IMAGES`
   exclusion (`release-channel-version`, `release-channel-version-prebuild`) from
   `reproducibility_check.py` — with fix (3) those images are reproducible, so within
   a single commit every image in the report is compared and any difference fails the
   check.

## Why do we need it, and what problem does it solve?
The scheduled reproducibility check failed on every run (baseline tied to `main` HEAD,
which rarely has a finished build when cron fires), and the dev-mode check produced
false positives on the release-channel images due to a wrong `CI_COMMIT_REF_NAME`.
Together these made the check effectively unusable. After the fixes the scheduled
(and manual-without-commit) run deterministically picks the newest green `main`
commit, dev reruns reproduce the exact baseline build context, and the comparison
flags any real digest difference without per-image exceptions.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: ci
type: chore
summary: Fix the build reproducibility check — resolve the baseline from the newest successful main build, reproduce the dev CI_COMMIT_REF_NAME context, and compare all images.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
