### PR TITLE
[dhctl] add support for pre-installing ModuleConfig CRD during bootstrap

### DIFF
--- a/.werf/defines/installer.tmpl
+++ b/.werf/defines/installer.tmpl
@@ -15,6 +15,10 @@
   - modules/*/openapi/conversions/*.yaml
   - global-hooks/openapi/config-values.yaml
   after: setup
+- image: dev-prebuild
+  add: /deckhouse/deckhouse-controller/crds/module-config.yaml
+  to: /deckhouse/crds/module-config.yaml
+  after: setup
 - image: images-digests
   add: /images_digests.json
   to: /deckhouse/candi/images_digests.json

--- a/.werf/werf-dev-candi.yaml
+++ b/.werf/werf-dev-candi.yaml
@@ -7,5 +7,9 @@ git:
   - candi
 {{ .Files.Get (printf "tools/build_includes/candi-cloud-providers-%s.yaml" .Env) }}
 {{ .Files.Get (printf "tools/build_includes/candi-%s.yaml" .Env) }}
+- add: /deckhouse-controller/crds
+  to: /deckhouse/crds
+  includePaths:
+  - module-config.yaml
 
 {{ include "candi_prepare_with_shell" (dict "CI_COMMIT_TAG" .CI_COMMIT_TAG) }}

--- a/dhctl/pkg/app/options/global.go
+++ b/dhctl/pkg/app/options/global.go
@@ -31,12 +31,14 @@ const (
 	DefaultGlobalHooksModule      = DefaultDeckhouseDir + "/global-hooks"
 	DefaultVersionMap             = DefaultCandiDir + "/version_map.yml"
 	DefaultModulesDir             = DefaultDeckhouseDir + "/modules"
+	DefaultModuleConfigCRDPath    = DefaultDeckhouseDir + "/crds/module-config.yaml"
 )
 
 var ConvergerPodsSpiCheckPaths = []string{
 	DefaultModulesDir,
 	DefaultGlobalHooksModule,
 	DefaultVersionMap,
+	DefaultModuleConfigCRDPath,
 }
 
 // GlobalOptions holds settings shared by every dhctl command.
@@ -61,6 +63,7 @@ type GlobalOptions struct {
 	GlobalHooksModule      string
 	VersionMap             string
 	ModulesDir             string
+	ModuleConfigCRDPath    string
 
 	// indecates if download is needed
 	NeedDownload bool
@@ -217,6 +220,10 @@ func CheckDirs(skip ...string) bool {
 			path:  DefaultModulesDir,
 			isDir: true,
 		},
+		{
+			path:  DefaultModuleConfigCRDPath,
+			isDir: false,
+		},
 	}
 
 	forCheck := make([]pathToIsDir, 0, len(forCheckDefaults))
@@ -261,4 +268,5 @@ func SetPaths(root string, o *GlobalOptions) {
 	o.GlobalHooksModule = filepath.Join(o.DeckhouseDir, "global-hooks")
 	o.VersionMap = filepath.Join(o.CandiDir, "version_map.yml")
 	o.ModulesDir = filepath.Join(o.DeckhouseDir, "modules")
+	o.ModuleConfigCRDPath = filepath.Join(o.DeckhouseDir, "crds", "module-config.yaml")
 }

--- a/dhctl/pkg/app/options/global_test.go
+++ b/dhctl/pkg/app/options/global_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetPathsModuleConfigCRDPath(t *testing.T) {
+	o := GlobalOptions{}
+	SetPaths("/some/root", &o)
+
+	require.Equal(t, "/some/root/deckhouse/crds/module-config.yaml", o.ModuleConfigCRDPath)
+}
+
+func TestDefaultModuleConfigCRDPath(t *testing.T) {
+	require.Equal(t, "/deckhouse/crds/module-config.yaml", DefaultModuleConfigCRDPath)
+}
+
+func TestConvergerSkipsModuleConfigCRDPath(t *testing.T) {
+	require.Contains(t, ConvergerPodsSpiCheckPaths, DefaultModuleConfigCRDPath)
+}

--- a/dhctl/pkg/config/deckhouse_config.go
+++ b/dhctl/pkg/config/deckhouse_config.go
@@ -52,6 +52,11 @@ type DeckhouseInstaller struct {
 	CloudDiscovery           []byte
 	ModuleConfigs            []*ModuleConfig
 
+	// ModuleConfigCRDPath is the path to the ModuleConfig CRD manifest shipped
+	// in the installer image (or downloaded candi image). Empty means the file
+	// is unavailable and the CRD will be installed by deckhouse-controller.
+	ModuleConfigCRDPath string
+
 	KubeadmBootstrap   bool
 	MasterNodeSelector bool
 
@@ -206,6 +211,11 @@ func PrepareDeckhouseInstallConfig(ctx context.Context, metaConfig *MetaConfig, 
 		metaConfig.ModuleConfigs = append(metaConfig.ModuleConfigs, deckhouseCm)
 	}
 
+	moduleConfigCRDPath := ""
+	if globalOptions != nil {
+		moduleConfigCRDPath = globalOptions.ModuleConfigCRDPath
+	}
+
 	installConfig := DeckhouseInstaller{
 		UUID:                  metaConfig.UUID,
 		Registry:              metaConfig.Registry,
@@ -217,6 +227,7 @@ func PrepareDeckhouseInstallConfig(ctx context.Context, metaConfig *MetaConfig, 
 		StaticClusterConfig:   staticClusterConfig,
 		ClusterConfig:         clusterConfig,
 		ModuleConfigs:         metaConfig.ModuleConfigs,
+		ModuleConfigCRDPath:   moduleConfigCRDPath,
 		InstallerVersion:      metaConfig.InstallerVersion,
 		VersionFilePath:       metaConfig.VersionFilePath,
 		DownloadDir:           metaConfig.DownloadRootDir,

--- a/dhctl/pkg/kubernetes/actions/deckhouse/crd.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/crd.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deckhouse
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	crdinstaller "github.com/deckhouse/module-sdk/pkg/crd-installer"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+// EnsureModuleConfigCRD applies the ModuleConfig CRD shipped in the installer
+// image (or in the downloaded candi image for standalone dhctl) so that
+// ModuleConfigs can be created without waiting for deckhouse-controller to
+// start. The same crd-installer library and heritage label are used as in
+// deckhouse-controller's EnsureCRDs, which re-applies the CRD on every startup
+// and remains its long-term owner.
+//
+// A missing file is not an error: bootstrap falls back to the previous
+// behavior where ModuleConfig creation retries until deckhouse-controller
+// installs the CRD.
+func EnsureModuleConfigCRD(ctx context.Context, kubeCl *client.KubernetesClient, crdPath string) error {
+	if crdPath == "" {
+		log.WarnLn("ModuleConfig CRD path is not set. The CRD will be installed by deckhouse-controller.")
+		return nil
+	}
+
+	if _, err := os.Stat(crdPath); err != nil {
+		log.WarnF("ModuleConfig CRD file %q is not available: %v. The CRD will be installed by deckhouse-controller.\n", crdPath, err)
+		return nil
+	}
+
+	return log.ProcessCtx(ctx, "default", "Install ModuleConfig CRD", func(ctx context.Context) error {
+		inst := crdinstaller.NewCRDsInstaller(
+			kubeCl.Dynamic(),
+			[]string{crdPath},
+			crdinstaller.WithExtraLabels(map[string]string{crdinstaller.LabelHeritage: "deckhouse"}),
+		)
+
+		if err := inst.Run(ctx); err != nil {
+			return fmt.Errorf("install ModuleConfig CRD: %w", err)
+		}
+
+		kubeCl.InvalidateDiscoveryCache()
+
+		return nil
+	})
+}

--- a/dhctl/pkg/kubernetes/actions/deckhouse/crd_test.go
+++ b/dhctl/pkg/kubernetes/actions/deckhouse/crd_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Flant JSC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deckhouse
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/deckhouse/deckhouse/dhctl/pkg/kubernetes/client"
+	"github.com/deckhouse/deckhouse/dhctl/pkg/log"
+)
+
+const testModuleConfigCRD = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: moduleconfigs.deckhouse.io
+spec:
+  group: deckhouse.io
+  names:
+    kind: ModuleConfig
+    listKind: ModuleConfigList
+    plural: moduleconfigs
+    singular: moduleconfig
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+func TestEnsureModuleConfigCRD(t *testing.T) {
+	ctx := context.Background()
+	log.InitLogger("json", false)
+
+	t.Run("creates CRD with heritage label from existing file", func(t *testing.T) {
+		crdPath := filepath.Join(t.TempDir(), "module-config.yaml")
+		require.NoError(t, os.WriteFile(crdPath, []byte(testModuleConfigCRD), 0o600))
+
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+			crdGVR: "CustomResourceDefinitionList",
+		})
+
+		err := EnsureModuleConfigCRD(ctx, fakeClient, crdPath)
+		require.NoError(t, err)
+
+		crd, err := fakeClient.Dynamic().Resource(crdGVR).
+			Get(ctx, "moduleconfigs.deckhouse.io", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Equal(t, "deckhouse", crd.GetLabels()["heritage"])
+	})
+
+	t.Run("missing file is not an error and creates nothing", func(t *testing.T) {
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+			crdGVR: "CustomResourceDefinitionList",
+		})
+
+		err := EnsureModuleConfigCRD(ctx, fakeClient, filepath.Join(t.TempDir(), "absent.yaml"))
+		require.NoError(t, err)
+
+		_, err = fakeClient.Dynamic().Resource(crdGVR).
+			Get(ctx, "moduleconfigs.deckhouse.io", metav1.GetOptions{})
+		require.Error(t, err)
+	})
+
+	t.Run("empty path is not an error", func(t *testing.T) {
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(nil)
+
+		require.NoError(t, EnsureModuleConfigCRD(ctx, fakeClient, ""))
+	})
+
+	t.Run("broken file returns error", func(t *testing.T) {
+		crdPath := filepath.Join(t.TempDir(), "module-config.yaml")
+		require.NoError(t, os.WriteFile(crdPath, []byte("{not yaml: ["), 0o600))
+
+		fakeClient := client.NewFakeKubernetesClientWithListGVR(map[schema.GroupVersionResource]string{
+			crdGVR: "CustomResourceDefinitionList",
+		})
+
+		require.Error(t, EnsureModuleConfigCRD(ctx, fakeClient, crdPath))
+	})
+}

--- a/dhctl/pkg/operations/bootstrap/steps_deckhouse.go
+++ b/dhctl/pkg/operations/bootstrap/steps_deckhouse.go
@@ -60,6 +60,17 @@ func InstallDeckhouse(
 			return err
 		}
 
+		// Install the ModuleConfig CRD before pre-Deckhouse resources and
+		// ModuleConfig manifests are applied, so they don't have to wait for
+		// deckhouse-controller to start. It is a file-based precondition (with
+		// version-merge semantics matching deckhouse-controller's EnsureCRDs),
+		// not a single-object manifest, so it lives here rather than inside the
+		// CreateDeckhouseManifests task list. No-op (with a warning) when the
+		// CRD file is unavailable.
+		if err := deckhouse.EnsureModuleConfigCRD(ctx, kubeCl, config.ModuleConfigCRDPath); err != nil {
+			return fmt.Errorf("ensure ModuleConfig CRD: %w", err)
+		}
+
 		resManifests, err := deckhouse.CreateDeckhouseManifests(ctx, kubeCl, config, params.BeforeDeckhouseTask)
 		if err != nil {
 			return fmt.Errorf("create Deckhouse manifests: %w", err)


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

dhctl now installs the moduleconfigs.deckhouse.io CRD itself during the bootstrap phase, right before the cluster resources and ModuleConfig objects are rolled out, instead of waiting for deckhouse-controller to install it after the Deckhouse pod starts.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

During bootstrap dhctl creates ModuleConfig objects from config.yml before deckhouse-controller is up. The first ModuleConfig create then dead-waits on the CRD to appear (the controller installs it only at pod start), retrying up to 600×1s. By pre-installing the CRD itself, dhctl makes those ModuleConfigs apply instantly.

## Why do we need it in the patch release (if we do)?

<!---
Describe why the changes need to be backported into the patch release.

If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".

Delete the section if the PR is for release, and not for the patch release.
-->

## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: dhctl
type: feature
summary: pre-install the ModuleConfig CRD during bootstrap so ModuleConfigs apply without waiting for deckhouse-controller
impact: 
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
