### PR TITLE
[cloud-provider-yandex] Retry on empty providerID

### DIFF
--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/v0.33.2/001-backfill-empty-providerid-during-lb-sync.patch
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/v0.33.2/001-backfill-empty-providerid-during-lb-sync.patch
@@ -1,0 +1,96 @@
+diff --git a/pkg/cloudprovider/yandex/cloud.go b/pkg/cloudprovider/yandex/cloud.go
+index 6cfd97f..ebb06f6 100644
+--- a/pkg/cloudprovider/yandex/cloud.go
++++ b/pkg/cloudprovider/yandex/cloud.go
+@@ -177,6 +177,7 @@ func (yc *Cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder,
+ 	yc.nodeTargetGroupSyncer = &NodeTargetGroupSyncer{
+ 		cloud:            yc,
+ 		serviceLister:    serviceInformer.Lister(),
++		nodeClient:       clientset.CoreV1().Nodes(),
+ 		lastVisitedNodes: mapset.NewSet(),
+ 	}
+ 
+diff --git a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+index 16ab63e..ddc3359 100644
+--- a/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
++++ b/pkg/cloudprovider/yandex/load_balancer_tg_controller.go
+@@ -16,8 +16,10 @@ import (
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/loadbalancer/v1"
+ 	"github.com/yandex-cloud/go-genproto/yandex/cloud/vpc/v1"
+ 	corev1 "k8s.io/api/core/v1"
++	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ 	"k8s.io/apimachinery/pkg/types"
+ 
++	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+ 	corev1listers "k8s.io/client-go/listers/core/v1"
+ 
+ 	mapset "github.com/deckarep/golang-set"
+@@ -31,6 +33,7 @@ type NodeTargetGroupSyncer struct {
+ 
+ 	lastVisitedNodes mapset.Set
+ 	serviceLister    corev1listers.ServiceLister
++	nodeClient       corev1client.NodeInterface
+ 
+ 	tgSyncLock sync.Mutex
+ }
+@@ -117,22 +120,16 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
+ 	// TODO: speed up by not performing individual lookups
+ 	var instances []*instanceWithNodeInfo
+ 	for _, node := range nodes {
+-		if node.Spec.ProviderID == "" {
+-			return errors.Errorf("node %s ProviderID is empty", node.Name)
++		instance, providerID, err := ntgs.getInstanceAndEnsureProviderID(ctx, node)
++		if err != nil {
++			return err
+ 		}
+ 
+-		if !(strings.Contains(node.Spec.ProviderID, "yandex")) {
+-			log.Printf("node %s ProviderID is not yandex (%s), skipping", node.Name, node.Spec.ProviderID)
++		if !(strings.Contains(providerID, "yandex")) {
++			log.Printf("node %s ProviderID is not yandex (%s), skipping", node.Name, providerID)
+ 			continue
+ 		}
+ 
+-		nodeName := MapNodeNameToInstanceName(types.NodeName(node.Name))
+-		log.Printf("Finding Instance by Folder %q and Name %q", ntgs.cloud.config.FolderID, nodeName)
+-		instance, err := ntgs.cloud.yandexService.ComputeSvc.FindInstanceByName(ctx, nodeName)
+-		if err != nil || instance == nil {
+-			return fmt.Errorf("failed to find Instance by its name: %s", err)
+-		}
+-
+ 		instances = append(instances, &instanceWithNodeInfo{Instance: instance, Node: node})
+ 	}
+ 
+@@ -153,6 +150,32 @@ func (ntgs *NodeTargetGroupSyncer) synchronizeNodesWithTargetGroups(ctx context.
+ 	return nil
+ }
+ 
++func (ntgs *NodeTargetGroupSyncer) getInstanceAndEnsureProviderID(ctx context.Context, node *corev1.Node) (*compute.Instance, string, error) {
++	nodeName := MapNodeNameToInstanceName(types.NodeName(node.Name))
++	log.Printf("Finding Instance by Folder %q and Name %q", ntgs.cloud.config.FolderID, nodeName)
++	instance, err := ntgs.cloud.yandexService.ComputeSvc.FindInstanceByName(ctx, nodeName)
++	if err != nil || instance == nil {
++		return nil, "", fmt.Errorf("failed to find Instance by its name: %s", err)
++	}
++
++	providerID := node.Spec.ProviderID
++	if providerID != "" {
++		return instance, providerID, nil
++	}
++
++	providerID = fmt.Sprintf("%s://%s", providerName, instance.Id)
++	patch := []byte(fmt.Sprintf(`{"spec":{"providerID":"%s"}}`, providerID))
++
++	if _, err := ntgs.nodeClient.Patch(ctx, node.Name, types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
++		return nil, "", errors.Wrapf(err, "failed to patch ProviderID for node %s", node.Name)
++	}
++
++	node.Spec.ProviderID = providerID
++	log.Printf("Patched ProviderID for node %s to %s", node.Name, providerID)
++
++	return instance, providerID, nil
++}
++
+ func (ntgs *NodeTargetGroupSyncer) constructTgNameToTargetMap(ctx context.Context, instances []*instanceWithNodeInfo) (tgNameToTargetMap, error) {
+ 	mapping := make(tgNameToTargetMap)
+ 

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/v0.33.2/README.md
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/patches/v0.33.2/README.md
@@ -1,0 +1,5 @@
+## Patches
+
+### 001-backfill-empty-providerid-during-lb-sync.patch
+
+Backfills an empty node `providerID` during load balancer target group synchronization so CCM can continue reconciling Yandex load balancers.

--- a/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
+++ b/modules/030-cloud-provider-yandex/images/cloud-controller-manager/werf.inc.yaml
@@ -1,4 +1,10 @@
 {{- $version := include "get_oss_version_by_id" (list "ccm-yandex" $) }}
+{{- $patches := (printf "/%smodules/%s-%s/images/%s" $.ModulePath $.ModulePriority $.ModuleName $.ImageName) }}
+{{- $src_version := toString $version | replace "/" "-" }}
+{{- $patch := false }}
+{{- range $path, $_ := $.Files.Glob (printf "%s/patches/%s/*.patch" $patches $src_version) }}
+  {{- $patch = true }}
+{{- end }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
@@ -14,6 +20,14 @@ imageSpec:
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
 final: false
 fromImage: common/src-artifact
+{{- if $patch }}
+git:
+  - add: {{ $patches }}/patches/{{ $src_version }}
+    to: /patches
+    stageDependencies:
+      install:
+        - '**/*'
+{{- end }}
 secrets:
 - id: SOURCE_REPO
   value: {{ .SOURCE_REPO }}
@@ -21,6 +35,9 @@ shell:
   install:
     - git clone --depth 1 --branch {{ $version }} $(cat /run/secrets/SOURCE_REPO)/deckhouse/yandex-cloud-controller-manager.git /src
     - cd /src
+    {{- if $patch }}
+    - git apply /patches/*.patch --verbose
+    {{- end }}
     - rm -rf .git
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
This PR adds a downstream patch to the Yandex cloud-controller-manager to handle nodes with an empty providerID during load balancer target group
  synchronization.
## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
In some cases, a node may reach CCM reconciliation with an empty providerID, which causes target group sync to fail and breaks load balancer reconciliation. This change resolves the instance by node name, backfills the missing providerID, and allows reconciliation to proceed normally

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: cloud-provider-yandex
type: feature
summary:  handle nodes with an empty providerID
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
