### PR TITLE
Fixed containerd creds screening

### DIFF
--- a/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
+++ b/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
@@ -86,10 +86,10 @@ bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/hosts.toml" - << EOF
     {{- with $mirror.auth }}
       {{- if or .auth .username }}
     [host.{{ $mirror_host_with_scheme | quote }}.auth]
-        {{- if .auth }}
-      auth = {{ .auth | quote }}
-        {{- else }}
+        {{- if .username }}
       auth = {{ printf "%s:%s" .username ( .password | default "" ) | b64enc | quote }}
+        {{- else }}
+      auth = {{ .auth | quote }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
+++ b/candi/bashible/common-steps/all/030_configure_containerd_registry.sh.tpl
@@ -61,7 +61,7 @@ mkdir -p "/etc/containerd/registry.d/{{ $host_name }}"
 {{- range $mirror := $host_values.mirrors }}
   {{- $mirror_ca_file_path := printf "/etc/containerd/registry.d/%s/%s-%s-ca.crt" $host_name $mirror.scheme $mirror.host }}
   {{- if $mirror.ca }}
-bb-sync-file {{ $mirror_ca_file_path | quote }} - << EOF
+bb-sync-file {{ $mirror_ca_file_path | quote }} - << "EOF"
 {{ $mirror.ca }}
 EOF
   {{- end }}
@@ -89,8 +89,7 @@ bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/hosts.toml" - << EOF
         {{- if .auth }}
       auth = {{ .auth | quote }}
         {{- else }}
-      username = {{ .username | quote }}
-      password = {{ .password | default "" | quote }}
+      auth = {{ printf "%s:%s" .username ( .password | default "" ) | b64enc | quote }}
         {{- end }}
       {{- end }}
     {{- end }}
@@ -112,7 +111,7 @@ EOF
 
 # Sync module sources host.toml and ca.crt
 mkdir -p "/etc/containerd/registry.d/{{ $host_name }}"
-bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/ca.crt" - << EOF
+bb-sync-file "/etc/containerd/registry.d/{{ $host_name }}/ca.crt" - << "EOF"
 {{ $CA }}
 EOF
 

--- a/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
+++ b/candi/bashible/common-steps/all/032_configure_containerd.sh.tpl
@@ -386,8 +386,7 @@ oom_score = 0
       [plugins."io.containerd.grpc.v1.cri".registry.configs]
         [plugins."io.containerd.grpc.v1.cri".registry.configs."{{ $mirror.host }}".auth]
           {{- if (($mirror).auth).username }}
-          username = {{ $mirror.auth.username | quote }}
-          password = {{ $mirror.auth.password | default "" | quote }}
+          auth = {{ printf "%s:%s" ($mirror.auth.username) ($mirror.auth.password | default "") | b64enc | quote }}
           {{- else }}
           auth = {{ (($mirror).auth).auth | default "" | quote }}
           {{- end }}


### PR DESCRIPTION
## Description

If the `username` and `password` parameters in the containerd auth configuration contained a `$` character, bashible rendered the manifests without escaping the parameters. This resulted in an incorrect containerd configuration.

This PR fixes the credential escaping issue. The `username` and `password` parameters are now rendered into an `auth` string.

### Why We Cannot Escape the Entire Manifest Rendering

- **`host.toml`** manifest: During the bootstrap process in `Local`/`Proxy` mode, the `discovered_node_ip` is used for manifest rendering. This value can only be obtained during bashible runtime and comes from an environment variable. Therefore, we cannot escape the rendering of the entire manifest.

- **`config.toml`** manifest: The `systemd_cgroup` environment variable is used for manifest rendering. Therefore, we cannot escape the rendering of the entire manifest.

### After fix (containerd v1)

**Old configuration:**
<img width="2286" height="376" alt="image" src="https://github.com/user-attachments/assets/c616bf10-231a-4702-bec8-bd61e763e72d" />
<img width="2272" height="325" alt="image" src="https://github.com/user-attachments/assets/d2732723-b984-4ddf-b3d0-74b81511a85e" />


**New configuration:**
<img width="1873" height="316" alt="image" src="https://github.com/user-attachments/assets/85c829e1-b01a-4ef0-8227-785bb2d72f82" />
<img width="1741" height="296" alt="image" src="https://github.com/user-attachments/assets/3bd08464-9d9f-4a71-8b5e-62ea26645d5c" />


### After fix (containerd v2)

**New configuration only:**
<img width="1676" height="287" alt="image" src="https://github.com/user-attachments/assets/e2266a20-7f32-4be3-86aa-2dc43064ee7c" />
<img width="1667" height="253" alt="image" src="https://github.com/user-attachments/assets/253ce337-e1d2-4783-ad32-5e516157826d" />


> [!WARNING]  
> These changes may restart containerd v1 to apply the new configuration.

## Why do we need it, and what problem does it solve?

Fix containerd credential escaping.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: candi
type: fix
summary: Fixed containerd credential escaping by rendering username and password into the auth string.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
