### PR TITLE
[docs] Add pdf path to static asset rewrite rule

### DIFF
--- a/docs/site/.helm/templates/10-cm-frontend.yaml
+++ b/docs/site/.helm/templates/10-cm-frontend.yaml
@@ -395,7 +395,7 @@ data:
                 deny all;
             }
 
-            rewrite .+/documentation/[^/]+/(images|presentations|assets)/.+$    /deckhouse-{{ $.Values.werf.env }}/$doc_version/docs-dkp/${doc_path} break;
+            rewrite .+/documentation/[^/]+/(images|presentations|assets|pdf)/.+$    /deckhouse-{{ $.Values.werf.env }}/$doc_version/docs-dkp/${doc_path} break;
             rewrite /$    /deckhouse-{{ $.Values.werf.env }}/$doc_version/docs-dkp/$lang/${doc_path}index.html break;
             rewrite [^/]$ /deckhouse-{{ $.Values.werf.env }}/$doc_version/docs-dkp/$lang/${doc_path} break;
 


### PR DESCRIPTION
## Description

Extend the nginx rewrite regex to include pdf as a recognised static resource directory alongside images, presentations, and assets

## Why do we need it, and what problem does it solve?

Add rules do download files from the pdf directory.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: docs
type: chore
summary: Add pdf path to static asset rewrite rule.
impact_level: low
```
