### PR TITLE
[webhook-handler] Fix empty includeSnapshotsFrom

### DIFF
--- a/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
+++ b/modules/002-deckhouse/images/webhook-handler/operator/cmd/main.go
@@ -135,6 +135,37 @@ func reloadHooks(ctx context.Context, shOp *shell_operator.ShellOperator, logger
 		shOp.ConversionWebhookManager.ClientConfigs = make(map[string]*conversion.CrdClientConfig)
 	}
 
+	// Re-enable kubernetes bindings on every newly loaded hook so that the
+	// monitors that maintain object caches (snapshots) are recreated and
+	// wired to the freshly rebuilt HookController.
+	//
+	// HookManager.Init() above replaces every Hook (and therefore every
+	// HookController) with a brand new instance whose KubernetesController
+	// has no registered monitors. Admission/conversion hooks that pull data
+	// via 'includeSnapshotsFrom' rely on these monitors; without this step
+	// their 'snapshots' field is delivered empty and validating webhooks
+	// make decisions on missing data (e.g. always denying because a
+	// ModuleConfig snapshot looks absent).
+	//
+	// EnableKubernetesBindings is idempotent: it adds and starts a monitor
+	// only when one is not already registered, and the initial list it
+	// performs repopulates the snapshot cache synchronously.
+	kubernetesHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.OnKubernetesEvent)
+	if err != nil {
+		return fmt.Errorf("get kubernetes hooks: %w", err)
+	}
+	for _, name := range kubernetesHookNames {
+		h := shOp.HookManager.GetHook(name)
+		if h == nil {
+			continue
+		}
+		if _, err := h.HookController.EnableKubernetesBindings(); err != nil {
+			return fmt.Errorf("enable kubernetes bindings for hook %q: %w", name, err)
+		}
+		// Allow the monitors to emit events now that their caches are filled.
+		h.HookController.UnlockKubernetesEvents()
+	}
+
 	// Enable admission bindings on every newly loaded hook so that
 	// AdmissionLinks are populated and CanHandleEvent works.
 	admissionHookNames, err := shOp.HookManager.GetHooksInOrder(hook_types.KubernetesValidating)


### PR DESCRIPTION
## Description

Fixes the webhook-handler operator so that validating/mutating/conversion hooks relying on `includeSnapshotsFrom` receive populated snapshots after a hook reload.

`reloadHooks()` calls `HookManager.Init()`, which atomically replaces every `Hook` (and therefore every `HookController`) with a brand-new instance whose `KubernetesController` has no registered monitors. After `Init()` the function re-enabled only the admission and conversion bindings, but it never re-enabled the `kubernetes` bindings that maintain the object caches (snapshots). The `kubernetes` monitors are enabled once via the main-queue bootstrap, but each subsequent `reloadHooks()` (triggered on startup while reconciling the ValidationWebhook/ConversionWebhook CRs, and on every CR change) rebuilt the hooks again and orphaned those monitors from the hook instances that actually serve admission requests.

As a result, the `snapshots` field of the binding context was delivered empty for affected hooks. The change adds a re-enable step in `reloadHooks()`: for every newly loaded hook with `kubernetes` bindings it calls `EnableKubernetesBindings()` (idempotent; its initial list repopulates the snapshot cache synchronously) and `UnlockKubernetesEvents()`, so the monitors are recreated and wired to the freshly rebuilt `HookController`.

## Why do we need it, and what problem does it solve?

After the migration of `webhook-handler` to use shell-operator as a library, the empty-snapshot behavior broke every `kubernetesValidating` (and similarly `kubernetesMutating`/conversion) hook that depends on `includeSnapshotsFrom`.

The most visible regression was in the `istio` module: the `istiofederations.deckhouse.io` and `istiomulticlusters.deckhouse.io` validating webhooks read the `istio` ModuleConfig from a snapshot to decide whether federation/multicluster is enabled. With an empty snapshot the `federationEnabled` `multiclusterEnabled` value was missing, so the webhooks always denied creation:

```
admission webhook "istiofederations.deckhouse.io" denied the request: IstioFederations can only be created when federation is enabled. Enable spec.settings.federation.enabled in the istio ModuleConfig.
```

even when `spec.settings.federation.enabled: true` was set. The same pattern affected other hooks using this technique (e.g. the kube-dns `cluster-domain-alias` webhook).

Verified manually on a test cluster:

- Before: binding context contained `{"istio_mc":[]}`, webhook returned `allowed=false`.
- After: binding context contains `{"istio_mc":[{"filterResult":{"federationEnabled":true}}]}`, the webhook returns `allowed=true`, and both `IstioFederation` and `IstioMulticluster` resources can be created when the corresponding feature is enabled.

## Checklist
- [ ] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

## Changelog entries

```changes
section: deckhouse
type: fix
summary: Re-enable kubernetes bindings in webhook-handler reload so hooks using `includeSnapshotsFrom` get populated snapshots.
impact_level: default
```