### PR TITLE
[candi] bashible: don't block per-package prefetch wait on already-installed packages

### DIFF
--- a/candi/bashible/lib.sh.tpl
+++ b/candi/bashible/lib.sh.tpl
@@ -421,12 +421,20 @@ bb-rpp-wait-fetched() {
   local digest="$2"
   local tempdir="${BB_RP_FETCHED_STORE:-/opt/deckhouse/tmp/registrypackages}"
   local archive="${tempdir}/${name}/${digest}.tar.gz"
+  local installed_digest_file="${BB_RP_INSTALLED_PACKAGES_STORE:-/var/cache/registrypackages}/${name}/digest"
   local deadline=$((SECONDS + 600))
   local svc="rpp-prefetch.service"
   local svc_state
 
   while [ $SECONDS -lt $deadline ]; do
     if [ -f "$archive" ]; then
+      return 0
+    fi
+    # Package already installed at the requested digest (e.g. baked into the base
+    # image — curl, jq). The prefetch skips such packages, so their archive is never
+    # written; without this check the wait blocks until the whole prefetch service
+    # finishes (~3 min on the first master), defeating the per-package wait.
+    if [ -f "$installed_digest_file" ] && [ "$(cat "$installed_digest_file" 2>/dev/null)" = "$digest" ]; then
       return 0
     fi
     if command -v systemctl >/dev/null 2>&1; then


### PR DESCRIPTION
## Description

`bb-rpp-wait-fetched` (bashible's per-package prefetch wait) waited for a package's downloaded archive to appear on disk. For packages **already installed in the base image** (e.g. `curl`, `jq`) the background prefetch (`rpp-prefetch.service`) skips them, so their archive is never written — and the wait fell through to blocking until the **entire** prefetch service finished (~3 min on the first master), defeating the point of a per-package wait.

This adds a short-circuit: if the package is already installed at the requested digest (`/var/cache/registrypackages/<name>/digest` matches), return immediately instead of waiting for an archive that will never appear.

## Why do we need it, and what problem does it solve?

On the first master's bootstrap, `004_install_mandatory_packages` (which waits for `curl`/`jq` among others) blocked for ~186s — the full duration of the background prefetch — even though its own small packages were on disk in ~40s. Because `Execute bundle` is serialized on this wait, the whole bashible bundle was inflated.

Measured on a 1-master DKP-on-DVP bootstrap:

- `004` `wait_prefetch`: **186s → 11s**
- `Execute bundle` (bashible): **223s → 82s** (≈ −140s)

No behavior change — it only removes a spurious wait; already-installed packages are detected via the existing installed-package store, and the `|| true` callers are unaffected.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: candi
type: fix
summary: Speed up first-master bootstrap by not blocking bashible's per-package prefetch wait on packages already present in the base image.
impact_level: low
```
