### PR TITLE
Rebuild commit time check

### DIFF
--- a/.github/scripts/python/reproducibility_timing_report.py
+++ b/.github/scripts/python/reproducibility_timing_report.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report rebuild timings of scheduled build-reproducibility-check runs.
+
+Queries the GitHub Actions API for SCHEDULED runs of the reproducibility check
+workflow within a look-back window, measures the duration of the successful
+'Build FE' rebuild job in each run, prints a per-run table and the average
+rebuild time to the log, and exposes the results (run_count, avg_seconds,
+avg_build_time) via GITHUB_OUTPUT for downstream CI steps.
+
+Only stdlib is used (urllib) so the script needs no extra dependencies.
+
+Environment variables (all optional ones have defaults):
+    GITHUB_TOKEN        - token for GitHub API calls (required)
+    GITHUB_REPOSITORY   - 'owner/repo' (required; set by GitHub Actions)
+    GITHUB_API_URL      - GitHub API base (default https://api.github.com)
+    WORKFLOW_FILE       - workflow file to inspect (default reproducibility-check.yml)
+    BUILD_JOB_PREFIX    - build job name prefix to match (default 'Build FE')
+    WINDOW_DAYS         - look-back window in days (default 7)
+    GITHUB_OUTPUT       - if set, emit run_count/avg_seconds/avg_build_time
+    GITHUB_STEP_SUMMARY - if set, write a markdown summary table
+"""
+
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+_GITHUB_TS = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def api_get(url: str, token: str):
+    req = urllib.request.Request(url)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urllib.request.urlopen(req) as resp:
+        body = json.loads(resp.read().decode("utf-8"))
+        link = resp.headers.get("Link", "")
+    return body, link
+
+
+def next_link(link_header: str):
+    for part in link_header.split(","):
+        section = part.split(";")
+        if len(section) < 2:
+            continue
+        url = section[0].strip().lstrip("<").rstrip(">")
+        if any(p.strip() == 'rel="next"' for p in section[1:]):
+            return url
+    return None
+
+
+def paginate(url: str, token: str, list_key: str) -> list:
+    items = []
+    while url:
+        body, link = api_get(url, token)
+        items.extend(body.get(list_key, []) if isinstance(body, dict) else body)
+        url = next_link(link)
+    return items
+
+
+def fmt_duration(total_seconds: float) -> str:
+    s = int(round(total_seconds))
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    parts = []
+    if h:
+        parts.append(f"{h}h")
+    if h or m:
+        parts.append(f"{m}m")
+    parts.append(f"{sec}s")
+    return " ".join(parts)
+
+
+def parse_ts(value: str) -> datetime:
+    return datetime.strptime(value, _GITHUB_TS).replace(tzinfo=timezone.utc)
+
+
+def collect_rows(owner, repo, api_url, token, workflow_file, build_prefix, since):
+    """Return (rows, durations) for successful build jobs created after `since`."""
+    since_date = since.date().isoformat()
+    runs_url = (
+        f"{api_url}/repos/{owner}/{repo}/actions/workflows/"
+        f"{urllib.parse.quote(workflow_file)}/runs"
+        f"?event=schedule&created=%3E%3D{since_date}&per_page=100"
+    )
+    runs = paginate(runs_url, token, "workflow_runs")
+    print(f"Found {len(runs)} scheduled run(s) in the API window")
+
+    rows = []
+    durations = []
+    for run in runs:
+        created_at = run.get("created_at", "")
+        # The 'created' filter is date-granular, so re-check the exact window.
+        if not created_at or parse_ts(created_at) < since:
+            continue
+
+        jobs_url = f"{api_url}/repos/{owner}/{repo}/actions/runs/{run['id']}/jobs?per_page=100"
+        jobs = paginate(jobs_url, token, "jobs")
+        build_job = next(
+            (j for j in jobs if (j.get("name") or "").startswith(build_prefix)), None
+        )
+        if build_job is None:
+            print(f"run={run['id']}: no '{build_prefix}' job found, skipping")
+            continue
+        if build_job.get("conclusion") != "success":
+            print(
+                f"run={run['id']}: build job conclusion="
+                f"'{build_job.get('conclusion')}', not success, skipping"
+            )
+            continue
+        started, completed = build_job.get("started_at"), build_job.get("completed_at")
+        if not started or not completed:
+            print(f"run={run['id']}: build job has no start/finish time, skipping")
+            continue
+
+        dur = (parse_ts(completed) - parse_ts(started)).total_seconds()
+        durations.append(dur)
+        rows.append(
+            {
+                "date": created_at[:10],
+                "dur_human": fmt_duration(dur),
+                "url": build_job.get("html_url", ""),
+            }
+        )
+
+    rows.sort(key=lambda r: r["date"])
+    return rows, durations
+
+
+def write_summary(path, days, rows, durations, avg_build_time):
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fp:
+        fp.write(f"## Build reproducibility — rebuild timing (last {days} days)\n\n")
+        fp.write(f"Successful scheduled build jobs: {len(durations)}\n\n")
+        fp.write(f"Average rebuild time: {avg_build_time}\n\n")
+        if rows:
+            fp.write("| Date | Rebuild time | Job |\n")
+            fp.write("|---|---|---|\n")
+            for r in rows:
+                fp.write(f"| {r['date']} | {r['dur_human']} | [link]({r['url']}) |\n")
+
+
+def write_outputs(path, run_count, avg_seconds, avg_build_time):
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fp:
+        fp.write(f"run_count={run_count}\n")
+        fp.write(f"avg_seconds={avg_seconds}\n")
+        fp.write(f"avg_build_time={avg_build_time}\n")
+
+
+def main() -> int:
+    token = os.environ.get("GITHUB_TOKEN")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    if not token or "/" not in repository:
+        print(
+            "ERROR: GITHUB_TOKEN and GITHUB_REPOSITORY (owner/repo) are required",
+            file=sys.stderr,
+        )
+        return 1
+    owner, repo = repository.split("/", 1)
+
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    workflow_file = os.environ.get("WORKFLOW_FILE", "reproducibility-check.yml")
+    build_prefix = os.environ.get("BUILD_JOB_PREFIX", "Build FE")
+    days = int(os.environ.get("WINDOW_DAYS", "7"))
+
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    print(f"Collecting scheduled '{workflow_file}' runs created since {since.isoformat()}")
+
+    rows, durations = collect_rows(
+        owner, repo, api_url, token, workflow_file, build_prefix, since
+    )
+
+    print()
+    print("| Дата | Время выполнения сборки | Ссылка на джобу |")
+    print("|---|---|---|")
+    for r in rows:
+        print(f"| {r['date']} | {r['dur_human']} | {r['url']} |")
+    print()
+
+    if durations:
+        avg_seconds = sum(durations) / len(durations)
+        avg_build_time = fmt_duration(avg_seconds)
+        print(
+            f"Среднее время пересборки за последние {days} дней "
+            f"({len(durations)} успешных запусков): {avg_build_time}"
+        )
+    else:
+        avg_seconds = 0.0
+        avg_build_time = "n/a"
+        print(f"Успешных джоб сборки за последние {days} дней не найдено.")
+
+    write_summary(os.environ.get("GITHUB_STEP_SUMMARY"), days, rows, durations, avg_build_time)
+    write_outputs(
+        os.environ.get("GITHUB_OUTPUT"),
+        len(durations),
+        int(round(avg_seconds)),
+        avg_build_time,
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/python/reproducibility_timing_report.py
+++ b/.github/scripts/python/reproducibility_timing_report.py
@@ -192,7 +192,7 @@ def main() -> int:
     )
 
     print()
-    print("| Дата | Время выполнения сборки | Ссылка на джобу |")
+    print("| Date | Build job duration | Job link |")
     print("|---|---|---|")
     for r in rows:
         print(f"| {r['date']} | {r['dur_human']} | {r['url']} |")
@@ -202,13 +202,13 @@ def main() -> int:
         avg_seconds = sum(durations) / len(durations)
         avg_build_time = fmt_duration(avg_seconds)
         print(
-            f"Среднее время пересборки за последние {days} дней "
-            f"({len(durations)} успешных запусков): {avg_build_time}"
+            f"Average rebuild time over the last {days} days "
+            f"({len(durations)} successful run(s)): {avg_build_time}"
         )
     else:
         avg_seconds = 0.0
         avg_build_time = "n/a"
-        print(f"Успешных джоб сборки за последние {days} дней не найдено.")
+        print(f"No successful build jobs found over the last {days} days.")
 
     write_summary(os.environ.get("GITHUB_STEP_SUMMARY"), days, rows, durations, avg_build_time)
     write_outputs(

--- a/.github/scripts/send-report.sh
+++ b/.github/scripts/send-report.sh
@@ -73,11 +73,11 @@ function send_post() {
     --data "{\"channel_id\": \"${channel_id}\",\"message\": \"${message}\",\"file_ids\": ${file_ids}}"
 }
 function send_post_with_webhook() {
-  file_ids=$(IFS=,; echo "[${file_id_array[*]}]")
   curl -f -L -X POST $server_url \
     -H "Content-Type: application/json" \
     --data "{\"type\": \"${webhook_type}\",\"message\":\"${message}\"}"
 }
+
 if [ "$upload" = true ]; then
   for file_path in ${upload_files[@]}; do
     file_id=$(upload_file "$file_path")

--- a/.github/workflow_templates/reproducibility-check.yml
+++ b/.github/workflow_templates/reproducibility-check.yml
@@ -362,10 +362,11 @@ jobs:
             baseline/build_report_FE/images_tags_werf.json \
             rerun/build_report_FE/images_tags_werf.json
 
-  # Notify the team in Loop when a scheduled check breaks: either the FE rebuild
-  # itself failed, or the rerun digests diverged from the baseline (the build is
-  # not reproducible). Only scheduled (automatic) runs alert; manual
-  # workflow_dispatch runs are assumed to be watched by the operator.
+  # Single Loop alert for the build reproducibility check. Runs on any trigger
+  # (run_attempt == 1, deckhouse/deckhouse only) and picks ONE reason to report,
+  # evaluated in priority order: a slow rebuild first (so it does not clash with
+  # the failure conditions), then a digest mismatch, then a failed FE rebuild,
+  # then a baseline-resolution error. If nothing is wrong, nothing is sent.
   send_alert_about_workflow_problem:
     name: Send alert about workflow problem
     runs-on: "regular"
@@ -374,12 +375,42 @@ jobs:
       - build_fe_main
       - build_fe_dev
       - compare_reports
-    if: ${{ failure() && github.event_name == 'schedule' && github.repository == 'deckhouse/deckhouse' && github.run_attempt == 1 }}
+    if: ${{ always() && github.repository == 'deckhouse/deckhouse' && github.run_attempt == 1 }}
     steps:
 {!{- $secrets := slice -}!}
 {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "token" "LOOP_CVE_REPORTS_SEND_TOKEN" ) $secrets -}!}
 {!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "channel_id" "LOOP_E2E_REPORT_CHANNEL_ID" ) $secrets -}!}
 {!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+    - name: Measure rebuild job duration
+      id: duration
+      if: always()
+      uses: {!{ index (ds "actions") "actions/github-script" }!}
+      with:
+        github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        script: |
+          const THRESHOLD_SECONDS = 300; // 5 minutes
+
+          const jobs = await github.paginate(
+            github.rest.actions.listJobsForWorkflowRun,
+            { owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId, per_page: 100 },
+          );
+          const buildJob = jobs.find(j => j.name && j.name.startsWith('Build FE'));
+          if (!buildJob || buildJob.conclusion !== 'success' || !buildJob.started_at || !buildJob.completed_at) {
+            core.info(`No completed-successful Build FE job (conclusion=${buildJob ? buildJob.conclusion : 'absent'}); slow check skipped.`);
+            core.setOutput('slow', 'false');
+            return;
+          }
+
+          const durSec = Math.round((new Date(buildJob.completed_at) - new Date(buildJob.started_at)) / 1000);
+          const durHuman = `${Math.floor(durSec / 60)}m ${durSec % 60}s`;
+          core.info(`Build FE job '${buildJob.name}' duration: ${durHuman} (${durSec}s); threshold ${THRESHOLD_SECONDS}s`);
+          if (durSec > THRESHOLD_SECONDS) {
+            core.setOutput('slow', 'true');
+            core.setOutput('duration_human', durHuman);
+            core.setOutput('job_url', buildJob.html_url);
+          } else {
+            core.setOutput('slow', 'false');
+          }
     - name: Check loop alerting credentials
       id: check_loop_alerting
       if: always()
@@ -387,30 +418,41 @@ jobs:
         LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
       run: |
         if [[ -n $LOOP_TOKEN ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-    - name: Send loop alert on fail
-      if: ${{ steps.check_loop_alerting.outputs.has_credentials == 'true' }}
+    - name: Send loop alert
+      if: ${{ always() && steps.check_loop_alerting.outputs.has_credentials == 'true' }}
       env:
         LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
         LOOP_CHANNEL_ID: ${{ steps.secrets.outputs.LOOP_E2E_REPORT_CHANNEL_ID }}
+        SLOW: ${{ steps.duration.outputs.slow }}
+        DURATION_HUMAN: ${{ steps.duration.outputs.duration_human }}
+        JOB_URL: ${{ steps.duration.outputs.job_url }}
         COMPARE_RESULT: ${{ needs.compare_reports.result }}
         BUILD_MAIN_RESULT: ${{ needs.build_fe_main.result }}
         BUILD_DEV_RESULT: ${{ needs.build_fe_dev.result }}
+        RESOLVE_RESULT: ${{ needs.resolve_target.result }}
         TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
       run: |
         WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
 
-        if [[ "$COMPARE_RESULT" == "failure" ]]; then
-          REASON="digest mismatch on rebuild (build is not reproducible)"
+        # Priority order: a slow (but successful) rebuild is checked first so it
+        # does not clash with the failure/mismatch conditions below.
+        if [[ "$SLOW" == "true" ]]; then
+          MESSAGE="🐢Build reproducibility rebuild is slow🐢\nBuild FE job took ${DURATION_HUMAN} (threshold 5m)\nSHA: ${TARGET_SHA}\n[URL](${JOB_URL})"
+        elif [[ "$COMPARE_RESULT" == "failure" ]]; then
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: digest mismatch on rebuild (build is not reproducible)\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
         elif [[ "$BUILD_MAIN_RESULT" == "failure" || "$BUILD_DEV_RESULT" == "failure" ]]; then
-          REASON="FE rebuild failed"
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: FE rebuild failed\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        elif [[ "$RESOLVE_RESULT" == "failure" ]]; then
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: failed to resolve baseline / workflow error\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
         else
-          REASON="failed to resolve baseline / workflow error"
+          echo "Nothing to alert about (build succeeded within the time budget)."
+          exit 0
         fi
 
         alertData=$(cat <<EOF
         {
         "channel_id": "${LOOP_CHANNEL_ID}",
-        "message": "🛑Build reproducibility check failed🛑\nReason: ${REASON}\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        "message": "${MESSAGE}"
         }
         EOF
         )

--- a/.github/workflow_templates/reproducibility-check.yml
+++ b/.github/workflow_templates/reproducibility-check.yml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Weekly build reproducibility check.
+# Build reproducibility check, runs 4 times a day.
 #
-# Trigger: schedule (Saturday 01:00 MSK = Friday 22:00 UTC) or workflow_dispatch.
+# Trigger: schedule (every 6 hours) or workflow_dispatch.
 # On schedule the latest 'main' commit is taken; on manual run the commit SHA
 # is provided as an input.
 #
@@ -29,9 +29,10 @@
 name: 'Build reproducibility check'
 
 on:
-  # Saturday 01:00 MSK (UTC+3, no DST) == Friday 22:00 UTC.
+  # 4 times a day, every 6 hours: 00:00, 06:00, 12:00, 18:00 UTC
+  # (03:00, 09:00, 15:00, 21:00 MSK, UTC+3, no DST).
   schedule:
-    - cron: '0 22 * * 5'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -360,3 +361,68 @@ jobs:
           python3 .github/scripts/python/reproducibility_check.py \
             baseline/build_report_FE/images_tags_werf.json \
             rerun/build_report_FE/images_tags_werf.json
+
+  # Notify the team in Loop when a scheduled check breaks: either the FE rebuild
+  # itself failed, or the rerun digests diverged from the baseline (the build is
+  # not reproducible). Only scheduled (automatic) runs alert; manual
+  # workflow_dispatch runs are assumed to be watched by the operator.
+  send_alert_about_workflow_problem:
+    name: Send alert about workflow problem
+    runs-on: "regular"
+    needs:
+      - resolve_target
+      - build_fe_main
+      - build_fe_dev
+      - compare_reports
+    if: ${{ failure() && github.event_name == 'schedule' && github.repository == 'deckhouse/deckhouse' && github.run_attempt == 1 }}
+    steps:
+{!{- $secrets := slice -}!}
+{!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "token" "LOOP_CVE_REPORTS_SEND_TOKEN" ) $secrets -}!}
+{!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "channel_id" "LOOP_E2E_REPORT_CHANNEL_ID" ) $secrets -}!}
+{!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+    - name: Check loop alerting credentials
+      id: check_loop_alerting
+      if: always()
+      env:
+        LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
+      run: |
+        if [[ -n $LOOP_TOKEN ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
+    - name: Send loop alert on fail
+      if: ${{ steps.check_loop_alerting.outputs.has_credentials == 'true' }}
+      env:
+        LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
+        LOOP_CHANNEL_ID: ${{ steps.secrets.outputs.LOOP_E2E_REPORT_CHANNEL_ID }}
+        COMPARE_RESULT: ${{ needs.compare_reports.result }}
+        BUILD_MAIN_RESULT: ${{ needs.build_fe_main.result }}
+        BUILD_DEV_RESULT: ${{ needs.build_fe_dev.result }}
+        TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+      run: |
+        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+
+        if [[ "$COMPARE_RESULT" == "failure" ]]; then
+          REASON="digest mismatch on rebuild (build is not reproducible)"
+        elif [[ "$BUILD_MAIN_RESULT" == "failure" || "$BUILD_DEV_RESULT" == "failure" ]]; then
+          REASON="FE rebuild failed"
+        else
+          REASON="failed to resolve baseline / workflow error"
+        fi
+
+        alertData=$(cat <<EOF
+        {
+        "channel_id": "${LOOP_CHANNEL_ID}",
+        "message": "🛑Build reproducibility check failed🛑\nReason: ${REASON}\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        }
+        EOF
+        )
+
+        for (( iter = 1; iter < 60; iter++ )); do
+          if curl -f -L -X POST "https://loop.flant.ru/api/v4/posts" -H "Content-Type: application/json" -H "Authorization: Bearer ${LOOP_TOKEN}" --data "${alertData}"; then
+            exit 0
+          fi
+
+          echo "Alert was not sent. Wait 5 seconds before next attempt"
+          sleep 5
+        done
+
+        echo "Alert was not sent. Timeout"
+        exit 1

--- a/.github/workflow_templates/reproducibility-timing-report.yml
+++ b/.github/workflow_templates/reproducibility-timing-report.yml
@@ -1,0 +1,67 @@
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build reproducibility rebuild-timing report.
+#
+# Trigger: schedule (Monday and Thursday 10:00 MSK == 07:00 UTC) or workflow_dispatch.
+#
+# All the logic lives in .github/scripts/python/reproducibility_timing_report.py:
+# it collects SCHEDULED reproducibility-check.yml runs from the last 7 days,
+# measures the duration of the successful 'Build FE' rebuild job in each, logs a
+# per-run table and the average rebuild time, and exposes the results via
+# GITHUB_OUTPUT. This workflow only invokes the script and forwards its output:
+# it exposes the job outputs (run_count/avg_seconds/avg_build_time) for downstream
+# jobs and sends the average to Loop via send-report.sh.
+
+name: 'Build reproducibility timing report'
+
+on:
+  # Monday and Thursday 10:00 MSK (UTC+3, no DST) == 07:00 UTC.
+  schedule:
+    - cron: '0 7 * * 1,4'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  timing_report:
+    name: Reproducibility rebuild timing report
+    runs-on: "self-slim"
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
+    outputs:
+      run_count: ${{ steps.collect.outputs.run_count }}
+      avg_seconds: ${{ steps.collect.outputs.avg_seconds }}
+      avg_build_time: ${{ steps.collect.outputs.avg_build_time }}
+    steps:
+{!{ tmpl.Exec "checkout_step" . | strings.Indent 4 }!}
+{!{- $secrets := slice -}!}
+{!{- $secrets = append ( slice "projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop" "webhook_url" "LOOP_SERVICE_NOTIFICATIONS" ) $secrets -}!}
+{!{ tmpl.Exec "import_secrets" $secrets | strings.Indent 4 }!}
+    - name: Collect scheduled rebuild timings
+      id: collect
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WORKFLOW_FILE: "reproducibility-check.yml"
+        BUILD_JOB_PREFIX: "Build FE"
+        WINDOW_DAYS: "7"
+      run: |
+        python3 .github/scripts/python/reproducibility_timing_report.py
+    - name: Send report to Loop
+      env:
+        LOOP_SERVICE_NOTIFICATIONS: ${{ steps.secrets.outputs.LOOP_SERVICE_NOTIFICATIONS }}
+        AVG_BUILD_TIME: ${{ steps.collect.outputs.avg_build_time }}
+      run: |
+        bash ./.github/scripts/send-report.sh --webhook "ci_report" ":passport_control: **Average build time on the same commit is ${AVG_BUILD_TIME}** :passport_control:"

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Weekly build reproducibility check.
+# Build reproducibility check, runs 4 times a day.
 #
-# Trigger: schedule (Saturday 01:00 MSK = Friday 22:00 UTC) or workflow_dispatch.
+# Trigger: schedule (every 6 hours) or workflow_dispatch.
 # On schedule the latest 'main' commit is taken; on manual run the commit SHA
 # is provided as an input.
 #
@@ -33,9 +33,10 @@
 name: 'Build reproducibility check'
 
 on:
-  # Saturday 01:00 MSK (UTC+3, no DST) == Friday 22:00 UTC.
+  # 4 times a day, every 6 hours: 00:00, 06:00, 12:00, 18:00 UTC
+  # (03:00, 09:00, 15:00, 21:00 MSK, UTC+3, no DST).
   schedule:
-    - cron: '0 22 * * 5'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       commit_sha:
@@ -991,3 +992,89 @@ jobs:
           python3 .github/scripts/python/reproducibility_check.py \
             baseline/build_report_FE/images_tags_werf.json \
             rerun/build_report_FE/images_tags_werf.json
+
+  # Notify the team in Loop when a scheduled check breaks: either the FE rebuild
+  # itself failed, or the rerun digests diverged from the baseline (the build is
+  # not reproducible). Only scheduled (automatic) runs alert; manual
+  # workflow_dispatch runs are assumed to be watched by the operator.
+  send_alert_about_workflow_problem:
+    name: Send alert about workflow problem
+    runs-on: "regular"
+    needs:
+      - resolve_target
+      - build_fe_main
+      - build_fe_dev
+      - compare_reports
+    if: ${{ failure() && github.event_name == 'schedule' && github.repository == 'deckhouse/deckhouse' && github.run_attempt == 1 }}
+    steps:
+    # <template: import_secrets>
+    - name: Split repository name
+      id: split
+      env:
+        REPO: ${{ github.repository }}
+      run: |
+        if [ $REPO == "deckhouse/deckhouse" ]; then
+          echo "name=deckhouse" >> $GITHUB_OUTPUT
+        else
+          echo "name=deckhouse-test" >> $GITHUB_OUTPUT
+        fi
+    - name: Import secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2
+      with:
+        url: https://seguro.flant.com
+        path: github
+        role: "${{ steps.split.outputs.name }}"
+        method: jwt
+        jwtGithubAudience: github-access-aud
+        secrets: |
+          projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop token | LOOP_CVE_REPORTS_SEND_TOKEN ;
+          projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop channel_id | LOOP_E2E_REPORT_CHANNEL_ID ;
+
+    # </template: import_secrets>
+    - name: Check loop alerting credentials
+      id: check_loop_alerting
+      if: always()
+      env:
+        LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
+      run: |
+        if [[ -n $LOOP_TOKEN ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
+    - name: Send loop alert on fail
+      if: ${{ steps.check_loop_alerting.outputs.has_credentials == 'true' }}
+      env:
+        LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
+        LOOP_CHANNEL_ID: ${{ steps.secrets.outputs.LOOP_E2E_REPORT_CHANNEL_ID }}
+        COMPARE_RESULT: ${{ needs.compare_reports.result }}
+        BUILD_MAIN_RESULT: ${{ needs.build_fe_main.result }}
+        BUILD_DEV_RESULT: ${{ needs.build_fe_dev.result }}
+        TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
+      run: |
+        WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
+
+        if [[ "$COMPARE_RESULT" == "failure" ]]; then
+          REASON="digest mismatch on rebuild (build is not reproducible)"
+        elif [[ "$BUILD_MAIN_RESULT" == "failure" || "$BUILD_DEV_RESULT" == "failure" ]]; then
+          REASON="FE rebuild failed"
+        else
+          REASON="failed to resolve baseline / workflow error"
+        fi
+
+        alertData=$(cat <<EOF
+        {
+        "channel_id": "${LOOP_CHANNEL_ID}",
+        "message": "🛑Build reproducibility check failed🛑\nReason: ${REASON}\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        }
+        EOF
+        )
+
+        for (( iter = 1; iter < 60; iter++ )); do
+          if curl -f -L -X POST "https://loop.flant.ru/api/v4/posts" -H "Content-Type: application/json" -H "Authorization: Bearer ${LOOP_TOKEN}" --data "${alertData}"; then
+            exit 0
+          fi
+
+          echo "Alert was not sent. Wait 5 seconds before next attempt"
+          sleep 5
+        done
+
+        echo "Alert was not sent. Timeout"
+        exit 1

--- a/.github/workflows/reproducibility-check.yml
+++ b/.github/workflows/reproducibility-check.yml
@@ -993,10 +993,11 @@ jobs:
             baseline/build_report_FE/images_tags_werf.json \
             rerun/build_report_FE/images_tags_werf.json
 
-  # Notify the team in Loop when a scheduled check breaks: either the FE rebuild
-  # itself failed, or the rerun digests diverged from the baseline (the build is
-  # not reproducible). Only scheduled (automatic) runs alert; manual
-  # workflow_dispatch runs are assumed to be watched by the operator.
+  # Single Loop alert for the build reproducibility check. Runs on any trigger
+  # (run_attempt == 1, deckhouse/deckhouse only) and picks ONE reason to report,
+  # evaluated in priority order: a slow rebuild first (so it does not clash with
+  # the failure conditions), then a digest mismatch, then a failed FE rebuild,
+  # then a baseline-resolution error. If nothing is wrong, nothing is sent.
   send_alert_about_workflow_problem:
     name: Send alert about workflow problem
     runs-on: "regular"
@@ -1005,7 +1006,7 @@ jobs:
       - build_fe_main
       - build_fe_dev
       - compare_reports
-    if: ${{ failure() && github.event_name == 'schedule' && github.repository == 'deckhouse/deckhouse' && github.run_attempt == 1 }}
+    if: ${{ always() && github.repository == 'deckhouse/deckhouse' && github.run_attempt == 1 }}
     steps:
     # <template: import_secrets>
     - name: Split repository name
@@ -1032,6 +1033,36 @@ jobs:
           projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop channel_id | LOOP_E2E_REPORT_CHANNEL_ID ;
 
     # </template: import_secrets>
+    - name: Measure rebuild job duration
+      id: duration
+      if: always()
+      uses: actions/github-script@v6.4.1
+      with:
+        github-token: ${{ secrets.BOATSWAIN_GITHUB_TOKEN }}
+        script: |
+          const THRESHOLD_SECONDS = 300; // 5 minutes
+
+          const jobs = await github.paginate(
+            github.rest.actions.listJobsForWorkflowRun,
+            { owner: context.repo.owner, repo: context.repo.repo, run_id: context.runId, per_page: 100 },
+          );
+          const buildJob = jobs.find(j => j.name && j.name.startsWith('Build FE'));
+          if (!buildJob || buildJob.conclusion !== 'success' || !buildJob.started_at || !buildJob.completed_at) {
+            core.info(`No completed-successful Build FE job (conclusion=${buildJob ? buildJob.conclusion : 'absent'}); slow check skipped.`);
+            core.setOutput('slow', 'false');
+            return;
+          }
+
+          const durSec = Math.round((new Date(buildJob.completed_at) - new Date(buildJob.started_at)) / 1000);
+          const durHuman = `${Math.floor(durSec / 60)}m ${durSec % 60}s`;
+          core.info(`Build FE job '${buildJob.name}' duration: ${durHuman} (${durSec}s); threshold ${THRESHOLD_SECONDS}s`);
+          if (durSec > THRESHOLD_SECONDS) {
+            core.setOutput('slow', 'true');
+            core.setOutput('duration_human', durHuman);
+            core.setOutput('job_url', buildJob.html_url);
+          } else {
+            core.setOutput('slow', 'false');
+          }
     - name: Check loop alerting credentials
       id: check_loop_alerting
       if: always()
@@ -1039,30 +1070,41 @@ jobs:
         LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
       run: |
         if [[ -n $LOOP_TOKEN ]]; then echo "has_credentials=true" >> $GITHUB_OUTPUT; fi
-    - name: Send loop alert on fail
-      if: ${{ steps.check_loop_alerting.outputs.has_credentials == 'true' }}
+    - name: Send loop alert
+      if: ${{ always() && steps.check_loop_alerting.outputs.has_credentials == 'true' }}
       env:
         LOOP_TOKEN: ${{ steps.secrets.outputs.LOOP_CVE_REPORTS_SEND_TOKEN }}
         LOOP_CHANNEL_ID: ${{ steps.secrets.outputs.LOOP_E2E_REPORT_CHANNEL_ID }}
+        SLOW: ${{ steps.duration.outputs.slow }}
+        DURATION_HUMAN: ${{ steps.duration.outputs.duration_human }}
+        JOB_URL: ${{ steps.duration.outputs.job_url }}
         COMPARE_RESULT: ${{ needs.compare_reports.result }}
         BUILD_MAIN_RESULT: ${{ needs.build_fe_main.result }}
         BUILD_DEV_RESULT: ${{ needs.build_fe_dev.result }}
+        RESOLVE_RESULT: ${{ needs.resolve_target.result }}
         TARGET_SHA: ${{ needs.resolve_target.outputs.sha }}
       run: |
         WORKFLOW_URL="${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}"
 
-        if [[ "$COMPARE_RESULT" == "failure" ]]; then
-          REASON="digest mismatch on rebuild (build is not reproducible)"
+        # Priority order: a slow (but successful) rebuild is checked first so it
+        # does not clash with the failure/mismatch conditions below.
+        if [[ "$SLOW" == "true" ]]; then
+          MESSAGE="🐢Build reproducibility rebuild is slow🐢\nBuild FE job took ${DURATION_HUMAN} (threshold 5m)\nSHA: ${TARGET_SHA}\n[URL](${JOB_URL})"
+        elif [[ "$COMPARE_RESULT" == "failure" ]]; then
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: digest mismatch on rebuild (build is not reproducible)\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
         elif [[ "$BUILD_MAIN_RESULT" == "failure" || "$BUILD_DEV_RESULT" == "failure" ]]; then
-          REASON="FE rebuild failed"
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: FE rebuild failed\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        elif [[ "$RESOLVE_RESULT" == "failure" ]]; then
+          MESSAGE="🛑Build reproducibility check failed🛑\nReason: failed to resolve baseline / workflow error\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
         else
-          REASON="failed to resolve baseline / workflow error"
+          echo "Nothing to alert about (build succeeded within the time budget)."
+          exit 0
         fi
 
         alertData=$(cat <<EOF
         {
         "channel_id": "${LOOP_CHANNEL_ID}",
-        "message": "🛑Build reproducibility check failed🛑\nReason: ${REASON}\nSHA: ${TARGET_SHA}\n[URL](${WORKFLOW_URL})"
+        "message": "${MESSAGE}"
         }
         EOF
         )

--- a/.github/workflows/reproducibility-timing-report.yml
+++ b/.github/workflows/reproducibility-timing-report.yml
@@ -1,0 +1,97 @@
+#
+# THIS FILE IS GENERATED, PLEASE DO NOT EDIT.
+#
+
+# Copyright 2026 Flant JSC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build reproducibility rebuild-timing report.
+#
+# Trigger: schedule (Monday and Thursday 10:00 MSK == 07:00 UTC) or workflow_dispatch.
+#
+# All the logic lives in .github/scripts/python/reproducibility_timing_report.py:
+# it collects SCHEDULED reproducibility-check.yml runs from the last 7 days,
+# measures the duration of the successful 'Build FE' rebuild job in each, logs a
+# per-run table and the average rebuild time, and exposes the results via
+# GITHUB_OUTPUT. This workflow only invokes the script and forwards its output:
+# it exposes the job outputs (run_count/avg_seconds/avg_build_time) for downstream
+# jobs and sends the average to Loop via send-report.sh.
+
+name: 'Build reproducibility timing report'
+
+on:
+  # Monday and Thursday 10:00 MSK (UTC+3, no DST) == 07:00 UTC.
+  schedule:
+    - cron: '0 7 * * 1,4'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  timing_report:
+    name: Reproducibility rebuild timing report
+    runs-on: "self-slim"
+    if: ${{ github.repository == 'deckhouse/deckhouse' }}
+    outputs:
+      run_count: ${{ steps.collect.outputs.run_count }}
+      avg_seconds: ${{ steps.collect.outputs.avg_seconds }}
+      avg_build_time: ${{ steps.collect.outputs.avg_build_time }}
+    steps:
+
+    # <template: checkout_step>
+    - name: Checkout sources
+      uses: actions/checkout@v3.5.2
+
+    # </template: checkout_step>
+    # <template: import_secrets>
+    - name: Split repository name
+      id: split
+      env:
+        REPO: ${{ github.repository }}
+      run: |
+        if [ $REPO == "deckhouse/deckhouse" ]; then
+          echo "name=deckhouse" >> $GITHUB_OUTPUT
+        else
+          echo "name=deckhouse-test" >> $GITHUB_OUTPUT
+        fi
+    - name: Import secrets
+      id: secrets
+      uses: hashicorp/vault-action@v2
+      with:
+        url: https://seguro.flant.com
+        path: github
+        role: "${{ steps.split.outputs.name }}"
+        method: jwt
+        jwtGithubAudience: github-access-aud
+        secrets: |
+          projects/data/6db2f1ee-9b6f-4f4f-8381-2fb43060478a/team-ssdlc/loop webhook_url | LOOP_SERVICE_NOTIFICATIONS ;
+
+    # </template: import_secrets>
+    - name: Collect scheduled rebuild timings
+      id: collect
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WORKFLOW_FILE: "reproducibility-check.yml"
+        BUILD_JOB_PREFIX: "Build FE"
+        WINDOW_DAYS: "7"
+      run: |
+        python3 .github/scripts/python/reproducibility_timing_report.py
+    - name: Send report to Loop
+      env:
+        LOOP_SERVICE_NOTIFICATIONS: ${{ steps.secrets.outputs.LOOP_SERVICE_NOTIFICATIONS }}
+        AVG_BUILD_TIME: ${{ steps.collect.outputs.avg_build_time }}
+      run: |
+        bash ./.github/scripts/send-report.sh --webhook "ci_report" ":passport_control: **Average build time on the same commit is ${AVG_BUILD_TIME}** :passport_control:"


### PR DESCRIPTION
## Description

Improves the build reproducibility CI and adds visibility into rebuild timing.
**`reproducibility-check` workflow:**
- Schedule increased from once a week to **4 times a day** (`0 */6 * * *`).
- The alerting job is now a **single Loop notification** that fires on **any trigger** (`always()`, `run_attempt == 1`, `deckhouse/deckhouse` only) and picks **one** reason in priority order:
  1. 🐢 **rebuild is slow** — a successful `Build FE` rebuild took longer than 5 minutes (new);
  2. 🛑 digest mismatch on rebuild (build is not reproducible);
  3. 🛑 FE rebuild failed;
  4. 🛑 failed to resolve the baseline / workflow error.
- If the build succeeds within the time budget, nothing is sent.
**`reproducibility-timing-report` workflow (new):**
- Runs on **Mon/Thu at 10:00 MSK** (`0 7 * * 1,4`) and via `workflow_dispatch` (manual run behaves identically to the scheduled one).
- Collects successful scheduled `Build FE` rebuilds over the last 7 days, prints a `date | build job duration | job link` table and the average rebuild time to the run summary, and posts the average build time to Loop (`ci_report`) via `send-report.sh`.
- All collection/processing logic lives in a standalone Python script `.github/scripts/python/reproducibility_timing_report.py`; the workflow only invokes it and consumes its outputs.


## Why do we need it, and what problem does it solve?
More frequent checks catch build-reproducibility regressions faster. Proactive Loop alerts (failure, digest mismatch, and slow rebuild) remove the need to watch CI manually, and the periodic timing report makes rebuild-time degradation visible before it becomes a problem.


## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
## Changelog entries
```changes
section: ci
type: chore
summary: Run the build reproducibility check 4 times a day, add Loop alerts (build failure, digest mismatch, slow rebuild) on any trigger, and add a periodic rebuild-timing report.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
