### PR TITLE
[istio] Remove d8-istio from exclude_namespaces in CM cni-config 

### DIFF
--- a/modules/110-istio/templates/cni/configmap.yaml
+++ b/modules/110-istio/templates/cni/configmap.yaml
@@ -24,7 +24,6 @@ data:
         "kubeconfig": "__KUBECONFIG_FILEPATH__",
         "cni_bin_dir": "/opt/cni/bin",
         "exclude_namespaces": [
-          "d8-istio",
           "d8-system",
           "kube-system"
         ]
@@ -36,7 +35,7 @@ data:
   AMBIENT_RECONCILE_POD_RULES_ON_STARTUP: "false"
   CHAINED_CNI_PLUGIN: "true"
   CNI_NET_DIR: "/etc/cni/net.d"
-  EXCLUDE_NAMESPACES: "d8-istio,d8-system,kube-system"
+  EXCLUDE_NAMESPACES: "d8-system,kube-system"
   LOG_LEVEL: "debug"
   REPAIR_ENABLED: "true"
   REPAIR_LABEL_PODS: "false"


### PR DESCRIPTION
## Description
d8-istio namespace was removed from `cni_network_config` list of excluded namespaces in ConfigMap `cni-config`.

## Why do we need it, and what problem does it solve?
This allows to run pods with istio-proxy sidecars within `d8-istio` namespace when `trafficRedirectionSetupMode: CNIPlugin` option of Istio ModuleConfig is set.

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: istio
type: chore
summary: Removed the d8-istio namespace from the exclude_namespaces list in cni-config.
impact_level: default
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
