### PR TITLE
[dvp] Fix VM pods chart on the namespaces dashboard

### DIFF
--- a/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/propagated-namespaces.json
+++ b/modules/340-monitoring-kubernetes/monitoring/grafana-dashboards/main/namespace/propagated-namespaces.json
@@ -1292,7 +1292,7 @@
             "uid": "$ds_prometheus"
           },
           "editorMode": "code",
-          "expr": "count by (namespace) (\n  max_over_time(kube_pod_info{node=~\"$node\", namespace=~\"$namespace\", created_by_kind=\"VirtualMachine\"}[$__rate_interval])\n  unless on (pod, namespace)\n  (kube_pod_status_phase{phase=~\"Succeeded|Failed\"} == 1)\n)",
+          "expr": "count by (namespace) (\n  max_over_time(kube_pod_info{node=~\"$node\", namespace=~\"$namespace\", created_by_kind=\"InternalVirtualizationVirtualMachineInstance\"}[$__rate_interval])\n  unless on (pod, namespace)\n  (kube_pod_status_phase{phase=~\"Succeeded|Failed\"} == 1)\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ namespace }}",


### PR DESCRIPTION
## Description
The chart that shows VM pods in the namespaces dashboard was not rendering due to a stale label reference in the query. Updated the query so the chart works again.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: common
type: fix
summary: Fixed VM pods chart on the namespaces dashboard in `monitoring-kubernetes`.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
