### PR TITLE
[control-plane-manager] Add etcd-defrag impl

### DIFF
--- a/go_lib/controlplane/etcd/client/client.go
+++ b/go_lib/controlplane/etcd/client/client.go
@@ -416,6 +416,28 @@ func (c *Client) getClusterStatus() (map[string]*clientv3.StatusResponse, error)
 	return clusterStatus, nil
 }
 
+// CheckClusterHealthy verifies that every known etcd member is reachable,
+// has an elected leader, and reports no internal errors.
+// Each member status call is bounded by the given timeout.
+func CheckClusterHealthy(ctx context.Context, etcdCli Interface, timeout time.Duration, logger *log.Logger) error {
+	for _, ep := range etcdCli.Endpoints() {
+		statusCtx, cancel := context.WithTimeout(ctx, timeout)
+		resp, err := etcdCli.Status(statusCtx, ep)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("member %s unreachable: %w", ep, err)
+		}
+		if resp.Leader == 0 {
+			return fmt.Errorf("member %s has no leader (cluster has no quorum)", ep)
+		}
+		if len(resp.Errors) > 0 {
+			return fmt.Errorf("member %s reported errors: %v", ep, resp.Errors)
+		}
+		logger.Info("etcd member healthy", slog.String("endpoint", ep))
+	}
+	return nil
+}
+
 func (c *Client) WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error) {
 	for i := 0; i < retries; i++ {
 		if i > 0 {

--- a/go_lib/controlplane/etcd/client/client.go
+++ b/go_lib/controlplane/etcd/client/client.go
@@ -53,6 +53,8 @@ type Interface interface {
 	WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error)
 	MemberAddAsLearner(ctx context.Context, peerAddrs string) (*clientv3.MemberAddResponse, error)
 	MemberPromote(ctx context.Context, id uint64) (*clientv3.MemberPromoteResponse, error)
+	CheckClusterHealthy(ctx context.Context, timeout time.Duration) error
+	Defragment(ctx context.Context, endpoint string) error
 	Raw() *clientv3.Client
 	Close() error
 }
@@ -419,10 +421,10 @@ func (c *Client) getClusterStatus() (map[string]*clientv3.StatusResponse, error)
 // CheckClusterHealthy verifies that every known etcd member is reachable,
 // has an elected leader, and reports no internal errors.
 // Each member status call is bounded by the given timeout.
-func CheckClusterHealthy(ctx context.Context, etcdCli Interface, timeout time.Duration, logger *log.Logger) error {
-	for _, ep := range etcdCli.Endpoints() {
+func (c *Client) CheckClusterHealthy(ctx context.Context, timeout time.Duration) error {
+	for _, ep := range c.Endpoints() {
 		statusCtx, cancel := context.WithTimeout(ctx, timeout)
-		resp, err := etcdCli.Status(statusCtx, ep)
+		resp, err := c.Status(statusCtx, ep)
 		cancel()
 		if err != nil {
 			return fmt.Errorf("member %s unreachable: %w", ep, err)
@@ -433,9 +435,13 @@ func CheckClusterHealthy(ctx context.Context, etcdCli Interface, timeout time.Du
 		if len(resp.Errors) > 0 {
 			return fmt.Errorf("member %s reported errors: %v", ep, resp.Errors)
 		}
-		logger.Info("etcd member healthy", slog.String("endpoint", ep))
 	}
 	return nil
+}
+
+func (c *Client) Defragment(ctx context.Context, endpoint string) error {
+	_, err := c.client.Defragment(ctx, endpoint)
+	return err
 }
 
 func (c *Client) WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error) {

--- a/go_lib/controlplane/etcd/client/client_test.go
+++ b/go_lib/controlplane/etcd/client/client_test.go
@@ -35,6 +35,7 @@ import (
 // the production 1-minute default.
 func TestMain(m *testing.M) {
 	constants.KubernetesAPICallTimeout = 200 * time.Millisecond
+	constants.EtcdAPICallTimeout = 200 * time.Millisecond
 	os.Exit(m.Run())
 }
 

--- a/go_lib/controlplane/etcd/client/client_test.go
+++ b/go_lib/controlplane/etcd/client/client_test.go
@@ -75,6 +75,14 @@ func (f *fakeClient) MemberPromote(_ context.Context, id uint64) (*clientv3.Memb
 	return &clientv3.MemberPromoteResponse{}, nil
 }
 
+func (f *fakeClient) CheckClusterHealthy(_ context.Context, _ time.Duration) error {
+	return nil
+}
+
+func (f *fakeClient) Defragment(_ context.Context, _ string) error {
+	return nil
+}
+
 func (f *fakeClient) Raw() *clientv3.Client {
 	return nil
 }

--- a/go_lib/controlplane/etcd/constants/constants.go
+++ b/go_lib/controlplane/etcd/constants/constants.go
@@ -50,9 +50,6 @@ const (
 	// Used as fallback during migration from kubeadm-managed to CPM-managed manifests.
 	LegacyEtcdAdvertiseClientUrlsAnnotationKey = "kubeadm.kubernetes.io/etcd.advertise-client-urls"
 
-	// EtcdAPICallTimeout specifies how much time to wait for completion of requests against the etcd API.
-	EtcdAPICallTimeout = 2 * time.Minute
-
 	// EtcdAPICallRetryInterval defines how long etcd should wait before retrying a failed API operation
 	EtcdAPICallRetryInterval = 500 * time.Millisecond
 
@@ -65,6 +62,10 @@ const (
 	// AdminKubeConfigFileName defines name for the kubeconfig aimed to be used by the admin of the cluster
 	AdminKubeConfigFileName = "admin.conf"
 )
+
+// EtcdAPICallTimeout specifies how much time to wait for completion of requests against the etcd API.
+// Declared as a variable (not const) so tests can override it with a shorter duration.
+var EtcdAPICallTimeout = 2 * time.Minute
 
 // KubernetesAPICallTimeout is the maximum time to wait for a Kubernetes API call to complete.
 // Declared as a variable (not const) so tests can override it with a shorter duration.

--- a/go_lib/controlplane/etcd/utils.go
+++ b/go_lib/controlplane/etcd/utils.go
@@ -30,6 +30,11 @@ func GetPeerURL(ip string) string {
 	return "https://" + net.JoinHostPort(ip, strconv.Itoa(constants.EtcdListenPeerPort))
 }
 
+// GetClientURL returns the HTTPS client endpoint for the given advertise IP.
+func GetClientURL(ip string) string {
+	return "https://" + net.JoinHostPort(ip, strconv.Itoa(constants.EtcdListenClientPort))
+}
+
 // GetStaticPodFilepath returns the location on the disk where the Static Pod should be present
 func GetStaticPodFilepath(componentName, manifestsDir string) string {
 	return filepath.Join(manifestsDir, componentName+".yaml")

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
@@ -83,7 +83,7 @@ func Register(mgr manager.Manager, metricsStorage metricsstorage.Storage) error 
 	}
 	// Inject Reconciler-level deps into steps that need them.
 	r.steps[controlplanev1alpha1.StepWaitPodReady].(*waitPodReadyStep).waitForPod = r.waitForPod
-	r.steps[controlplanev1alpha1.StepDefragEtcd].(*defragEtcdStep).isEtcdPodReady = r.isEtcdPodReady
+	r.steps[controlplanev1alpha1.StepDefragEtcd].(*defragEtcdStep).defragEtcd = r.reconcileEtcdDefrag
 
 	// harden admin kubeconfig perms and align root kubeconfig symlink during controller startup.
 	r.enforceNodePolicy(r.log)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
@@ -83,7 +83,7 @@ func Register(mgr manager.Manager, metricsStorage metricsstorage.Storage) error 
 	}
 	// Inject Reconciler-level deps into steps that need them.
 	r.steps[controlplanev1alpha1.StepWaitPodReady].(*waitPodReadyStep).waitForPod = r.waitForPod
-	r.steps[controlplanev1alpha1.StepDefragEtcd].(*defragEtcdStep).defragEtcd = r.reconcileEtcdDefrag
+	r.steps[controlplanev1alpha1.StepDefragEtcd].(*defragEtcdStep).defragEtcd = r.defragEtcd
 
 	// harden admin kubeconfig perms and align root kubeconfig symlink during controller startup.
 	r.enforceNodePolicy(r.log)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/controller.go
@@ -83,6 +83,7 @@ func Register(mgr manager.Manager, metricsStorage metricsstorage.Storage) error 
 	}
 	// Inject Reconciler-level deps into steps that need them.
 	r.steps[controlplanev1alpha1.StepWaitPodReady].(*waitPodReadyStep).waitForPod = r.waitForPod
+	r.steps[controlplanev1alpha1.StepDefragEtcd].(*defragEtcdStep).isEtcdPodReady = r.isEtcdPodReady
 
 	// harden admin kubeconfig perms and align root kubeconfig symlink during controller startup.
 	r.enforceNodePolicy(r.log)

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -106,9 +106,9 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 	return true, nil
 }
 
-// reconcileEtcdDefrag is the Reconciler-level implementation of the DefragEtcd step.
-// It checks that the etcd pod is ready, then defragments if fragmentation exceeds the threshold.
-func (r *Reconciler) reconcileEtcdDefrag(ctx context.Context, state *controlplanev1alpha1.OperationState, logger *log.Logger) (StepResult, error) {
+// defragEtcd is the Reconciler-level implementation of the DefragEtcd step.
+// It ensures the etcd pod is Ready, then defragments if fragmentation exceeds the threshold.
+func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1.OperationState, logger *log.Logger) (StepResult, error) {
 	if state.Raw().Spec.Component != controlplanev1alpha1.OperationComponentEtcd {
 		return StepResult{Outcome: OutcomeCompleted}, nil
 	}
@@ -151,3 +151,4 @@ func (r *Reconciler) reconcileEtcdDefrag(ctx context.Context, state *controlplan
 	}
 	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
 }
+

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplaneoperation
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	etcdclient "github.com/deckhouse/deckhouse/go_lib/controlplane/etcd/client"
+	etcdconstants "github.com/deckhouse/deckhouse/go_lib/controlplane/etcd/constants"
+	"github.com/deckhouse/deckhouse/pkg/log"
+
+	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
+	"control-plane-manager/internal/constants"
+)
+
+const (
+	// etcdDefragFragRatioThreshold is the minimum fragmentation ratio (fragmented/total)
+	// that triggers defragmentation. 0.20 means defrag when ≥20% of the DB is fragmented.
+	etcdDefragFragRatioThreshold = 0.20
+
+	etcdDefragTimeout       = 2 * time.Minute
+	etcdDefragStatusTimeout = 10 * time.Second
+)
+
+// defragEtcdIfNeeded connects to the local etcd endpoint, checks fragmentation,
+// and runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.
+// Returns true if defragmentation was performed, false if it was skipped.
+func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
+	adminConfPath := filepath.Join(kubeconfigDir, "admin.conf")
+	kubeClient, err := etcdclient.ClientSetFromFile(adminConfPath)
+	if err != nil {
+		return false, fmt.Errorf("create k8s client from admin.conf: %w", err)
+	}
+
+	etcdCli, err := etcdclient.New(kubeClient, pkiDir)
+	if err != nil {
+		return false, fmt.Errorf("create etcd client: %w", err)
+	}
+	defer etcdCli.Close()
+
+	localEndpoint := "https://" + net.JoinHostPort(advertiseIP, strconv.Itoa(etcdconstants.EtcdListenClientPort))
+
+	statusCtx, cancel := context.WithTimeout(ctx, etcdDefragStatusTimeout)
+	defer cancel()
+
+	resp, err := etcdCli.Status(statusCtx, localEndpoint)
+	if err != nil {
+		return false, fmt.Errorf("get etcd status at %s: %w", localEndpoint, err)
+	}
+
+	if resp.DbSize == 0 {
+		logger.Info("etcd defrag skipped: db size is zero")
+		return false, nil
+	}
+
+	fragmented := resp.DbSize - resp.DbSizeInUse
+	fragRatio := float64(fragmented) / float64(resp.DbSize)
+
+	logger.Info("etcd defrag: fragmentation check",
+		slog.String("endpoint", localEndpoint),
+		slog.Int64("dbSizeBytes", resp.DbSize),
+		slog.Int64("dbSizeInUseBytes", resp.DbSizeInUse),
+		slog.Int64("fragmentedBytes", fragmented),
+		slog.Float64("fragRatio", fragRatio),
+		slog.Float64("threshold", etcdDefragFragRatioThreshold))
+
+	if fragRatio < etcdDefragFragRatioThreshold {
+		logger.Info("etcd defrag skipped: fragmentation below threshold")
+		return false, nil
+	}
+
+	logger.Info("etcd defrag: starting", slog.String("endpoint", localEndpoint))
+
+	defragCtx, defragCancel := context.WithTimeout(ctx, etcdDefragTimeout)
+	defer defragCancel()
+
+	if _, err = etcdCli.Raw().Defragment(defragCtx, localEndpoint); err != nil {
+		return false, fmt.Errorf("defragment etcd at %s: %w", localEndpoint, err)
+	}
+
+	logger.Info("etcd defrag: completed successfully", slog.String("endpoint", localEndpoint))
+	return true, nil
+}
+
+// isEtcdPodReady checks whether the local etcd static pod has the Ready condition.
+func (r *Reconciler) isEtcdPodReady(ctx context.Context) (bool, error) {
+	podName := fmt.Sprintf("%s-%s",
+		controlplanev1alpha1.OperationComponentEtcd.PodComponentName(),
+		r.node.Name)
+	pod := &corev1.Pod{}
+	if err := r.client.Get(ctx, client.ObjectKey{
+		Name:      podName,
+		Namespace: constants.KubeSystemNamespace,
+	}, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get pod %s: %w", podName, err)
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -44,7 +44,7 @@ const (
 
 // defragEtcdIfNeeded runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.
 // Returns true if defragmentation was performed, false if it was skipped.
-func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
+func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
 	adminConfPath := filepath.Join(kubeconfigDir, "admin.conf")
 	kubeClient, err := etcdclient.ClientSetFromFile(adminConfPath)
 	if err != nil {
@@ -57,14 +57,19 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 	}
 	defer etcdCli.Close()
 
-	localEndpoint := etcd.GetClientURL(advertiseIP)
+	// Always connect to the local member directly — the controller runs on the same node.
+	localEndpoint := etcd.GetClientURL("127.0.0.1")
+
+	if err := etcdclient.CheckClusterHealthy(ctx, etcdCli, etcdDefragStatusTimeout, logger); err != nil {
+		return false, fmt.Errorf("etcd cluster not healthy, skipping defrag: %w", err)
+	}
 
 	statusCtx, cancel := context.WithTimeout(ctx, etcdDefragStatusTimeout)
 	defer cancel()
 
 	resp, err := etcdCli.Status(statusCtx, localEndpoint)
 	if err != nil {
-		return false, fmt.Errorf("get etcd status at %s: %w", localEndpoint, err)
+		return false, fmt.Errorf("get etcd status: %w", err)
 	}
 
 	if resp.DbSize <= 0 {
@@ -76,7 +81,6 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 	fragRatio := float64(fragmented) / float64(resp.DbSize)
 
 	logger.Info("etcd defrag: fragmentation check",
-		slog.String("endpoint", localEndpoint),
 		slog.Int64("dbSizeBytes", resp.DbSize),
 		slog.Int64("dbSizeInUseBytes", resp.DbSizeInUse),
 		slog.Int64("fragmentedBytes", fragmented),
@@ -88,18 +92,19 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 		return false, nil
 	}
 
-	logger.Info("etcd defrag: starting", slog.String("endpoint", localEndpoint))
+	logger.Info("etcd defrag: starting")
 
 	defragCtx, defragCancel := context.WithTimeout(ctx, etcdDefragTimeout)
 	defer defragCancel()
 
 	if _, err = etcdCli.Raw().Defragment(defragCtx, localEndpoint); err != nil {
-		return false, fmt.Errorf("defragment etcd at %s: %w", localEndpoint, err)
+		return false, fmt.Errorf("defragment etcd: %w", err)
 	}
 
-	logger.Info("etcd defrag: completed successfully", slog.String("endpoint", localEndpoint))
+	logger.Info("etcd defrag: completed successfully")
 	return true, nil
 }
+
 
 // defragEtcd is the Reconciler-level implementation of the DefragEtcd step.
 // It ensures the etcd pod is Ready, then defragments if fragmentation exceeds the threshold.
@@ -127,15 +132,6 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		return StepResult{}, fmt.Errorf("get pod %s: %w", podName, err)
 	}
 
-	if isPodCrashLooping(pod) {
-		logger.Warn("etcd pod is crash looping, will retry before defragmentation", slog.String("pod", podName))
-		return StepResult{
-			Outcome:      OutcomePending,
-			Message:      fmt.Sprintf("pod %s is in CrashLoopBackOff, waiting before defragmentation", podName),
-			RequeueAfter: requeueWaitPod,
-		}, nil
-	}
-
 	if !isPodReady(pod) {
 		logger.Info("etcd pod not ready, will retry before defragmentation", slog.String("pod", podName))
 		return StepResult{
@@ -145,7 +141,7 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		}, nil
 	}
 
-	defragged, err := defragEtcdIfNeeded(ctx, r.node.AdvertiseIP, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
+	defragged, err := defragEtcdIfNeeded(ctx, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
 	if err != nil {
 		return StepResult{}, err
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -121,10 +121,5 @@ func (r *Reconciler) isEtcdPodReady(ctx context.Context) (bool, error) {
 		}
 		return false, fmt.Errorf("get pod %s: %w", podName, err)
 	}
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true, nil
-		}
-	}
-	return false, nil
+	return isPodReady(pod), nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -72,7 +72,7 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 		return false, fmt.Errorf("get etcd status at %s: %w", localEndpoint, err)
 	}
 
-	if resp.DbSize == 0 {
+	if resp.DbSize <= 0 {
 		logger.Info("etcd defrag skipped: db size is zero")
 		return false, nil
 	}
@@ -122,7 +122,8 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		Namespace: constants.KubeSystemNamespace,
 	}, pod); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("etcd pod not found, will retry before defragmentation")
+			logger.Info("etcd pod not found, will retry before defragmentation",
+				slog.String("pod", podName))
 			return StepResult{
 				Outcome:      OutcomePending,
 				Message:      "waiting for etcd pod to be ready before defragmentation",
@@ -132,8 +133,19 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		return StepResult{}, fmt.Errorf("get pod %s: %w", podName, err)
 	}
 
+	if isPodCrashLooping(pod) {
+		logger.Warn("etcd pod is crash looping, will retry before defragmentation",
+			slog.String("pod", podName))
+		return StepResult{
+			Outcome:      OutcomePending,
+			Message:      fmt.Sprintf("pod %s is in CrashLoopBackOff, waiting before defragmentation", podName),
+			RequeueAfter: requeueWaitPod,
+		}, nil
+	}
+
 	if !isPodReady(pod) {
-		logger.Info("etcd pod not ready, will retry before defragmentation")
+		logger.Info("etcd pod not ready, will retry before defragmentation",
+			slog.String("pod", podName))
 		return StepResult{
 			Outcome:      OutcomePending,
 			Message:      "waiting for etcd pod to be ready before defragmentation",
@@ -151,4 +163,3 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 	}
 	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
 }
-

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -44,7 +44,7 @@ const (
 
 // defragEtcdIfNeeded runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.
 // Returns true if defragmentation was performed, false if it was skipped.
-func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
+func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
 	adminConfPath := filepath.Join(kubeconfigDir, "admin.conf")
 	kubeClient, err := etcdclient.ClientSetFromFile(adminConfPath)
 	if err != nil {
@@ -57,7 +57,8 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 	}
 	defer etcdCli.Close()
 
-	localEndpoint := etcd.GetClientURL(advertiseIP)
+	// Always connect to the local member directly — the controller runs on the same node.
+	localEndpoint := etcd.GetClientURL("127.0.0.1")
 
 	if err := etcdclient.CheckClusterHealthy(ctx, etcdCli, etcdDefragStatusTimeout, logger); err != nil {
 		return false, fmt.Errorf("etcd cluster not healthy, skipping defrag: %w", err)
@@ -140,7 +141,7 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		}, nil
 	}
 
-	defragged, err := defragEtcdIfNeeded(ctx, r.node.AdvertiseIP, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
+	defragged, err := defragEtcdIfNeeded(ctx, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
 	if err != nil {
 		return StepResult{}, err
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -20,17 +20,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/deckhouse/deckhouse/go_lib/controlplane/etcd"
 	etcdclient "github.com/deckhouse/deckhouse/go_lib/controlplane/etcd/client"
-	etcdconstants "github.com/deckhouse/deckhouse/go_lib/controlplane/etcd/constants"
 	"github.com/deckhouse/deckhouse/pkg/log"
 
 	controlplanev1alpha1 "control-plane-manager/api/v1alpha1"
@@ -38,16 +36,13 @@ import (
 )
 
 const (
-	// etcdDefragFragRatioThreshold is the minimum fragmentation ratio (fragmented/total)
-	// that triggers defragmentation. 0.20 means defrag when ≥20% of the DB is fragmented.
 	etcdDefragFragRatioThreshold = 0.20
 
 	etcdDefragTimeout       = 2 * time.Minute
 	etcdDefragStatusTimeout = 10 * time.Second
 )
 
-// defragEtcdIfNeeded connects to the local etcd endpoint, checks fragmentation,
-// and runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.
+// defragEtcdIfNeeded runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.
 // Returns true if defragmentation was performed, false if it was skipped.
 func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
 	adminConfPath := filepath.Join(kubeconfigDir, "admin.conf")
@@ -62,7 +57,7 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 	}
 	defer etcdCli.Close()
 
-	localEndpoint := "https://" + net.JoinHostPort(advertiseIP, strconv.Itoa(etcdconstants.EtcdListenClientPort))
+	localEndpoint := etcd.GetClientURL(advertiseIP)
 
 	statusCtx, cancel := context.WithTimeout(ctx, etcdDefragStatusTimeout)
 	defer cancel()
@@ -122,8 +117,7 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		Namespace: constants.KubeSystemNamespace,
 	}, pod); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("etcd pod not found, will retry before defragmentation",
-				slog.String("pod", podName))
+			logger.Info("etcd pod not found, will retry before defragmentation", slog.String("pod", podName))
 			return StepResult{
 				Outcome:      OutcomePending,
 				Message:      "waiting for etcd pod to be ready before defragmentation",
@@ -134,8 +128,7 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 	}
 
 	if isPodCrashLooping(pod) {
-		logger.Warn("etcd pod is crash looping, will retry before defragmentation",
-			slog.String("pod", podName))
+		logger.Warn("etcd pod is crash looping, will retry before defragmentation", slog.String("pod", podName))
 		return StepResult{
 			Outcome:      OutcomePending,
 			Message:      fmt.Sprintf("pod %s is in CrashLoopBackOff, waiting before defragmentation", podName),
@@ -144,8 +137,7 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 	}
 
 	if !isPodReady(pod) {
-		logger.Info("etcd pod not ready, will retry before defragmentation",
-			slog.String("pod", podName))
+		logger.Info("etcd pod not ready, will retry before defragmentation", slog.String("pod", podName))
 		return StepResult{
 			Outcome:      OutcomePending,
 			Message:      "waiting for etcd pod to be ready before defragmentation",

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -81,10 +81,10 @@ func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logge
 	fragRatio := float64(fragmented) / float64(resp.DbSize)
 
 	logger.Info("etcd defrag: fragmentation check",
-		slog.Int64("dbSizeBytes", resp.DbSize),
-		slog.Int64("dbSizeInUseBytes", resp.DbSizeInUse),
-		slog.Int64("fragmentedBytes", fragmented),
-		slog.Float64("fragRatio", fragRatio),
+		slog.Int64("db_size_bytes", resp.DbSize),
+		slog.Int64("db_size_in_use_bytes", resp.DbSizeInUse),
+		slog.Int64("fragmented_bytes", fragmented),
+		slog.Float64("frag_ratio", fragRatio),
 		slog.Float64("threshold", etcdDefragFragRatioThreshold))
 
 	if fragRatio < etcdDefragFragRatioThreshold {
@@ -104,7 +104,6 @@ func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logge
 	logger.Info("etcd defrag: completed successfully")
 	return true, nil
 }
-
 
 // defragEtcd is the Reconciler-level implementation of the DefragEtcd step.
 // It ensures the etcd pod is Ready, then defragments if fragmentation exceeds the threshold.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -106,8 +106,13 @@ func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir 
 	return true, nil
 }
 
-// isEtcdPodReady checks whether the local etcd static pod has the Ready condition.
-func (r *Reconciler) isEtcdPodReady(ctx context.Context) (bool, error) {
+// reconcileEtcdDefrag is the Reconciler-level implementation of the DefragEtcd step.
+// It checks that the etcd pod is ready, then defragments if fragmentation exceeds the threshold.
+func (r *Reconciler) reconcileEtcdDefrag(ctx context.Context, state *controlplanev1alpha1.OperationState, logger *log.Logger) (StepResult, error) {
+	if state.Raw().Spec.Component != controlplanev1alpha1.OperationComponentEtcd {
+		return StepResult{Outcome: OutcomeCompleted}, nil
+	}
+
 	podName := fmt.Sprintf("%s-%s",
 		controlplanev1alpha1.OperationComponentEtcd.PodComponentName(),
 		r.node.Name)
@@ -117,9 +122,32 @@ func (r *Reconciler) isEtcdPodReady(ctx context.Context) (bool, error) {
 		Namespace: constants.KubeSystemNamespace,
 	}, pod); err != nil {
 		if apierrors.IsNotFound(err) {
-			return false, nil
+			logger.Info("etcd pod not found, will retry before defragmentation")
+			return StepResult{
+				Outcome:      OutcomePending,
+				Message:      "waiting for etcd pod to be ready before defragmentation",
+				RequeueAfter: requeueWaitPod,
+			}, nil
 		}
-		return false, fmt.Errorf("get pod %s: %w", podName, err)
+		return StepResult{}, fmt.Errorf("get pod %s: %w", podName, err)
 	}
-	return isPodReady(pod), nil
+
+	if !isPodReady(pod) {
+		logger.Info("etcd pod not ready, will retry before defragmentation")
+		return StepResult{
+			Outcome:      OutcomePending,
+			Message:      "waiting for etcd pod to be ready before defragmentation",
+			RequeueAfter: requeueWaitPod,
+		}, nil
+	}
+
+	defragged, err := defragEtcdIfNeeded(ctx, r.node.AdvertiseIP, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	if defragged {
+		return StepResult{Outcome: OutcomeCompleted, Message: "defragmented"}, nil
+	}
+	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
 }

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -60,7 +60,7 @@ func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logge
 	// Always connect to the local member directly — the controller runs on the same node.
 	localEndpoint := etcd.GetClientURL("127.0.0.1")
 
-	if err := etcdclient.CheckClusterHealthy(ctx, etcdCli, etcdDefragStatusTimeout, logger); err != nil {
+	if err := etcdCli.CheckClusterHealthy(ctx, etcdDefragStatusTimeout); err != nil {
 		return false, fmt.Errorf("etcd cluster not healthy, skipping defrag: %w", err)
 	}
 
@@ -97,7 +97,7 @@ func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logge
 	defragCtx, defragCancel := context.WithTimeout(ctx, etcdDefragTimeout)
 	defer defragCancel()
 
-	if _, err = etcdCli.Raw().Defragment(defragCtx, localEndpoint); err != nil {
+	if err = etcdCli.Defragment(defragCtx, localEndpoint); err != nil {
 		return false, fmt.Errorf("defragment etcd: %w", err)
 	}
 

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/defrag.go
@@ -44,7 +44,7 @@ const (
 
 // defragEtcdIfNeeded runs defragmentation if the fragmented ratio exceeds etcdDefragFragRatioThreshold.
 // Returns true if defragmentation was performed, false if it was skipped.
-func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
+func defragEtcdIfNeeded(ctx context.Context, advertiseIP, pkiDir, kubeconfigDir string, logger *log.Logger) (bool, error) {
 	adminConfPath := filepath.Join(kubeconfigDir, "admin.conf")
 	kubeClient, err := etcdclient.ClientSetFromFile(adminConfPath)
 	if err != nil {
@@ -57,8 +57,7 @@ func defragEtcdIfNeeded(ctx context.Context, pkiDir, kubeconfigDir string, logge
 	}
 	defer etcdCli.Close()
 
-	// Always connect to the local member directly — the controller runs on the same node.
-	localEndpoint := etcd.GetClientURL("127.0.0.1")
+	localEndpoint := etcd.GetClientURL(advertiseIP)
 
 	if err := etcdclient.CheckClusterHealthy(ctx, etcdCli, etcdDefragStatusTimeout, logger); err != nil {
 		return false, fmt.Errorf("etcd cluster not healthy, skipping defrag: %w", err)
@@ -141,7 +140,7 @@ func (r *Reconciler) defragEtcd(ctx context.Context, state *controlplanev1alpha1
 		}, nil
 	}
 
-	defragged, err := defragEtcdIfNeeded(ctx, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
+	defragged, err := defragEtcdIfNeeded(ctx, r.node.AdvertiseIP, constants.KubernetesPkiPath, r.node.KubeconfigDir, logger)
 	if err != nil {
 		return StepResult{}, err
 	}

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/pods.go
@@ -121,6 +121,16 @@ func isPodCrashLooping(pod *corev1.Pod) bool {
 	return false
 }
 
+// isPodReady returns true if the pod has the Ready condition set to True.
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
 // isPodReadyWithChecksums returns true if the pod has the expected checksum annotations and is in Ready condition.
 func isPodReadyWithChecksums(pod *corev1.Pod, expected checksumAnnotations) bool {
 	if pod == nil {
@@ -134,13 +144,7 @@ func isPodReadyWithChecksums(pod *corev1.Pod, expected checksumAnnotations) bool
 		}
 	}
 
-	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
+	return isPodReady(pod)
 }
 
 func findContainerByName(pod *corev1.Pod, name string) *corev1.Container {

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -256,36 +256,11 @@ func syncAnnotationsOnly(component controlplanev1alpha1.OperationComponent, anno
 // defragEtcdStep defragments the local etcd data store if fragmentation exceeds the threshold.
 // No-op for non-Etcd components. Requires the etcd pod to be Ready before running.
 type defragEtcdStep struct {
-	isEtcdPodReady func(ctx context.Context) (bool, error)
+	defragEtcd func(ctx context.Context, state *controlplanev1alpha1.OperationState, logger *log.Logger) (StepResult, error)
 }
 
 func (c *defragEtcdStep) Execute(ctx context.Context, env *StepEnv, logger *log.Logger) (StepResult, error) {
-	if env.State.Raw().Spec.Component != controlplanev1alpha1.OperationComponentEtcd {
-		return StepResult{Outcome: OutcomeCompleted}, nil
-	}
-
-	ready, err := c.isEtcdPodReady(ctx)
-	if err != nil {
-		return StepResult{}, fmt.Errorf("check etcd pod readiness: %w", err)
-	}
-	if !ready {
-		logger.Info("etcd pod not ready, will retry before defragmentation")
-		return StepResult{
-			Outcome:      OutcomePending,
-			Message:      "waiting for etcd pod to be ready before defragmentation",
-			RequeueAfter: requeueWaitPod,
-		}, nil
-	}
-
-	defragged, err := defragEtcdIfNeeded(ctx, env.Node.AdvertiseIP, constants.KubernetesPkiPath, env.Node.KubeconfigDir, logger)
-	if err != nil {
-		return StepResult{}, err
-	}
-
-	if defragged {
-		return StepResult{Outcome: OutcomeCompleted, Message: "defragmented"}, nil
-	}
-	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
+	return c.defragEtcd(ctx, env.State, logger)
 }
 
 // waitPodReadyStep waits for the static pod to become ready with the expected checksum annotations.

--- a/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
+++ b/modules/040-control-plane-manager/images/control-plane-manager/src/internal/controllers/control-plane-operation/steps.go
@@ -37,6 +37,7 @@ var (
 	_ Step = (*renewKubeconfigsStep)(nil)
 	_ Step = (*syncManifestsStep)(nil)
 	_ Step = (*joinEtcdClusterStep)(nil)
+	_ Step = (*defragEtcdStep)(nil)
 	_ Step = (*waitPodReadyStep)(nil)
 	_ Step = (*certObserveStep)(nil)
 )
@@ -72,6 +73,7 @@ func defaultSteps() map[controlplanev1alpha1.StepName]Step {
 		controlplanev1alpha1.StepRenewKubeconfigs: &renewKubeconfigsStep{},
 		controlplanev1alpha1.StepSyncManifests:    &syncManifestsStep{},
 		controlplanev1alpha1.StepJoinEtcdCluster:  &joinEtcdClusterStep{},
+		controlplanev1alpha1.StepDefragEtcd:       &defragEtcdStep{},
 		controlplanev1alpha1.StepWaitPodReady:     &waitPodReadyStep{},
 		controlplanev1alpha1.StepCertObserve:      &certObserveStep{},
 	}
@@ -249,6 +251,41 @@ func syncAnnotationsOnly(component controlplanev1alpha1.OperationComponent, anno
 		return nil, fmt.Errorf("update checksum annotations: %w", err)
 	}
 	return []fileWriteResult{manifestResult}, nil
+}
+
+// defragEtcdStep defragments the local etcd data store if fragmentation exceeds the threshold.
+// No-op for non-Etcd components. Requires the etcd pod to be Ready before running.
+type defragEtcdStep struct {
+	isEtcdPodReady func(ctx context.Context) (bool, error)
+}
+
+func (c *defragEtcdStep) Execute(ctx context.Context, env *StepEnv, logger *log.Logger) (StepResult, error) {
+	if env.State.Raw().Spec.Component != controlplanev1alpha1.OperationComponentEtcd {
+		return StepResult{Outcome: OutcomeCompleted}, nil
+	}
+
+	ready, err := c.isEtcdPodReady(ctx)
+	if err != nil {
+		return StepResult{}, fmt.Errorf("check etcd pod readiness: %w", err)
+	}
+	if !ready {
+		logger.Info("etcd pod not ready, will retry before defragmentation")
+		return StepResult{
+			Outcome:      OutcomePending,
+			Message:      "waiting for etcd pod to be ready before defragmentation",
+			RequeueAfter: requeueWaitPod,
+		}, nil
+	}
+
+	defragged, err := defragEtcdIfNeeded(ctx, env.Node.AdvertiseIP, constants.KubernetesPkiPath, env.Node.KubeconfigDir, logger)
+	if err != nil {
+		return StepResult{}, err
+	}
+
+	if defragged {
+		return StepResult{Outcome: OutcomeCompleted, Message: "defragmented"}, nil
+	}
+	return StepResult{Outcome: OutcomeCompleted, Message: "skipped: fragmentation below threshold"}, nil
 }
 
 // waitPodReadyStep waits for the static pod to become ready with the expected checksum annotations.


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->
Added implementation of the `etcd-defrag` step for `Control Plane Manager`.

The step performs etcd defragmentation when the etcd database size exceeds the configured threshold.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->
We need this to allow Control Plane Manager to perform etcd defragmentation automatically.

## Why do we need it in the patch release (if we do)?
<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->
Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: feature
summary: Added etcd defragmentation step to Control Plane Manager.
impact: During etcd defragmentation, Kubernetes API server requests may occasionally take slightly longer. Usually, the response time remains close to normal operation without defragmentation.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
