### PR TITLE
[docs] Update documentation about adding CloudPermanent nodes to a cloud cluster

### DIFF
--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE.md
@@ -504,19 +504,31 @@ spec:
 
 ## Adding CloudPermanent nodes to a cloud cluster
 
-To add CloudPermanent nodes to a DKP cloud cluster:
+To add `CloudPermanent` nodes to a DKP cloud cluster:
 
-1. Make sure the cloud provider module is enabled. For example: [`cloud-provider-yandex`](/modules/cloud-provider-yandex/), [`cloud-provider-openstack`](/modules/cloud-provider-openstack/), [`cloud-provider-aws`](/modules/cloud-provider-aws/), etc.
+1. Make sure that the corresponding cloud provider module is enabled, for example, [`cloud-provider-yandex`](/modules/cloud-provider-yandex/), [`cloud-provider-openstack`](/modules/cloud-provider-openstack/), or [`cloud-provider-aws`](/modules/cloud-provider-aws/).
 
-   You can check this by running the following command:
+   You can check the status of a specific module using the following command:
 
    ```shell
-   d8 k -n d8-system get modules
+   d8 k -n d8-system get module <MODULE_NAME>
    ```
 
-   Or view it in the Deckhouse web interface.
+   For example:
 
-1. Create a [NodeGroup](/modules/node-manager/cr.html#nodegroup) object with the `CloudPermanent` type. Nodes of this type are managed via Terraform, which is integrated into DKP. The configuration for such nodes is located in the `(Provider)ClusterConfiguration` object. You edit this configuration using the `dhctl` utility from the installation container. Example:
+   ```shell
+   d8 k -n d8-system get module cloud-provider-yandex
+   ```
+
+1. Add a `CloudPermanent` node group to the `nodeGroups` section of the `(Provider)ClusterConfiguration` object. `CloudPermanent` nodes are managed by Terraform built into DKP.
+
+   To edit the configuration of a running cluster, use the following command:
+
+   ```shell
+   d8 system edit provider-cluster-configuration
+   ```
+
+   Example:
 
    ```yaml
    nodeGroups:
@@ -531,43 +543,59 @@ To add CloudPermanent nodes to a DKP cloud cluster:
        nova: ceph-ssd
    ```
 
-1. Specify the instance template parameters. The fields inside the `instanceClass` section depend on the specific cloud provider. Below is an example for OpenStack:
-   - `flavorName`: Instance type (resources: CPU, RAM).
-   - `imageName`: OS image.
-   - `rootDiskSize`: Size of the root disk (in GB).
-   - `mainNetwork`: Network name.
-   - If needed: etcd disk, zones, volume types, etc.
+1. Specify the instance template parameters. The fields inside `instanceClass` depend on the cloud provider. The following fields are used in the OpenStack example:
 
-   For other cloud providers, the field names and structure may differ. For specific fields, refer to the CRD definition or the documentation for the corresponding cloud provider.
+   - `flavorName` — instance type and its resources, such as CPU and RAM
+   - `imageName` — operating system image
+   - `rootDiskSize` — root disk size in GB
+   - `mainNetwork` — network name
+   - optionally: etcd disk, zones, volume types, and other parameters
 
-1. Apply the configuration using `dhctl converge`. After editing the `(Provider)ClusterConfiguration`, run:
+   Field names and structure may differ for other cloud providers. Refer to the `(Provider)ClusterConfiguration` specification or the documentation for the corresponding cloud provider, for example, [YandexClusterConfiguration](/modules/cloud-provider-yandex/cluster_configuration.html#yandexclusterconfiguration).
+
+1. Start the DKP installer container on your local computer or an administrative host. Use an image with the same edition and version as the cluster:
+
+   ```shell
+   docker run --pull=always --rm -it \
+     -v "$HOME/.ssh/:/tmp/.ssh/" \
+     registry.deckhouse.io/deckhouse/<EDITION>/install:<VERSION> \
+     bash
+   ```
+
+1. In the installer container, check the Terraform state:
+
+   ```shell
+   dhctl terraform check \
+     --ssh-host <MASTER_NODE_IP> \
+     --ssh-user <USER_NAME> \
+     --ssh-agent-private-keys /tmp/.ssh/<KEY>
+   ```
+
+1. Apply the configuration. For the `--ssh-user` parameter, specify a user that can connect to the master node over SSH and execute commands using `sudo`:
 
    ```shell
    dhctl converge \
-     --ssh-host <master node IP> \
-     --ssh-user <username> \
-     --ssh-agent-private-keys /tmp/.ssh/<key>
+     --ssh-host <MASTER_NODE_IP> \
+     --ssh-user <USER_NAME> \
+     --ssh-agent-private-keys /tmp/.ssh/<KEY>
    ```
 
    This command will:
 
-   - Launch Terraform.
-   - Create the required virtual machines.
-   - Install DKP on them (using `bootstrap.sh`).
-   - Register the nodes in the cluster.
+   - run Terraform
+   - create the required virtual machines
+   - bootstrap and configure the new nodes
+   - register the nodes in the cluster
 
-1. Done — the new nodes will automatically appear in the cluster.  
-   You can view them by running:
+1. The new nodes will automatically appear in the cluster. You can check that the nodes have been added using the following command:
 
    ```shell
    d8 k get nodes
    ```
 
-   The list of newly created nodes is also available in the Deckhouse web interface.
+   The new nodes are also available in the Deckhouse web interface.
 
-Deckhouse Kubernetes Platform can run on top of Managed Kubernetes services (e.g., GKE and EKS).  
-In such cases, the [`node-manager`](/modules/node-manager/) module provides node configuration management and automation,  
-but its capabilities may be limited by the respective cloud provider's API.
+Deckhouse Kubernetes Platform can run on top of Managed Kubernetes services, such as GKE and EKS. In this case, the [`node-manager`](/modules/node-manager/) module manages node configuration and automates node-related operations, but some features may be limited by the API of the corresponding cloud provider.
 
 ## Adding a CloudStatic node to a cluster
 

--- a/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE_RU.md
+++ b/docs/documentation/pages/admin/configuration/platform-scaling/node/CLOUD_NODE_RU.md
@@ -505,17 +505,29 @@ spec:
 
 Чтобы добавить узлы типа CloudPermanent в облачный кластер DKP:
 
-1. Убедитесь, что включён модуль облачного провайдера. Например, [`cloud-provider-yandex`](/modules/cloud-provider-yandex/), [`cloud-provider-openstack`](/modules/cloud-provider-openstack/), [`cloud-provider-aws`](/modules/cloud-provider-aws/) и др.
+1. Убедитесь, что включён модуль соответствующего облачного провайдера, например [`cloud-provider-yandex`](/modules/cloud-provider-yandex/), [`cloud-provider-openstack`](/modules/cloud-provider-openstack/) или [`cloud-provider-aws`](/modules/cloud-provider-aws/).
 
-   Это можно проверить с помощью команды:
+   Проверить состояние конкретного модуля можно командой:
 
    ```shell
-   d8 k -n d8-system get modules
+   d8 k -n d8-system get module <ИМЯ_МОДУЛЯ>
    ```
 
-   Или посмотреть в веб-интерфейсе Deckhouse.
+   Например:
 
-1. Создайте объект [NodeGroup](/modules/node-manager/cr.html#nodegroup) с типом `CloudPermanent`. Узлы типа `CloudPermanent` управляются через Terraform, встроенный в DKP. Конфигурация таких узлов находится в объекте `(Provider)ClusterConfiguration`. Редактировать его нужно с помощью утилиты `dhctl` в установочном контейнере. Пример:
+   ```shell
+   d8 k -n d8-system get module cloud-provider-yandex
+   ```
+
+1. Добавьте группу узлов типа `CloudPermanent` в секцию `nodeGroups` объекта (Provider)ClusterConfiguration. Узлы типа `CloudPermanent` управляются через Terraform, встроенный в DKP.
+
+   Отредактировать конфигурацию работающего кластера можно с помощью команды:
+
+   ```shell
+   d8 system edit provider-cluster-configuration
+   ```
+
+   Пример:
 
    ```yaml
    nodeGroups:
@@ -531,30 +543,50 @@ spec:
    ```
 
 1. Укажите параметры шаблона инстанса. Поля внутри `instanceClass` зависят от конкретного облачного провайдера. Ниже приведён пример для OpenStack:
+
    - `flavorName` — тип инстанса (ресурсы: CPU, RAM);
    - `imageName` — образ ОС;
    - `rootDiskSize` — размер системного диска (в ГБ);
    - `mainNetwork` — имя сети;
    - при необходимости: диск etcd, зоны, volume types и т.д.
 
-     Для других облаков названия и структура параметров могут отличаться. Актуальные поля можно посмотреть в описании CRD или в документации по соответствующему облачному провайдеру.
+   Для других облачных провайдеров названия и структура параметров могут отличаться. Актуальные поля можно посмотреть в описании (Provider)ClusterConfiguration или в документации по соответствующему облачному провайдеру, например [YandexClusterConfiguration](/modules/cloud-provider-yandex/cluster_configuration.html#yandexclusterconfiguration).
 
-1. Примените конфигурацию с помощью `dhctl converge`. После редактирования `(Provider)ClusterConfiguration` выполните:
+1. На локальном компьютере или административном узле запустите установочный контейнер DKP. Используйте образ той же редакции и версии, что и в кластере:
+
+   ```shell
+   docker run --pull=always --rm -it \
+     -v "$HOME/.ssh/:/tmp/.ssh/" \
+     registry.deckhouse.io/deckhouse/<РЕДАКЦИЯ>/install:<ВЕРСИЯ> \
+     bash
+   ```
+
+1. В установочном контейнере проверьте состояние Terraform:
+
+   ```shell
+   dhctl terraform check \
+     --ssh-host <IP МАСТЕР-УЗЛА> \
+     --ssh-user <ИМЯ ПОЛЬЗОВАТЕЛЯ> \
+     --ssh-agent-private-keys /tmp/.ssh/<КЛЮЧ>
+   ```  
+
+1. Примените конфигурацию. В параметре `--ssh-user` укажите пользователя, от имени которого доступен вход на мастер-узел по SSH и который может выполнять команды через `sudo`:
 
    ```shell
    dhctl converge \
-     --ssh-host <IP мастер-узла> \
-     --ssh-user <имя пользователя> \
-     --ssh-agent-private-keys /tmp/.ssh/<ключ>
+     --ssh-host <IP МАСТЕР-УЗЛА> \
+     --ssh-user <ИМЯ ПОЛЬЗОВАТЕЛЯ> \
+     --ssh-agent-private-keys /tmp/.ssh/<КЛЮЧ>
    ```
 
    Эта команда:
+
    - запустит Terraform;
    - создаст нужные виртуальные машины;
-   - выполнит на них установку DKP (через `bootstrap.sh`);
+   - выполнит bootstrap и настройку новых узлов;
    - зарегистрирует узлы в кластере.
 
-1. Готово — новые узлы появятся в кластере автоматически. Их можно увидеть выполнив команду:
+1. Новые узлы появятся в кластере автоматически. Проверить появление узлов можно с помощью команды:
 
    ```shell
    d8 k get nodes


### PR DESCRIPTION
## Description
Updated documentation about adding CloudPermanent nodes to a cloud cluster.

## Why do we need it, and what problem does it solve?


## Why do we need it in the patch release (if we do)?



## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries


```changes
section: docs
type: chore
summary: Updated documentation about adding CloudPermanent nodes to a cloud cluster.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
