### PR TITLE
[rpp-get] direct registry fetch + streaming extract

### DIFF
--- a/candi/bashible/common-steps/all/001_prefetch_registry_packages.sh.tpl
+++ b/candi/bashible/common-steps/all/001_prefetch_registry_packages.sh.tpl
@@ -81,11 +81,52 @@ for var in PACKAGES_PROXY_ADDRESSES PACKAGES_PROXY_TOKEN PACKAGES_PROXY_KUBE_API
   fi
 done
 
+{{- if ne .registry.mode "Local" }}
+# Fetch packages straight from the registry (rpp-get --registry-direct) so the
+# prefetch does not depend on the rpp server / dhctl ssh tunnel. These vars are
+# confined to the prefetch env file: if the direct fetch fails, the prefetch unit
+# fails and the install steps fall back to inline `rpp-get install` over the rpp
+# proxy. Skipped for Local mode (the node has no reachable upstream registry).
+{{-   if eq .registry.mode "Proxy" }}
+{{-     with (.registry.bootstrap).proxy }}
+{
+  echo 'export REGISTRY_DIRECT=true'
+  echo {{ printf "export REGISTRY_REPO=%s/%s" .host .path | quote }}
+  echo {{ printf "export REGISTRY_SCHEME=%s" .scheme | quote }}
+  echo {{ printf "export REGISTRY_AUTH=%s" (printf "%s:%s" .username (.password | default "") | b64enc) | quote }}
+} >>"$env_file"
+{{-       if .ca }}
+printf '%s\n' {{ .ca | quote }} > /run/rpp-registry-ca.crt
+echo 'export REGISTRY_CA_FILE=/run/rpp-registry-ca.crt' >>"$env_file"
+{{-       end }}
+{{-     end }}
+{{-   else }}
+{{-     $host := .registry.imagesBase | splitList "/" | first }}
+{{-     with index .registry.hosts $host }}
+{{-       $mirror := index .mirrors 0 }}
+{
+  echo 'export REGISTRY_DIRECT=true'
+  echo {{ printf "export REGISTRY_REPO=%s" $.registry.imagesBase | quote }}
+  echo {{ printf "export REGISTRY_SCHEME=%s" $mirror.scheme | quote }}
+{{-         if $mirror.auth.username }}
+  echo {{ printf "export REGISTRY_AUTH=%s" (printf "%s:%s" $mirror.auth.username ($mirror.auth.password | default "") | b64enc) | quote }}
+{{-         else }}
+  echo {{ printf "export REGISTRY_AUTH=%s" $mirror.auth.auth | quote }}
+{{-         end }}
+} >>"$env_file"
+{{-         if $mirror.ca }}
+printf '%s\n' {{ $mirror.ca | quote }} > /run/rpp-registry-ca.crt
+echo 'export REGISTRY_CA_FILE=/run/rpp-registry-ca.crt' >>"$env_file"
+{{-         end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+
 if ! systemd-run \
     --unit="$unit" \
     --description="Prefetch deckhouse registry packages (parallel with bashible system prep)" \
     --collect \
-    /bin/bash -c ". \"$env_file\" && exec /opt/deckhouse/bin/rpp-get fetch \
+    /bin/bash -c ". \"$env_file\" && exec /opt/deckhouse/bin/rpp-get fetch --extract \
       \"d8:{{ .images.registrypackages.d8 }}\" \
       \"yq:{{ .images.registrypackages.yq4471 }}\" \
       \"curl:{{ .images.registrypackages.d8Curl891 }}\" \

--- a/candi/bashible/lib.sh.tpl
+++ b/candi/bashible/lib.sh.tpl
@@ -421,13 +421,16 @@ bb-rpp-wait-fetched() {
   local digest="$2"
   local tempdir="${BB_RP_FETCHED_STORE:-/opt/deckhouse/tmp/registrypackages}"
   local archive="${tempdir}/${name}/${digest}.tar.gz"
+  # Prefetch with --extract decompresses ahead into a directory instead of saving
+  # the .tar.gz; either form counts as "fetched".
+  local extracted="${tempdir}/${name}/${digest}.extracted"
   local installed_digest_file="${BB_RP_INSTALLED_PACKAGES_STORE:-/var/cache/registrypackages}/${name}/digest"
   local deadline=$((SECONDS + 600))
   local svc="rpp-prefetch.service"
   local svc_state
 
   while [ $SECONDS -lt $deadline ]; do
-    if [ -f "$archive" ]; then
+    if [ -f "$archive" ] || [ -d "$extracted" ]; then
       return 0
     fi
     # Package already installed at the requested digest (e.g. baked into the base

--- a/modules/007-registrypackages/images/rpp-get/README.md
+++ b/modules/007-registrypackages/images/rpp-get/README.md
@@ -46,3 +46,19 @@ rpp-get/
 4. kube-apiserver via bootstrap token (`/var/lib/bashible/bootstrap-token`) + `--kube-apiserver-endpoints`
 
 If neither endpoints nor token are supplied explicitly (flags or env), the tool queries kube-apiserver to obtain them. It first attempts to use the kubelet kubeconfig (`/etc/kubernetes/kubelet.conf`). If that file is absent, it falls back to the bootstrap token (`/var/lib/bashible/bootstrap-token`); in that case the kube-apiserver address must be provided via `--kube-apiserver-endpoints`, as there is no other source for it at that stage.
+
+## Direct registry mode
+
+By default `rpp-get` downloads package archives from RPP. With `--registry-direct` it instead pulls them straight from the container registry over the OCI Distribution v2 protocol, bypassing RPP entirely. This removes the dependency on the rpp server (and, during bootstrap, on the SSH tunnel to the dhctl machine).
+
+Direct mode requires the registry connection parameters. It does not query kube-apiserver and does not resolve RPP endpoints.
+
+| Flag                  | Env                | Description                              |
+|-----------------------|--------------------|------------------------------------------|
+| `--registry-direct`   | `REGISTRY_DIRECT`  | enable direct mode                       |
+| `--registry-repo`     | `REGISTRY_REPO`    | full registry repository (`host/path`)   |
+| `--registry-auth`     | `REGISTRY_AUTH`    | `base64(user:password)` registry auth    |
+| `--registry-ca-file`  | `REGISTRY_CA_FILE` | path to a PEM CA bundle (optional)       |
+| `--registry-scheme`   | `REGISTRY_SCHEME`  | `https` (default) or `http`              |
+
+`rpp-get` fetches the image manifest by digest, selects its last layer, and streams that layer's blob — the same gzipped tar archive RPP would return. Image signatures are not verified in direct mode; integrity is guaranteed by the manifest digest.

--- a/modules/007-registrypackages/images/rpp-get/src/config.go
+++ b/modules/007-registrypackages/images/rpp-get/src/config.go
@@ -42,6 +42,12 @@ type config struct {
 	endpoints      []string
 	token          string
 	packages       []string
+
+	registryDirect bool
+	registryRepo   string
+	registryAuth   string
+	registryCA     string
+	registryScheme string
 }
 
 type cliConfig struct {
@@ -49,7 +55,13 @@ type cliConfig struct {
 	rppEndpoints           string
 	rppToken               string
 	kubeAPIServerEndpoints string
+	registryCAFile         string
 }
+
+var (
+	errRegistryRepoRequired = errors.New("--registry-direct requires --registry-repo (or REGISTRY_REPO)")
+	errRegistryAuthRequired = errors.New("--registry-direct requires --registry-auth (or REGISTRY_AUTH)")
+)
 
 func defaultConfig() config {
 	return config{
@@ -77,6 +89,11 @@ func parseConfig(args []string) (cliConfig, error) {
 	fs.StringVar(&cli.rppPath, "rpp-path", cli.rppPath, "RPP additional path")
 	fs.StringVar(&cli.kubeAPIServerEndpoints, "kube-apiserver-endpoints", "", "Comma-separated kube-apiserver endpoints for bootstrap-token mode")
 	fs.BoolVar(&cli.force, "force", cli.force, "Force download and install even if package is already present")
+	fs.BoolVar(&cli.registryDirect, "registry-direct", false, "Download packages directly from the registry, bypassing rpp server")
+	fs.StringVar(&cli.registryRepo, "registry-repo", "", "Full registry repository (host/path) for direct mode")
+	fs.StringVar(&cli.registryAuth, "registry-auth", "", "base64(user:password) registry auth for direct mode")
+	fs.StringVar(&cli.registryCAFile, "registry-ca-file", "", "Path to a PEM CA bundle for the registry (direct mode)")
+	fs.StringVar(&cli.registryScheme, "registry-scheme", "", "Registry scheme: https (default) or http (direct mode)")
 
 	if err := fs.Parse(args[1:]); err != nil {
 		return cliConfig{}, err
@@ -90,11 +107,68 @@ func parseConfig(args []string) (cliConfig, error) {
 
 	cli.packages = fs.Args()
 
+	if err := cli.finalizeRegistry(); err != nil {
+		return cliConfig{}, err
+	}
+
 	return cli, nil
+}
+
+func envOrFlag(flagValue, envKey string) string {
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(envKey))
+}
+
+func resolveRegistryDirect(flagSet bool) bool {
+	if flagSet {
+		return true
+	}
+	v := strings.TrimSpace(os.Getenv("REGISTRY_DIRECT"))
+	return v == "true" || v == "1"
+}
+
+func (c *cliConfig) finalizeRegistry() error {
+	c.registryDirect = resolveRegistryDirect(c.registryDirect)
+	c.registryRepo = envOrFlag(c.registryRepo, "REGISTRY_REPO")
+	c.registryAuth = envOrFlag(c.registryAuth, "REGISTRY_AUTH")
+	c.registryScheme = envOrFlag(c.registryScheme, "REGISTRY_SCHEME")
+	caFile := envOrFlag(c.registryCAFile, "REGISTRY_CA_FILE")
+
+	if !c.registryDirect {
+		return nil
+	}
+
+	if c.registryRepo == "" {
+		return errRegistryRepoRequired
+	}
+	if c.registryAuth == "" {
+		return errRegistryAuthRequired
+	}
+	switch strings.ToLower(c.registryScheme) {
+	case "", "https", "http":
+	default:
+		return fmt.Errorf("invalid --registry-scheme %q, expected http or https", c.registryScheme)
+	}
+
+	if caFile != "" {
+		data, err := os.ReadFile(caFile)
+		if err != nil {
+			return fmt.Errorf("read registry CA file %q: %w", caFile, err)
+		}
+		c.registryCA = string(data)
+	}
+
+	return nil
 }
 
 func (c *cliConfig) resolve(ctx context.Context) error {
 	if c.mode == modeUninstall {
+		return nil
+	}
+
+	if c.registryDirect {
 		return nil
 	}
 

--- a/modules/007-registrypackages/images/rpp-get/src/config.go
+++ b/modules/007-registrypackages/images/rpp-get/src/config.go
@@ -39,6 +39,7 @@ type config struct {
 	rppRepository  string
 	rppPath        string
 	force          bool
+	extract        bool
 	endpoints      []string
 	token          string
 	packages       []string
@@ -89,6 +90,7 @@ func parseConfig(args []string) (cliConfig, error) {
 	fs.StringVar(&cli.rppPath, "rpp-path", cli.rppPath, "RPP additional path")
 	fs.StringVar(&cli.kubeAPIServerEndpoints, "kube-apiserver-endpoints", "", "Comma-separated kube-apiserver endpoints for bootstrap-token mode")
 	fs.BoolVar(&cli.force, "force", cli.force, "Force download and install even if package is already present")
+	fs.BoolVar(&cli.extract, "extract", cli.extract, "In fetch mode, stream-extract the archive instead of saving the .tar.gz (overlaps decompression with download)")
 	fs.BoolVar(&cli.registryDirect, "registry-direct", false, "Download packages directly from the registry, bypassing rpp server")
 	fs.StringVar(&cli.registryRepo, "registry-repo", "", "Full registry repository (host/path) for direct mode")
 	fs.StringVar(&cli.registryAuth, "registry-auth", "", "base64(user:password) registry auth for direct mode")

--- a/modules/007-registrypackages/images/rpp-get/src/config_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/config_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -88,6 +90,109 @@ func TestParseConfig(t *testing.T) {
 			t.Error("force = false, want true when --force passed")
 		}
 	})
+}
+
+func TestParseConfigRegistryDirectRequiresRepo(t *testing.T) {
+	t.Setenv("REGISTRY_REPO", "")
+	t.Setenv("REGISTRY_AUTH", "")
+
+	_, err := parseConfig([]string{"fetch", "--registry-direct", "pkg:sha256:abc"})
+	if err == nil {
+		t.Fatal("parseConfig() error = nil, want error for missing --registry-repo")
+	}
+}
+
+func TestParseConfigRegistryDirectRequiresAuth(t *testing.T) {
+	t.Setenv("REGISTRY_REPO", "")
+	t.Setenv("REGISTRY_AUTH", "")
+
+	_, err := parseConfig([]string{"fetch", "--registry-direct", "--registry-repo", "registry.local/repo", "pkg:sha256:abc"})
+	if err == nil {
+		t.Fatal("parseConfig() error = nil, want error for missing --registry-auth")
+	}
+}
+
+func TestParseConfigRegistryDirectValid(t *testing.T) {
+	t.Setenv("REGISTRY_REPO", "")
+	t.Setenv("REGISTRY_AUTH", "")
+
+	cli, err := parseConfig([]string{"fetch", "--registry-direct", "--registry-repo", "registry.local/repo", "--registry-auth", "YXV0aA==", "pkg:sha256:abc"})
+	if err != nil {
+		t.Fatalf("parseConfig() error = %v", err)
+	}
+	if !cli.registryDirect {
+		t.Error("registryDirect = false, want true")
+	}
+	if cli.registryRepo != "registry.local/repo" {
+		t.Errorf("registryRepo = %q, want %q", cli.registryRepo, "registry.local/repo")
+	}
+	if cli.registryAuth != "YXV0aA==" {
+		t.Errorf("registryAuth = %q, want %q", cli.registryAuth, "YXV0aA==")
+	}
+}
+
+func TestParseConfigRegistryDirectInvalidScheme(t *testing.T) {
+	t.Setenv("REGISTRY_REPO", "")
+	t.Setenv("REGISTRY_AUTH", "")
+
+	_, err := parseConfig([]string{"fetch", "--registry-direct", "--registry-repo", "registry.local/repo", "--registry-auth", "YXV0aA==", "--registry-scheme", "ftp", "pkg:sha256:abc"})
+	if err == nil {
+		t.Fatal("parseConfig() error = nil, want error for invalid scheme")
+	}
+}
+
+func TestParseConfigRegistryDirectFromEnv(t *testing.T) {
+	t.Setenv("REGISTRY_DIRECT", "true")
+	t.Setenv("REGISTRY_REPO", "registry.local/repo")
+	t.Setenv("REGISTRY_AUTH", "YXV0aA==")
+
+	cli, err := parseConfig([]string{"fetch", "pkg:sha256:abc"})
+	if err != nil {
+		t.Fatalf("parseConfig() error = %v", err)
+	}
+	if !cli.registryDirect {
+		t.Error("registryDirect = false, want true from REGISTRY_DIRECT env")
+	}
+	if cli.registryRepo != "registry.local/repo" {
+		t.Errorf("registryRepo = %q, want from env", cli.registryRepo)
+	}
+}
+
+func TestParseConfigRegistryCAFileIsRead(t *testing.T) {
+	t.Setenv("REGISTRY_REPO", "")
+	t.Setenv("REGISTRY_AUTH", "")
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	const pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+	if err := os.WriteFile(caPath, []byte(pem), 0o600); err != nil {
+		t.Fatalf("write ca file: %v", err)
+	}
+
+	cli, err := parseConfig([]string{"fetch", "--registry-direct", "--registry-repo", "registry.local/repo", "--registry-auth", "YXV0aA==", "--registry-ca-file", caPath, "pkg:sha256:abc"})
+	if err != nil {
+		t.Fatalf("parseConfig() error = %v", err)
+	}
+	if cli.registryCA != pem {
+		t.Errorf("registryCA = %q, want %q", cli.registryCA, pem)
+	}
+}
+
+func TestParseConfigNonDirectUnaffected(t *testing.T) {
+	cli, err := parseConfig([]string{"fetch", "pkg:sha256:abc"})
+	if err != nil {
+		t.Fatalf("parseConfig() error = %v", err)
+	}
+	if cli.registryDirect {
+		t.Error("registryDirect = true, want false by default")
+	}
+}
+
+func TestResolveSkipsWhenRegistryDirect(t *testing.T) {
+	cli := cliConfig{config: config{mode: modeFetch, registryDirect: true}}
+	if err := cli.resolve(context.Background()); err != nil {
+		t.Fatalf("resolve() error = %v, want nil in direct mode", err)
+	}
 }
 
 func TestParseEndpoints(t *testing.T) {

--- a/modules/007-registrypackages/images/rpp-get/src/main.go
+++ b/modules/007-registrypackages/images/rpp-get/src/main.go
@@ -93,6 +93,7 @@ func run(ctx context.Context, logger *log.Logger) error {
 		Retries:        cfg.retries,
 		RetryDelay:     cfg.retryDelay,
 		Force:          cfg.force,
+		Extract:        cfg.extract,
 		TempDir:        cfg.tempDir,
 		InstalledStore: cfg.installedStore,
 		RegistryDirect: cfg.registryDirect,

--- a/modules/007-registrypackages/images/rpp-get/src/main.go
+++ b/modules/007-registrypackages/images/rpp-get/src/main.go
@@ -95,6 +95,11 @@ func run(ctx context.Context, logger *log.Logger) error {
 		Force:          cfg.force,
 		TempDir:        cfg.tempDir,
 		InstalledStore: cfg.installedStore,
+		RegistryDirect: cfg.registryDirect,
+		RegistryRepo:   cfg.registryRepo,
+		RegistryAuth:   cfg.registryAuth,
+		RegistryCA:     cfg.registryCA,
+		RegistryScheme: cfg.registryScheme,
 	}
 
 	client := rpp.NewClient(rppCfg, logger, recorder)

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/archive.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/archive.go
@@ -43,6 +43,30 @@ func extractTarGz(ctx context.Context, src, dst string) error {
 	return fmt.Errorf("%w: %s", err, message)
 }
 
+// extractTarGzStream extracts a gzip-compressed tar read from r into dst without
+// buffering the archive to disk first, so the gzip inflate runs concurrently
+// with the network read feeding r. gzip (-z) is forced because tar cannot
+// auto-detect compression from a non-seekable pipe; registry package layers are
+// always gzip (application/vnd.*.tar+gzip).
+func extractTarGzStream(ctx context.Context, r io.Reader, dst string) error {
+	ctx, cancel := context.WithTimeout(ctx, archiveExtractTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "tar", "-xz", "-f", "-", "-C", dst)
+	cmd.Stdin = r
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	message := strings.TrimSpace(string(output))
+	if message == "" {
+		return err
+	}
+
+	return fmt.Errorf("%w: %s", err, message)
+}
+
 func copyFile(src, dst string) error {
 	info, err := os.Stat(src)
 	if err != nil {

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/archive_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/archive_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rpp
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractTarGzStream(t *testing.T) {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	content := []byte("hello from install\n")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "install",
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+
+	dst := t.TempDir()
+	require.NoError(t, extractTarGzStream(context.Background(), &buf, dst))
+
+	got, err := os.ReadFile(filepath.Join(dst, "install"))
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
@@ -37,6 +37,7 @@ type Config struct {
 	Retries        int
 	RetryDelay     time.Duration
 	Force          bool
+	Extract        bool
 	TempDir        string
 	InstalledStore string
 
@@ -52,6 +53,7 @@ type packageRef struct {
 	name         string
 	digest       string
 	archivePath  string
+	extractDir   string
 	installedDir string
 }
 
@@ -223,6 +225,7 @@ func (c *Client) newPackageRef(packageWithDigest string) (packageRef, error) {
 		name:         name,
 		digest:       digest,
 		archivePath:  filepath.Join(defaultFetchedStore(c.cfg.TempDir), name, digest+".tar.gz"),
+		extractDir:   filepath.Join(defaultFetchedStore(c.cfg.TempDir), name, digest+".extracted"),
 		installedDir: filepath.Join(c.cfg.InstalledStore, name),
 	}, nil
 }
@@ -374,7 +377,66 @@ func (c *Client) fetchPackage(ctx context.Context, ref packageRef) error {
 		return nil
 	}
 
+	if c.cfg.Extract {
+		return c.ensureExtracted(ctx, ref)
+	}
+
 	return c.ensureFetchedArchive(ctx, ref)
+}
+
+func (c *Client) ensureExtracted(ctx context.Context, ref packageRef) error {
+	if !c.cfg.Force {
+		extracted, err := c.isExtracted(ref)
+		if err != nil {
+			return err
+		}
+		if extracted {
+			c.logf(ref, "'%s' package already extracted", ref.raw)
+			return nil
+		}
+	}
+
+	c.logf(ref, "downloading and extracting '%s' to %s", ref.raw, ref.extractDir)
+	if err := c.retry(ctx, ref, c.cfg.Retries, shouldRetryFetch, func() error {
+		return c.downloadAndExtractOnce(ctx, ref)
+	}); err != nil {
+		return ref.errorf("download+extract %s: %w", ref.digest, err)
+	}
+	return nil
+}
+
+func (c *Client) isExtracted(ref packageRef) (bool, error) {
+	entries, err := os.ReadDir(ref.extractDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, ref.wrapErr("read extract dir", err)
+	}
+	return len(entries) > 0, nil
+}
+
+func (c *Client) downloadAndExtractOnce(ctx context.Context, ref packageRef) error {
+	if err := os.RemoveAll(ref.extractDir); err != nil {
+		return ref.wrapErr("clean extract dir", err)
+	}
+	if err := os.MkdirAll(ref.extractDir, 0o755); err != nil {
+		return ref.wrapErr("create extract dir", err)
+	}
+
+	start := time.Now()
+	body, source, err := c.fetcher.Get(ctx, ref.digest)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	if err := extractTarGzStream(ctx, body, ref.extractDir); err != nil {
+		return ref.errorf("stream extract %s: %w", ref.digest, err)
+	}
+
+	c.logf(ref, "downloaded+extracted from %s in %s", source, time.Since(start).Truncate(time.Millisecond))
+	return nil
 }
 
 func (c *Client) shouldSkipInstalled(ref packageRef) (bool, error) {

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
@@ -39,6 +39,12 @@ type Config struct {
 	Force          bool
 	TempDir        string
 	InstalledStore string
+
+	RegistryDirect bool
+	RegistryRepo   string
+	RegistryAuth   string
+	RegistryCA     string
+	RegistryScheme string
 }
 
 type packageRef struct {
@@ -62,7 +68,7 @@ func (r packageRef) errorf(msg string, args ...any) error {
 
 type Client struct {
 	cfg            Config
-	httpClient     *httpClient
+	fetcher        fetcher
 	logger         *log.Logger
 	resultRecorder *ResultRecorder
 }
@@ -70,7 +76,7 @@ type Client struct {
 func NewClient(cfg Config, logger *log.Logger, recorder *ResultRecorder) *Client {
 	return &Client{
 		cfg:            cfg,
-		httpClient:     newHTTPClient(cfg),
+		fetcher:        newFetcher(cfg),
 		logger:         logger,
 		resultRecorder: recorder,
 	}
@@ -104,9 +110,12 @@ func (c *Client) Classify(packages []string) ([]InstallStatus, error) {
 }
 
 func (c *Client) UpdateAuth(endpoints []string, token string) {
+	if c.cfg.RegistryDirect {
+		return
+	}
 	c.cfg.Endpoints = endpoints
 	c.cfg.Token = token
-	c.httpClient = newHTTPClient(c.cfg)
+	c.fetcher = newHTTPClient(c.cfg)
 }
 
 // installWorkerCount caps install parallelism at runtime.NumCPU because install
@@ -332,17 +341,17 @@ func (c *Client) fetchArchive(ctx context.Context, ref packageRef) error {
 
 func (c *Client) downloadOnce(ctx context.Context, ref packageRef) error {
 	start := time.Now()
-	response, err := c.httpClient.Get(ctx, ref.digest)
+	body, source, err := c.fetcher.Get(ctx, ref.digest)
 	if err != nil {
 		return err
 	}
-	defer response.Body.Close()
+	defer body.Close()
 	httpDur := time.Since(start)
 
 	bodyStart := time.Now()
-	n, err := writeResponseBody(ref.archivePath, response.Body)
+	n, err := writeResponseBody(ref.archivePath, body)
 	if err != nil {
-		return fmt.Errorf("write response body from %s: %w", response.Request.URL.String(), err)
+		return fmt.Errorf("write response body from %s: %w", source, err)
 	}
 	bodyDur := time.Since(bodyStart)
 
@@ -352,7 +361,7 @@ func (c *Client) downloadOnce(ctx context.Context, ref packageRef) error {
 		throughput = fmt.Sprintf(", %.2f MB/s", mbps)
 	}
 	c.logf(ref, "archive downloaded from %s: %d bytes, http=%s body=%s%s",
-		response.Request.URL.Host, n, httpDur.Truncate(time.Millisecond), bodyDur.Truncate(time.Millisecond), throughput)
+		source, n, httpDur.Truncate(time.Millisecond), bodyDur.Truncate(time.Millisecond), throughput)
 	return nil
 }
 

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/client.go
@@ -282,23 +282,41 @@ func (c *Client) installPackageOnce(ctx context.Context, ref packageRef) error {
 	}
 	skipCheckDur := time.Since(t)
 
-	t = time.Now()
-	if err := c.ensureFetchedArchive(ctx, ref); err != nil {
-		return err
-	}
-	fetchDur := time.Since(t)
-
-	workDir, err := c.createWorkDir(ref)
+	preExtracted, err := c.isExtracted(ref)
 	if err != nil {
 		return err
 	}
-	defer c.cleanupWorkDir(ref, workDir)
 
-	t = time.Now()
-	if err := c.extractArchive(ctx, ref, workDir); err != nil {
-		return err
+	var (
+		workDir    string
+		fetchDur   time.Duration
+		extractDur time.Duration
+	)
+	if preExtracted && !c.cfg.Force {
+		// Prefetch (`fetch --extract`) already downloaded and decompressed this
+		// package; install straight from that directory and skip the download
+		// and extraction on the critical path.
+		workDir = ref.extractDir
+		c.logf(ref, "using pre-extracted package at %s", workDir)
+	} else {
+		t = time.Now()
+		if err := c.ensureFetchedArchive(ctx, ref); err != nil {
+			return err
+		}
+		fetchDur = time.Since(t)
+
+		workDir, err = c.createWorkDir(ref)
+		if err != nil {
+			return err
+		}
+
+		t = time.Now()
+		if err := c.extractArchive(ctx, ref, workDir); err != nil {
+			return err
+		}
+		extractDur = time.Since(t)
 	}
-	extractDur := time.Since(t)
+	defer c.cleanupWorkDir(ref, workDir)
 
 	t = time.Now()
 	if err := c.runInstallScript(ctx, ref, workDir); err != nil {

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/client_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/client_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rpp
+
+import "testing"
+
+func TestNewFetcherSelectsBackend(t *testing.T) {
+	direct := newFetcher(Config{RegistryDirect: true, RegistryRepo: "registry.local/repo", RegistryAuth: "x"})
+	if _, ok := direct.(*directClient); !ok {
+		t.Fatalf("RegistryDirect=true: got %T, want *directClient", direct)
+	}
+
+	proxy := newFetcher(Config{Endpoints: []string{"1.2.3.4:4219"}})
+	if _, ok := proxy.(*httpClient); !ok {
+		t.Fatalf("RegistryDirect=false: got %T, want *httpClient", proxy)
+	}
+}
+
+func TestUpdateAuthIsNoOpInDirectMode(t *testing.T) {
+	c := NewClient(Config{RegistryDirect: true, RegistryRepo: "registry.local/repo", RegistryAuth: "x"}, nil, nil)
+	before := c.fetcher
+
+	c.UpdateAuth([]string{"5.6.7.8:4219"}, "tok")
+
+	if c.fetcher != before {
+		t.Error("UpdateAuth replaced the fetcher in direct mode, want unchanged")
+	}
+	if _, ok := c.fetcher.(*directClient); !ok {
+		t.Fatalf("fetcher = %T, want *directClient", c.fetcher)
+	}
+}

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/direct.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/direct.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -143,6 +144,9 @@ type directClient struct {
 	repository string
 	auth       string
 	scheme     string
+
+	mu    sync.Mutex
+	token string // cached Bearer token, shared across manifest/blob requests
 }
 
 func newDirectClient(cfg Config) *directClient {
@@ -235,13 +239,15 @@ func (c *directClient) fetchBlob(ctx context.Context, host, repoPath, digest str
 }
 
 func (c *directClient) doRegistryGet(ctx context.Context, requestURL, accept string) (*http.Response, error) {
-	resp, err := c.sendGet(ctx, requestURL, accept, c.basicAuthHeader())
+	usedToken := c.cachedToken()
+
+	resp, err := c.sendGet(ctx, requestURL, accept, c.authorization(usedToken))
 	if err != nil {
 		return nil, err
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		token, tokenErr := c.fetchBearerToken(ctx, resp)
+		token, tokenErr := c.refreshToken(ctx, resp, usedToken)
 		resp.Body.Close()
 		if tokenErr != nil {
 			return nil, tokenErr
@@ -260,6 +266,44 @@ func (c *directClient) doRegistryGet(ctx context.Context, requestURL, accept str
 	}
 
 	return resp, nil
+}
+
+func (c *directClient) cachedToken() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.token
+}
+
+// authorization returns the header for an outgoing request: a cached Bearer
+// token if we have one, otherwise the Basic credentials used to bootstrap the
+// first token.
+func (c *directClient) authorization(token string) string {
+	if token != "" {
+		return "Bearer " + token
+	}
+	return c.basicAuthHeader()
+}
+
+// refreshToken exchanges the Basic credentials for a Bearer token using the 401
+// challenge, caches it, and returns it. usedToken is the token that just got
+// rejected; if another goroutine already refreshed past it, that token is
+// reused instead of fetching again. Holding the lock across the fetch serializes
+// concurrent refreshers so only one token request is made per challenge.
+func (c *directClient) refreshToken(ctx context.Context, challenge *http.Response, usedToken string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.token != "" && c.token != usedToken {
+		return c.token, nil
+	}
+
+	token, err := c.fetchBearerToken(ctx, challenge)
+	if err != nil {
+		return "", err
+	}
+
+	c.token = token
+	return token, nil
 }
 
 func (c *directClient) sendGet(ctx context.Context, requestURL, accept, authorization string) (*http.Response, error) {

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/direct.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/direct.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rpp
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	registrySchemeHTTPS = "https"
+	registrySchemeHTTP  = "http"
+
+	manifestAccept = "application/vnd.oci.image.manifest.v1+json," +
+		"application/vnd.docker.distribution.manifest.v2+json"
+)
+
+func splitRepository(repository string) (string, string) {
+	repository = strings.Trim(strings.TrimSpace(repository), "/")
+	host, repoPath, ok := strings.Cut(repository, "/")
+	if !ok || host == "" || repoPath == "" {
+		return "", ""
+	}
+	return host, repoPath
+}
+
+func registrySchemeOrDefault(scheme string) string {
+	if strings.ToLower(strings.TrimSpace(scheme)) == registrySchemeHTTP {
+		return registrySchemeHTTP
+	}
+	return registrySchemeHTTPS
+}
+
+func buildManifestURL(scheme, host, repoPath, digest string) string {
+	return fmt.Sprintf("%s://%s/v2/%s/manifests/%s", scheme, host, repoPath, digest)
+}
+
+func buildBlobURL(scheme, host, repoPath, digest string) string {
+	return fmt.Sprintf("%s://%s/v2/%s/blobs/%s", scheme, host, repoPath, digest)
+}
+
+func parseWWWAuthenticate(header string) (realm, service, scope string, ok bool) {
+	header = strings.TrimSpace(header)
+	const prefix = "Bearer "
+	if len(header) < len(prefix) || !strings.EqualFold(header[:len(prefix)], prefix) {
+		return "", "", "", false
+	}
+
+	params := parseAuthParams(header[len(prefix):])
+	realm = params["realm"]
+	if realm == "" {
+		return "", "", "", false
+	}
+	return realm, params["service"], params["scope"], true
+}
+
+func parseAuthParams(s string) map[string]string {
+	params := make(map[string]string)
+	for _, part := range strings.Split(s, ",") {
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.Trim(strings.TrimSpace(value), `"`)
+		if key != "" {
+			params[key] = value
+		}
+	}
+	return params
+}
+
+func selectLastLayerDigest(manifest []byte) (string, error) {
+	var parsed struct {
+		MediaType string            `json:"mediaType"`
+		Manifests []json.RawMessage `json:"manifests"`
+		Layers    []struct {
+			Digest string `json:"digest"`
+		} `json:"layers"`
+	}
+	if err := json.Unmarshal(manifest, &parsed); err != nil {
+		return "", fmt.Errorf("parse manifest: %w", err)
+	}
+	if len(parsed.Manifests) > 0 {
+		return "", fmt.Errorf("manifest is an index/list, not a single image manifest")
+	}
+	if len(parsed.Layers) == 0 {
+		return "", fmt.Errorf("manifest has no layers")
+	}
+	digest := parsed.Layers[len(parsed.Layers)-1].Digest
+	if digest == "" {
+		return "", fmt.Errorf("last layer has empty digest")
+	}
+	return digest, nil
+}
+
+func buildTokenURL(realm, service, scope string) (string, error) {
+	u, err := url.Parse(realm)
+	if err != nil {
+		return "", fmt.Errorf("parse token realm %q: %w", realm, err)
+	}
+	q := u.Query()
+	if service != "" {
+		q.Set("service", service)
+	}
+	if scope != "" {
+		q.Set("scope", scope)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func readErrorBody(body io.Reader) string {
+	data, _ := io.ReadAll(io.LimitReader(body, 255))
+	return strings.TrimSpace(string(data))
+}
+
+type directClient struct {
+	client     *http.Client
+	repository string
+	auth       string
+	scheme     string
+}
+
+func newDirectClient(cfg Config) *directClient {
+	return &directClient{
+		client:     newDirectHTTPClient(cfg.RegistryCA),
+		repository: cfg.RegistryRepo,
+		auth:       cfg.RegistryAuth,
+		scheme:     registrySchemeOrDefault(cfg.RegistryScheme),
+	}
+}
+
+func newDirectHTTPClient(ca string) *http.Client {
+	tlsConfig := &tls.Config{}
+	if ca != "" {
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		pool.AppendCertsFromPEM([]byte(ca))
+		tlsConfig.RootCAs = pool
+	}
+
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: (&net.Dialer{
+			Timeout:   connectTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		TLSHandshakeTimeout:   connectTimeout,
+		IdleConnTimeout:       90 * time.Second,
+		ExpectContinueTimeout: time.Second,
+		TLSClientConfig:       tlsConfig,
+	}
+
+	return &http.Client{Transport: transport}
+}
+
+func (c *directClient) Get(ctx context.Context, digest string) (io.ReadCloser, string, error) {
+	if err := validateDigest(digest); err != nil {
+		return nil, "", err
+	}
+	digest = strings.TrimSpace(digest)
+
+	host, repoPath := splitRepository(c.repository)
+	if host == "" || repoPath == "" {
+		return nil, "", fmt.Errorf("invalid registry repository %q, expected host/path", c.repository)
+	}
+
+	manifest, err := c.fetchManifest(ctx, host, repoPath, digest)
+	if err != nil {
+		return nil, "", err
+	}
+
+	layerDigest, err := selectLastLayerDigest(manifest)
+	if err != nil {
+		return nil, "", fmt.Errorf("select layer for %s: %w", digest, err)
+	}
+
+	body, err := c.fetchBlob(ctx, host, repoPath, layerDigest)
+	if err != nil {
+		return nil, "", err
+	}
+	return body, host, nil
+}
+
+func (c *directClient) fetchManifest(ctx context.Context, host, repoPath, digest string) ([]byte, error) {
+	manifestURL := buildManifestURL(c.scheme, host, repoPath, digest)
+
+	resp, err := c.doRegistryGet(ctx, manifestURL, manifestAccept)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest body: %w", err)
+	}
+	return body, nil
+}
+
+func (c *directClient) fetchBlob(ctx context.Context, host, repoPath, digest string) (io.ReadCloser, error) {
+	blobURL := buildBlobURL(c.scheme, host, repoPath, digest)
+	resp, err := c.doRegistryGet(ctx, blobURL, "")
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+func (c *directClient) doRegistryGet(ctx context.Context, requestURL, accept string) (*http.Response, error) {
+	resp, err := c.sendGet(ctx, requestURL, accept, c.basicAuthHeader())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		token, tokenErr := c.fetchBearerToken(ctx, resp)
+		resp.Body.Close()
+		if tokenErr != nil {
+			return nil, tokenErr
+		}
+
+		resp, err = c.sendGet(ctx, requestURL, accept, "Bearer "+token)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		bodyText := readErrorBody(resp.Body)
+		resp.Body.Close()
+		return nil, &httpStatusError{packageURL: requestURL, statusCode: resp.StatusCode, body: bodyText}
+	}
+
+	return resp, nil
+}
+
+func (c *directClient) sendGet(ctx context.Context, requestURL, accept, authorization string) (*http.Response, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if accept != "" {
+		request.Header.Set("Accept", accept)
+	}
+	if authorization != "" {
+		request.Header.Set("Authorization", authorization)
+	}
+
+	response, err := c.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("request %s: %w", requestURL, err)
+	}
+	return response, nil
+}
+
+func (c *directClient) basicAuthHeader() string {
+	if c.auth == "" {
+		return ""
+	}
+	return "Basic " + c.auth
+}
+
+func (c *directClient) fetchBearerToken(ctx context.Context, challenge *http.Response) (string, error) {
+	realm, service, scope, ok := parseWWWAuthenticate(challenge.Header.Get("WWW-Authenticate"))
+	if !ok {
+		return "", fmt.Errorf("registry returned 401 without a usable Bearer challenge")
+	}
+
+	tokenURL, err := buildTokenURL(realm, service, scope)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := c.sendGet(ctx, tokenURL, "", c.basicAuthHeader())
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", &httpStatusError{packageURL: tokenURL, statusCode: resp.StatusCode, body: readErrorBody(resp.Body)}
+	}
+
+	var payload struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode token response: %w", err)
+	}
+
+	if payload.Token != "" {
+		return payload.Token, nil
+	}
+	if payload.AccessToken != "" {
+		return payload.AccessToken, nil
+	}
+	return "", fmt.Errorf("token response contained no token")
+}

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/direct_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/direct_test.go
@@ -198,6 +198,65 @@ func TestDirectClientGet(t *testing.T) {
 	}
 }
 
+func TestDirectClientReusesToken(t *testing.T) {
+	const (
+		repoPath    = "deckhouse/ce"
+		layerDigest = "sha256:layer"
+		blobContent = "blob"
+		basicAuth   = "dXNlcjpwYXNz"
+	)
+	digests := []string{"sha256:first", "sha256:second"}
+
+	var serverURL string
+	var tokenHits int
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		tokenHits++
+		_, _ = w.Write([]byte(`{"token":"bearer-xyz"}`))
+	})
+	challenge := func(w http.ResponseWriter) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="`+serverURL+`/token",service="registry"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}
+	for _, d := range digests {
+		mux.HandleFunc("/v2/"+repoPath+"/manifests/"+d, func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer bearer-xyz" {
+				challenge(w)
+				return
+			}
+			_, _ = w.Write([]byte(`{"layers":[{"digest":"` + layerDigest + `"}]}`))
+		})
+	}
+	mux.HandleFunc("/v2/"+repoPath+"/blobs/"+layerDigest, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer bearer-xyz" {
+			challenge(w)
+			return
+		}
+		_, _ = w.Write([]byte(blobContent))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	serverURL = server.URL
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	client := newDirectClient(Config{
+		RegistryRepo:   host + "/" + repoPath,
+		RegistryAuth:   basicAuth,
+		RegistryScheme: "http",
+	})
+
+	for _, d := range digests {
+		body, _, err := client.Get(context.Background(), d)
+		require.NoError(t, err)
+		_, _ = io.ReadAll(body)
+		body.Close()
+	}
+
+	assert.Equal(t, 1, tokenHits, "token endpoint should be hit once across both Get calls")
+}
+
 func TestDirectClientGetNotFound(t *testing.T) {
 	const repoPath = "deckhouse/ce"
 	mux := http.NewServeMux()

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/direct_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/direct_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rpp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitRepository(t *testing.T) {
+	tests := []struct {
+		name     string
+		repo     string
+		wantHost string
+		wantPath string
+	}{
+		{name: "host and path", repo: "dev-registry.deckhouse.io/deckhouse/ce", wantHost: "dev-registry.deckhouse.io", wantPath: "deckhouse/ce"},
+		{name: "single segment path", repo: "registry.local/repo", wantHost: "registry.local", wantPath: "repo"},
+		{name: "trailing slash", repo: "registry.local/repo/", wantHost: "registry.local", wantPath: "repo"},
+		{name: "host only", repo: "registry.local", wantHost: "", wantPath: ""},
+		{name: "empty", repo: "", wantHost: "", wantPath: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, path := splitRepository(tt.repo)
+			assert.Equal(t, tt.wantHost, host)
+			assert.Equal(t, tt.wantPath, path)
+		})
+	}
+}
+
+func TestRegistrySchemeOrDefault(t *testing.T) {
+	assert.Equal(t, "https", registrySchemeOrDefault(""))
+	assert.Equal(t, "https", registrySchemeOrDefault("https"))
+	assert.Equal(t, "https", registrySchemeOrDefault("HTTPS"))
+	assert.Equal(t, "http", registrySchemeOrDefault("http"))
+	assert.Equal(t, "http", registrySchemeOrDefault(" HTTP "))
+}
+
+func TestBuildManifestURL(t *testing.T) {
+	got := buildManifestURL("https", "registry.local", "deckhouse/ce", "sha256:abc123")
+	assert.Equal(t, "https://registry.local/v2/deckhouse/ce/manifests/sha256:abc123", got)
+}
+
+func TestBuildBlobURL(t *testing.T) {
+	got := buildBlobURL("http", "registry.local", "deckhouse/ce", "sha256:layer1")
+	assert.Equal(t, "http://registry.local/v2/deckhouse/ce/blobs/sha256:layer1", got)
+}
+
+func TestParseWWWAuthenticate(t *testing.T) {
+	t.Run("full bearer challenge", func(t *testing.T) {
+		realm, service, scope, ok := parseWWWAuthenticate(`Bearer realm="https://auth.local/token",service="registry.local",scope="repository:deckhouse/ce:pull"`)
+		require.True(t, ok)
+		assert.Equal(t, "https://auth.local/token", realm)
+		assert.Equal(t, "registry.local", service)
+		assert.Equal(t, "repository:deckhouse/ce:pull", scope)
+	})
+	t.Run("realm only", func(t *testing.T) {
+		realm, service, scope, ok := parseWWWAuthenticate(`Bearer realm="https://auth.local/token"`)
+		require.True(t, ok)
+		assert.Equal(t, "https://auth.local/token", realm)
+		assert.Equal(t, "", service)
+		assert.Equal(t, "", scope)
+	})
+	t.Run("not bearer", func(t *testing.T) {
+		_, _, _, ok := parseWWWAuthenticate(`Basic realm="x"`)
+		assert.False(t, ok)
+	})
+	t.Run("bearer without realm", func(t *testing.T) {
+		_, _, _, ok := parseWWWAuthenticate(`Bearer service="x"`)
+		assert.False(t, ok)
+	})
+	t.Run("empty", func(t *testing.T) {
+		_, _, _, ok := parseWWWAuthenticate("")
+		assert.False(t, ok)
+	})
+}
+
+func TestSelectLastLayerDigest(t *testing.T) {
+	t.Run("multiple layers returns last", func(t *testing.T) {
+		manifest := []byte(`{"mediaType":"application/vnd.oci.image.manifest.v1+json","layers":[{"digest":"sha256:first"},{"digest":"sha256:last"}]}`)
+		digest, err := selectLastLayerDigest(manifest)
+		require.NoError(t, err)
+		assert.Equal(t, "sha256:last", digest)
+	})
+	t.Run("index is rejected", func(t *testing.T) {
+		manifest := []byte(`{"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"digest":"sha256:a"}]}`)
+		_, err := selectLastLayerDigest(manifest)
+		require.Error(t, err)
+	})
+	t.Run("no layers", func(t *testing.T) {
+		manifest := []byte(`{"layers":[]}`)
+		_, err := selectLastLayerDigest(manifest)
+		require.Error(t, err)
+	})
+	t.Run("empty layer digest", func(t *testing.T) {
+		manifest := []byte(`{"layers":[{"digest":""}]}`)
+		_, err := selectLastLayerDigest(manifest)
+		require.Error(t, err)
+	})
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := selectLastLayerDigest([]byte(`not json`))
+		require.Error(t, err)
+	})
+}
+
+func TestBuildTokenURL(t *testing.T) {
+	got, err := buildTokenURL("https://auth.local/token", "registry.local", "repository:deckhouse/ce:pull")
+	require.NoError(t, err)
+	assert.Equal(t, "https://auth.local/token?scope=repository%3Adeckhouse%2Fce%3Apull&service=registry.local", got)
+}
+
+func TestDirectClientGet(t *testing.T) {
+	const (
+		repoPath       = "deckhouse/ce"
+		manifestDigest = "sha256:manifestdigest"
+		layerDigest    = "sha256:layerdigest"
+		blobContent    = "gzipped-tar-layer-bytes"
+		basicAuth      = "dXNlcjpwYXNz" // base64("user:pass")
+	)
+
+	var serverURL string
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Basic "+basicAuth {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"token":"bearer-xyz"}`))
+	})
+
+	mux.HandleFunc("/v2/"+repoPath+"/manifests/"+manifestDigest, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer bearer-xyz" {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="`+serverURL+`/token",service="registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(`{"mediaType":"application/vnd.oci.image.manifest.v1+json","layers":[{"digest":"` + layerDigest + `"}]}`))
+	})
+
+	mux.HandleFunc("/v2/"+repoPath+"/blobs/"+layerDigest, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer bearer-xyz" {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="`+serverURL+`/token",service="registry"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = w.Write([]byte(blobContent))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	serverURL = server.URL
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	client := newDirectClient(Config{
+		RegistryRepo:   host + "/" + repoPath,
+		RegistryAuth:   basicAuth,
+		RegistryScheme: "http",
+	})
+
+	body, source, err := client.Get(context.Background(), manifestDigest)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read body error = %v", err)
+	}
+	if string(got) != blobContent {
+		t.Errorf("body = %q, want %q", string(got), blobContent)
+	}
+	if source != host {
+		t.Errorf("source = %q, want %q", source, host)
+	}
+}
+
+func TestDirectClientGetNotFound(t *testing.T) {
+	const repoPath = "deckhouse/ce"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/"+repoPath+"/manifests/sha256:missing", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+	client := newDirectClient(Config{
+		RegistryRepo:   host + "/" + repoPath,
+		RegistryScheme: "http",
+	})
+
+	_, _, err := client.Get(context.Background(), "sha256:missing")
+	if err == nil {
+		t.Fatal("Get() error = nil, want error")
+	}
+	if shouldRetryFetch(err) {
+		t.Error("shouldRetryFetch(404) = true, want false")
+	}
+}

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/fetcher.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/fetcher.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 Flant JSC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rpp
+
+import (
+	"context"
+	"io"
+)
+
+// fetcher retrieves a package archive (a gzipped tar of the image's last layer)
+// for a given OCI manifest digest. source is a human-readable origin (host) used
+// only for logging.
+type fetcher interface {
+	Get(ctx context.Context, digest string) (io.ReadCloser, string, error)
+}
+
+func newFetcher(cfg Config) fetcher {
+	if cfg.RegistryDirect {
+		return newDirectClient(cfg)
+	}
+	return newHTTPClient(cfg)
+}

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/http.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/http.go
@@ -80,20 +80,24 @@ func newBaseHTTPClient() *http.Client {
 	return &http.Client{Transport: transport}
 }
 
-func (c *httpClient) Get(ctx context.Context, digest string) (*http.Response, error) {
+func (c *httpClient) Get(ctx context.Context, digest string) (io.ReadCloser, string, error) {
 	if err := validateDigest(digest); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	digest = strings.TrimSpace(digest)
 
 	if len(c.endpoints) == 0 {
-		return nil, errNoEndpoints
+		return nil, "", errNoEndpoints
 	}
 
 	endpoint := c.endpoints[rand.IntN(len(c.endpoints))]
 
 	packageURL := buildPackageURL(endpoint, digest, c.repository, c.path)
-	return c.doGet(ctx, packageURL, c.token)
+	response, err := c.doGet(ctx, packageURL, c.token)
+	if err != nil {
+		return nil, "", err
+	}
+	return response.Body, response.Request.URL.Host, nil
 }
 
 func (c *httpClient) doGet(ctx context.Context, packageURL, token string) (*http.Response, error) {

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/install_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/install_test.go
@@ -194,7 +194,7 @@ func TestInstallPackageRetriesAndSucceeds(t *testing.T) {
 	client.cfg.Token = token
 	client.cfg.RetryDelay = 0
 	client.cfg.Retries = 1
-	client.httpClient = newHTTPClient(client.cfg)
+	client.fetcher = newHTTPClient(client.cfg)
 	ref := mustPackageRef(t, client, "zeta:sha256:retrysuccess")
 
 	if err := client.installPackage(context.Background(), ref); err != nil {
@@ -230,7 +230,7 @@ func TestInstallPackageFailsAfterRetriesAndCleansUp(t *testing.T) {
 	client.cfg.Token = token
 	client.cfg.RetryDelay = 0
 	client.cfg.Retries = 1
-	client.httpClient = newHTTPClient(client.cfg)
+	client.fetcher = newHTTPClient(client.cfg)
 	ref := mustPackageRef(t, client, "eta:sha256:retryfail")
 
 	err := client.installPackage(context.Background(), ref)
@@ -319,7 +319,7 @@ func TestInstallAllReturnsErrorWhenOnePackageFails(t *testing.T) {
 	client.cfg.Token = token
 	client.cfg.RetryDelay = 0
 	client.cfg.Retries = 1
-	client.httpClient = newHTTPClient(client.cfg)
+	client.fetcher = newHTTPClient(client.cfg)
 
 	goodRef := mustPackageRef(t, client, "kappa:sha256:allgood3")
 	badRef := mustPackageRef(t, client, "lambda:sha256:allbad1")

--- a/modules/007-registrypackages/images/rpp-get/src/rpp/install_test.go
+++ b/modules/007-registrypackages/images/rpp-get/src/rpp/install_test.go
@@ -397,6 +397,29 @@ func TestUninstallAllWritesResultFile(t *testing.T) {
 	})
 }
 
+func TestInstallUsesPreExtracted(t *testing.T) {
+	client := newTestClient(t, nil) // no endpoints: any network fetch would fail
+	ref := mustPackageRef(t, client, "pre:sha256:abcdef")
+
+	marker := filepath.Join(t.TempDir(), "install-ran")
+
+	// Simulate `fetch --extract`: populate the extract dir directly, no archive.
+	assertNoError(t, os.MkdirAll(ref.extractDir, 0o755))
+	assertNoError(t, os.WriteFile(filepath.Join(ref.extractDir, "install"),
+		[]byte("#!/usr/bin/env bash\nset -e\necho ok > "+marker+"\n"), 0o755))
+	assertNoError(t, os.WriteFile(filepath.Join(ref.extractDir, "uninstall"),
+		[]byte("#!/usr/bin/env bash\nexit 0\n"), 0o755))
+
+	if err := client.installPackage(context.Background(), ref); err != nil {
+		t.Fatalf("installPackage() error = %v", err)
+	}
+
+	assertPathExists(t, marker)
+	assertFileContent(t, filepath.Join(ref.installedDir, "digest"), ref.digest+"\n")
+	assertPathExists(t, filepath.Join(ref.installedDir, "install"))
+	assertPathExists(t, filepath.Join(ref.installedDir, "uninstall"))
+}
+
 func newTestClient(t *testing.T, endpoints []string) *Client {
 	t.Helper()
 


### PR DESCRIPTION
## Description

`rpp-get` (registry packages downloader run on nodes during bootstrap) and its bashible wiring.

- **rpp-get: direct registry mode** (`--registry-direct`, env `REGISTRY_DIRECT/REPO/AUTH/CA_FILE/SCHEME`). Pulls package layers straight from the OCI registry over Distribution v2 (manifest-by-digest → last layer → blob), bypassing `registry-packages-proxy`. Stdlib only, no new deps. Bearer token fetched once and reused across requests. In this mode RPP-endpoint and kube-apiserver resolution are skipped.
- **rpp-get: streaming extract** (`fetch --extract`). Pipes the layer blob through `tar` in a single pass, overlapping download with decompression and dropping the intermediate `.tar.gz`.
- **rpp-get: prefetch consumption.** `install` uses a pre-extracted `<digest>.extracted/` dir when present, otherwise falls back to the existing download+extract path.
- **candi/bashible (bootstrap):** `001_prefetch_registry_packages` runs `rpp-get fetch --extract`; for registry mode `!= Local` it exports `REGISTRY_*` into the prefetch env (Direct/Unmanaged → `imagesBase` + host mirror; Proxy → `bootstrap.proxy`). Vars are confined to the prefetch env file; on direct failure the prefetch unit fails and install steps fall back to inline fetch over the rpp proxy.
- **candi/bashible:** `bb-rpp-wait-fetched` now treats the `.extracted` dir as fetched, in addition to `.tar.gz`.

## Why do we need it, and what problem does it solve?

- Removes the bootstrap node's dependency on the dhctl ssh-tunnelled rpp server for registry-package fetch (direct mode).
- Overlapping decompression with download cuts fetch+extract on the prefetch path by ~46% (measured: 210 MB / 20 packages, 7.5s → 4.0s). Registry download itself is link-saturated, so the gain is in extraction overlap, not parallelism.

Backward compatible: all flags optional, default behavior unchanged.

## Why do we need it in the patch release (if we do)?

Not necessarily.

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [x] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.

<!-- Direct fetch validated manually on a node (20 packages). Full node bootstrap with the bashible wiring NOT yet exercised. -->

## Changelog entries

```changes
section: candi
type: feature
summary: rpp-get fetches registry packages directly from the registry and stream-extracts them during bootstrap prefetch.
impact_level: low
```
