### PR TITLE
[control-plane-manager]  use single image for control-plane-manager

### DIFF
--- a/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
+++ b/modules/040-control-plane-manager/images/control-plane-manager/werf.inc.yaml
@@ -1,9 +1,5 @@
-{{- range $key, $value := .CandiVersionMap.k8s }}
-  {{- $version := toString $key }}
-  {{- $patch := $value.patch | toString }}
-  {{- $image_version := printf "%s.%s" $version $patch | replace "." "-" }}
 ---
-image: {{ $.ModuleName }}/{{ $.ImageName }}-{{ $version | replace "." "-" }}
+image: {{ $.ModuleName }}/{{ $.ImageName }}
 fromImage: common/distroless
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
@@ -15,12 +11,10 @@ imageSpec:
   config:
     entrypoint: ["/control-plane-manager"]
 ---
-{{- include "vex mitigation" (list $ (printf "%s/%s-%s" $.ModuleName $.ImageName ($version | replace "." "-"))) }}
-{{- end }}
+{{- include "vex mitigation" (list $ (printf "%s/%s" $.ModuleName $.ImageName )) }}
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-artifact
 from: {{ index $.Images "builder/golang-alpine" }}
-fromCacheVersion: "2025-07-25-3"
 final: false
 import:
 - image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
@@ -47,7 +41,6 @@ shell:
     - GOPROXY=$(cat /run/secrets/GOPROXY) GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $BUILD_TAGS -ldflags="-s -w $ETCD_SIGN_ENABLED" -o /control-plane-manager .
 ---
 image: {{ $.ModuleName }}/{{ $.ImageName }}-src-artifact
-fromCacheVersion: "2025-07-25-3"
 fromImage: common/src-artifact
 final: false
 git:

--- a/modules/040-control-plane-manager/template_tests/publish_api_test.go
+++ b/modules/040-control-plane-manager/template_tests/publish_api_test.go
@@ -42,11 +42,7 @@ const globalValues = `
   modulesImages:
     digests:
       controlPlaneManager:
-        controlPlaneManager131: sha256:abcdefgh
-        controlPlaneManager132: sha256:abcdefgh
-        controlPlaneManager133: sha256:abcdefgh
-        controlPlaneManager134: sha256:abcdefgh
-        controlPlaneManager135: sha256:abcdefgh
+        controlPlaneManager: sha256:abcdefgh
         etcd: sha256:abcdefgh
         etcdBackup: sha256:abcdefgh
         kubeApiserver131: sha256:abcdefgh

--- a/modules/040-control-plane-manager/templates/daemonset.yaml
+++ b/modules/040-control-plane-manager/templates/daemonset.yaml
@@ -277,7 +277,7 @@ spec:
       containers:
       - name: control-plane-manager
         {{- include "helm_lib_module_container_security_context_read_only_root_filesystem_capabilities_drop_all_and_add" (list $ (list "SYS_CHROOT")) | nindent 8 }}
-        image: {{ include "helm_lib_module_image" (list $ (printf "controlPlaneManager%s" $kubeImageTagSuffix)) }}
+        image: {{ include "helm_lib_module_image" (list $ "controlPlaneManager" ) }}
         volumeMounts:
         - mountPath: /var/lib/etcd
           name: etcd

--- a/testing/library/images_tags_generated.go
+++ b/testing/library/images_tags_generated.go
@@ -228,11 +228,7 @@ var DefaultImagesDigests = map[string]interface{}{
 		"vxlanOffloadingFixer":      "imageHash-common-vxlanOffloadingFixer",
 	},
 	"controlPlaneManager": map[string]interface{}{
-		"controlPlaneManager132":   "imageHash-controlPlaneManager-controlPlaneManager132",
-		"controlPlaneManager133":   "imageHash-controlPlaneManager-controlPlaneManager133",
-		"controlPlaneManager134":   "imageHash-controlPlaneManager-controlPlaneManager134",
-		"controlPlaneManager135":   "imageHash-controlPlaneManager-controlPlaneManager135",
-		"controlPlaneManager136":   "imageHash-controlPlaneManager-controlPlaneManager136",
+		"controlPlaneManager":      "imageHash-controlPlaneManager-controlPlaneManager",
 		"etcd":                     "imageHash-controlPlaneManager-etcd",
 		"etcdBackup":               "imageHash-controlPlaneManager-etcdBackup",
 		"kubeApiserver132":         "imageHash-controlPlaneManager-kubeApiserver132",


### PR DESCRIPTION
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

The `control-plane-manager` module now ships one container image instead of a separate image per supported Kubernetes minor version (`controlPlaneManager132`, `controlPlaneManager133`, and so on).

Unlike `kube-apiserver`, `kube-controller-manager`, and `kube-scheduler`, the `control-plane-manager` controller binary is not tied to a specific Kubernetes minor version, so version-specific images were redundant.

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

Previously, `control-plane-manager` followed the same per-minor-version image pattern as Kubernetes control plane components. That produced multiple functionally identical images and digest entries for the same Go binary.

This added unnecessary build and registry overhead without changing runtime behavior. A single image simplifies the build pipeline, image digests in `global.modulesImages`, and module maintenance while keeping version-specific images only where they are actually required.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
<!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
-->

```changes
section: control-plane-manager
type: chore
summary: Use a single `control-plane-manager` image instead of per-Kubernetes-minor-version images.
impact_level: low
```

<!---
`impact_level: default` adds to changelog as usual, this is the default that can be omitted
`impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
`impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores

Tip for the section field:

  - <kebab-case of a module>, e.g. "cloud-provider-aws", "node-manager"
  - "ci", has forced low impact
  - "docs", includes website changes, should have low impact
  - "candi"
  - "deckhouse-controller"
  - "dhctl"
  - "global-hooks"
  - "go_lib"
  - "helm_lib"
  - "jq_lib"
  - "shell_lib"
  - "testing", has forced low impact
  - "tools", has forced low impact

Find changed sections:

gh pr diff   $PULL_REQUEST_NUMBER   |
  egrep "^([+]{3} b|[-]{3} a)/" |
  cut -d/ -f2- |
  sed 's#^ee/##' |
  sed 's#^fe/##' |
  sed 's#^modules/##' |
  sed 's#[0-9][0-9][0-9]-##' |
  egrep -v 'Makefile' |       # add file exclusion here
  cut -d/ -f1 |
  sort |
  uniq

Find all possible sections (excluding ci):

node -e 'console.log(require("./.github/scripts/js/changelog-find-sections.js")().join("\n"))'
-->
