### PR TITLE
[cert-manager] fix rbac for challenges

### DIFF
--- a/modules/101-cert-manager/templates/rbacv2/use/edit.yaml
+++ b/modules/101-cert-manager/templates/rbacv2/use/edit.yaml
@@ -23,7 +23,6 @@ rules:
 - apiGroups:
   - cert-manager.io
   resources:
-  - challenges
   - certificaterequests    
   verbs:
   - delete
@@ -31,6 +30,7 @@ rules:
 - apiGroups:
   - acme.cert-manager.io
   resources:
+  - challenges
   - orders
   verbs:
   - delete

--- a/modules/101-cert-manager/templates/rbacv2/use/view.yaml
+++ b/modules/101-cert-manager/templates/rbacv2/use/view.yaml
@@ -15,7 +15,6 @@ rules:
   - certificaterequests
   - certificates
   - issuers
-  - challenges
   - clusterissuers
   verbs:
   - get
@@ -24,6 +23,7 @@ rules:
 - apiGroups:
   - acme.cert-manager.io
   resources:
+  - challenges
   - orders
   verbs:
   - get

--- a/modules/101-cert-manager/templates/user-authz-cluster-roles.yaml
+++ b/modules/101-cert-manager/templates/user-authz-cluster-roles.yaml
@@ -12,7 +12,6 @@ rules:
   resources:
   - certificates
   - issuers
-  - challenges
   - clusterissuers
   - certificaterequests
   verbs:
@@ -22,6 +21,7 @@ rules:
 - apiGroups:
   - acme.cert-manager.io
   resources:
+  - challenges
   - orders
   verbs:
   - get
@@ -59,7 +59,6 @@ rules:
 - apiGroups:
   - cert-manager.io
   resources:
-  - challenges
   - certificaterequests    
   verbs:
   - delete
@@ -67,6 +66,7 @@ rules:
 - apiGroups:
   - acme.cert-manager.io
   resources:
+  - challenges
   - orders
   verbs:
   - delete

--- a/modules/140-user-authz/docs/README.md
+++ b/modules/140-user-authz/docs/README.md
@@ -146,6 +146,7 @@ To view the permissions created by source modules, use the [command](#get_rules)
 
 ```text
 read:
+    - acme.cert-manager.io/challenges
     - acme.cert-manager.io/orders
     - apiextensions.k8s.io/customresourcedefinitions
     - apps/daemonsets
@@ -159,7 +160,6 @@ read:
     - batch/jobs
     - cert-manager.io/certificaterequests
     - cert-manager.io/certificates
-    - cert-manager.io/challenges
     - cert-manager.io/clusterissuers
     - cert-manager.io/issuers
     - cilium.io/ciliumclusterwidenetworkpolicies
@@ -389,10 +389,10 @@ write:
 create,patch,update:
     - pods
 delete,deletecollection:
+    - acme.cert-manager.io/challenges
     - acme.cert-manager.io/orders
     - apps/replicasets
     - cert-manager.io/certificaterequests
-    - cert-manager.io/challenges
     - extensions/replicasets
 read:
     - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
@@ -424,9 +424,9 @@ write:
 
 ```text
 delete,deletecollection:
+    - acme.cert-manager.io/challenges
     - acme.cert-manager.io/orders
     - cert-manager.io/certificaterequests
-    - cert-manager.io/challenges
 patch,update:
     - nodes
 read:

--- a/modules/140-user-authz/docs/README_RU.md
+++ b/modules/140-user-authz/docs/README_RU.md
@@ -154,6 +154,7 @@ Manage-роль определяет права на доступ:
 
 ```text
 read:
+    - acme.cert-manager.io/challenges
     - acme.cert-manager.io/orders
     - apiextensions.k8s.io/customresourcedefinitions
     - apps/daemonsets
@@ -167,7 +168,6 @@ read:
     - batch/jobs
     - cert-manager.io/certificaterequests
     - cert-manager.io/certificates
-    - cert-manager.io/challenges
     - cert-manager.io/clusterissuers
     - cert-manager.io/issuers
     - cilium.io/ciliumclusterwidenetworkpolicies
@@ -397,10 +397,10 @@ write:
 create,patch,update:
     - pods
 delete,deletecollection:
+    - acme.cert-manager.io/challenges
     - acme.cert-manager.io/orders
     - apps/replicasets
     - cert-manager.io/certificaterequests
-    - cert-manager.io/challenges
     - extensions/replicasets
 read:
     - 'deckhouse.io/moduleconfigs (resourceNames: deckhouse)'
@@ -432,9 +432,9 @@ write:
 
 ```text
 delete,deletecollection:
+    - acme.cert-manager.io/challenges
     - acme.cert-manager.io/orders
     - cert-manager.io/certificaterequests
-    - cert-manager.io/challenges
 patch,update:
     - nodes
 read:


### PR DESCRIPTION
## Description
Fixed cert-manager RBAC rules for ACME Challenge resources.

## Why do we need it, and what problem does it solve?
Users with cert-manager view/admin permissions could inspect ACME Orders but not Challenges because `challenges` were assigned to the wrong API group.

## Why do we need it in the patch release (if we do)?
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
```changes
section: cert-manager
type: fix
summary: Fixed user RBAC permissions for ACME Challenge resources.
impact_level: low
```